### PR TITLE
Potential fix for code scanning alert no. 38: Bad redirect check

### DIFF
--- a/pkg/common/redirect.go
+++ b/pkg/common/redirect.go
@@ -164,10 +164,11 @@ func sanitizedRedirectTarget(redirectURL, currentHost string) (string, error) {
 		Fragment: u.Fragment,
 	}
 	if result := clean.String(); result != "" {
-		if strings.HasPrefix(result, "/") {
+		// Only allow paths starting with a single slash and not followed by '/' or '\'
+		if strings.HasPrefix(result, "/") && (len(result) == 1 || (result[1] != '/' && result[1] != '\\')) {
 			return result, nil
 		}
-		return "/" + result, nil
+		return "/", nil
 	}
 	return "/", nil
 }


### PR DESCRIPTION
Potential fix for [https://github.com/equaltoai/lesser/security/code-scanning/38](https://github.com/equaltoai/lesser/security/code-scanning/38)

To fix the vulnerability, we need to strengthen the check at the point where we ensure the redirect path is safe. Instead of only verifying that the redirect URL starts with a single slash, we should also check that the second character, if present, is **neither** a slash nor a backslash. This blocks dangerous browser behavior where redirects to `//evil.com` or `/\evil.com` are interpreted as external absolute URLs.

Specifically, in `sanitizedRedirectTarget` (lines 167-170), update the check to:
- Only accept paths that start with a single `/` and whose second character, if present, is not `/` or `\`.

No new external imports are needed: the change can use standard Go string indexing.

We only need to update the logic in pkg/common/redirect.go, lines 167–170, inside the `sanitizedRedirectTarget` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
