### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/archived/test_api_fixed.py
+++ b/tests/archived/test_api_fixed.py
@@ -3,7 +3,6 @@
 Fixed version of the test script with better error handling
 """
 
-from mastodon import Mastodon
 import requests
 
 # Your lesser instance


### PR DESCRIPTION
To fix the problem, remove the import statement `from mastodon import Mastodon` from line 6 of `tests/archived/test_api_fixed.py`. This change eliminates unnecessary code, reduces clutter, and prevents confusion about dependencies. No additional code or dependencies are needed; simply delete the line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._