### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/moderation/test_filters_mutes.py
+++ b/tests/moderation/test_filters_mutes.py
@@ -4,7 +4,6 @@ Test script for Filters & Mutes functionality
 """
 
 import requests
-import time
 from datetime import datetime
 
 # Configuration


### PR DESCRIPTION
To fix the problem, simply delete the unused `import time` statement on line 7 from tests/moderation/test_filters_mutes.py. This will remove unnecessary code, aligning the file with best practices by only importing modules that are actually used. Only this single-line change is needed; no changes to the logic or imports elsewhere are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._