### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/search/test_hashtag_search.py
+++ b/tests/search/test_hashtag_search.py
@@ -3,7 +3,7 @@
 
 import requests
 import time
-from typing import Dict, Any
+from typing import Dict
 
 # Test configuration
 BASE_URL = "https://lab.lesser.aronprice.com/api/v1"


### PR DESCRIPTION
To fix the problem, remove the unused import `Any` from the line `from typing import Dict, Any` in tests/search/test_hashtag_search.py. The only type from `typing` actually used is `Dict`, so the line should instead be `from typing import Dict`. No other changes are necessary. Only line 6 is affected.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._