### PR TITLE
Fix for Unused import

### DIFF
--- a/scripts/validate_graphql_comprehensive.py
+++ b/scripts/validate_graphql_comprehensive.py
@@ -6,7 +6,6 @@ Tests social interactions, content operations, and other features
 import os
 import sys
 import time
-import json
 import requests
 from typing import Dict, Optional
 


### PR DESCRIPTION
To fix this issue, the unused import statement should be removed from the file. Specifically, delete the line `import json` (line 9) in `scripts/validate_graphql_comprehensive.py`. No other changes are required, and no functionality will be impacted, because there are no usages of the `json` module in the shown code regions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._