### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/api/test_notifications.py
+++ b/tests/api/test_notifications.py
@@ -16,7 +16,6 @@ It also tests notification generation for:
 """
 
 import requests
-import json
 import sys
 import time
 import argparse


### PR DESCRIPTION
To fix the error, simply remove the unused import of the `json` module from the file `tests/api/test_notifications.py` (specifically, line 19). No change to other functionality, imports, or logic is necessary—just delete that line. As all uses of `.json()` are on `requests.Response` objects and do not refer to the `json` module, there is no risk from removing the import.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._