### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/archived/test_utilities_demo.py
+++ b/tests/archived/test_utilities_demo.py
@@ -8,7 +8,6 @@ import asyncio
 import json
 from test_data_generator import LesserTestDataGenerator
 from federation_test_harness import FederationTestHarness
-from performance_benchmark import LesserPerformanceBenchmark
 
 
 def demo_test_data_generator():


### PR DESCRIPTION
To fix this problem, you should remove the unused import statement of `LesserPerformanceBenchmark` from `performance_benchmark` on line 11 in the file `tests/archived/test_utilities_demo.py`. This will clean up the code and resolve the static analysis warning, without changing any functionality, since the class is not referenced anywhere else in the shown snippet.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._