### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/search/test_semantic_search.py
+++ b/tests/search/test_semantic_search.py
@@ -5,7 +5,6 @@ Tests AWS Bedrock embeddings, Comprehend query analysis, and semantic search.
 """
 
 import requests
-import json
 import time
 import argparse
 from typing import Dict, List


### PR DESCRIPTION
The problem can be resolved by removing the unnecessary import statement for the `json` module on line 8. This can be safely done because no function or class references `json` in the shown code, so it will have no impact on the script's functionality or any tests. The best way to fix this is to simply delete line 8 (`import json`) in the file `tests/search/test_semantic_search.py`. No further changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._