### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/auth/test_oauth.py
+++ b/tests/auth/test_oauth.py
@@ -3,7 +3,6 @@
 
 import base64
 import hashlib
-import json
 import secrets
 from urllib.parse import urlencode, urlparse, parse_qs, parse_qsl
 


### PR DESCRIPTION
To resolve the unused import, simply remove the line `import json` (line 6) from the file. This will eliminate the unnecessary import while retaining all existing functionality, as there is no usage of the `json` module elsewhere in the provided code. Only the import statement on line 6 needs to be deleted; no other code changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._