### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/api/test_polls.py
+++ b/tests/api/test_polls.py
@@ -13,7 +13,6 @@ Tests:
 """
 
 import requests
-import json
 import argparse
 
 def test_polls(base_url, token):


### PR DESCRIPTION
To fix the problem, the unused import statement for the `json` module on line 16 should be removed from `tests/api/test_polls.py`. This will clean up the code, remove unnecessary dependencies, and eliminate the warning from CodeQL. No other changes are needed, as nothing in the script relies on `json`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._