### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/api/test_push_notifications.py
+++ b/tests/api/test_push_notifications.py
@@ -6,7 +6,6 @@ Tests VAPID key generation, subscription management, and notification delivery.
 
 import argparse
 import requests
-import json
 import sys
 import base64
 import os


### PR DESCRIPTION
To fix this issue, simply remove the unused `import json` statement from line 9 of the file `tests/api/test_push_notifications.py`. No additional edits, imports, or code changes are needed, as the removal will not affect any existing functionality demonstrated in the shown code. Only lines directly importing `json` should be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._