### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/archived/test_search_v2.py
+++ b/tests/archived/test_search_v2.py
@@ -2,7 +2,6 @@
 """Test the search v2 endpoint implementation."""
 
 import requests
-import json
 from typing import Dict, Any
 
 # Test configuration


### PR DESCRIPTION
The best fix is to remove the unused `import json` statement.  
- In general, to resolve this issue, delete the unused import from the file.  
- Specifically, in `tests/archived/test_search_v2.py` at line 5, remove the entire line: `import json`.
- No other changes, definitions, or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._