### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/archived/test_search_week4.py
+++ b/tests/archived/test_search_week4.py
@@ -5,7 +5,6 @@ Tests popularity search, analytics tracking, and search filters
 """
 
 import requests
-import json
 import time
 import argparse
 import sys


### PR DESCRIPTION
To fix the problem, remove the unused import statement for the `json` module from the top of the file `tests/archived/test_search_week4.py`. This involves deleting only line 8 (`import json`) to ensure that the script no longer imports a module that is not used. This change will not affect any other functionality, as no parts of the code rely on `json`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._