### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/archived/test_search_v2.py
+++ b/tests/archived/test_search_v2.py
@@ -2,7 +2,7 @@
 """Test the search v2 endpoint implementation."""
 
 import requests
-from typing import Dict, Any
+
 from typing import Dict
 # Test configuration
 BASE_URL = "https://lab.lesser.aronprice.com/api/v1"


### PR DESCRIPTION
To resolve this problem, we should remove the unused `Any` from the `from typing import Dict, Any` import statement on line 5. Since `Dict` is imported both on line 5 and line 6, we should also consolidate imports to avoid redundancy. The single best way is to remove line 5 entirely and keep line 6 (`from typing import Dict`) for clarity and Python best practices.  
No other modifications are required, and no functional behaviour will change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._