### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/archived/test_search_week4.py
+++ b/tests/archived/test_search_week4.py
@@ -7,7 +7,6 @@ Tests popularity search, analytics tracking, and search filters
 import requests
 import time
 import argparse
-import sys
 
 # ANSI color codes
 GREEN = '\033[92m'


### PR DESCRIPTION
The most appropriate fix for this issue is to remove the unused import statement `import sys` from line 10. This change poses no risk to existing functionality, as the `sys` module is not referenced anywhere else in the provided code.  
To implement the fix:
- Delete the line containing `import sys` from the imports section.
- No additional methods, definitions, or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._