### PR TITLE
Potential fix for code scanning alert no. 104: Size computation for allocation may overflow

### DIFF
--- a/pkg/streaming/publisher_queue.go
+++ b/pkg/streaming/publisher_queue.go
@@ -98,12 +98,17 @@ func (p *queuePublisher) logQueueError(message string, err error, fields map[str
 	}
 
 	fieldCount := len(fields)
-	if fieldCount > maxLogQueueFields {
+	if fieldCount < 0 || fieldCount > maxLogQueueFields {
 		p.logger.Error("logQueueError: too many fields, possible malformed input", zap.Int("field_count", fieldCount), zap.Error(err))
 		return
 	}
 
-	zapFields := make([]zap.Field, 0, fieldCount+1)
+	safeCap := fieldCount + 1
+	if safeCap < 0 || safeCap > maxLogQueueFields+1 {
+		// Defensive: should never happen, but guard against integer overflow or corrupted input
+		safeCap = maxLogQueueFields + 1
+	}
+	zapFields := make([]zap.Field, 0, safeCap)
 	for k, v := range fields {
 		zapFields = append(zapFields, zap.Any(k, v))
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/equaltoai/lesser/security/code-scanning/104](https://github.com/equaltoai/lesser/security/code-scanning/104)

To robustly fix this issue, ensure that the `fieldCount` used in `make([]zap.Field, 0, fieldCount+1)` is not only less than `maxLogQueueFields`, but also non-negative and controlled such that it cannot cause allocation panics (due to resource exhaustion). The best approach is:
- Check that `fieldCount >= 0` to guard against any future code changes or abuse that could cause underflow.
- Explicitly cap the `fieldCount` used to allocate the slice to `maxLogQueueFields` (e.g., use `min(fieldCount, maxLogQueueFields)`), with an additional lower bound of 0.
- Optionally, you may want to use a helper function such as `safeCap := min(max(fieldCount, 0), maxLogQueueFields)`, ensuring that allocations are always in a safe, bounded range.

This fix requires only adding a local capping and non-negativity logic at the allocation site in `logQueueError` in `pkg/streaming/publisher_queue.go`. No changes to other files are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
