### PR TITLE
release workflow: support workflow_dispatch version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,17 +5,28 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version tag (example: v1.2.3)"
+        required: true
+        type: string
 
 permissions:
   contents: write
 
 jobs:
   publish:
+    # Prevent duplicate releases when a workflow_dispatch run creates + pushes a tag.
+    if: ${{ github.event_name != 'push' || github.actor != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.ref_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -26,13 +37,41 @@ jobs:
             go.sum
             infra/cdk/go.sum
 
+      - name: Create and push tag (workflow_dispatch)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF_NAME}" != "main" ]]; then
+            echo "workflow_dispatch releases must be run from the main branch (got '${GITHUB_REF_NAME}')" >&2
+            exit 1
+          fi
+          if [[ "${RELEASE_VERSION}" != v* ]]; then
+            echo "release version must start with 'v' (example: v1.0.0); got '${RELEASE_VERSION}'" >&2
+            exit 1
+          fi
+
+          git fetch --tags --force
+          if git rev-parse -q --verify "refs/tags/${RELEASE_VERSION}" >/dev/null; then
+            existing_sha="$(git rev-list -n 1 "${RELEASE_VERSION}")"
+            if [[ "${existing_sha}" != "${GITHUB_SHA}" ]]; then
+              echo "tag '${RELEASE_VERSION}' already exists at ${existing_sha}; refusing to retag ${GITHUB_SHA}" >&2
+              exit 1
+            fi
+            echo "tag '${RELEASE_VERSION}' already exists at ${existing_sha}"
+            exit 0
+          fi
+
+          git tag "${RELEASE_VERSION}" "${GITHUB_SHA}"
+          git push origin "refs/tags/${RELEASE_VERSION}"
+
       - name: Build release assets
-        run: bash scripts/build_release_assets.sh "${GITHUB_REF_NAME}" dist/release
+        run: bash scripts/build_release_assets.sh "${RELEASE_VERSION}" dist/release
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ env.RELEASE_VERSION }}
           files: |
             dist/release/lesser-linux-amd64
             dist/release/lesser-linux-arm64


### PR DESCRIPTION
Fixes manual release workflow_dispatch runs by requiring a v* version input, tagging main at the selected commit, and publishing the GitHub Release using that tag. Also prevents duplicate runs when the workflow creates + pushes the tag.