### PR TITLE
M0: cli auth device flow roadmap + scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Binaries
 bin/
 build/
+dist/
 *.exe
 *.dll
 *.so

--- a/cmd/api/handlers/oauth_device.go
+++ b/cmd/api/handlers/oauth_device.go
@@ -1,0 +1,139 @@
+package handlers
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	apimodels "github.com/equaltoai/lesser/cmd/api/models"
+	"github.com/equaltoai/lesser/pkg/common"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"go.uber.org/zap"
+)
+
+const (
+	oauthDeviceCodeTTLSeconds      = 10 * 60
+	oauthDevicePollIntervalSeconds = 5
+)
+
+// HandleOAuthDeviceCodeLift handles POST /oauth/device/code.
+//
+// This is a headless-friendly OAuth bootstrap flow used by the Lesser CLI.
+// Wallet authentication remains in the web UI; the CLI polls /oauth/token using the device_code grant.
+func (h *Handler) HandleOAuthDeviceCodeLift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	if h == nil || ctx == nil {
+		return common.RespondInternalServerError(ctx)
+	}
+	if h.cfg == nil || !h.cfg.AllowDeviceFlow {
+		return apptheory.JSON(http.StatusForbidden, apimodels.OAuthErrorResponse{
+			Error:            "access_denied",
+			ErrorDescription: "device authorization is disabled",
+		})
+	}
+
+	if h.repos == nil || h.repos.Account() == nil {
+		return apptheory.JSON(http.StatusServiceUnavailable, apimodels.OAuthErrorResponse{
+			Error:            "server_error",
+			ErrorDescription: "storage is not initialized",
+		})
+	}
+
+	if err := common.ValidateSliceNotEmpty("request_body", ctx.Request.Body); err != nil {
+		return apptheory.JSON(http.StatusBadRequest, apimodels.OAuthErrorResponse{
+			Error:            "invalid_request",
+			ErrorDescription: "empty request body",
+		})
+	}
+
+	params, err := common.ParseFormURLEncoded(string(ctx.Request.Body))
+	if err != nil {
+		return apptheory.JSON(http.StatusBadRequest, apimodels.OAuthErrorResponse{
+			Error:            "invalid_request",
+			ErrorDescription: "unable to parse form data",
+		})
+	}
+
+	clientID := strings.TrimSpace(params["client_id"])
+	if err := common.ValidateRequiredParam("client_id", clientID); err != nil {
+		return apptheory.JSON(http.StatusBadRequest, apimodels.OAuthErrorResponse{
+			Error:            "invalid_request",
+			ErrorDescription: "client_id is required",
+		})
+	}
+
+	// Validate that the client exists (public clients are allowed; secret is not required here).
+	if _, err := h.repos.Account().GetOAuthClient(ctx.Context(), clientID); err != nil {
+		return apptheory.JSON(http.StatusBadRequest, apimodels.OAuthErrorResponse{
+			Error:            "invalid_client",
+			ErrorDescription: "unknown client",
+		})
+	}
+
+	deviceCode, err := generateOAuthDeviceCode()
+	if err != nil {
+		h.logger.Error("failed to generate device_code", zap.Error(err))
+		return common.RespondInternalServerError(ctx)
+	}
+
+	userCode, err := generateOAuthUserCode()
+	if err != nil {
+		h.logger.Error("failed to generate user_code", zap.Error(err))
+		return common.RespondInternalServerError(ctx)
+	}
+
+	base := strings.TrimRight(h.cfg.BaseURL(), "/")
+	verificationURI := base + "/auth/device"
+
+	verificationComplete := verificationURI
+	if encoded := url.QueryEscape(userCode); encoded != "" {
+		verificationComplete = verificationURI + "?user_code=" + encoded
+	}
+
+	return okJSON(apimodels.OAuthDeviceCodeResponse{
+		DeviceCode:              deviceCode,
+		UserCode:                userCode,
+		VerificationURI:         verificationURI,
+		VerificationURIComplete: verificationComplete,
+		ExpiresIn:               oauthDeviceCodeTTLSeconds,
+		Interval:                oauthDevicePollIntervalSeconds,
+	})
+}
+
+func generateOAuthDeviceCode() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func generateOAuthUserCode() (string, error) {
+	// Avoid ambiguous characters for manual entry.
+	const alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+
+	out := make([]byte, 0, 9)
+	for i := 0; i < 8; i++ {
+		if i == 4 {
+			out = append(out, '-')
+		}
+		out = append(out, alphabet[int(b[i])%len(alphabet)])
+	}
+	return string(out), nil
+}
+
+// oauthDeviceCodeExpiresAt returns the TTL cutoff for device sessions.
+//
+// NOTE: this is only used once we persist device sessions (M1); it is kept here so the constants stay close.
+func oauthDeviceCodeExpiresAt(now time.Time) time.Time {
+	if now.IsZero() {
+		now = time.Now()
+	}
+	return now.Add(time.Duration(oauthDeviceCodeTTLSeconds) * time.Second)
+}

--- a/cmd/api/models/oauth.go
+++ b/cmd/api/models/oauth.go
@@ -4,12 +4,32 @@ package models
 type OAuthTokenRequest struct {
 	GrantType    string `json:"grant_type"`
 	Code         string `json:"code,omitempty"`
+	DeviceCode   string `json:"device_code,omitempty"`
 	RedirectURI  string `json:"redirect_uri,omitempty"`
 	ClientID     string `json:"client_id"`
 	ClientSecret string `json:"client_secret,omitempty"`
 	CodeVerifier string `json:"code_verifier,omitempty"`
 	RefreshToken string `json:"refresh_token,omitempty"`
 	Scope        string `json:"scope,omitempty"`
+}
+
+// OAuthDeviceCodeRequest represents a device authorization request (RFC 8628-style).
+//
+// This is sent as application/x-www-form-urlencoded to POST /oauth/device/code.
+type OAuthDeviceCodeRequest struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+}
+
+// OAuthDeviceCodeResponse represents the server response for device authorization initiation.
+type OAuthDeviceCodeResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete,omitempty"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
 }
 
 // OAuthTokenResponse represents a token response

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -80,6 +80,9 @@ func configureRoutes(app *apptheory.App) {
 	app.Post("/oauth/consent", ratelimit.ApplyRateLimit(
 		apiHandler.HandleOAuthConsentLift,
 		20, 5*time.Minute, logger))
+	app.Post("/oauth/device/code", ratelimit.ApplyRateLimit(
+		apiHandler.HandleOAuthDeviceCodeLift,
+		10, time.Minute, logger))
 	app.Post("/oauth/token", ratelimit.ApplyRateLimit(
 		apiHandler.HandleOAuthTokenLift,
 		10, time.Minute, logger))
@@ -87,6 +90,7 @@ func configureRoutes(app *apptheory.App) {
 	// OPTIONS handlers for OAuth endpoints (CORS preflight)
 	app.Handle("OPTIONS", "/oauth/authorize", optionsHandler)
 	app.Handle("OPTIONS", "/oauth/consent", optionsHandler)
+	app.Handle("OPTIONS", "/oauth/device/code", optionsHandler)
 	app.Handle("OPTIONS", "/oauth/token", optionsHandler)
 
 	// NodeInfo endpoints with native Lift implementation

--- a/cmd/api/testdata/routes_manifest.txt
+++ b/cmd/api/testdata/routes_manifest.txt
@@ -186,6 +186,7 @@ OPTIONS /auth/wallet/unlink/{address}
 OPTIONS /auth/wallet/verify
 OPTIONS /oauth/authorize
 OPTIONS /oauth/consent
+OPTIONS /oauth/device/code
 OPTIONS /oauth/token
 OPTIONS /setup/admin
 OPTIONS /setup/bootstrap/challenge
@@ -291,6 +292,7 @@ POST /auth/wallet/link
 POST /auth/wallet/login
 POST /auth/wallet/verify
 POST /oauth/consent
+POST /oauth/device/code
 POST /oauth/token
 POST /setup/admin
 POST /setup/bootstrap/challenge

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -3267,6 +3267,40 @@ components:
             required:
                 - redirect_uri
             type: object
+        OAuthDeviceCodeRequest:
+            additionalProperties: false
+            properties:
+                client_id:
+                    type: string
+                client_secret:
+                    type: string
+                scope:
+                    type: string
+            required:
+                - client_id
+            type: object
+        OAuthDeviceCodeResponse:
+            additionalProperties: false
+            properties:
+                device_code:
+                    type: string
+                expires_in:
+                    type: integer
+                interval:
+                    type: integer
+                user_code:
+                    type: string
+                verification_uri:
+                    type: string
+                verification_uri_complete:
+                    type: string
+            required:
+                - device_code
+                - expires_in
+                - interval
+                - user_code
+                - verification_uri
+            type: object
         OAuthErrorResponse:
             additionalProperties: false
             properties:
@@ -3305,6 +3339,8 @@ components:
                 code:
                     type: string
                 code_verifier:
+                    type: string
+                device_code:
                     type: string
                 grant_type:
                     type: string
@@ -17061,6 +17097,52 @@ paths:
                 "500":
                     $ref: '#/components/responses/InternalServerError'
             x-lesser-handler: HandleOAuthConsentLift
+            x-lesser-lambda: api
+            x-lesser-routeSources:
+                - cmd/api/routes.go
+    /oauth/device/code:
+        post:
+            operationId: post_oauth_device_code
+            tags:
+                - oauth
+            requestBody:
+                required: true
+                content:
+                    application/x-www-form-urlencoded:
+                        schema:
+                            $ref: '#/components/schemas/OAuthDeviceCodeRequest'
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/OAuthDeviceCodeResponse'
+                    headers:
+                        X-RateLimit-Limit:
+                            description: Request limit per window.
+                            schema:
+                                type: integer
+                                format: int32
+                        X-RateLimit-Remaining:
+                            description: Requests remaining in the current window.
+                            schema:
+                                type: integer
+                                format: int32
+                        X-RateLimit-Reset:
+                            description: Unix timestamp (seconds) when the current window resets.
+                            schema:
+                                type: integer
+                                format: int64
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "422":
+                    $ref: '#/components/responses/UnprocessableEntity'
+                "429":
+                    $ref: '#/components/responses/TooManyRequests'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+            x-lesser-handler: HandleOAuthDeviceCodeLift
             x-lesser-lambda: api
             x-lesser-routeSources:
                 - cmd/api/routes.go

--- a/docs/planning/lesser-cli-auth-device-flow-roadmap.md
+++ b/docs/planning/lesser-cli-auth-device-flow-roadmap.md
@@ -1,0 +1,335 @@
+# Lesser: CLI Auth (Wallet → OAuth Device Flow) + Automation Safety Rails Roadmap (Spec draft, 2026-02-10)
+
+This roadmap defines how to extend the existing `lesser` CLI so it can authenticate with a wallet (via the web UI)
+and interact with Lesser’s API like any other OAuth client, **while enforcing stricter server-side and client-side
+rate protection** because CLI access is a high-abuse-risk path.
+
+Core decisions locked for this roadmap:
+- **True device-style flow** (no inbound ports required; headless friendly).
+- **Wallet handling stays in the web UI**; the CLI never needs to sign wallet challenges.
+- **CLI traffic is treated like “LLM agent traffic” for safety rails** (concurrency + circuit-breakers + stricter
+  throttles) **regardless of username**.
+- **Server-side classification is not spoofable** (no “X-CLI: true” headers); it must be derived from OAuth issuance.
+
+Non-goals (for this roadmap):
+- Build a full interactive TUI.
+- Replace existing web client auth.
+- Make local credential encryption resilient to full local compromise (goal is “headless-safe + reduces accidents”).
+
+---
+
+## Invariants / constraints (do not violate)
+
+- **Email-free / passwordless:** no email-based flows; authentication remains wallet/WebAuthn-first.
+- **Minimal user interaction:** web auth is one-time/infrequent; routine CLI usage should be non-interactive.
+- **Headless-first:** the default auth flow must work without opening ports or requiring a GUI on the CLI machine.
+- **Automation safety rails apply regardless of username:** any token minted for the CLI class must be governed.
+- **Rate protection exists on both sides:**
+  - client-side: guardrails to prevent accidental/naive abuse
+  - server-side: strict throttles + concurrency caps + lockouts
+- **Fail-safe security posture:** if classification is missing/unknown, default to stricter behavior for device-flow
+  tokens (and/or deny device grant issuance when policy disallows).
+
+---
+
+## Baseline (what Lesser already has)
+
+- OAuth endpoints: `GET /oauth/authorize`, `POST /oauth/consent`, `POST /oauth/token` (auth code + refresh).
+- Wallet login endpoints used by the web UI: `/auth/wallet/*` (username required).
+- OAuth app registration: `POST /api/v1/apps`.
+- LLM-agent safety rails middleware (concurrency + error-rate lockout) currently triggered by `claims.IsAgent`.
+- Distributed rate limiting primitives:
+  - `pkg/ratelimit.ApplyRateLimit` (Dynamo-backed sliding window; currently keyed by path)
+  - `repos.RateLimit().CheckAPIRateLimit(...)` counters/lockouts used by agent rails
+
+---
+
+## Roadmap milestones
+
+Milestones are ordered to keep the system safe at every step. Each milestone includes acceptance criteria and
+suggested verification commands (adapt as implementation evolves).
+
+### M0 — Contract + policy decisions (device flow + automation class)
+
+**Goal:** freeze the contract and the server-side classification approach so the CLI + API don’t drift.
+
+**Decisions (locked for M1+)**
+- Implement RFC 8628-style device authorization:
+  - `POST /oauth/device/code` (issue device_code + user_code)
+  - `POST /oauth/token` supports `grant_type=urn:ietf:params:oauth:grant-type:device_code`
+- Tokens minted from the device grant are classified as **automation/CLI** (new claim, not `is_agent`).
+- Refresh-token exchange preserves the same classification.
+- Instance policy/feature flag gates:
+  - `AllowDeviceFlow` (default false)
+  - `AllowCLIAutomation` (default false, or implied by AllowDeviceFlow)
+
+**Acceptance criteria**
+- OpenAPI contract updated (`docs/contracts/openapi.yaml`) with:
+  - request/response schemas for device-code issuance and polling
+  - documented error codes: `authorization_pending`, `slow_down`, `access_denied`, `expired_token`, `invalid_client`
+- A short design note exists (this roadmap is sufficient) documenting:
+  - classification mechanism (“derived from grant type and persisted through refresh”)
+  - rate-limit posture and why it applies regardless of username
+
+**Suggested verification**
+```bash
+./lesser verify openapi --strict
+./lesser test unit
+```
+
+---
+
+### M1 — Server: device authorization sessions (storage + endpoints)
+
+**Goal:** add a true device-style login handshake that works headless without exposing tokens via URLs.
+
+**Implementation notes (recommended)**
+- Add a storage model for device auth sessions with TTL (DynamoDB):
+  - `device_code` (high entropy, treated as secret) stored hashed or as PK; **never logged**
+  - `user_code` (short, human-entered), stored with a lookup index
+  - `client_id`, requested `scopes`, `created_at`, `expires_at`, `poll_interval`
+  - `status`: `pending|approved|denied|consumed|expired`
+  - `approved_username` (set only when approved)
+  - polling throttle metadata (`last_poll_at`, `poll_count`) for abuse control
+- Add endpoints:
+  - `POST /oauth/device/code` → issue codes + verification URLs
+  - Extend `POST /oauth/token` for device grant → return OAuth tokens or the correct RFC error
+- Add strict rate limits to:
+  - device-code issuance (per IP + per client_id)
+  - device token polling (per device_code + per IP; enforce `interval` and return `slow_down`)
+
+**Acceptance criteria**
+- `POST /oauth/device/code` returns:
+  - `device_code`, `user_code`, `verification_uri`, `verification_uri_complete`, `expires_in`, `interval`
+- Polling `POST /oauth/token`:
+  - returns `authorization_pending` until approved
+  - enforces polling interval and uses `slow_down` when violated
+  - returns `access_denied` on denial
+  - returns `expired_token` after expiry
+  - returns access + refresh tokens once approved and marks the session consumed (one-time)
+- No secrets are written to logs (device_code, refresh_token, authorization code).
+
+**Suggested verification**
+```bash
+./lesser test unit
+./lesser lint
+```
+
+---
+
+### M2 — Web UI: device verification + wallet login + consent
+
+**Goal:** let a user approve a device login from any browser, using existing wallet auth, with minimal friction.
+
+**Implementation notes (recommended)**
+- Add an auth UI route like `GET /auth/device`:
+  - supports `?user_code=XXXX-XXXX` deep link
+  - renders “enter code” if missing; then shows app + scopes and requests consent
+- Reuse existing wallet login UX:
+  - **requires username** (supports wallets with multiple actors)
+  - after login, confirm the account that will authorize the CLI session
+- On approval, write `approved_username` + `approved_at` to device session.
+- On denial, mark `denied` and optionally record reason/audit event.
+
+**Acceptance criteria**
+- A user can complete device flow from a different machine:
+  - CLI shows URL + code
+  - user authenticates via wallet on the web UI and approves
+  - CLI receives tokens via polling
+- Consent screen clearly labels:
+  - instance domain
+  - app name (“lesser cli”)
+  - requested scopes
+  - the username being authorized
+
+**Suggested verification**
+```bash
+./lesser test unit
+./lesser test integration
+```
+
+---
+
+### M3 — Token classification: `client_class=cli` (persisted across refresh)
+
+**Goal:** make CLI traffic enforceable server-side without spoofable headers and without depending on the account type.
+
+**Implementation notes (recommended)**
+- Add a new JWT claim (example): `client_class` with values like `web|cli|agent`.
+  - Device-grant tokens must be minted with `client_class=cli`.
+  - Do **not** set `is_agent=true` for CLI tokens (avoids agent-only content restrictions).
+- Ensure the classification persists through refresh:
+  - store `client_class` (or equivalent) on refresh token records, or
+  - store `client_class` on the OAuth client record and derive it during refresh issuance.
+- Ensure CLI tokens have a stable session identifier (`sid`) for concurrency enforcement:
+  - set `sid` for `client_class=cli` tokens (and ensure refresh preserves it, or uses a stable family/session id).
+
+**Acceptance criteria**
+- Access tokens minted for device flow contain `client_class=cli`.
+- Refreshing a CLI token yields a new access token still containing `client_class=cli`.
+- Concurrency enforcement has a stable identifier to key on (not path, not IP-only).
+
+**Suggested verification**
+```bash
+./lesser test unit
+./lesser test race
+```
+
+---
+
+### M4 — Server: automation safety rails + strict throttles for CLI tokens
+
+**Goal:** apply “agent-like” safety rails and strict rate limits to CLI tokens **regardless of username**, to reduce
+abuse impact even if credentials leak or the CLI is scripted aggressively.
+
+**Implementation notes (recommended)**
+- Extend/rename the existing middleware so it can be triggered by:
+  - `claims.IsAgent == true` **OR**
+  - `claims.ClientClass == "cli"` (or equivalent)
+- Enforce (initial suggested defaults; should be configurable):
+  - **max concurrent in-flight requests per session (`sid`):** 2
+  - **strict request throttles (per `sid`):**
+    - **burst:** 20 requests / 10s
+    - **sustained:** 60 requests / 1m
+  - **error-rate circuit breaker:** >10% 4xx/5xx in 1 minute (min 10 requests) → 1 hour lockout
+  - **GraphQL depth limit:** 3 for `client_class=cli` (same as agents), without setting `is_agent=true`
+- Important: keep **agent-account** restrictions keyed to account type (`user.IsAgent`) and keep **automation-client**
+  restrictions keyed to token classification (`client_class=cli`). Do **not** set `is_agent=true` for CLI tokens, or
+  human accounts using the CLI will trip agent-only rails (and GraphQL depth is currently derived from `is_agent`).
+- Ensure rate-limit keys have stable cardinality:
+  - do not key by full path; use route classes (e.g., `read`, `write`, `search`, `graphql`) or “api:all”
+- Add clear 429 semantics:
+  - `retry-after`
+  - `x-ratelimit-*` headers
+- Add an operator escape hatch:
+  - instance config to tune limits
+  - ability to disable device flow entirely
+
+**Acceptance criteria**
+- Any request with a `client_class=cli` access token:
+  - is subject to strict throttles and concurrency caps
+  - can be locked out by circuit breakers
+  - returns consistent 429 responses with `retry-after`
+- Safety rails apply even for human accounts using the CLI.
+- Limits are configurable at the instance level without code changes.
+
+**Suggested verification**
+```bash
+./lesser test unit
+./lesser test integration
+./lesser lint
+```
+
+---
+
+### M5 — CLI: `lesser auth` (device login + encrypted session store)
+
+**Goal:** add first-class CLI authentication while keeping the CLI simple, headless-friendly, and safe-by-default.
+
+**Command UX (recommended)**
+- `lesser auth login --base-url <https://instance>`:
+  - calls `POST /api/v1/apps` (if needed) to obtain `client_id` (and store it)
+  - calls `POST /oauth/device/code`
+  - prints `verification_uri_complete` (and `user_code` as fallback)
+  - polls until success/deny/timeout
+  - stores an encrypted session blob locally
+- `lesser auth status` / `lesser auth whoami`
+- `lesser auth logout`:
+  - deletes local session
+  - (optional, later milestone) calls token revocation endpoint
+- Non-interactive/multi-step mode for scripts:
+  - `lesser auth device start --json`
+  - `lesser auth device poll --device-code ...` (or reads from a temp file)
+
+**Local encryption (recommended)**
+- Store a single JSON session blob (client_id, refresh_token, base_url, username, scopes, timestamps).
+- Encrypt with AES-256-GCM.
+- Key derivation:
+  - default: machine-derived secret (hostname + user + `/etc/machine-id` + homedir + base_url) → SHA-256 → 32 bytes
+  - override for portability/CI: `LESSER_AUTH_SECRET` (or `--secret-file`)
+- File layout and permissions:
+  - `~/.lesser/auth/<base_url_hash>/session.enc` (dir `0700`, file `0600`)
+
+**Acceptance criteria**
+- A headless user can authenticate by copying a URL/code into any browser.
+- Refresh tokens are never stored in plaintext.
+- The CLI automatically refreshes access tokens and survives token expiry.
+- The CLI never prints tokens by default; debug logging redacts secrets.
+
+**Suggested verification**
+```bash
+./lesser test unit
+./lesser lint
+```
+
+---
+
+### M6 — CLI: API client + client-side rate protection
+
+**Goal:** make “CLI behaves like any other client” true in practice while preventing accidental abuse.
+
+**Implementation notes (recommended)**
+- Add an HTTP client layer used by all CLI API commands:
+  - reads encrypted session
+  - refreshes tokens automatically
+  - retries with backoff on transient failures
+  - respects `retry-after` on 429
+- Client-side throttles (defaults; configurable):
+  - max concurrency: 2
+  - max requests/sec: conservative token bucket
+  - optional “cost” weighting (search/graphql/write heavier)
+- Provide a minimal “API passthrough” command:
+  - `lesser api request --method GET --path /api/v1/accounts/verify_credentials`
+  - plus a small set of ergonomic shortcuts over time (statuses, timelines, etc.)
+
+**Acceptance criteria**
+- With a valid session, `lesser api request ...` works against protected endpoints.
+- The CLI never exceeds its configured concurrency/RPS even under parallel command usage.
+- `429` handling does not busy-loop; it sleeps at least `retry-after`.
+
+**Suggested verification**
+```bash
+./lesser test unit
+./lesser test race
+```
+
+---
+
+### M7 — E2E tests, observability, docs, rollout
+
+**Goal:** make this safe to ship and easy to operate.
+
+**Implementation notes (recommended)**
+- Tests:
+  - unit tests for device-flow state machine and error mapping
+  - unit tests for encrypted session store (permissions, encrypt/decrypt, corruption handling)
+  - integration test for “device start → approve → token → refresh”
+- Observability:
+  - metrics for CLI issuance, polling volume, approvals/denials, throttles, lockouts
+  - structured logs include `client_class`, `client_id`, and rate-limit decisions (but never secrets)
+- Docs:
+  - `docs/cli/auth.md` (headless flow, secret override, troubleshooting)
+  - operator doc: how to tune CLI limits and how lockouts work
+- Rollout:
+  - feature flags default to disabled
+  - staged enablement plan (dev → staging → live)
+
+**Acceptance criteria**
+- `./lesser verify ci` passes.
+- Operators can enable/disable device flow and tune CLI limits via config.
+- Docs cover headless and non-interactive flows clearly.
+
+**Suggested verification**
+```bash
+./lesser verify ci
+./lesser test integration
+```
+
+---
+
+## Optional follow-ons (post-M7)
+
+- **Loopback callback flow** as a convenience for laptop users (still classified as `client_class=cli`).
+- **Token revocation endpoint** (RFC 7009) for server-side logout and incident response.
+- **WebSocket/SSE “push” for device completion** to reduce polling load (keep polling as the baseline).
+- **Keyring integration** when available (must remain headless-safe).

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -101,6 +101,7 @@ type Config struct {
 	AllowRegistration      bool  // Whether new users can register
 	AllowAgents            bool  // Whether agent accounts are enabled
 	AllowAgentRegistration bool  // Whether new agent accounts can be registered/delegated
+	AllowDeviceFlow        bool  // Whether OAuth device authorization is enabled
 
 	// CMS Configuration
 	CMSLongFormPublishingEnabled  bool // Enable Article creation and CMS reads
@@ -348,6 +349,7 @@ func loadConfig() *Config {
 		AllowRegistration:      getEnvAsBoolOrDefault("ALLOW_REGISTRATION", false),
 		AllowAgents:            getEnvAsBoolOrDefault("ALLOW_AGENTS", false),
 		AllowAgentRegistration: getEnvAsBoolOrDefault("ALLOW_AGENT_REGISTRATION", false),
+		AllowDeviceFlow:        getEnvAsBoolOrDefault("ALLOW_DEVICE_FLOW", false),
 
 		// CMS Configuration
 		CMSLongFormPublishingEnabled:  getEnvAsBoolOrDefault("CMS_LONG_FORM_PUBLISHING_ENABLED", cmsEnabledByMode),

--- a/tools/openapi/operation_overrides.go
+++ b/tools/openapi/operation_overrides.go
@@ -63,6 +63,8 @@ func applyOAuthOverrides(op *operation, route routeDef) {
 	switch {
 	case route.Method == methodPOST && route.Path == "/oauth/token":
 		applyOAuthTokenOverrides(op)
+	case route.Method == methodPOST && route.Path == "/oauth/device/code":
+		applyOAuthDeviceCodeOverrides(op)
 	case route.Method == methodPOST && route.Path == "/oauth/consent":
 		applyOAuthConsentOverrides(op)
 	case route.Method == methodGET && route.Path == "/oauth/authorize":
@@ -87,6 +89,23 @@ func applyOAuthTokenOverrides(op *operation) {
 	}
 
 	ensureJSONResponseSchema(op, "200", "OAuthTokenResponse")
+}
+
+func applyOAuthDeviceCodeOverrides(op *operation) {
+	if op == nil {
+		return
+	}
+
+	op.RequestBody = &requestBody{
+		Required: true,
+		Content: map[string]mediaType{
+			"application/x-www-form-urlencoded": {
+				Schema: schemaRef{Ref: "#/components/schemas/OAuthDeviceCodeRequest"},
+			},
+		},
+	}
+
+	ensureJSONResponseSchema(op, "200", "OAuthDeviceCodeResponse")
 }
 
 func applyOAuthConsentOverrides(op *operation) {

--- a/tools/openapi/strict_verify.go
+++ b/tools/openapi/strict_verify.go
@@ -276,7 +276,7 @@ func validateStrictOperationContentTypes(op *operation, route routeDef) error {
 		if !operationHasRequestContentType(op, "multipart/form-data") {
 			return errors.New("missing multipart/form-data request body")
 		}
-	case routeKey(methodPOST, "/oauth/token"), routeKey(methodPOST, "/oauth/consent"):
+	case routeKey(methodPOST, "/oauth/token"), routeKey(methodPOST, "/oauth/consent"), routeKey(methodPOST, "/oauth/device/code"):
 		if !operationHasRequestContentType(op, "application/x-www-form-urlencoded") {
 			return errors.New("missing application/x-www-form-urlencoded request body")
 		}


### PR DESCRIPTION
Adds M0 roadmap + OpenAPI updates and scaffolds POST /oauth/device/code behind ALLOW_DEVICE_FLOW.\n\nFollow-ups (M1+): persist device sessions, implement device_code grant on /oauth/token, and wire approval UI.