### PR TITLE
m1: oauth device flow storage + token grant

### DIFF
--- a/cmd/api/handlers/oauth.go
+++ b/cmd/api/handlers/oauth.go
@@ -36,6 +36,8 @@ type authorizeFlow struct {
 	scopes   []string
 }
 
+const oauthDeviceCodeGrantType = "urn:ietf:params:oauth:grant-type:device_code"
+
 func (h *Handler) isOAuthAuthorizeUIMode(ctx *apptheory.Context) bool {
 	if strings.EqualFold(queryValue(ctx, "mode"), "ui") {
 		return true
@@ -427,6 +429,7 @@ func (h *Handler) HandleOAuthTokenLift(ctx *apptheory.Context) (*apptheory.Respo
 	clientSecret := params["client_secret"]
 	codeVerifier := params["code_verifier"]
 	refreshToken := params["refresh_token"]
+	deviceCode := params["device_code"]
 
 	// Initialize OAuth service
 	oauthSvc := createOAuthService(h.cfg.JWTSecret, h.cfg, h.repos, h.logger)
@@ -531,10 +534,156 @@ func (h *Handler) HandleOAuthTokenLift(ctx *apptheory.Context) (*apptheory.Respo
 			RefreshToken: newRefreshToken,
 		})
 
+	case oauthDeviceCodeGrantType:
+		if h.cfg == nil || !h.cfg.AllowDeviceFlow {
+			return apptheory.JSON(http.StatusForbidden, map[string]string{
+				"error":             "access_denied",
+				"error_description": "device authorization is disabled",
+			})
+		}
+
+		// Validate required parameters using centralized validation
+		if err := common.ValidateMultipleRequiredParams(map[string]string{
+			"device_code": deviceCode,
+			"client_id":   clientID,
+		}); err != nil {
+			return apptheory.JSON(http.StatusBadRequest, map[string]string{
+				"error":             "invalid_request",
+				"error_description": err.Error(),
+			})
+		}
+
+		// Validate client credentials if provided
+		if clientSecret != "" {
+			if err := oauthSvc.ValidateClient(ctx.Context(), clientID, clientSecret); err != nil {
+				return apptheory.JSON(http.StatusBadRequest, map[string]string{
+					"error":             "invalid_client",
+					"error_description": "Invalid client credentials",
+				})
+			}
+		}
+
+		session, err := h.repos.Account().GetOAuthDeviceSession(ctx.Context(), oauthDeviceCodeHash(deviceCode))
+		if err != nil || session == nil {
+			return apptheory.JSON(http.StatusBadRequest, map[string]string{
+				"error":             "invalid_grant",
+				"error_description": "Invalid device_code",
+			})
+		}
+
+		if session.ClientID != clientID {
+			return apptheory.JSON(http.StatusBadRequest, map[string]string{
+				"error":             "invalid_grant",
+				"error_description": "Invalid device_code",
+			})
+		}
+
+		now := time.Now().UTC()
+		if !session.ExpiresAt.IsZero() && now.After(session.ExpiresAt) {
+			return apptheory.JSON(http.StatusBadRequest, map[string]string{
+				"error":             "expired_token",
+				"error_description": "The device_code has expired",
+			})
+		}
+
+		intervalSeconds := session.IntervalSeconds
+		if intervalSeconds <= 0 {
+			intervalSeconds = oauthDevicePollIntervalSeconds
+		}
+
+		if !session.LastPolledAt.IsZero() {
+			nextAllowed := session.LastPolledAt.Add(time.Duration(intervalSeconds) * time.Second)
+			if now.Before(nextAllowed) {
+				session.PollCount++
+				if updateErr := h.repos.Account().UpdateOAuthDeviceSession(ctx.Context(), session); updateErr != nil {
+					h.logger.Warn("failed to update oauth device session poll metadata", zap.Error(updateErr))
+				}
+
+				return apptheory.JSON(http.StatusBadRequest, map[string]string{
+					"error":             "slow_down",
+					"error_description": "Polling too frequently",
+				})
+			}
+		}
+
+		session.PollCount++
+		session.LastPolledAt = now
+		if updateErr := h.repos.Account().UpdateOAuthDeviceSession(ctx.Context(), session); updateErr != nil {
+			h.logger.Warn("failed to update oauth device session poll metadata", zap.Error(updateErr))
+		}
+
+		switch strings.ToLower(strings.TrimSpace(session.Status)) {
+		case "pending":
+			return apptheory.JSON(http.StatusBadRequest, map[string]string{
+				"error":             "authorization_pending",
+				"error_description": "Authorization is pending",
+			})
+		case "denied":
+			return apptheory.JSON(http.StatusBadRequest, map[string]string{
+				"error":             "access_denied",
+				"error_description": "Access denied",
+			})
+		case "consumed":
+			return apptheory.JSON(http.StatusBadRequest, map[string]string{
+				"error":             "invalid_grant",
+				"error_description": "Invalid device_code",
+			})
+		case "approved":
+			username := strings.TrimSpace(session.ApprovedUsername)
+			if username == "" {
+				return apptheory.JSON(http.StatusInternalServerError, map[string]string{
+					"error":             "server_error",
+					"error_description": "Device authorization is in an invalid state",
+				})
+			}
+
+			accessToken, refreshTokenOut, err := oauthSvc.GenerateTokens(ctx.Context(), username, clientID, "", session.Scopes)
+			if err != nil {
+				h.logger.Error("failed to generate tokens for device flow", zap.Error(err))
+				return apptheory.JSON(http.StatusInternalServerError, map[string]string{
+					"error":             "server_error",
+					"error_description": "Failed to generate tokens",
+				})
+			}
+
+			oauthRefreshToken := &storage.RefreshToken{
+				Token:     refreshTokenOut,
+				Username:  username,
+				ClientID:  clientID,
+				Scopes:    session.Scopes,
+				CreatedAt: now,
+				ExpiresAt: now.Add(auth.RefreshTokenDuration),
+			}
+			if err := h.repos.Account().CreateRefreshToken(ctx.Context(), oauthRefreshToken); err != nil {
+				h.logger.Error("failed to store refresh token for device flow", zap.Error(err))
+				// Continue - access token is still valid
+			}
+
+			session.Status = "consumed"
+			session.ConsumedAt = now
+			if updateErr := h.repos.Account().UpdateOAuthDeviceSession(ctx.Context(), session); updateErr != nil {
+				h.logger.Warn("failed to mark oauth device session consumed", zap.Error(updateErr))
+			}
+
+			return okJSON(apimodels.OAuthTokenResponse{
+				AccessToken:  accessToken,
+				TokenType:    "Bearer",
+				Scope:        "read write follow push",
+				CreatedAt:    now.Unix(),
+				ExpiresIn:    3600,
+				RefreshToken: refreshTokenOut,
+			})
+		default:
+			return apptheory.JSON(http.StatusInternalServerError, map[string]string{
+				"error":             "server_error",
+				"error_description": "Device authorization is in an invalid state",
+			})
+		}
+
 	default:
 		return apptheory.JSON(http.StatusBadRequest, map[string]string{
 			"error":             "unsupported_grant_type",
-			"error_description": "Only authorization_code and refresh_token grant types are supported",
+			"error_description": "Only authorization_code, refresh_token, and device_code grant types are supported",
 		})
 	}
 }

--- a/cmd/api/handlers/oauth_device.go
+++ b/cmd/api/handlers/oauth_device.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"net/http"
 	"net/url"
 	"strings"
@@ -10,13 +12,14 @@ import (
 
 	apimodels "github.com/equaltoai/lesser/cmd/api/models"
 	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/storage"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	"go.uber.org/zap"
 )
 
 const (
 	oauthDeviceCodeTTLSeconds      = 10 * 60
-	oauthDevicePollIntervalSeconds = 5
+	oauthDevicePollIntervalSeconds = 10
 )
 
 // HandleOAuthDeviceCodeLift handles POST /oauth/device/code.
@@ -72,6 +75,14 @@ func (h *Handler) HandleOAuthDeviceCodeLift(ctx *apptheory.Context) (*apptheory.
 		})
 	}
 
+	scopes, err := h.normalizeAuthorizeScopes(params["scope"])
+	if err != nil {
+		return apptheory.JSON(http.StatusBadRequest, apimodels.OAuthErrorResponse{
+			Error:            "invalid_scope",
+			ErrorDescription: err.Error(),
+		})
+	}
+
 	deviceCode, err := generateOAuthDeviceCode()
 	if err != nil {
 		h.logger.Error("failed to generate device_code", zap.Error(err))
@@ -82,6 +93,32 @@ func (h *Handler) HandleOAuthDeviceCodeLift(ctx *apptheory.Context) (*apptheory.
 	if err != nil {
 		h.logger.Error("failed to generate user_code", zap.Error(err))
 		return common.RespondInternalServerError(ctx)
+	}
+
+	now := time.Now().UTC()
+	session := &storage.OAuthDeviceSession{
+		DeviceCodeHash:  oauthDeviceCodeHash(deviceCode),
+		UserCode:        userCode,
+		ClientID:        clientID,
+		Scopes:          scopes,
+		Status:          "pending",
+		IntervalSeconds: oauthDevicePollIntervalSeconds,
+		PollCount:       0,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		ExpiresAt:       oauthDeviceCodeExpiresAt(now),
+	}
+
+	if err := h.repos.Account().CreateOAuthDeviceSession(ctx.Context(), session); err != nil {
+		// Never log the device_code or user_code; the device_code is a secret, and the user_code is short.
+		h.logger.Error("failed to create oauth device session",
+			zap.Error(err),
+			zap.String("client_id", clientID),
+		)
+		return apptheory.JSON(http.StatusInternalServerError, apimodels.OAuthErrorResponse{
+			Error:            "server_error",
+			ErrorDescription: "unable to start device authorization",
+		})
 	}
 
 	base := strings.TrimRight(h.cfg.BaseURL(), "/")
@@ -126,6 +163,11 @@ func generateOAuthUserCode() (string, error) {
 		out = append(out, alphabet[int(b[i])%len(alphabet)])
 	}
 	return string(out), nil
+}
+
+func oauthDeviceCodeHash(deviceCode string) string {
+	sum := sha256.Sum256([]byte(deviceCode))
+	return hex.EncodeToString(sum[:])
 }
 
 // oauthDeviceCodeExpiresAt returns the TTL cutoff for device sessions.

--- a/cmd/api/handlers/oauth_device_round12_test.go
+++ b/cmd/api/handlers/oauth_device_round12_test.go
@@ -1,0 +1,57 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	apimodels "github.com/equaltoai/lesser/cmd/api/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOAuthDeviceCodeLiftRound12(t *testing.T) {
+	cfg := round11TestConfig()
+
+	t.Run("disabled returns access_denied", func(t *testing.T) {
+		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/device/code", nil, nil, []byte("client_id=client-1"))
+		resp := requireStatus(t, http.StatusForbidden)(h.HandleOAuthDeviceCodeLift(ctx))
+
+		var body apimodels.OAuthErrorResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "access_denied", body.Error)
+	})
+
+	t.Run("create failure returns server_error", func(t *testing.T) {
+		cfgDevice := round11TestConfig()
+		cfgDevice.AllowDeviceFlow = true
+		state := &round10QueryState{
+			createErrorOnce: errors.New("boom"),
+		}
+		h, _, _ := round11NewHandler(t, cfgDevice, state)
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/device/code", nil, nil, []byte("client_id=client-1"))
+		resp := requireStatus(t, http.StatusInternalServerError)(h.HandleOAuthDeviceCodeLift(ctx))
+
+		var body apimodels.OAuthErrorResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "server_error", body.Error)
+	})
+
+	t.Run("success returns device and user codes", func(t *testing.T) {
+		cfgDevice := round11TestConfig()
+		cfgDevice.AllowDeviceFlow = true
+		h, _, _ := round11NewHandler(t, cfgDevice, &round10QueryState{})
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/device/code", nil, nil, []byte("client_id=client-1&scope=read%20write"))
+		resp := requireStatus(t, http.StatusOK)(h.HandleOAuthDeviceCodeLift(ctx))
+
+		var body apimodels.OAuthDeviceCodeResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.NotEmpty(t, body.DeviceCode)
+		require.NotEmpty(t, body.UserCode)
+		require.NotEmpty(t, body.VerificationURI)
+		require.NotEmpty(t, body.VerificationURIComplete)
+		require.Equal(t, oauthDeviceCodeTTLSeconds, body.ExpiresIn)
+		require.Equal(t, oauthDevicePollIntervalSeconds, body.Interval)
+	})
+}

--- a/cmd/api/handlers/oauth_round12_test.go
+++ b/cmd/api/handlers/oauth_round12_test.go
@@ -511,4 +511,222 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		require.NotEmpty(t, body.AccessToken)
 		require.NotEmpty(t, body.RefreshToken)
 	})
+
+	t.Run("device_code grant disabled returns access_denied", func(t *testing.T) {
+		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type="+oauthDeviceCodeGrantType+"&device_code=dc-1&client_id=client-1"))
+		resp := requireStatus(t, http.StatusForbidden)(h.HandleOAuthTokenLift(ctx))
+		var body map[string]string
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "access_denied", body["error"])
+	})
+
+	t.Run("device_code missing params", func(t *testing.T) {
+		cfgDevice := round11TestConfig()
+		cfgDevice.AllowDeviceFlow = true
+		h, _, _ := round11NewHandler(t, cfgDevice, &round10QueryState{})
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type="+oauthDeviceCodeGrantType+"&client_id=client-1"))
+		resp := requireStatus(t, http.StatusBadRequest)(h.HandleOAuthTokenLift(ctx))
+		var body map[string]string
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "invalid_request", body["error"])
+	})
+
+	t.Run("device_code invalid_grant when device_code missing", func(t *testing.T) {
+		cfgDevice := round11TestConfig()
+		cfgDevice.AllowDeviceFlow = true
+		deviceCode := "missing"
+		deviceHash := oauthDeviceCodeHash(deviceCode)
+
+		state := &round10QueryState{
+			notFoundPKs: map[string]bool{
+				"OAUTH_DEVICE#" + deviceHash: true,
+			},
+		}
+		h, _, _ := round11NewHandler(t, cfgDevice, state)
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type="+oauthDeviceCodeGrantType+"&device_code="+deviceCode+"&client_id=client-1"))
+		resp := requireStatus(t, http.StatusBadRequest)(h.HandleOAuthTokenLift(ctx))
+		var body map[string]string
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "invalid_grant", body["error"])
+	})
+
+	t.Run("device_code expired_token when device session expired", func(t *testing.T) {
+		cfgDevice := round11TestConfig()
+		cfgDevice.AllowDeviceFlow = true
+		deviceCode := "expired"
+		deviceHash := oauthDeviceCodeHash(deviceCode)
+
+		state := &round10QueryState{
+			oauthDeviceSessionsByHash: map[string]storagemodels.OAuthDeviceSession{
+				deviceHash: {
+					DeviceCodeHash:  deviceHash,
+					UserCode:        "ABCD-EFGH",
+					ClientID:        "client-1",
+					Scopes:          []string{auth.ScopeRead, auth.ScopeWrite},
+					Status:          "pending",
+					IntervalSeconds: oauthDevicePollIntervalSeconds,
+					CreatedAt:       time.Now().Add(-2 * time.Minute),
+					UpdatedAt:       time.Now().Add(-2 * time.Minute),
+					ExpiresAt:       time.Now().Add(-1 * time.Minute),
+				},
+			},
+		}
+		h, _, _ := round11NewHandler(t, cfgDevice, state)
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type="+oauthDeviceCodeGrantType+"&device_code="+deviceCode+"&client_id=client-1"))
+		resp := requireStatus(t, http.StatusBadRequest)(h.HandleOAuthTokenLift(ctx))
+		var body map[string]string
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "expired_token", body["error"])
+	})
+
+	t.Run("device_code authorization_pending when pending", func(t *testing.T) {
+		cfgDevice := round11TestConfig()
+		cfgDevice.AllowDeviceFlow = true
+		deviceCode := "pending"
+		deviceHash := oauthDeviceCodeHash(deviceCode)
+
+		state := &round10QueryState{
+			oauthDeviceSessionsByHash: map[string]storagemodels.OAuthDeviceSession{
+				deviceHash: {
+					DeviceCodeHash:  deviceHash,
+					UserCode:        "ABCD-EFGH",
+					ClientID:        "client-1",
+					Scopes:          []string{auth.ScopeRead, auth.ScopeWrite},
+					Status:          "pending",
+					IntervalSeconds: oauthDevicePollIntervalSeconds,
+					CreatedAt:       time.Now().Add(-2 * time.Minute),
+					UpdatedAt:       time.Now().Add(-2 * time.Minute),
+					ExpiresAt:       time.Now().Add(5 * time.Minute),
+				},
+			},
+		}
+		h, _, _ := round11NewHandler(t, cfgDevice, state)
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type="+oauthDeviceCodeGrantType+"&device_code="+deviceCode+"&client_id=client-1"))
+		resp := requireStatus(t, http.StatusBadRequest)(h.HandleOAuthTokenLift(ctx))
+		var body map[string]string
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "authorization_pending", body["error"])
+	})
+
+	t.Run("device_code slow_down when polled too frequently", func(t *testing.T) {
+		cfgDevice := round11TestConfig()
+		cfgDevice.AllowDeviceFlow = true
+		deviceCode := "slow"
+		deviceHash := oauthDeviceCodeHash(deviceCode)
+		last := time.Now().UTC()
+
+		state := &round10QueryState{
+			oauthDeviceSessionsByHash: map[string]storagemodels.OAuthDeviceSession{
+				deviceHash: {
+					DeviceCodeHash:  deviceHash,
+					UserCode:        "ABCD-EFGH",
+					ClientID:        "client-1",
+					Scopes:          []string{auth.ScopeRead, auth.ScopeWrite},
+					Status:          "pending",
+					IntervalSeconds: oauthDevicePollIntervalSeconds,
+					PollCount:       1,
+					LastPolledAt:    &last,
+					CreatedAt:       time.Now().Add(-2 * time.Minute),
+					UpdatedAt:       time.Now().Add(-2 * time.Minute),
+					ExpiresAt:       time.Now().Add(5 * time.Minute),
+				},
+			},
+		}
+		h, _, _ := round11NewHandler(t, cfgDevice, state)
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type="+oauthDeviceCodeGrantType+"&device_code="+deviceCode+"&client_id=client-1"))
+		resp := requireStatus(t, http.StatusBadRequest)(h.HandleOAuthTokenLift(ctx))
+		var body map[string]string
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "slow_down", body["error"])
+	})
+
+	t.Run("device_code access_denied when denied", func(t *testing.T) {
+		cfgDevice := round11TestConfig()
+		cfgDevice.AllowDeviceFlow = true
+		deviceCode := "denied"
+		deviceHash := oauthDeviceCodeHash(deviceCode)
+
+		state := &round10QueryState{
+			oauthDeviceSessionsByHash: map[string]storagemodels.OAuthDeviceSession{
+				deviceHash: {
+					DeviceCodeHash:  deviceHash,
+					UserCode:        "ABCD-EFGH",
+					ClientID:        "client-1",
+					Scopes:          []string{auth.ScopeRead, auth.ScopeWrite},
+					Status:          "denied",
+					IntervalSeconds: oauthDevicePollIntervalSeconds,
+					CreatedAt:       time.Now().Add(-2 * time.Minute),
+					UpdatedAt:       time.Now().Add(-2 * time.Minute),
+					ExpiresAt:       time.Now().Add(5 * time.Minute),
+				},
+			},
+		}
+		h, _, _ := round11NewHandler(t, cfgDevice, state)
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type="+oauthDeviceCodeGrantType+"&device_code="+deviceCode+"&client_id=client-1"))
+		resp := requireStatus(t, http.StatusBadRequest)(h.HandleOAuthTokenLift(ctx))
+		var body map[string]string
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "access_denied", body["error"])
+	})
+
+	t.Run("device_code invalid_grant when consumed", func(t *testing.T) {
+		cfgDevice := round11TestConfig()
+		cfgDevice.AllowDeviceFlow = true
+		deviceCode := "consumed"
+		deviceHash := oauthDeviceCodeHash(deviceCode)
+
+		state := &round10QueryState{
+			oauthDeviceSessionsByHash: map[string]storagemodels.OAuthDeviceSession{
+				deviceHash: {
+					DeviceCodeHash:  deviceHash,
+					UserCode:        "ABCD-EFGH",
+					ClientID:        "client-1",
+					Scopes:          []string{auth.ScopeRead, auth.ScopeWrite},
+					Status:          "consumed",
+					IntervalSeconds: oauthDevicePollIntervalSeconds,
+					CreatedAt:       time.Now().Add(-2 * time.Minute),
+					UpdatedAt:       time.Now().Add(-2 * time.Minute),
+					ExpiresAt:       time.Now().Add(5 * time.Minute),
+				},
+			},
+		}
+		h, _, _ := round11NewHandler(t, cfgDevice, state)
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type="+oauthDeviceCodeGrantType+"&device_code="+deviceCode+"&client_id=client-1"))
+		resp := requireStatus(t, http.StatusBadRequest)(h.HandleOAuthTokenLift(ctx))
+		var body map[string]string
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "invalid_grant", body["error"])
+	})
+
+	t.Run("device_code approved issues tokens", func(t *testing.T) {
+		cfgDevice := round11TestConfig()
+		cfgDevice.AllowDeviceFlow = true
+		deviceCode := "approved"
+		deviceHash := oauthDeviceCodeHash(deviceCode)
+
+		state := &round10QueryState{
+			oauthDeviceSessionsByHash: map[string]storagemodels.OAuthDeviceSession{
+				deviceHash: {
+					DeviceCodeHash:   deviceHash,
+					UserCode:         "ABCD-EFGH",
+					ClientID:         "client-1",
+					Scopes:           []string{auth.ScopeRead, auth.ScopeWrite},
+					Status:           "approved",
+					IntervalSeconds:  oauthDevicePollIntervalSeconds,
+					ApprovedUsername: "alice",
+					CreatedAt:        time.Now().Add(-2 * time.Minute),
+					UpdatedAt:        time.Now().Add(-2 * time.Minute),
+					ExpiresAt:        time.Now().Add(5 * time.Minute),
+				},
+			},
+		}
+		h, _, _ := round11NewHandler(t, cfgDevice, state)
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type="+oauthDeviceCodeGrantType+"&device_code="+deviceCode+"&client_id=client-1"))
+		resp := requireStatus(t, http.StatusOK)(h.HandleOAuthTokenLift(ctx))
+		var body apimodels.OAuthTokenResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.NotEmpty(t, body.AccessToken)
+		require.NotEmpty(t, body.RefreshToken)
+	})
 }

--- a/cmd/api/handlers/round10_test_helpers_test.go
+++ b/cmd/api/handlers/round10_test_helpers_test.go
@@ -30,56 +30,58 @@ type round10Where struct {
 type round10QueryState struct {
 	wheres []round10Where
 
-	usersByUsername             map[string]storagemodels.User
-	actorsByUser                map[string]storagemodels.Actor
-	actorList                   []storagemodels.Actor
-	activitiesByID              map[string]*storagemodels.Activity
-	statusByID                  map[string]storagemodels.Status
-	statusList                  []storagemodels.Status
-	objectsByID                 map[string]storagemodels.Object
-	objectList                  []storagemodels.Object
-	tombstonesByObjectID        map[string]storagemodels.Tombstone
-	reportsByID                 map[string]storagemodels.Report
-	eventsByID                  map[string]storagemodels.ModerationEvent
-	userMediaByUser             map[string][]*storagemodels.Media
-	sessionsByID                map[string]storagemodels.Session
-	filtersByID                 map[string]storagemodels.Filter
-	filterKeywords              map[string][]storagemodels.FilterKeyword
-	filterStatuses              map[string][]storagemodels.FilterStatus
-	importsByID                 map[string]storagemodels.Import
-	importsByUser               map[string][]storagemodels.Import
-	importBudgetsByPKSK         map[string]storagemodels.ImportBudget
-	pushSubscriptionsByUser     map[string][]storagemodels.PushSubscription
-	webAuthnCredentialsByUser   map[string][]storagemodels.WebAuthnCredential
-	webAuthnCredentialByID      map[string]storagemodels.WebAuthnCredential
-	webAuthnChallengesByID      map[string]storagemodels.WebAuthnChallenge
-	oauthClientsByID            map[string]storagemodels.OAuthClient
-	authorizationCodesByCode    map[string]storagemodels.AuthorizationCode
-	refreshTokensByToken        map[string]storagemodels.RefreshToken
-	setupSessionsByID           map[string]storagemodels.SetupSession
-	pollsByID                   map[string]storagemodels.Poll
-	pollVotesByKey              map[string]storagemodels.PollVote
-	costRecords                 []*storagemodels.DynamoDBCostRecord
-	costAggregations            []*storagemodels.DynamoDBCostAggregation
-	metricRecords               []storagemodels.MetricRecord
-	instanceHistories           []storagemodels.InstanceHistory
-	instanceMetrics             map[string]storagemodels.InstanceMetrics
-	instanceState               *storagemodels.InstanceState
-	agentInstanceConfig         *storagemodels.AgentInstanceConfig
-	quoteRelationships          []storagemodels.QuoteRelationship
-	announcesByKey              map[string]storagemodels.Announce
-	oauthStates                 map[string]storagemodels.OAuthState
-	notificationsByID           map[string]storagemodels.Notification
-	domainBlocks                []storagemodels.InstanceDomainBlock
-	domainAllows                []storagemodels.DomainAllow
-	emailDomainBlocks           []storagemodels.EmailDomainBlock
-	federationInstancesByDomain map[string]storagemodels.FederationInstance
-	federationInstances         []storagemodels.FederationInstance
-	moderationReviews           []storagemodels.ModerationReview
-	moderationDecisionsByObject map[string]storagemodels.ModerationDecision
-	exportsByID                 map[string]storagemodels.Export
-	exportList                  []storagemodels.Export
-	communityNotesByGSI3PK      map[string][]storagemodels.CommunityNote
+	usersByUsername               map[string]storagemodels.User
+	actorsByUser                  map[string]storagemodels.Actor
+	actorList                     []storagemodels.Actor
+	activitiesByID                map[string]*storagemodels.Activity
+	statusByID                    map[string]storagemodels.Status
+	statusList                    []storagemodels.Status
+	objectsByID                   map[string]storagemodels.Object
+	objectList                    []storagemodels.Object
+	tombstonesByObjectID          map[string]storagemodels.Tombstone
+	reportsByID                   map[string]storagemodels.Report
+	eventsByID                    map[string]storagemodels.ModerationEvent
+	userMediaByUser               map[string][]*storagemodels.Media
+	sessionsByID                  map[string]storagemodels.Session
+	filtersByID                   map[string]storagemodels.Filter
+	filterKeywords                map[string][]storagemodels.FilterKeyword
+	filterStatuses                map[string][]storagemodels.FilterStatus
+	importsByID                   map[string]storagemodels.Import
+	importsByUser                 map[string][]storagemodels.Import
+	importBudgetsByPKSK           map[string]storagemodels.ImportBudget
+	pushSubscriptionsByUser       map[string][]storagemodels.PushSubscription
+	webAuthnCredentialsByUser     map[string][]storagemodels.WebAuthnCredential
+	webAuthnCredentialByID        map[string]storagemodels.WebAuthnCredential
+	webAuthnChallengesByID        map[string]storagemodels.WebAuthnChallenge
+	oauthClientsByID              map[string]storagemodels.OAuthClient
+	authorizationCodesByCode      map[string]storagemodels.AuthorizationCode
+	refreshTokensByToken          map[string]storagemodels.RefreshToken
+	oauthDeviceSessionsByHash     map[string]storagemodels.OAuthDeviceSession
+	oauthDeviceSessionsByUserCode map[string]storagemodels.OAuthDeviceSession
+	setupSessionsByID             map[string]storagemodels.SetupSession
+	pollsByID                     map[string]storagemodels.Poll
+	pollVotesByKey                map[string]storagemodels.PollVote
+	costRecords                   []*storagemodels.DynamoDBCostRecord
+	costAggregations              []*storagemodels.DynamoDBCostAggregation
+	metricRecords                 []storagemodels.MetricRecord
+	instanceHistories             []storagemodels.InstanceHistory
+	instanceMetrics               map[string]storagemodels.InstanceMetrics
+	instanceState                 *storagemodels.InstanceState
+	agentInstanceConfig           *storagemodels.AgentInstanceConfig
+	quoteRelationships            []storagemodels.QuoteRelationship
+	announcesByKey                map[string]storagemodels.Announce
+	oauthStates                   map[string]storagemodels.OAuthState
+	notificationsByID             map[string]storagemodels.Notification
+	domainBlocks                  []storagemodels.InstanceDomainBlock
+	domainAllows                  []storagemodels.DomainAllow
+	emailDomainBlocks             []storagemodels.EmailDomainBlock
+	federationInstancesByDomain   map[string]storagemodels.FederationInstance
+	federationInstances           []storagemodels.FederationInstance
+	moderationReviews             []storagemodels.ModerationReview
+	moderationDecisionsByObject   map[string]storagemodels.ModerationDecision
+	exportsByID                   map[string]storagemodels.Export
+	exportList                    []storagemodels.Export
+	communityNotesByGSI3PK        map[string][]storagemodels.CommunityNote
 
 	relationshipRecords []storagemodels.RelationshipRecord
 	trustRelationships  []storagemodels.TrustRelationship
@@ -620,6 +622,28 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 				ExpiresAt: time.Now().Add(24 * time.Hour),
 				Scopes:    []string{"read", "write"},
 				CreatedAt: time.Now().Add(-1 * time.Minute),
+			}
+			_ = d.UpdateKeys()
+		case *storagemodels.OAuthDeviceSession:
+			deviceCodeHash := ""
+			if pk, ok := state.whereString("PK"); ok && strings.HasPrefix(pk, "OAUTH_DEVICE#") {
+				deviceCodeHash = strings.TrimPrefix(pk, "OAUTH_DEVICE#")
+			}
+			if session, ok := state.oauthDeviceSessionsByHash[deviceCodeHash]; ok {
+				*d = session
+				return
+			}
+			*d = storagemodels.OAuthDeviceSession{
+				DeviceCodeHash:  deviceCodeHash,
+				UserCode:        "ABCD-EFGH",
+				ClientID:        "client-1",
+				Scopes:          []string{"read", "write"},
+				Status:          "pending",
+				IntervalSeconds: oauthDevicePollIntervalSeconds,
+				PollCount:       0,
+				CreatedAt:       time.Now().Add(-1 * time.Minute),
+				UpdatedAt:       time.Now().Add(-1 * time.Minute),
+				ExpiresAt:       time.Now().Add(10 * time.Minute),
 			}
 			_ = d.UpdateKeys()
 		case *storagemodels.SetupSession:
@@ -1201,6 +1225,16 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 				}
 			}
 			*d = []storagemodels.AgentMemoryEvent{}
+		case *[]storagemodels.OAuthDeviceSession:
+			gsi1PK, _ := state.whereString("gsi1PK")
+			userCode := strings.TrimPrefix(gsi1PK, "OAUTH_DEVICE_USER_CODE#")
+			if state.oauthDeviceSessionsByUserCode != nil {
+				if session, ok := state.oauthDeviceSessionsByUserCode[userCode]; ok {
+					*d = []storagemodels.OAuthDeviceSession{session}
+					return
+				}
+			}
+			*d = []storagemodels.OAuthDeviceSession{}
 		case *[]storagemodels.User:
 			role, _ := state.whereString("gsi3PK")
 			switch role {

--- a/pkg/storage/models/oauth_device_session.go
+++ b/pkg/storage/models/oauth_device_session.go
@@ -1,0 +1,84 @@
+package models
+
+import (
+	"fmt"
+	"time"
+)
+
+// OAuthDeviceSession represents an OAuth device authorization session (RFC 8628-style).
+//
+// The device_code is treated as a secret and is never stored directly; callers store only a hash.
+// The user_code is short and human-entered, and is indexed for lookup by the web UI approval flow.
+type OAuthDeviceSession struct {
+	_ struct{} `theorydb:"naming:camelCase"`
+
+	// Primary keys
+	PK string `theorydb:"pk,attr:PK" json:"-"` // OAUTH_DEVICE#<deviceCodeHash>
+	SK string `theorydb:"sk,attr:SK" json:"-"` // SESSION
+
+	// GSI1 - user_code lookup (web approval flow)
+	GSI1PK string `theorydb:"index:gsi1,pk,attr:gsi1PK" json:"-"` // OAUTH_DEVICE_USER_CODE#<userCode>
+	GSI1SK string `theorydb:"index:gsi1,sk,attr:gsi1SK" json:"-"` // <createdAt>#<deviceCodeHash>
+
+	// Core fields
+	DeviceCodeHash string   `theorydb:"attr:deviceCodeHash" json:"device_code_hash"`
+	UserCode       string   `theorydb:"attr:userCode" json:"user_code"`
+	ClientID       string   `theorydb:"attr:clientID" json:"client_id"`
+	Scopes         []string `theorydb:"attr:scopes" json:"scopes,omitempty"`
+
+	// State machine
+	Status string `theorydb:"attr:status" json:"status"` // pending|approved|denied|consumed
+
+	// Polling governance (abuse control)
+	IntervalSeconds int        `theorydb:"attr:intervalSeconds" json:"interval_seconds"`
+	PollCount       int        `theorydb:"attr:pollCount" json:"poll_count,omitempty"`
+	LastPolledAt    *time.Time `theorydb:"attr:lastPolledAt" json:"last_polled_at,omitempty"`
+
+	// Approval outcome
+	ApprovedUsername string     `theorydb:"attr:approvedUsername" json:"approved_username,omitempty"`
+	ApprovedAt       *time.Time `theorydb:"attr:approvedAt" json:"approved_at,omitempty"`
+	DeniedAt         *time.Time `theorydb:"attr:deniedAt" json:"denied_at,omitempty"`
+	ConsumedAt       *time.Time `theorydb:"attr:consumedAt" json:"consumed_at,omitempty"`
+
+	// Timestamps
+	CreatedAt time.Time `theorydb:"attr:createdAt" json:"created_at"`
+	UpdatedAt time.Time `theorydb:"attr:updatedAt" json:"updated_at"`
+	ExpiresAt time.Time `theorydb:"attr:expiresAt" json:"expires_at"`
+
+	// DynamoDB TTL (derived from ExpiresAt)
+	TTL int64 `theorydb:"ttl,attr:ttl" json:"-"`
+}
+
+func (OAuthDeviceSession) TableName() string {
+	return MainTableName
+}
+
+func (o *OAuthDeviceSession) GetPK() string {
+	return o.PK
+}
+
+func (o *OAuthDeviceSession) GetSK() string {
+	return o.SK
+}
+
+func (o *OAuthDeviceSession) UpdateKeys() error {
+	if o.DeviceCodeHash != "" {
+		o.PK = "OAUTH_DEVICE#" + o.DeviceCodeHash
+		o.SK = "SESSION"
+	}
+
+	if o.UserCode != "" {
+		o.GSI1PK = "OAUTH_DEVICE_USER_CODE#" + o.UserCode
+		created := o.CreatedAt
+		if created.IsZero() {
+			created = time.Now().UTC()
+		}
+		o.GSI1SK = fmt.Sprintf("%s#%s", created.Format(time.RFC3339Nano), o.DeviceCodeHash)
+	}
+
+	if !o.ExpiresAt.IsZero() {
+		o.TTL = o.ExpiresAt.Unix()
+	}
+
+	return nil
+}

--- a/pkg/storage/repositories/account_repository_oauth_device.go
+++ b/pkg/storage/repositories/account_repository_oauth_device.go
@@ -1,0 +1,248 @@
+package repositories
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/theory-cloud/tabletheory/pkg/errors"
+	"go.uber.org/zap"
+)
+
+const (
+	oauthDeviceSessionSK = "SESSION"
+)
+
+func (r *AccountRepository) CreateOAuthDeviceSession(ctx context.Context, session *storage.OAuthDeviceSession) error {
+	if r == nil || r.db == nil {
+		return ErrorHandler.HandleCreateError(storage.ErrDatabaseConnectionFailed, "oauth device session", "init")
+	}
+	if session == nil {
+		return ErrorHandler.HandleCreateError(storage.ErrInvalidInput, "oauth device session", "nil")
+	}
+
+	session.DeviceCodeHash = strings.TrimSpace(session.DeviceCodeHash)
+	session.UserCode = strings.TrimSpace(session.UserCode)
+	session.ClientID = strings.TrimSpace(session.ClientID)
+	session.Status = strings.TrimSpace(session.Status)
+
+	if err := common.ValidateMultipleRequiredParams(map[string]string{
+		"device_code_hash": session.DeviceCodeHash,
+		"user_code":        session.UserCode,
+		"client_id":        session.ClientID,
+		"status":           session.Status,
+	}); err != nil {
+		return ErrorHandler.HandleCreateError(storage.ErrInvalidInput, "oauth device session", "validation")
+	}
+	if session.ExpiresAt.IsZero() {
+		return ErrorHandler.HandleCreateError(storage.ErrInvalidInput, "oauth device session", "expires_at")
+	}
+
+	now := time.Now().UTC()
+	if session.CreatedAt.IsZero() {
+		session.CreatedAt = now
+	}
+	session.UpdatedAt = now
+
+	model := oauthDeviceSessionModelFromStorage(session)
+	_ = model.UpdateKeys()
+
+	if err := r.db.WithContext(ctx).Model(model).Create(); err != nil {
+		if strings.Contains(err.Error(), "ConditionalCheckFailed") || strings.Contains(err.Error(), "already exists") {
+			return ErrorHandler.HandleCreateError(storage.ErrAlreadyExists, "oauth device session", session.DeviceCodeHash)
+		}
+		r.logger.Error("failed to create oauth device session",
+			zap.Error(err),
+			zap.String("client_id", session.ClientID),
+		)
+		return ErrorHandler.HandleCreateError(err, "oauth device session", session.DeviceCodeHash)
+	}
+
+	return nil
+}
+
+func (r *AccountRepository) GetOAuthDeviceSession(ctx context.Context, deviceCodeHash string) (*storage.OAuthDeviceSession, error) {
+	if r == nil || r.db == nil {
+		return nil, ErrorHandler.HandleGetError(storage.ErrDatabaseConnectionFailed, "oauth device session", "init")
+	}
+
+	deviceCodeHash = strings.TrimSpace(deviceCodeHash)
+	if deviceCodeHash == "" {
+		return nil, ErrorHandler.HandleGetError(storage.ErrInvalidInput, "oauth device session", "device_code_hash")
+	}
+
+	pk := "OAUTH_DEVICE#" + deviceCodeHash
+	sk := oauthDeviceSessionSK
+
+	var model models.OAuthDeviceSession
+	err := r.db.WithContext(ctx).Model(&models.OAuthDeviceSession{}).
+		Where("PK", "=", pk).
+		Where("SK", "=", sk).
+		First(&model)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, ErrorHandler.HandleGetError(storage.ErrNotFound, "oauth device session", deviceCodeHash)
+		}
+		r.logger.Error("failed to get oauth device session",
+			zap.Error(err),
+			zap.String("device_code_hash", deviceCodeHash),
+		)
+		return nil, ErrorHandler.HandleGetError(err, "oauth device session", deviceCodeHash)
+	}
+
+	out := oauthDeviceSessionStorageFromModel(&model)
+	if out == nil {
+		return nil, ErrorHandler.HandleGetError(storage.ErrNotFound, "oauth device session", deviceCodeHash)
+	}
+
+	return out, nil
+}
+
+func (r *AccountRepository) GetOAuthDeviceSessionByUserCode(ctx context.Context, userCode string) (*storage.OAuthDeviceSession, error) {
+	if r == nil || r.db == nil {
+		return nil, ErrorHandler.HandleGetError(storage.ErrDatabaseConnectionFailed, "oauth device session", "init")
+	}
+
+	userCode = strings.TrimSpace(userCode)
+	if userCode == "" {
+		return nil, ErrorHandler.HandleGetError(storage.ErrInvalidInput, "oauth device session", "user_code")
+	}
+
+	gsi1PK := "OAUTH_DEVICE_USER_CODE#" + userCode
+
+	var modelsOut []models.OAuthDeviceSession
+	err := r.db.WithContext(ctx).Model(&models.OAuthDeviceSession{}).
+		Index(models.IndexGSI1).
+		Where("gsi1PK", "=", gsi1PK).
+		Limit(2).
+		All(&modelsOut)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, ErrorHandler.HandleGetError(storage.ErrNotFound, "oauth device session", userCode)
+		}
+		r.logger.Error("failed to get oauth device session by user code", zap.Error(err))
+		return nil, ErrorHandler.HandleGetError(err, "oauth device session", userCode)
+	}
+
+	if len(modelsOut) == 0 {
+		return nil, ErrorHandler.HandleGetError(storage.ErrNotFound, "oauth device session", userCode)
+	}
+
+	// user_code is expected to be unique; if duplicates exist, pick the first item.
+	out := oauthDeviceSessionStorageFromModel(&modelsOut[0])
+	if out == nil {
+		return nil, ErrorHandler.HandleGetError(storage.ErrNotFound, "oauth device session", userCode)
+	}
+
+	return out, nil
+}
+
+func (r *AccountRepository) UpdateOAuthDeviceSession(ctx context.Context, session *storage.OAuthDeviceSession) error {
+	if r == nil || r.db == nil {
+		return ErrorHandler.HandleUpdateError(storage.ErrDatabaseConnectionFailed, "oauth device session", "init")
+	}
+	if session == nil {
+		return ErrorHandler.HandleUpdateError(storage.ErrInvalidInput, "oauth device session", "nil")
+	}
+
+	session.DeviceCodeHash = strings.TrimSpace(session.DeviceCodeHash)
+	if session.DeviceCodeHash == "" {
+		return ErrorHandler.HandleUpdateError(storage.ErrInvalidInput, "oauth device session", "device_code_hash")
+	}
+
+	session.UpdatedAt = time.Now().UTC()
+	model := oauthDeviceSessionModelFromStorage(session)
+	_ = model.UpdateKeys()
+
+	if err := r.db.WithContext(ctx).Model(model).Update(); err != nil {
+		r.logger.Error("failed to update oauth device session",
+			zap.Error(err),
+			zap.String("device_code_hash", session.DeviceCodeHash),
+		)
+		return ErrorHandler.HandleUpdateError(err, "oauth device session", session.DeviceCodeHash)
+	}
+
+	return nil
+}
+
+func oauthDeviceSessionModelFromStorage(session *storage.OAuthDeviceSession) *models.OAuthDeviceSession {
+	if session == nil {
+		return nil
+	}
+
+	var lastPolledAt *time.Time
+	if !session.LastPolledAt.IsZero() {
+		t := session.LastPolledAt
+		lastPolledAt = &t
+	}
+	var approvedAt *time.Time
+	if !session.ApprovedAt.IsZero() {
+		t := session.ApprovedAt
+		approvedAt = &t
+	}
+	var deniedAt *time.Time
+	if !session.DeniedAt.IsZero() {
+		t := session.DeniedAt
+		deniedAt = &t
+	}
+	var consumedAt *time.Time
+	if !session.ConsumedAt.IsZero() {
+		t := session.ConsumedAt
+		consumedAt = &t
+	}
+
+	return &models.OAuthDeviceSession{
+		DeviceCodeHash:   session.DeviceCodeHash,
+		UserCode:         session.UserCode,
+		ClientID:         session.ClientID,
+		Scopes:           session.Scopes,
+		Status:           session.Status,
+		IntervalSeconds:  session.IntervalSeconds,
+		PollCount:        session.PollCount,
+		LastPolledAt:     lastPolledAt,
+		ApprovedUsername: session.ApprovedUsername,
+		ApprovedAt:       approvedAt,
+		DeniedAt:         deniedAt,
+		ConsumedAt:       consumedAt,
+		CreatedAt:        session.CreatedAt,
+		UpdatedAt:        session.UpdatedAt,
+		ExpiresAt:        session.ExpiresAt,
+	}
+}
+
+func oauthDeviceSessionStorageFromModel(model *models.OAuthDeviceSession) *storage.OAuthDeviceSession {
+	if model == nil {
+		return nil
+	}
+
+	out := &storage.OAuthDeviceSession{
+		DeviceCodeHash:   model.DeviceCodeHash,
+		UserCode:         model.UserCode,
+		ClientID:         model.ClientID,
+		Scopes:           model.Scopes,
+		Status:           model.Status,
+		IntervalSeconds:  model.IntervalSeconds,
+		PollCount:        model.PollCount,
+		ApprovedUsername: model.ApprovedUsername,
+		CreatedAt:        model.CreatedAt,
+		UpdatedAt:        model.UpdatedAt,
+		ExpiresAt:        model.ExpiresAt,
+	}
+	if model.LastPolledAt != nil {
+		out.LastPolledAt = *model.LastPolledAt
+	}
+	if model.ApprovedAt != nil {
+		out.ApprovedAt = *model.ApprovedAt
+	}
+	if model.DeniedAt != nil {
+		out.DeniedAt = *model.DeniedAt
+	}
+	if model.ConsumedAt != nil {
+		out.ConsumedAt = *model.ConsumedAt
+	}
+	return out
+}

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -312,6 +312,27 @@ type OAuthState struct {
 	ExpiresAt           time.Time `json:"expires_at"`
 }
 
+// OAuthDeviceSession represents an OAuth device authorization session (RFC 8628-style).
+//
+// The device_code is treated as a secret and is never stored directly; callers should store only a hash.
+type OAuthDeviceSession struct {
+	DeviceCodeHash   string    `json:"device_code_hash"`
+	UserCode         string    `json:"user_code"`
+	ClientID         string    `json:"client_id"`
+	Scopes           []string  `json:"scopes,omitempty"`
+	Status           string    `json:"status"`
+	IntervalSeconds  int       `json:"interval_seconds"`
+	PollCount        int       `json:"poll_count,omitempty"`
+	LastPolledAt     time.Time `json:"last_polled_at,omitempty"`
+	ApprovedUsername string    `json:"approved_username,omitempty"`
+	ApprovedAt       time.Time `json:"approved_at,omitempty"`
+	DeniedAt         time.Time `json:"denied_at,omitempty"`
+	ConsumedAt       time.Time `json:"consumed_at,omitempty"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+	ExpiresAt        time.Time `json:"expires_at"`
+}
+
 // OAuthClient represents an OAuth client application
 type OAuthClient struct {
 	ID           string `json:"id"`


### PR DESCRIPTION
Implements M1 server-side pieces for CLI OAuth device authorization flow.

- Persist device sessions (hashed device_code) in Dynamo-backed main table (GSI1 user_code lookup)
- POST /oauth/device/code now stores a pending session + returns device_code/user_code
- POST /oauth/token supports grant_type=urn:ietf:params:oauth:grant-type:device_code with polling interval + RFC-style errors
- Adds handler + harness tests for device flow

Notes:
- Poll interval default is 10s to stay within existing /oauth/token route rate limit.
