### PR TITLE
m2: device verification ui

### DIFF
--- a/auth-ui/src/components/OAuthDeviceVerificationScreen.svelte
+++ b/auth-ui/src/components/OAuthDeviceVerificationScreen.svelte
@@ -1,0 +1,395 @@
+<script lang="ts">
+  /**
+   * OAuthDeviceVerificationScreen - OAuth device authorization approval (CLI bootstrap)
+   *
+   * ⚠️ STATELESS STATIC APPLICATION - NO SESSIONS OR COOKIES PERMITTED ⚠️
+   *
+   * This component:
+   * - Lets the user enter a short user_code (or deep-links via ?user_code=...)
+   * - Fetches device session metadata from Lesser
+   * - Requires wallet/WebAuthn login (JWT in sessionStorage) to approve/deny
+   * - Never sets cookies or server-side sessions
+   */
+
+  import { onMount } from 'svelte';
+  import Button from 'src/lib/greater/primitives/components/Button.svelte';
+  import TextField from 'src/lib/greater/primitives/components/TextField.svelte';
+  import PasswordlessLogin from './PasswordlessLogin.svelte';
+
+  // API base URL - single-domain CloudFront routes API + UI by path.
+  // For local dev, optionally set PUBLIC_LESSER_API_ORIGIN (e.g., http://localhost:8080).
+  const API_URL = import.meta.env.PUBLIC_LESSER_API_ORIGIN || window.location.origin;
+  const UI_BASE_PATH = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
+
+  type VerifyResponse = {
+    user_code: string;
+    client_id: string;
+    client_name?: string;
+    client_url?: string;
+    scopes?: string[];
+    status: string;
+    expires_in: number;
+    interval: number;
+  };
+
+  type ConsentResponse = {
+    status: string;
+    message?: string;
+  };
+
+  type OAuthError = {
+    error?: string;
+    error_description?: string;
+  };
+
+  let userCode = $state('');
+  let verifyResult = $state<VerifyResponse | null>(null);
+  let jwt = $state('');
+  let authorizedUsername = $state('');
+
+  let error = $state('');
+  let isVerifying = $state(false);
+  let isApproving = $state(false);
+  let isDenying = $state(false);
+
+  let doneStatus = $state('');
+  let doneMessage = $state('');
+
+  // Map scope names to user-friendly descriptions
+  const scopeDescriptions: Record<string, string> = {
+    read: 'Read your profile and timeline',
+    write: 'Create and manage posts',
+    follow: 'Follow and unfollow accounts',
+    push: 'Send push notifications',
+    admin: 'Access admin features',
+    'admin:read': 'Read admin data',
+    'admin:write': 'Perform admin actions',
+  };
+
+  function getScopeDescription(scope: string): string {
+    return scopeDescriptions[scope] || scope;
+  }
+
+  function updateURLUserCode(code: string) {
+    try {
+      const url = new URL(window.location.href);
+      url.searchParams.set('user_code', code);
+      window.history.replaceState(null, '', url.toString());
+    } catch (e) {
+      console.error('Failed to update URL user_code', e);
+    }
+  }
+
+  async function refreshAuthState() {
+    jwt = sessionStorage.getItem('lesser_auth_jwt') || '';
+    if (!jwt) {
+      authorizedUsername = '';
+      return;
+    }
+
+    try {
+      const resp = await fetch(`${API_URL}/api/v1/accounts/verify_credentials`, {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Bearer ${jwt}`,
+        },
+      });
+
+      if (!resp.ok) {
+        authorizedUsername = '';
+        return;
+      }
+
+      const data = await resp.json().catch(() => ({} as any));
+      authorizedUsername = data.username || data.acct || '';
+    } catch (e) {
+      console.error('Failed to load authorized user', e);
+      authorizedUsername = '';
+    }
+  }
+
+  async function verifyUserCode() {
+    error = '';
+    doneStatus = '';
+    doneMessage = '';
+    verifyResult = null;
+
+    const trimmed = userCode.trim();
+    if (!trimmed) {
+      error = 'Please enter the code shown in your CLI.';
+      return;
+    }
+
+    isVerifying = true;
+    try {
+      const resp = await fetch(`${API_URL}/oauth/device/verify`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Accept: 'application/json',
+        },
+        body: new URLSearchParams({
+          user_code: trimmed,
+        }),
+      });
+
+      const data = (await resp.json().catch(() => ({}))) as VerifyResponse & OAuthError;
+      if (!resp.ok) {
+        error = data.error_description || data.error || 'Unable to verify code';
+        return;
+      }
+
+      verifyResult = data as VerifyResponse;
+      if (verifyResult?.user_code) {
+        userCode = verifyResult.user_code;
+        updateURLUserCode(verifyResult.user_code);
+      }
+
+      // If the session is already complete, display a friendly message.
+      const status = (verifyResult?.status || '').toLowerCase();
+      if (status === 'approved') {
+        doneStatus = 'approved';
+        doneMessage = 'This device has already been approved. Return to your CLI to continue.';
+      } else if (status === 'denied') {
+        doneStatus = 'denied';
+        doneMessage = 'This device authorization was denied. Return to your CLI to retry.';
+      }
+    } catch (e) {
+      console.error('verifyUserCode error', e);
+      error = e instanceof Error ? e.message : 'Unable to verify code';
+    } finally {
+      isVerifying = false;
+    }
+  }
+
+  async function submitConsent(action: 'approve' | 'deny') {
+    error = '';
+
+    const token = sessionStorage.getItem('lesser_auth_jwt') || '';
+    if (!token) {
+      error = 'Not authenticated. Please sign in to approve this device.';
+      return;
+    }
+
+    if (!verifyResult?.user_code) {
+      error = 'Missing verification code. Please verify again.';
+      return;
+    }
+
+    if (action === 'approve') {
+      isApproving = true;
+    } else {
+      isDenying = true;
+    }
+
+    try {
+      const resp = await fetch(`${API_URL}/oauth/device/consent`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Accept: 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: new URLSearchParams({
+          user_code: verifyResult.user_code,
+          action,
+        }),
+      });
+
+      const data = (await resp.json().catch(() => ({}))) as ConsentResponse & OAuthError;
+      if (!resp.ok) {
+        error = data.error_description || data.error || 'Unable to update device authorization';
+        return;
+      }
+
+      doneStatus = (data.status || action).toLowerCase();
+      doneMessage =
+        doneStatus === 'approved'
+          ? 'Approved. Return to your CLI to finish signing in.'
+          : 'Denied. Return to your CLI to retry.';
+
+      // Clear JWT after use
+      sessionStorage.removeItem('lesser_auth_jwt');
+      jwt = '';
+      authorizedUsername = '';
+    } catch (e) {
+      console.error('submitConsent error', e);
+      error = e instanceof Error ? e.message : 'Unable to update device authorization';
+    } finally {
+      isApproving = false;
+      isDenying = false;
+    }
+  }
+
+  onMount(async () => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const fromURL = urlParams.get('user_code') || '';
+    if (fromURL) {
+      userCode = fromURL;
+    }
+
+    await refreshAuthState();
+
+    if (fromURL) {
+      await verifyUserCode();
+    }
+  });
+</script>
+
+<div class="device-verify">
+  {#if error}
+    <div class="alert alert-error">{error}</div>
+  {/if}
+
+  {#if doneStatus}
+    <div class="alert alert-info">{doneMessage}</div>
+  {/if}
+
+  <!-- Step 1: enter/verify code -->
+  <div class="form-group">
+    <TextField
+      id="user_code"
+      type="text"
+      label="Verification Code"
+      placeholder="ABCD-EFGH"
+      bind:value={userCode}
+      disabled={isVerifying || isApproving || isDenying}
+      autocomplete="one-time-code"
+      required
+    />
+  </div>
+
+  <div class="actions">
+    <Button type="button" variant="solid" onclick={verifyUserCode} disabled={isVerifying || isApproving || isDenying}>
+      {#if isVerifying}
+        <span class="spinner"></span>
+        Verifying...
+      {:else}
+        Verify Code
+      {/if}
+    </Button>
+  </div>
+
+  {#if verifyResult}
+    <div class="device-session">
+      <h2 class="section-title">Request Details</h2>
+
+      <div class="oauth-app-info">
+        <h3 class="oauth-app-name">{verifyResult.client_name || verifyResult.client_id}</h3>
+        {#if verifyResult.client_url}
+          <a href={verifyResult.client_url} target="_blank" rel="noopener noreferrer" class="oauth-app-url">
+            {verifyResult.client_url}
+          </a>
+        {/if}
+
+        <div class="oauth-scopes">
+          <p class="oauth-scopes-title">This CLI client would like to:</p>
+          <ul class="oauth-scope-list">
+            {#each (verifyResult.scopes || []) as scope}
+              <li class="oauth-scope-item">{getScopeDescription(scope)}</li>
+            {/each}
+          </ul>
+        </div>
+      </div>
+
+      {#if !doneStatus && (verifyResult.status || '').toLowerCase() === 'pending'}
+        <div class="alert alert-info">
+          <strong>Heads up</strong><br />
+          Approving will authorize your CLI to act as your account with the requested permissions.
+        </div>
+
+        {#if jwt}
+          <div class="alert alert-info">
+            Authorizing as <strong>@{authorizedUsername || 'your account'}</strong>.
+          </div>
+
+          <div class="consent-actions">
+            <Button type="button" variant="solid" onclick={() => submitConsent('approve')} disabled={isApproving || isDenying}>
+              {#if isApproving}
+                <span class="spinner"></span>
+                Approving...
+              {:else}
+                Approve
+              {/if}
+            </Button>
+
+            <Button type="button" variant="outline" onclick={() => submitConsent('deny')} disabled={isApproving || isDenying}>
+              {#if isDenying}
+                Denying...
+              {:else}
+                Deny
+              {/if}
+            </Button>
+          </div>
+        {:else}
+          <div class="login-block">
+            <h3 class="section-title">Sign in to approve</h3>
+            <PasswordlessLogin
+              hideRegisterLink={true}
+              authFlow="redirect"
+              postAuthRedirectTo={`${UI_BASE_PATH}/device?user_code=${encodeURIComponent(userCode)}`}
+            />
+          </div>
+        {/if}
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .device-verify {
+    width: 100%;
+    max-width: 520px;
+    margin: 0 auto;
+  }
+
+  .form-group {
+    margin-bottom: var(--spacing-md);
+    width: 100%;
+  }
+
+  .actions {
+    display: flex;
+    gap: var(--spacing-sm);
+    margin-bottom: var(--spacing-lg);
+  }
+
+  .device-session {
+    margin-top: var(--spacing-lg);
+  }
+
+  .section-title {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: var(--spacing-sm);
+    color: var(--text-primary, #fff);
+  }
+
+  .consent-actions {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-md);
+    margin-top: var(--spacing-lg);
+  }
+
+  .spinner {
+    display: inline-block;
+    width: 1rem;
+    height: 1rem;
+    border: 2px solid currentColor;
+    border-top-color: transparent;
+    border-radius: 50%;
+    animation: spin 0.6s linear infinite;
+  }
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  .login-block {
+    margin-top: var(--spacing-lg);
+  }
+</style>

--- a/auth-ui/src/components/PasswordlessLogin.svelte
+++ b/auth-ui/src/components/PasswordlessLogin.svelte
@@ -53,6 +53,10 @@
     hideRegisterLink?: boolean;
     /** Whether this is a registration flow (allows unlinked wallets) */
     isRegistration?: boolean;
+    /** How to proceed after successful authentication */
+    authFlow?: 'oauth' | 'redirect';
+    /** Redirect destination when authFlow=redirect */
+    postAuthRedirectTo?: string;
   }
   
   let { 
@@ -67,7 +71,9 @@
     codeChallenge,
     codeChallengeMethod,
     hideRegisterLink = false, 
-    isRegistration = false 
+    isRegistration = false,
+    authFlow = 'oauth',
+    postAuthRedirectTo = ''
   }: Props = $props();
   
   // API base URL - single-domain CloudFront routes API + UI by path.
@@ -87,6 +93,21 @@
   let walletConnected = $state(false);
   let connectedAddress = $state('');
   let walletChallengeId = $state('');
+
+  function handleAuthSuccess() {
+    if (authFlow === 'redirect') {
+      const target = postAuthRedirectTo || window.location.href;
+      try {
+        window.location.href = new URL(target, window.location.origin).toString();
+      } catch (e) {
+        console.error('Invalid postAuthRedirectTo:', target, e);
+        window.location.href = window.location.href;
+      }
+      return;
+    }
+
+    continueOAuthFlow();
+  }
   
   // Build authRequest query string from OAuth params
   // Read directly from URL since this is client-side only
@@ -282,7 +303,7 @@
       // Step 6: Store JWT temporarily in sessionStorage ONLY for the redirect
       if (finishData.access_token) {
         sessionStorage.setItem('lesser_auth_jwt', finishData.access_token);
-        continueOAuthFlow();
+        handleAuthSuccess();
       }
     } catch (err) {
       error = err instanceof Error ? err.message : 'WebAuthn login failed';
@@ -373,7 +394,7 @@
       if (verifyData.access_token) {
         // Login successful - store JWT temporarily for OAuth flow
         sessionStorage.setItem('lesser_auth_jwt', verifyData.access_token);
-        continueOAuthFlow();
+        handleAuthSuccess();
       } else if (isRegistration && verifyData.verified) {
         // Wallet verified for registration - proceed with account creation
         // Username was already collected and bound to signature - proceed directly
@@ -457,7 +478,7 @@
       if (jwt) {
         // Store JWT and continue OAuth flow
         sessionStorage.setItem('lesser_auth_jwt', jwt);
-        continueOAuthFlow();
+        handleAuthSuccess();
       } else {
         // Fallback: if backend doesn't return JWT (shouldn't happen, but handle gracefully)
         error = 'Registration successful, but authentication token missing. Please log in.';

--- a/auth-ui/src/pages/device.astro
+++ b/auth-ui/src/pages/device.astro
@@ -1,0 +1,15 @@
+---
+/**
+ * ⚠️ STATELESS STATIC APPLICATION - NO SESSIONS OR COOKIES PERMITTED ⚠️
+ *
+ * Device verification is used for OAuth device authorization (CLI bootstrap).
+ * The user logs in via wallet/WebAuthn, then approves the pending device session.
+ */
+import AuthLayout from '../layouts/AuthLayout.astro';
+import OAuthDeviceVerificationScreen from '../components/OAuthDeviceVerificationScreen.svelte';
+---
+
+<AuthLayout title="Authorize Device" subtitle="Connect your CLI client">
+  <OAuthDeviceVerificationScreen client:only="svelte" />
+</AuthLayout>
+

--- a/cmd/api/handlers/oauth_device_verification.go
+++ b/cmd/api/handlers/oauth_device_verification.go
@@ -1,0 +1,264 @@
+package handlers
+
+import (
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	apimodels "github.com/equaltoai/lesser/cmd/api/models"
+	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/common"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"go.uber.org/zap"
+)
+
+var oauthDeviceUserCodePattern = regexp.MustCompile(`^[A-HJ-NP-Z2-9]{4}-[A-HJ-NP-Z2-9]{4}$`)
+
+func normalizeOAuthDeviceUserCode(input string) string {
+	trimmed := strings.ToUpper(strings.TrimSpace(input))
+	trimmed = strings.ReplaceAll(trimmed, " ", "")
+
+	withoutHyphen := strings.ReplaceAll(trimmed, "-", "")
+	if len(withoutHyphen) == 8 {
+		return withoutHyphen[:4] + "-" + withoutHyphen[4:]
+	}
+
+	return trimmed
+}
+
+func validateOAuthDeviceUserCode(userCode string) bool {
+	userCode = strings.TrimSpace(userCode)
+	if userCode == "" {
+		return false
+	}
+	return oauthDeviceUserCodePattern.MatchString(userCode)
+}
+
+// HandleOAuthDeviceVerifyLift handles POST /oauth/device/verify.
+//
+// This endpoint is used by the hosted auth UI (verification_uri) to look up the pending device session
+// by user_code and display the requesting app + scopes before the user approves.
+func (h *Handler) HandleOAuthDeviceVerifyLift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	if h == nil || ctx == nil {
+		return common.RespondInternalServerError(ctx)
+	}
+	if h.cfg == nil || !h.cfg.AllowDeviceFlow {
+		return apptheory.JSON(http.StatusForbidden, apimodels.OAuthErrorResponse{
+			Error:            "access_denied",
+			ErrorDescription: "device authorization is disabled",
+		})
+	}
+
+	if h.repos == nil || h.repos.Account() == nil {
+		return apptheory.JSON(http.StatusServiceUnavailable, apimodels.OAuthErrorResponse{
+			Error:            "server_error",
+			ErrorDescription: "storage is not initialized",
+		})
+	}
+
+	if err := common.ValidateSliceNotEmpty("request_body", ctx.Request.Body); err != nil {
+		return apptheory.JSON(http.StatusBadRequest, apimodels.OAuthErrorResponse{
+			Error:            "invalid_request",
+			ErrorDescription: "empty request body",
+		})
+	}
+
+	params, err := common.ParseFormURLEncoded(string(ctx.Request.Body))
+	if err != nil {
+		return apptheory.JSON(http.StatusBadRequest, apimodels.OAuthErrorResponse{
+			Error:            "invalid_request",
+			ErrorDescription: "unable to parse form data",
+		})
+	}
+
+	userCode := normalizeOAuthDeviceUserCode(params["user_code"])
+	if !validateOAuthDeviceUserCode(userCode) {
+		return apptheory.JSON(http.StatusBadRequest, apimodels.OAuthErrorResponse{
+			Error:            "invalid_request",
+			ErrorDescription: "invalid user_code",
+		})
+	}
+
+	session, err := h.repos.Account().GetOAuthDeviceSessionByUserCode(ctx.Context(), userCode)
+	if err != nil || session == nil {
+		// Avoid leaking existence information.
+		return apptheory.JSON(http.StatusBadRequest, apimodels.OAuthErrorResponse{
+			Error:            "invalid_request",
+			ErrorDescription: "invalid or expired user_code",
+		})
+	}
+
+	now := time.Now().UTC()
+	if !session.ExpiresAt.IsZero() && now.After(session.ExpiresAt) {
+		return apptheory.JSON(http.StatusBadRequest, apimodels.OAuthErrorResponse{
+			Error:            "expired_token",
+			ErrorDescription: "the user_code has expired",
+		})
+	}
+
+	status := strings.ToLower(strings.TrimSpace(session.Status))
+	switch status {
+	case "pending", "approved", "denied":
+		// allowed
+	case "consumed":
+		return apptheory.JSON(http.StatusBadRequest, apimodels.OAuthErrorResponse{
+			Error:            "invalid_request",
+			ErrorDescription: "the user_code has already been used",
+		})
+	default:
+		return apptheory.JSON(http.StatusBadRequest, apimodels.OAuthErrorResponse{
+			Error:            "invalid_request",
+			ErrorDescription: "invalid device session state",
+		})
+	}
+
+	clientName := session.ClientID
+	clientURL := ""
+	if client, err := h.repos.Account().GetOAuthClient(ctx.Context(), session.ClientID); err == nil && client != nil {
+		if v := strings.TrimSpace(client.Name); v != "" {
+			clientName = v
+		}
+		clientURL = strings.TrimSpace(client.Website)
+	} else if err != nil {
+		h.logger.Warn("failed to load oauth client for device session",
+			zap.Error(err),
+			zap.String("client_id", session.ClientID),
+		)
+	}
+
+	expiresIn := 0
+	if !session.ExpiresAt.IsZero() {
+		remaining := time.Until(session.ExpiresAt)
+		if remaining > 0 {
+			expiresIn = int(remaining.Seconds())
+		}
+	}
+
+	intervalSeconds := session.IntervalSeconds
+	if intervalSeconds <= 0 {
+		intervalSeconds = oauthDevicePollIntervalSeconds
+	}
+
+	return okJSON(apimodels.OAuthDeviceVerifyResponse{
+		UserCode:   userCode,
+		ClientID:   session.ClientID,
+		ClientName: clientName,
+		ClientURL:  clientURL,
+		Scopes:     session.Scopes,
+		Status:     status,
+		ExpiresIn:  expiresIn,
+		Interval:   intervalSeconds,
+	})
+}
+
+// HandleOAuthDeviceConsentLift handles POST /oauth/device/consent.
+//
+// This endpoint requires authentication (wallet/WebAuthn) and is used by the auth UI to approve/deny a device session.
+func (h *Handler) HandleOAuthDeviceConsentLift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	if h == nil || ctx == nil {
+		return common.RespondInternalServerError(ctx)
+	}
+	if h.cfg == nil || !h.cfg.AllowDeviceFlow {
+		return apptheory.JSON(http.StatusForbidden, apimodels.OAuthErrorResponse{
+			Error:            "access_denied",
+			ErrorDescription: "device authorization is disabled",
+		})
+	}
+
+	if h.repos == nil || h.repos.Account() == nil {
+		return apptheory.JSON(http.StatusServiceUnavailable, apimodels.OAuthErrorResponse{
+			Error:            "server_error",
+			ErrorDescription: "storage is not initialized",
+		})
+	}
+
+	claims, err := h.authenticateWithScope(ctx, auth.ScopeRead)
+	if err != nil {
+		if isInsufficientScopeError(err) {
+			return common.RespondForbidden(ctx, err.Error())
+		}
+		return common.RespondUnauthorized(ctx)
+	}
+
+	if err := common.ValidateSliceNotEmpty("request_body", ctx.Request.Body); err != nil {
+		return apptheory.JSON(http.StatusBadRequest, apimodels.OAuthErrorResponse{
+			Error:            "invalid_request",
+			ErrorDescription: "empty request body",
+		})
+	}
+
+	params, err := common.ParseFormURLEncoded(string(ctx.Request.Body))
+	if err != nil {
+		return apptheory.JSON(http.StatusBadRequest, apimodels.OAuthErrorResponse{
+			Error:            "invalid_request",
+			ErrorDescription: "unable to parse form data",
+		})
+	}
+
+	userCode := normalizeOAuthDeviceUserCode(params["user_code"])
+	if !validateOAuthDeviceUserCode(userCode) {
+		return apptheory.JSON(http.StatusBadRequest, apimodels.OAuthErrorResponse{
+			Error:            "invalid_request",
+			ErrorDescription: "invalid user_code",
+		})
+	}
+
+	action := strings.ToLower(strings.TrimSpace(params["action"]))
+	if action != "approve" && action != "deny" {
+		return apptheory.JSON(http.StatusBadRequest, apimodels.OAuthErrorResponse{
+			Error:            "invalid_request",
+			ErrorDescription: "invalid action",
+		})
+	}
+
+	session, err := h.repos.Account().GetOAuthDeviceSessionByUserCode(ctx.Context(), userCode)
+	if err != nil || session == nil {
+		return apptheory.JSON(http.StatusBadRequest, apimodels.OAuthErrorResponse{
+			Error:            "invalid_request",
+			ErrorDescription: "invalid or expired user_code",
+		})
+	}
+
+	now := time.Now().UTC()
+	if !session.ExpiresAt.IsZero() && now.After(session.ExpiresAt) {
+		return apptheory.JSON(http.StatusBadRequest, apimodels.OAuthErrorResponse{
+			Error:            "expired_token",
+			ErrorDescription: "the user_code has expired",
+		})
+	}
+
+	status := strings.ToLower(strings.TrimSpace(session.Status))
+	if status == "consumed" {
+		return apptheory.JSON(http.StatusBadRequest, apimodels.OAuthErrorResponse{
+			Error:            "invalid_request",
+			ErrorDescription: "the user_code has already been used",
+		})
+	}
+
+	switch action {
+	case "approve":
+		session.Status = "approved"
+		session.ApprovedUsername = strings.TrimSpace(claims.Username)
+		session.ApprovedAt = now
+	case "deny":
+		session.Status = "denied"
+		session.DeniedAt = now
+	}
+
+	if err := h.repos.Account().UpdateOAuthDeviceSession(ctx.Context(), session); err != nil {
+		h.logger.Error("failed to update oauth device session consent",
+			zap.Error(err),
+			zap.String("client_id", session.ClientID),
+		)
+		return apptheory.JSON(http.StatusInternalServerError, apimodels.OAuthErrorResponse{
+			Error:            "server_error",
+			ErrorDescription: "unable to update device authorization",
+		})
+	}
+
+	return okJSON(apimodels.OAuthDeviceConsentResponse{
+		Status:  session.Status,
+		Message: "device authorization updated",
+	})
+}

--- a/cmd/api/handlers/oauth_device_verification_round12_test.go
+++ b/cmd/api/handlers/oauth_device_verification_round12_test.go
@@ -1,0 +1,132 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	apimodels "github.com/equaltoai/lesser/cmd/api/models"
+	"github.com/equaltoai/lesser/pkg/auth"
+	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOAuthDeviceVerifyLiftRound12(t *testing.T) {
+	cfg := round11TestConfig()
+
+	t.Run("disabled returns access_denied", func(t *testing.T) {
+		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/device/verify", nil, nil, []byte("user_code=ABCD-EFGH"))
+		resp := requireStatus(t, http.StatusForbidden)(h.HandleOAuthDeviceVerifyLift(ctx))
+
+		var body apimodels.OAuthErrorResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "access_denied", body.Error)
+	})
+
+	t.Run("invalid user_code returns invalid_request", func(t *testing.T) {
+		cfgDevice := round11TestConfig()
+		cfgDevice.AllowDeviceFlow = true
+		h, _, _ := round11NewHandler(t, cfgDevice, &round10QueryState{})
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/device/verify", nil, nil, []byte("user_code=not-a-code"))
+		resp := requireStatus(t, http.StatusBadRequest)(h.HandleOAuthDeviceVerifyLift(ctx))
+
+		var body apimodels.OAuthErrorResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "invalid_request", body.Error)
+	})
+
+	t.Run("success returns device session metadata", func(t *testing.T) {
+		cfgDevice := round11TestConfig()
+		cfgDevice.AllowDeviceFlow = true
+
+		now := time.Now().UTC()
+		state := &round10QueryState{
+			oauthDeviceSessionsByUserCode: map[string]storagemodels.OAuthDeviceSession{
+				"ABCD-EFGH": {
+					DeviceCodeHash:  "hash",
+					UserCode:        "ABCD-EFGH",
+					ClientID:        "client-1",
+					Scopes:          []string{auth.ScopeRead, auth.ScopeWrite},
+					Status:          "pending",
+					IntervalSeconds: oauthDevicePollIntervalSeconds,
+					CreatedAt:       now.Add(-1 * time.Minute),
+					UpdatedAt:       now.Add(-1 * time.Minute),
+					ExpiresAt:       now.Add(5 * time.Minute),
+				},
+			},
+		}
+
+		h, _, _ := round11NewHandler(t, cfgDevice, state)
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/device/verify", nil, nil, []byte("user_code=abcd-efgh"))
+		resp := requireStatus(t, http.StatusOK)(h.HandleOAuthDeviceVerifyLift(ctx))
+
+		var body apimodels.OAuthDeviceVerifyResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "ABCD-EFGH", body.UserCode)
+		require.Equal(t, "client-1", body.ClientID)
+		require.NotEmpty(t, body.ClientName)
+		require.Contains(t, body.Scopes, auth.ScopeRead)
+		require.Equal(t, "pending", body.Status)
+		require.Greater(t, body.ExpiresIn, 0)
+		require.Equal(t, oauthDevicePollIntervalSeconds, body.Interval)
+	})
+}
+
+func TestOAuthDeviceConsentLiftRound12(t *testing.T) {
+	cfgDevice := round11TestConfig()
+	cfgDevice.AllowDeviceFlow = true
+
+	now := time.Now().UTC()
+	state := &round10QueryState{
+		oauthDeviceSessionsByUserCode: map[string]storagemodels.OAuthDeviceSession{
+			"ABCD-EFGH": {
+				DeviceCodeHash:  "hash",
+				UserCode:        "ABCD-EFGH",
+				ClientID:        "client-1",
+				Scopes:          []string{auth.ScopeRead, auth.ScopeWrite},
+				Status:          "pending",
+				IntervalSeconds: oauthDevicePollIntervalSeconds,
+				CreatedAt:       now.Add(-1 * time.Minute),
+				UpdatedAt:       now.Add(-1 * time.Minute),
+				ExpiresAt:       now.Add(5 * time.Minute),
+			},
+		},
+	}
+
+	h, _, _ := round11NewHandler(t, cfgDevice, state)
+
+	oauthSvc := createOAuthService(cfgDevice.JWTSecret, cfgDevice, h.repos, h.logger)
+	accessToken, _, err := oauthSvc.GenerateTokens(context.Background(), "alice", "client-1", "", []string{auth.ScopeRead, auth.ScopeWrite})
+	require.NoError(t, err)
+
+	t.Run("missing auth returns 401", func(t *testing.T) {
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/device/consent", nil, nil, []byte("user_code=ABCD-EFGH&action=approve"))
+		requireStatus(t, http.StatusUnauthorized)(h.HandleOAuthDeviceConsentLift(ctx))
+	})
+
+	t.Run("approve updates status", func(t *testing.T) {
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/device/consent", map[string]string{
+			"authorization": "Bearer " + accessToken,
+		}, nil, []byte("user_code=ABCD-EFGH&action=approve"))
+		resp := requireStatus(t, http.StatusOK)(h.HandleOAuthDeviceConsentLift(ctx))
+
+		var body apimodels.OAuthDeviceConsentResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "approved", strings.ToLower(body.Status))
+	})
+
+	t.Run("deny updates status", func(t *testing.T) {
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/device/consent", map[string]string{
+			"authorization": "Bearer " + accessToken,
+		}, nil, []byte("user_code=ABCD-EFGH&action=deny"))
+		resp := requireStatus(t, http.StatusOK)(h.HandleOAuthDeviceConsentLift(ctx))
+
+		var body apimodels.OAuthDeviceConsentResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "denied", strings.ToLower(body.Status))
+	})
+}

--- a/cmd/api/models/oauth.go
+++ b/cmd/api/models/oauth.go
@@ -32,6 +32,39 @@ type OAuthDeviceCodeResponse struct {
 	Interval                int    `json:"interval"`
 }
 
+// OAuthDeviceVerifyRequest represents a device verification lookup request.
+//
+// This is sent as application/x-www-form-urlencoded to POST /oauth/device/verify.
+type OAuthDeviceVerifyRequest struct {
+	UserCode string `json:"user_code"`
+}
+
+// OAuthDeviceVerifyResponse represents the device session metadata used by the auth UI to show consent.
+type OAuthDeviceVerifyResponse struct {
+	UserCode   string   `json:"user_code"`
+	ClientID   string   `json:"client_id"`
+	ClientName string   `json:"client_name,omitempty"`
+	ClientURL  string   `json:"client_url,omitempty"`
+	Scopes     []string `json:"scopes,omitempty"`
+	Status     string   `json:"status"`
+	ExpiresIn  int      `json:"expires_in"`
+	Interval   int      `json:"interval"`
+}
+
+// OAuthDeviceConsentRequest represents a device session consent action.
+//
+// This is sent as application/x-www-form-urlencoded to POST /oauth/device/consent.
+type OAuthDeviceConsentRequest struct {
+	UserCode string `json:"user_code"`
+	Action   string `json:"action"` // approve|deny
+}
+
+// OAuthDeviceConsentResponse represents the server response after approving/denying a device session.
+type OAuthDeviceConsentResponse struct {
+	Status  string `json:"status"`
+	Message string `json:"message,omitempty"`
+}
+
 // OAuthTokenResponse represents a token response
 type OAuthTokenResponse struct {
 	AccessToken  string `json:"access_token"`

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -83,6 +83,12 @@ func configureRoutes(app *apptheory.App) {
 	app.Post("/oauth/device/code", ratelimit.ApplyRateLimit(
 		apiHandler.HandleOAuthDeviceCodeLift,
 		10, time.Minute, logger))
+	app.Post("/oauth/device/verify", ratelimit.ApplyRateLimit(
+		apiHandler.HandleOAuthDeviceVerifyLift,
+		20, 5*time.Minute, logger))
+	app.Post("/oauth/device/consent", ratelimit.ApplyRateLimit(
+		apiHandler.HandleOAuthDeviceConsentLift,
+		20, 5*time.Minute, logger))
 	app.Post("/oauth/token", ratelimit.ApplyRateLimit(
 		apiHandler.HandleOAuthTokenLift,
 		10, time.Minute, logger))
@@ -91,6 +97,8 @@ func configureRoutes(app *apptheory.App) {
 	app.Handle("OPTIONS", "/oauth/authorize", optionsHandler)
 	app.Handle("OPTIONS", "/oauth/consent", optionsHandler)
 	app.Handle("OPTIONS", "/oauth/device/code", optionsHandler)
+	app.Handle("OPTIONS", "/oauth/device/verify", optionsHandler)
+	app.Handle("OPTIONS", "/oauth/device/consent", optionsHandler)
 	app.Handle("OPTIONS", "/oauth/token", optionsHandler)
 
 	// NodeInfo endpoints with native Lift implementation

--- a/cmd/api/testdata/routes_manifest.txt
+++ b/cmd/api/testdata/routes_manifest.txt
@@ -187,6 +187,8 @@ OPTIONS /auth/wallet/verify
 OPTIONS /oauth/authorize
 OPTIONS /oauth/consent
 OPTIONS /oauth/device/code
+OPTIONS /oauth/device/consent
+OPTIONS /oauth/device/verify
 OPTIONS /oauth/token
 OPTIONS /setup/admin
 OPTIONS /setup/bootstrap/challenge
@@ -293,6 +295,8 @@ POST /auth/wallet/login
 POST /auth/wallet/verify
 POST /oauth/consent
 POST /oauth/device/code
+POST /oauth/device/consent
+POST /oauth/device/verify
 POST /oauth/token
 POST /setup/admin
 POST /setup/bootstrap/challenge

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -3301,6 +3301,63 @@ components:
                 - user_code
                 - verification_uri
             type: object
+        OAuthDeviceConsentRequest:
+            additionalProperties: false
+            properties:
+                action:
+                    type: string
+                user_code:
+                    type: string
+            required:
+                - action
+                - user_code
+            type: object
+        OAuthDeviceConsentResponse:
+            additionalProperties: false
+            properties:
+                message:
+                    type: string
+                status:
+                    type: string
+            required:
+                - status
+            type: object
+        OAuthDeviceVerifyRequest:
+            additionalProperties: false
+            properties:
+                user_code:
+                    type: string
+            required:
+                - user_code
+            type: object
+        OAuthDeviceVerifyResponse:
+            additionalProperties: false
+            properties:
+                client_id:
+                    type: string
+                client_name:
+                    type: string
+                client_url:
+                    type: string
+                expires_in:
+                    type: integer
+                interval:
+                    type: integer
+                scopes:
+                    items:
+                        type: string
+                    type: array
+                status:
+                    type: string
+                user_code:
+                    type: string
+            required:
+                - client_id
+                - expires_in
+                - interval
+                - status
+                - user_code
+            type: object
         OAuthErrorResponse:
             additionalProperties: false
             properties:
@@ -17143,6 +17200,106 @@ paths:
                 "500":
                     $ref: '#/components/responses/InternalServerError'
             x-lesser-handler: HandleOAuthDeviceCodeLift
+            x-lesser-lambda: api
+            x-lesser-routeSources:
+                - cmd/api/routes.go
+    /oauth/device/consent:
+        post:
+            operationId: post_oauth_device_consent
+            tags:
+                - oauth
+            security:
+                - bearerAuth: []
+            requestBody:
+                required: true
+                content:
+                    application/x-www-form-urlencoded:
+                        schema:
+                            $ref: '#/components/schemas/OAuthDeviceConsentRequest'
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/OAuthDeviceConsentResponse'
+                    headers:
+                        X-RateLimit-Limit:
+                            description: Request limit per window.
+                            schema:
+                                type: integer
+                                format: int32
+                        X-RateLimit-Remaining:
+                            description: Requests remaining in the current window.
+                            schema:
+                                type: integer
+                                format: int32
+                        X-RateLimit-Reset:
+                            description: Unix timestamp (seconds) when the current window resets.
+                            schema:
+                                type: integer
+                                format: int64
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "401":
+                    $ref: '#/components/responses/Unauthorized'
+                "403":
+                    $ref: '#/components/responses/Forbidden'
+                "422":
+                    $ref: '#/components/responses/UnprocessableEntity'
+                "429":
+                    $ref: '#/components/responses/TooManyRequests'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+            x-lesser-handler: HandleOAuthDeviceConsentLift
+            x-lesser-lambda: api
+            x-lesser-routeSources:
+                - cmd/api/routes.go
+            x-oauth-scopes:
+                - read
+    /oauth/device/verify:
+        post:
+            operationId: post_oauth_device_verify
+            tags:
+                - oauth
+            requestBody:
+                required: true
+                content:
+                    application/x-www-form-urlencoded:
+                        schema:
+                            $ref: '#/components/schemas/OAuthDeviceVerifyRequest'
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/OAuthDeviceVerifyResponse'
+                    headers:
+                        X-RateLimit-Limit:
+                            description: Request limit per window.
+                            schema:
+                                type: integer
+                                format: int32
+                        X-RateLimit-Remaining:
+                            description: Requests remaining in the current window.
+                            schema:
+                                type: integer
+                                format: int32
+                        X-RateLimit-Reset:
+                            description: Unix timestamp (seconds) when the current window resets.
+                            schema:
+                                type: integer
+                                format: int64
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "422":
+                    $ref: '#/components/responses/UnprocessableEntity'
+                "429":
+                    $ref: '#/components/responses/TooManyRequests'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+            x-lesser-handler: HandleOAuthDeviceVerifyLift
             x-lesser-lambda: api
             x-lesser-routeSources:
                 - cmd/api/routes.go

--- a/tools/openapi/operation_overrides.go
+++ b/tools/openapi/operation_overrides.go
@@ -65,6 +65,10 @@ func applyOAuthOverrides(op *operation, route routeDef) {
 		applyOAuthTokenOverrides(op)
 	case route.Method == methodPOST && route.Path == "/oauth/device/code":
 		applyOAuthDeviceCodeOverrides(op)
+	case route.Method == methodPOST && route.Path == "/oauth/device/verify":
+		applyOAuthDeviceVerifyOverrides(op)
+	case route.Method == methodPOST && route.Path == "/oauth/device/consent":
+		applyOAuthDeviceConsentOverrides(op)
 	case route.Method == methodPOST && route.Path == "/oauth/consent":
 		applyOAuthConsentOverrides(op)
 	case route.Method == methodGET && route.Path == "/oauth/authorize":
@@ -106,6 +110,40 @@ func applyOAuthDeviceCodeOverrides(op *operation) {
 	}
 
 	ensureJSONResponseSchema(op, "200", "OAuthDeviceCodeResponse")
+}
+
+func applyOAuthDeviceVerifyOverrides(op *operation) {
+	if op == nil {
+		return
+	}
+
+	op.RequestBody = &requestBody{
+		Required: true,
+		Content: map[string]mediaType{
+			"application/x-www-form-urlencoded": {
+				Schema: schemaRef{Ref: "#/components/schemas/OAuthDeviceVerifyRequest"},
+			},
+		},
+	}
+
+	ensureJSONResponseSchema(op, "200", "OAuthDeviceVerifyResponse")
+}
+
+func applyOAuthDeviceConsentOverrides(op *operation) {
+	if op == nil {
+		return
+	}
+
+	op.RequestBody = &requestBody{
+		Required: true,
+		Content: map[string]mediaType{
+			"application/x-www-form-urlencoded": {
+				Schema: schemaRef{Ref: "#/components/schemas/OAuthDeviceConsentRequest"},
+			},
+		},
+	}
+
+	ensureJSONResponseSchema(op, "200", "OAuthDeviceConsentResponse")
 }
 
 func applyOAuthConsentOverrides(op *operation) {

--- a/tools/openapi/strict_verify.go
+++ b/tools/openapi/strict_verify.go
@@ -276,7 +276,11 @@ func validateStrictOperationContentTypes(op *operation, route routeDef) error {
 		if !operationHasRequestContentType(op, "multipart/form-data") {
 			return errors.New("missing multipart/form-data request body")
 		}
-	case routeKey(methodPOST, "/oauth/token"), routeKey(methodPOST, "/oauth/consent"), routeKey(methodPOST, "/oauth/device/code"):
+	case routeKey(methodPOST, "/oauth/token"),
+		routeKey(methodPOST, "/oauth/consent"),
+		routeKey(methodPOST, "/oauth/device/code"),
+		routeKey(methodPOST, "/oauth/device/verify"),
+		routeKey(methodPOST, "/oauth/device/consent"):
 		if !operationHasRequestContentType(op, "application/x-www-form-urlencoded") {
 			return errors.New("missing application/x-www-form-urlencoded request body")
 		}


### PR DESCRIPTION
Adds the web UI + API for OAuth device verification/consent.

- New endpoints: POST /oauth/device/verify, POST /oauth/device/consent (gated by AllowDeviceFlow)
- New auth-ui page: /auth/device (enter/prefill user_code, login, approve/deny)
- OpenAPI + route manifest updates
- Tests for verification + consent handlers