### PR TITLE
m3: client_class=cli tokens

### DIFF
--- a/cmd/api/handlers/oauth.go
+++ b/cmd/api/handlers/oauth.go
@@ -637,7 +637,17 @@ func (h *Handler) HandleOAuthTokenLift(ctx *apptheory.Context) (*apptheory.Respo
 				})
 			}
 
-			accessToken, refreshTokenOut, err := oauthSvc.GenerateTokens(ctx.Context(), username, clientID, "", session.Scopes)
+			cliSessionID := common.GenerateSessionIDULID()
+			accessToken, refreshTokenOut, err := oauthSvc.GenerateTokensWithAccessTokenTTLAndClientContext(
+				ctx.Context(),
+				username,
+				clientID,
+				"",
+				session.Scopes,
+				auth.AccessTokenDuration,
+				auth.ClientClassCLI,
+				cliSessionID,
+			)
 			if err != nil {
 				h.logger.Error("failed to generate tokens for device flow", zap.Error(err))
 				return apptheory.JSON(http.StatusInternalServerError, map[string]string{
@@ -647,12 +657,14 @@ func (h *Handler) HandleOAuthTokenLift(ctx *apptheory.Context) (*apptheory.Respo
 			}
 
 			oauthRefreshToken := &storage.RefreshToken{
-				Token:     refreshTokenOut,
-				Username:  username,
-				ClientID:  clientID,
-				Scopes:    session.Scopes,
-				CreatedAt: now,
-				ExpiresAt: now.Add(auth.RefreshTokenDuration),
+				Token:       refreshTokenOut,
+				Username:    username,
+				ClientID:    clientID,
+				Scopes:      session.Scopes,
+				CreatedAt:   now,
+				ExpiresAt:   now.Add(auth.RefreshTokenDuration),
+				ClientClass: auth.ClientClassCLI,
+				SessionID:   cliSessionID,
 			}
 			if err := h.repos.Account().CreateRefreshToken(ctx.Context(), oauthRefreshToken); err != nil {
 				h.logger.Error("failed to store refresh token for device flow", zap.Error(err))
@@ -800,19 +812,21 @@ func (h *Handler) exchangeRefreshToken(ctx context.Context, oauthSvc *auth.OAuth
 		refreshExpiry = storedToken.ExpiresAt
 	}
 
-	accessToken, newRefreshToken, err := oauthSvc.GenerateTokensWithAccessTokenTTL(ctx, storedToken.Username, clientID, "", storedToken.Scopes, accessTTL)
+	accessToken, newRefreshToken, err := oauthSvc.GenerateTokensWithAccessTokenTTLAndClientContext(ctx, storedToken.Username, clientID, "", storedToken.Scopes, accessTTL, storedToken.ClientClass, storedToken.SessionID)
 	if err != nil {
 		return "", "", errors.Join(failedToGenerateNewTokens(), err)
 	}
 
 	// Create new refresh token record
 	newOAuthRefreshToken := &storage.RefreshToken{
-		Token:     newRefreshToken,
-		Username:  storedToken.Username,
-		ClientID:  clientID,
-		Scopes:    storedToken.Scopes,
-		CreatedAt: time.Now(),
-		ExpiresAt: refreshExpiry,
+		Token:       newRefreshToken,
+		Username:    storedToken.Username,
+		ClientID:    clientID,
+		Scopes:      storedToken.Scopes,
+		CreatedAt:   time.Now(),
+		ExpiresAt:   refreshExpiry,
+		ClientClass: storedToken.ClientClass,
+		SessionID:   storedToken.SessionID,
 	}
 
 	// Store new refresh token

--- a/cmd/api/handlers/oauth_round12_test.go
+++ b/cmd/api/handlers/oauth_round12_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +19,20 @@ import (
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/require"
 )
+
+func round12DecodeJWTClaims(t *testing.T, tokenString string) auth.Claims {
+	t.Helper()
+
+	parts := strings.Split(tokenString, ".")
+	require.Len(t, parts, 3)
+
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+
+	var claims auth.Claims
+	require.NoError(t, json.Unmarshal(payloadBytes, &claims))
+	return claims
+}
 
 func TestOAuthAuthorizeFlowRound12(t *testing.T) {
 	cfg := round11TestConfig()
@@ -728,5 +743,35 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		require.NoError(t, json.Unmarshal(resp.Body, &body))
 		require.NotEmpty(t, body.AccessToken)
 		require.NotEmpty(t, body.RefreshToken)
+
+		claims1 := round12DecodeJWTClaims(t, body.AccessToken)
+		require.Equal(t, auth.ClientClassCLI, claims1.ClientClass)
+		require.NotEmpty(t, claims1.SessionID)
+
+		// The test harness does not persist Create() mutations, so seed the refresh token lookup explicitly.
+		if state.refreshTokensByToken == nil {
+			state.refreshTokensByToken = map[string]storagemodels.RefreshToken{}
+		}
+		state.refreshTokensByToken[body.RefreshToken] = storagemodels.RefreshToken{
+			Token:       body.RefreshToken,
+			ClientID:    "client-1",
+			Username:    "alice",
+			ExpiresAt:   time.Now().Add(1 * time.Hour),
+			Scopes:      []string{auth.ScopeRead, auth.ScopeWrite},
+			CreatedAt:   time.Now().Add(-1 * time.Minute),
+			ClientClass: auth.ClientClassCLI,
+			SessionID:   claims1.SessionID,
+		}
+
+		ctxRefresh := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type=refresh_token&refresh_token="+url.QueryEscape(body.RefreshToken)+"&client_id=client-1"))
+		respRefresh := requireStatus(t, http.StatusOK)(h.HandleOAuthTokenLift(ctxRefresh))
+		var refreshBody apimodels.OAuthTokenResponse
+		require.NoError(t, json.Unmarshal(respRefresh.Body, &refreshBody))
+		require.NotEmpty(t, refreshBody.AccessToken)
+		require.NotEmpty(t, refreshBody.RefreshToken)
+
+		refreshClaims := round12DecodeJWTClaims(t, refreshBody.AccessToken)
+		require.Equal(t, auth.ClientClassCLI, refreshClaims.ClientClass)
+		require.Equal(t, claims1.SessionID, refreshClaims.SessionID)
 	})
 }

--- a/docs/planning/lesser-cli-auth-device-flow-roadmap.md
+++ b/docs/planning/lesser-cli-auth-device-flow-roadmap.md
@@ -155,6 +155,9 @@ suggested verification commands (adapt as implementation evolves).
 **Goal:** ensure GraphQL-first clients (and any CLI usage of GraphQL) can correctly discover, filter, and attribute
 agent-authored content without falling back to REST.
 
+**Sequencing note:** M3/M4 are security-critical for “CLI treated like agent traffic” and are recommended to land
+before M2.5 unless a GraphQL-first client is currently blocked.
+
 Tracked by client issues:
 - #73 GraphQL agent directory + management parity (delegate/activity/update/admin ops)
 - #74 GraphQL timeline filter parity: `excludeAgents` (REST `exclude_agents=true`)

--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -63,12 +63,22 @@ const (
 	RefreshTokenFamilyExpiry = 30 * 24 * time.Hour // 30 days for family tracking
 )
 
+// Client classes identify the client category that minted an access token.
+// These are used for server-side policy decisions (e.g., automation safety rails) without relying on spoofable headers.
+const (
+	ClientClassWeb   = "web"
+	ClientClassCLI   = "cli"
+	ClientClassAgent = "agent"
+)
+
 // Claims represents the JWT claims for access tokens with enhanced security
 type Claims struct {
 	jwt.RegisteredClaims
 	Username string   `json:"username"`
 	Scopes   []string `json:"scopes"`
 	ClientID string   `json:"client_id"`
+	// ClientClass categorizes the client that minted the token (e.g., "cli" for device-flow CLI tokens).
+	ClientClass string `json:"client_class,omitempty"`
 	// Enhanced security fields
 	SessionID    string `json:"sid,omitempty"` // Session ID for validation
 	DeviceID     string `json:"did,omitempty"` // Device fingerprint
@@ -259,22 +269,34 @@ func (s *OAuthService) GenerateTokens(ctx context.Context, username, clientID, i
 
 // GenerateTokensWithAccessTokenTTL generates both access and refresh tokens with a custom access token TTL.
 func (s *OAuthService) GenerateTokensWithAccessTokenTTL(ctx context.Context, username, clientID, ipAddress string, scopes []string, accessTokenTTL time.Duration) (accessToken, refreshToken string, err error) {
+	return s.GenerateTokensWithAccessTokenTTLAndClientContext(ctx, username, clientID, ipAddress, scopes, accessTokenTTL, "", "")
+}
+
+// GenerateTokensWithAccessTokenTTLAndClientContext generates tokens with an explicit client class and session ID.
+//
+// This enables downstream middleware to enforce server-side policies (e.g., automation safety rails) based on
+// non-spoofable classification derived at token issuance time. For agent accounts, if a sessionID is not provided,
+// a new session ID is generated.
+func (s *OAuthService) GenerateTokensWithAccessTokenTTLAndClientContext(ctx context.Context, username, clientID, ipAddress string, scopes []string, accessTokenTTL time.Duration, clientClass, sessionID string) (accessToken, refreshToken string, err error) {
 	if accessTokenTTL <= 0 {
 		accessTokenTTL = AccessTokenDuration
 	}
 
 	isAgent, agentType, delegatedBy := s.resolveAgentClaims(ctx, username)
+	effectiveSessionID := strings.TrimSpace(sessionID)
 	agentSessionID := ""
-	sessionID := ""
 	if isAgent {
-		agentSessionID = generateSecureJTI()
-		sessionID = agentSessionID
+		if effectiveSessionID == "" {
+			effectiveSessionID = generateSecureJTI()
+		}
+		agentSessionID = effectiveSessionID
 	}
 
 	accessToken, err = s.generateAccessTokenWithMetadata(username, clientID, scopes, accessTokenMetadata{
 		ExpiresAt:      time.Now().Add(accessTokenTTL),
 		IPAddress:      ipAddress,
-		SessionID:      sessionID,
+		SessionID:      effectiveSessionID,
+		ClientClass:    clientClass,
 		IsAgent:        isAgent,
 		AgentType:      agentType,
 		DelegatedBy:    delegatedBy,
@@ -314,6 +336,8 @@ type accessTokenMetadata struct {
 	AgentType      string
 	DelegatedBy    string
 	AgentSessionID string
+
+	ClientClass string
 }
 
 // generateAccessTokenWithMetadata creates a JWT access token with enhanced security context.
@@ -336,6 +360,7 @@ func (s *OAuthService) generateAccessTokenWithMetadata(username, clientID string
 		Username:       username,
 		ClientID:       clientID,
 		Scopes:         scopes,
+		ClientClass:    meta.ClientClass,
 		SessionID:      meta.SessionID,
 		DeviceID:       meta.DeviceID,
 		TokenVersion:   meta.TokenVersion,

--- a/pkg/storage/models/refresh_token.go
+++ b/pkg/storage/models/refresh_token.go
@@ -13,11 +13,13 @@ type RefreshToken struct {
 	SK string `theorydb:"sk,attr:SK" json:"-"` // TOKEN
 
 	// Core fields from legacy storage.RefreshToken
-	Token     string    `theorydb:"attr:token" json:"Token"`
-	ClientID  string    `theorydb:"attr:clientID" json:"ClientID"`
-	Username  string    `theorydb:"attr:username" json:"Username"`
-	ExpiresAt time.Time `theorydb:"attr:expiresAt" json:"ExpiresAt"`
-	Scopes    []string  `theorydb:"attr:scopes" json:"Scopes"`
+	Token       string    `theorydb:"attr:token" json:"Token"`
+	ClientID    string    `theorydb:"attr:clientID" json:"ClientID"`
+	Username    string    `theorydb:"attr:username" json:"Username"`
+	ExpiresAt   time.Time `theorydb:"attr:expiresAt" json:"ExpiresAt"`
+	Scopes      []string  `theorydb:"attr:scopes" json:"Scopes"`
+	ClientClass string    `theorydb:"attr:clientClass" json:"ClientClass,omitempty"`
+	SessionID   string    `theorydb:"attr:sessionID" json:"SessionID,omitempty"`
 
 	// Tracking fields
 	CreatedAt time.Time `theorydb:"attr:createdAt" json:"CreatedAt"`

--- a/pkg/storage/repositories/oauth_helpers.go
+++ b/pkg/storage/repositories/oauth_helpers.go
@@ -519,12 +519,14 @@ func (h *OAuthHelper) DeleteAuthorizationCodeGeneric(ctx context.Context, code s
 func (h *OAuthHelper) CreateRefreshTokenGeneric(ctx context.Context, token *storage.RefreshToken) error {
 	// Create DynamORM model
 	model := &models.RefreshToken{
-		Token:     token.Token,
-		ClientID:  token.ClientID,
-		Username:  token.Username,
-		ExpiresAt: token.ExpiresAt,
-		Scopes:    token.Scopes,
-		CreatedAt: time.Now(),
+		Token:       token.Token,
+		ClientID:    token.ClientID,
+		Username:    token.Username,
+		ExpiresAt:   token.ExpiresAt,
+		Scopes:      token.Scopes,
+		ClientClass: token.ClientClass,
+		SessionID:   token.SessionID,
+		CreatedAt:   time.Now(),
 	}
 
 	// BeforeCreate will set up keys and TTL
@@ -580,11 +582,13 @@ func (h *OAuthHelper) GetRefreshTokenGeneric(ctx context.Context, token string) 
 
 	// Convert to storage model
 	result := &storage.RefreshToken{
-		Token:     model.Token,
-		ClientID:  model.ClientID,
-		Username:  model.Username,
-		ExpiresAt: model.ExpiresAt,
-		Scopes:    model.Scopes,
+		Token:       model.Token,
+		ClientID:    model.ClientID,
+		Username:    model.Username,
+		ExpiresAt:   model.ExpiresAt,
+		Scopes:      model.Scopes,
+		ClientClass: model.ClientClass,
+		SessionID:   model.SessionID,
 	}
 
 	h.logger.Debug("retrieved refresh token",

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -258,12 +258,14 @@ type AuthorizationCode struct {
 
 // RefreshToken represents an OAuth refresh token
 type RefreshToken struct {
-	Token     string    `json:"token"`
-	Username  string    `json:"username"`
-	ClientID  string    `json:"client_id"`
-	Scopes    []string  `json:"scopes"`
-	CreatedAt time.Time `json:"created_at"`
-	ExpiresAt time.Time `json:"expires_at"`
+	Token       string    `json:"token"`
+	Username    string    `json:"username"`
+	ClientID    string    `json:"client_id"`
+	Scopes      []string  `json:"scopes"`
+	CreatedAt   time.Time `json:"created_at"`
+	ExpiresAt   time.Time `json:"expires_at"`
+	ClientClass string    `json:"client_class,omitempty"`
+	SessionID   string    `json:"session_id,omitempty"`
 }
 
 // WebAuthnChallenge represents a WebAuthn challenge


### PR DESCRIPTION
Implements M3 token classification for the CLI device flow.

- Adds JWT claim `client_class` (constants: `web|cli|agent`) and threads it through OAuth token issuance.
- Device grant mints tokens with `client_class=cli` and a stable `sid`.
- Refresh token records now store `client_class` + `session_id` and refresh preserves both.
- Roadmap note clarifies M3/M4 should land before M2.5 unless a GraphQL-first client is blocked.