### PR TITLE
m4: cli automation safety rails

### DIFF
--- a/cmd/api/agent_safety_middleware.go
+++ b/cmd/api/agent_safety_middleware.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -22,6 +23,9 @@ import (
 )
 
 const (
+	agentConcurrencyPKPrefix       = "AGENT_CONCURRENCY"
+	cliAutomationConcurrencyPrefix = "CLI_CONCURRENCY"
+
 	agentConcurrencyLimit         = 2
 	agentConcurrencyLeaseDuration = 30 * time.Second
 
@@ -31,6 +35,16 @@ const (
 	agentErrorRateCounterCap  = 100000
 
 	agentErrorRateLockoutDuration = time.Hour
+
+	cliAutomationDefaultConcurrencyLimit = 2
+	cliAutomationDefaultBurstLimit       = 20
+	cliAutomationDefaultBurstWindow      = 10 * time.Second
+	cliAutomationDefaultSustainedLimit   = 60
+	cliAutomationDefaultSustainedWindow  = time.Minute
+	cliAutomationDefaultErrorRateWindow  = time.Minute
+	cliAutomationDefaultErrorRateMin     = 10
+	cliAutomationDefaultErrorRateThresh  = 0.10
+	cliAutomationDefaultLockoutDuration  = time.Hour
 )
 
 var errAgentConcurrencyExceeded = errors.New("agent concurrency exceeded")
@@ -89,31 +103,40 @@ func createAgentSafetyRailsMiddleware(cfg *config.Config, repos core.RepositoryS
 	return func(next apptheory.Handler) apptheory.Handler {
 		return func(ctx *apptheory.Context) (*apptheory.Response, error) {
 			claims := agentClaimsFromContext(ctx)
-			if claims == nil || !claims.IsAgent {
+			if claims == nil {
 				return next(ctx)
 			}
 
-			if resp, err := rejectLockedAgent(ctx, rateRepo, claims); resp != nil || err != nil {
-				return resp, err
-			}
-
-			if lease, err := enforceAgentConcurrency(ctx, repos, claims); err != nil {
-				if errors.Is(err, errAgentConcurrencyExceeded) {
-					return apptheory.JSON(http.StatusTooManyRequests, map[string]any{
-						"error":             "too_many_requests",
-						"error_description": "agent concurrency limit exceeded",
-					})
+			if claims.IsAgent {
+				if resp, err := rejectLockedAgent(ctx, rateRepo, claims); resp != nil || err != nil {
+					return resp, err
 				}
-				logger.Debug("agent concurrency check failed - allowing request", zap.Error(err))
-			} else if lease != nil {
-				defer lease.release(ctx.Context(), repos.GetDB())
+
+				if lease, err := enforceAgentConcurrency(ctx, repos, claims); err != nil {
+					if errors.Is(err, errAgentConcurrencyExceeded) {
+						return apptheory.JSON(http.StatusTooManyRequests, map[string]any{
+							"error":             "too_many_requests",
+							"error_description": "agent concurrency limit exceeded",
+						})
+					}
+					logger.Debug("agent concurrency check failed - allowing request", zap.Error(err))
+				} else if lease != nil {
+					defer lease.release(ctx.Context(), repos.GetDB())
+				}
+
+				resp, handlerErr := next(ctx)
+
+				maybeApplyAgentErrorRateLockout(ctx, rateRepo, claims, resp, handlerErr)
+
+				return resp, handlerErr
 			}
 
-			resp, handlerErr := next(ctx)
+			if isCLIAutomationClaims(claims) {
+				resp, handlerErr := handleCLIAutomationSafetyRails(ctx, cfg, repos, rateRepo, logger, next, claims)
+				return resp, handlerErr
+			}
 
-			maybeApplyAgentErrorRateLockout(ctx, rateRepo, claims, resp, handlerErr)
-
-			return resp, handlerErr
+			return next(ctx)
 		}
 	}
 }
@@ -181,12 +204,21 @@ func maybeApplyAgentErrorRateLockout(ctx *apptheory.Context, rateRepo *storageRe
 }
 
 type agentConcurrencyLease struct {
+	pkPrefix  string
 	sessionID string
 	slot      int
 	leaseID   string
 }
 
 func acquireAgentConcurrencyLease(ctx context.Context, db dynamormCore.DB, sessionID string, limit int, leaseDuration time.Duration) (*agentConcurrencyLease, error) {
+	return acquireConcurrencyLease(ctx, db, agentConcurrencyPKPrefix, sessionID, limit, leaseDuration)
+}
+
+func acquireCLIAutomationConcurrencyLease(ctx context.Context, db dynamormCore.DB, sessionID string, limit int, leaseDuration time.Duration) (*agentConcurrencyLease, error) {
+	return acquireConcurrencyLease(ctx, db, cliAutomationConcurrencyPrefix, sessionID, limit, leaseDuration)
+}
+
+func acquireConcurrencyLease(ctx context.Context, db dynamormCore.DB, pkPrefix string, sessionID string, limit int, leaseDuration time.Duration) (*agentConcurrencyLease, error) {
 	if db == nil {
 		return nil, nil
 	}
@@ -195,13 +227,17 @@ func acquireAgentConcurrencyLease(ctx context.Context, db dynamormCore.DB, sessi
 	if sessionID == "" || limit <= 0 {
 		return nil, nil
 	}
+	pkPrefix = strings.TrimSpace(pkPrefix)
+	if pkPrefix == "" {
+		pkPrefix = agentConcurrencyPKPrefix
+	}
 	if leaseDuration <= 0 {
 		leaseDuration = agentConcurrencyLeaseDuration
 	}
 
 	now := time.Now().UTC()
 	leaseID := common.GenerateOperationIDULID()
-	pk := fmt.Sprintf("AGENT_CONCURRENCY#%s", sessionID)
+	pk := fmt.Sprintf("%s#%s", pkPrefix, sessionID)
 
 	for slot := 0; slot < limit; slot++ {
 		sk := fmt.Sprintf("SLOT#%d", slot)
@@ -216,7 +252,7 @@ func acquireAgentConcurrencyLease(ctx context.Context, db dynamormCore.DB, sessi
 
 		err := db.Model(slotModel).WithContext(ctx).IfNotExists().Create()
 		if err == nil {
-			return &agentConcurrencyLease{sessionID: sessionID, slot: slot, leaseID: leaseID}, nil
+			return &agentConcurrencyLease{pkPrefix: pkPrefix, sessionID: sessionID, slot: slot, leaseID: leaseID}, nil
 		}
 
 		if !dynamormErrors.IsConditionFailed(err) {
@@ -237,7 +273,7 @@ func acquireAgentConcurrencyLease(ctx context.Context, db dynamormCore.DB, sessi
 			Execute()
 
 		if claimErr == nil {
-			return &agentConcurrencyLease{sessionID: sessionID, slot: slot, leaseID: leaseID}, nil
+			return &agentConcurrencyLease{pkPrefix: pkPrefix, sessionID: sessionID, slot: slot, leaseID: leaseID}, nil
 		}
 		if dynamormErrors.IsConditionFailed(claimErr) {
 			continue
@@ -245,7 +281,7 @@ func acquireAgentConcurrencyLease(ctx context.Context, db dynamormCore.DB, sessi
 		if dynamormErrors.IsNotFound(claimErr) {
 			// Lease disappeared between create + takeover attempt; retry create once.
 			if retryErr := db.Model(slotModel).WithContext(ctx).IfNotExists().Create(); retryErr == nil {
-				return &agentConcurrencyLease{sessionID: sessionID, slot: slot, leaseID: leaseID}, nil
+				return &agentConcurrencyLease{pkPrefix: pkPrefix, sessionID: sessionID, slot: slot, leaseID: leaseID}, nil
 			}
 		} else {
 			return nil, claimErr
@@ -260,7 +296,12 @@ func (l *agentConcurrencyLease) release(ctx context.Context, db dynamormCore.DB)
 		return
 	}
 
-	pk := fmt.Sprintf("AGENT_CONCURRENCY#%s", l.sessionID)
+	prefix := strings.TrimSpace(l.pkPrefix)
+	if prefix == "" {
+		prefix = agentConcurrencyPKPrefix
+	}
+
+	pk := fmt.Sprintf("%s#%s", prefix, l.sessionID)
 	sk := fmt.Sprintf("SLOT#%d", l.slot)
 
 	model := &storageModels.AgentConcurrencySlot{
@@ -290,6 +331,278 @@ func agentLockoutIdentifier(username string) string {
 		return "agent:unknown"
 	}
 	return "agent:" + strings.ToLower(username)
+}
+
+func isCLIAutomationClaims(claims *auth.Claims) bool {
+	if claims == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(claims.ClientClass), auth.ClientClassCLI)
+}
+
+func cliAutomationSessionID(claims *auth.Claims) string {
+	if claims == nil {
+		return ""
+	}
+
+	if sessionID := strings.TrimSpace(claims.SessionID); sessionID != "" {
+		return sessionID
+	}
+	if clientID := strings.TrimSpace(claims.ClientID); clientID != "" {
+		return clientID
+	}
+	if subject := strings.TrimSpace(claims.Subject); subject != "" {
+		return subject
+	}
+	if username := strings.TrimSpace(claims.Username); username != "" {
+		return username
+	}
+
+	return ""
+}
+
+func cliAutomationLockoutIdentifier(sessionID string) string {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return "cli:unknown"
+	}
+	return "cli:" + strings.ToLower(sessionID)
+}
+
+func handleCLIAutomationSafetyRails(ctx *apptheory.Context, cfg *config.Config, repos core.RepositoryStorage, rateRepo *storageRepos.RateLimitRepository, logger *zap.Logger, next apptheory.Handler, claims *auth.Claims) (*apptheory.Response, error) {
+	if ctx == nil || repos == nil || rateRepo == nil || next == nil || claims == nil {
+		return next(ctx)
+	}
+
+	sessionID := cliAutomationSessionID(claims)
+	if sessionID == "" {
+		sessionID = "unknown"
+	}
+
+	if resp, err := rejectLockedCLIAutomation(ctx, rateRepo, sessionID); resp != nil || err != nil {
+		return resp, err
+	}
+
+	sustainedLimit := cliAutomationDefaultSustainedLimit
+	sustainedWindow := cliAutomationDefaultSustainedWindow
+	burstLimit := cliAutomationDefaultBurstLimit
+	burstWindow := cliAutomationDefaultBurstWindow
+	concurrencyLimit := cliAutomationDefaultConcurrencyLimit
+	errorRateThreshold := cliAutomationDefaultErrorRateThresh
+	errorRateMinRequests := cliAutomationDefaultErrorRateMin
+	errorRateWindow := cliAutomationDefaultErrorRateWindow
+	lockoutDuration := cliAutomationDefaultLockoutDuration
+
+	if cfg != nil {
+		if cfg.CLIAutomationSustainedLimit > 0 {
+			sustainedLimit = cfg.CLIAutomationSustainedLimit
+		}
+		if cfg.CLIAutomationSustainedWindow > 0 {
+			sustainedWindow = cfg.CLIAutomationSustainedWindow
+		}
+		if cfg.CLIAutomationBurstLimit > 0 {
+			burstLimit = cfg.CLIAutomationBurstLimit
+		}
+		if cfg.CLIAutomationBurstWindow > 0 {
+			burstWindow = cfg.CLIAutomationBurstWindow
+		}
+		if cfg.CLIAutomationConcurrencyLimit > 0 {
+			concurrencyLimit = cfg.CLIAutomationConcurrencyLimit
+		}
+		if cfg.CLIAutomationErrorRateThreshold > 0 {
+			errorRateThreshold = cfg.CLIAutomationErrorRateThreshold
+		}
+		if cfg.CLIAutomationErrorRateMin > 0 {
+			errorRateMinRequests = cfg.CLIAutomationErrorRateMin
+		}
+		if cfg.CLIAutomationErrorRateWindow > 0 {
+			errorRateWindow = cfg.CLIAutomationErrorRateWindow
+		}
+		if cfg.CLIAutomationLockoutDuration > 0 {
+			lockoutDuration = cfg.CLIAutomationLockoutDuration
+		}
+	}
+
+	// Throttles (per session ID; stable cardinality).
+	identifier := "cli:" + strings.ToLower(sessionID)
+	if ok, remaining, resetAt, err := rateRepo.CheckFixedWindowRateLimit(ctx.Context(), identifier, "api_all_sustained", sustainedLimit, sustainedWindow); err != nil {
+		logger.Debug("cli sustained throttle check failed - allowing request", zap.Error(err))
+	} else if !ok {
+		return cliRateLimitedResponse("cli sustained rate limit exceeded", sustainedLimit, remaining, resetAt)
+	}
+
+	if ok, remaining, resetAt, err := rateRepo.CheckFixedWindowRateLimit(ctx.Context(), identifier, "api_all_burst", burstLimit, burstWindow); err != nil {
+		logger.Debug("cli burst throttle check failed - allowing request", zap.Error(err))
+	} else if !ok {
+		return cliRateLimitedResponse("cli burst rate limit exceeded", burstLimit, remaining, resetAt)
+	}
+
+	if lease, err := acquireCLIAutomationConcurrencyLease(ctx.Context(), repos.GetDB(), sessionID, concurrencyLimit, agentConcurrencyLeaseDuration); err != nil {
+		if errors.Is(err, errAgentConcurrencyExceeded) {
+			return cliTooManyRequestsResponse("cli concurrency limit exceeded", 1)
+		}
+		logger.Debug("cli concurrency check failed - allowing request", zap.Error(err))
+	} else if lease != nil {
+		defer lease.release(ctx.Context(), repos.GetDB())
+	}
+
+	resp, handlerErr := next(ctx)
+
+	maybeApplyCLIAutomationErrorRateLockout(ctx, rateRepo, sessionID, resp, handlerErr, errorRateThreshold, errorRateMinRequests, errorRateWindow, lockoutDuration)
+
+	return resp, handlerErr
+}
+
+func rejectLockedCLIAutomation(ctx *apptheory.Context, rateRepo *storageRepos.RateLimitRepository, sessionID string) (*apptheory.Response, error) {
+	if ctx == nil || rateRepo == nil {
+		return nil, nil
+	}
+
+	locked, unlockAt, err := rateRepo.IsRateLimited(ctx.Context(), cliAutomationLockoutIdentifier(sessionID))
+	if err != nil || !locked {
+		return nil, nil
+	}
+
+	retryAfter := ceilSeconds(time.Until(unlockAt))
+	resp, respErr := apptheory.JSON(http.StatusTooManyRequests, map[string]any{
+		"error":             "cli_locked",
+		"error_description": "cli session is temporarily locked",
+		"unlock_time":       unlockAt.Format(time.RFC3339),
+	})
+	if resp != nil {
+		attachRateLimitHeaders(resp, rateLimitHeaders{
+			retryAfterSeconds: retryAfter,
+		})
+	}
+	return resp, respErr
+}
+
+func maybeApplyCLIAutomationErrorRateLockout(ctx *apptheory.Context, rateRepo *storageRepos.RateLimitRepository, sessionID string, resp *apptheory.Response, handlerErr error, threshold float64, minRequests int, window time.Duration, lockoutDuration time.Duration) {
+	if ctx == nil || rateRepo == nil || strings.TrimSpace(sessionID) == "" {
+		return
+	}
+
+	if threshold <= 0 {
+		threshold = cliAutomationDefaultErrorRateThresh
+	}
+	if minRequests <= 0 {
+		minRequests = cliAutomationDefaultErrorRateMin
+	}
+	if window <= 0 {
+		window = cliAutomationDefaultErrorRateWindow
+	}
+	if lockoutDuration <= 0 {
+		lockoutDuration = cliAutomationDefaultLockoutDuration
+	}
+
+	isError := handlerErr != nil || (resp != nil && resp.Status >= 400)
+	_ = rateRepo.CheckAPIRateLimit(ctx.Context(), "cli:"+sessionID, "cli_request_total", agentErrorRateCounterCap, window)
+	if !isError {
+		return
+	}
+
+	_ = rateRepo.CheckAPIRateLimit(ctx.Context(), "cli:"+sessionID, "cli_request_error", agentErrorRateCounterCap, window)
+
+	totalRemaining, _, _ := rateRepo.GetAPIRateLimitInfo(ctx.Context(), "cli:"+sessionID, "cli_request_total", agentErrorRateCounterCap, window)
+	errorRemaining, _, _ := rateRepo.GetAPIRateLimitInfo(ctx.Context(), "cli:"+sessionID, "cli_request_error", agentErrorRateCounterCap, window)
+
+	totalCount := agentErrorRateCounterCap - totalRemaining
+	errorCount := agentErrorRateCounterCap - errorRemaining
+
+	if totalCount < minRequests || totalCount <= 0 {
+		return
+	}
+
+	errorRate := float64(errorCount) / float64(totalCount)
+	if errorRate > threshold {
+		_ = rateRepo.ImposeLockout(ctx.Context(), cliAutomationLockoutIdentifier(sessionID), lockoutDuration)
+	}
+}
+
+type rateLimitHeaders struct {
+	limit             int
+	remaining         int
+	resetTimeUnix     int64
+	retryAfterSeconds int
+}
+
+func attachRateLimitHeaders(resp *apptheory.Response, hdr rateLimitHeaders) {
+	if resp == nil {
+		return
+	}
+	if resp.Headers == nil {
+		resp.Headers = map[string][]string{}
+	}
+
+	if hdr.limit > 0 {
+		resp.Headers["x-ratelimit-limit"] = []string{strconv.Itoa(hdr.limit)}
+	}
+	resp.Headers["x-ratelimit-remaining"] = []string{strconv.Itoa(maxInt(0, hdr.remaining))}
+	if hdr.resetTimeUnix > 0 {
+		resp.Headers["x-ratelimit-reset"] = []string{strconv.FormatInt(hdr.resetTimeUnix, 10)}
+	}
+	if hdr.retryAfterSeconds > 0 {
+		resp.Headers["retry-after"] = []string{strconv.Itoa(hdr.retryAfterSeconds)}
+	}
+}
+
+func cliRateLimitedResponse(description string, limit int, remaining int, resetAt time.Time) (*apptheory.Response, error) {
+	retryAfter := ceilSeconds(time.Until(resetAt))
+	resp, err := apptheory.JSON(http.StatusTooManyRequests, map[string]any{
+		"error":             "too_many_requests",
+		"error_description": description,
+		"limit":             limit,
+		"remaining":         maxInt(0, remaining),
+		"reset_at":          resetAt.Unix(),
+		"retry_after":       retryAfter,
+	})
+	if resp != nil {
+		attachRateLimitHeaders(resp, rateLimitHeaders{
+			limit:             limit,
+			remaining:         remaining,
+			resetTimeUnix:     resetAt.Unix(),
+			retryAfterSeconds: retryAfter,
+		})
+	}
+	return resp, err
+}
+
+func cliTooManyRequestsResponse(description string, retryAfterSeconds int) (*apptheory.Response, error) {
+	if retryAfterSeconds <= 0 {
+		retryAfterSeconds = 1
+	}
+	resp, err := apptheory.JSON(http.StatusTooManyRequests, map[string]any{
+		"error":             "too_many_requests",
+		"error_description": description,
+		"retry_after":       retryAfterSeconds,
+	})
+	if resp != nil {
+		attachRateLimitHeaders(resp, rateLimitHeaders{
+			retryAfterSeconds: retryAfterSeconds,
+		})
+	}
+	return resp, err
+}
+
+func ceilSeconds(d time.Duration) int {
+	if d <= 0 {
+		return 1
+	}
+	seconds := int(d / time.Second)
+	if d%time.Second != 0 {
+		seconds++
+	}
+	if seconds < 1 {
+		return 1
+	}
+	return seconds
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 func safeRateLimitRepo(repos core.RepositoryStorage) (repo *storageRepos.RateLimitRepository) {

--- a/cmd/api/agent_safety_middleware_round13_test.go
+++ b/cmd/api/agent_safety_middleware_round13_test.go
@@ -10,6 +10,7 @@ import (
 	apiHandlers "github.com/equaltoai/lesser/cmd/api/handlers"
 	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/config"
+	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
 	storageRepos "github.com/equaltoai/lesser/pkg/storage/repositories"
 	"github.com/golang-jwt/jwt/v5"
@@ -68,6 +69,37 @@ func newConcurrencyDB(t *testing.T) (*tablemocks.MockDB, *tablemocks.MockQuery, 
 	q.On("Delete").Return(nil).Maybe()
 
 	return db, q, update
+}
+
+func newRateLimitRepoForCLISafety(t *testing.T) (*storageRepos.RateLimitRepository, *tablemocks.MockUpdateBuilder) {
+	t.Helper()
+
+	db := new(tablemocks.MockDB)
+	q := new(tablemocks.MockQuery)
+	update := new(tablemocks.MockUpdateBuilder)
+
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.Anything).Return(q).Maybe()
+	q.On("WithContext", mock.Anything).Return(q).Maybe()
+	q.On("Index", mock.Anything).Return(q).Maybe()
+	q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q).Maybe()
+	q.On("OrderBy", mock.Anything, mock.Anything).Return(q).Maybe()
+	q.On("Limit", mock.Anything).Return(q).Maybe()
+	q.On("Cursor", mock.Anything).Return(q).Maybe()
+	q.On("ConsistentRead").Return(q).Maybe()
+	q.On("UpdateBuilder").Return(update).Maybe()
+
+	update.On("Set", mock.Anything, mock.Anything).Return(update).Maybe()
+	update.On("SetIfNotExists", mock.Anything, mock.Anything, mock.Anything).Return(update).Maybe()
+	update.On("Increment", mock.Anything).Return(update).Maybe()
+	update.On("ReturnValues", mock.Anything).Return(update).Maybe()
+
+	// Default: treat reads as not found and allow writes.
+	q.On("First", mock.Anything).Return(dynamormErrors.ErrItemNotFound).Maybe()
+	q.On("Create").Return(nil).Maybe()
+	q.On("Delete").Return(nil).Maybe()
+
+	return storageRepos.NewRateLimitRepository(db, "test-table", zap.NewNop(), nil), update
 }
 
 func TestCreateOptionalOAuthAuthMiddleware_Round13(t *testing.T) {
@@ -242,6 +274,102 @@ func TestCreateAgentSafetyRailsMiddleware_Round13(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, called)
 		require.Equal(t, http.StatusOK, resp.Status)
+	})
+
+	t.Run("cli tokens are throttled with retry-after + x-ratelimit headers", func(t *testing.T) {
+		rateRepo, update := newRateLimitRepoForCLISafety(t)
+		update.On("ExecuteWithResult", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+			limit := args.Get(0).(*storageModels.APIRateLimit)
+			limit.Count = 61 // sustained default (60) exceeded
+		}).Once()
+
+		repos := &apiHandlers.MockRepositoryStorage{}
+		repos.On("RateLimit").Return(rateRepo).Maybe()
+		repos.On("GetDB").Return((*tablemocks.MockDB)(nil)).Maybe()
+
+		mw := createAgentSafetyRailsMiddleware(cfg, repos, zap.NewNop())
+
+		ctx := &apptheory.Context{Request: apptheory.Request{Method: http.MethodGet, Path: "/api/v1/timelines/home"}}
+		ctx.Set("claims", &auth.Claims{ClientClass: auth.ClientClassCLI, SessionID: "sid-1"})
+
+		called := false
+		resp, err := mw(func(*apptheory.Context) (*apptheory.Response, error) {
+			called = true
+			return apptheory.Text(http.StatusOK, "ok"), nil
+		})(ctx)
+		require.NoError(t, err)
+		require.False(t, called)
+		require.Equal(t, http.StatusTooManyRequests, resp.Status)
+		require.Equal(t, "60", resp.Headers["x-ratelimit-limit"][0])
+		require.NotEmpty(t, resp.Headers["x-ratelimit-reset"][0])
+		require.NotEmpty(t, resp.Headers["retry-after"][0])
+	})
+
+	t.Run("cli tokens enforce burst throttle after sustained passes", func(t *testing.T) {
+		rateRepo, update := newRateLimitRepoForCLISafety(t)
+
+		callCount := 0
+		update.On("ExecuteWithResult", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+			callCount++
+			limit := args.Get(0).(*storageModels.APIRateLimit)
+			switch callCount {
+			case 1:
+				limit.Count = 1 // sustained ok
+			default:
+				limit.Count = 21 // burst default (20) exceeded
+			}
+		}).Twice()
+
+		repos := &apiHandlers.MockRepositoryStorage{}
+		repos.On("RateLimit").Return(rateRepo).Maybe()
+		repos.On("GetDB").Return((*tablemocks.MockDB)(nil)).Maybe()
+
+		mw := createAgentSafetyRailsMiddleware(cfg, repos, zap.NewNop())
+
+		ctx := &apptheory.Context{Request: apptheory.Request{Method: http.MethodGet, Path: "/api/v1/timelines/home"}}
+		ctx.Set("claims", &auth.Claims{ClientClass: auth.ClientClassCLI, SessionID: "sid-2"})
+
+		called := false
+		resp, err := mw(func(*apptheory.Context) (*apptheory.Response, error) {
+			called = true
+			return apptheory.Text(http.StatusOK, "ok"), nil
+		})(ctx)
+		require.NoError(t, err)
+		require.False(t, called)
+		require.Equal(t, http.StatusTooManyRequests, resp.Status)
+		require.Equal(t, "20", resp.Headers["x-ratelimit-limit"][0])
+		require.NotEmpty(t, resp.Headers["retry-after"][0])
+	})
+
+	t.Run("cli tokens return 429 when concurrency exceeded", func(t *testing.T) {
+		rateRepo, update := newRateLimitRepoForCLISafety(t)
+		update.On("ExecuteWithResult", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+			limit := args.Get(0).(*storageModels.APIRateLimit)
+			limit.Count = 1
+		}).Twice()
+
+		concurrencyDB, q, updateConcurrency := newConcurrencyDB(t)
+		q.On("Create").Return(dynamormErrors.ErrConditionFailed).Twice()
+		updateConcurrency.On("Execute").Return(dynamormErrors.ErrConditionFailed).Twice()
+
+		repos := &apiHandlers.MockRepositoryStorage{}
+		repos.On("RateLimit").Return(rateRepo).Maybe()
+		repos.On("GetDB").Return(concurrencyDB).Maybe()
+
+		mw := createAgentSafetyRailsMiddleware(cfg, repos, zap.NewNop())
+
+		ctx := &apptheory.Context{Request: apptheory.Request{Method: http.MethodPost, Path: "/api/v1/statuses"}}
+		ctx.Set("claims", &auth.Claims{ClientClass: auth.ClientClassCLI, SessionID: "sid-3"})
+
+		called := false
+		resp, err := mw(func(*apptheory.Context) (*apptheory.Response, error) {
+			called = true
+			return apptheory.Text(http.StatusOK, "ok"), nil
+		})(ctx)
+		require.NoError(t, err)
+		require.False(t, called)
+		require.Equal(t, http.StatusTooManyRequests, resp.Status)
+		require.Equal(t, "1", resp.Headers["retry-after"][0])
 	})
 
 	t.Run("returns 429 when concurrency exceeded", func(t *testing.T) {

--- a/cmd/graphql-ws/main.go
+++ b/cmd/graphql-ws/main.go
@@ -1011,8 +1011,30 @@ func initializeResolver() (*graph.Resolver, *executor.Executor) {
 		if cfg.GraphQLParserTokenLimit > 0 {
 			exec.SetParserTokenLimit(cfg.GraphQLParserTokenLimit)
 		}
+		// Depth enforcement: agents and CLI automation tokens are restricted to shallow queries (max depth 3),
+		// humans use configured depth.
 		if cfg.GraphQLMaxDepth > 0 {
-			exec.Use(gqllimits.FixedDepthLimit(cfg.GraphQLMaxDepth))
+			exec.Use(&gqllimits.DepthLimit{
+				Func: func(ctx context.Context, _ *graphql.OperationContext) int {
+					if claimsVal := ctx.Value(common.ContextKeyClaims); claimsVal != nil {
+						if claims, ok := claimsVal.(*auth.Claims); ok && (claims.IsAgent || strings.EqualFold(claims.ClientClass, auth.ClientClassCLI)) {
+							return 3
+						}
+					}
+					return cfg.GraphQLMaxDepth
+				},
+			})
+		} else {
+			exec.Use(&gqllimits.DepthLimit{
+				Func: func(ctx context.Context, _ *graphql.OperationContext) int {
+					if claimsVal := ctx.Value(common.ContextKeyClaims); claimsVal != nil {
+						if claims, ok := claimsVal.(*auth.Claims); ok && (claims.IsAgent || strings.EqualFold(claims.ClientClass, auth.ClientClassCLI)) {
+							return 3
+						}
+					}
+					return 0
+				},
+			})
 		}
 		if cfg.GraphQLMaxComplexity > 0 {
 			exec.Use(extension.FixedComplexityLimit(cfg.GraphQLMaxComplexity))

--- a/cmd/graphql/main.go
+++ b/cmd/graphql/main.go
@@ -342,12 +342,13 @@ func initializeGraphQLSpecificServices() {
 	if cfg.GraphQLParserTokenLimit > 0 {
 		server.SetParserTokenLimit(cfg.GraphQLParserTokenLimit)
 	}
-	// Depth enforcement: agents are restricted to shallow queries (max depth 3), humans use configured depth.
+	// Depth enforcement: agents and CLI automation tokens are restricted to shallow queries (max depth 3),
+	// humans use configured depth.
 	if cfg.GraphQLMaxDepth > 0 {
 		server.Use(&gqllimits.DepthLimit{
 			Func: func(ctx context.Context, _ *graphql.OperationContext) int {
 				if claimsVal := ctx.Value(common.ContextKeyClaims); claimsVal != nil {
-					if claims, ok := claimsVal.(*auth.Claims); ok && claims.IsAgent {
+					if claims, ok := claimsVal.(*auth.Claims); ok && (claims.IsAgent || strings.EqualFold(claims.ClientClass, auth.ClientClassCLI)) {
 						return 3
 					}
 				}
@@ -359,7 +360,7 @@ func initializeGraphQLSpecificServices() {
 		server.Use(&gqllimits.DepthLimit{
 			Func: func(ctx context.Context, _ *graphql.OperationContext) int {
 				if claimsVal := ctx.Value(common.ContextKeyClaims); claimsVal != nil {
-					if claims, ok := claimsVal.(*auth.Claims); ok && claims.IsAgent {
+					if claims, ok := claimsVal.(*auth.Claims); ok && (claims.IsAgent || strings.EqualFold(claims.ClientClass, auth.ClientClassCLI)) {
 						return 3
 					}
 				}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -103,6 +103,17 @@ type Config struct {
 	AllowAgentRegistration bool  // Whether new agent accounts can be registered/delegated
 	AllowDeviceFlow        bool  // Whether OAuth device authorization is enabled
 
+	// CLI automation safety rails (device-flow tokens classified as client_class=cli)
+	CLIAutomationConcurrencyLimit   int           // Max concurrent in-flight requests per CLI session (sid)
+	CLIAutomationBurstLimit         int           // Burst requests allowed per window
+	CLIAutomationBurstWindow        time.Duration // Burst window duration
+	CLIAutomationSustainedLimit     int           // Sustained requests allowed per window
+	CLIAutomationSustainedWindow    time.Duration // Sustained window duration
+	CLIAutomationErrorRateThreshold float64       // Fraction of requests in window that may be errors before lockout
+	CLIAutomationErrorRateMin       int           // Minimum requests in window before error-rate lockout can trigger
+	CLIAutomationErrorRateWindow    time.Duration // Error-rate evaluation window
+	CLIAutomationLockoutDuration    time.Duration // Lockout duration when error-rate threshold exceeded
+
 	// CMS Configuration
 	CMSLongFormPublishingEnabled  bool // Enable Article creation and CMS reads
 	CMSDraftSystemEnabled         bool // Enable draft storage and editing workflows
@@ -344,12 +355,21 @@ func loadConfig() *Config {
 		Argon2Threads: getEnvAsUint8OrDefault("ARGON2_THREADS", 4),
 		Argon2KeyLen:  getEnvAsUint32OrDefault("ARGON2_KEY_LENGTH", 32),
 
-		MaxUploadSize:          getEnvAsInt64OrDefault("MAX_UPLOAD_SIZE", 10*1024*1024), // 10MB default
-		PageSize:               getEnvAsIntOrDefault("PAGE_SIZE", 20),
-		AllowRegistration:      getEnvAsBoolOrDefault("ALLOW_REGISTRATION", false),
-		AllowAgents:            getEnvAsBoolOrDefault("ALLOW_AGENTS", false),
-		AllowAgentRegistration: getEnvAsBoolOrDefault("ALLOW_AGENT_REGISTRATION", false),
-		AllowDeviceFlow:        getEnvAsBoolOrDefault("ALLOW_DEVICE_FLOW", false),
+		MaxUploadSize:                   getEnvAsInt64OrDefault("MAX_UPLOAD_SIZE", 10*1024*1024), // 10MB default
+		PageSize:                        getEnvAsIntOrDefault("PAGE_SIZE", 20),
+		AllowRegistration:               getEnvAsBoolOrDefault("ALLOW_REGISTRATION", false),
+		AllowAgents:                     getEnvAsBoolOrDefault("ALLOW_AGENTS", false),
+		AllowAgentRegistration:          getEnvAsBoolOrDefault("ALLOW_AGENT_REGISTRATION", false),
+		AllowDeviceFlow:                 getEnvAsBoolOrDefault("ALLOW_DEVICE_FLOW", false),
+		CLIAutomationConcurrencyLimit:   getEnvAsIntOrDefault("CLI_AUTOMATION_CONCURRENCY_LIMIT", 2),
+		CLIAutomationBurstLimit:         getEnvAsIntOrDefault("CLI_AUTOMATION_BURST_LIMIT", 20),
+		CLIAutomationBurstWindow:        getEnvAsDurationOrDefault("CLI_AUTOMATION_BURST_WINDOW", 10*time.Second),
+		CLIAutomationSustainedLimit:     getEnvAsIntOrDefault("CLI_AUTOMATION_SUSTAINED_LIMIT", 60),
+		CLIAutomationSustainedWindow:    getEnvAsDurationOrDefault("CLI_AUTOMATION_SUSTAINED_WINDOW", time.Minute),
+		CLIAutomationErrorRateThreshold: getEnvAsFloat64OrDefault("CLI_AUTOMATION_ERROR_RATE_THRESHOLD", 0.10),
+		CLIAutomationErrorRateMin:       getEnvAsIntOrDefault("CLI_AUTOMATION_ERROR_RATE_MIN_REQUESTS", 10),
+		CLIAutomationErrorRateWindow:    getEnvAsDurationOrDefault("CLI_AUTOMATION_ERROR_RATE_WINDOW", time.Minute),
+		CLIAutomationLockoutDuration:    getEnvAsDurationOrDefault("CLI_AUTOMATION_LOCKOUT_DURATION", time.Hour),
 
 		// CMS Configuration
 		CMSLongFormPublishingEnabled:  getEnvAsBoolOrDefault("CMS_LONG_FORM_PUBLISHING_ENABLED", cmsEnabledByMode),
@@ -739,6 +759,18 @@ func getEnvAsUint8OrDefault(key string, defaultValue uint8) uint8 {
 	}
 	var result uint8
 	if _, err := fmt.Sscanf(value, "%d", &result); err != nil {
+		return defaultValue
+	}
+	return result
+}
+
+func getEnvAsFloat64OrDefault(key string, defaultValue float64) float64 {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	var result float64
+	if _, err := fmt.Sscanf(value, "%f", &result); err != nil {
 		return defaultValue
 	}
 	return result

--- a/pkg/storage/repositories/rate_limit_repository.go
+++ b/pkg/storage/repositories/rate_limit_repository.go
@@ -423,6 +423,72 @@ func (r *RateLimitRepository) GetAPIRateLimitInfo(ctx context.Context, userID, e
 	return r.getRateLimitInfo(ctx, key, limit, window, logContext)
 }
 
+// CheckFixedWindowRateLimit atomically increments a counter for a fixed time window and returns the rate limit state.
+//
+// Unlike CheckAPIRateLimit, this helper does not apply escalating penalties or record violations. It is intended
+// for strict, predictable throttles (e.g., automation safety rails).
+//
+// Fail-open: storage errors are returned to the caller to decide policy; callers should generally allow the request
+// rather than failing user traffic due to rate limit storage outages.
+func (r *RateLimitRepository) CheckFixedWindowRateLimit(ctx context.Context, identifier, bucket string, limit int, window time.Duration) (allowed bool, remaining int, resetTime time.Time, err error) {
+	if r == nil || r.db == nil {
+		return true, limit, time.Time{}, nil
+	}
+
+	identifier = strings.TrimSpace(identifier)
+	bucket = strings.TrimSpace(bucket)
+	if identifier == "" || bucket == "" || limit <= 0 {
+		return true, limit, time.Time{}, nil
+	}
+	if window <= 0 {
+		window = time.Minute
+	}
+
+	now := time.Now().UTC()
+	windowStart := now.Truncate(window)
+	resetTime = windowStart.Add(window)
+
+	key := fmt.Sprintf("%s:%s", identifier, bucket)
+	pk := fmt.Sprintf("RATELIMIT#%s", key)
+	sk := fmt.Sprintf("WINDOW#%s", windowStart.Format(time.RFC3339))
+
+	ttl := resetTime.Add(24 * time.Hour).Unix()
+
+	current := &models.APIRateLimit{PK: pk, SK: sk}
+	update := r.db.Model(current).WithContext(ctx).UpdateBuilder().
+		SetIfNotExists("Type", nil, "APIRateLimit").
+		SetIfNotExists("UserID", nil, identifier).
+		SetIfNotExists("Endpoint", nil, bucket).
+		SetIfNotExists("Window", nil, windowStart).
+		Set("UpdatedAt", now).
+		Set("TTL", ttl).
+		Increment("Count").
+		ReturnValues("ALL_NEW")
+
+	if execErr := update.ExecuteWithResult(current); execErr != nil {
+		return true, limit, resetTime, execErr
+	}
+
+	// Some executors may not support returning results; fall back to a read for the updated count.
+	if current.Count <= 0 && r.apiRateLimits != nil {
+		fetched := &models.APIRateLimit{}
+		if getErr := r.apiRateLimits.Get(ctx, pk, sk, fetched); getErr != nil {
+			return true, limit, resetTime, getErr
+		}
+		current = fetched
+	}
+
+	if current.Count <= limit {
+		allowed = true
+		remaining = limit - current.Count
+	} else {
+		allowed = false
+		remaining = 0
+	}
+
+	return allowed, remaining, resetTime, nil
+}
+
 // updateAPIRateLimit updates an API rate limit record using BaseRepository
 func (r *RateLimitRepository) updateAPIRateLimit(ctx context.Context, limit *models.APIRateLimit) error {
 	// Use BaseRepository Create method which acts like PUT in DynamoDB


### PR DESCRIPTION
Implements M4 from `docs/planning/lesser-cli-auth-device-flow-roadmap.md`.

- Adds config knobs for CLI automation rails (concurrency, burst/sustained throttles, error-rate lockout).
- Extends agent safety middleware to apply to `client_class=cli` tokens (keyed by `sid`).
- Enforces GraphQL depth=3 for CLI tokens (same as agents).
- Adds fixed-window rate limiting helper + unit tests.

Verification: `go test ./...`
