### PR TITLE
M5: CLI auth (device flow) + encrypted session store

### DIFF
--- a/cmd/lesser/auth_cmd.go
+++ b/cmd/lesser/auth_cmd.go
@@ -1,0 +1,438 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+func runAuth(argv []string) error {
+	if len(argv) == 0 {
+		printUsage()
+		return nil
+	}
+
+	switch argv[0] {
+	case helpFlagShort, helpFlagLong, helpCommand:
+		printUsage()
+		return nil
+	case "login":
+		return runAuthLogin(argv[1:])
+	case "logout":
+		return runAuthLogout(argv[1:])
+	case "status":
+		return runAuthStatus(argv[1:])
+	case "whoami":
+		return runAuthWhoami(argv[1:])
+	case "device":
+		return runAuthDevice(argv[1:])
+	default:
+		if argv[0] != "" && argv[0][0] == '-' {
+			printUsage()
+			return nil
+		}
+		return fmt.Errorf("unknown auth command %q", argv[0])
+	}
+}
+
+type authFlags struct {
+	BaseURL     string
+	Scopes      string
+	SecretFile  string
+	Debug       bool
+	JSON        bool
+	ClientID    string
+	DeviceCode  string
+	ExpiresIn   int
+	PollSeconds int
+}
+
+func (a *authFlags) debugf(format string, args ...any) {
+	if a == nil || !a.Debug {
+		return
+	}
+	_, _ = fmt.Fprintf(os.Stderr, "debug: "+format+"\n", args...)
+}
+
+func runAuthLogin(argv []string) error {
+	fs := flag.NewFlagSet("lesser auth login", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	var args authFlags
+	fs.StringVar(&args.BaseURL, "base-url", os.Getenv("LESSER_BASE_URL"), "instance base url (env: LESSER_BASE_URL)")
+	fs.StringVar(&args.Scopes, "scopes", envOrDefault("LESSER_OAUTH_SCOPES", "read write follow push"), "oauth scopes (env: LESSER_OAUTH_SCOPES)")
+	fs.StringVar(&args.SecretFile, "secret-file", os.Getenv("LESSER_AUTH_SECRET_FILE"), "path to auth secret file (env: LESSER_AUTH_SECRET_FILE)")
+	fs.BoolVar(&args.Debug, "debug", false, "enable debug logging (never prints tokens)")
+	fs.BoolVar(&args.JSON, "json", false, "print device login instructions as json (never prints tokens)")
+
+	if err := fs.Parse(argv); err != nil {
+		return err
+	}
+
+	baseURL, err := normalizeBaseURL(args.BaseURL)
+	if err != nil {
+		return err
+	}
+
+	secret, err := readAuthSecret(args.SecretFile)
+	if err != nil {
+		return err
+	}
+	key := deriveAuthKey(baseURL, secret)
+
+	clientID, err := getOrCreateOAuthClientID(context.Background(), baseURL, args.Scopes, key, &args)
+	if err != nil {
+		return err
+	}
+
+	deviceResp, err := startDeviceAuthorization(context.Background(), baseURL, clientID, args.Scopes)
+	if err != nil {
+		return err
+	}
+
+	if args.JSON {
+		out := map[string]any{
+			"verification_uri":          deviceResp.VerificationURI,
+			"verification_uri_complete": deviceResp.VerificationURIComplete,
+			"user_code":                 deviceResp.UserCode,
+			"expires_in":                deviceResp.ExpiresIn,
+			"interval":                  deviceResp.Interval,
+		}
+		return json.NewEncoder(os.Stdout).Encode(out)
+	}
+
+	fmt.Println("Complete device login in your browser:")
+	if strings.TrimSpace(deviceResp.VerificationURIComplete) != "" {
+		fmt.Println("  ", deviceResp.VerificationURIComplete)
+	} else {
+		fmt.Println("  ", deviceResp.VerificationURI)
+		fmt.Println("  Code:", deviceResp.UserCode)
+	}
+
+	pollInterval := time.Duration(deviceResp.Interval) * time.Second
+	if pollInterval <= 0 {
+		pollInterval = 10 * time.Second
+	}
+
+	tokenResp, err := pollDeviceToken(context.Background(), baseURL, clientID, deviceResp.DeviceCode, pollInterval, time.Duration(deviceResp.ExpiresIn)*time.Second, &args)
+	if err != nil {
+		return err
+	}
+
+	username, scopes, err := resolveViewerAndScopes(context.Background(), baseURL, tokenResp.AccessToken, tokenResp.Scope)
+	if err != nil {
+		return err
+	}
+
+	session := &cliAuthSession{
+		Version:      cliAuthSessionVersion,
+		BaseURL:      baseURL,
+		ClientID:     clientID,
+		RefreshToken: tokenResp.RefreshToken,
+		Username:     username,
+		Scopes:       scopes,
+		CreatedAt:    time.Now().UTC(),
+		UpdatedAt:    time.Now().UTC(),
+	}
+	if err := writeAuthSession(baseURL, key, session); err != nil {
+		return err
+	}
+
+	fmt.Printf("Authenticated as @%s on %s\n", username, baseURL)
+	return nil
+}
+
+func runAuthLogout(argv []string) error {
+	fs := flag.NewFlagSet("lesser auth logout", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	var baseURL string
+	fs.StringVar(&baseURL, "base-url", os.Getenv("LESSER_BASE_URL"), "instance base url (env: LESSER_BASE_URL)")
+	if err := fs.Parse(argv); err != nil {
+		return err
+	}
+
+	baseURL, err := normalizeBaseURL(baseURL)
+	if err != nil {
+		return err
+	}
+
+	removed, err := deleteAuthSession(baseURL)
+	if err != nil {
+		return err
+	}
+	if !removed {
+		fmt.Printf("No session found for %s\n", baseURL)
+		return nil
+	}
+
+	fmt.Printf("Logged out from %s\n", baseURL)
+	return nil
+}
+
+func runAuthStatus(argv []string) error {
+	fs := flag.NewFlagSet("lesser auth status", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	var args authFlags
+	fs.StringVar(&args.BaseURL, "base-url", os.Getenv("LESSER_BASE_URL"), "instance base url (env: LESSER_BASE_URL)")
+	fs.StringVar(&args.SecretFile, "secret-file", os.Getenv("LESSER_AUTH_SECRET_FILE"), "path to auth secret file (env: LESSER_AUTH_SECRET_FILE)")
+	fs.BoolVar(&args.Debug, "debug", false, "enable debug logging (never prints tokens)")
+
+	if err := fs.Parse(argv); err != nil {
+		return err
+	}
+
+	baseURL, err := normalizeBaseURL(args.BaseURL)
+	if err != nil {
+		return err
+	}
+
+	secret, err := readAuthSecret(args.SecretFile)
+	if err != nil {
+		return err
+	}
+	key := deriveAuthKey(baseURL, secret)
+
+	session, err := readAuthSession(baseURL, key)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Printf("Not logged in to %s\n", baseURL)
+			return nil
+		}
+		return err
+	}
+
+	fmt.Printf("Logged in to %s as @%s\n", baseURL, session.Username)
+	if len(session.Scopes) > 0 {
+		fmt.Println("Scopes:", strings.Join(session.Scopes, " "))
+	}
+	return nil
+}
+
+func runAuthWhoami(argv []string) error {
+	fs := flag.NewFlagSet("lesser auth whoami", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	var args authFlags
+	fs.StringVar(&args.BaseURL, "base-url", os.Getenv("LESSER_BASE_URL"), "instance base url (env: LESSER_BASE_URL)")
+	fs.StringVar(&args.SecretFile, "secret-file", os.Getenv("LESSER_AUTH_SECRET_FILE"), "path to auth secret file (env: LESSER_AUTH_SECRET_FILE)")
+	fs.BoolVar(&args.Debug, "debug", false, "enable debug logging (never prints tokens)")
+
+	if err := fs.Parse(argv); err != nil {
+		return err
+	}
+
+	baseURL, err := normalizeBaseURL(args.BaseURL)
+	if err != nil {
+		return err
+	}
+
+	secret, err := readAuthSecret(args.SecretFile)
+	if err != nil {
+		return err
+	}
+	key := deriveAuthKey(baseURL, secret)
+
+	session, err := readAuthSession(baseURL, key)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("not logged in to %s (run: lesser auth login --base-url %s)", baseURL, baseURL)
+		}
+		return err
+	}
+
+	tokenResp, err := refreshAccessToken(context.Background(), baseURL, session.ClientID, session.RefreshToken)
+	if err != nil {
+		return err
+	}
+
+	username, scopes, err := resolveViewerAndScopes(context.Background(), baseURL, tokenResp.AccessToken, tokenResp.Scope)
+	if err != nil {
+		return err
+	}
+
+	updated := *session
+	updated.Username = username
+	updated.Scopes = scopes
+	if strings.TrimSpace(tokenResp.RefreshToken) != "" && tokenResp.RefreshToken != session.RefreshToken {
+		updated.RefreshToken = tokenResp.RefreshToken
+	}
+	updated.UpdatedAt = time.Now().UTC()
+	if err := writeAuthSession(baseURL, key, &updated); err != nil {
+		return err
+	}
+
+	fmt.Printf("@%s\n", username)
+	return nil
+}
+
+func runAuthDevice(argv []string) error {
+	if len(argv) == 0 {
+		printUsage()
+		return nil
+	}
+
+	switch argv[0] {
+	case helpFlagShort, helpFlagLong, helpCommand:
+		printUsage()
+		return nil
+	case "start":
+		return runAuthDeviceStart(argv[1:])
+	case "poll":
+		return runAuthDevicePoll(argv[1:])
+	default:
+		return fmt.Errorf("unknown auth device command %q", argv[0])
+	}
+}
+
+func runAuthDeviceStart(argv []string) error {
+	fs := flag.NewFlagSet("lesser auth device start", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	var args authFlags
+	fs.StringVar(&args.BaseURL, "base-url", os.Getenv("LESSER_BASE_URL"), "instance base url (env: LESSER_BASE_URL)")
+	fs.StringVar(&args.Scopes, "scopes", envOrDefault("LESSER_OAUTH_SCOPES", "read write follow push"), "oauth scopes (env: LESSER_OAUTH_SCOPES)")
+	fs.StringVar(&args.SecretFile, "secret-file", os.Getenv("LESSER_AUTH_SECRET_FILE"), "path to auth secret file (env: LESSER_AUTH_SECRET_FILE)")
+	fs.StringVar(&args.ClientID, "client-id", os.Getenv("LESSER_OAUTH_CLIENT_ID"), "oauth client id (env: LESSER_OAUTH_CLIENT_ID)")
+	fs.BoolVar(&args.Debug, "debug", false, "enable debug logging (never prints tokens)")
+	fs.BoolVar(&args.JSON, "json", false, "print json output (includes device_code)")
+
+	if err := fs.Parse(argv); err != nil {
+		return err
+	}
+
+	baseURL, err := normalizeBaseURL(args.BaseURL)
+	if err != nil {
+		return err
+	}
+
+	clientID := strings.TrimSpace(args.ClientID)
+	if clientID == "" {
+		secret, err := readAuthSecret(args.SecretFile)
+		if err != nil {
+			return err
+		}
+		key := deriveAuthKey(baseURL, secret)
+
+		clientID, err = getOrCreateOAuthClientID(context.Background(), baseURL, args.Scopes, key, &args)
+		if err != nil {
+			return err
+		}
+	}
+
+	deviceResp, err := startDeviceAuthorization(context.Background(), baseURL, clientID, args.Scopes)
+	if err != nil {
+		return err
+	}
+
+	if args.JSON {
+		out := map[string]any{
+			"base_url":                  baseURL,
+			"client_id":                 clientID,
+			"device_code":               deviceResp.DeviceCode,
+			"user_code":                 deviceResp.UserCode,
+			"verification_uri":          deviceResp.VerificationURI,
+			"verification_uri_complete": deviceResp.VerificationURIComplete,
+			"expires_in":                deviceResp.ExpiresIn,
+			"interval":                  deviceResp.Interval,
+		}
+		return json.NewEncoder(os.Stdout).Encode(out)
+	}
+
+	fmt.Println("Complete device login in your browser:")
+	if strings.TrimSpace(deviceResp.VerificationURIComplete) != "" {
+		fmt.Println("  ", deviceResp.VerificationURIComplete)
+	} else {
+		fmt.Println("  ", deviceResp.VerificationURI)
+		fmt.Println("  Code:", deviceResp.UserCode)
+	}
+	fmt.Println("Then run: lesser auth device poll --base-url", baseURL, "--client-id", clientID, "--device-code <device_code>")
+	return nil
+}
+
+func runAuthDevicePoll(argv []string) error {
+	fs := flag.NewFlagSet("lesser auth device poll", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	var args authFlags
+	fs.StringVar(&args.BaseURL, "base-url", os.Getenv("LESSER_BASE_URL"), "instance base url (env: LESSER_BASE_URL)")
+	fs.StringVar(&args.SecretFile, "secret-file", os.Getenv("LESSER_AUTH_SECRET_FILE"), "path to auth secret file (env: LESSER_AUTH_SECRET_FILE)")
+	fs.StringVar(&args.ClientID, "client-id", os.Getenv("LESSER_OAUTH_CLIENT_ID"), "oauth client id (env: LESSER_OAUTH_CLIENT_ID)")
+	fs.StringVar(&args.DeviceCode, "device-code", os.Getenv("LESSER_OAUTH_DEVICE_CODE"), "device code from start step (env: LESSER_OAUTH_DEVICE_CODE)")
+	fs.IntVar(&args.ExpiresIn, "expires-in", 10*60, "device code ttl seconds (default 600)")
+	fs.IntVar(&args.PollSeconds, "interval", 10, "poll interval seconds (default 10)")
+	fs.BoolVar(&args.Debug, "debug", false, "enable debug logging (never prints tokens)")
+	fs.BoolVar(&args.JSON, "json", false, "print json output (never prints tokens)")
+
+	if err := fs.Parse(argv); err != nil {
+		return err
+	}
+
+	baseURL, err := normalizeBaseURL(args.BaseURL)
+	if err != nil {
+		return err
+	}
+
+	clientID := strings.TrimSpace(args.ClientID)
+	if err := requireNonEmpty("client-id", clientID); err != nil {
+		return err
+	}
+
+	deviceCode := strings.TrimSpace(args.DeviceCode)
+	if err := requireNonEmpty("device-code", deviceCode); err != nil {
+		return err
+	}
+
+	secret, err := readAuthSecret(args.SecretFile)
+	if err != nil {
+		return err
+	}
+	key := deriveAuthKey(baseURL, secret)
+
+	interval := time.Duration(args.PollSeconds) * time.Second
+	if interval <= 0 {
+		interval = 10 * time.Second
+	}
+
+	tokenResp, err := pollDeviceToken(context.Background(), baseURL, clientID, deviceCode, interval, time.Duration(args.ExpiresIn)*time.Second, &args)
+	if err != nil {
+		return err
+	}
+
+	username, scopes, err := resolveViewerAndScopes(context.Background(), baseURL, tokenResp.AccessToken, tokenResp.Scope)
+	if err != nil {
+		return err
+	}
+
+	session := &cliAuthSession{
+		Version:      cliAuthSessionVersion,
+		BaseURL:      baseURL,
+		ClientID:     clientID,
+		RefreshToken: tokenResp.RefreshToken,
+		Username:     username,
+		Scopes:       scopes,
+		CreatedAt:    time.Now().UTC(),
+		UpdatedAt:    time.Now().UTC(),
+	}
+	if err := writeAuthSession(baseURL, key, session); err != nil {
+		return err
+	}
+
+	if args.JSON {
+		out := map[string]any{
+			"base_url":  baseURL,
+			"client_id": clientID,
+			"username":  username,
+			"scopes":    scopes,
+		}
+		return json.NewEncoder(os.Stdout).Encode(out)
+	}
+
+	fmt.Printf("Authenticated as @%s on %s\n", username, baseURL)
+	return nil
+}

--- a/cmd/lesser/auth_http.go
+++ b/cmd/lesser/auth_http.go
@@ -1,0 +1,296 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	apimodels "github.com/equaltoai/lesser/cmd/api/models"
+)
+
+const (
+	defaultAuthClientName    = "lesser cli"
+	defaultAuthRedirectURIs  = "urn:ietf:wg:oauth:2.0:oob"
+	defaultHTTPTimeout       = 15 * time.Second
+	defaultDevicePollBackoff = 5 * time.Second
+)
+
+func getOrCreateOAuthClientID(ctx context.Context, baseURL, scopes string, key []byte, flags *authFlags) (string, error) {
+	if flags == nil {
+		flags = &authFlags{}
+	}
+
+	// Prefer existing cached session's client_id (avoids registering an app each login).
+	if existing, err := readAuthSession(baseURL, key); err == nil && existing != nil {
+		if clientID := strings.TrimSpace(existing.ClientID); clientID != "" {
+			flags.debugf("reusing existing client_id")
+			return clientID, nil
+		}
+	}
+
+	flags.debugf("registering oauth app via /api/v1/apps")
+	clientID, err := registerOAuthApp(ctx, baseURL, scopes)
+	if err != nil {
+		return "", err
+	}
+	return clientID, nil
+}
+
+func registerOAuthApp(ctx context.Context, baseURL, scopes string) (string, error) {
+	form := url.Values{}
+	form.Set("client_name", defaultAuthClientName)
+	form.Set("redirect_uris", defaultAuthRedirectURIs)
+	form.Set("scopes", strings.TrimSpace(scopes))
+
+	var resp apimodels.AppRegistrationResponse
+	if err := doFormPOST(ctx, baseURL, "/api/v1/apps", form, &resp); err != nil {
+		return "", err
+	}
+	clientID := strings.TrimSpace(resp.ClientID)
+	if clientID == "" {
+		return "", fmt.Errorf("app registration response is missing client_id")
+	}
+	return clientID, nil
+}
+
+func startDeviceAuthorization(ctx context.Context, baseURL, clientID, scopes string) (*apimodels.OAuthDeviceCodeResponse, error) {
+	form := url.Values{}
+	form.Set("client_id", strings.TrimSpace(clientID))
+	if scope := strings.TrimSpace(scopes); scope != "" {
+		form.Set("scope", scope)
+	}
+
+	var resp apimodels.OAuthDeviceCodeResponse
+	if err := doFormPOST(ctx, baseURL, "/oauth/device/code", form, &resp); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(resp.DeviceCode) == "" || strings.TrimSpace(resp.UserCode) == "" {
+		return nil, fmt.Errorf("device code response missing required fields")
+	}
+	return &resp, nil
+}
+
+func pollDeviceToken(ctx context.Context, baseURL, clientID, deviceCode string, interval time.Duration, ttl time.Duration, flags *authFlags) (*apimodels.OAuthTokenResponse, error) {
+	if ttl <= 0 {
+		ttl = 10 * time.Minute
+	}
+
+	deadline := time.Now().Add(ttl)
+	nextInterval := interval
+	if nextInterval <= 0 {
+		nextInterval = 10 * time.Second
+	}
+
+	for {
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("device authorization timed out")
+		}
+
+		tokenResp, oauthErr, err := exchangeDeviceCodeForToken(ctx, baseURL, clientID, deviceCode)
+		if err != nil {
+			return nil, err
+		}
+		if tokenResp != nil {
+			return tokenResp, nil
+		}
+
+		code := strings.ToLower(strings.TrimSpace(oauthErr.Error))
+		if flags != nil {
+			flags.debugf("device poll error=%s", code)
+		}
+
+		switch code {
+		case "authorization_pending":
+			// Keep waiting.
+		case "slow_down":
+			nextInterval += defaultDevicePollBackoff
+		case "access_denied":
+			return nil, fmt.Errorf("device authorization denied")
+		case "expired_token":
+			return nil, fmt.Errorf("device code expired")
+		case "invalid_grant":
+			return nil, fmt.Errorf("device authorization invalid")
+		default:
+			msg := strings.TrimSpace(oauthErr.ErrorDescription)
+			if msg == "" {
+				msg = "oauth error"
+			}
+			return nil, fmt.Errorf("%s (%s)", msg, code)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(nextInterval):
+		}
+	}
+}
+
+func exchangeDeviceCodeForToken(ctx context.Context, baseURL, clientID, deviceCode string) (*apimodels.OAuthTokenResponse, *apimodels.OAuthErrorResponse, error) {
+	form := url.Values{}
+	form.Set("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
+	form.Set("device_code", strings.TrimSpace(deviceCode))
+	form.Set("client_id", strings.TrimSpace(clientID))
+
+	var resp apimodels.OAuthTokenResponse
+	err := doFormPOST(ctx, baseURL, "/oauth/token", form, &resp)
+	if err == nil {
+		return &resp, nil, nil
+	}
+
+	var oauthErr *oauthHTTPError
+	if errors.As(err, &oauthErr) {
+		return nil, &oauthErr.OAuth, nil
+	}
+
+	return nil, nil, err
+}
+
+func refreshAccessToken(ctx context.Context, baseURL, clientID, refreshToken string) (*apimodels.OAuthTokenResponse, error) {
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("client_id", strings.TrimSpace(clientID))
+	form.Set("refresh_token", strings.TrimSpace(refreshToken))
+
+	var resp apimodels.OAuthTokenResponse
+	if err := doFormPOST(ctx, baseURL, "/oauth/token", form, &resp); err != nil {
+		var oauthErr *oauthHTTPError
+		if errors.As(err, &oauthErr) {
+			code := strings.ToLower(strings.TrimSpace(oauthErr.OAuth.Error))
+			if code == "invalid_grant" {
+				return nil, fmt.Errorf("refresh token invalid; re-auth required")
+			}
+		}
+		return nil, err
+	}
+	return &resp, nil
+}
+
+type verifyCredentialsResponse struct {
+	Username string `json:"username"`
+}
+
+func resolveViewerAndScopes(ctx context.Context, baseURL, accessToken, scope string) (string, []string, error) {
+	var out verifyCredentialsResponse
+	if err := doGETJSON(ctx, baseURL, "/api/v1/accounts/verify_credentials", accessToken, &out); err != nil {
+		return "", nil, err
+	}
+
+	username := strings.TrimSpace(out.Username)
+	if username == "" {
+		return "", nil, fmt.Errorf("verify_credentials response missing username")
+	}
+
+	scopes := strings.Fields(strings.TrimSpace(scope))
+	if len(scopes) == 0 {
+		scopes = nil
+	}
+	return username, scopes, nil
+}
+
+type oauthHTTPError struct {
+	Status int
+	OAuth  apimodels.OAuthErrorResponse
+}
+
+func (e *oauthHTTPError) Error() string {
+	code := strings.TrimSpace(e.OAuth.Error)
+	desc := strings.TrimSpace(e.OAuth.ErrorDescription)
+	if desc == "" {
+		desc = "oauth error"
+	}
+	if code == "" {
+		return desc
+	}
+	return fmt.Sprintf("%s (%s)", desc, code)
+}
+
+func doFormPOST(ctx context.Context, baseURL, path string, form url.Values, out any) error {
+	client := &http.Client{Timeout: defaultHTTPTimeout}
+	endpoint := strings.TrimRight(baseURL, "/") + path
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode >= 400 {
+		var oauthErr apimodels.OAuthErrorResponse
+		if jsonErr := json.Unmarshal(body, &oauthErr); jsonErr == nil && strings.TrimSpace(oauthErr.Error) != "" {
+			return &oauthHTTPError{Status: resp.StatusCode, OAuth: oauthErr}
+		}
+
+		msg := strings.TrimSpace(string(body))
+		if msg == "" {
+			msg = http.StatusText(resp.StatusCode)
+		}
+		return fmt.Errorf("%s: %s", endpoint, msg)
+	}
+
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("decode %s response: %w", path, err)
+	}
+	return nil
+}
+
+func doGETJSON(ctx context.Context, baseURL, path, accessToken string, out any) error {
+	client := &http.Client{Timeout: defaultHTTPTimeout}
+	endpoint := strings.TrimRight(baseURL, "/") + path
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+	if token := strings.TrimSpace(accessToken); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode >= 400 {
+		msg := strings.TrimSpace(string(body))
+		if msg == "" {
+			msg = http.StatusText(resp.StatusCode)
+		}
+		return fmt.Errorf("%s: %s", endpoint, msg)
+	}
+
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("decode %s response: %w", path, err)
+	}
+	return nil
+}

--- a/cmd/lesser/auth_session_store.go
+++ b/cmd/lesser/auth_session_store.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	cliAuthSessionVersion = 1
+)
+
+var (
+	authSessionMagic = []byte("lesser-auth-session:v1\n")
+)
+
+type cliAuthSession struct {
+	Version int `json:"version"`
+
+	BaseURL  string `json:"base_url"`
+	ClientID string `json:"client_id"`
+
+	RefreshToken string   `json:"refresh_token"`
+	Username     string   `json:"username"`
+	Scopes       []string `json:"scopes,omitempty"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+func readAuthSecret(secretFile string) (string, error) {
+	if value := strings.TrimSpace(os.Getenv("LESSER_AUTH_SECRET")); value != "" {
+		return value, nil
+	}
+
+	secretFile = strings.TrimSpace(secretFile)
+	if secretFile == "" {
+		return "", nil
+	}
+
+	data, err := os.ReadFile(secretFile) // #nosec G304 -- CLI reads an operator-provided local secret path
+	if err != nil {
+		return "", fmt.Errorf("read secret file %s: %w", secretFile, err)
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func deriveAuthKey(baseURL, secret string) []byte {
+	baseURL = strings.TrimSpace(baseURL)
+	secret = strings.TrimSpace(secret)
+
+	material := ""
+	if secret != "" {
+		material = secret
+	} else {
+		material = machineDerivedSecret()
+	}
+
+	sum := sha256.Sum256([]byte(material + "|" + baseURL))
+	return sum[:]
+}
+
+func machineDerivedSecret() string {
+	host, _ := os.Hostname()
+	user := strings.TrimSpace(os.Getenv("USER"))
+	home, _ := os.UserHomeDir()
+	machineID := readMachineID()
+
+	return strings.Join([]string{
+		strings.TrimSpace(host),
+		user,
+		machineID,
+		strings.TrimSpace(home),
+	}, "|")
+}
+
+func readMachineID() string {
+	for _, path := range []string{"/etc/machine-id", "/var/lib/dbus/machine-id"} {
+		data, err := os.ReadFile(path) // #nosec G304 -- reads known system paths
+		if err != nil {
+			continue
+		}
+		if value := strings.TrimSpace(string(data)); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func authBaseDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".lesser", "auth"), nil
+}
+
+func authBaseURLHash(baseURL string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(baseURL)))
+	return hex.EncodeToString(sum[:])
+}
+
+func authSessionFile(baseURL string) (string, error) {
+	baseDir, err := authBaseDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(baseDir, authBaseURLHash(baseURL), "session.enc"), nil
+}
+
+func readAuthSession(baseURL string, key []byte) (*cliAuthSession, error) {
+	path, err := authSessionFile(baseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := os.ReadFile(path) // #nosec G304 -- local cli session store
+	if err != nil {
+		return nil, err
+	}
+
+	plaintext, err := decryptAuthBlob(raw, key, baseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	var session cliAuthSession
+	if err := json.Unmarshal(plaintext, &session); err != nil {
+		return nil, fmt.Errorf("parse session: %w", err)
+	}
+	return &session, nil
+}
+
+func writeAuthSession(baseURL string, key []byte, session *cliAuthSession) error {
+	if session == nil {
+		return fmt.Errorf("session is nil")
+	}
+
+	path, err := authSessionFile(baseURL)
+	if err != nil {
+		return err
+	}
+
+	session.BaseURL = strings.TrimSpace(baseURL)
+
+	plaintext, err := json.Marshal(session)
+	if err != nil {
+		return err
+	}
+
+	blob, err := encryptAuthBlob(plaintext, key, baseURL)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, blob, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func deleteAuthSession(baseURL string) (bool, error) {
+	path, err := authSessionFile(baseURL)
+	if err != nil {
+		return false, err
+	}
+
+	err = os.Remove(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func encryptAuthBlob(plaintext, key []byte, baseURL string) ([]byte, error) {
+	if len(key) != 32 {
+		return nil, fmt.Errorf("auth key must be 32 bytes (got %d)", len(key))
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+
+	aad := []byte("base_url:" + strings.TrimSpace(baseURL))
+	ciphertext := gcm.Seal(nil, nonce, plaintext, aad)
+
+	out := make([]byte, 0, len(authSessionMagic)+len(nonce)+len(ciphertext))
+	out = append(out, authSessionMagic...)
+	out = append(out, nonce...)
+	out = append(out, ciphertext...)
+	return out, nil
+}
+
+func decryptAuthBlob(blob, key []byte, baseURL string) ([]byte, error) {
+	if len(key) != 32 {
+		return nil, fmt.Errorf("auth key must be 32 bytes (got %d)", len(key))
+	}
+
+	if len(blob) < len(authSessionMagic) || !strings.HasPrefix(string(blob[:len(authSessionMagic)]), string(authSessionMagic)) {
+		return nil, errors.New("unsupported session file format")
+	}
+
+	payload := blob[len(authSessionMagic):]
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(payload) < gcm.NonceSize() {
+		return nil, errors.New("corrupt session file")
+	}
+
+	nonce := payload[:gcm.NonceSize()]
+	ciphertext := payload[gcm.NonceSize():]
+
+	aad := []byte("base_url:" + strings.TrimSpace(baseURL))
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, aad)
+	if err != nil {
+		return nil, err
+	}
+
+	return plaintext, nil
+}
+
+func requireNonEmpty(name, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("%s is required", name)
+	}
+	return nil
+}
+
+func normalizeBaseURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("base-url is required (or set LESSER_BASE_URL)")
+	}
+	raw = strings.TrimRight(raw, "/")
+
+	if !strings.HasPrefix(raw, "http://") && !strings.HasPrefix(raw, "https://") {
+		return "", fmt.Errorf("base-url must start with http:// or https:// (got %q)", raw)
+	}
+	return raw, nil
+}

--- a/cmd/lesser/auth_session_store_test.go
+++ b/cmd/lesser/auth_session_store_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthSessionStore_EncryptsAndDecrypts(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("LESSER_AUTH_SECRET", "test-secret")
+
+	baseURL := "https://example.com"
+	key := deriveAuthKey(baseURL, "test-secret")
+
+	session := &cliAuthSession{
+		Version:      cliAuthSessionVersion,
+		BaseURL:      baseURL,
+		ClientID:     "client-1",
+		RefreshToken: "refresh-token-1",
+		Username:     "alice",
+		Scopes:       []string{"read", "write"},
+		CreatedAt:    time.Now().UTC(),
+		UpdatedAt:    time.Now().UTC(),
+	}
+
+	require.NoError(t, writeAuthSession(baseURL, key, session))
+
+	path, err := authSessionFile(baseURL)
+	require.NoError(t, err)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.NotContains(t, string(raw), session.RefreshToken)
+
+	roundTrip, err := readAuthSession(baseURL, key)
+	require.NoError(t, err)
+	require.Equal(t, session.ClientID, roundTrip.ClientID)
+	require.Equal(t, session.Username, roundTrip.Username)
+	require.Equal(t, session.RefreshToken, roundTrip.RefreshToken)
+	require.Equal(t, session.Scopes, roundTrip.Scopes)
+}
+
+func TestAuthSessionStore_Delete(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("LESSER_AUTH_SECRET", "test-secret")
+
+	baseURL := "https://example.com"
+	key := deriveAuthKey(baseURL, "test-secret")
+
+	require.NoError(t, writeAuthSession(baseURL, key, &cliAuthSession{
+		Version:      cliAuthSessionVersion,
+		BaseURL:      baseURL,
+		ClientID:     "client-1",
+		RefreshToken: "refresh-token-1",
+		Username:     "alice",
+		CreatedAt:    time.Now().UTC(),
+		UpdatedAt:    time.Now().UTC(),
+	}))
+
+	path, err := authSessionFile(baseURL)
+	require.NoError(t, err)
+	require.FileExists(t, path)
+
+	removed, err := deleteAuthSession(baseURL)
+	require.NoError(t, err)
+	require.True(t, removed)
+	require.NoFileExists(t, path)
+
+	// ensure we don't accidentally remove the parent directory; it's fine to keep it.
+	dir := filepath.Dir(path)
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+}

--- a/cmd/lesser/main.go
+++ b/cmd/lesser/main.go
@@ -34,6 +34,7 @@ var (
 	runErrorsFn       = runErrors
 	runDashboardFn    = runDashboard
 	runSmokeFn        = runSmoke
+	runAuthFn         = runAuth
 )
 
 func runCLI(args []string, stderr io.Writer) int {
@@ -106,6 +107,8 @@ func runCLI(args []string, stderr io.Writer) int {
 		return exitCodeFromErr(runDashboardFn(args[2:]), stderr)
 	case "smoke":
 		return exitCodeFromErr(runSmokeFn(args[2:]), stderr)
+	case "auth":
+		return exitCodeFromErr(runAuthFn(args[2:]), stderr)
 	case helpFlagShort, helpFlagLong, helpCommand:
 		printUsageTo(stderr)
 		return 0
@@ -143,6 +146,7 @@ func printUsageTo(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  lesser logs --app <slug> --function <name> [--env dev|staging|live] [--aws-profile <profile>]")
 	_, _ = fmt.Fprintln(w, "  lesser metrics|errors|dashboard --app <slug> [--env dev|staging|live] [--aws-profile <profile>] [--region <aws-region>]")
 	_, _ = fmt.Fprintln(w, "  lesser smoke core|federation [flags...]")
+	_, _ = fmt.Fprintln(w, "  lesser auth login|logout|status|whoami|device [flags...]")
 }
 
 func exitCodeFromErr(err error, stderr io.Writer) int {

--- a/cmd/lesser/main_test.go
+++ b/cmd/lesser/main_test.go
@@ -132,6 +132,7 @@ func TestRunCLI_DispatchesAllCommands(t *testing.T) {
 	prevErrors := runErrorsFn
 	prevDashboard := runDashboardFn
 	prevSmoke := runSmokeFn
+	prevAuth := runAuthFn
 	t.Cleanup(func() {
 		runUpFn = prevUp
 		runDownFn = prevDown
@@ -156,6 +157,7 @@ func TestRunCLI_DispatchesAllCommands(t *testing.T) {
 		runErrorsFn = prevErrors
 		runDashboardFn = prevDashboard
 		runSmokeFn = prevSmoke
+		runAuthFn = prevAuth
 	})
 
 	type call struct {
@@ -192,6 +194,7 @@ func TestRunCLI_DispatchesAllCommands(t *testing.T) {
 	runErrorsFn = stub("errors")
 	runDashboardFn = stub("dashboard")
 	runSmokeFn = stub("smoke")
+	runAuthFn = stub("auth")
 
 	var buf bytes.Buffer
 	require.Equal(t, 0, runCLI([]string{"lesser", helpFlagShort}, &buf))
@@ -272,6 +275,9 @@ func TestRunCLI_DispatchesAllCommands(t *testing.T) {
 
 	require.Equal(t, 0, runCLI([]string{"lesser", "smoke", "core"}, &buf))
 	require.Equal(t, []string{"core"}, calls["smoke"].argv)
+
+	require.Equal(t, 0, runCLI([]string{"lesser", "auth", "status", "--base-url", "https://example.com"}, &buf))
+	require.Equal(t, []string{"status", "--base-url", "https://example.com"}, calls["auth"].argv)
 }
 
 func TestExitCodeFromErr(t *testing.T) {


### PR DESCRIPTION
Implements M5 from `docs/planning/lesser-cli-auth-device-flow-roadmap.md`.

## What’s included
- New CLI commands under `lesser auth`:
  - `lesser auth login --base-url <https://instance>` (device flow, stores encrypted session)
  - `lesser auth status`, `lesser auth whoami`, `lesser auth logout`
  - Non-interactive: `lesser auth device start --json` and `lesser auth device poll ...`
- Encrypted session store at `~/.lesser/auth/<base_url_hash>/session.enc` (AES-256-GCM)
  - Key derivation defaults to machine-derived secret
  - Override via `LESSER_AUTH_SECRET` or `--secret-file`

## Verification
- `go test ./...`