### PR TITLE
M6: CLI API client + client-side throttles

### DIFF
--- a/cmd/lesser/api_client.go
+++ b/cmd/lesser/api_client.go
@@ -1,0 +1,550 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	apimodels "github.com/equaltoai/lesser/cmd/api/models"
+)
+
+type cliAPIClientOptions struct {
+	MaxConcurrency int
+	RPS            float64
+	Burst          int
+
+	Retries int
+	Timeout time.Duration
+}
+
+type cliAPIClient struct {
+	baseURL string
+	key     []byte
+
+	sessionMu sync.Mutex
+	session   *cliAuthSession
+
+	accessTokenMu        sync.Mutex
+	accessToken          string
+	accessTokenExpiresAt time.Time
+
+	httpClient *http.Client
+	limiter    *clientLimiter
+
+	retries int
+
+	nowFn   func() time.Time
+	sleepFn func(time.Duration)
+}
+
+func newCLIAPIClient(baseURL string, key []byte, opts cliAPIClientOptions) (*cliAPIClient, error) {
+	if baseURL == "" {
+		return nil, fmt.Errorf("baseURL is empty")
+	}
+	if len(key) != 32 {
+		return nil, fmt.Errorf("auth key must be 32 bytes (got %d)", len(key))
+	}
+
+	if opts.MaxConcurrency <= 0 {
+		opts.MaxConcurrency = 1
+	}
+	if opts.Burst <= 0 {
+		opts.Burst = 1
+	}
+	if opts.Timeout <= 0 {
+		opts.Timeout = 30 * time.Second
+	}
+	if opts.Retries < 0 {
+		opts.Retries = 0
+	}
+
+	session, err := readAuthSession(baseURL, key)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("not logged in to %s (run: lesser auth login --base-url %s)", baseURL, baseURL)
+		}
+		return nil, err
+	}
+
+	limiter, err := newClientLimiter(opts.MaxConcurrency, opts.RPS, opts.Burst)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cliAPIClient{
+		baseURL: baseURL,
+		key:     key,
+		session: session,
+		httpClient: &http.Client{
+			Timeout: opts.Timeout,
+		},
+		limiter: limiter,
+		retries: opts.Retries,
+		nowFn:   time.Now,
+		sleepFn: time.Sleep,
+	}, nil
+}
+
+func (c *cliAPIClient) Close() {
+	if c == nil || c.limiter == nil {
+		return
+	}
+	c.limiter.Close()
+}
+
+func (c *cliAPIClient) Request(ctx context.Context, method, path string, headers http.Header, body []byte) (int, http.Header, []byte, error) {
+	if c == nil {
+		return 0, nil, nil, fmt.Errorf("client is nil")
+	}
+
+	accessToken, err := c.getAccessToken(ctx)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+
+	headers = cloneHeader(headers)
+	if headers.Get("Authorization") == "" {
+		headers.Set("Authorization", "Bearer "+accessToken)
+	}
+
+	status, respHeaders, respBody, err := c.doRequestWithRetries(ctx, method, path, headers, body)
+	return status, respHeaders, respBody, err
+}
+
+func (c *cliAPIClient) getAccessToken(ctx context.Context) (string, error) {
+	c.accessTokenMu.Lock()
+	token := strings.TrimSpace(c.accessToken)
+	expiresAt := c.accessTokenExpiresAt
+	c.accessTokenMu.Unlock()
+
+	now := c.nowFn().UTC()
+	if token != "" && !expiresAt.IsZero() && now.Before(expiresAt.Add(-30*time.Second)) {
+		return token, nil
+	}
+
+	c.sessionMu.Lock()
+	session := c.session
+	c.sessionMu.Unlock()
+	if session == nil {
+		return "", fmt.Errorf("missing auth session")
+	}
+
+	tokenResp, err := c.refreshTokens(ctx, session.ClientID, session.RefreshToken)
+	if err != nil {
+		return "", err
+	}
+
+	accessToken := strings.TrimSpace(tokenResp.AccessToken)
+	if accessToken == "" {
+		return "", fmt.Errorf("token refresh response missing access_token")
+	}
+
+	expiresIn := tokenResp.ExpiresIn
+	if expiresIn <= 0 {
+		expiresIn = 3600
+	}
+
+	c.accessTokenMu.Lock()
+	c.accessToken = accessToken
+	c.accessTokenExpiresAt = now.Add(time.Duration(expiresIn) * time.Second)
+	c.accessTokenMu.Unlock()
+
+	newRefresh := strings.TrimSpace(tokenResp.RefreshToken)
+	if newRefresh != "" && newRefresh != session.RefreshToken {
+		updated := *session
+		updated.RefreshToken = newRefresh
+		updated.UpdatedAt = now
+		if err := writeAuthSession(c.baseURL, c.key, &updated); err != nil {
+			return "", err
+		}
+		c.sessionMu.Lock()
+		c.session = &updated
+		c.sessionMu.Unlock()
+	}
+
+	return accessToken, nil
+}
+
+func (c *cliAPIClient) refreshTokens(ctx context.Context, clientID, refreshToken string) (*apimodels.OAuthTokenResponse, error) {
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("client_id", strings.TrimSpace(clientID))
+	form.Set("refresh_token", strings.TrimSpace(refreshToken))
+
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/x-www-form-urlencoded")
+	headers.Set("Accept", "application/json")
+
+	status, _, body, err := c.doRequestWithRetries(ctx, http.MethodPost, "/oauth/token", headers, []byte(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+
+	if status >= 400 {
+		var oauthErr apimodels.OAuthErrorResponse
+		if jsonErr := json.Unmarshal(body, &oauthErr); jsonErr == nil && strings.TrimSpace(oauthErr.Error) != "" {
+			code := strings.ToLower(strings.TrimSpace(oauthErr.Error))
+			if code == "invalid_grant" {
+				return nil, fmt.Errorf("refresh token invalid; re-auth required")
+			}
+			desc := strings.TrimSpace(oauthErr.ErrorDescription)
+			if desc == "" {
+				desc = "oauth error"
+			}
+			return nil, fmt.Errorf("%s (%s)", desc, code)
+		}
+		msg := strings.TrimSpace(string(body))
+		if msg == "" {
+			msg = http.StatusText(status)
+		}
+		return nil, fmt.Errorf("token refresh failed (%d): %s", status, msg)
+	}
+
+	var tokenResp apimodels.OAuthTokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return nil, fmt.Errorf("decode token refresh response: %w", err)
+	}
+
+	return &tokenResp, nil
+}
+
+func (c *cliAPIClient) doRequestWithRetries(ctx context.Context, method, path string, headers http.Header, body []byte) (int, http.Header, []byte, error) {
+	if c == nil {
+		return 0, nil, nil, fmt.Errorf("client is nil")
+	}
+
+	method = strings.ToUpper(strings.TrimSpace(method))
+	if method == "" {
+		return 0, nil, nil, fmt.Errorf("method is empty")
+	}
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return 0, nil, nil, fmt.Errorf("path is empty")
+	}
+	if !strings.HasPrefix(path, "/") {
+		return 0, nil, nil, fmt.Errorf("path must start with '/' (got %q)", path)
+	}
+
+	attempts := c.retries + 1
+	cost := requestCost(method, path)
+
+	var lastErr error
+	for attempt := 0; attempt < attempts; attempt++ {
+		if err := c.limiter.Acquire(ctx, cost); err != nil {
+			return 0, nil, nil, err
+		}
+
+		status, respHeaders, respBody, err := c.doSingleRequest(ctx, method, path, headers, body)
+		c.limiter.Release()
+
+		if err == nil && status < 429 && status < 500 {
+			return status, respHeaders, respBody, nil
+		}
+
+		if attempt == attempts-1 {
+			if err != nil {
+				return status, respHeaders, respBody, err
+			}
+			return status, respHeaders, respBody, nil
+		}
+
+		if err != nil {
+			lastErr = err
+			c.sleepFn(backoffDuration(attempt))
+			continue
+		}
+
+		if status == http.StatusTooManyRequests {
+			wait := retryAfterDuration(respHeaders.Get("Retry-After"), c.nowFn())
+			if wait <= 0 {
+				wait = 5 * time.Second
+			}
+			c.sleepFn(wait)
+			continue
+		}
+
+		if status >= 500 {
+			c.sleepFn(backoffDuration(attempt))
+			continue
+		}
+
+		return status, respHeaders, respBody, nil
+	}
+
+	if lastErr != nil {
+		return 0, nil, nil, lastErr
+	}
+	return 0, nil, nil, fmt.Errorf("request failed")
+}
+
+func (c *cliAPIClient) doSingleRequest(ctx context.Context, method, path string, headers http.Header, body []byte) (int, http.Header, []byte, error) {
+	endpoint := strings.TrimRight(c.baseURL, "/") + path
+
+	var bodyReader io.Reader
+	if len(body) > 0 {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, bodyReader)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+
+	for k, values := range headers {
+		for _, v := range values {
+			req.Header.Add(k, v)
+		}
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+	if err != nil {
+		return resp.StatusCode, resp.Header, nil, err
+	}
+
+	return resp.StatusCode, resp.Header, data, nil
+}
+
+func cloneHeader(h http.Header) http.Header {
+	if h == nil {
+		return http.Header{}
+	}
+	out := make(http.Header, len(h))
+	for k, values := range h {
+		out[k] = append([]string(nil), values...)
+	}
+	return out
+}
+
+func requestCost(method, path string) int {
+	cost := 1
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		cost++
+	}
+	pathLower := strings.ToLower(path)
+	if strings.Contains(pathLower, "/search") || strings.Contains(pathLower, "/graphql") {
+		cost++
+	}
+	if cost < 1 {
+		return 1
+	}
+	if cost > 5 {
+		return 5
+	}
+	return cost
+}
+
+func backoffDuration(attempt int) time.Duration {
+	if attempt < 0 {
+		return 0
+	}
+	base := 250 * time.Millisecond
+	d := time.Duration(float64(base) * math.Pow(2, float64(attempt)))
+	if d > 5*time.Second {
+		d = 5 * time.Second
+	}
+	return d
+}
+
+func retryAfterDuration(header string, now time.Time) time.Duration {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return 0
+	}
+
+	if seconds, err := strconv.Atoi(header); err == nil {
+		if seconds <= 0 {
+			return 0
+		}
+		return time.Duration(seconds) * time.Second
+	}
+
+	if t, err := http.ParseTime(header); err == nil {
+		d := t.Sub(now)
+		if d < 0 {
+			return 0
+		}
+		return d
+	}
+
+	return 0
+}
+
+type clientLimiter struct {
+	sem *semaphore
+	tb  *tokenBucket
+}
+
+func newClientLimiter(maxConcurrency int, rps float64, burst int) (*clientLimiter, error) {
+	sem := newSemaphore(maxConcurrency)
+
+	var tb *tokenBucket
+	if rps > 0 {
+		b, err := newTokenBucket(rps, burst)
+		if err != nil {
+			return nil, err
+		}
+		tb = b
+	}
+
+	return &clientLimiter{
+		sem: sem,
+		tb:  tb,
+	}, nil
+}
+
+func (l *clientLimiter) Acquire(ctx context.Context, cost int) error {
+	if l == nil {
+		return nil
+	}
+	if err := l.sem.Acquire(ctx); err != nil {
+		return err
+	}
+	if l.tb == nil {
+		return nil
+	}
+	if cost < 1 {
+		cost = 1
+	}
+	if err := l.tb.Wait(ctx, cost); err != nil {
+		l.sem.Release()
+		return err
+	}
+	return nil
+}
+
+func (l *clientLimiter) Release() {
+	if l == nil || l.sem == nil {
+		return
+	}
+	l.sem.Release()
+}
+
+func (l *clientLimiter) Close() {
+	if l == nil || l.tb == nil {
+		return
+	}
+	l.tb.Stop()
+}
+
+type semaphore struct {
+	ch chan struct{}
+}
+
+func newSemaphore(n int) *semaphore {
+	if n <= 0 {
+		n = 1
+	}
+	return &semaphore{ch: make(chan struct{}, n)}
+}
+
+func (s *semaphore) Acquire(ctx context.Context) error {
+	select {
+	case s.ch <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *semaphore) Release() {
+	select {
+	case <-s.ch:
+	default:
+	}
+}
+
+type tokenBucket struct {
+	tokens chan struct{}
+	stop   chan struct{}
+}
+
+func newTokenBucket(rps float64, burst int) (*tokenBucket, error) {
+	if rps <= 0 {
+		return nil, fmt.Errorf("rps must be > 0")
+	}
+	if burst <= 0 {
+		burst = 1
+	}
+
+	interval := time.Duration(float64(time.Second) / rps)
+	if interval <= 0 {
+		interval = time.Millisecond
+	}
+
+	tb := &tokenBucket{
+		tokens: make(chan struct{}, burst),
+		stop:   make(chan struct{}),
+	}
+
+	for i := 0; i < burst; i++ {
+		tb.tokens <- struct{}{}
+	}
+
+	ticker := time.NewTicker(interval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-tb.stop:
+				return
+			case <-ticker.C:
+				select {
+				case tb.tokens <- struct{}{}:
+				default:
+				}
+			}
+		}
+	}()
+
+	return tb, nil
+}
+
+func (t *tokenBucket) Stop() {
+	if t == nil {
+		return
+	}
+	select {
+	case <-t.stop:
+	default:
+		close(t.stop)
+	}
+}
+
+func (t *tokenBucket) Wait(ctx context.Context, cost int) error {
+	if t == nil {
+		return nil
+	}
+	if cost < 1 {
+		cost = 1
+	}
+
+	for i := 0; i < cost; i++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-t.tokens:
+		}
+	}
+	return nil
+}

--- a/cmd/lesser/api_client_test.go
+++ b/cmd/lesser/api_client_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCLIAPIClient_RefreshesAndUpdatesSession(t *testing.T) {
+	var tokenCalls atomic.Int32
+	var verifyCalls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/token":
+			tokenCalls.Add(1)
+			require.NoError(t, r.ParseForm())
+			require.Equal(t, "refresh_token", r.FormValue("grant_type"))
+			require.Equal(t, "client-1", r.FormValue("client_id"))
+			require.Equal(t, "refresh-1", r.FormValue("refresh_token"))
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"access-1","token_type":"Bearer","expires_in":3600,"refresh_token":"refresh-2","scope":"read write","created_at":1}`))
+		case "/api/v1/accounts/verify_credentials":
+			verifyCalls.Add(1)
+			require.Equal(t, "Bearer access-1", r.Header.Get("Authorization"))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"username":"alice"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("LESSER_AUTH_SECRET", "test-secret")
+
+	baseURL := srv.URL
+	key := deriveAuthKey(baseURL, "test-secret")
+
+	require.NoError(t, writeAuthSession(baseURL, key, &cliAuthSession{
+		Version:      cliAuthSessionVersion,
+		BaseURL:      baseURL,
+		ClientID:     "client-1",
+		RefreshToken: "refresh-1",
+		Username:     "alice",
+		CreatedAt:    time.Now().UTC(),
+		UpdatedAt:    time.Now().UTC(),
+	}))
+
+	client, err := newCLIAPIClient(baseURL, key, cliAPIClientOptions{Retries: 0, Timeout: 5 * time.Second})
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	t.Cleanup(cancel)
+
+	status, _, body, err := client.Request(ctx, http.MethodGet, "/api/v1/accounts/verify_credentials", nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, 200, status)
+	require.Contains(t, string(body), "alice")
+
+	// Refresh token rotation is persisted.
+	updated, err := readAuthSession(baseURL, key)
+	require.NoError(t, err)
+	require.Equal(t, "refresh-2", updated.RefreshToken)
+
+	// Second call reuses access token (no additional refresh).
+	status, _, _, err = client.Request(ctx, http.MethodGet, "/api/v1/accounts/verify_credentials", nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, 200, status)
+
+	require.Equal(t, int32(1), tokenCalls.Load())
+	require.Equal(t, int32(2), verifyCalls.Load())
+}
+
+func TestCLIAPIClient_RetryAfterRespected(t *testing.T) {
+	var apiCalls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/token":
+			require.NoError(t, r.ParseForm())
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"access-1","token_type":"Bearer","expires_in":3600,"refresh_token":"refresh-1","scope":"read","created_at":1}`))
+		case "/api/test":
+			call := apiCalls.Add(1)
+			if call == 1 {
+				w.Header().Set("Retry-After", "2")
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = w.Write([]byte("rate limited"))
+				return
+			}
+			_, _ = w.Write([]byte("ok"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("LESSER_AUTH_SECRET", "test-secret")
+
+	baseURL := srv.URL
+	key := deriveAuthKey(baseURL, "test-secret")
+
+	require.NoError(t, writeAuthSession(baseURL, key, &cliAuthSession{
+		Version:      cliAuthSessionVersion,
+		BaseURL:      baseURL,
+		ClientID:     "client-1",
+		RefreshToken: "refresh-1",
+		Username:     "alice",
+		CreatedAt:    time.Now().UTC(),
+		UpdatedAt:    time.Now().UTC(),
+	}))
+
+	client, err := newCLIAPIClient(baseURL, key, cliAPIClientOptions{Retries: 1, Timeout: 5 * time.Second})
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+
+	var slept time.Duration
+	client.sleepFn = func(d time.Duration) { slept += d }
+	client.nowFn = func() time.Time { return time.Unix(0, 0).UTC() }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	t.Cleanup(cancel)
+
+	status, _, body, err := client.Request(ctx, http.MethodGet, "/api/test", nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, 200, status)
+	require.Equal(t, "ok", string(body))
+
+	require.Equal(t, int32(2), apiCalls.Load())
+	require.GreaterOrEqual(t, slept, 2*time.Second)
+}

--- a/cmd/lesser/api_cmd.go
+++ b/cmd/lesser/api_cmd.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func runAPI(argv []string) error {
+	if len(argv) == 0 {
+		printUsage()
+		return nil
+	}
+
+	switch argv[0] {
+	case helpFlagShort, helpFlagLong, helpCommand:
+		printUsage()
+		return nil
+	case "request":
+		return runAPIRequest(argv[1:])
+	default:
+		if argv[0] != "" && argv[0][0] == '-' {
+			printUsage()
+			return nil
+		}
+		return fmt.Errorf("unknown api command %q", argv[0])
+	}
+}
+
+type apiRequestFlags struct {
+	BaseURL    string
+	SecretFile string
+
+	Method string
+	Path   string
+
+	Data     string
+	DataFile string
+
+	Headers multiValueFlag
+
+	ContentType string
+	Accept      string
+
+	MaxConcurrency int
+	RPS            float64
+	Burst          int
+	Retries        int
+	TimeoutSeconds int
+}
+
+func runAPIRequest(argv []string) error {
+	fs := flag.NewFlagSet("lesser api request", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	var args apiRequestFlags
+	fs.StringVar(&args.BaseURL, "base-url", os.Getenv("LESSER_BASE_URL"), "instance base url (env: LESSER_BASE_URL)")
+	fs.StringVar(&args.SecretFile, "secret-file", os.Getenv("LESSER_AUTH_SECRET_FILE"), "path to auth secret file (env: LESSER_AUTH_SECRET_FILE)")
+
+	fs.StringVar(&args.Method, "method", http.MethodGet, "http method (GET, POST, ...)")
+	fs.StringVar(&args.Path, "path", "", "request path (example: /api/v1/accounts/verify_credentials)")
+
+	fs.StringVar(&args.Data, "data", "", "request body string")
+	fs.StringVar(&args.DataFile, "data-file", "", "request body file path")
+	fs.Var(&args.Headers, "header", "header (repeatable): 'Name: value'")
+
+	fs.StringVar(&args.ContentType, "content-type", "", "content type header (default: application/json when body is set)")
+	fs.StringVar(&args.Accept, "accept", "application/json", "accept header")
+
+	fs.IntVar(&args.MaxConcurrency, "max-concurrency", envOrDefaultInt("LESSER_CLI_MAX_CONCURRENCY", 2), "max concurrent in-flight http requests (env: LESSER_CLI_MAX_CONCURRENCY)")
+	fs.Float64Var(&args.RPS, "rps", envOrDefaultFloat("LESSER_CLI_RPS", 2.0), "max requests per second (env: LESSER_CLI_RPS)")
+	fs.IntVar(&args.Burst, "burst", envOrDefaultInt("LESSER_CLI_BURST", 4), "token bucket burst size (env: LESSER_CLI_BURST)")
+	fs.IntVar(&args.Retries, "retries", envOrDefaultInt("LESSER_CLI_RETRIES", 3), "max retries for 429/5xx/transient errors (env: LESSER_CLI_RETRIES)")
+	fs.IntVar(&args.TimeoutSeconds, "timeout", envOrDefaultInt("LESSER_CLI_TIMEOUT", 30), "overall request timeout seconds (env: LESSER_CLI_TIMEOUT)")
+
+	if err := fs.Parse(argv); err != nil {
+		return err
+	}
+
+	baseURL, err := normalizeBaseURL(args.BaseURL)
+	if err != nil {
+		return err
+	}
+
+	method := strings.ToUpper(strings.TrimSpace(args.Method))
+	if method == "" {
+		return fmt.Errorf("method is required")
+	}
+
+	path := strings.TrimSpace(args.Path)
+	if err := requireNonEmpty("path", path); err != nil {
+		return err
+	}
+	if !strings.HasPrefix(path, "/") {
+		return fmt.Errorf("path must start with '/' (got %q)", path)
+	}
+
+	body, err := readBodyArg(args.Data, args.DataFile)
+	if err != nil {
+		return err
+	}
+
+	headers := http.Header{}
+	for _, raw := range args.Headers.Values() {
+		name, value, err := splitHeader(raw)
+		if err != nil {
+			return err
+		}
+		headers.Add(name, value)
+	}
+	if accept := strings.TrimSpace(args.Accept); accept != "" && headers.Get("Accept") == "" {
+		headers.Set("Accept", accept)
+	}
+	if len(body) > 0 && headers.Get("Content-Type") == "" {
+		contentType := strings.TrimSpace(args.ContentType)
+		if contentType == "" {
+			contentType = "application/json"
+		}
+		headers.Set("Content-Type", contentType)
+	}
+
+	secret, err := readAuthSecret(args.SecretFile)
+	if err != nil {
+		return err
+	}
+	key := deriveAuthKey(baseURL, secret)
+
+	client, err := newCLIAPIClient(baseURL, key, cliAPIClientOptions{
+		MaxConcurrency: args.MaxConcurrency,
+		RPS:            args.RPS,
+		Burst:          args.Burst,
+		Retries:        args.Retries,
+		Timeout:        time.Duration(args.TimeoutSeconds) * time.Second,
+	})
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(args.TimeoutSeconds)*time.Second)
+	defer cancel()
+
+	status, respHeaders, respBody, err := client.Request(ctx, method, path, headers, body)
+	if len(respBody) > 0 {
+		_, _ = os.Stdout.Write(respBody)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if status >= 400 {
+		retryAfter := strings.TrimSpace(respHeaders.Get("Retry-After"))
+		if retryAfter != "" {
+			return fmt.Errorf("api request failed (%d); retry-after=%s", status, retryAfter)
+		}
+		return fmt.Errorf("api request failed (%d)", status)
+	}
+
+	return nil
+}
+
+type multiValueFlag []string
+
+func (m *multiValueFlag) String() string {
+	if m == nil {
+		return ""
+	}
+	return strings.Join(*m, ",")
+}
+
+func (m *multiValueFlag) Set(value string) error {
+	*m = append(*m, value)
+	return nil
+}
+
+func (m *multiValueFlag) Values() []string {
+	if m == nil {
+		return nil
+	}
+	return append([]string(nil), *m...)
+}
+
+func readBodyArg(data, dataFile string) ([]byte, error) {
+	if strings.TrimSpace(data) != "" && strings.TrimSpace(dataFile) != "" {
+		return nil, fmt.Errorf("only one of --data or --data-file may be set")
+	}
+	if strings.TrimSpace(dataFile) != "" {
+		body, err := os.ReadFile(dataFile) // #nosec G304 -- CLI reads an operator-provided local path
+		if err != nil {
+			return nil, fmt.Errorf("read data-file %s: %w", dataFile, err)
+		}
+		return body, nil
+	}
+	if strings.TrimSpace(data) != "" {
+		return []byte(data), nil
+	}
+	return nil, nil
+}
+
+func splitHeader(raw string) (string, string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", fmt.Errorf("header is empty")
+	}
+	parts := strings.SplitN(raw, ":", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("header must be in 'Name: value' format (got %q)", raw)
+	}
+	name := strings.TrimSpace(parts[0])
+	value := strings.TrimSpace(parts[1])
+	if name == "" {
+		return "", "", fmt.Errorf("header name is empty (got %q)", raw)
+	}
+	return name, value, nil
+}
+
+func envOrDefaultInt(key string, value int) int {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return value
+	}
+	parsed, err := strconv.Atoi(raw)
+	if err != nil {
+		return value
+	}
+	return parsed
+}
+
+func envOrDefaultFloat(key string, value float64) float64 {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return value
+	}
+	parsed, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return value
+	}
+	return parsed
+}

--- a/cmd/lesser/main.go
+++ b/cmd/lesser/main.go
@@ -35,6 +35,7 @@ var (
 	runDashboardFn    = runDashboard
 	runSmokeFn        = runSmoke
 	runAuthFn         = runAuth
+	runAPIFn          = runAPI
 )
 
 func runCLI(args []string, stderr io.Writer) int {
@@ -109,6 +110,8 @@ func runCLI(args []string, stderr io.Writer) int {
 		return exitCodeFromErr(runSmokeFn(args[2:]), stderr)
 	case "auth":
 		return exitCodeFromErr(runAuthFn(args[2:]), stderr)
+	case "api":
+		return exitCodeFromErr(runAPIFn(args[2:]), stderr)
 	case helpFlagShort, helpFlagLong, helpCommand:
 		printUsageTo(stderr)
 		return 0
@@ -147,6 +150,7 @@ func printUsageTo(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  lesser metrics|errors|dashboard --app <slug> [--env dev|staging|live] [--aws-profile <profile>] [--region <aws-region>]")
 	_, _ = fmt.Fprintln(w, "  lesser smoke core|federation [flags...]")
 	_, _ = fmt.Fprintln(w, "  lesser auth login|logout|status|whoami|device [flags...]")
+	_, _ = fmt.Fprintln(w, "  lesser api request --method GET --path /api/v1/accounts/verify_credentials [flags...]")
 }
 
 func exitCodeFromErr(err error, stderr io.Writer) int {

--- a/cmd/lesser/main_test.go
+++ b/cmd/lesser/main_test.go
@@ -133,6 +133,7 @@ func TestRunCLI_DispatchesAllCommands(t *testing.T) {
 	prevDashboard := runDashboardFn
 	prevSmoke := runSmokeFn
 	prevAuth := runAuthFn
+	prevAPI := runAPIFn
 	t.Cleanup(func() {
 		runUpFn = prevUp
 		runDownFn = prevDown
@@ -158,6 +159,7 @@ func TestRunCLI_DispatchesAllCommands(t *testing.T) {
 		runDashboardFn = prevDashboard
 		runSmokeFn = prevSmoke
 		runAuthFn = prevAuth
+		runAPIFn = prevAPI
 	})
 
 	type call struct {
@@ -195,6 +197,7 @@ func TestRunCLI_DispatchesAllCommands(t *testing.T) {
 	runDashboardFn = stub("dashboard")
 	runSmokeFn = stub("smoke")
 	runAuthFn = stub("auth")
+	runAPIFn = stub("api")
 
 	var buf bytes.Buffer
 	require.Equal(t, 0, runCLI([]string{"lesser", helpFlagShort}, &buf))
@@ -278,6 +281,9 @@ func TestRunCLI_DispatchesAllCommands(t *testing.T) {
 
 	require.Equal(t, 0, runCLI([]string{"lesser", "auth", "status", "--base-url", "https://example.com"}, &buf))
 	require.Equal(t, []string{"status", "--base-url", "https://example.com"}, calls["auth"].argv)
+
+	require.Equal(t, 0, runCLI([]string{"lesser", "api", "request", "--method", "GET", "--path", "/api/v1/accounts/verify_credentials"}, &buf))
+	require.Equal(t, []string{"request", "--method", "GET", "--path", "/api/v1/accounts/verify_credentials"}, calls["api"].argv)
 }
 
 func TestExitCodeFromErr(t *testing.T) {


### PR DESCRIPTION
Implements M6 from `docs/planning/lesser-cli-auth-device-flow-roadmap.md`.

## What’s included
- New CLI command: `lesser api request` (generic OAuth-authenticated API passthrough)
  - Example: `lesser api request --base-url https://instance --method GET --path /api/v1/accounts/verify_credentials`
- CLI HTTP client layer:
  - Reads encrypted session from M5
  - Refreshes access tokens automatically (persists refresh-token rotation)
  - Retries on transient errors + respects `Retry-After` on `429`
  - Client-side throttles (defaults): max concurrency `2`, token bucket `2 rps` with burst `4` (tunable via flags/env)

## Verification
- `go test ./...`
