### PR TITLE
auth-ui: update vendored greater components

### DIFF
--- a/auth-ui/components.json
+++ b/auth-ui/components.json
@@ -25,49 +25,49 @@
     {
       "name": "icons",
       "version": "e1d159717a8f14f727f5e6df780754e0da5bf370",
-      "installedAt": "2026-02-08T16:18:57.844Z",
+      "installedAt": "2026-02-12T13:49:09.754Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "tokens",
       "version": "e1d159717a8f14f727f5e6df780754e0da5bf370",
-      "installedAt": "2026-02-08T16:18:57.851Z",
+      "installedAt": "2026-02-12T13:49:09.759Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "utils",
       "version": "e1d159717a8f14f727f5e6df780754e0da5bf370",
-      "installedAt": "2026-02-08T16:18:57.855Z",
+      "installedAt": "2026-02-12T13:49:09.764Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "primitives",
       "version": "e1d159717a8f14f727f5e6df780754e0da5bf370",
-      "installedAt": "2026-02-08T16:18:57.869Z",
+      "installedAt": "2026-02-12T13:49:09.779Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "content",
       "version": "e1d159717a8f14f727f5e6df780754e0da5bf370",
-      "installedAt": "2026-02-08T16:18:57.872Z",
+      "installedAt": "2026-02-12T13:49:09.783Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "adapters",
       "version": "e1d159717a8f14f727f5e6df780754e0da5bf370",
-      "installedAt": "2026-02-08T16:18:57.881Z",
+      "installedAt": "2026-02-12T13:49:09.793Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "headless",
       "version": "e1d159717a8f14f727f5e6df780754e0da5bf370",
-      "installedAt": "2026-02-08T16:18:57.892Z",
+      "installedAt": "2026-02-12T13:49:09.797Z",
       "modified": false,
       "checksums": []
     }

--- a/auth-ui/src/components/OAuthConsentScreen.svelte
+++ b/auth-ui/src/components/OAuthConsentScreen.svelte
@@ -253,7 +253,7 @@
     </div>
     
     <!-- Additional Info -->
-    <div class="text-center mt-4" style="font-size: 0.75rem; color: var(--text-muted);">
+    <div class="auth-footnote auth-footnote--xs text-center mt-4">
       By authorizing, you agree to share your profile information and grant the requested permissions.
     </div>
   </div>

--- a/auth-ui/src/components/PasswordlessLogin.svelte
+++ b/auth-ui/src/components/PasswordlessLogin.svelte
@@ -734,8 +734,8 @@
       {/if}
       
       {#if !hideRegisterLink}
-        <div class="text-center mt-4" style="font-size: 0.875rem; color: var(--text-muted);">
-          Don't have an account? <a href={registerHref} style="color: var(--lesser-primary-500); text-decoration: none;">Register</a>
+        <div class="auth-footnote text-center mt-4">
+          Don't have an account? <a class="auth-link" href={registerHref}>Register</a>
         </div>
       {/if}
   </div>

--- a/auth-ui/src/lib/greater/content/index.ts
+++ b/auth-ui/src/lib/greater/content/index.ts
@@ -27,8 +27,10 @@ export { default as CodeBlock } from './components/CodeBlock.svelte';
  */
 export { default as MarkdownRenderer } from './components/MarkdownRenderer.svelte';
 
+// Import component types for prop inference
+import type CodeBlockComponent from './components/CodeBlock.svelte';
+import type MarkdownRendererComponent from './components/MarkdownRenderer.svelte';
+
 // Component prop types
-export type CodeBlockProps = ComponentProps<typeof import('./components/CodeBlock.svelte').default>;
-export type MarkdownRendererProps = ComponentProps<
-	typeof import('./components/MarkdownRenderer.svelte').default
->;
+export type CodeBlockProps = ComponentProps<CodeBlockComponent>;
+export type MarkdownRendererProps = ComponentProps<MarkdownRendererComponent>;

--- a/auth-ui/src/lib/greater/primitives/index.ts
+++ b/auth-ui/src/lib/greater/primitives/index.ts
@@ -22,18 +22,7 @@ export type {
 	CustomPalette,
 	ColorScale,
 	ColorShade,
-	FontPreset,
 } from 'src/lib/greater/tokens';
-
-// Preset types for strict-CSP-safe APIs
-export type { WidthPreset, HeightPreset } from './components/Skeleton.svelte';
-export type { ContainerSize, GutterPreset } from './components/Container.svelte';
-export type {
-	SpacingPreset,
-	BackgroundPreset,
-	GradientDirection,
-} from './components/Section.svelte';
-export type { Placement } from './components/Tooltip.svelte';
 
 // Import all components (for both export and prop type inference)
 import Button from './components/Button.svelte';

--- a/auth-ui/src/pages/register.astro
+++ b/auth-ui/src/pages/register.astro
@@ -24,7 +24,7 @@ const sessionId = Astro.url.searchParams.get('session_id') || '';
     hideRegisterLink={true}
     isRegistration={true}
   />
-  <div class="text-center mt-4" style="font-size: 0.875rem; color: var(--text-muted);">
-    Already have an account? <a href={`${import.meta.env.BASE_URL}login`} style="color: var(--lesser-primary-500); text-decoration: none;">Sign in</a>
+  <div class="auth-footnote text-center mt-4">
+    Already have an account? <a class="auth-link" href={`${import.meta.env.BASE_URL}login`}>Sign in</a>
   </div>
 </AuthLayout>

--- a/auth-ui/src/styles/global.css
+++ b/auth-ui/src/styles/global.css
@@ -334,6 +334,25 @@ body {
   font-weight: 700;
 }
 
+/* Auth UI footnotes + links (CSP-safe: avoid inline style attributes) */
+.auth-footnote {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+}
+
+.auth-footnote--xs {
+  font-size: 0.75rem;
+}
+
+.auth-link {
+  color: var(--lesser-primary-500);
+  text-decoration: none;
+}
+
+.auth-link:hover {
+  text-decoration: underline;
+}
+
 /* Utility classes */
 .text-center {
   text-align: center;

--- a/infra/cdk/constructs/frontend_response_headers.go
+++ b/infra/cdk/constructs/frontend_response_headers.go
@@ -99,10 +99,11 @@ func authUIInlineScriptHashes() []string {
 
 func authUIInlineStyleHashes() []string {
 	return []string{
+		"'sha256-Eq62DWSZ57jJZCUv6mhFsTpy7vjhvM2oZhAX+bvTTN4='",
+		"'sha256-Np+0wo4qGeEiSfIZluf224zV9nNLY+nOGde1KcwOB8g='",
+		"'sha256-1mD1INqKidrIyg8naC+GEWKaF7uCtCKeBQqXOxf8LM8='",
+		"'sha256-iegu0Wb3dMBfhqOyzQ8kCD9W04jq6I7g1SiDlmvSiSg='",
+		"'sha256-qkbV7mmkk3RRKy6Ha/Sdwvz6VwoEghyumJdMY397/D0='",
 		"'sha256-vv9IoKo7BSLbWcUHr3tNmfNVmm5L/9Cfn2H6LMk7/ow='",
-		"'sha256-Kvbe5KKdv2cGHo4KJK01eJk9hDZVsoTUBvT9jk+rGXk='",
-		"'sha256-MidiNUa5kdpxl2SpSrnhDmWJ8kgApzwzkjnx+3qPfAQ='",
-		"'sha256-M6ZZZEFYxarhKkoC2dpmdcNsH126xrQ7hscemunVkKQ='",
-		"'sha256-Pf213LDBtMPs63dfYF449lKLszal3Ml4UCtfrnNBROE='",
 	}
 }


### PR DESCRIPTION
Updates auth-ui's vendored Greater Components (via greater CLI) and keeps the deployed /auth/* UI compatible with Lesser's strict CloudFront CSP (no unsafe-inline).\n\nKey changes:\n- Refresh vendored Greater shared packages in auth-ui\n- Remove inline style attributes (CSP-blocked) in auth-ui pages/components\n- Update inline <style> hash allow-list used by static-site CSP\n\nVerification:\n- cd auth-ui && pnpm build\n- cd infra/cdk && go test ./...\n