### PR TITLE
fix oauth scopes

### DIFF
--- a/cmd/api/handlers/oauth.go
+++ b/cmd/api/handlers/oauth.go
@@ -43,7 +43,6 @@ const (
 	oauthGrantTypeRefreshToken      = "refresh_token"
 
 	oauthTokenTypeBearer       = "Bearer"
-	oauthTokenDefaultScope     = "read write follow push" // #nosec G101 -- OAuth scope string, not a credential
 	oauthTokenExpiresInSeconds = 3600
 )
 
@@ -491,7 +490,7 @@ func (h *Handler) handleOAuthAuthorizationCodeGrant(ctx context.Context, oauthSv
 		})
 	}
 
-	accessToken, refreshTokenOut, err := h.exchangeAuthorizationCode(ctx, oauthSvc, req.code, req.clientID, req.redirectURI, req.codeVerifier, req.clientSecret)
+	accessToken, refreshTokenOut, grantedScopes, err := h.exchangeAuthorizationCode(ctx, oauthSvc, req.code, req.clientID, req.redirectURI, req.codeVerifier, req.clientSecret)
 	if err != nil {
 		h.logger.Error("failed to exchange authorization code", zap.Error(err))
 		switch err {
@@ -521,7 +520,7 @@ func (h *Handler) handleOAuthAuthorizationCodeGrant(ctx context.Context, oauthSv
 	return okJSON(apimodels.OAuthTokenResponse{
 		AccessToken:  accessToken,
 		TokenType:    oauthTokenTypeBearer,
-		Scope:        oauthTokenDefaultScope,
+		Scope:        strings.Join(grantedScopes, " "),
 		CreatedAt:    time.Now().Unix(),
 		ExpiresIn:    oauthTokenExpiresInSeconds,
 		RefreshToken: refreshTokenOut,
@@ -539,7 +538,7 @@ func (h *Handler) handleOAuthRefreshTokenGrant(ctx context.Context, oauthSvc *au
 		})
 	}
 
-	accessToken, newRefreshToken, err := h.exchangeRefreshToken(ctx, oauthSvc, req.refreshToken, req.clientID, req.clientSecret)
+	accessToken, newRefreshToken, grantedScopes, err := h.exchangeRefreshToken(ctx, oauthSvc, req.refreshToken, req.clientID, req.clientSecret)
 	if err != nil {
 		h.logger.Error("failed to refresh tokens", zap.Error(err))
 		switch err {
@@ -564,7 +563,7 @@ func (h *Handler) handleOAuthRefreshTokenGrant(ctx context.Context, oauthSvc *au
 	return okJSON(apimodels.OAuthTokenResponse{
 		AccessToken:  accessToken,
 		TokenType:    oauthTokenTypeBearer,
-		Scope:        oauthTokenDefaultScope,
+		Scope:        strings.Join(grantedScopes, " "),
 		CreatedAt:    time.Now().Unix(),
 		ExpiresIn:    oauthTokenExpiresInSeconds,
 		RefreshToken: newRefreshToken,
@@ -767,7 +766,7 @@ func (h *Handler) oauthDeviceSessionApprovedTokenResponse(ctx context.Context, o
 	return okJSON(apimodels.OAuthTokenResponse{
 		AccessToken:  accessToken,
 		TokenType:    oauthTokenTypeBearer,
-		Scope:        oauthTokenDefaultScope,
+		Scope:        strings.Join(session.Scopes, " "),
 		CreatedAt:    now.Unix(),
 		ExpiresIn:    oauthTokenExpiresInSeconds,
 		RefreshToken: refreshTokenOut,
@@ -775,7 +774,7 @@ func (h *Handler) oauthDeviceSessionApprovedTokenResponse(ctx context.Context, o
 }
 
 // exchangeAuthorizationCode exchanges an authorization code for access and refresh tokens
-func (h *Handler) exchangeAuthorizationCode(ctx context.Context, oauthSvc *auth.OAuthService, code, clientID, redirectURI, codeVerifier, clientSecret string) (string, string, error) {
+func (h *Handler) exchangeAuthorizationCode(ctx context.Context, oauthSvc *auth.OAuthService, code, clientID, redirectURI, codeVerifier, clientSecret string) (string, string, []string, error) {
 	code = strings.TrimSpace(code)
 	clientID = strings.TrimSpace(clientID)
 	redirectURI = strings.TrimSpace(redirectURI)
@@ -784,7 +783,7 @@ func (h *Handler) exchangeAuthorizationCode(ctx context.Context, oauthSvc *auth.
 	// Load OAuth client once to enforce confidential client authentication and avoid repeated DB calls.
 	client, err := h.repos.Account().GetOAuthClient(ctx, clientID)
 	if err != nil || client == nil {
-		return "", "", auth.ErrInvalidClient
+		return "", "", nil, auth.ErrInvalidClient
 	}
 
 	// Validate redirect URI for this client (exact match required).
@@ -793,7 +792,7 @@ func (h *Handler) exchangeAuthorizationCode(ctx context.Context, oauthSvc *auth.
 		"redirectURI": redirectURI,
 		"authCode":    code,
 	}); err != nil {
-		return "", "", auth.ErrInvalidRequest
+		return "", "", nil, auth.ErrInvalidRequest
 	}
 
 	redirectAllowed := false
@@ -804,44 +803,44 @@ func (h *Handler) exchangeAuthorizationCode(ctx context.Context, oauthSvc *auth.
 		}
 	}
 	if !redirectAllowed {
-		return "", "", auth.ErrInvalidRequest
+		return "", "", nil, auth.ErrInvalidRequest
 	}
 
 	// Enforce confidential client authentication.
 	if client.Confidential {
 		if clientSecret == "" {
-			return "", "", auth.ErrInvalidClient
+			return "", "", nil, auth.ErrInvalidClient
 		}
 		if err := oauthSvc.ValidateClient(ctx, clientID, clientSecret); err != nil {
-			return "", "", err
+			return "", "", nil, err
 		}
 	} else if clientSecret != "" {
 		// If the client provided a secret anyway, validate it.
 		if err := oauthSvc.ValidateClient(ctx, clientID, clientSecret); err != nil {
-			return "", "", err
+			return "", "", nil, err
 		}
 	}
 
 	// Get authorization code from storage
 	authCode, err := h.repos.Account().GetAuthorizationCode(ctx, code)
 	if err != nil {
-		return "", "", auth.ErrInvalidGrant
+		return "", "", nil, auth.ErrInvalidGrant
 	}
 
 	// Validate authorization code
 	if authCode.ClientID != clientID {
-		return "", "", auth.ErrInvalidGrant
+		return "", "", nil, auth.ErrInvalidGrant
 	}
 
 	// Validate redirect_uri binding per RFC 6749 Section 4.1.3.
 	if strings.TrimSpace(authCode.RedirectURI) == "" || authCode.RedirectURI != redirectURI {
-		return "", "", auth.ErrInvalidGrant
+		return "", "", nil, auth.ErrInvalidGrant
 	}
 
 	// Verify PKCE if used
 	if authCode.CodeChallenge != "" || codeVerifier != "" {
 		if err := oauthSvc.VerifyCodeChallenge(authCode.CodeChallenge, codeVerifier, "S256"); err != nil {
-			return "", "", err
+			return "", "", nil, err
 		}
 	}
 
@@ -849,7 +848,7 @@ func (h *Handler) exchangeAuthorizationCode(ctx context.Context, oauthSvc *auth.
 	// concurrent exchanges in the (small) TOCTOU window between read and delete.
 	if err := h.repos.Account().DeleteAuthorizationCode(ctx, code); err != nil {
 		h.logger.Warn("failed to consume authorization code", zap.Error(err))
-		return "", "", auth.ErrInvalidGrant
+		return "", "", nil, auth.ErrInvalidGrant
 	}
 
 	clientClass := ""
@@ -862,7 +861,7 @@ func (h *Handler) exchangeAuthorizationCode(ctx context.Context, oauthSvc *auth.
 	// Generate tokens
 	accessToken, refreshToken, err := oauthSvc.GenerateTokensWithAccessTokenTTLAndClientContext(ctx, authCode.Username, clientID, "", authCode.Scopes, auth.AccessTokenDuration, clientClass, sessionID)
 	if err != nil {
-		return "", "", errors.Join(failedToGenerateTokens(), err)
+		return "", "", nil, errors.Join(failedToGenerateTokens(), err)
 	}
 
 	now := time.Now().UTC()
@@ -884,11 +883,11 @@ func (h *Handler) exchangeAuthorizationCode(ctx context.Context, oauthSvc *auth.
 		// Continue - access token is still valid
 	}
 
-	return accessToken, refreshToken, nil
+	return accessToken, refreshToken, authCode.Scopes, nil
 }
 
 // exchangeRefreshToken exchanges a refresh token for new access and refresh tokens
-func (h *Handler) exchangeRefreshToken(ctx context.Context, oauthSvc *auth.OAuthService, refreshToken, clientID, clientSecret string) (string, string, error) {
+func (h *Handler) exchangeRefreshToken(ctx context.Context, oauthSvc *auth.OAuthService, refreshToken, clientID, clientSecret string) (string, string, []string, error) {
 	refreshToken = strings.TrimSpace(refreshToken)
 	clientID = strings.TrimSpace(clientID)
 	clientSecret = strings.TrimSpace(clientSecret)
@@ -896,18 +895,18 @@ func (h *Handler) exchangeRefreshToken(ctx context.Context, oauthSvc *auth.OAuth
 	if clientID != delegatedAgentClientID {
 		client, err := h.repos.Account().GetOAuthClient(ctx, clientID)
 		if err != nil || client == nil {
-			return "", "", auth.ErrInvalidClient
+			return "", "", nil, auth.ErrInvalidClient
 		}
 
 		// Enforce confidential client authentication.
 		if client.Confidential && clientSecret == "" {
-			return "", "", auth.ErrInvalidClient
+			return "", "", nil, auth.ErrInvalidClient
 		}
 
 		// Validate client credentials if provided (or required).
 		if clientSecret != "" {
 			if err := oauthSvc.ValidateClient(ctx, clientID, clientSecret); err != nil {
-				return "", "", err
+				return "", "", nil, err
 			}
 		}
 	}
@@ -916,24 +915,24 @@ func (h *Handler) exchangeRefreshToken(ctx context.Context, oauthSvc *auth.OAuth
 	storedToken, err := h.repos.Account().GetRefreshToken(ctx, refreshToken)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
-			return "", "", auth.ErrInvalidToken
+			return "", "", nil, auth.ErrInvalidToken
 		}
 		if strings.Contains(err.Error(), "expired") {
-			return "", "", auth.ErrInvalidToken
+			return "", "", nil, auth.ErrInvalidToken
 		}
-		return "", "", errors.Join(failedToValidateRefreshToken(), err)
+		return "", "", nil, errors.Join(failedToValidateRefreshToken(), err)
 	}
 
 	// Validate refresh token belongs to the client
 	if storedToken.ClientID != clientID {
-		return "", "", auth.ErrInvalidToken
+		return "", "", nil, auth.ErrInvalidToken
 	}
 
 	// Check expiration
 	if time.Now().After(storedToken.ExpiresAt) {
 		// Clean up expired token
 		_ = h.repos.Account().DeleteRefreshToken(ctx, refreshToken)
-		return "", "", auth.ErrInvalidToken
+		return "", "", nil, auth.ErrInvalidToken
 	}
 
 	accessTTL := auth.AccessTokenDuration
@@ -944,7 +943,7 @@ func (h *Handler) exchangeRefreshToken(ctx context.Context, oauthSvc *auth.OAuth
 		remaining := time.Until(storedToken.ExpiresAt)
 		if remaining <= 0 {
 			_ = h.repos.Account().DeleteRefreshToken(ctx, refreshToken)
-			return "", "", auth.ErrInvalidToken
+			return "", "", nil, auth.ErrInvalidToken
 		}
 		if remaining < accessTTL {
 			accessTTL = remaining
@@ -954,7 +953,7 @@ func (h *Handler) exchangeRefreshToken(ctx context.Context, oauthSvc *auth.OAuth
 
 	accessToken, newRefreshToken, err := oauthSvc.GenerateTokensWithAccessTokenTTLAndClientContext(ctx, storedToken.Username, clientID, "", storedToken.Scopes, accessTTL, storedToken.ClientClass, storedToken.SessionID)
 	if err != nil {
-		return "", "", errors.Join(failedToGenerateNewTokens(), err)
+		return "", "", nil, errors.Join(failedToGenerateNewTokens(), err)
 	}
 
 	// Create new refresh token record
@@ -972,7 +971,7 @@ func (h *Handler) exchangeRefreshToken(ctx context.Context, oauthSvc *auth.OAuth
 	// Store new refresh token
 	if err := h.repos.Account().CreateRefreshToken(ctx, newOAuthRefreshToken); err != nil {
 		h.logger.Error("failed to store new refresh token", zap.Error(err))
-		return "", "", errors.Join(failedToStoreNewRefreshToken(), err)
+		return "", "", nil, errors.Join(failedToStoreNewRefreshToken(), err)
 	}
 
 	// Delete the old refresh token to prevent reuse
@@ -981,5 +980,5 @@ func (h *Handler) exchangeRefreshToken(ctx context.Context, oauthSvc *auth.OAuth
 		// Continue - new token is already stored
 	}
 
-	return accessToken, newRefreshToken, nil
+	return accessToken, newRefreshToken, storedToken.Scopes, nil
 }

--- a/cmd/api/handlers/oauth_round12_test.go
+++ b/cmd/api/handlers/oauth_round12_test.go
@@ -137,6 +137,40 @@ func TestOAuthAuthorizeFlowRound12(t *testing.T) {
 		require.Contains(t, body.NextURL, "error=invalid_scope")
 	})
 
+	t.Run("admin:read/admin:write scopes are accepted", func(t *testing.T) {
+		var issuedCode string
+		accountsSvc := &AccountsServiceStub{
+			GetUserAppConsentFunc: func(context.Context, *accounts.GetUserAppConsentQuery) (*accounts.GetUserAppConsentResult, error) {
+				return &accounts.GetUserAppConsentResult{Consent: &storage.UserAppConsent{Scopes: []string{"read", "write", "follow", "admin", "admin:read", "admin:write"}}}, nil
+			},
+			CreateAuthorizationCodeFunc: func(_ context.Context, cmd *accounts.CreateAuthorizationCodeCommand) (*accounts.CreateAuthorizationCodeResult, error) {
+				issuedCode = cmd.AuthCode.Code
+				return &accounts.CreateAuthorizationCodeResult{}, nil
+			},
+		}
+		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{}, &RegistryStub{AccountsSvc: accountsSvc})
+		ctx, err := round10NewLiftContext(http.MethodGet, "/oauth/authorize", map[string]string{"Accept": "text/html"}, map[string]string{
+			"response_type": "code",
+			"client_id":     "client-1",
+			"redirect_uri":  "https://example.com/callback",
+			"scope":         "read write follow admin admin:read admin:write",
+			"state":         "state-admin",
+		}, nil)
+		require.NoError(t, err)
+		ctx.Set("username", "alice")
+
+		resp := requireStatus(t, http.StatusFound)(h.HandleOAuthAuthorizeLift(ctx))
+		redirectURL := firstStringValue(resp.Headers, "location")
+		require.NotEmpty(t, redirectURL)
+
+		parsed, parseErr := url.Parse(redirectURL)
+		require.NoError(t, parseErr)
+		require.NotEmpty(t, parsed.Query().Get("code"))
+		require.Empty(t, parsed.Query().Get("error"))
+		require.Equal(t, "state-admin", parsed.Query().Get("state"))
+		require.NotEmpty(t, issuedCode)
+	})
+
 	t.Run("service registry missing returns server_error redirect (handled)", func(t *testing.T) {
 		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
 		ctx, err := round10NewLiftContext(http.MethodGet, "/oauth/authorize", nil, map[string]string{
@@ -489,6 +523,7 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		require.NoError(t, json.Unmarshal(resp.Body, &body))
 		require.NotEmpty(t, body.AccessToken)
 		require.NotEmpty(t, body.RefreshToken)
+		require.Equal(t, "read write", body.Scope)
 	})
 
 	t.Run("authorization_code cli client issues cli tokens", func(t *testing.T) {
@@ -513,6 +548,7 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		require.NoError(t, json.Unmarshal(resp.Body, &body))
 		require.NotEmpty(t, body.AccessToken)
 		require.NotEmpty(t, body.RefreshToken)
+		require.Equal(t, "read write", body.Scope)
 
 		claims := round12DecodeJWTClaims(t, body.AccessToken)
 		require.Equal(t, auth.ClientClassCLI, claims.ClientClass)
@@ -638,6 +674,7 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		require.NoError(t, json.Unmarshal(resp.Body, &body))
 		require.NotEmpty(t, body.AccessToken)
 		require.NotEmpty(t, body.RefreshToken)
+		require.Equal(t, "read", body.Scope)
 	})
 
 	t.Run("device_code grant disabled returns access_denied", func(t *testing.T) {
@@ -856,6 +893,7 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		require.NoError(t, json.Unmarshal(resp.Body, &body))
 		require.NotEmpty(t, body.AccessToken)
 		require.NotEmpty(t, body.RefreshToken)
+		require.Equal(t, "read write", body.Scope)
 
 		claims1 := round12DecodeJWTClaims(t, body.AccessToken)
 		require.Equal(t, auth.ClientClassCLI, claims1.ClientClass)
@@ -882,6 +920,7 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		require.NoError(t, json.Unmarshal(respRefresh.Body, &refreshBody))
 		require.NotEmpty(t, refreshBody.AccessToken)
 		require.NotEmpty(t, refreshBody.RefreshToken)
+		require.Equal(t, "read write", refreshBody.Scope)
 
 		refreshClaims := round12DecodeJWTClaims(t, refreshBody.AccessToken)
 		require.Equal(t, auth.ClientClassCLI, refreshClaims.ClientClass)

--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -557,7 +557,8 @@ func ValidateScopes(scopes []string) error {
 	}
 
 	for _, scope := range scopes {
-		if !validScopes[scope] {
+		baseScope := strings.Split(scope, ":")[0]
+		if !validScopes[baseScope] {
 			return ErrInvalidScope
 		}
 	}

--- a/pkg/auth/oauth_test.go
+++ b/pkg/auth/oauth_test.go
@@ -312,6 +312,11 @@ func TestValidateScopes(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name:    "valid hierarchical scopes",
+			scopes:  []string{"admin:read", "admin:write"},
+			wantErr: nil,
+		},
+		{
 			name:    "single valid scope",
 			scopes:  []string{ScopeRead},
 			wantErr: nil,
@@ -324,6 +329,11 @@ func TestValidateScopes(t *testing.T) {
 		{
 			name:    "invalid scope",
 			scopes:  []string{ScopeRead, "invalid"},
+			wantErr: ErrInvalidScope,
+		},
+		{
+			name:    "invalid base scope",
+			scopes:  []string{"invalid:scope"},
 			wantErr: ErrInvalidScope,
 		},
 		{

--- a/pkg/auth/oauth_validation_demo_test.go
+++ b/pkg/auth/oauth_validation_demo_test.go
@@ -61,7 +61,7 @@ func TestMastodonOAuthValidationDemo(t *testing.T) {
 			{"invalid"},
 			{ScopeRead, "nonexistent"},
 			{"custom-scope"},
-			{"read:custom"},
+			{"invalid:custom"},
 		}
 
 		for _, scopes := range invalidScopes {


### PR DESCRIPTION
Fixes two OAuth scope issues:

- Accept hierarchical scopes (e.g. `admin:read`, `admin:write`) during `/oauth/authorize` validation.
- Return the actual granted scopes in `/oauth/token` responses (auth code, refresh, device), instead of a static default.

Tests:
- `go test ./...`

Closes #89