### PR TITLE
fix issues 91-95

### DIFF
--- a/cmd/api/handlers/round11_wallet_test.go
+++ b/cmd/api/handlers/round11_wallet_test.go
@@ -108,6 +108,33 @@ func TestWalletHandlers_FullFlow(t *testing.T) {
 	requireStatus(t, http.StatusOK)(handler.HandleGetWalletsLift(ctxList))
 }
 
+func TestWalletHandlers_GetWallets_OAuthTokenDoesNotRequireSession(t *testing.T) {
+	cfg := round11TestConfig()
+	now := time.Now()
+
+	state := &round10QueryState{
+		notFoundPKs: map[string]bool{
+			// Simulate a production-like behavior where a session lookup for an OAuth token fails.
+			"session#": true,
+		},
+		usersByUsername: map[string]storagemodels.User{
+			"alice": {PK: "USER#alice", SK: storagemodels.SKMetadata, Username: "alice", Role: "user", Approved: true, Version: 1, CreatedAt: now.Add(-24 * time.Hour)},
+		},
+		walletCredentialsByUser: map[string][]storagemodels.WalletCredential{
+			"alice": {},
+		},
+	}
+
+	handler, _, _ := round11NewHandler(t, cfg, state)
+
+	token := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{auth.ScopeRead})
+	headers := map[string]string{"Authorization": "Bearer " + token}
+
+	ctxList, err := round10NewLiftContext(http.MethodGet, "/auth/wallet/list", headers, nil, nil)
+	require.NoError(t, err)
+	requireStatus(t, http.StatusOK)(handler.HandleGetWalletsLift(ctxList))
+}
+
 func TestWalletHandlers_CreateAndLinkRegistration(t *testing.T) {
 	cfg := round11TestConfig()
 	now := time.Now()

--- a/cmd/api/handlers/wallet.go
+++ b/cmd/api/handlers/wallet.go
@@ -388,14 +388,9 @@ func (h *Handler) getAuthenticatedUserLift(ctx *apptheory.Context) string {
 		return ""
 	}
 
-	// Create auth service and validate token
-	authService, err := auth.NewAuthService(h.cfg, h.repos)
-	if err != nil {
-		return ""
-	}
-
-	claims, err := authService.ValidateAccessToken(token)
-	if err != nil {
+	oauthSvc := createOAuthService(h.cfg.JWTSecret, h.cfg, h.repos, h.logger)
+	claims, err := oauthSvc.ValidateAccessToken(token)
+	if err != nil || claims == nil {
 		return ""
 	}
 

--- a/graph/actor_resolver_created_at_test.go
+++ b/graph/actor_resolver_created_at_test.go
@@ -1,0 +1,47 @@
+package graph
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/graph/model"
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/stretchr/testify/require"
+)
+
+func TestActorResolver_CreatedAt_Fallbacks(t *testing.T) {
+	resolver := &actorResolver{}
+	ctx := context.Background()
+
+	created := time.Date(2026, 2, 13, 12, 0, 0, 0, time.UTC)
+	actorWithCreated := &activitypub.Actor{CreatedAt: &created}
+	got, err := resolver.CreatedAt(ctx, actorWithCreated)
+	require.NoError(t, err)
+	require.Equal(t, model.Time(created), *got)
+
+	published := time.Date(2026, 2, 13, 12, 1, 0, 0, time.UTC)
+	actorWithPublished := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{Published: &published},
+	}
+	got, err = resolver.CreatedAt(ctx, actorWithPublished)
+	require.NoError(t, err)
+	require.Equal(t, model.Time(published), *got)
+
+	updated := time.Date(2026, 2, 13, 12, 2, 0, 0, time.UTC)
+	actorWithUpdated := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{Updated: &updated},
+	}
+	got, err = resolver.CreatedAt(ctx, actorWithUpdated)
+	require.NoError(t, err)
+	require.Equal(t, model.Time(updated), *got)
+
+	before := time.Now().UTC()
+	got, err = resolver.CreatedAt(ctx, &activitypub.Actor{})
+	after := time.Now().UTC()
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.False(t, time.Time(*got).Before(before))
+	require.False(t, time.Time(*got).After(after))
+}
+

--- a/graph/agent_resolvers_stubs.go
+++ b/graph/agent_resolvers_stubs.go
@@ -771,9 +771,42 @@ func (r *mutationResolver) DelegateToAgent(ctx context.Context, input model.Dele
 
 // RevokeAgentToken is the resolver for the revokeAgentToken field.
 func (r *mutationResolver) RevokeAgentToken(ctx context.Context, username string) (bool, error) {
-	_ = ctx
-	_ = username
-	return false, errAgentSupportNotImplemented
+	if err := r.ensureAgentsEnabled(ctx); err != nil {
+		return false, err
+	}
+
+	username = strings.TrimSpace(username)
+	if err := common.ValidateUsernameParamID(username); err != nil {
+		return false, err
+	}
+
+	claims, err := r.requireAuthClaims(ctx)
+	if err != nil {
+		return false, err
+	}
+	if !claims.HasScope("write:accounts") && !claims.HasScope(auth.ScopeWrite) {
+		return false, apperrors.InsufficientScope("write:accounts")
+	}
+
+	if r.Storage == nil || r.Storage.Account() == nil {
+		return false, ErrStorageUnavailable
+	}
+
+	account, err := r.Storage.Account().GetAccount(ctx, username)
+	if err != nil || account == nil || account.User == nil || !account.User.IsAgent {
+		return false, apperrors.NewAppError(apperrors.CodeNotFound, apperrors.CategoryBusiness, "agent not found")
+	}
+
+	if !isAgentOwnerOrAdmin(claims, account.User) {
+		return false, apperrors.Forbidden("not authorized to revoke agent tokens")
+	}
+
+	_, err = r.Storage.Account().DeleteRefreshTokensByUsernameAndClientID(ctx, username, delegatedAgentClientID)
+	if err != nil {
+		return false, apperrors.InternalWithCause(err, "failed to revoke agent tokens")
+	}
+
+	return true, nil
 }
 
 // UpdateAdminAgentPolicy is the resolver for the updateAdminAgentPolicy field.

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -2965,10 +2965,19 @@ func (r *actorResolver) Locked(_ context.Context, obj *activitypub.Actor) (bool,
 
 // CreatedAt implements ActorResolver
 func (r *actorResolver) CreatedAt(_ context.Context, obj *activitypub.Actor) (*model.Time, error) {
-	if obj.Published == nil {
-		return nil, nil
+	if obj.CreatedAt != nil {
+		t := model.Time(*obj.CreatedAt)
+		return &t, nil
 	}
-	t := model.Time(*obj.Published)
+	if obj.Published != nil {
+		t := model.Time(*obj.Published)
+		return &t, nil
+	}
+	if obj.Updated != nil {
+		t := model.Time(*obj.Updated)
+		return &t, nil
+	}
+	t := model.Time(time.Now().UTC())
 	return &t, nil
 }
 

--- a/pkg/storage/repositories/account_repository_oauth.go
+++ b/pkg/storage/repositories/account_repository_oauth.go
@@ -197,6 +197,45 @@ func (r *AccountRepository) DeleteRefreshToken(ctx context.Context, token string
 	return helper.DeleteRefreshTokenGeneric(ctx, token)
 }
 
+// DeleteRefreshTokensByUsernameAndClientID deletes all OAuth refresh tokens for the given user+client pair.
+// This is intended for revoking delegated/agent tokens where only refresh-token invalidation is required.
+func (r *AccountRepository) DeleteRefreshTokensByUsernameAndClientID(ctx context.Context, username, clientID string) (int, error) {
+	username = strings.TrimSpace(username)
+	clientID = strings.TrimSpace(clientID)
+	if err := common.ValidateRequiredParam("username", username); err != nil {
+		return 0, err
+	}
+	if err := common.ValidateRequiredParam("clientID", clientID); err != nil {
+		return 0, err
+	}
+
+	var tokenModels []models.RefreshToken
+	query := r.db.WithContext(ctx).Model(&models.RefreshToken{}).
+		Where("Username", "=", username).
+		Where("ClientID", "=", clientID)
+	if err := query.Scan(&tokenModels); err != nil {
+		if errors.IsNotFound(err) {
+			return 0, nil
+		}
+		return 0, ErrorHandler.HandleQueryError(err, EntityRefreshToken, "by username/clientID")
+	}
+
+	helper := NewOAuthHelper(r.db, r.logger)
+	deleted := 0
+	for _, tokenModel := range tokenModels {
+		tokenValue := strings.TrimSpace(tokenModel.Token)
+		if tokenValue == "" {
+			continue
+		}
+		if err := helper.DeleteRefreshTokenGeneric(ctx, tokenValue); err != nil && !errors.IsNotFound(err) {
+			return deleted, err
+		}
+		deleted++
+	}
+
+	return deleted, nil
+}
+
 // ===== OAuth Client Operations =====
 
 // CreateOAuthClient creates a new OAuth client

--- a/pkg/storage/repositories/account_repository_oauth_test.go
+++ b/pkg/storage/repositories/account_repository_oauth_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	dynamormerrors "github.com/theory-cloud/tabletheory/pkg/errors"
 	dynamock "github.com/theory-cloud/tabletheory/pkg/mocks"
 	"go.uber.org/zap/zaptest"
 
@@ -102,6 +103,47 @@ func TestAccountRepository_ListOAuthClients_InvalidCursor(t *testing.T) {
 	assert.Empty(t, nextCursor)
 
 	mockDB.AssertExpectations(t)
+}
+
+func TestAccountRepository_DeleteRefreshTokensByUsernameAndClientID_ScanNotFound(t *testing.T) {
+	ctx := context.Background()
+	mockDB := new(dynamock.MockDB)
+	mockQuery := new(dynamock.MockQuery)
+	repo := NewAccountRepository(mockDB, "test-table", "example.com", zaptest.NewLogger(t))
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB).Maybe()
+	mockDB.On("Model", mock.Anything).Return(mockQuery).Maybe()
+	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery).Maybe()
+	mockQuery.On("Scan", mock.Anything).Return(dynamormerrors.ErrItemNotFound).Once()
+
+	deleted, err := repo.DeleteRefreshTokensByUsernameAndClientID(ctx, "alice", "client-1")
+	require.NoError(t, err)
+	require.Equal(t, 0, deleted)
+	mockQuery.AssertNotCalled(t, "Delete")
+}
+
+func TestAccountRepository_DeleteRefreshTokensByUsernameAndClientID_DeletesAll(t *testing.T) {
+	ctx := context.Background()
+	mockDB := new(dynamock.MockDB)
+	mockQuery := new(dynamock.MockQuery)
+	repo := NewAccountRepository(mockDB, "test-table", "example.com", zaptest.NewLogger(t))
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB).Maybe()
+	mockDB.On("Model", mock.Anything).Return(mockQuery).Maybe()
+	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery).Maybe()
+	mockQuery.On("Scan", mock.Anything).Run(func(args mock.Arguments) {
+		dest := args.Get(0).(*[]models.RefreshToken)
+		*dest = []models.RefreshToken{
+			{Token: "token-1", Username: "alice", ClientID: "client-1"},
+			{Token: "token-2", Username: "alice", ClientID: "client-1"},
+		}
+	}).Return(nil).Once()
+	mockQuery.On("Delete").Return(nil).Maybe()
+
+	deleted, err := repo.DeleteRefreshTokensByUsernameAndClientID(ctx, "alice", "client-1")
+	require.NoError(t, err)
+	require.Equal(t, 2, deleted)
+	mockQuery.AssertNumberOfCalls(t, "Delete", 2)
 }
 
 func buildOAuthClientModel(t *testing.T, clientID string, createdAt time.Time) *models.OAuthClient {

--- a/pkg/storage/repositories/actor_repository.go
+++ b/pkg/storage/repositories/actor_repository.go
@@ -3,7 +3,6 @@ package repositories
 import (
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	neturl "net/url"
@@ -148,7 +147,9 @@ func (r *ActorRepository) GetActor(ctx context.Context, username string) (*activ
 		return nil, ErrorHandler.HandleGetError(err, EntityActor, username)
 	}
 
-	return actorModel.Actor, nil
+	actor := actorModel.Actor
+	hydrateActivityPubActorTimestamps(actor, actorModel.CreatedAt, actorModel.UpdatedAt)
+	return actor, nil
 }
 
 // GetActorWithMetadata retrieves an actor with metadata
@@ -170,7 +171,9 @@ func (r *ActorRepository) GetActorWithMetadata(ctx context.Context, username str
 		Fields:       convertActorFields(actorModel.Fields),
 	}
 
-	return actorModel.Actor, metadata, nil
+	actor := actorModel.Actor
+	hydrateActivityPubActorTimestamps(actor, actorModel.CreatedAt, actorModel.UpdatedAt)
+	return actor, metadata, nil
 }
 
 // GetActorByNumericID retrieves an actor by numeric ID
@@ -241,6 +244,25 @@ func (r *ActorRepository) GetActorPrivateKey(ctx context.Context, username strin
 	return string(decrypted), nil
 }
 
+func hydrateActivityPubActorTimestamps(actor *activitypub.Actor, createdAt, updatedAt time.Time) {
+	if actor == nil {
+		return
+	}
+
+	if actor.CreatedAt == nil && !createdAt.IsZero() {
+		t := createdAt.UTC()
+		actor.CreatedAt = &t
+	}
+	if actor.Published == nil && !createdAt.IsZero() {
+		t := createdAt.UTC()
+		actor.Published = &t
+	}
+	if actor.Updated == nil && !updatedAt.IsZero() {
+		t := updatedAt.UTC()
+		actor.Updated = &t
+	}
+}
+
 // UpdateActor updates an existing actor
 func (r *ActorRepository) UpdateActor(ctx context.Context, actor *activitypub.Actor) error {
 	// Validate actor entity using centralized validation
@@ -284,17 +306,7 @@ func (r *ActorRepository) UpdateActor(ctx context.Context, actor *activitypub.Ac
 		Where("SK", "=", actorModel.SK).
 		UpdateBuilder()
 
-	actorBytes, err := json.Marshal(actor)
-	if err != nil {
-		return fmt.Errorf("failed to marshal actor: %w", err)
-	}
-
-	var actorMap map[string]interface{}
-	if err := json.Unmarshal(actorBytes, &actorMap); err != nil {
-		return fmt.Errorf("failed to unmarshal actor into map: %w", err)
-	}
-
-	updateBuilder.Set("Actor", actorMap)
+	updateBuilder.Set("Actor", actor)
 	updateBuilder.Set("UpdatedAt", now)
 
 	gsi1PK, gsi1SK := buildActorGSI1Keys(username)

--- a/pkg/storage/repositories/moderation_repository.go
+++ b/pkg/storage/repositories/moderation_repository.go
@@ -2665,6 +2665,9 @@ func (r *ModerationRepository) GetReportsByStatus(ctx context.Context, status st
 	query = query.Limit(limit + 1)
 
 	if err := query.All(&models); err != nil {
+		if errors.IsNotFound(err) {
+			return []*storage.Report{}, "", nil
+		}
 		return nil, "", ErrorHandler.HandleQueryError(err, EntityReport, "by status")
 	}
 

--- a/pkg/storage/repositories/moderation_repository_error_paths_test.go
+++ b/pkg/storage/repositories/moderation_repository_error_paths_test.go
@@ -89,6 +89,21 @@ func TestModerationRepository_GetModerationEvent_NotFoundAndError(t *testing.T) 
 	})
 }
 
+func TestModerationRepository_GetReportsByStatus_NotFoundReturnsEmpty(t *testing.T) {
+	ctx := context.Background()
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+
+	mockQuery.On("All", mock.Anything).Return(errors.ErrItemNotFound).Once()
+	setupPermissiveDynamormMocks(mockDB, mockQuery)
+
+	repo := NewModerationRepository(mockDB, "test-table", zap.NewNop())
+	reports, nextCursor, err := repo.GetReportsByStatus(ctx, storage.ReportStatusOpen, 50, "")
+	require.NoError(t, err)
+	require.Empty(t, nextCursor)
+	require.Empty(t, reports)
+}
+
 func TestModerationRepository_DeleteModerationPattern_NotFoundAndError(t *testing.T) {
 	t.Run("not found returns storage.ErrNotFound", func(t *testing.T) {
 		ctx := context.Background()


### PR DESCRIPTION
Fixes:
- Fixes #91 (adminReports returns 500 when empty)
- Fixes #92 (Actor.createdAt non-null violations in adminAccounts)
- Fixes #93 (agent update failing due to actor update conversion)
- Fixes #94 (implement revokeAgentToken)
- Fixes #95 (/auth/wallet/list accepts OAuth access tokens)

Validation:
- go test ./...
- STAGE=development ./lesser lint