### PR TITLE
fix agent query hydration

### DIFF
--- a/cmd/api/handlers/agent_feature_round12_more_coverage_test.go
+++ b/cmd/api/handlers/agent_feature_round12_more_coverage_test.go
@@ -128,7 +128,7 @@ func TestAgentsRound12_DirectoryLifecycleAndActivity(t *testing.T) {
 		var out apimodels.Agent
 		require.NoError(t, json.Unmarshal(resp.Body, &out))
 		require.Equal(t, "alice", out.Username)
-		require.False(t, out.Verified)
+		require.True(t, out.Verified)
 	})
 
 	t.Run("updates_agent_as_owner", func(t *testing.T) {

--- a/graph/agent_model_helpers_test.go
+++ b/graph/agent_model_helpers_test.go
@@ -1,0 +1,49 @@
+package graph
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/agents"
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertStorageUserToAgent_HydratesMetadataAndCapabilities(t *testing.T) {
+	resolver := &Resolver{}
+	createdAt := time.Date(2026, 2, 13, 12, 42, 10, 0, time.UTC)
+
+	user := &storage.User{
+		Username:     "lowkey",
+		DisplayName:  "Lowkey",
+		Note:         "bio",
+		IsAgent:      true,
+		AgentType:    "assistant",
+		AgentVersion: "1.0.0",
+		AgentOwner:   "@alice",
+		AgentCapabilities: &agents.Capabilities{
+			CanPost:          true,
+			CanDM:            true,
+			MaxPostsPerHour:  0,
+			RequiresApproval: true,
+		},
+		Metadata: map[string]any{
+			"agent_verified":         true,
+			"agent_verified_at":      "2026-02-13T13:56:01Z",
+			"agent_delegated_scopes": []any{"read"},
+		},
+		CreatedAt: createdAt,
+	}
+
+	agent := resolver.convertStorageUserToAgent(context.Background(), user)
+	require.NotNil(t, agent)
+	require.Equal(t, "lowkey", agent.Username)
+	require.True(t, agent.Verified)
+	require.Contains(t, agent.DelegatedScopes, "read")
+	require.NotNil(t, agent.AgentCapabilities)
+	require.True(t, agent.AgentCapabilities.CanPost)
+	require.True(t, agent.AgentCapabilities.CanDM)
+	require.Equal(t, 0, agent.AgentCapabilities.MaxPostsPerHour)
+	require.True(t, agent.AgentCapabilities.RequiresApproval)
+}

--- a/pkg/storage/repositories/user_repository.go
+++ b/pkg/storage/repositories/user_repository.go
@@ -503,28 +503,51 @@ func (r *UserRepository) GetLinkedProviders(ctx context.Context, username string
 
 // modelToStorage converts a models.User to storage.User
 func (r *UserRepository) modelToStorage(userModel *models.User) *storage.User {
-	return &storage.User{
-		Username:          userModel.Username,
-		Email:             userModel.Email,
-		PasswordHash:      userModel.PasswordHash,
-		DisplayName:       userModel.DisplayName,
-		IsAgent:           userModel.IsAgent,
-		AgentType:         userModel.AgentType,
-		AgentCapabilities: userModel.AgentCapabilities,
-		AgentVersion:      userModel.AgentVersion,
-		AgentOwner:        userModel.AgentOwner,
-		AgentCreatedBy:    userModel.AgentCreatedBy,
-		AgentPublicKey:    userModel.AgentPublicKey,
-		AgentKeyType:      userModel.AgentKeyType,
-		CreatedAt:         userModel.CreatedAt,
-		UpdatedAt:         userModel.UpdatedAt,
-		Approved:          userModel.Approved,
-		Suspended:         userModel.Suspended,
-		Silenced:          userModel.Silenced,
-		Role:              userModel.Role,
-		Locale:            userModel.Locale,
-		RecoveryMethods:   userModel.RecoveryMethods,
+	user := &storage.User{
+		ID:                 common.GenerateNumericID(userModel.Username),
+		Username:           userModel.Username,
+		Email:              userModel.Email,
+		PasswordHash:       userModel.PasswordHash,
+		DisplayName:        userModel.DisplayName,
+		Note:               userModel.Note,
+		Avatar:             userModel.Avatar,
+		Header:             userModel.Header,
+		URL:                userModel.URL,
+		Locked:             userModel.Locked,
+		Discoverable:       userModel.Discoverable,
+		Fields:             userModel.Fields,
+		CreatedAt:          userModel.CreatedAt,
+		UpdatedAt:          userModel.UpdatedAt,
+		Approved:           userModel.Approved,
+		Suspended:          userModel.Suspended,
+		Silenced:           userModel.Silenced,
+		Role:               userModel.Role,
+		Locale:             userModel.Locale,
+		RecoveryMethods:    userModel.RecoveryMethods,
+		AllowNSFW:          userModel.AllowNSFW,
+		RequireNSFWWarning: userModel.RequireNSFWWarning,
+		Metadata:           userModel.Metadata,
+		IsAgent:            userModel.IsAgent,
+		AgentType:          userModel.AgentType,
+		AgentCapabilities:  userModel.AgentCapabilities,
+		AgentVersion:       userModel.AgentVersion,
+		AgentOwner:         userModel.AgentOwner,
+		AgentCreatedBy:     userModel.AgentCreatedBy,
+		AgentPublicKey:     userModel.AgentPublicKey,
+		AgentKeyType:       userModel.AgentKeyType,
+		Version:            userModel.Version,
 	}
+
+	baseURL := strings.TrimSpace(config.Get().Domain)
+	if baseURL != "" && !strings.HasPrefix(baseURL, "http://") && !strings.HasPrefix(baseURL, "https://") {
+		baseURL = "https://" + baseURL
+	}
+	baseURL = strings.TrimSuffix(baseURL, "/")
+	if baseURL != "" && strings.TrimSpace(user.URL) == "" {
+		user.URL = fmt.Sprintf("%s/@%s", baseURL, userModel.Username)
+	}
+
+	return user
 }
 
 type userUpdateApplier func(*models.User, any)

--- a/pkg/storage/repositories/user_repository_pure_helpers_test.go
+++ b/pkg/storage/repositories/user_repository_pure_helpers_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/equaltoai/lesser/pkg/agents"
+	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/trust"
@@ -33,32 +35,88 @@ func TestUserRepository_modelToStorage(t *testing.T) {
 		{
 			name: "complete user model",
 			userModel: &models.User{
-				Username:        "alice",
-				Email:           "alice@example.com",
-				PasswordHash:    "hashed",
-				DisplayName:     "Alice Wonder",
-				CreatedAt:       time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
-				UpdatedAt:       time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC),
-				Approved:        true,
-				Suspended:       false,
-				Silenced:        true,
-				Role:            "admin",
-				Locale:          "fr",
-				RecoveryMethods: []string{"email", "passkey"},
+				Username:           "alice",
+				Email:              "alice@example.com",
+				PasswordHash:       "hashed",
+				DisplayName:        "Alice Wonder",
+				Note:               "bio",
+				Avatar:             "avatar.png",
+				Header:             "header.png",
+				URL:                "https://example.com/@alice",
+				Locked:             true,
+				Discoverable:       true,
+				Fields:             []map[string]string{{"name": "x", "value": "y"}},
+				CreatedAt:          time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				UpdatedAt:          time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC),
+				Approved:           true,
+				Suspended:          false,
+				Silenced:           true,
+				Role:               "admin",
+				Locale:             "fr",
+				RecoveryMethods:    []string{"email", "passkey"},
+				AllowNSFW:          true,
+				RequireNSFWWarning: false,
+				Metadata: map[string]interface{}{
+					"agent_verified":         true,
+					"agent_delegated_scopes": []any{"read"},
+				},
+				IsAgent:      true,
+				AgentType:    "assistant",
+				AgentVersion: "1.0.0",
+				AgentOwner:   "@bob",
+				AgentCapabilities: &agents.Capabilities{
+					CanPost:           true,
+					CanReply:          true,
+					CanBoost:          true,
+					CanFollow:         true,
+					CanDM:             true,
+					RestrictedDomains: []string{"example.com"},
+					MaxPostsPerHour:   0,
+					RequiresApproval:  true,
+				},
+				Version: 6,
 			},
 			want: &storage.User{
-				Username:        "alice",
-				Email:           "alice@example.com",
-				PasswordHash:    "hashed",
-				DisplayName:     "Alice Wonder",
-				CreatedAt:       time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
-				UpdatedAt:       time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC),
-				Approved:        true,
-				Suspended:       false,
-				Silenced:        true,
-				Role:            "admin",
-				Locale:          "fr",
-				RecoveryMethods: []string{"email", "passkey"},
+				Username:           "alice",
+				Email:              "alice@example.com",
+				PasswordHash:       "hashed",
+				DisplayName:        "Alice Wonder",
+				Note:               "bio",
+				Avatar:             "avatar.png",
+				Header:             "header.png",
+				URL:                "https://example.com/@alice",
+				Locked:             true,
+				Discoverable:       true,
+				Fields:             []map[string]string{{"name": "x", "value": "y"}},
+				CreatedAt:          time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				UpdatedAt:          time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC),
+				Approved:           true,
+				Suspended:          false,
+				Silenced:           true,
+				Role:               "admin",
+				Locale:             "fr",
+				RecoveryMethods:    []string{"email", "passkey"},
+				AllowNSFW:          true,
+				RequireNSFWWarning: false,
+				Metadata: map[string]interface{}{
+					"agent_verified":         true,
+					"agent_delegated_scopes": []any{"read"},
+				},
+				IsAgent:      true,
+				AgentType:    "assistant",
+				AgentVersion: "1.0.0",
+				AgentOwner:   "@bob",
+				AgentCapabilities: &agents.Capabilities{
+					CanPost:           true,
+					CanReply:          true,
+					CanBoost:          true,
+					CanFollow:         true,
+					CanDM:             true,
+					RestrictedDomains: []string{"example.com"},
+					MaxPostsPerHour:   0,
+					RequiresApproval:  true,
+				},
+				Version: 6,
 			},
 		},
 		{
@@ -87,10 +145,20 @@ func TestUserRepository_modelToStorage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := repo.modelToStorage(tt.userModel)
+			assert.Equal(t, common.GenerateNumericID(tt.userModel.Username), got.ID)
 			assert.Equal(t, tt.want.Username, got.Username)
 			assert.Equal(t, tt.want.Email, got.Email)
 			assert.Equal(t, tt.want.PasswordHash, got.PasswordHash)
 			assert.Equal(t, tt.want.DisplayName, got.DisplayName)
+			assert.Equal(t, tt.want.Note, got.Note)
+			assert.Equal(t, tt.want.Avatar, got.Avatar)
+			assert.Equal(t, tt.want.Header, got.Header)
+			if tt.want.URL != "" {
+				assert.Equal(t, tt.want.URL, got.URL)
+			}
+			assert.Equal(t, tt.want.Locked, got.Locked)
+			assert.Equal(t, tt.want.Discoverable, got.Discoverable)
+			assert.Equal(t, tt.want.Fields, got.Fields)
 			assert.Equal(t, tt.want.CreatedAt, got.CreatedAt)
 			assert.Equal(t, tt.want.UpdatedAt, got.UpdatedAt)
 			assert.Equal(t, tt.want.Approved, got.Approved)
@@ -99,6 +167,18 @@ func TestUserRepository_modelToStorage(t *testing.T) {
 			assert.Equal(t, tt.want.Role, got.Role)
 			assert.Equal(t, tt.want.Locale, got.Locale)
 			assert.Equal(t, tt.want.RecoveryMethods, got.RecoveryMethods)
+			assert.Equal(t, tt.want.AllowNSFW, got.AllowNSFW)
+			assert.Equal(t, tt.want.RequireNSFWWarning, got.RequireNSFWWarning)
+			assert.Equal(t, tt.want.Metadata, got.Metadata)
+			assert.Equal(t, tt.want.IsAgent, got.IsAgent)
+			assert.Equal(t, tt.want.AgentType, got.AgentType)
+			assert.Equal(t, tt.want.AgentCapabilities, got.AgentCapabilities)
+			assert.Equal(t, tt.want.AgentVersion, got.AgentVersion)
+			assert.Equal(t, tt.want.AgentOwner, got.AgentOwner)
+			assert.Equal(t, tt.want.AgentCreatedBy, got.AgentCreatedBy)
+			assert.Equal(t, tt.want.AgentPublicKey, got.AgentPublicKey)
+			assert.Equal(t, tt.want.AgentKeyType, got.AgentKeyType)
+			assert.Equal(t, tt.want.Version, got.Version)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #97.

Agent reads via UserRepository were dropping agent metadata/capabilities due to incomplete model-to-storage hydration.

- Hydrate user Metadata + profile fields + Version in UserRepository.modelToStorage
- Add regression tests for agent conversion/hydration

Commands:
- go test ./...
- STAGE=development ./lesser lint