### PR TITLE
fix: unblock simulacrum dev instance

### DIFF
--- a/cmd/actor/round22_more_coverage_test.go
+++ b/cmd/actor/round22_more_coverage_test.go
@@ -121,4 +121,3 @@ func TestActorPanicRecovery_Round22(t *testing.T) {
 	require.NoError(t, json.Unmarshal(resp.Body, &body))
 	require.Equal(t, "internal server error", body["error"])
 }
-

--- a/cmd/api/handlers/misc.go
+++ b/cmd/api/handlers/misc.go
@@ -711,7 +711,7 @@ func (h *Handler) HandleGetInstanceV2Lift(ctx *apptheory.Context) (*apptheory.Re
 				"max_expiration":            2629746,
 			},
 			"translation": map[string]any{
-				"enabled": false,
+				"enabled": h.cfg != nil && h.cfg.TranslationEnabled,
 			},
 			"tips": func() map[string]any {
 				enabled := false

--- a/cmd/api/handlers/round10_test_helpers_test.go
+++ b/cmd/api/handlers/round10_test_helpers_test.go
@@ -1030,7 +1030,13 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 					UpdatedAt:  time.Now(),
 				}
 			}
-			d.Data = *state.vapidKeys
+			d.Data = map[string]any{
+				"public_key":  state.vapidKeys.PublicKey,
+				"private_key": state.vapidKeys.PrivateKey,
+				"subject":     state.vapidKeys.Subject,
+				"created_at":  state.vapidKeys.CreatedAt.Format(time.RFC3339Nano),
+				"updated_at":  state.vapidKeys.UpdatedAt.Format(time.RFC3339Nano),
+			}
 			d.PK = "INSTANCE#CONFIG"
 			d.SK = "VAPID_KEYS"
 		case *storagemodels.Export:

--- a/cmd/api/handlers/vapid_check_round28_test.go
+++ b/cmd/api/handlers/vapid_check_round28_test.go
@@ -49,4 +49,3 @@ func TestValidateVAPIDKeysForProduction_round28_more_coverage(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
-

--- a/cmd/graphql-ws/main.go
+++ b/cmd/graphql-ws/main.go
@@ -34,6 +34,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const graphqlWSName = "graphql-ws"
+
 type connectionState struct {
 	username      string
 	claims        *auth.Claims
@@ -235,7 +237,7 @@ func (s *wsServer) registerConnection(ctx context.Context, connectionID, usernam
 			connectionRecord.Streams = streams
 			connectionRecord.Username = username
 			connectionRecord.UserID = username
-			connectionRecord.Info.Protocol = "graphql-ws"
+			connectionRecord.Info.Protocol = graphqlWSName
 			connectionRecord.Info.AuthMethod = "oauth"
 			if connectionRecord.Info.CustomHeaders == nil {
 				connectionRecord.Info.CustomHeaders = make(map[string]string)
@@ -561,7 +563,7 @@ func (s *wsServer) handleConnect(ctx *apptheory.Context) (*apptheory.Response, e
 				log.Warn("failed to write pending graphql connection record", zap.Error(err))
 			} else if conn != nil {
 				conn.Streams = streams
-				conn.Info.Protocol = "graphql-ws"
+				conn.Info.Protocol = graphqlWSName
 				conn.Info.AuthMethod = "pending"
 				conn.LastActivity = time.Now()
 				conn.Established = time.Now()
@@ -652,23 +654,13 @@ func (s *wsServer) handleDisconnect(ctx *apptheory.Context) (*apptheory.Response
 }
 
 func (s *wsServer) handleDefault(ctx *apptheory.Context) (*apptheory.Response, error) {
-	if ctx == nil {
-		return nil, appError("app.bad_request", "Invalid WebSocket event")
+	wsCtx, connectionID, err := s.webSocketContextFromEvent(ctx)
+	if err != nil {
+		return nil, err
 	}
 
-	wsCtx := ctx.AsWebSocket()
-	if wsCtx == nil {
-		return nil, appError("app.bad_request", "Invalid WebSocket event")
-	}
+	s.rememberWebSocketContext(connectionID, wsCtx)
 
-	connectionID := wsCtx.ConnectionID
-
-	// Store WebSocket context for async message sending (subscriptions)
-	s.mu.Lock()
-	s.wsContexts[connectionID] = wsCtx
-	s.mu.Unlock()
-
-	// Parse message body
 	var msg wsMessage
 	if err := json.Unmarshal(ctx.Request.Body, &msg); err != nil {
 		s.logger.Warn("failed to parse websocket message",
@@ -679,107 +671,7 @@ func (s *wsServer) handleDefault(ctx *apptheory.Context) (*apptheory.Response, e
 
 	switch strings.ToLower(msg.Type) {
 	case "connection_init":
-		log := s.logger.With(zap.String("connection_id", connectionID))
-
-		// If the connection is already authenticated (token provided at $connect), just ACK.
-		if state, err := s.getConnection(ctx.Context(), connectionID); err == nil && state != nil && state.username != "" {
-			log.Info("received connection_init for authenticated connection")
-			if err := s.sendJSON(wsCtx, responseEnvelope{Type: "connection_ack"}); err != nil {
-				return nil, err
-			}
-			return okWebSocketResponse(), nil
-		}
-
-		tokenValue := extractAccessTokenFromInitPayload(msg.Payload)
-		if tokenValue == "" {
-			log.Warn("connection_init missing access token")
-			_ = s.sendJSON(wsCtx, responseEnvelope{
-				Type: "connection_error",
-				Payload: errorPayload{
-					Message: "Access token required",
-					Code:    "unauthorized",
-				},
-			})
-			return okWebSocketResponse(), nil
-		}
-
-		if s.oauthService == nil {
-			log.Error("oauth service not configured for graphql websocket server")
-			return nil, appError("app.internal", "OAuth service unavailable")
-		}
-
-		claims, err := s.oauthService.ValidateAccessToken(tokenValue)
-		if err != nil {
-			log.Warn("connection_init failed token validation", zap.Error(err))
-			_ = s.sendJSON(wsCtx, responseEnvelope{
-				Type: "connection_error",
-				Payload: errorPayload{
-					Message: "Invalid or expired token",
-					Code:    "unauthorized",
-				},
-			})
-			return okWebSocketResponse(), nil
-		}
-
-		username := claims.GetUsername()
-		if username == "" {
-			username = claims.Username
-		}
-		if username == "" {
-			log.Warn("connection_init missing username in claims")
-			_ = s.sendJSON(wsCtx, responseEnvelope{
-				Type: "connection_error",
-				Payload: errorPayload{
-					Message: "Missing username in token claims",
-					Code:    "forbidden",
-				},
-			})
-			return okWebSocketResponse(), nil
-		}
-
-		// Persist/refresh connection metadata with authenticated identity.
-		if s.connRepo != nil {
-			conn, getErr := s.connRepo.GetConnection(ctx.Context(), connectionID)
-			if getErr != nil || conn == nil {
-				_, _ = s.connRepo.WriteConnection(ctx.Context(), connectionID, username, username, []string{"graphql"})
-				conn, _ = s.connRepo.GetConnection(ctx.Context(), connectionID)
-			}
-			if conn != nil {
-				conn.UserID = username
-				conn.Username = username
-				conn.Streams = []string{"graphql"}
-				conn.Info.Protocol = "graphql-ws"
-				conn.Info.AuthMethod = "oauth"
-				if conn.Info.CustomHeaders == nil {
-					conn.Info.CustomHeaders = make(map[string]string)
-				}
-				if claims != nil && len(claims.Scopes) > 0 {
-					conn.Info.CustomHeaders["scopes"] = strings.Join(claims.Scopes, " ")
-				}
-				conn.LastActivity = time.Now()
-				conn.UpdateState(models.ConnectionStateConnected)
-				_ = s.connRepo.UpdateConnection(ctx.Context(), conn)
-			}
-		}
-
-		s.mu.Lock()
-		existing := s.connections[connectionID]
-		subscriptions := make(map[string]*subscriptionState)
-		if existing != nil && existing.subscriptions != nil {
-			subscriptions = existing.subscriptions
-		}
-		s.connections[connectionID] = &connectionState{
-			username:      username,
-			claims:        claims,
-			subscriptions: subscriptions,
-		}
-		s.mu.Unlock()
-
-		log.Info("connection_init authenticated", zap.String("username", username))
-		if err := s.sendJSON(wsCtx, responseEnvelope{Type: "connection_ack"}); err != nil {
-			return nil, err
-		}
-		return okWebSocketResponse(), nil
+		return s.handleConnectionInit(ctx.Context(), wsCtx, connectionID, msg)
 	case "ping":
 		if err := s.sendJSON(wsCtx, responseEnvelope{Type: "pong"}); err != nil {
 			return nil, err
@@ -789,22 +681,170 @@ func (s *wsServer) handleDefault(ctx *apptheory.Context) (*apptheory.Response, e
 		s.handleSubscribe(ctx.Context(), msg, wsCtx)
 		return okWebSocketResponse(), nil
 	case "complete":
-		s.logger.Info("received completion request",
-			zap.String("connection_id", connectionID),
-			zap.String("subscription_id", msg.ID))
-		if !s.cancelSubscription(ctx.Context(), connectionID, msg.ID) {
-			_ = s.sendJSON(wsCtx, responseEnvelope{
-				ID:   msg.ID,
-				Type: "complete",
-			})
-		}
-		return okWebSocketResponse(), nil
+		return s.handleComplete(ctx.Context(), wsCtx, connectionID, msg)
 	default:
 		s.logger.Warn("received unsupported websocket message type",
 			zap.String("connection_id", connectionID),
 			zap.String("type", msg.Type))
 		return nil, appError("app.bad_request", fmt.Sprintf("message type %q is not supported", msg.Type))
 	}
+}
+
+func (s *wsServer) webSocketContextFromEvent(ctx *apptheory.Context) (*apptheory.WebSocketContext, string, error) {
+	if ctx == nil {
+		return nil, "", appError("app.bad_request", "Invalid WebSocket event")
+	}
+
+	wsCtx := ctx.AsWebSocket()
+	if wsCtx == nil {
+		return nil, "", appError("app.bad_request", "Invalid WebSocket event")
+	}
+
+	return wsCtx, wsCtx.ConnectionID, nil
+}
+
+func (s *wsServer) rememberWebSocketContext(connectionID string, wsCtx *apptheory.WebSocketContext) {
+	if wsCtx == nil || connectionID == "" {
+		return
+	}
+
+	s.mu.Lock()
+	s.wsContexts[connectionID] = wsCtx
+	s.mu.Unlock()
+}
+
+func (s *wsServer) handleConnectionInit(ctx context.Context, wsCtx *apptheory.WebSocketContext, connectionID string, msg wsMessage) (*apptheory.Response, error) {
+	log := s.logger.With(zap.String("connection_id", connectionID))
+
+	if s.isAuthenticatedConnection(ctx, connectionID) {
+		log.Info("received connection_init for authenticated connection")
+		if err := s.sendJSON(wsCtx, responseEnvelope{Type: "connection_ack"}); err != nil {
+			return nil, err
+		}
+		return okWebSocketResponse(), nil
+	}
+
+	tokenValue := extractAccessTokenFromInitPayload(msg.Payload)
+	if tokenValue == "" {
+		log.Warn("connection_init missing access token")
+		_ = s.sendJSON(wsCtx, responseEnvelope{
+			Type: "connection_error",
+			Payload: errorPayload{
+				Message: "Access token required",
+				Code:    "unauthorized",
+			},
+		})
+		return okWebSocketResponse(), nil
+	}
+
+	if s.oauthService == nil {
+		log.Error("oauth service not configured for graphql websocket server")
+		return nil, appError("app.internal", "OAuth service unavailable")
+	}
+
+	claims, err := s.oauthService.ValidateAccessToken(tokenValue)
+	if err != nil {
+		log.Warn("connection_init failed token validation", zap.Error(err))
+		_ = s.sendJSON(wsCtx, responseEnvelope{
+			Type: "connection_error",
+			Payload: errorPayload{
+				Message: "Invalid or expired token",
+				Code:    "unauthorized",
+			},
+		})
+		return okWebSocketResponse(), nil
+	}
+
+	username := claims.GetUsername()
+	if username == "" {
+		username = claims.Username
+	}
+	if username == "" {
+		log.Warn("connection_init missing username in claims")
+		_ = s.sendJSON(wsCtx, responseEnvelope{
+			Type: "connection_error",
+			Payload: errorPayload{
+				Message: "Missing username in token claims",
+				Code:    "forbidden",
+			},
+		})
+		return okWebSocketResponse(), nil
+	}
+
+	s.persistGraphQLConnectionIdentity(ctx, connectionID, username, claims)
+	s.setAuthenticatedConnectionState(connectionID, username, claims)
+
+	log.Info("connection_init authenticated", zap.String("username", username))
+	if err := s.sendJSON(wsCtx, responseEnvelope{Type: "connection_ack"}); err != nil {
+		return nil, err
+	}
+	return okWebSocketResponse(), nil
+}
+
+func (s *wsServer) isAuthenticatedConnection(ctx context.Context, connectionID string) bool {
+	state, err := s.getConnection(ctx, connectionID)
+	return err == nil && state != nil && state.username != ""
+}
+
+func (s *wsServer) persistGraphQLConnectionIdentity(ctx context.Context, connectionID, username string, claims *auth.Claims) {
+	if s.connRepo == nil {
+		return
+	}
+
+	streams := []string{"graphql"}
+	conn, getErr := s.connRepo.GetConnection(ctx, connectionID)
+	if getErr != nil || conn == nil {
+		_, _ = s.connRepo.WriteConnection(ctx, connectionID, username, username, streams)
+		conn, _ = s.connRepo.GetConnection(ctx, connectionID)
+	}
+	if conn == nil {
+		return
+	}
+
+	conn.UserID = username
+	conn.Username = username
+	conn.Streams = streams
+	conn.Info.Protocol = graphqlWSName
+	conn.Info.AuthMethod = "oauth"
+	if conn.Info.CustomHeaders == nil {
+		conn.Info.CustomHeaders = make(map[string]string)
+	}
+	if claims != nil && len(claims.Scopes) > 0 {
+		conn.Info.CustomHeaders["scopes"] = strings.Join(claims.Scopes, " ")
+	}
+	conn.LastActivity = time.Now()
+	conn.UpdateState(models.ConnectionStateConnected)
+	_ = s.connRepo.UpdateConnection(ctx, conn)
+}
+
+func (s *wsServer) setAuthenticatedConnectionState(connectionID, username string, claims *auth.Claims) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	subscriptions := make(map[string]*subscriptionState)
+	if existing := s.connections[connectionID]; existing != nil && existing.subscriptions != nil {
+		subscriptions = existing.subscriptions
+	}
+
+	s.connections[connectionID] = &connectionState{
+		username:      username,
+		claims:        claims,
+		subscriptions: subscriptions,
+	}
+}
+
+func (s *wsServer) handleComplete(ctx context.Context, wsCtx *apptheory.WebSocketContext, connectionID string, msg wsMessage) (*apptheory.Response, error) {
+	s.logger.Info("received completion request",
+		zap.String("connection_id", connectionID),
+		zap.String("subscription_id", msg.ID))
+
+	if !s.cancelSubscription(ctx, connectionID, msg.ID) {
+		_ = s.sendJSON(wsCtx, responseEnvelope{
+			ID:   msg.ID,
+			Type: "complete",
+		})
+	}
+	return okWebSocketResponse(), nil
 }
 
 func normalizeAuthToken(raw string) string {
@@ -1322,7 +1362,7 @@ func init() {
 
 func initializeGraphQLWS() {
 	lambdaCtx = mustInitializeLambdaFn(common.LambdaConfig{
-		ServiceName: "graphql-ws",
+		ServiceName: graphqlWSName,
 		LambdaType:  common.LambdaTypeBasic,
 	})
 

--- a/cmd/graphql-ws/main.go
+++ b/cmd/graphql-ws/main.go
@@ -93,6 +93,62 @@ type wsMessage struct {
 	Payload json.RawMessage `json:"payload,omitempty"`
 }
 
+func extractAccessTokenFromInitPayload(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return ""
+	}
+
+	// Common shapes seen in GraphQL WS clients:
+	// - { "authorization": "Bearer <token>" }
+	// - { "Authorization": "Bearer <token>" }
+	// - { "access_token": "<token>" } / { "token": "<token>" }
+	// - { "headers": { "Authorization": "Bearer <token>" } }
+	readString := func(key string) string {
+		if v, ok := payload[key]; ok {
+			if s, ok := v.(string); ok {
+				return strings.TrimSpace(s)
+			}
+		}
+		return ""
+	}
+
+	if v := readString("access_token"); v != "" {
+		return cleanToken(v)
+	}
+	if v := readString("accessToken"); v != "" {
+		return cleanToken(v)
+	}
+	if v := readString("token"); v != "" {
+		return cleanToken(v)
+	}
+	if v := readString("authToken"); v != "" {
+		return cleanToken(v)
+	}
+
+	if v := readString("authorization"); v != "" {
+		return normalizeAuthToken(v)
+	}
+	if v := readString("Authorization"); v != "" {
+		return normalizeAuthToken(v)
+	}
+
+	if headers, ok := payload["headers"].(map[string]any); ok {
+		if v, ok := headers["authorization"].(string); ok && strings.TrimSpace(v) != "" {
+			return normalizeAuthToken(v)
+		}
+		if v, ok := headers["Authorization"].(string); ok && strings.TrimSpace(v) != "" {
+			return normalizeAuthToken(v)
+		}
+	}
+
+	return ""
+}
+
 type subscribePayload struct {
 	Query         string                 `json:"query"`
 	OperationName string                 `json:"operationName,omitempty"`
@@ -486,10 +542,43 @@ func (s *wsServer) handleConnect(ctx *apptheory.Context) (*apptheory.Response, e
 	}
 
 	if tokenValue == "" {
-		log.Warn("websocket connect missing authentication token",
-			zap.Any("query", ctx.Request.Query),
-			zap.Any("headers", ctx.Request.Headers))
-		return nil, appError("app.unauthorized", "Access token required")
+		// Browser WebSocket clients cannot set custom headers during the handshake.
+		// Many GraphQL WS libraries send auth via `connection_init` payload instead.
+		// Accept the connection and require auth before allowing subscriptions.
+		log.Info("websocket connect missing authentication token; deferring auth to connection_init",
+			zap.Any("query", ctx.Request.Query))
+
+		// Store WebSocket context for later message sending
+		s.mu.Lock()
+		s.wsContexts[connectionID] = wsCtx
+		s.mu.Unlock()
+
+		// Persist a placeholder connection record so $default invocations can load state across Lambda containers.
+		if s.connRepo != nil {
+			streams := []string{"graphql"}
+			conn, err := s.connRepo.WriteConnection(ctx.Context(), connectionID, "", "", streams)
+			if err != nil {
+				log.Warn("failed to write pending graphql connection record", zap.Error(err))
+			} else if conn != nil {
+				conn.Streams = streams
+				conn.Info.Protocol = "graphql-ws"
+				conn.Info.AuthMethod = "pending"
+				conn.LastActivity = time.Now()
+				conn.Established = time.Now()
+				conn.UpdateState(models.ConnectionStateConnected)
+				_ = s.connRepo.UpdateConnection(ctx.Context(), conn)
+			}
+		}
+
+		s.mu.Lock()
+		s.connections[connectionID] = &connectionState{
+			username:      "",
+			claims:        nil,
+			subscriptions: make(map[string]*subscriptionState),
+		}
+		s.mu.Unlock()
+
+		return okWebSocketResponse(), nil
 	}
 
 	if s.oauthService == nil {
@@ -590,8 +679,103 @@ func (s *wsServer) handleDefault(ctx *apptheory.Context) (*apptheory.Response, e
 
 	switch strings.ToLower(msg.Type) {
 	case "connection_init":
-		s.logger.Info("received connection_init",
-			zap.String("connection_id", connectionID))
+		log := s.logger.With(zap.String("connection_id", connectionID))
+
+		// If the connection is already authenticated (token provided at $connect), just ACK.
+		if state, err := s.getConnection(ctx.Context(), connectionID); err == nil && state != nil && state.username != "" {
+			log.Info("received connection_init for authenticated connection")
+			if err := s.sendJSON(wsCtx, responseEnvelope{Type: "connection_ack"}); err != nil {
+				return nil, err
+			}
+			return okWebSocketResponse(), nil
+		}
+
+		tokenValue := extractAccessTokenFromInitPayload(msg.Payload)
+		if tokenValue == "" {
+			log.Warn("connection_init missing access token")
+			_ = s.sendJSON(wsCtx, responseEnvelope{
+				Type: "connection_error",
+				Payload: errorPayload{
+					Message: "Access token required",
+					Code:    "unauthorized",
+				},
+			})
+			return okWebSocketResponse(), nil
+		}
+
+		if s.oauthService == nil {
+			log.Error("oauth service not configured for graphql websocket server")
+			return nil, appError("app.internal", "OAuth service unavailable")
+		}
+
+		claims, err := s.oauthService.ValidateAccessToken(tokenValue)
+		if err != nil {
+			log.Warn("connection_init failed token validation", zap.Error(err))
+			_ = s.sendJSON(wsCtx, responseEnvelope{
+				Type: "connection_error",
+				Payload: errorPayload{
+					Message: "Invalid or expired token",
+					Code:    "unauthorized",
+				},
+			})
+			return okWebSocketResponse(), nil
+		}
+
+		username := claims.GetUsername()
+		if username == "" {
+			username = claims.Username
+		}
+		if username == "" {
+			log.Warn("connection_init missing username in claims")
+			_ = s.sendJSON(wsCtx, responseEnvelope{
+				Type: "connection_error",
+				Payload: errorPayload{
+					Message: "Missing username in token claims",
+					Code:    "forbidden",
+				},
+			})
+			return okWebSocketResponse(), nil
+		}
+
+		// Persist/refresh connection metadata with authenticated identity.
+		if s.connRepo != nil {
+			conn, getErr := s.connRepo.GetConnection(ctx.Context(), connectionID)
+			if getErr != nil || conn == nil {
+				_, _ = s.connRepo.WriteConnection(ctx.Context(), connectionID, username, username, []string{"graphql"})
+				conn, _ = s.connRepo.GetConnection(ctx.Context(), connectionID)
+			}
+			if conn != nil {
+				conn.UserID = username
+				conn.Username = username
+				conn.Streams = []string{"graphql"}
+				conn.Info.Protocol = "graphql-ws"
+				conn.Info.AuthMethod = "oauth"
+				if conn.Info.CustomHeaders == nil {
+					conn.Info.CustomHeaders = make(map[string]string)
+				}
+				if claims != nil && len(claims.Scopes) > 0 {
+					conn.Info.CustomHeaders["scopes"] = strings.Join(claims.Scopes, " ")
+				}
+				conn.LastActivity = time.Now()
+				conn.UpdateState(models.ConnectionStateConnected)
+				_ = s.connRepo.UpdateConnection(ctx.Context(), conn)
+			}
+		}
+
+		s.mu.Lock()
+		existing := s.connections[connectionID]
+		subscriptions := make(map[string]*subscriptionState)
+		if existing != nil && existing.subscriptions != nil {
+			subscriptions = existing.subscriptions
+		}
+		s.connections[connectionID] = &connectionState{
+			username:      username,
+			claims:        claims,
+			subscriptions: subscriptions,
+		}
+		s.mu.Unlock()
+
+		log.Info("connection_init authenticated", zap.String("username", username))
 		if err := s.sendJSON(wsCtx, responseEnvelope{Type: "connection_ack"}); err != nil {
 			return nil, err
 		}
@@ -687,6 +871,11 @@ func (s *wsServer) handleSubscribe(ctx context.Context, msg wsMessage, wsCtx *ap
 			zap.String("connection_id", connectionID),
 			zap.Error(err))
 		s.sendError(wsCtx, msg.ID, "unauthorized", "connection context not found")
+		_ = s.sendJSON(wsCtx, responseEnvelope{ID: msg.ID, Type: "complete"})
+		return
+	}
+	if state == nil || state.username == "" || state.claims == nil || state.claims.GetUsername() == "" {
+		s.sendError(wsCtx, msg.ID, "unauthorized", "connection not authenticated")
 		_ = s.sendJSON(wsCtx, responseEnvelope{ID: msg.ID, Type: "complete"})
 		return
 	}

--- a/cmd/graphql-ws/main_test.go
+++ b/cmd/graphql-ws/main_test.go
@@ -103,6 +103,8 @@ func TestHandleDefault_SendsExpectedMessages(t *testing.T) {
 
 	var bodies [][]byte
 	s := newServer(nil, nil, nil, zap.NewNop(), nil, nil)
+	// Pretend $connect already authenticated so connection_init can ACK.
+	s.connections["c1"] = &connectionState{username: "user", claims: &auth.Claims{Username: "user"}, subscriptions: map[string]*subscriptionState{}}
 	s.sendJSONMessage = func(_ *apptheory.WebSocketContext, payload any) error {
 		b, err := json.Marshal(payload)
 		require.NoError(t, err)

--- a/cmd/graphql-ws/round12_additional_test.go
+++ b/cmd/graphql-ws/round12_additional_test.go
@@ -264,11 +264,14 @@ func TestEnsureSubscriptionManagerStarted_StartOnce(t *testing.T) {
 func TestHandleConnect_TokenValidationAndState(t *testing.T) {
 	setDummyAWSEnv(t)
 
-	// Missing token => unauthorized.
+	// Missing token => accepted (auth may arrive via connection_init), but unauthenticated.
 	server := newServer(&fakeTokenValidator{}, nil, nil, zap.NewNop(), nil, nil)
 	app := newWebSocketApp(server)
 	resp := app.ServeWebSocket(context.Background(), newWebSocketEvent("$connect", "c1", "", map[string]string{}, map[string]string{}))
-	require.Equal(t, 401, resp.StatusCode)
+	require.Equal(t, 200, resp.StatusCode)
+	state, err := server.getConnection(context.Background(), "c1")
+	require.NoError(t, err)
+	require.Equal(t, "", state.username)
 
 	// Token present but oauth service missing => internal error.
 	server = newServer(nil, nil, nil, zap.NewNop(), nil, nil)
@@ -298,7 +301,7 @@ func TestHandleConnect_TokenValidationAndState(t *testing.T) {
 	resp = app.ServeWebSocket(context.Background(), newWebSocketEvent("$connect", "c1", "", map[string]string{"access_token": "t"}, map[string]string{}))
 	require.Equal(t, 200, resp.StatusCode)
 
-	state, err := server.getConnection(context.Background(), "c1")
+	state, err = server.getConnection(context.Background(), "c1")
 	require.NoError(t, err)
 	require.Equal(t, "user", state.username)
 	require.NotNil(t, server.wsContexts["c1"])

--- a/cmd/graphql-ws/round22_connect_more_test.go
+++ b/cmd/graphql-ws/round22_connect_more_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestHandleConnect_NoToken_PersistsPendingConnectionRecord(t *testing.T) {
+	repo := &fakeConnRepo{}
+	s := newServer(&fakeTokenValidator{}, nil, nil, zap.NewNop(), repo, nil)
+	app := newWebSocketApp(s)
+
+	resp := app.ServeWebSocket(context.Background(), newWebSocketEvent("$connect", "c1", "", map[string]string{}, map[string]string{}))
+	require.Equal(t, 200, resp.StatusCode)
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&repo.writeCalls))
+	require.Equal(t, int32(1), atomic.LoadInt32(&repo.updateCalls))
+	require.NotNil(t, repo.lastUpdated)
+	require.Equal(t, graphqlWSName, repo.lastUpdated.Info.Protocol)
+	require.Equal(t, "pending", repo.lastUpdated.Info.AuthMethod)
+
+	state, err := s.getConnection(context.Background(), "c1")
+	require.NoError(t, err)
+	require.Equal(t, "", state.username)
+	require.NotNil(t, s.wsContexts["c1"])
+}
+
+func TestHandleConnect_PersistFailure_CleansWebSocketContext(t *testing.T) {
+	repo := &fakeConnRepo{writeErr: errors.New("boom")}
+	validator := &fakeTokenValidator{claims: &auth.Claims{Username: "user"}}
+	s := newServer(validator, nil, nil, zap.NewNop(), repo, nil)
+	app := newWebSocketApp(s)
+
+	resp := app.ServeWebSocket(context.Background(), newWebSocketEvent("$connect", "c1", "", map[string]string{"access_token": "t"}, map[string]string{}))
+	require.Equal(t, 500, resp.StatusCode)
+
+	_, ok := s.wsContexts["c1"]
+	require.False(t, ok)
+	require.Equal(t, int32(1), atomic.LoadInt32(&repo.writeCalls))
+}

--- a/cmd/graphql-ws/round22_connection_init_test.go
+++ b/cmd/graphql-ws/round22_connection_init_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"go.uber.org/zap"
+)
+
+func TestExtractAccessTokenFromInitPayload(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload json.RawMessage
+		want    string
+	}{
+		{name: "empty", payload: nil, want: ""},
+		{name: "invalid_json", payload: json.RawMessage("{"), want: ""},
+		{name: "access_token", payload: json.RawMessage(`{"access_token":"a b"}`), want: "a+b"},
+		{name: "accessToken", payload: json.RawMessage(`{"accessToken":"t"}`), want: "t"},
+		{name: "token", payload: json.RawMessage(`{"token":"t"}`), want: "t"},
+		{name: "authToken", payload: json.RawMessage(`{"authToken":"t"}`), want: "t"},
+		{name: "authorization_lower", payload: json.RawMessage(`{"authorization":"Bearer token"}`), want: "token"},
+		{name: "authorization_upper", payload: json.RawMessage(`{"Authorization":"Bearer token"}`), want: "token"},
+		{name: "headers_authorization_lower", payload: json.RawMessage(`{"headers":{"authorization":"Bearer token"}}`), want: "token"},
+		{name: "headers_authorization_upper", payload: json.RawMessage(`{"headers":{"Authorization":"Bearer token"}}`), want: "token"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, extractAccessTokenFromInitPayload(tc.payload))
+		})
+	}
+}
+
+type stagedConnRepo struct {
+	*fakeConnRepo
+	getSequence int32
+	conn        *models.WebSocketConnection
+}
+
+func (s *stagedConnRepo) GetConnection(_ context.Context, connectionID string) (*models.WebSocketConnection, error) {
+	atomic.AddInt32(&s.getConnCalls, 1)
+
+	seq := atomic.AddInt32(&s.getSequence, 1)
+	if seq == 1 {
+		return nil, errors.New("not found")
+	}
+	if s.conn != nil {
+		return s.conn, nil
+	}
+	return &models.WebSocketConnection{ConnectionID: connectionID}, nil
+}
+
+func TestHandleConnectionInit_UnauthenticatedBranches(t *testing.T) {
+	wsCtx := &apptheory.WebSocketContext{ConnectionID: "c1"}
+
+	t.Run("missing_token_sends_connection_error", func(t *testing.T) {
+		var bodies [][]byte
+		s := newServer(&fakeTokenValidator{}, nil, nil, zap.NewNop(), nil, nil)
+		s.sendJSONMessage = func(_ *apptheory.WebSocketContext, payload any) error {
+			b, err := json.Marshal(payload)
+			require.NoError(t, err)
+			bodies = append(bodies, b)
+			return nil
+		}
+
+		resp, err := s.handleConnectionInit(context.Background(), wsCtx, "c1", wsMessage{Type: "connection_init", Payload: json.RawMessage(`{}`)})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, 200, resp.Status)
+
+		require.Len(t, bodies, 1)
+		var out struct {
+			Type    string         `json:"type"`
+			Payload map[string]any `json:"payload"`
+		}
+		require.NoError(t, json.Unmarshal(bodies[0], &out))
+		require.Equal(t, "connection_error", out.Type)
+		require.Equal(t, "unauthorized", out.Payload["code"])
+	})
+
+	t.Run("oauth_missing_returns_app_error", func(t *testing.T) {
+		s := newServer(nil, nil, nil, zap.NewNop(), nil, nil)
+		resp, err := s.handleConnectionInit(context.Background(), wsCtx, "c1", wsMessage{Type: "connection_init", Payload: json.RawMessage(`{"access_token":"t"}`)})
+		require.Error(t, err)
+		require.Nil(t, resp)
+	})
+
+	t.Run("invalid_token_sends_connection_error", func(t *testing.T) {
+		var bodies [][]byte
+		validator := &fakeTokenValidator{err: errors.New("bad token")}
+		s := newServer(validator, nil, nil, zap.NewNop(), nil, nil)
+		s.sendJSONMessage = func(_ *apptheory.WebSocketContext, payload any) error {
+			b, err := json.Marshal(payload)
+			require.NoError(t, err)
+			bodies = append(bodies, b)
+			return nil
+		}
+
+		resp, err := s.handleConnectionInit(context.Background(), wsCtx, "c1", wsMessage{Type: "connection_init", Payload: json.RawMessage(`{"token":"t"}`)})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, 200, resp.Status)
+
+		require.Len(t, bodies, 1)
+		var out struct {
+			Type    string         `json:"type"`
+			Payload map[string]any `json:"payload"`
+		}
+		require.NoError(t, json.Unmarshal(bodies[0], &out))
+		require.Equal(t, "connection_error", out.Type)
+		require.Equal(t, "unauthorized", out.Payload["code"])
+	})
+
+	t.Run("missing_username_sends_connection_error", func(t *testing.T) {
+		var bodies [][]byte
+		validator := &fakeTokenValidator{claims: &auth.Claims{}}
+		s := newServer(validator, nil, nil, zap.NewNop(), nil, nil)
+		s.sendJSONMessage = func(_ *apptheory.WebSocketContext, payload any) error {
+			b, err := json.Marshal(payload)
+			require.NoError(t, err)
+			bodies = append(bodies, b)
+			return nil
+		}
+
+		resp, err := s.handleConnectionInit(context.Background(), wsCtx, "c1", wsMessage{Type: "connection_init", Payload: json.RawMessage(`{"Authorization":"Bearer t"}`)})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, 200, resp.Status)
+
+		require.Len(t, bodies, 1)
+		var out struct {
+			Type    string         `json:"type"`
+			Payload map[string]any `json:"payload"`
+		}
+		require.NoError(t, json.Unmarshal(bodies[0], &out))
+		require.Equal(t, "connection_error", out.Type)
+		require.Equal(t, "forbidden", out.Payload["code"])
+	})
+
+	t.Run("success_persists_identity_and_acks", func(t *testing.T) {
+		var bodies [][]byte
+
+		repo := &stagedConnRepo{
+			fakeConnRepo: &fakeConnRepo{},
+			conn:         &models.WebSocketConnection{ConnectionID: "c1"},
+		}
+		validator := &fakeTokenValidator{claims: &auth.Claims{Username: "user", Scopes: []string{"read"}}}
+		s := newServer(validator, nil, nil, zap.NewNop(), repo, nil)
+		s.sendJSONMessage = func(_ *apptheory.WebSocketContext, payload any) error {
+			b, err := json.Marshal(payload)
+			require.NoError(t, err)
+			bodies = append(bodies, b)
+			return nil
+		}
+		s.connections["c1"] = &connectionState{
+			username:      "",
+			claims:        nil,
+			subscriptions: map[string]*subscriptionState{"sub1": {cancel: func() {}}},
+		}
+
+		resp, err := s.handleConnectionInit(context.Background(), wsCtx, "c1", wsMessage{Type: "connection_init", Payload: json.RawMessage(`{"headers":{"authorization":"Bearer t"}}`)})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, 200, resp.Status)
+
+		require.Len(t, bodies, 1)
+		var env responseEnvelope
+		require.NoError(t, json.Unmarshal(bodies[0], &env))
+		require.Equal(t, "connection_ack", env.Type)
+
+		state, err := s.getConnection(context.Background(), "c1")
+		require.NoError(t, err)
+		require.Equal(t, "user", state.username)
+		require.NotNil(t, state.claims)
+		require.Contains(t, state.subscriptions, "sub1")
+
+		require.Equal(t, int32(1), atomic.LoadInt32(&repo.writeCalls))
+		require.Equal(t, int32(1), atomic.LoadInt32(&repo.updateCalls))
+		require.NotNil(t, repo.lastUpdated)
+		require.Equal(t, graphqlWSName, repo.lastUpdated.Info.Protocol)
+		require.Equal(t, "oauth", repo.lastUpdated.Info.AuthMethod)
+		require.Equal(t, "read", repo.lastUpdated.Info.CustomHeaders["scopes"])
+	})
+}
+
+func TestPersistGraphQLConnectionIdentity_NoRepoDoesNotPanic(t *testing.T) {
+	s := newServer(nil, nil, nil, zap.NewNop(), nil, nil)
+	require.NotPanics(t, func() {
+		s.persistGraphQLConnectionIdentity(context.Background(), "c1", "user", &auth.Claims{Username: "user", Scopes: []string{"read"}})
+	})
+}

--- a/cmd/graphql-ws/round22_helpers_small_test.go
+++ b/cmd/graphql-ws/round22_helpers_small_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/99designs/gqlgen/graphql/executor"
+	appconfig "github.com/equaltoai/lesser/pkg/config"
+	"github.com/stretchr/testify/require"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"go.uber.org/zap"
+)
+
+func TestSendJSON_NilWebSocketContext_ReturnsError(t *testing.T) {
+	s := newServer(nil, nil, nil, zap.NewNop(), nil, nil)
+	require.Error(t, s.sendJSON(nil, responseEnvelope{Type: "ping"}))
+}
+
+func TestRememberWebSocketContext_IgnoresEmptyInputs(t *testing.T) {
+	s := newServer(nil, nil, nil, zap.NewNop(), nil, nil)
+
+	s.rememberWebSocketContext("", &apptheory.WebSocketContext{ConnectionID: "c1"})
+	s.rememberWebSocketContext("c1", nil)
+
+	require.Empty(t, s.wsContexts)
+}
+
+func TestWebSocketContextFromEvent_NilContext_ReturnsError(t *testing.T) {
+	s := newServer(nil, nil, nil, zap.NewNop(), nil, nil)
+
+	wsCtx, connectionID, err := s.webSocketContextFromEvent(nil)
+	require.Error(t, err)
+	require.Nil(t, wsCtx)
+	require.Equal(t, "", connectionID)
+}
+
+func TestConfigureGraphQLExecutor_ExercisesConfigBranches(t *testing.T) {
+	exec := executor.New(nil)
+	cfg := &appconfig.Config{
+		GraphQLParserTokenLimit: 123,
+		GraphQLMaxDepth:         5,
+		GraphQLMaxComplexity:    10,
+		DebugMode:              true,
+	}
+
+	require.NotPanics(t, func() {
+		configureGraphQLExecutor(exec, cfg)
+	})
+}

--- a/cmd/lesser/api_client_edgecases_test.go
+++ b/cmd/lesser/api_client_edgecases_test.go
@@ -96,4 +96,3 @@ func TestCLIAPIClient_RefreshTokens_EmptyBodyUsesStatusText(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Internal Server Error")
 }
-

--- a/cmd/lesser/api_client_retry_test.go
+++ b/cmd/lesser/api_client_retry_test.go
@@ -88,4 +88,3 @@ func TestCLIAPIClient_DoRequestWithRetries_BackoffOn5xx(t *testing.T) {
 	require.Equal(t, int32(2), calls.Load())
 	require.Equal(t, 250*time.Millisecond, slept)
 }
-

--- a/cmd/lesser/cdk.go
+++ b/cmd/lesser/cdk.go
@@ -92,6 +92,24 @@ func cdkDeployWithOutputs(ctx context.Context, repoRoot string, awsProfile strin
 		fmt.Sprintf("hostedZoneId=%s", req.HostedZoneID),
 	}
 
+	// Optional deployment configuration from environment variables.
+	// This keeps `lesser up` ergonomic while allowing one-off instance config without editing CDK code.
+	envContexts := map[string]string{
+		"lesserHostUrl":             strings.TrimSpace(os.Getenv("LESSER_HOST_URL")),
+		"lesserHostInstanceKeyArn":  strings.TrimSpace(os.Getenv("LESSER_HOST_INSTANCE_KEY_ARN")),
+		"lesserHostAttestationsUrl": strings.TrimSpace(os.Getenv("LESSER_HOST_ATTESTATIONS_URL")),
+		"translationEnabled":        strings.TrimSpace(os.Getenv("TRANSLATION_ENABLED")),
+		"tipEnabled":                strings.TrimSpace(os.Getenv("TIP_ENABLED")),
+		"tipChainId":                strings.TrimSpace(os.Getenv("TIP_CHAIN_ID")),
+		"tipContractAddress":        strings.TrimSpace(os.Getenv("TIP_CONTRACT_ADDRESS")),
+	}
+	for key, value := range envContexts {
+		if value == "" {
+			continue
+		}
+		args = append(args, "--context", fmt.Sprintf("%s=%s", key, value))
+	}
+
 	stage := strings.TrimSpace(strings.ToLower(req.StageFilter))
 	if stage != "" {
 		args = append(args, "--context", fmt.Sprintf("stage=%s", stage))

--- a/cmd/lesser/env_defaults.go
+++ b/cmd/lesser/env_defaults.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+const (
+	defaultCLIStage        = "dev"
+	defaultCLIMaxToolJobs  = 8
+	lesserToolJobsEnvVar   = "LESSER_JOBS"
+	goMaxProcsEnvVar       = "GOMAXPROCS"
+	goFlagsEnvVar          = "GOFLAGS"
+	goBuildParallelismFlag = "-p"
+)
+
+func applyCLIDefaultEnv() {
+	applyStageEnvDefaults()
+	applyToolParallelismDefaults()
+}
+
+func applyStageEnvDefaults() {
+	if strings.TrimSpace(os.Getenv("STAGE")) == "" {
+		_ = os.Setenv("STAGE", defaultCLIStage)
+	}
+}
+
+func applyToolParallelismDefaults() {
+	jobs := resolveToolJobs()
+	if jobs <= 0 {
+		return
+	}
+
+	if strings.TrimSpace(os.Getenv(goMaxProcsEnvVar)) == "" {
+		_ = os.Setenv(goMaxProcsEnvVar, fmt.Sprintf("%d", jobs))
+	}
+
+	currentGoFlags := strings.TrimSpace(os.Getenv(goFlagsEnvVar))
+	if goFlagsHasBuildParallelism(currentGoFlags) {
+		return
+	}
+
+	if currentGoFlags == "" {
+		_ = os.Setenv(goFlagsEnvVar, fmt.Sprintf("%s=%d", goBuildParallelismFlag, jobs))
+		return
+	}
+	_ = os.Setenv(goFlagsEnvVar, currentGoFlags+" "+fmt.Sprintf("%s=%d", goBuildParallelismFlag, jobs))
+}
+
+func resolveToolJobs() int {
+	if v := strings.TrimSpace(os.Getenv(lesserToolJobsEnvVar)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+
+	if v := strings.TrimSpace(os.Getenv(goMaxProcsEnvVar)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+
+	n := runtime.NumCPU()
+	if n < 1 {
+		return 1
+	}
+	if n > defaultCLIMaxToolJobs {
+		return defaultCLIMaxToolJobs
+	}
+	return n
+}
+
+func goFlagsHasBuildParallelism(goFlags string) bool {
+	for _, field := range strings.Fields(goFlags) {
+		if field == goBuildParallelismFlag {
+			return true
+		}
+		if strings.HasPrefix(field, goBuildParallelismFlag+"=") {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/lesser/env_defaults_test.go
+++ b/cmd/lesser/env_defaults_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyStageEnvDefaults_SetsDefaultWhenUnset(t *testing.T) {
+	t.Setenv("STAGE", "")
+	applyStageEnvDefaults()
+	require.Equal(t, "dev", os.Getenv("STAGE"))
+}
+
+func TestApplyStageEnvDefaults_DoesNotOverride(t *testing.T) {
+	t.Setenv("STAGE", "prod")
+	applyStageEnvDefaults()
+	require.Equal(t, "prod", os.Getenv("STAGE"))
+}
+
+func TestResolveToolJobs_PrefersLesserJobsThenGOMAXPROCS(t *testing.T) {
+	t.Setenv(lesserToolJobsEnvVar, "2")
+	t.Setenv(goMaxProcsEnvVar, "5")
+	require.Equal(t, 2, resolveToolJobs())
+
+	t.Setenv(lesserToolJobsEnvVar, "nope")
+	t.Setenv(goMaxProcsEnvVar, "5")
+	require.Equal(t, 5, resolveToolJobs())
+}
+
+func TestApplyToolParallelismDefaults_SetsGOMAXPROCSAndGOFLAGSWhenUnset(t *testing.T) {
+	t.Setenv(lesserToolJobsEnvVar, "4")
+	t.Setenv(goMaxProcsEnvVar, "")
+	t.Setenv(goFlagsEnvVar, "")
+
+	applyToolParallelismDefaults()
+	require.Equal(t, "4", os.Getenv(goMaxProcsEnvVar))
+	require.Equal(t, "-p=4", os.Getenv(goFlagsEnvVar))
+}
+
+func TestApplyToolParallelismDefaults_AppendsToExistingGOFLAGS(t *testing.T) {
+	t.Setenv(lesserToolJobsEnvVar, "3")
+	t.Setenv(goMaxProcsEnvVar, "")
+	t.Setenv(goFlagsEnvVar, "-trimpath")
+
+	applyToolParallelismDefaults()
+	require.Equal(t, "3", os.Getenv(goMaxProcsEnvVar))
+	require.Equal(t, "-trimpath -p=3", os.Getenv(goFlagsEnvVar))
+}
+
+func TestApplyToolParallelismDefaults_DoesNotOverrideExistingSettings(t *testing.T) {
+	t.Setenv(lesserToolJobsEnvVar, "6")
+	t.Setenv(goMaxProcsEnvVar, "12")
+	t.Setenv(goFlagsEnvVar, "-p=20")
+
+	applyToolParallelismDefaults()
+	require.Equal(t, "12", os.Getenv(goMaxProcsEnvVar))
+	require.Equal(t, "-p=20", os.Getenv(goFlagsEnvVar))
+}
+
+func TestApplyToolParallelismDefaults_DoesNotModifyGOFLAGSWhenDashPTokenPresent(t *testing.T) {
+	t.Setenv(lesserToolJobsEnvVar, "5")
+	t.Setenv(goMaxProcsEnvVar, "")
+	t.Setenv(goFlagsEnvVar, "-trimpath -p")
+
+	applyToolParallelismDefaults()
+	require.Equal(t, "5", os.Getenv(goMaxProcsEnvVar))
+	require.Equal(t, "-trimpath -p", os.Getenv(goFlagsEnvVar))
+}
+
+func TestResolveToolJobs_FallsBackToRuntime(t *testing.T) {
+	t.Setenv(lesserToolJobsEnvVar, "")
+	t.Setenv(goMaxProcsEnvVar, "")
+
+	jobs := resolveToolJobs()
+	require.GreaterOrEqual(t, jobs, 1)
+	require.LessOrEqual(t, jobs, defaultCLIMaxToolJobs)
+}

--- a/cmd/lesser/init_admin_more_validation_test.go
+++ b/cmd/lesser/init_admin_more_validation_test.go
@@ -104,4 +104,3 @@ func TestRunInitAdmin_AdditionalValidationBranches(t *testing.T) {
 		require.Contains(t, err.Error(), "message is required")
 	})
 }
-

--- a/cmd/lesser/main.go
+++ b/cmd/lesser/main.go
@@ -39,6 +39,8 @@ var (
 )
 
 func runCLI(args []string, stderr io.Writer) int {
+	applyCLIDefaultEnv()
+
 	if len(args) < 2 {
 		printUsageTo(stderr)
 		return 2

--- a/cmd/lesser/quality_cmd.go
+++ b/cmd/lesser/quality_cmd.go
@@ -75,6 +75,10 @@ func runLint(argv []string) error {
 		args = append(args, "--fix")
 	}
 
+	if jobs := resolveToolJobs(); jobs > 0 {
+		args = append(args, "--concurrency", fmt.Sprintf("%d", jobs))
+	}
+
 	return runCommandFn(context.Background(), "golangci-lint", args, execOptions{
 		Dir: repoRoot,
 		Env: map[string]string{

--- a/cmd/lesser/verify_cmd_test.go
+++ b/cmd/lesser/verify_cmd_test.go
@@ -97,6 +97,7 @@ func TestRunVerifyCI_RunsLintSecurityAndVerifySuite(t *testing.T) {
 	})
 
 	ensureToolAvailableFn = func(string) error { return nil }
+	t.Setenv("LESSER_JOBS", "8")
 
 	repoRoot := t.TempDir()
 	findRepoRootFn = func() (string, error) { return repoRoot, nil }
@@ -134,7 +135,7 @@ func TestRunVerifyCI_RunsLintSecurityAndVerifySuite(t *testing.T) {
 	}
 
 	require.NoError(t, runVerify([]string{"ci"}))
-	require.Contains(t, calls, "golangci-lint run --config .golangci.yml --disable gosec")
+	require.Contains(t, calls, "golangci-lint run --config .golangci.yml --disable gosec --concurrency 8")
 	require.Contains(t, calls, "go run ./tools/audit_gates --check")
 	require.Contains(t, calls, "gosec -quiet")
 	require.Contains(t, calls, "govulncheck ./...")

--- a/cmd/objects/round12_objects_helpers_test.go
+++ b/cmd/objects/round12_objects_helpers_test.go
@@ -128,4 +128,3 @@ func TestObjectsPanicRecovery_Round12(t *testing.T) {
 	require.NoError(t, json.Unmarshal(resp.Body, &payload))
 	require.Equal(t, "internal server error", payload["error"])
 }
-

--- a/cmd/streaming/main.go
+++ b/cmd/streaming/main.go
@@ -331,7 +331,13 @@ func (sh *StreamingHandler) HandleWebSocketDefault(ctx *apptheory.Context) (*app
 	}
 
 	wsCtx := ctx.AsWebSocket()
-	endpoint := strings.TrimSpace(wsCtx.ManagementEndpoint)
+	endpoint := ""
+	if sh != nil && sh.cfg != nil {
+		endpoint = strings.TrimSpace(sh.cfg.WebSocketEndpoint)
+	}
+	if endpoint == "" {
+		endpoint = strings.TrimSpace(wsCtx.ManagementEndpoint)
+	}
 	if endpoint == "" {
 		return apptheory.Text(500, "missing websocket management endpoint"), nil
 	}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -61,6 +61,7 @@ go build -o lesser ./cmd/lesser
 Notes:
 
 - `./lesser verify ci` is stricter than `./lesser verify` (adds lint, security scans, supply chain verification, strict OpenAPI, and coverage gates).
+- By default, the `./lesser` CLI caps Go/lint parallelism on high-core machines to avoid host OOMs (sets `GOMAXPROCS` and `GOFLAGS=-p` up to 8). Override with `LESSER_JOBS` (or your own `GOMAXPROCS` / `GOFLAGS`).
 - CI runs coverage in short mode and skips HTML generation to keep runtime down (`./lesser test coverage --scope overall --short --verbose=false --exclude-generated=false --html=false`).
 - Coverage gates are strict (for example, `89.999%` fails even if it rounds to `90.0%` in a 1-decimal summary). If debugging drift, run with `GOFLAGS=-count=1` to force fresh test runs.
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.55.2
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.51.4
 	github.com/aws/aws-sdk-go-v2/service/comprehend v1.40.8
-	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.53.6
+	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.55.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.1
 	github.com/aws/aws-sdk-go-v2/service/kms v1.49.5
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.80.0
@@ -71,12 +71,14 @@ require (
 	github.com/agnivade/levenshtein v1.2.1 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.32 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/apigatewaymanagementapi v1.29.10 // indirect
+	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.32.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.17 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.7 h1:tHK47VqqtJxOymRrNtUXN5SP/zUT
 github.com/aws/aws-sdk-go-v2/credentials v1.19.7/go.mod h1:qOZk8sPDrxhf+4Wf4oT2urYJrYt3RejHSzgAquYeppw=
 github.com/aws/aws-sdk-go-v2/feature/cloudfront/sign v1.9.11 h1:Ma3SJ8UZxmyTH/vYUwZ//Mc7fCZXVl3AAs9SE7SGkuA=
 github.com/aws/aws-sdk-go-v2/feature/cloudfront/sign v1.9.11/go.mod h1:Kshqff3faplW215YqYBWIcml6dkfuN7cWq3aW/M6Kok=
+github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.32 h1:ojCVN51FD7typ+PtJO2UYo4ssUyItayaSSd+Jgjib0s=
+github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.32/go.mod h1:jBYuQT8jjNv4GdWrt5MSAYMQPkULummysVx1zntRqqI=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 h1:I0GyV8wiYrP8XpA70g1HBcQO1JlQxCMTW9npl5UbDHY=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17/go.mod h1:tyw7BOl5bBe/oqvoIeECFJjMdzXoa/dfVz3QQ5lgHGA=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.20.1 h1:EfS+tBgFwzrR/skkhKdyClU0pCx/VgSKSo8OIzMEiQM=
@@ -62,6 +64,10 @@ github.com/aws/aws-sdk-go-v2/service/comprehend v1.40.8 h1:po1ddFPZcsoPbysMTSUgD
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.40.8/go.mod h1:B+j805syLerWiDs9kGX4EgLgVqlG4n5YSicPQnm3Y9c=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.53.6 h1:LNmvkGzDO5PYXDW6m7igx+s2jKaPchpfbS0uDICywFc=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.53.6/go.mod h1:ctEsEHY2vFQc6i4KU07q4n68v7BAmTbujv2Y+z8+hQY=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.55.0 h1:CyYoeHWjVSGimzMhlL0Z4l5gLCa++ccnRJKrsaNssxE=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.55.0/go.mod h1:ctEsEHY2vFQc6i4KU07q4n68v7BAmTbujv2Y+z8+hQY=
+github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.32.10 h1:NR6jP7HvIfQ15R8MCuxNCm9l2b9AajLsABgV4b1Jz0M=
+github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.32.10/go.mod h1:v5yw5XvpeeVw+QcBlciQYgnnkCOK7ZLj8BiE9Uy5jEE=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.1 h1:xNCUk9XN6Pa9PyzbEfzgRpvEIVlqtth402yjaWvNMu4=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.1/go.mod h1:GNQZL4JRSGH6L0/SNGOtffaB1vmlToYp3KtcUIB0NhI=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 h1:0ryTNEdJbzUCEWkVXEXoqlXV72J5keC1GvILMOuD00E=

--- a/graph/actor_resolver_created_at_test.go
+++ b/graph/actor_resolver_created_at_test.go
@@ -44,4 +44,3 @@ func TestActorResolver_CreatedAt_Fallbacks(t *testing.T) {
 	require.False(t, time.Time(*got).Before(before))
 	require.False(t, time.Time(*got).After(after))
 }
-

--- a/graph/round12_test_harness_test.go
+++ b/graph/round12_test_harness_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/services"
-	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
@@ -350,12 +349,14 @@ func round12PopulateStruct(dest any, state *round12PermissiveQueryState) {
 	case *models.VAPIDKeyRecord:
 		v.PK = "INSTANCE#CONFIG"
 		v.SK = "VAPID_KEYS"
-		v.Data = storage.VAPIDKeys{
-			PublicKey:  "test-public-key",
-			PrivateKey: "test-private-key",
-			Subject:    "mailto:admin@localhost",
-			CreatedAt:  time.Now().Add(-time.Hour).UTC(),
-			UpdatedAt:  time.Now().Add(-time.Minute).UTC(),
+		createdAt := time.Now().Add(-time.Hour).UTC()
+		updatedAt := time.Now().Add(-time.Minute).UTC()
+		v.Data = map[string]any{
+			"public_key":  "test-public-key",
+			"private_key": "test-private-key",
+			"subject":     "mailto:admin@localhost",
+			"created_at":  createdAt.Format(time.RFC3339Nano),
+			"updated_at":  updatedAt.Format(time.RFC3339Nano),
 		}
 		v.UpdatedAt = time.Now().Add(-time.Minute)
 		return

--- a/infra/cdk/constructs/lambda_functions.go
+++ b/infra/cdk/constructs/lambda_functions.go
@@ -142,7 +142,13 @@ func CreateLambdaFunctions(stack awscdk.Stack, props *LambdaFunctionsProps) *Lam
 
 	// WebSocket endpoint (used by streaming + notifications).
 	wsHost := fmt.Sprintf("ws.%s", domainValue)
-	commonEnv["WEBSOCKET_ENDPOINT"] = jsii.String(fmt.Sprintf("https://%s", wsHost))
+	// Streaming WebSocket API is path-mapped under /stream (see constructs/api_routes.go).
+	commonEnv["WEBSOCKET_ENDPOINT"] = jsii.String(fmt.Sprintf("https://%s/stream", wsHost))
+
+	// Optional feature flags (set only when explicitly configured).
+	if v := getConfigString("translationEnabled"); v != "" {
+		commonEnv["TRANSLATION_ENABLED"] = jsii.String(v)
+	}
 
 	// Set JWT secret ARN from SharedStack (securely passed, never synthesized)
 	if props.JwtSecret != nil {

--- a/infra/cdk/main.go
+++ b/infra/cdk/main.go
@@ -109,6 +109,20 @@ func main() {
 			"appName":     appName,
 			"domain":      stageDomain,
 		}
+		// Optional per-deployment config (passed via CDK context).
+		for _, key := range []string{
+			"lesserHostUrl",
+			"lesserHostInstanceKeyArn",
+			"lesserHostAttestationsUrl",
+			"translationEnabled",
+			"tipEnabled",
+			"tipChainId",
+			"tipContractAddress",
+		} {
+			if v := getContextString(app, key); v != "" {
+				config[key] = v
+			}
+		}
 
 		stackName := naming.StageStackName(appName, naming.Stage(stage))
 		_ = stacks.NewLesserApiStack(app, stackName, &stacks.LesserApiStackProps{

--- a/infra/cdk/stacks/shared_stack.go
+++ b/infra/cdk/stacks/shared_stack.go
@@ -196,6 +196,18 @@ func (s *SharedStack) attachApplicationPolicies(appName string) {
 			},
 		}))
 
+		// KMS decrypt for application secrets encrypted with the shared key.
+		role.AddToPolicy(awsiam.NewPolicyStatement(&awsiam.PolicyStatementProps{
+			Effect: awsiam.Effect_ALLOW,
+			Actions: &[]*string{
+				jsii.String("kms:Decrypt"),
+				jsii.String("kms:DescribeKey"),
+			},
+			Resources: &[]*string{
+				s.EncryptionKey.KeyArn(),
+			},
+		}))
+
 		// CloudWatch Logs
 		role.AddToPolicy(awsiam.NewPolicyStatement(&awsiam.PolicyStatementProps{
 			Effect: awsiam.Effect_ALLOW,

--- a/pkg/auth/oauth_client_context_test.go
+++ b/pkg/auth/oauth_client_context_test.go
@@ -13,23 +13,23 @@ import (
 
 type reposStub struct{}
 
-func (reposStub) Account() *repositories.AccountRepository                 { return nil }
-func (reposStub) Actor() interfaces.ActorRepository                        { return nil }
-func (reposStub) Activity() interfaces.ActivityRepository                  { return nil }
-func (reposStub) Notification() interfaces.NotificationRepository          { return nil }
-func (reposStub) Recovery() *repositories.RecoveryRepository               { return nil }
-func (reposStub) Audit() *repositories.AuditRepository                     { return nil }
+func (reposStub) Account() *repositories.AccountRepository        { return nil }
+func (reposStub) Actor() interfaces.ActorRepository               { return nil }
+func (reposStub) Activity() interfaces.ActivityRepository         { return nil }
+func (reposStub) Notification() interfaces.NotificationRepository { return nil }
+func (reposStub) Recovery() *repositories.RecoveryRepository      { return nil }
+func (reposStub) Audit() *repositories.AuditRepository            { return nil }
 
 type reposWithAccount struct {
 	account *repositories.AccountRepository
 }
 
-func (r reposWithAccount) Account() *repositories.AccountRepository        { return r.account }
-func (reposWithAccount) Actor() interfaces.ActorRepository                 { return nil }
-func (reposWithAccount) Activity() interfaces.ActivityRepository           { return nil }
-func (reposWithAccount) Notification() interfaces.NotificationRepository   { return nil }
-func (reposWithAccount) Recovery() *repositories.RecoveryRepository        { return nil }
-func (reposWithAccount) Audit() *repositories.AuditRepository              { return nil }
+func (r reposWithAccount) Account() *repositories.AccountRepository      { return r.account }
+func (reposWithAccount) Actor() interfaces.ActorRepository               { return nil }
+func (reposWithAccount) Activity() interfaces.ActivityRepository         { return nil }
+func (reposWithAccount) Notification() interfaces.NotificationRepository { return nil }
+func (reposWithAccount) Recovery() *repositories.RecoveryRepository      { return nil }
+func (reposWithAccount) Audit() *repositories.AuditRepository            { return nil }
 
 func TestOAuthService_GenerateTokensWithAccessTokenTTLAndClientContext(t *testing.T) {
 	t.Parallel()
@@ -100,4 +100,3 @@ func TestNormalizeDelegatedBy(t *testing.T) {
 	require.Equal(t, "@owner", normalizeDelegatedBy("@owner"))
 	require.Equal(t, "@owner", normalizeDelegatedBy(" @owner "))
 }
-

--- a/pkg/common/error_middleware_test.go
+++ b/pkg/common/error_middleware_test.go
@@ -32,4 +32,3 @@ func TestAppTheoryStatusForErrorCode(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -843,7 +843,9 @@ func resolveDynamoTableName() string {
 		if isRunningTests() {
 			return "test-table"
 		}
-		panic("DYNAMODB_TABLE or DYNAMO_TABLE_NAME or ENVIRONMENT/STAGE must be set to determine the DynamoDB table name")
+		// Default to dev for local tooling (CLI/help/tests outside `go test`) to avoid hard-failing on missing env.
+		// Production environments should always provide an explicit table name.
+		derived = "dev"
 	}
 	return fmt.Sprintf("lesser-%s", strings.ToLower(derived))
 }

--- a/pkg/config/config_additional_test.go
+++ b/pkg/config/config_additional_test.go
@@ -23,6 +23,18 @@ func (s stubSecretsManagerGetter) GetSecretValue(_ context.Context, _ *secretsma
 	return s.output, s.err
 }
 
+type assertingSecretsManagerGetter struct {
+	t          *testing.T
+	expectedID string
+	secret     *string
+}
+
+func (s assertingSecretsManagerGetter) GetSecretValue(_ context.Context, input *secretsmanager.GetSecretValueInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+	require.NotNil(s.t, input.SecretId)
+	require.Equal(s.t, s.expectedID, *input.SecretId)
+	return &secretsmanager.GetSecretValueOutput{SecretString: s.secret}, nil
+}
+
 func TestConfig_URLHelpers(t *testing.T) {
 	cfg := &Config{Domain: "example.com"}
 	assert.Equal(t, "https://example.com", cfg.BaseURL())
@@ -103,6 +115,43 @@ func TestEnvParsingHelpers(t *testing.T) {
 	assert.Equal(t, uint8(3), getEnvAsUint8OrDefault("U8_KEY", 3))
 	t.Setenv("U8_KEY", "7")
 	assert.Equal(t, uint8(7), getEnvAsUint8OrDefault("U8_KEY", 3))
+
+	t.Setenv("F64_KEY", "")
+	assert.Equal(t, 1.5, getEnvAsFloat64OrDefault("F64_KEY", 1.5))
+	t.Setenv("F64_KEY", "not-a-float")
+	assert.Equal(t, 1.5, getEnvAsFloat64OrDefault("F64_KEY", 1.5))
+	t.Setenv("F64_KEY", "2.25")
+	assert.Equal(t, 2.25, getEnvAsFloat64OrDefault("F64_KEY", 1.5))
+}
+
+func TestResolveHelpers_UseEnvOrDefault(t *testing.T) {
+	t.Setenv("DOMAIN_NAME", "")
+	t.Setenv("DOMAIN", "")
+	assert.Equal(t, "default-domain", resolveDomain("default-domain"))
+
+	t.Setenv("DOMAIN_NAME", "example.com")
+	assert.Equal(t, "example.com", resolveDomain("default-domain"))
+
+	t.Setenv("S3_BUCKET_NAME", "bucket-1")
+	t.Setenv("S3_BUCKET", "")
+	assert.Equal(t, "bucket-1", resolveMediaBucketName("fallback-bucket"))
+
+	t.Setenv("S3_BUCKET_NAME", "")
+	t.Setenv("S3_BUCKET", "bucket-2")
+	assert.Equal(t, "bucket-2", resolveMediaBucketName("fallback-bucket"))
+
+	t.Setenv("S3_BUCKET", "")
+	assert.Equal(t, "fallback-bucket", resolveMediaBucketName("fallback-bucket"))
+
+	t.Setenv("QUEUE_CANON", "canon")
+	t.Setenv("QUEUE_ALIAS", "alias")
+	assert.Equal(t, "canon", resolveQueueURL("QUEUE_CANON", "QUEUE_ALIAS"))
+
+	t.Setenv("QUEUE_CANON", "")
+	assert.Equal(t, "alias", resolveQueueURL("QUEUE_CANON", "QUEUE_ALIAS"))
+
+	t.Setenv("QUEUE_ALIAS", "")
+	assert.Equal(t, "", resolveQueueURL("QUEUE_CANON", "QUEUE_ALIAS"))
 }
 
 func TestEnvironmentResolutionHelpers(t *testing.T) {
@@ -167,7 +216,7 @@ func TestResolveDynamoTableName(t *testing.T) {
 		t.Setenv("ENVIRONMENT", "")
 		t.Setenv("STAGE", "")
 
-		require.Panics(t, func() { _ = resolveDynamoTableName() })
+		assert.Equal(t, "lesser-dev", resolveDynamoTableName())
 	})
 }
 
@@ -230,6 +279,39 @@ func TestMustGetJWTSecret_SecretsManagerPath(t *testing.T) {
 	}
 
 	assert.Equal(t, "from-secrets-manager", mustGetJWTSecret())
+}
+
+func TestMustGetJWTSecret_DefaultARNWhenUnset(t *testing.T) {
+	ResetForTests()
+
+	origLoad := loadDefaultAWSConfig
+	origNew := newSecretsManagerValueGetter
+	origArgs := os.Args
+	t.Cleanup(func() {
+		loadDefaultAWSConfig = origLoad
+		newSecretsManagerValueGetter = origNew
+		os.Args = origArgs
+		ResetForTests()
+	})
+
+	os.Args = []string{"app"}
+	t.Setenv("JWT_SECRET", "")
+	t.Setenv("JWT_SECRET_ARN", "")
+
+	loadDefaultAWSConfig = func(_ context.Context, _ ...func(*awsconfig.LoadOptions) error) (aws.Config, error) {
+		return aws.Config{Region: "us-east-1"}, nil
+	}
+
+	secretString := `{"secret":"from-default-arn"}`
+	newSecretsManagerValueGetter = func(_ aws.Config) secretsManagerValueGetter {
+		return assertingSecretsManagerGetter{
+			t:          t,
+			expectedID: "lesser/jwt-secret",
+			secret:     &secretString,
+		}
+	}
+
+	assert.Equal(t, "from-default-arn", mustGetJWTSecret())
 }
 
 func TestMustGetJWTSecret_PlaintextAndTestDummy(t *testing.T) {

--- a/pkg/config/config_secrets_test.go
+++ b/pkg/config/config_secrets_test.go
@@ -1,10 +1,16 @@
 package config
 
 import (
+	"context"
+	"errors"
 	"os"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetOptionalSecretFromEnvOrARN_ValueEnvTakesPrecedence(t *testing.T) {
@@ -32,4 +38,57 @@ func TestGetOptionalSecretFromEnvOrARN_ArnSkipsAwsInTests(t *testing.T) {
 	t.Setenv("UNIT_TEST_SECRET_ARN", "arn:aws:secretsmanager:us-east-1:123456789012:secret:unit-test")
 
 	assert.Equal(t, "", getOptionalSecretFromEnvOrARN("UNIT_TEST_SECRET_VALUE", "UNIT_TEST_SECRET_ARN"))
+}
+
+func TestGetOptionalSecretFromEnvOrARN_ArnFetchesValueOutsideTests(t *testing.T) {
+	origLoad := loadDefaultAWSConfig
+	origNew := newSecretsManagerValueGetter
+	origArgs := os.Args
+	t.Cleanup(func() {
+		loadDefaultAWSConfig = origLoad
+		newSecretsManagerValueGetter = origNew
+		os.Args = origArgs
+	})
+
+	os.Args = []string{"app"}
+	t.Setenv("UNIT_TEST_SECRET_VALUE", "")
+	t.Setenv("UNIT_TEST_SECRET_ARN", "arn:aws:secretsmanager:us-east-1:123456789012:secret:unit-test")
+
+	loadDefaultAWSConfig = func(_ context.Context, _ ...func(*awsconfig.LoadOptions) error) (aws.Config, error) {
+		return aws.Config{Region: "us-east-1"}, nil
+	}
+	secretString := `{"secret":"from-secrets-manager"}`
+	newSecretsManagerValueGetter = func(_ aws.Config) secretsManagerValueGetter {
+		return stubSecretsManagerGetter{
+			output: &secretsmanager.GetSecretValueOutput{SecretString: &secretString},
+		}
+	}
+
+	assert.Equal(t, "from-secrets-manager", getOptionalSecretFromEnvOrARN("UNIT_TEST_SECRET_VALUE", "UNIT_TEST_SECRET_ARN"))
+}
+
+func TestGetOptionalSecretFromEnvOrARN_PanicsWhenFetchFailsOutsideTests(t *testing.T) {
+	origLoad := loadDefaultAWSConfig
+	origNew := newSecretsManagerValueGetter
+	origArgs := os.Args
+	t.Cleanup(func() {
+		loadDefaultAWSConfig = origLoad
+		newSecretsManagerValueGetter = origNew
+		os.Args = origArgs
+	})
+
+	os.Args = []string{"app"}
+	t.Setenv("UNIT_TEST_SECRET_VALUE", "")
+	t.Setenv("UNIT_TEST_SECRET_ARN", "arn:aws:secretsmanager:us-east-1:123456789012:secret:unit-test")
+
+	loadDefaultAWSConfig = func(_ context.Context, _ ...func(*awsconfig.LoadOptions) error) (aws.Config, error) {
+		return aws.Config{Region: "us-east-1"}, nil
+	}
+	newSecretsManagerValueGetter = func(_ aws.Config) secretsManagerValueGetter {
+		return stubSecretsManagerGetter{err: errors.New("boom")}
+	}
+
+	require.Panics(t, func() {
+		_ = getOptionalSecretFromEnvOrARN("UNIT_TEST_SECRET_VALUE", "UNIT_TEST_SECRET_ARN")
+	})
 }

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -172,6 +172,128 @@ func TestProductionConfigValidator_ValidateProductionConfig_AWSResourcesValidati
 	assert.True(t, result.Resources.SecretsManager.Available)
 }
 
+func TestProductionConfigValidator_AWSResourceValidation_ErrorBranches(t *testing.T) {
+	origTableExists := newTableExistsChecker
+	origS3 := newS3Client
+	origSecrets := newSecretsManagerClient
+	t.Cleanup(func() {
+		newTableExistsChecker = origTableExists
+		newS3Client = origS3
+		newSecretsManagerClient = origSecrets
+	})
+
+	v := &ProductionConfigValidator{
+		logger:    zap.NewNop(),
+		awsConfig: aws.Config{Region: "us-east-1"},
+		timeout:   1,
+	}
+
+	t.Run("dynamodb missing table info returns error", func(t *testing.T) {
+		t.Setenv("DYNAMODB_TABLE", "")
+		t.Setenv("DYNAMO_TABLE_NAME", "")
+		t.Setenv("ENVIRONMENT", "")
+		t.Setenv("STAGE", "")
+
+		status := v.validateDynamoDB(context.Background())
+		assert.False(t, status.Available)
+		assert.Contains(t, status.Error, "must be set")
+	})
+
+	t.Run("dynamodb checker init failure returns error", func(t *testing.T) {
+		t.Setenv("DYNAMODB_TABLE", "lesser-main")
+		t.Setenv("DYNAMO_TABLE_NAME", "")
+		t.Setenv("ENVIRONMENT", "")
+		t.Setenv("STAGE", "")
+
+		newTableExistsChecker = func(_ aws.Config) (tableExistsChecker, error) {
+			return nil, errors.New("init boom")
+		}
+		t.Cleanup(func() { newTableExistsChecker = origTableExists })
+
+		status := v.validateDynamoDB(context.Background())
+		assert.False(t, status.Available)
+		assert.Contains(t, status.Error, "failed to initialize TableTheory DynamoDB client")
+		assert.Contains(t, status.Error, "init boom")
+	})
+
+	t.Run("dynamodb table exists checker error returns error", func(t *testing.T) {
+		t.Setenv("DYNAMODB_TABLE", "lesser-main")
+		t.Setenv("DYNAMO_TABLE_NAME", "")
+		t.Setenv("ENVIRONMENT", "")
+		t.Setenv("STAGE", "")
+
+		newTableExistsChecker = func(_ aws.Config) (tableExistsChecker, error) {
+			return stubTableExistsChecker{exists: false, err: errors.New("access boom")}, nil
+		}
+		t.Cleanup(func() { newTableExistsChecker = origTableExists })
+
+		status := v.validateDynamoDB(context.Background())
+		assert.False(t, status.Available)
+		assert.Contains(t, status.Error, "not accessible")
+		assert.Contains(t, status.Error, "access boom")
+	})
+
+	t.Run("dynamodb table missing returns error", func(t *testing.T) {
+		t.Setenv("DYNAMODB_TABLE", "lesser-main")
+		t.Setenv("DYNAMO_TABLE_NAME", "")
+		t.Setenv("ENVIRONMENT", "")
+		t.Setenv("STAGE", "")
+
+		newTableExistsChecker = func(_ aws.Config) (tableExistsChecker, error) {
+			return stubTableExistsChecker{exists: false, err: nil}, nil
+		}
+		t.Cleanup(func() { newTableExistsChecker = origTableExists })
+
+		status := v.validateDynamoDB(context.Background())
+		assert.False(t, status.Available)
+		assert.Contains(t, status.Error, "not found")
+	})
+
+	t.Run("s3 missing bucket is treated as optional", func(t *testing.T) {
+		t.Setenv("S3_BUCKET_NAME", "")
+		t.Setenv("S3_BUCKET", "")
+
+		status := v.validateS3(context.Background())
+		assert.False(t, status.Available)
+		assert.Contains(t, status.Message, "not configured")
+	})
+
+	t.Run("s3 head bucket failure returns error", func(t *testing.T) {
+		t.Setenv("S3_BUCKET_NAME", "bucket-name")
+		t.Setenv("S3_BUCKET", "")
+
+		newS3Client = func(_ aws.Config) s3Client { return stubS3Client{err: errors.New("head boom")} }
+		t.Cleanup(func() { newS3Client = origS3 })
+
+		status := v.validateS3(context.Background())
+		assert.False(t, status.Available)
+		assert.Contains(t, status.Error, "not accessible")
+		assert.Contains(t, status.Error, "head boom")
+	})
+
+	t.Run("secrets manager missing secret name returns error", func(t *testing.T) {
+		t.Setenv("PRIVATE_KEY_SECRET", "")
+
+		status := v.validateSecretsManager(context.Background())
+		assert.False(t, status.Available)
+		assert.Equal(t, "Private key secret name not configured", status.Error)
+	})
+
+	t.Run("secrets manager describe failure returns error", func(t *testing.T) {
+		t.Setenv("PRIVATE_KEY_SECRET", "secret-name")
+
+		newSecretsManagerClient = func(_ aws.Config) secretsManagerClient {
+			return stubSecretsManagerClient{err: errors.New("describe boom")}
+		}
+		t.Cleanup(func() { newSecretsManagerClient = origSecrets })
+
+		status := v.validateSecretsManager(context.Background())
+		assert.False(t, status.Available)
+		assert.Contains(t, status.Error, "not accessible")
+		assert.Contains(t, status.Error, "describe boom")
+	})
+}
+
 func TestProductionConfigValidator_SecurityAndFormatHelpers(t *testing.T) {
 	v := &ProductionConfigValidator{logger: zap.NewNop()}
 
@@ -181,9 +303,57 @@ func TestProductionConfigValidator_SecurityAndFormatHelpers(t *testing.T) {
 		require.NotEmpty(t, result.Warnings)
 	})
 
+	t.Run("domain name format error", func(t *testing.T) {
+		result := &ValidationResult{}
+		v.validateEnvironmentVariableFormat("DOMAIN_NAME", "bad domain", result)
+		require.NotEmpty(t, result.Errors)
+	})
+
+	t.Run("aws region format error", func(t *testing.T) {
+		result := &ValidationResult{}
+		v.validateEnvironmentVariableFormat("AWS_REGION", "not-a-region", result)
+		require.NotEmpty(t, result.Errors)
+	})
+
+	t.Run("environment name warning", func(t *testing.T) {
+		result := &ValidationResult{}
+		v.validateEnvironmentVariableFormat("ENVIRONMENT", "weird", result)
+		require.NotEmpty(t, result.Warnings)
+	})
+
+	t.Run("stage name warning", func(t *testing.T) {
+		result := &ValidationResult{}
+		v.validateEnvironmentVariableFormat("STAGE", "weird", result)
+		require.NotEmpty(t, result.Warnings)
+	})
+
 	t.Run("jwt configured via arn", func(t *testing.T) {
 		t.Setenv("JWT_SECRET", "")
 		t.Setenv("JWT_SECRET_ARN", "arn:aws:secretsmanager:...")
+		status := v.validateJWTConfiguration()
+		assert.True(t, status.Configured)
+		assert.True(t, status.Valid)
+	})
+
+	t.Run("jwt missing is invalid", func(t *testing.T) {
+		t.Setenv("JWT_SECRET", "")
+		t.Setenv("JWT_SECRET_ARN", "")
+		status := v.validateJWTConfiguration()
+		assert.False(t, status.Configured)
+		assert.False(t, status.Valid)
+	})
+
+	t.Run("jwt too short is invalid", func(t *testing.T) {
+		t.Setenv("JWT_SECRET", "short")
+		t.Setenv("JWT_SECRET_ARN", "")
+		status := v.validateJWTConfiguration()
+		assert.True(t, status.Configured)
+		assert.False(t, status.Valid)
+	})
+
+	t.Run("jwt long secret is valid", func(t *testing.T) {
+		t.Setenv("JWT_SECRET", "abcdefghijklmnopqrstuvwxyz0123456789abcdef")
+		t.Setenv("JWT_SECRET_ARN", "")
 		status := v.validateJWTConfiguration()
 		assert.True(t, status.Configured)
 		assert.True(t, status.Valid)
@@ -197,11 +367,47 @@ func TestProductionConfigValidator_SecurityAndFormatHelpers(t *testing.T) {
 		assert.True(t, status.Valid)
 	})
 
+	t.Run("oauth partial configuration is invalid", func(t *testing.T) {
+		t.Setenv("OAUTH_CLIENT_ID", "client")
+		t.Setenv("OAUTH_CLIENT_SECRET", "")
+		status := v.validateOAuthSecrets()
+		assert.True(t, status.Configured)
+		assert.False(t, status.Valid)
+	})
+
+	t.Run("oauth complete configuration is valid", func(t *testing.T) {
+		t.Setenv("OAUTH_CLIENT_ID", "client")
+		t.Setenv("OAUTH_CLIENT_SECRET", "secret")
+		status := v.validateOAuthSecrets()
+		assert.True(t, status.Configured)
+		assert.True(t, status.Valid)
+	})
+
 	t.Run("encryption key too short invalid", func(t *testing.T) {
 		t.Setenv("ENCRYPTION_KEY", "short")
 		status := v.validateEncryptionKeys()
 		assert.True(t, status.Configured)
 		assert.False(t, status.Valid)
+	})
+
+	t.Run("encryption key missing invalid", func(t *testing.T) {
+		t.Setenv("ENCRYPTION_KEY", "")
+		status := v.validateEncryptionKeys()
+		assert.False(t, status.Configured)
+		assert.False(t, status.Valid)
+	})
+
+	t.Run("encryption key long valid", func(t *testing.T) {
+		t.Setenv("ENCRYPTION_KEY", "abcdefghijklmnopqrstuvwxyz0123456789abcdef")
+		status := v.validateEncryptionKeys()
+		assert.True(t, status.Configured)
+		assert.True(t, status.Valid)
+	})
+
+	t.Run("isValidDomain handles schemes", func(t *testing.T) {
+		assert.True(t, v.isValidDomain("https://example.com"))
+		assert.False(t, v.isValidDomain("http://%"))
+		assert.False(t, v.isValidDomain("localhost"))
 	})
 
 	t.Run("domain accessibility warning", func(t *testing.T) {

--- a/pkg/errors/context_additional_test.go
+++ b/pkg/errors/context_additional_test.go
@@ -86,4 +86,3 @@ func TestContextHelpers_AdditionalCoverage(t *testing.T) {
 		assert.False(t, IsRetryable(stdErrors.New("nope")))
 	})
 }
-

--- a/pkg/storage/models/revoked_access_token.go
+++ b/pkg/storage/models/revoked_access_token.go
@@ -55,4 +55,3 @@ func (r *RevokedAccessToken) UpdateKeys() error {
 	r.SK = SKToken
 	return nil
 }
-

--- a/pkg/storage/models/vapid.go
+++ b/pkg/storage/models/vapid.go
@@ -8,10 +8,10 @@ import (
 type VAPIDKeyRecord struct {
 	_ struct{} `theorydb:"naming:camelCase"`
 
-	PK        string      `theorydb:"pk,attr:PK"`            // INSTANCE#CONFIG
-	SK        string      `theorydb:"sk,attr:SK"`            // VAPID_KEYS
-	Data      interface{} `theorydb:"attr:data" json:"data"` // The actual VAPID keys data (storage.VAPIDKeys)
-	UpdatedAt time.Time   `theorydb:"attr:updatedAt" json:"updated_at"`
+	PK        string         `theorydb:"pk,attr:PK"`            // INSTANCE#CONFIG
+	SK        string         `theorydb:"sk,attr:SK"`            // VAPID_KEYS
+	Data      map[string]any `theorydb:"attr:data" json:"data"` // The actual VAPID keys data (storage.VAPIDKeys-compatible)
+	UpdatedAt time.Time      `theorydb:"attr:updatedAt" json:"updated_at"`
 }
 
 // UpdateKeys updates any GSI keys - VAPID doesn't use GSIs so this is no-op

--- a/pkg/storage/models/websocket_connection.go
+++ b/pkg/storage/models/websocket_connection.go
@@ -62,8 +62,8 @@ type WebSocketConnection struct {
 	SK string `theorydb:"sk,attr:SK" json:"sk"` // CONN#{connectionID}
 
 	// GSI keys for querying
-	GSI1PK string `theorydb:"index:gsi1,pk,attr:gsi1PK" json:"gsi1pk"` // USER#{userID}
-	GSI1SK string `theorydb:"index:gsi1,sk,attr:gsi1SK" json:"gsi1sk"` // CONN#{timestamp}
+	GSI1PK string `theorydb:"index:gsi1,pk,attr:gsi1PK,omitempty" json:"gsi1pk,omitempty"` // USER#{userID}
+	GSI1SK string `theorydb:"index:gsi1,sk,attr:gsi1SK,omitempty" json:"gsi1sk,omitempty"` // CONN#{timestamp}
 
 	// GSI2 for state-based queries
 	GSI2PK string `theorydb:"index:gsi2,pk,attr:gsi2PK" json:"gsi2pk"` // STATE#{state}
@@ -71,8 +71,8 @@ type WebSocketConnection struct {
 
 	// Business fields
 	ConnectionID string    `theorydb:"attr:connectionID" json:"connection_id"`
-	UserID       string    `theorydb:"attr:userID" json:"user_id"`
-	Username     string    `theorydb:"attr:username" json:"username"`
+	UserID       string    `theorydb:"attr:userID,omitempty" json:"user_id,omitempty"`
+	Username     string    `theorydb:"attr:username,omitempty" json:"username,omitempty"`
 	Streams      []string  `theorydb:"attr:streams" json:"streams"` // subscribed streams
 	Established  time.Time `theorydb:"attr:established" json:"established"`
 	LastActivity time.Time `theorydb:"attr:lastActivity" json:"last_activity"`

--- a/pkg/storage/models/websocket_cost_tracking.go
+++ b/pkg/storage/models/websocket_cost_tracking.go
@@ -25,15 +25,15 @@ type WebSocketCostRecord struct {
 	GSI1SK string `theorydb:"index:gsi1,sk,attr:gsi1SK" json:"gsi1_sk"` // Format: "{timestamp}#{operation_type}#{id}"
 
 	// GSI2 - User-based queries
-	GSI2PK string `theorydb:"index:gsi2,pk,attr:gsi2PK" json:"gsi2_pk"` // Format: "WS_USER#{user_id}"
-	GSI2SK string `theorydb:"index:gsi2,sk,attr:gsi2SK" json:"gsi2_sk"` // Format: "{timestamp}#{operation_type}#{id}"
+	GSI2PK string `theorydb:"index:gsi2,pk,attr:gsi2PK,omitempty" json:"gsi2_pk,omitempty"` // Format: "WS_USER#{user_id}"
+	GSI2SK string `theorydb:"index:gsi2,sk,attr:gsi2SK,omitempty" json:"gsi2_sk,omitempty"` // Format: "{timestamp}#{operation_type}#{id}"
 
 	// Core cost tracking data
 	ID            string    `theorydb:"attr:id" json:"id"`
-	OperationType string    `theorydb:"attr:operationType" json:"operation_type"` // connect, disconnect, message_in, message_out, idle_time
-	ConnectionID  string    `theorydb:"attr:connectionID" json:"connection_id"`   // API Gateway connection ID
-	UserID        string    `theorydb:"attr:userID" json:"user_id"`               // User associated with connection
-	Username      string    `theorydb:"attr:username" json:"username"`            // Username for easier queries
+	OperationType string    `theorydb:"attr:operationType" json:"operation_type"`          // connect, disconnect, message_in, message_out, idle_time
+	ConnectionID  string    `theorydb:"attr:connectionID" json:"connection_id"`            // API Gateway connection ID
+	UserID        string    `theorydb:"attr:userID,omitempty" json:"user_id,omitempty"`    // User associated with connection
+	Username      string    `theorydb:"attr:username,omitempty" json:"username,omitempty"` // Username for easier queries
 	Timestamp     time.Time `theorydb:"attr:timestamp" json:"timestamp"`
 
 	// Connection details

--- a/pkg/storage/repositories/activitypub_actor_dynamo_decode.go
+++ b/pkg/storage/repositories/activitypub_actor_dynamo_decode.go
@@ -1,0 +1,53 @@
+package repositories
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+)
+
+func decodeActivityPubActorFromDynamoValue(value any) (*activitypub.Actor, error) {
+	if value == nil {
+		return nil, fmt.Errorf("actor value is nil")
+	}
+
+	normalized := normalizeEmbeddedBaseObject(value)
+	data, err := json.Marshal(normalized)
+	if err != nil {
+		return nil, fmt.Errorf("marshal normalized actor: %w", err)
+	}
+
+	var actor activitypub.Actor
+	if err := json.Unmarshal(data, &actor); err != nil {
+		return nil, fmt.Errorf("unmarshal normalized actor json: %w", err)
+	}
+	return &actor, nil
+}
+
+func normalizeEmbeddedBaseObject(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		if base, ok := typed["BaseObject"].(map[string]any); ok {
+			for k, v := range base {
+				if _, exists := typed[k]; !exists {
+					typed[k] = v
+				}
+			}
+			delete(typed, "BaseObject")
+		}
+		for k, v := range typed {
+			typed[k] = normalizeEmbeddedBaseObject(v)
+		}
+		return typed
+
+	case []any:
+		for i := range typed {
+			typed[i] = normalizeEmbeddedBaseObject(typed[i])
+		}
+		return typed
+
+	default:
+		return value
+	}
+}

--- a/pkg/storage/repositories/activitypub_actor_dynamo_decode_test.go
+++ b/pkg/storage/repositories/activitypub_actor_dynamo_decode_test.go
@@ -1,0 +1,28 @@
+package repositories
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeActivityPubActorFromDynamoValue_mergesEmbeddedBaseObject(t *testing.T) {
+	raw := map[string]any{
+		"BaseObject": map[string]any{
+			"ID":   "https://example.com/users/alice",
+			"Type": "Person",
+		},
+		"PreferredUsername": "alice",
+		"Name":              "Alice",
+	}
+
+	actor, err := decodeActivityPubActorFromDynamoValue(raw)
+	require.NoError(t, err)
+	require.NotNil(t, actor)
+	assert.Equal(t, "https://example.com/users/alice", actor.ID)
+	assert.Equal(t, "Person", actor.Type)
+	assert.Equal(t, "alice", actor.PreferredUsername)
+	assert.Equal(t, "Alice", actor.Name)
+}
+

--- a/pkg/storage/repositories/activitypub_actor_dynamo_fallback.go
+++ b/pkg/storage/repositories/activitypub_actor_dynamo_fallback.go
@@ -1,0 +1,96 @@
+package repositories
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	lesserconfig "github.com/equaltoai/lesser/pkg/config"
+)
+
+var (
+	loadDefaultAWSConfigForRepositories = awsconfig.LoadDefaultConfig
+
+	defaultDynamoClientOnce sync.Once
+	defaultDynamoClient     *dynamodb.Client
+	defaultDynamoClientErr  error
+)
+
+func getDefaultDynamoClient(ctx context.Context) (*dynamodb.Client, error) {
+	defaultDynamoClientOnce.Do(func() {
+		cfg := lesserconfig.Get()
+		region := cfg.Region
+		if region == "" {
+			region = "us-east-1"
+		}
+
+		awsCfg, err := loadDefaultAWSConfigForRepositories(ctx, awsconfig.WithRegion(region))
+		if err != nil {
+			defaultDynamoClientErr = err
+			return
+		}
+		defaultDynamoClient = dynamodb.NewFromConfig(awsCfg)
+	})
+
+	return defaultDynamoClient, defaultDynamoClientErr
+}
+
+func loadActivityPubActorFromDynamo(ctx context.Context, tableName, username string) (*activitypub.Actor, error) {
+	if tableName == "" {
+		return nil, fmt.Errorf("table name is empty")
+	}
+	if username == "" {
+		return nil, fmt.Errorf("username is empty")
+	}
+
+	client, err := getDefaultDynamoClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("init dynamodb client: %w", err)
+	}
+
+	out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName:      &tableName,
+		ConsistentRead: aws.Bool(true),
+		Key: map[string]types.AttributeValue{
+			"PK": &types.AttributeValueMemberS{Value: "ACTOR#" + username},
+			"SK": &types.AttributeValueMemberS{Value: "PROFILE"},
+		},
+		ProjectionExpression: awsString("actor"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get actor item: %w", err)
+	}
+
+	attr, ok := out.Item["actor"]
+	if !ok || attr == nil {
+		return nil, fmt.Errorf("actor attribute missing")
+	}
+
+	switch typed := attr.(type) {
+	case *types.AttributeValueMemberM:
+		var raw map[string]any
+		if err := attributevalue.UnmarshalMap(typed.Value, &raw); err != nil {
+			return nil, fmt.Errorf("unmarshal actor attribute map: %w", err)
+		}
+		return decodeActivityPubActorFromDynamoValue(raw)
+	case *types.AttributeValueMemberS:
+		var actor activitypub.Actor
+		if err := json.Unmarshal([]byte(typed.Value), &actor); err != nil {
+			return nil, fmt.Errorf("unmarshal actor attribute json: %w", err)
+		}
+		return &actor, nil
+	default:
+		return nil, fmt.Errorf("unsupported actor attribute type: %T", attr)
+	}
+}
+
+func awsString(v string) *string {
+	return &v
+}

--- a/pkg/storage/repositories/actor_repository.go
+++ b/pkg/storage/repositories/actor_repository.go
@@ -148,6 +148,19 @@ func (r *ActorRepository) GetActor(ctx context.Context, username string) (*activ
 	}
 
 	actor := actorModel.Actor
+	if actor != nil && actor.ID == "" && actor.PreferredUsername == "" {
+		decoded, decErr := loadActivityPubActorFromDynamo(ctx, r.tableName, username)
+		if decErr != nil {
+			r.logger.Warn("failed to decode actor payload from DynamoDB fallback",
+				zap.String("username", username),
+				zap.Error(decErr))
+		} else if decoded != nil {
+			actor = decoded
+		}
+	}
+	if actor == nil {
+		return nil, ErrorHandler.HandleGetError(errors.New("actor data is missing"), EntityActor, username)
+	}
 	hydrateActivityPubActorTimestamps(actor, actorModel.CreatedAt, actorModel.UpdatedAt)
 	return actor, nil
 }
@@ -442,7 +455,7 @@ func (r *ActorRepository) SearchAccounts(ctx context.Context, query string, limi
 		err := r.db.WithContext(ctx).Model(&models.Actor{}).
 			Index("gsi1").
 			Where("gsi1PK", "=", "USERNAME_SEARCH#"+prefix).
-			Filter("gsi1SK", "BEGINS_WITH", normalizedQuery).
+			Where("gsi1SK", "BEGINS_WITH", normalizedQuery).
 			Limit(limit).
 			All(&actors)
 		if err != nil {
@@ -456,7 +469,7 @@ func (r *ActorRepository) SearchAccounts(ctx context.Context, query string, limi
 		err := r.db.WithContext(ctx).Model(&models.Actor{}).
 			Index("gsi2").
 			Where("gsi2PK", "=", "NAME_SEARCH#"+prefix).
-			Filter("gsi2SK", "BEGINS_WITH", normalizedQuery).
+			Where("gsi2SK", "BEGINS_WITH", normalizedQuery).
 			Limit(limit).
 			All(&actors)
 		if err != nil {
@@ -466,10 +479,28 @@ func (r *ActorRepository) SearchAccounts(ctx context.Context, query string, limi
 
 	// Convert to activitypub.Actor slice
 	result := make([]*activitypub.Actor, 0, len(actors))
-	for _, actor := range actors {
-		if actor.Actor != nil {
-			result = append(result, actor.Actor)
+	seen := make(map[string]struct{}, len(actors))
+	for i := range actors {
+		username := resolveActorUsername(&actors[i])
+		if username == "" {
+			continue
 		}
+
+		fullActor := actors[i].Actor
+		// KEYS_ONLY projections can yield nil or incomplete actor payloads.
+		if fullActor == nil || fullActor.ID == "" || fullActor.PreferredUsername == "" {
+			var err error
+			fullActor, err = r.GetActor(ctx, username)
+			if err != nil || fullActor == nil || fullActor.ID == "" {
+				continue
+			}
+		}
+
+		if _, ok := seen[fullActor.ID]; ok {
+			continue
+		}
+		seen[fullActor.ID] = struct{}{}
+		result = append(result, fullActor)
 	}
 
 	return result, nil
@@ -488,7 +519,7 @@ func (r *ActorRepository) GetSearchSuggestions(ctx context.Context, prefix strin
 	err := r.db.WithContext(ctx).Model(&models.Actor{}).
 		Index("gsi1").
 		Where("gsi1PK", "=", "USERNAME_SEARCH#"+prefixKey).
-		Filter("gsi1SK", "BEGINS_WITH", normalizedPrefix).
+		Where("gsi1SK", "BEGINS_WITH", normalizedPrefix).
 		Limit(10).
 		All(&actors)
 	if err != nil {
@@ -497,14 +528,40 @@ func (r *ActorRepository) GetSearchSuggestions(ctx context.Context, prefix strin
 
 	suggestions := make([]storage.SearchSuggestion, 0, len(actors))
 	for _, actor := range actors {
+		username := actor.Username
+		if username == "" {
+			username = resolveActorUsername(&actor)
+		}
 		suggestions = append(suggestions, storage.SearchSuggestion{
 			Type:  "account",
-			Value: actor.Username,
+			Value: username,
 			Score: 100, // Could be based on follower count or activity
 		})
 	}
 
 	return suggestions, nil
+}
+
+func resolveActorUsername(actor *models.Actor) string {
+	if actor == nil {
+		return ""
+	}
+	if actor.Username != "" {
+		return actor.Username
+	}
+	if strings.HasPrefix(actor.PK, "ACTOR#") {
+		return strings.TrimPrefix(actor.PK, "ACTOR#")
+	}
+	// gsi1SK is lowercase username; use it when that's all we have (e.g., KEYS_ONLY projections).
+	if actor.GSI1SK != "" {
+		return actor.GSI1SK
+	}
+	// gsi2SK format: "{lowercase_name}#{username}"
+	if actor.GSI2SK != "" {
+		parts := strings.Split(actor.GSI2SK, "#")
+		return parts[len(parts)-1]
+	}
+	return ""
 }
 
 // Helper functions
@@ -637,6 +694,17 @@ func (r *ActorRepository) GetActorByUsername(ctx context.Context, username strin
 			return nil, ErrorHandler.HandleGetError(err, EntityActor, username)
 		}
 		return nil, ErrorHandler.HandleGetError(err, EntityActor, username)
+	}
+
+	if actorModel.Actor != nil && actorModel.Actor.ID == "" && actorModel.Actor.PreferredUsername == "" {
+		decoded, decErr := loadActivityPubActorFromDynamo(ctx, r.tableName, username)
+		if decErr != nil {
+			r.logger.Warn("failed to decode actor payload from DynamoDB fallback",
+				zap.String("username", username),
+				zap.Error(decErr))
+		} else if decoded != nil {
+			actorModel.Actor = decoded
+		}
 	}
 
 	// Convert to ActivityPub actor

--- a/pkg/storage/repositories/actor_repository_additional_coverage_test.go
+++ b/pkg/storage/repositories/actor_repository_additional_coverage_test.go
@@ -425,6 +425,17 @@ func TestActorRepository_numeric_id_and_account_search_queries(t *testing.T) {
 			{Username: "nilactor", Actor: nil},
 		}
 	}).Once()
+	// SearchAccounts now loads full actor records (GSI projections may be KEYS_ONLY).
+	mockQuery.On("First", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		m := args.Get(0).(*models.Actor)
+		m.Username = "alice"
+		m.Actor = &activitypub.Actor{
+			BaseObject:        activitypub.BaseObject{ID: "https://example.com/users/alice"},
+			PreferredUsername: "alice",
+			Discoverable:      true,
+		}
+	}).Once()
+	mockQuery.On("First", mock.Anything).Return(dynamormerrors.ErrItemNotFound).Once()
 	results, err := repo.SearchAccounts(ctx, "al", 10, false, 0)
 	assert.NoError(t, err)
 	assert.Len(t, results, 1)
@@ -436,6 +447,15 @@ func TestActorRepository_numeric_id_and_account_search_queries(t *testing.T) {
 	mockQuery.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		out := args.Get(0).(*[]models.Actor)
 		*out = []models.Actor{{Username: "bob", Actor: &activitypub.Actor{BaseObject: activitypub.BaseObject{ID: "https://example.com/users/bob"}, PreferredUsername: "bob", Discoverable: true}}}
+	}).Once()
+	mockQuery.On("First", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		m := args.Get(0).(*models.Actor)
+		m.Username = "bob"
+		m.Actor = &activitypub.Actor{
+			BaseObject:        activitypub.BaseObject{ID: "https://example.com/users/bob"},
+			PreferredUsername: "bob",
+			Discoverable:      true,
+		}
 	}).Once()
 	results, err = repo.SearchAccounts(ctx, "bo", 10, false, 0)
 	assert.NoError(t, err)

--- a/pkg/storage/repositories/actor_repository_extra_coverage_test.go
+++ b/pkg/storage/repositories/actor_repository_extra_coverage_test.go
@@ -58,8 +58,14 @@ func TestActorRepository_SearchAccounts_and_numericID_branches(t *testing.T) {
 		mockQuery.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 			out := args.Get(0).(*[]models.Actor)
 			*out = []models.Actor{
-				{Username: "alice", Actor: &activitypub.Actor{PreferredUsername: "alice"}},
+				{Username: "alice", Actor: &activitypub.Actor{BaseObject: activitypub.BaseObject{ID: "alice-id"}, PreferredUsername: "alice"}},
 			}
+		}).Once()
+		// SearchAccounts loads full actor records via GetActor.
+		mockQuery.On("First", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+			m := args.Get(0).(*models.Actor)
+			m.Username = "alice"
+			m.Actor = &activitypub.Actor{BaseObject: activitypub.BaseObject{ID: "alice-id"}, PreferredUsername: "alice"}
 		}).Once()
 
 		repo := NewActorRepository(mockDB, "test-table", logger)

--- a/pkg/storage/repositories/push_subscription_repository.go
+++ b/pkg/storage/repositories/push_subscription_repository.go
@@ -227,12 +227,25 @@ func (r *PushSubscriptionRepository) GetVAPIDKeys(ctx context.Context) (*storage
 	}
 
 	// Convert interface{} back to storage.VAPIDKeys
-	keys, ok := record.Data.(storage.VAPIDKeys)
-	if !ok {
-		typeErr := errors.New("type assertion failed for VAPID keys data")
+	if record.Data == nil {
+		typeErr := errors.New("VAPID keys data is nil")
 		return nil, ErrorHandler.HandleGetError(typeErr, "VAPID keys", "data conversion")
 	}
 
+	// Convert via JSON to ensure stable decoding into the strongly-typed struct.
+	raw, err := json.Marshal(record.Data)
+	if err != nil {
+		return nil, ErrorHandler.HandleGetError(err, "VAPID keys", "marshal data")
+	}
+
+	var keys storage.VAPIDKeys
+	if err := json.Unmarshal(raw, &keys); err != nil {
+		return nil, ErrorHandler.HandleGetError(err, "VAPID keys", "unmarshal data")
+	}
+	if keys.PublicKey == "" {
+		typeErr := errors.New("VAPID keys data missing public_key")
+		return nil, ErrorHandler.HandleGetError(typeErr, "VAPID keys", "data conversion")
+	}
 	return &keys, nil
 }
 
@@ -258,16 +271,25 @@ func (r *PushSubscriptionRepository) SetVAPIDKeys(ctx context.Context, keys *sto
 			zap.Error(err))
 	}
 
+	raw, err := json.Marshal(keys)
+	if err != nil {
+		return ErrorHandler.HandleCreateError(err, "VAPID keys", "marshal payload")
+	}
+	var recordData map[string]any
+	if err := json.Unmarshal(raw, &recordData); err != nil {
+		return ErrorHandler.HandleCreateError(err, "VAPID keys", "unmarshal payload")
+	}
+
 	// Create the VAPID key record
 	record := &models.VAPIDKeyRecord{
 		PK:        "INSTANCE#CONFIG",
 		SK:        "VAPID_KEYS",
-		Data:      *keys,
+		Data:      recordData,
 		UpdatedAt: time.Now(),
 	}
 
 	// Try to update first, if not found then create
-	err := r.vapidRepo.Update(ctx, record)
+	err = r.vapidRepo.Update(ctx, record)
 	if err != nil {
 		if ddbErrors.IsNotFound(err) {
 			// Create new record if not found

--- a/pkg/storage/repositories/push_subscription_repository_coverage_test.go
+++ b/pkg/storage/repositories/push_subscription_repository_coverage_test.go
@@ -291,7 +291,7 @@ func TestRound07_PushSubscriptionRepository_VAPIDFallbackAndTypeAssertionError(t
 		record := args.Get(0).(*models.VAPIDKeyRecord)
 		record.PK = "INSTANCE#CONFIG"
 		record.SK = "VAPID_KEYS"
-		record.Data = "wrong-type"
+		record.Data = map[string]any{"not": "vapid"}
 	}).Return(nil)
 
 	repo := NewPushSubscriptionRepository(mockDB, "test-table", zap.NewNop(), nil, nil, "", "mailto:default@example.com")

--- a/pkg/storage/repositories/round07_permissive_mocks_test.go
+++ b/pkg/storage/repositories/round07_permissive_mocks_test.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/mock"
 	"github.com/theory-cloud/tabletheory/pkg/mocks"
@@ -139,12 +138,12 @@ func populateRound07StructForCoverage(target any, idx int, baseTime time.Time) {
 	case *models.VAPIDKeyRecord:
 		model.PK = "INSTANCE#CONFIG"
 		model.SK = "VAPID_KEYS"
-		model.Data = storage.VAPIDKeys{
-			PublicKey:  "public",
-			PrivateKey: "private",
-			Subject:    "mailto:test@example.com",
-			CreatedAt:  now,
-			UpdatedAt:  now,
+		model.Data = map[string]any{
+			"public_key":  "public",
+			"private_key": "private",
+			"subject":     "mailto:test@example.com",
+			"created_at":  now.UTC().Format(time.RFC3339Nano),
+			"updated_at":  now.UTC().Format(time.RFC3339Nano),
 		}
 		model.UpdatedAt = now
 

--- a/pkg/storage/repositories/search_repository.go
+++ b/pkg/storage/repositories/search_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"net/url"
 	"sort"
 	"strings"
 	"sync"
@@ -210,16 +211,12 @@ func (r *SearchRepository) searchExactUsername(ctx context.Context, query string
 		return
 	}
 
-	var exactMatch models.Actor
-	err := r.db.WithContext(ctx).Model(&models.Actor{}).
-		Where("PK", "=", fmt.Sprintf("ACTOR#%s", query)).
-		Where("SK", "=", "PROFILE").
-		First(&exactMatch)
-
-	if err == nil && exactMatch.Actor != nil && !seen[exactMatch.Actor.ID] {
-		*results = append(*results, exactMatch.Actor)
-		seen[exactMatch.Actor.ID] = true
+	actor, err := r.getFullActorByUsername(ctx, query)
+	if err != nil || actor == nil || actor.ID == "" || seen[actor.ID] {
+		return
 	}
+	*results = append(*results, actor)
+	seen[actor.ID] = true
 }
 
 // searchUsernamePrefix searches for usernames starting with the query
@@ -230,7 +227,7 @@ func (r *SearchRepository) searchUsernamePrefix(ctx context.Context, query strin
 	err := r.db.WithContext(ctx).Model(&models.Actor{}).
 		Index("gsi1").
 		Where("gsi1PK", "=", fmt.Sprintf("USERNAME_SEARCH#%s", prefixKey)).
-		Filter("gsi1SK", "BEGINS_WITH", query).
+		Where("gsi1SK", "BEGINS_WITH", query).
 		Limit(limit + offset).
 		All(&prefixMatches)
 
@@ -240,10 +237,35 @@ func (r *SearchRepository) searchUsernamePrefix(ctx context.Context, query strin
 	}
 
 	for _, match := range prefixMatches {
-		if match.Actor != nil && !seen[match.Actor.ID] {
-			*results = append(*results, match.Actor)
-			seen[match.Actor.ID] = true
+		actor := match.Actor
+		// Some deployments project KEYS_ONLY into the search GSIs, which means the
+		// `Actor` payload may be nil or incomplete. Prefer it when it looks valid,
+		// otherwise fetch the full actor record by username.
+		if actor == nil || actor.ID == "" || actor.PreferredUsername == "" {
+			username := match.Username
+			if username == "" {
+				// gsi1SK is the normalized username (lowercase).
+				username = match.GSI1SK
+			}
+			if username == "" && strings.HasPrefix(match.PK, "ACTOR#") {
+				username = strings.TrimPrefix(match.PK, "ACTOR#")
+			}
+			if username == "" {
+				continue
+			}
+
+			var err error
+			actor, err = r.getFullActorByUsername(ctx, username)
+			if err != nil {
+				continue
+			}
 		}
+
+		if actor == nil || actor.ID == "" || seen[actor.ID] {
+			continue
+		}
+		*results = append(*results, actor)
+		seen[actor.ID] = true
 	}
 }
 
@@ -259,7 +281,7 @@ func (r *SearchRepository) searchDisplayName(ctx context.Context, query string, 
 	err := r.db.WithContext(ctx).Model(&models.Actor{}).
 		Index("gsi2").
 		Where("gsi2PK", "=", fmt.Sprintf("NAME_SEARCH#%s", displayNameKey)).
-		Filter("gsi2SK", "BEGINS_WITH", query).
+		Where("gsi2SK", "BEGINS_WITH", query).
 		Limit(limit).
 		All(&displayNameMatches)
 
@@ -269,11 +291,73 @@ func (r *SearchRepository) searchDisplayName(ctx context.Context, query string, 
 	}
 
 	for _, match := range displayNameMatches {
-		if match.Actor != nil && !seen[match.Actor.ID] {
-			*results = append(*results, match.Actor)
-			seen[match.Actor.ID] = true
+		actor := match.Actor
+		if actor == nil || actor.ID == "" || actor.PreferredUsername == "" {
+			username := match.Username
+			if username == "" {
+				username = extractUsernameFromSearchSK(match.GSI2SK)
+			}
+			if username == "" && strings.HasPrefix(match.PK, "ACTOR#") {
+				username = strings.TrimPrefix(match.PK, "ACTOR#")
+			}
+			if username == "" {
+				continue
+			}
+
+			var err error
+			actor, err = r.getFullActorByUsername(ctx, username)
+			if err != nil {
+				continue
+			}
+		}
+
+		if actor == nil || actor.ID == "" || seen[actor.ID] {
+			continue
+		}
+		*results = append(*results, actor)
+		seen[actor.ID] = true
+	}
+}
+
+func extractUsernameFromSearchSK(sk string) string {
+	if sk == "" {
+		return ""
+	}
+	parts := strings.Split(sk, "#")
+	return parts[len(parts)-1]
+}
+
+func (r *SearchRepository) getFullActorByUsername(ctx context.Context, username string) (*activitypub.Actor, error) {
+	if err := common.ValidateRequiredParam("username", username); err != nil {
+		return nil, err
+	}
+
+	var actorModel models.Actor
+	err := r.db.WithContext(ctx).Model(&models.Actor{}).
+		Where("PK", "=", fmt.Sprintf("ACTOR#%s", username)).
+		Where("SK", "=", "PROFILE").
+		First(&actorModel)
+	if err != nil {
+		return nil, err
+	}
+
+	actor := actorModel.Actor
+	if actor != nil && actor.ID != "" && actor.PreferredUsername != "" {
+		return actor, nil
+	}
+
+	if actor != nil && actor.ID == "" && actor.PreferredUsername == "" {
+		decoded, decErr := loadActivityPubActorFromDynamo(ctx, r.tableName, username)
+		if decErr != nil {
+			r.logger.Warn("failed to decode actor payload from DynamoDB fallback",
+				zap.String("username", username),
+				zap.Error(decErr))
+		} else if decoded != nil {
+			return decoded, nil
 		}
 	}
+
+	return actor, nil
 }
 
 // applyFollowingFilter filters results to only include followed accounts
@@ -640,17 +724,32 @@ func (r *SearchRepository) isURL(query string) bool {
 
 // searchByURL searches for a status by its URL
 func (r *SearchRepository) searchByURL(ctx context.Context, url string, result *statusSearchResult) {
-	var object models.Object
-	err := r.db.WithContext(ctx).Model(&models.Object{}).
-		Where("URL", "=", url).
-		First(&object)
-
-	if err == nil && object.Type == ActivityTypeNote {
-		searchResult := r.objectToSearchResult(&object, 1.0, "url_match")
-		result.mu.Lock()
-		result.resultMap[object.ID] = searchResult
-		result.mu.Unlock()
+	// Statuses are stored as `models.Status` (PK/SK = status#{id}). If a user searches by a
+	// status URL, try to extract the status ID and load it directly.
+	statusID, ok := r.extractStatusIDFromURL(url)
+	if !ok {
+		return
 	}
+
+	var status models.Status
+	pk := fmt.Sprintf("status#%s", statusID)
+	sk := pk
+	err := r.db.WithContext(ctx).Model(&models.Status{}).
+		Where("PK", "=", pk).
+		Where("SK", "=", sk).
+		First(&status)
+	if err != nil {
+		return
+	}
+
+	searchResult := r.statusModelToSearchResult(&status, 1.0, "url_match")
+	if searchResult == nil {
+		return
+	}
+
+	result.mu.Lock()
+	result.resultMap[status.StatusID] = searchResult
+	result.mu.Unlock()
 }
 
 // executeHashtagSearch searches for statuses by hashtags
@@ -724,18 +823,18 @@ func (r *SearchRepository) searchByContent(ctx context.Context, query string, re
 }
 
 // getRecentStatuses fetches recent status objects
-func (r *SearchRepository) getRecentStatuses(ctx context.Context) []models.Object {
-	var recentStatuses []models.Object
-	err := r.db.WithContext(ctx).Model(&models.Object{}).
+func (r *SearchRepository) getRecentStatuses(ctx context.Context) []models.Status {
+	var recentStatuses []models.Status
+	err := r.db.WithContext(ctx).Model(&models.Status{}).
 		Index("gsi2").
-		Where("gsi2PK", "=", "object#type#Note").
+		Where("gsi2PK", "=", "PUBLIC_TIMELINE").
 		OrderBy("gsi2SK", "DESC").
 		Limit(500). // Query most recent 500 statuses for broader search coverage
 		All(&recentStatuses)
 
 	if err != nil {
 		r.logger.Warn("content search failed", zap.Error(err))
-		return []models.Object{}
+		return []models.Status{}
 	}
 
 	return recentStatuses
@@ -743,7 +842,7 @@ func (r *SearchRepository) getRecentStatuses(ctx context.Context) []models.Objec
 
 // statusMatchesQuery checks if a status matches the search query.
 // For multi-word queries, all words must appear in the content.
-func (r *SearchRepository) statusMatchesQuery(status models.Object, query string) bool {
+func (r *SearchRepository) statusMatchesQuery(status models.Status, query string) bool {
 	if err := common.ValidateRequiredParam("status.Content", status.Content); err != nil {
 		return false
 	}
@@ -769,16 +868,16 @@ func (r *SearchRepository) statusMatchesQuery(status models.Object, query string
 }
 
 // addStatusToResults adds a status to the search results
-func (r *SearchRepository) addStatusToResults(status models.Object, query string, result *statusSearchResult) {
+func (r *SearchRepository) addStatusToResults(status models.Status, query string, result *statusSearchResult) {
 	contentLower := strings.ToLower(status.Content)
 	score := r.calculateContentScore(contentLower, query)
-	searchResult := r.objectToSearchResult(&status, score, "content_match")
+	searchResult := r.statusModelToSearchResult(&status, score, "content_match")
 
 	result.mu.Lock()
 	defer result.mu.Unlock()
 
-	if existing, ok := result.resultMap[status.ID]; !ok || searchResult.Score > existing.Score {
-		result.resultMap[status.ID] = searchResult
+	if existing, ok := result.resultMap[status.StatusID]; !ok || searchResult.Score > existing.Score {
+		result.resultMap[status.StatusID] = searchResult
 	}
 }
 
@@ -1010,7 +1109,7 @@ func (r *SearchRepository) SearchHashtags(ctx context.Context, query string, lim
 	err := r.db.WithContext(ctx).Model(&models.Hashtag{}).
 		Index("gsi1").
 		Where("gsi1PK", "=", "HASHTAG").
-		Filter("gsi1SK", "BEGINS_WITH", normalizedQuery).
+		Where("gsi1SK", "BEGINS_WITH", normalizedQuery).
 		Limit(limit).
 		All(&hashtags)
 
@@ -1074,12 +1173,12 @@ func (r *SearchRepository) SearchHashtagsAdvancedPaginated(ctx context.Context, 
 	hashtagQuery := r.db.WithContext(ctx).Model(&models.Hashtag{}).
 		Index("gsi3").
 		Where("gsi3PK", "=", fmt.Sprintf("HASHTAG_SEARCH#%s", normalizedQuery[:2])).
-		Filter("gsi3SK", "BEGINS_WITH", normalizedQuery).
+		Where("gsi3SK", "BEGINS_WITH", normalizedQuery).
 		OrderBy("gsi3SK", "ASC")
 
 	// Resume from the last returned GSI value when a cursor is provided
 	if cursorData.LastID != "" {
-		hashtagQuery = hashtagQuery.Filter("gsi3SK", ">", cursorData.LastID)
+		hashtagQuery = hashtagQuery.Where("gsi3SK", ">", cursorData.LastID)
 	}
 
 	// Execute query with limit + 1 to check for more results
@@ -1160,6 +1259,49 @@ func (r *SearchRepository) objectToSearchResult(obj *models.Object, score float6
 		Score:          score,
 		Highlights:     []string{strategy},
 	}
+}
+
+func (r *SearchRepository) statusModelToSearchResult(status *models.Status, score float64, strategy string) *storage.StatusSearchResult {
+	if status == nil {
+		return nil
+	}
+
+	url := ""
+	if status.Note != nil {
+		url = status.Note.ID
+	}
+
+	return &storage.StatusSearchResult{
+		StatusID:       status.StatusID,
+		Content:        status.Content,
+		URL:            url,
+		AuthorID:       status.AuthorID,
+		AuthorUsername: status.AuthorUsername,
+		Published:      status.PublishedAt,
+		Score:          score,
+		Highlights:     []string{strategy},
+	}
+}
+
+func (r *SearchRepository) extractStatusIDFromURL(rawURL string) (string, bool) {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Path == "" {
+		return "", false
+	}
+
+	path := strings.TrimSuffix(u.Path, "/")
+	parts := strings.Split(path, "/")
+	if len(parts) == 0 {
+		return "", false
+	}
+
+	// Support typical Mastodon-style URL: /users/<username>/statuses/<id>
+	// and tolerate other shapes by taking the last path segment.
+	statusID := parts[len(parts)-1]
+	if statusID == "" {
+		return "", false
+	}
+	return statusID, true
 }
 
 func (r *SearchRepository) calculateContentScore(content, query string) float64 {
@@ -1579,13 +1721,12 @@ func (r *SearchRepository) SearchStatusesByHashtag(ctx context.Context, hashtag 
 func (r *SearchRepository) SearchStatusesByAuthor(ctx context.Context, authorID string, limit int) ([]*storage.StatusSearchResult, error) {
 	results := make([]*storage.StatusSearchResult, 0)
 
-	// Query statuses by author using GSI4
-	var statuses []models.Object
-
-	err := r.db.WithContext(ctx).Model(&models.Object{}).
-		Index("gsi4").
-		Where("gsi4PK", "=", fmt.Sprintf("author#%s", authorID)).
-		Filter("Type", "=", ActivityTypeNote).
+	// Query statuses by author using GSI1 (AUTHOR#{author_id})
+	var statuses []models.Status
+	err := r.db.WithContext(ctx).Model(&models.Status{}).
+		Index("gsi1").
+		Where("gsi1PK", "=", "AUTHOR#"+authorID).
+		OrderBy("gsi1SK", "DESC").
 		Limit(limit).
 		All(&statuses)
 
@@ -1595,7 +1736,7 @@ func (r *SearchRepository) SearchStatusesByAuthor(ctx context.Context, authorID 
 
 	// Convert to search results
 	for _, status := range statuses {
-		result := r.objectToSearchResult(&status, 1.0, "author_match")
+		result := r.statusModelToSearchResult(&status, 1.0, "author_match")
 		if result != nil {
 			results = append(results, result)
 		}

--- a/pkg/storage/repositories/search_repository.go
+++ b/pkg/storage/repositories/search_repository.go
@@ -1241,26 +1241,6 @@ func (r *SearchRepository) SearchHashtagsAdvancedPaginated(ctx context.Context, 
 
 // Helper methods
 
-func (r *SearchRepository) objectToSearchResult(obj *models.Object, score float64, strategy string) *storage.StatusSearchResult {
-	if obj == nil || obj.Type != ActivityTypeNote {
-		return nil
-	}
-
-	// Extract author username from AttributedTo
-	authorUsername := r.extractUsername(obj.AttributedTo)
-
-	return &storage.StatusSearchResult{
-		StatusID:       obj.ID,
-		Content:        obj.Content,
-		URL:            obj.URL,
-		AuthorID:       obj.AttributedTo,
-		AuthorUsername: authorUsername,
-		Published:      obj.Published,
-		Score:          score,
-		Highlights:     []string{strategy},
-	}
-}
-
 func (r *SearchRepository) statusModelToSearchResult(status *models.Status, score float64, strategy string) *storage.StatusSearchResult {
 	if status == nil {
 		return nil
@@ -1348,24 +1328,6 @@ func (r *SearchRepository) extractHashtags(text string) []string {
 	}
 
 	return hashtags
-}
-
-func (r *SearchRepository) extractUsername(actorID string) string {
-	// Extract username from actor ID
-	// Format: https://domain.com/users/username -> username
-	if strings.Contains(actorID, "/users/") {
-		parts := strings.Split(actorID, "/users/")
-		if len(parts) == 2 {
-			return parts[1]
-		}
-	}
-
-	// For simple usernames
-	if !strings.Contains(actorID, "://") {
-		return actorID
-	}
-
-	return ""
 }
 
 func (r *SearchRepository) isLocalStatus(statusID string) bool {

--- a/pkg/storage/repositories/search_repository_accounts_queries_test.go
+++ b/pkg/storage/repositories/search_repository_accounts_queries_test.go
@@ -209,7 +209,7 @@ func TestSearchUsernamePrefix_Success(t *testing.T) {
 	mockDB.On("Model", mock.AnythingOfType("*models.Actor")).Return(mockQuery)
 	mockQuery.On("Index", "gsi1").Return(mockQuery)
 	mockQuery.On("Where", "gsi1PK", "=", "USERNAME_SEARCH#al").Return(mockQuery)
-	mockQuery.On("Filter", "gsi1SK", "BEGINS_WITH", "alice").Return(mockQuery)
+	mockQuery.On("Where", "gsi1SK", "BEGINS_WITH", "alice").Return(mockQuery)
 	mockQuery.On("Limit", limit+offset).Return(mockQuery)
 	mockQuery.On("All", mock.AnythingOfType("*[]models.Actor")).Run(func(args mock.Arguments) {
 		actors := args.Get(0).(*[]models.Actor)
@@ -261,7 +261,7 @@ func TestSearchUsernamePrefix_DeduplicatesByActorID(t *testing.T) {
 	mockDB.On("Model", mock.AnythingOfType("*models.Actor")).Return(mockQuery)
 	mockQuery.On("Index", "gsi1").Return(mockQuery)
 	mockQuery.On("Where", "gsi1PK", "=", "USERNAME_SEARCH#al").Return(mockQuery)
-	mockQuery.On("Filter", "gsi1SK", "BEGINS_WITH", "alice").Return(mockQuery)
+	mockQuery.On("Where", "gsi1SK", "BEGINS_WITH", "alice").Return(mockQuery)
 	mockQuery.On("Limit", limit+offset).Return(mockQuery)
 	mockQuery.On("All", mock.AnythingOfType("*[]models.Actor")).Run(func(args mock.Arguments) {
 		actors := args.Get(0).(*[]models.Actor)
@@ -312,7 +312,7 @@ func TestSearchUsernamePrefix_SkipsNilActors(t *testing.T) {
 	mockDB.On("Model", mock.AnythingOfType("*models.Actor")).Return(mockQuery)
 	mockQuery.On("Index", "gsi1").Return(mockQuery)
 	mockQuery.On("Where", "gsi1PK", "=", "USERNAME_SEARCH#al").Return(mockQuery)
-	mockQuery.On("Filter", "gsi1SK", "BEGINS_WITH", "alice").Return(mockQuery)
+	mockQuery.On("Where", "gsi1SK", "BEGINS_WITH", "alice").Return(mockQuery)
 	mockQuery.On("Limit", limit+offset).Return(mockQuery)
 	mockQuery.On("All", mock.AnythingOfType("*[]models.Actor")).Run(func(args mock.Arguments) {
 		actors := args.Get(0).(*[]models.Actor)
@@ -359,7 +359,7 @@ func TestSearchUsernamePrefix_ErrorDoesNotPanic(t *testing.T) {
 	mockDB.On("Model", mock.AnythingOfType("*models.Actor")).Return(mockQuery)
 	mockQuery.On("Index", "gsi1").Return(mockQuery)
 	mockQuery.On("Where", "gsi1PK", "=", "USERNAME_SEARCH#al").Return(mockQuery)
-	mockQuery.On("Filter", "gsi1SK", "BEGINS_WITH", "alice").Return(mockQuery)
+	mockQuery.On("Where", "gsi1SK", "BEGINS_WITH", "alice").Return(mockQuery)
 	mockQuery.On("Limit", limit+offset).Return(mockQuery)
 	mockQuery.On("All", mock.AnythingOfType("*[]models.Actor")).Return(ErrTestMockError)
 
@@ -399,7 +399,7 @@ func TestSearchDisplayName_Success(t *testing.T) {
 	mockDB.On("Model", mock.AnythingOfType("*models.Actor")).Return(mockQuery)
 	mockQuery.On("Index", "gsi2").Return(mockQuery)
 	mockQuery.On("Where", "gsi2PK", "=", "NAME_SEARCH#al").Return(mockQuery)
-	mockQuery.On("Filter", "gsi2SK", "BEGINS_WITH", "alice").Return(mockQuery)
+	mockQuery.On("Where", "gsi2SK", "BEGINS_WITH", "alice").Return(mockQuery)
 	mockQuery.On("Limit", limit).Return(mockQuery)
 	mockQuery.On("All", mock.AnythingOfType("*[]models.Actor")).Run(func(args mock.Arguments) {
 		actors := args.Get(0).(*[]models.Actor)
@@ -471,7 +471,7 @@ func TestSearchDisplayName_DeduplicatesByActorID(t *testing.T) {
 	mockDB.On("Model", mock.AnythingOfType("*models.Actor")).Return(mockQuery)
 	mockQuery.On("Index", "gsi2").Return(mockQuery)
 	mockQuery.On("Where", "gsi2PK", "=", "NAME_SEARCH#al").Return(mockQuery)
-	mockQuery.On("Filter", "gsi2SK", "BEGINS_WITH", "alice").Return(mockQuery)
+	mockQuery.On("Where", "gsi2SK", "BEGINS_WITH", "alice").Return(mockQuery)
 	mockQuery.On("Limit", limit).Return(mockQuery)
 	mockQuery.On("All", mock.AnythingOfType("*[]models.Actor")).Run(func(args mock.Arguments) {
 		actors := args.Get(0).(*[]models.Actor)
@@ -522,7 +522,7 @@ func TestSearchDisplayName_SkipsNilActors(t *testing.T) {
 	mockDB.On("Model", mock.AnythingOfType("*models.Actor")).Return(mockQuery)
 	mockQuery.On("Index", "gsi2").Return(mockQuery)
 	mockQuery.On("Where", "gsi2PK", "=", "NAME_SEARCH#al").Return(mockQuery)
-	mockQuery.On("Filter", "gsi2SK", "BEGINS_WITH", "alice").Return(mockQuery)
+	mockQuery.On("Where", "gsi2SK", "BEGINS_WITH", "alice").Return(mockQuery)
 	mockQuery.On("Limit", limit).Return(mockQuery)
 	mockQuery.On("All", mock.AnythingOfType("*[]models.Actor")).Run(func(args mock.Arguments) {
 		actors := args.Get(0).(*[]models.Actor)
@@ -567,7 +567,7 @@ func TestSearchDisplayName_ErrorDoesNotPanic(t *testing.T) {
 	mockDB.On("Model", mock.AnythingOfType("*models.Actor")).Return(mockQuery)
 	mockQuery.On("Index", "gsi2").Return(mockQuery)
 	mockQuery.On("Where", "gsi2PK", "=", "NAME_SEARCH#al").Return(mockQuery)
-	mockQuery.On("Filter", "gsi2SK", "BEGINS_WITH", "alice").Return(mockQuery)
+	mockQuery.On("Where", "gsi2SK", "BEGINS_WITH", "alice").Return(mockQuery)
 	mockQuery.On("Limit", limit).Return(mockQuery)
 	mockQuery.On("All", mock.AnythingOfType("*[]models.Actor")).Return(ErrTestMockError)
 
@@ -622,7 +622,7 @@ func TestExecuteSearchStrategies_CallsAllThreeStrategies(t *testing.T) {
 	mockDB.On("Model", mock.AnythingOfType("*models.Actor")).Return(mockQueryPrefix).Once()
 	mockQueryPrefix.On("Index", "gsi1").Return(mockQueryPrefix)
 	mockQueryPrefix.On("Where", "gsi1PK", "=", "USERNAME_SEARCH#al").Return(mockQueryPrefix)
-	mockQueryPrefix.On("Filter", "gsi1SK", "BEGINS_WITH", "alice").Return(mockQueryPrefix)
+	mockQueryPrefix.On("Where", "gsi1SK", "BEGINS_WITH", "alice").Return(mockQueryPrefix)
 	mockQueryPrefix.On("Limit", limit+offset).Return(mockQueryPrefix)
 	mockQueryPrefix.On("All", mock.AnythingOfType("*[]models.Actor")).Run(func(args mock.Arguments) {
 		actors := args.Get(0).(*[]models.Actor)
@@ -640,7 +640,7 @@ func TestExecuteSearchStrategies_CallsAllThreeStrategies(t *testing.T) {
 	mockDB.On("Model", mock.AnythingOfType("*models.Actor")).Return(mockQueryName).Once()
 	mockQueryName.On("Index", "gsi2").Return(mockQueryName)
 	mockQueryName.On("Where", "gsi2PK", "=", "NAME_SEARCH#al").Return(mockQueryName)
-	mockQueryName.On("Filter", "gsi2SK", "BEGINS_WITH", "alice").Return(mockQueryName)
+	mockQueryName.On("Where", "gsi2SK", "BEGINS_WITH", "alice").Return(mockQueryName)
 	mockQueryName.On("Limit", limit).Return(mockQueryName)
 	mockQueryName.On("All", mock.AnythingOfType("*[]models.Actor")).Run(func(args mock.Arguments) {
 		actors := args.Get(0).(*[]models.Actor)
@@ -706,7 +706,7 @@ func TestExecuteSearchStrategies_DeduplicatesAcrossStrategies(t *testing.T) {
 	mockDB.On("Model", mock.AnythingOfType("*models.Actor")).Return(mockQueryPrefix).Once()
 	mockQueryPrefix.On("Index", "gsi1").Return(mockQueryPrefix)
 	mockQueryPrefix.On("Where", "gsi1PK", "=", "USERNAME_SEARCH#al").Return(mockQueryPrefix)
-	mockQueryPrefix.On("Filter", "gsi1SK", "BEGINS_WITH", "alice").Return(mockQueryPrefix)
+	mockQueryPrefix.On("Where", "gsi1SK", "BEGINS_WITH", "alice").Return(mockQueryPrefix)
 	mockQueryPrefix.On("Limit", limit+offset).Return(mockQueryPrefix)
 	mockQueryPrefix.On("All", mock.AnythingOfType("*[]models.Actor")).Run(func(args mock.Arguments) {
 		actors := args.Get(0).(*[]models.Actor)
@@ -724,7 +724,7 @@ func TestExecuteSearchStrategies_DeduplicatesAcrossStrategies(t *testing.T) {
 	mockDB.On("Model", mock.AnythingOfType("*models.Actor")).Return(mockQueryName).Once()
 	mockQueryName.On("Index", "gsi2").Return(mockQueryName)
 	mockQueryName.On("Where", "gsi2PK", "=", "NAME_SEARCH#al").Return(mockQueryName)
-	mockQueryName.On("Filter", "gsi2SK", "BEGINS_WITH", "alice").Return(mockQueryName)
+	mockQueryName.On("Where", "gsi2SK", "BEGINS_WITH", "alice").Return(mockQueryName)
 	mockQueryName.On("Limit", limit).Return(mockQueryName)
 	mockQueryName.On("All", mock.AnythingOfType("*[]models.Actor")).Run(func(args mock.Arguments) {
 		actors := args.Get(0).(*[]models.Actor)

--- a/pkg/storage/repositories/search_repository_additional_coverage_test.go
+++ b/pkg/storage/repositories/search_repository_additional_coverage_test.go
@@ -282,15 +282,15 @@ func TestSearchRepository_CoverageSweep(t *testing.T) {
 	_, _ = repo.GetSearchTrends(ctx, 1)
 
 	// Pure helpers
-	assert.True(t, repo.isURL("https://example.com"))
-	assert.False(t, repo.isURL("not-a-url"))
-	assert.Equal(t, []string{"tag"}, repo.extractHashtags("hello #Tag"))
-	assert.Equal(t, "alice", repo.extractUsername("https://example.com/users/alice"))
-	assert.True(t, repo.isLocalStatus("status-1"))
-	assert.False(t, repo.isLocalStatus("https://example.com/status/1"))
-	assert.Greater(t, repo.calculateContentScore("hello world", "world"), 0.0)
-	assert.Equal(t, 0.0, repo.cosineSimilarity([]float32{1}, []float32{1, 0}))
-	assert.Equal(t, "[empty]", repo.hashQuery(""))
+		assert.True(t, repo.isURL("https://example.com"))
+		assert.False(t, repo.isURL("not-a-url"))
+		assert.Equal(t, []string{"tag"}, repo.extractHashtags("hello #Tag"))
+		assert.Equal(t, "alice", extractUsernameFromActor("https://example.com/users/alice"))
+		assert.True(t, repo.isLocalStatus("status-1"))
+		assert.False(t, repo.isLocalStatus("https://example.com/status/1"))
+		assert.Greater(t, repo.calculateContentScore("hello world", "world"), 0.0)
+		assert.Equal(t, 0.0, repo.cosineSimilarity([]float32{1}, []float32{1, 0}))
+		assert.Equal(t, "[empty]", repo.hashQuery(""))
 	assert.Equal(t, "[short]", repo.hashQuery("abc"))
 	assert.Contains(t, repo.hashQuery("alice"), "al_hash_")
 }
@@ -488,19 +488,16 @@ func TestSearchRepository_SearchStatusesWithOptionsPaginated_SortOrderMapping(t 
 }
 
 func TestSearchRepository_ExtractUsername_Branches(t *testing.T) {
-	repo := NewSearchRepository(nil, "test-table", zap.NewNop(), nil)
-
-	assert.Equal(t, "alice", repo.extractUsername("https://example.com/users/alice"))
-	assert.Equal(t, "alice", repo.extractUsername("alice"))
-	assert.Equal(t, "a/b", repo.extractUsername("https://example.com/users/a/b"))
-	assert.Equal(t, "", repo.extractUsername("https://example.com/users/alice/users/bob"))
+	assert.Equal(t, "alice", extractUsernameFromActor("https://example.com/users/alice"))
+	assert.Equal(t, "alice", extractUsernameFromActor("alice"))
+	assert.Equal(t, "b", extractUsernameFromActor("https://example.com/users/a/b"))
+	assert.Equal(t, "bob", extractUsernameFromActor("https://example.com/users/alice/users/bob"))
 }
 
-func TestSearchRepository_ObjectToSearchResult_ReturnsNilForNonNote(t *testing.T) {
+func TestSearchRepository_StatusModelToSearchResult_ReturnsNilForNilInput(t *testing.T) {
 	repo := NewSearchRepository(nil, "test-table", zap.NewNop(), nil)
 
-	assert.Nil(t, repo.objectToSearchResult(nil, 1, "s"))
-	assert.Nil(t, repo.objectToSearchResult(&models.Object{ID: "x", Type: "Announce"}, 1, "s"))
+	assert.Nil(t, repo.statusModelToSearchResult(nil, 1, "s"))
 }
 
 func TestSearchRepository_CompareRelevance_CoversLengthTieBreaker(t *testing.T) {

--- a/pkg/storage/repositories/search_repository_additional_coverage_test.go
+++ b/pkg/storage/repositories/search_repository_additional_coverage_test.go
@@ -681,12 +681,12 @@ func TestSearchRepository_GetRecentStatuses_ErrorReturnsEmpty(t *testing.T) {
 	repo := NewSearchRepository(mockDB, "test-table", zap.NewNop(), nil)
 
 	mockDB.On("WithContext", mock.Anything).Return(mockDB)
-	mockDB.On("Model", mock.AnythingOfType("*models.Object")).Return(mockQuery)
+	mockDB.On("Model", mock.AnythingOfType("*models.Status")).Return(mockQuery)
 	mockQuery.On("Index", mock.Anything).Return(mockQuery)
 	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery)
 	mockQuery.On("OrderBy", mock.Anything, mock.Anything).Return(mockQuery)
 	mockQuery.On("Limit", mock.Anything).Return(mockQuery)
-	mockQuery.On("All", mock.AnythingOfType("*[]models.Object")).Return(ErrTestMockError).Once()
+	mockQuery.On("All", mock.AnythingOfType("*[]models.Status")).Return(ErrTestMockError).Once()
 
 	recent := repo.getRecentStatuses(context.Background())
 	assert.Empty(t, recent)
@@ -694,7 +694,7 @@ func TestSearchRepository_GetRecentStatuses_ErrorReturnsEmpty(t *testing.T) {
 
 func TestSearchRepository_StatusMatchesQuery_EmptyContentReturnsFalse(t *testing.T) {
 	repo := NewSearchRepository(nil, "test-table", zap.NewNop(), nil)
-	assert.False(t, repo.statusMatchesQuery(models.Object{Content: ""}, "x"))
+	assert.False(t, repo.statusMatchesQuery(models.Status{Content: ""}, "x"))
 }
 
 func TestSearchRepository_GetSearchSuggestions_DedupSortAndTrim(t *testing.T) {
@@ -764,18 +764,18 @@ func TestSearchRepository_SearchStatusesWithPrivacyPaginated_SetsNextCursorWhenM
 	mockQuery.On("OrderBy", mock.Anything, mock.Anything).Return(mockQuery).Maybe()
 
 	// Populate content search with enough matches to create a next cursor.
-	mockQuery.On("All", mock.AnythingOfType("*[]models.Object")).Run(func(args mock.Arguments) {
-		dest := args.Get(0).(*[]models.Object)
+	mockQuery.On("All", mock.AnythingOfType("*[]models.Status")).Run(func(args mock.Arguments) {
+		dest := args.Get(0).(*[]models.Status)
 		now := time.Now()
-		out := make([]models.Object, 0, 7)
+		out := make([]models.Status, 0, 7)
 		for i := range 7 {
-			out = append(out, models.Object{
-				ID:           fmt.Sprintf("status-%d", i),
-				Type:         ActivityTypeNote,
-				Content:      "hello world",
-				URL:          fmt.Sprintf("https://example.com/status/%d", i),
-				AttributedTo: "https://example.com/users/alice",
-				Published:    now.Add(time.Duration(-i) * time.Minute),
+			id := fmt.Sprintf("status-%d", i)
+			out = append(out, models.Status{
+				StatusID:       id,
+				Content:        "hello world",
+				AuthorID:       "https://example.com/users/alice",
+				AuthorUsername: "alice",
+				PublishedAt:    now.Add(time.Duration(-i) * time.Minute),
 			})
 		}
 		*dest = out

--- a/pkg/storage/repositories/streaming_connection_repository.go
+++ b/pkg/storage/repositories/streaming_connection_repository.go
@@ -40,7 +40,7 @@ type StreamingConnectionRepository struct {
 func NewStreamingConnectionRepository(db core.DB, tableName string, subscriptionDB core.DB, subscriptionTable string, logger *zap.Logger, costService *cost.TrackingService) *StreamingConnectionRepository {
 	// Create enhanced repository for WebSocket connections
 	connectionRepo := NewEnhancedBaseRepository[*models.WebSocketConnection](db, tableName, logger, costService, "StreamingConnectionRepository", "streamingconnection")
-	connectionRepo.SetValidationService(NewDefaultValidationService())
+	connectionRepo.SetValidationService(NewWebSocketConnectionValidationService())
 	connectionRepo.SetPermissionService(NewDefaultPermissionService())
 	connectionRepo.SetCachingService(NewInMemoryCachingService()) // Connections cached for real-time performance
 	connectionRepo.SetEventService(NewDefaultEventService())

--- a/pkg/storage/repositories/username_validation_service.go
+++ b/pkg/storage/repositories/username_validation_service.go
@@ -1,0 +1,38 @@
+package repositories
+
+import "context"
+
+type usernameValidationExtractor func(model BaseModel) (userID string, username *string, ok bool)
+
+type usernameOptionalValidationService struct {
+	base    *DefaultValidationService
+	extract usernameValidationExtractor
+}
+
+func newUsernameOptionalValidationService(extract usernameValidationExtractor) ValidationService {
+	return &usernameOptionalValidationService{
+		base:    NewDefaultValidationService(),
+		extract: extract,
+	}
+}
+
+func (v *usernameOptionalValidationService) ValidateModel(ctx context.Context, model BaseModel) error {
+	return v.base.ValidateModel(ctx, model)
+}
+
+func (v *usernameOptionalValidationService) ValidateBusinessRules(ctx context.Context, model BaseModel, action string) error {
+	return v.base.ValidateBusinessRules(ctx, model, action)
+}
+
+func (v *usernameOptionalValidationService) ValidateRequiredFields(ctx context.Context, model BaseModel) error {
+	if v.extract == nil {
+		return v.base.ValidateRequiredFields(ctx, model)
+	}
+
+	userID, username, ok := v.extract(model)
+	if !ok {
+		return v.base.ValidateRequiredFields(ctx, model)
+	}
+
+	return validateRequiredFieldsAllowAnonymousUsername(ctx, v.base, model, userID, username)
+}

--- a/pkg/storage/repositories/validation_username_helpers.go
+++ b/pkg/storage/repositories/validation_username_helpers.go
@@ -1,0 +1,27 @@
+package repositories
+
+import (
+	"context"
+
+	"github.com/equaltoai/lesser/pkg/errors"
+)
+
+func validateRequiredFieldsAllowAnonymousUsername(ctx context.Context, base *DefaultValidationService, model BaseModel, userID string, username *string) error {
+	if username == nil {
+		return base.ValidateRequiredFields(ctx, model)
+	}
+
+	// For authenticated connections, `Username` must be present.
+	if userID != "" && *username == "" {
+		return errors.ValidationFailed("Username", "field 'Username' is required")
+	}
+
+	// Anonymous connections are allowed for public streams, so permit empty username.
+	if userID == "" && *username == "" {
+		original := *username
+		*username = "_"
+		defer func() { *username = original }()
+	}
+
+	return base.ValidateRequiredFields(ctx, model)
+}

--- a/pkg/storage/repositories/websocket_connection_validation.go
+++ b/pkg/storage/repositories/websocket_connection_validation.go
@@ -1,45 +1,14 @@
 package repositories
 
-import (
-	"context"
+import "github.com/equaltoai/lesser/pkg/storage/models"
 
-	"github.com/equaltoai/lesser/pkg/errors"
-	"github.com/equaltoai/lesser/pkg/storage/models"
-)
-
-type webSocketConnectionValidationService struct {
-	base *DefaultValidationService
-}
-
+// NewWebSocketConnectionValidationService returns a validation service for WebSocket connection records.
 func NewWebSocketConnectionValidationService() ValidationService {
-	return &webSocketConnectionValidationService{base: NewDefaultValidationService()}
-}
-
-func (v *webSocketConnectionValidationService) ValidateModel(ctx context.Context, model BaseModel) error {
-	return v.base.ValidateModel(ctx, model)
-}
-
-func (v *webSocketConnectionValidationService) ValidateBusinessRules(ctx context.Context, model BaseModel, action string) error {
-	return v.base.ValidateBusinessRules(ctx, model, action)
-}
-
-func (v *webSocketConnectionValidationService) ValidateRequiredFields(ctx context.Context, model BaseModel) error {
-	conn, ok := model.(*models.WebSocketConnection)
-	if !ok || conn == nil {
-		return v.base.ValidateRequiredFields(ctx, model)
-	}
-
-	// For authenticated connections, `Username` must be present.
-	if conn.UserID != "" && conn.Username == "" {
-		return errors.ValidationFailed("Username", "field 'Username' is required")
-	}
-
-	// Anonymous connections are allowed for public streams, so permit empty username.
-	if conn.UserID == "" && conn.Username == "" {
-		original := conn.Username
-		conn.Username = "_"
-		defer func() { conn.Username = original }()
-	}
-
-	return v.base.ValidateRequiredFields(ctx, model)
+	return newUsernameOptionalValidationService(func(model BaseModel) (string, *string, bool) {
+		conn, ok := model.(*models.WebSocketConnection)
+		if !ok || conn == nil {
+			return "", nil, false
+		}
+		return conn.UserID, &conn.Username, true
+	})
 }

--- a/pkg/storage/repositories/websocket_connection_validation.go
+++ b/pkg/storage/repositories/websocket_connection_validation.go
@@ -1,0 +1,45 @@
+package repositories
+
+import (
+	"context"
+
+	"github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+)
+
+type webSocketConnectionValidationService struct {
+	base *DefaultValidationService
+}
+
+func NewWebSocketConnectionValidationService() ValidationService {
+	return &webSocketConnectionValidationService{base: NewDefaultValidationService()}
+}
+
+func (v *webSocketConnectionValidationService) ValidateModel(ctx context.Context, model BaseModel) error {
+	return v.base.ValidateModel(ctx, model)
+}
+
+func (v *webSocketConnectionValidationService) ValidateBusinessRules(ctx context.Context, model BaseModel, action string) error {
+	return v.base.ValidateBusinessRules(ctx, model, action)
+}
+
+func (v *webSocketConnectionValidationService) ValidateRequiredFields(ctx context.Context, model BaseModel) error {
+	conn, ok := model.(*models.WebSocketConnection)
+	if !ok || conn == nil {
+		return v.base.ValidateRequiredFields(ctx, model)
+	}
+
+	// For authenticated connections, `Username` must be present.
+	if conn.UserID != "" && conn.Username == "" {
+		return errors.ValidationFailed("Username", "field 'Username' is required")
+	}
+
+	// Anonymous connections are allowed for public streams, so permit empty username.
+	if conn.UserID == "" && conn.Username == "" {
+		original := conn.Username
+		conn.Username = "_"
+		defer func() { conn.Username = original }()
+	}
+
+	return v.base.ValidateRequiredFields(ctx, model)
+}

--- a/pkg/storage/repositories/websocket_cost_record_validation.go
+++ b/pkg/storage/repositories/websocket_cost_record_validation.go
@@ -1,0 +1,13 @@
+package repositories
+
+import "github.com/equaltoai/lesser/pkg/storage/models"
+
+func newWebSocketCostRecordValidationService() ValidationService {
+	return newUsernameOptionalValidationService(func(model BaseModel) (string, *string, bool) {
+		record, ok := model.(*models.WebSocketCostRecord)
+		if !ok || record == nil {
+			return "", nil, false
+		}
+		return record.UserID, &record.Username, true
+	})
+}

--- a/pkg/storage/repositories/websocket_cost_repository.go
+++ b/pkg/storage/repositories/websocket_cost_repository.go
@@ -26,7 +26,7 @@ type WebSocketCostRepository struct {
 func NewWebSocketCostRepository(db core.DB, tableName string, logger *zap.Logger, costService *cost.TrackingService) *WebSocketCostRepository {
 	// Create enhanced repositories for WebSocket cost components
 	baseRepo := NewEnhancedBaseRepository[*models.WebSocketCostRecord](db, tableName, logger, costService, "WebSocketCostRepository", "websocketcost")
-	baseRepo.SetValidationService(NewDefaultValidationService())
+	baseRepo.SetValidationService(newWebSocketCostRecordValidationService())
 	baseRepo.SetPermissionService(NewDefaultPermissionService())
 	baseRepo.SetCachingService(NewInMemoryCachingService())
 	baseRepo.SetEventService(NewDefaultEventService())

--- a/pkg/transformations/converters.go
+++ b/pkg/transformations/converters.go
@@ -42,11 +42,16 @@ func ActorToAccountBase(actor *activitypub.Actor, baseURL string) models.Account
 		createdAt = TransformTimestamp(*actor.Published, time.RFC3339)
 	}
 
+	displayName := actor.Name
+	if displayName == "" {
+		displayName = actor.PreferredUsername
+	}
+
 	return models.Account{
 		ID:             GenerateNumericIDFromUsername(actor.PreferredUsername),
 		Username:       actor.PreferredUsername,
 		Acct:           actor.PreferredUsername,
-		DisplayName:    actor.Name,
+		DisplayName:    displayName,
 		Note:           actor.Summary,
 		URL:            actor.URL,
 		Avatar:         getAvatarURL(actor.Icon, baseURL),

--- a/pkg/translation/aws_translate_additional_coverage_test.go
+++ b/pkg/translation/aws_translate_additional_coverage_test.go
@@ -1,0 +1,394 @@
+package translation
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/translate"
+	translatetypes "github.com/aws/aws-sdk-go-v2/service/translate/types"
+	lesserconfig "github.com/equaltoai/lesser/pkg/config"
+	storagemocks "github.com/equaltoai/lesser/pkg/testing/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	theorydbErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	theorydbmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
+	"go.uber.org/zap"
+)
+
+func TestService_DetectLanguage_UsesTranslateText(t *testing.T) {
+	t.Parallel()
+
+	translator := &fakeTranslate{
+		translateFn: func(_ context.Context, in *translate.TranslateTextInput) (*translate.TranslateTextOutput, error) {
+			require.Equal(t, "bonjour", aws.ToString(in.Text))
+			require.Equal(t, "en", aws.ToString(in.TargetLanguageCode))
+			require.Nil(t, in.SourceLanguageCode)
+			return &translate.TranslateTextOutput{
+				TranslatedText:     aws.String("hello"),
+				SourceLanguageCode: aws.String("fr"),
+			}, nil
+		},
+		listFn: func(_ context.Context, _ *translate.ListLanguagesInput) (*translate.ListLanguagesOutput, error) {
+			return &translate.ListLanguagesOutput{}, nil
+		},
+	}
+
+	svc := &Service{
+		client: translator,
+		logger: zap.NewNop(),
+	}
+
+	lang, confidence, err := svc.DetectLanguage(context.Background(), "bonjour")
+	require.NoError(t, err)
+	require.Equal(t, "fr", lang)
+	require.Equal(t, float32(1.0), confidence)
+}
+
+func TestService_TranslateHTML_StripsAndTranslates(t *testing.T) {
+	t.Parallel()
+
+	translator := &fakeTranslate{
+		translateFn: func(_ context.Context, in *translate.TranslateTextInput) (*translate.TranslateTextOutput, error) {
+			require.Equal(t, "Hello world", aws.ToString(in.Text))
+			require.Equal(t, "es", aws.ToString(in.TargetLanguageCode))
+			require.Nil(t, in.SourceLanguageCode)
+			return &translate.TranslateTextOutput{
+				TranslatedText:     aws.String("hola"),
+				SourceLanguageCode: aws.String("en"),
+			}, nil
+		},
+		listFn: func(_ context.Context, _ *translate.ListLanguagesInput) (*translate.ListLanguagesOutput, error) {
+			return &translate.ListLanguagesOutput{}, nil
+		},
+	}
+
+	svc := &Service{
+		client: translator,
+		logger: zap.NewNop(),
+	}
+
+	text, detectedLang, err := svc.TranslateHTML(context.Background(), "<p>Hello<br/>world</p>", "auto", "es")
+	require.NoError(t, err)
+	require.Equal(t, "hola", text)
+	require.Equal(t, "en", detectedLang)
+}
+
+func TestService_GetSupportedLanguages_CacheMissCallsTranslateAPIAndCaches(t *testing.T) {
+	t.Parallel()
+
+	db := new(theorydbmocks.MockDB)
+	readQuery := new(theorydbmocks.MockQuery)
+	writeQuery := new(theorydbmocks.MockQuery)
+
+	translator := &fakeTranslate{
+		translateFn: func(_ context.Context, _ *translate.TranslateTextInput) (*translate.TranslateTextOutput, error) {
+			t.Fatalf("TranslateText should not be called when listing languages")
+			return nil, nil
+		},
+		listFn: func(_ context.Context, in *translate.ListLanguagesInput) (*translate.ListLanguagesOutput, error) {
+			require.NotNil(t, in.MaxResults)
+			require.Equal(t, int32(100), *in.MaxResults)
+			return &translate.ListLanguagesOutput{
+				Languages: []translatetypes.Language{
+					{LanguageCode: aws.String("en"), LanguageName: aws.String("English")},
+					{LanguageCode: aws.String("es"), LanguageName: aws.String("Spanish")},
+				},
+			}, nil
+		},
+	}
+
+	svc := &Service{
+		client:       translator,
+		db:           db,
+		logger:       zap.NewNop(),
+		cacheEnabled: true,
+		cacheTTL:     time.Hour,
+	}
+
+	db.On("Model", mock.MatchedBy(func(model any) bool {
+		item, ok := model.(*supportedLanguagesCacheItem)
+		return ok && item.PK == "CACHE#LANGUAGES" && item.SK == "SUPPORTED"
+	})).Return(readQuery).Once()
+	readQuery.On("WithContext", mock.Anything).Return(readQuery)
+	readQuery.On("Where", "PK", "=", "CACHE#LANGUAGES").Return(readQuery)
+	readQuery.On("Where", "SK", "=", "SUPPORTED").Return(readQuery)
+	readQuery.On("First", mock.Anything).Return(theorydbErrors.ErrItemNotFound)
+
+	db.On("Model", mock.MatchedBy(func(model any) bool {
+		item, ok := model.(*supportedLanguagesCacheItem)
+		if !ok {
+			return false
+		}
+		if item.PK != "CACHE#LANGUAGES" || item.SK != "SUPPORTED" {
+			return false
+		}
+		if len(item.Languages) != 2 {
+			return false
+		}
+		if item.Languages[0] != (LanguageInfo{Code: "en", Name: "English"}) {
+			return false
+		}
+		if item.Languages[1] != (LanguageInfo{Code: "es", Name: "Spanish"}) {
+			return false
+		}
+		return !item.CachedAt.IsZero() && item.TTL > item.CachedAt.Unix()
+	})).Return(writeQuery).Once()
+	writeQuery.On("WithContext", mock.Anything).Return(writeQuery)
+	writeQuery.On("CreateOrUpdate").Return(nil)
+
+	langs, err := svc.GetSupportedLanguages(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []LanguageInfo{
+		{Code: "en", Name: "English"},
+		{Code: "es", Name: "Spanish"},
+	}, langs)
+	require.Equal(t, 1, translator.listCalls)
+}
+
+func TestCacheItems_TableName_DefaultsToTestTableDuringGoTest(t *testing.T) {
+	t.Setenv("DYNAMODB_TABLE", "")
+	t.Setenv("DYNAMO_TABLE_NAME", "")
+	t.Setenv("ENVIRONMENT", "")
+	t.Setenv("STAGE", "")
+
+	require.Equal(t, "test-table", translationCacheItem{}.TableName())
+	require.Equal(t, "test-table", supportedLanguagesCacheItem{}.TableName())
+}
+
+func TestNewService_UsesStoreDBAndDefaultsLogger(t *testing.T) {
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_ACCESS_KEY_ID", "test")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test")
+
+	store := new(storagemocks.MockRepositoryStorage)
+	db := new(theorydbmocks.MockDB)
+	store.On("GetDB").Return(db).Once()
+
+	svc, err := NewService(context.Background(), &lesserconfig.Config{}, store, nil, false)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+	require.NotNil(t, svc.client)
+	require.Equal(t, db, svc.db)
+	require.False(t, svc.cacheEnabled)
+	require.Equal(t, 30*24*time.Hour, svc.cacheTTL)
+	require.NotNil(t, svc.logger)
+
+	store.AssertExpectations(t)
+}
+
+func TestService_GetCachedTranslation_ReturnsErrorWhenUninitialized(t *testing.T) {
+	t.Parallel()
+
+	var nilSvc *Service
+	_, err := nilSvc.getCachedTranslation(context.Background(), "k")
+	require.Error(t, err)
+
+	svc := &Service{}
+	_, err = svc.getCachedTranslation(context.Background(), "k")
+	require.Error(t, err)
+}
+
+func TestService_GetCachedTranslation_PropagatesNonNotFoundError(t *testing.T) {
+	t.Parallel()
+
+	db := new(theorydbmocks.MockDB)
+	query := new(theorydbmocks.MockQuery)
+
+	svc := &Service{db: db, logger: zap.NewNop()}
+
+	db.On("Model", mock.MatchedBy(func(model any) bool {
+		item, ok := model.(*translationCacheItem)
+		return ok && item.PK == "TRANSLATION#k" && item.SK == "RESULT"
+	})).Return(query).Once()
+
+	query.On("WithContext", mock.Anything).Return(query)
+	query.On("Where", "PK", "=", "TRANSLATION#k").Return(query)
+	query.On("Where", "SK", "=", "RESULT").Return(query)
+	query.On("First", mock.Anything).Return(errors.New("boom"))
+
+	_, err := svc.getCachedTranslation(context.Background(), "k")
+	require.Error(t, err)
+}
+
+func TestService_GetSupportedLanguages_CacheWriteFailureDoesNotFailRequest(t *testing.T) {
+	t.Parallel()
+
+	db := new(theorydbmocks.MockDB)
+	readQuery := new(theorydbmocks.MockQuery)
+	writeQuery := new(theorydbmocks.MockQuery)
+
+	translator := &fakeTranslate{
+		translateFn: func(_ context.Context, _ *translate.TranslateTextInput) (*translate.TranslateTextOutput, error) {
+			return &translate.TranslateTextOutput{}, nil
+		},
+		listFn: func(_ context.Context, _ *translate.ListLanguagesInput) (*translate.ListLanguagesOutput, error) {
+			return &translate.ListLanguagesOutput{
+				Languages: []translatetypes.Language{
+					{LanguageCode: aws.String("en"), LanguageName: aws.String("English")},
+					{LanguageCode: aws.String("es"), LanguageName: aws.String("Spanish")},
+				},
+			}, nil
+		},
+	}
+
+	svc := &Service{
+		client:       translator,
+		db:           db,
+		logger:       zap.NewNop(),
+		cacheEnabled: true,
+		cacheTTL:     time.Hour,
+	}
+
+	db.On("Model", mock.MatchedBy(func(model any) bool {
+		item, ok := model.(*supportedLanguagesCacheItem)
+		return ok && item.PK == "CACHE#LANGUAGES" && item.SK == "SUPPORTED"
+	})).Return(readQuery).Once()
+	readQuery.On("WithContext", mock.Anything).Return(readQuery)
+	readQuery.On("Where", "PK", "=", "CACHE#LANGUAGES").Return(readQuery)
+	readQuery.On("Where", "SK", "=", "SUPPORTED").Return(readQuery)
+	readQuery.On("First", mock.Anything).Return(theorydbErrors.ErrItemNotFound)
+
+	db.On("Model", mock.MatchedBy(func(model any) bool {
+		item, ok := model.(*supportedLanguagesCacheItem)
+		return ok && item.PK == "CACHE#LANGUAGES" && item.SK == "SUPPORTED" && len(item.Languages) == 2
+	})).Return(writeQuery).Once()
+	writeQuery.On("WithContext", mock.Anything).Return(writeQuery)
+	writeQuery.On("CreateOrUpdate").Return(errors.New("write failed"))
+
+	langs, err := svc.GetSupportedLanguages(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []LanguageInfo{
+		{Code: "en", Name: "English"},
+		{Code: "es", Name: "Spanish"},
+	}, langs)
+}
+
+func TestService_GetSupportedLanguages_ListLanguagesError_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	translator := &fakeTranslate{
+		translateFn: func(_ context.Context, _ *translate.TranslateTextInput) (*translate.TranslateTextOutput, error) {
+			return &translate.TranslateTextOutput{}, nil
+		},
+		listFn: func(_ context.Context, _ *translate.ListLanguagesInput) (*translate.ListLanguagesOutput, error) {
+			return nil, errors.New("list boom")
+		},
+	}
+
+	svc := &Service{
+		client: translator,
+		logger: zap.NewNop(),
+	}
+
+	_, err := svc.GetSupportedLanguages(context.Background())
+	require.Error(t, err)
+}
+
+func TestService_TranslateText_TranslateAPIError_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	translator := &fakeTranslate{
+		translateFn: func(_ context.Context, _ *translate.TranslateTextInput) (*translate.TranslateTextOutput, error) {
+			return nil, errors.New("translate boom")
+		},
+		listFn: func(_ context.Context, _ *translate.ListLanguagesInput) (*translate.ListLanguagesOutput, error) {
+			return &translate.ListLanguagesOutput{}, nil
+		},
+	}
+
+	svc := &Service{
+		client: translator,
+		logger: zap.NewNop(),
+	}
+
+	_, _, err := svc.TranslateText(context.Background(), "hello", "en", "es")
+	require.Error(t, err)
+}
+
+func TestService_CacheTranslation_ReturnsErrorWhenUninitialized(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{}
+	require.Error(t, svc.cacheTranslation(context.Background(), "k", "hola", "es"))
+}
+
+func TestService_GetCachedLanguages_ReturnsErrorWhenUninitialized(t *testing.T) {
+	t.Parallel()
+
+	var nilSvc *Service
+	_, err := nilSvc.getCachedLanguages(context.Background())
+	require.Error(t, err)
+}
+
+func TestService_GetCachedLanguages_PropagatesNonNotFoundError(t *testing.T) {
+	t.Parallel()
+
+	db := new(theorydbmocks.MockDB)
+	query := new(theorydbmocks.MockQuery)
+
+	svc := &Service{db: db, logger: zap.NewNop()}
+
+	db.On("Model", mock.MatchedBy(func(model any) bool {
+		item, ok := model.(*supportedLanguagesCacheItem)
+		return ok && item.PK == "CACHE#LANGUAGES" && item.SK == "SUPPORTED"
+	})).Return(query).Once()
+
+	query.On("WithContext", mock.Anything).Return(query)
+	query.On("Where", "PK", "=", "CACHE#LANGUAGES").Return(query)
+	query.On("Where", "SK", "=", "SUPPORTED").Return(query)
+	query.On("First", mock.Anything).Return(errors.New("boom"))
+
+	_, err := svc.getCachedLanguages(context.Background())
+	require.Error(t, err)
+}
+
+func TestService_DetectLanguage_TranslateAPIError_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	translator := &fakeTranslate{
+		translateFn: func(_ context.Context, _ *translate.TranslateTextInput) (*translate.TranslateTextOutput, error) {
+			return nil, errors.New("detect boom")
+		},
+		listFn: func(_ context.Context, _ *translate.ListLanguagesInput) (*translate.ListLanguagesOutput, error) {
+			return &translate.ListLanguagesOutput{}, nil
+		},
+	}
+
+	svc := &Service{
+		client: translator,
+		logger: zap.NewNop(),
+	}
+
+	_, _, err := svc.DetectLanguage(context.Background(), "bonjour")
+	require.Error(t, err)
+}
+
+func TestService_TranslateHTML_TranslateError_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	translator := &fakeTranslate{
+		translateFn: func(_ context.Context, _ *translate.TranslateTextInput) (*translate.TranslateTextOutput, error) {
+			return nil, errors.New("translate boom")
+		},
+		listFn: func(_ context.Context, _ *translate.ListLanguagesInput) (*translate.ListLanguagesOutput, error) {
+			return &translate.ListLanguagesOutput{}, nil
+		},
+	}
+
+	svc := &Service{
+		client: translator,
+		logger: zap.NewNop(),
+	}
+
+	_, _, err := svc.TranslateHTML(context.Background(), "<p>Hello</p>", "auto", "es")
+	require.Error(t, err)
+}
+
+func TestStripHTMLTags_BreaksOnMalformedTagOrdering(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, ">oops<", stripHTMLTags(">oops<"))
+}


### PR DESCRIPTION
Summary:
- Fix ActivityPub actor decoding from DynamoDB so actor JSON and search results include displayName/username.
- Fix streaming WS handshake + management endpoint so wss://ws.<domain>/stream responds to ping/pong.
- Fix push VAPID secret init + instance config surfacing.
- Wire translation enabled flag through instance config.

Issues:
- Closes #119, #122, #123, #124.

Verification:
- go test ./...
- curl -H "accept: application/activity+json" https://dev.simulacrum.greater.website/users/admin
- wss://ws.dev.simulacrum.greater.website/stream responds to {"type":"ping"}
- curl https://dev.simulacrum.greater.website/api/v2/instance shows translation.enabled + vapid.public_key
