### PR TITLE
Add AgentCore MCP endpoint on api.<stageDomain>

### DIFF
--- a/infra/cdk/constructs/api_routes.go
+++ b/infra/cdk/constructs/api_routes.go
@@ -10,9 +10,11 @@ import (
 	"github.com/aws/aws-cdk-go/awscdk/v2/awsapigatewayv2"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awsapigatewayv2integrations"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awscertificatemanager"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awslambda"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awslogs"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awsroute53"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awsroute53targets"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awsssm"
 	"github.com/aws/constructs-go/constructs/v10"
 	"github.com/aws/jsii-runtime-go"
 	"github.com/equaltoai/lesser/pkg/deploy/naming"
@@ -27,6 +29,7 @@ type APIGatewayProps struct {
 	WebSocketCertificate awscertificatemanager.ICertificate
 	Functions            *LambdaFunctions
 	HostedZone           awsroute53.IHostedZone
+	SoulEnabled          bool
 }
 
 type APIGateway struct {
@@ -85,6 +88,9 @@ func CreateAPIGateway(scope constructs.Construct, props *APIGatewayProps) *APIGa
 
 	// Add routes
 	addRestRoutes(gateway.RestApi, props.Functions, streamTimeoutSeconds)
+	if props.SoulEnabled {
+		addMcpRoute(scope, gateway.RestApi, appName, apiStage)
+	}
 
 	// Shared custom domain for all WebSocket APIs.
 	var wsDomainName awsapigatewayv2.DomainName
@@ -118,6 +124,25 @@ func CreateAPIGateway(scope constructs.Construct, props *APIGatewayProps) *APIGa
 	gateway.GraphQLWebSocketApi = createGraphQLWebSocketApi(scope, props, wsDomainName)
 
 	return gateway
+}
+
+func addMcpRoute(scope constructs.Construct, api apptheorycdk.AppTheoryRestApiRouter, appName string, stage naming.Stage) {
+	if scope == nil || api == nil || strings.TrimSpace(appName) == "" || strings.TrimSpace(string(stage)) == "" {
+		return
+	}
+
+	paramName := fmt.Sprintf("/%s/%s/lesser-body/exports/v1/mcp_lambda_arn", appName, stage)
+	lambdaArnParam := awsssm.StringParameter_FromStringParameterName(
+		scope,
+		jsii.String("LesserBodyMcpLambdaArnParamLookup"),
+		jsii.String(paramName),
+	)
+
+	mcpLambda := awslambda.Function_FromFunctionArn(scope, jsii.String("ImportedLesserBodyMcpLambda"), lambdaArnParam.StringValue())
+	options := &apptheorycdk.AppTheoryRestApiRouterIntegrationOptions{
+		Streaming: jsii.Bool(true),
+	}
+	api.AddLambdaIntegration(jsii.String("/mcp"), &[]*string{jsii.String("POST")}, mcpLambda, options)
 }
 
 func addRestApiGatewayResponses(scope constructs.Construct, api awsapigateway.RestApi) {

--- a/infra/cdk/constructs/api_routes_test.go
+++ b/infra/cdk/constructs/api_routes_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-cdk-go/awscdk/v2"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awsdynamodb"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awsiam"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awslambda"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awss3"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awssecretsmanager"
 	_jsii "github.com/aws/jsii-runtime-go"
@@ -152,6 +153,120 @@ func TestFederationHttpRoutesGeneratedFromInventory(t *testing.T) {
 	}
 }
 
+func TestSoulEnabledAddsMcpRoute(t *testing.T) {
+	outdir := t.TempDir()
+	app := awscdk.NewApp(&awscdk.AppProps{Outdir: _jsii.String(outdir)})
+	stack := awscdk.NewStack(app, _jsii.String("TestStack"), nil)
+
+	dummy := awslambda.NewFunction(stack, _jsii.String("DummyFn"), &awslambda.FunctionProps{
+		Runtime: awslambda.Runtime_NODEJS_20_X(),
+		Handler: _jsii.String("index.handler"),
+		Code:    awslambda.Code_FromInline(_jsii.String("exports.handler = async () => ({ statusCode: 200, body: 'ok' });")),
+	})
+
+	functions := &LambdaFunctions{
+		Functions: map[string]awslambda.Function{
+			"api":         dummy,
+			"graphql":     dummy,
+			"sse":         dummy,
+			"streaming":   dummy,
+			"graphql-ws":  dummy,
+			"actor":       dummy,
+			"collections": dummy,
+			"inbox":       dummy,
+			"objects":     dummy,
+			"outbox":      dummy,
+			"webfinger":   dummy,
+		},
+	}
+
+	_ = CreateAPIGateway(stack, &APIGatewayProps{
+		Environment: "development",
+		Functions:   functions,
+		SoulEnabled: true,
+	})
+
+	app.Synth(nil)
+
+	templatePath := filepath.Join(outdir, "TestStack.template.json")
+	b, err := os.ReadFile(templatePath)
+	if err != nil {
+		t.Fatalf("read template %s: %v", templatePath, err)
+	}
+
+	var tpl map[string]any
+	if err := json.Unmarshal(b, &tpl); err != nil {
+		t.Fatalf("unmarshal template: %v", err)
+	}
+
+	gotRoutes := extractHttpRouteToIntegrationURI(t, tpl)
+	uri, ok := gotRoutes["POST /mcp"]
+	if !ok {
+		t.Fatalf("expected POST /mcp route to exist when soulEnabled=true")
+	}
+
+	wantParamName := "/lesser/dev/lesser-body/exports/v1/mcp_lambda_arn"
+	if !integrationURIReferencesSSMParameterDefault(t, tpl, uri, wantParamName) {
+		uriJSON, err := json.Marshal(uri)
+		if err != nil {
+			t.Fatalf("marshal integration uri: %v", err)
+		}
+		t.Fatalf("expected POST /mcp integration to reference SSM param %q (got %s)", wantParamName, string(uriJSON))
+	}
+}
+
+func TestSoulDisabledDoesNotAddMcpRoute(t *testing.T) {
+	outdir := t.TempDir()
+	app := awscdk.NewApp(&awscdk.AppProps{Outdir: _jsii.String(outdir)})
+	stack := awscdk.NewStack(app, _jsii.String("TestStack"), nil)
+
+	dummy := awslambda.NewFunction(stack, _jsii.String("DummyFn"), &awslambda.FunctionProps{
+		Runtime: awslambda.Runtime_NODEJS_20_X(),
+		Handler: _jsii.String("index.handler"),
+		Code:    awslambda.Code_FromInline(_jsii.String("exports.handler = async () => ({ statusCode: 200, body: 'ok' });")),
+	})
+
+	functions := &LambdaFunctions{
+		Functions: map[string]awslambda.Function{
+			"api":         dummy,
+			"graphql":     dummy,
+			"sse":         dummy,
+			"streaming":   dummy,
+			"graphql-ws":  dummy,
+			"actor":       dummy,
+			"collections": dummy,
+			"inbox":       dummy,
+			"objects":     dummy,
+			"outbox":      dummy,
+			"webfinger":   dummy,
+		},
+	}
+
+	_ = CreateAPIGateway(stack, &APIGatewayProps{
+		Environment: "development",
+		Functions:   functions,
+		SoulEnabled: false,
+	})
+
+	app.Synth(nil)
+
+	templatePath := filepath.Join(outdir, "TestStack.template.json")
+	b, err := os.ReadFile(templatePath)
+	if err != nil {
+		t.Fatalf("read template %s: %v", templatePath, err)
+	}
+
+	var tpl map[string]any
+	if err := json.Unmarshal(b, &tpl); err != nil {
+		t.Fatalf("unmarshal template: %v", err)
+	}
+
+	gotRoutes := extractHttpRouteToIntegrationURI(t, tpl)
+	if _, ok := gotRoutes["POST /mcp"]; ok {
+		t.Fatalf("unexpected POST /mcp route present when soulEnabled=false")
+	}
+}
+
 func expectedFederationHttpRoutes(t *testing.T, environment string) map[string]string {
 	t.Helper()
 
@@ -175,6 +290,186 @@ func expectedFederationHttpRoutes(t *testing.T, environment string) map[string]s
 		}
 	}
 	return want
+}
+
+func extractHttpRouteToIntegrationURI(t *testing.T, tpl map[string]any) map[string]any {
+	t.Helper()
+
+	resources, ok := tpl["Resources"].(map[string]any)
+	if !ok {
+		t.Fatalf("template Resources missing or wrong type")
+	}
+
+	restApiLogicalID := ""
+	for logicalID, raw := range resources {
+		res, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if res["Type"] == "AWS::ApiGateway::RestApi" {
+			restApiLogicalID = logicalID
+			break
+		}
+	}
+
+	resourceToPathPart := make(map[string]string)
+	resourceToParent := make(map[string]string)
+	for logicalID, raw := range resources {
+		res, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if res["Type"] != "AWS::ApiGateway::Resource" {
+			continue
+		}
+		props, ok := res["Properties"].(map[string]any)
+		if !ok {
+			continue
+		}
+		part, ok := props["PathPart"].(string)
+		if !ok || part == "" {
+			continue
+		}
+		resourceToPathPart[logicalID] = part
+
+		parentID := props["ParentId"]
+		if restApiLogicalID != "" && isRestApiRootResourceRef(parentID, restApiLogicalID) {
+			resourceToParent[logicalID] = ""
+			continue
+		}
+		if parentLogicalID, ok := findFirstRefLogicalID(parentID); ok {
+			resourceToParent[logicalID] = parentLogicalID
+		}
+	}
+
+	resourceLogicalIDToFullPath := make(map[string]string)
+	var buildPath func(logicalID string) string
+	buildPath = func(logicalID string) string {
+		if logicalID == "" {
+			return ""
+		}
+		if existing, ok := resourceLogicalIDToFullPath[logicalID]; ok {
+			return existing
+		}
+		part := resourceToPathPart[logicalID]
+		parent := resourceToParent[logicalID]
+		full := ""
+		if parent == "" {
+			full = "/" + part
+		} else {
+			full = buildPath(parent) + "/" + part
+		}
+		resourceLogicalIDToFullPath[logicalID] = full
+		return full
+	}
+
+	routeKeyToURI := make(map[string]any)
+	for _, raw := range resources {
+		res, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if res["Type"] != "AWS::ApiGateway::Method" {
+			continue
+		}
+		props, ok := res["Properties"].(map[string]any)
+		if !ok {
+			continue
+		}
+		httpMethod, ok := props["HttpMethod"].(string)
+		if !ok || httpMethod == "" {
+			continue
+		}
+
+		fullPath := ""
+		if resourceLogicalID, ok := findFirstRefLogicalID(props["ResourceId"]); ok {
+			fullPath = buildPath(resourceLogicalID)
+		} else if restApiLogicalID != "" && isRestApiRootResourceRef(props["ResourceId"], restApiLogicalID) {
+			fullPath = "/"
+		}
+		if fullPath == "" {
+			continue
+		}
+
+		integration, ok := props["Integration"].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		routeKeyToURI[fmt.Sprintf("%s %s", httpMethod, fullPath)] = integration["Uri"]
+	}
+
+	return routeKeyToURI
+}
+
+func integrationURIReferencesSSMParameterDefault(t *testing.T, tpl map[string]any, uri any, wantDefault string) bool {
+	t.Helper()
+
+	rawParameters, ok := tpl["Parameters"].(map[string]any)
+	if !ok {
+		return false
+	}
+
+	type paramInfo struct {
+		Type    string
+		Default string
+	}
+	params := make(map[string]paramInfo, len(rawParameters))
+	for logicalID, raw := range rawParameters {
+		typed, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		paramType, _ := typed["Type"].(string)
+		paramDefault, _ := typed["Default"].(string)
+		params[logicalID] = paramInfo{Type: paramType, Default: paramDefault}
+	}
+
+	refs := findAllRefLogicalIDs(uri)
+	seen := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		if _, ok := seen[ref]; ok {
+			continue
+		}
+		seen[ref] = struct{}{}
+
+		p, ok := params[ref]
+		if !ok {
+			continue
+		}
+		if !strings.HasPrefix(p.Type, "AWS::SSM::Parameter::Value") {
+			continue
+		}
+		if p.Default == wantDefault {
+			return true
+		}
+	}
+
+	return false
+}
+
+func findAllRefLogicalIDs(v any) []string {
+	switch typed := v.(type) {
+	case map[string]any:
+		out := make([]string, 0)
+		if ref, ok := typed["Ref"]; ok {
+			if s, ok := ref.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		for _, child := range typed {
+			out = append(out, findAllRefLogicalIDs(child)...)
+		}
+		return out
+	case []any:
+		out := make([]string, 0, len(typed))
+		for _, child := range typed {
+			out = append(out, findAllRefLogicalIDs(child)...)
+		}
+		return out
+	default:
+		return nil
+	}
 }
 
 func extractHttpRouteToFunctionName(t *testing.T, tpl map[string]any) map[string]string {

--- a/infra/cdk/go.mod
+++ b/infra/cdk/go.mod
@@ -3,11 +3,11 @@ module cdk
 go 1.26.0
 
 require (
-	github.com/aws/aws-cdk-go/awscdk/v2 v2.236.0
+	github.com/aws/aws-cdk-go/awscdk/v2 v2.238.0
 	github.com/aws/constructs-go/constructs/v10 v10.4.5
-	github.com/aws/jsii-runtime-go v1.125.0
+	github.com/aws/jsii-runtime-go v1.126.0
 	github.com/equaltoai/lesser v0.0.0
-	github.com/theory-cloud/apptheory v0.8.0
+	github.com/theory-cloud/apptheory v0.10.0
 )
 
 require (

--- a/infra/cdk/go.sum
+++ b/infra/cdk/go.sum
@@ -1,11 +1,11 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/aws/aws-cdk-go/awscdk/v2 v2.236.0 h1:QauWNI/IAGi00KIAUcDZEXWTHuITvIr3R2lJ9zllbVo=
-github.com/aws/aws-cdk-go/awscdk/v2 v2.236.0/go.mod h1:xiTNGHJfRdjNZ+vkLx+NELBM2QP3fqkRVpHp9S09BpE=
+github.com/aws/aws-cdk-go/awscdk/v2 v2.238.0 h1:N/lbEdzRSyG1D32Q1CrYidON5lkwZXwlmLqSbOFmNp4=
+github.com/aws/aws-cdk-go/awscdk/v2 v2.238.0/go.mod h1:pY8b8Nk6V8pX2H/4kb9s3Lv0OyCqEut+vVdAn1g3nC0=
 github.com/aws/constructs-go/constructs/v10 v10.4.5 h1:sI7BEPucBQmbotxUF78qpCh4wP0ABvyinDLG7SOZIGE=
 github.com/aws/constructs-go/constructs/v10 v10.4.5/go.mod h1:L0tXWpvmTRneeFNX4efyD1haL1wQudQGHVXZWuLw74k=
-github.com/aws/jsii-runtime-go v1.125.0 h1:s5gM2ATWcCPQS61G5WHZZiqjUqejZFjed702OBrr4yo=
-github.com/aws/jsii-runtime-go v1.125.0/go.mod h1:67f+oydH0cMr//tkmNNj9QpKk02hNEEVu4CByxkpGB0=
+github.com/aws/jsii-runtime-go v1.126.0 h1:cT+yo8OMyWjgzXm7Pvy5Hq36irSIZ7bL/ds33YVDrEk=
+github.com/aws/jsii-runtime-go v1.126.0/go.mod h1:67f+oydH0cMr//tkmNNj9QpKk02hNEEVu4CByxkpGB0=
 github.com/cdklabs/awscdk-asset-awscli-go/awscliv1/v2 v2.2.263 h1:lklcDiqF0Pn1gmmv3+1nK/k40U/mAjlvcfWHYLGtFFQ=
 github.com/cdklabs/awscdk-asset-awscli-go/awscliv1/v2 v2.2.263/go.mod h1:pQx6AJJlqdc7mbkWASwwlYobLIu3TiiLV24MPDl2q4w=
 github.com/cdklabs/awscdk-asset-node-proxy-agent-go/nodeproxyagentv6/v2 v2.1.0 h1:kElXjprC8wkpJu58vp+WFH6z0AJw4zitg5iSKJPKe3c=
@@ -26,8 +26,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/theory-cloud/apptheory v0.8.0 h1:RaliALwKrWTQO3VOsSjDSBlf/2DmYyPgZh7AoYtqhAU=
-github.com/theory-cloud/apptheory v0.8.0/go.mod h1:4/Xa8E8SfIBOgm82BeJxcN2naWTVySsAaGDMJJJnPWU=
+github.com/theory-cloud/apptheory v0.10.0 h1:3EbKQwPJKwRTgStj9WRmL0Wgo9+Qq/Uy7fOG+LDF4mQ=
+github.com/theory-cloud/apptheory v0.10.0/go.mod h1:AA5tPLQBhSxX2+NnwDy6lOCvUk8nxYtzikI0L0Qe/Zk=
 github.com/yuin/goldmark v1.7.13 h1:GPddIs617DnBLFFVJFgpo1aBfe/4xcvMc3SB5t/D0pA=
 github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/infra/cdk/stacks/lesser_api_stack.go
+++ b/infra/cdk/stacks/lesser_api_stack.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-cdk-go/awscdk/v2/awsapigatewayv2"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awscertificatemanager"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awscloudfront"
-	"github.com/aws/aws-cdk-go/awscdk/v2/awscloudfrontorigins"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awsdynamodb"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awsiam"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awsroute53"
@@ -320,9 +319,6 @@ func (s *LesserApiStack) createClientInfrastructure(domain string) {
 	overridePathRoutedFrontendRewriteFunction(frontend)
 
 	s.FrontendDistribution = frontend.Distribution()
-	if s.soulEnabled() {
-		addSoulOrchestratorRouting(s.Stack, s.FrontendDistribution, domain)
-	}
 	s.ClientBucket = clientAssetsBucket
 	s.AuthUIBucket = authAssetsBucket
 }
@@ -351,33 +347,6 @@ func isTruthyConfigValue(value interface{}) bool {
 	default:
 		return false
 	}
-}
-
-func addSoulOrchestratorRouting(stack awscdk.Stack, distribution awscloudfront.Distribution, stageDomain string) {
-	if stack == nil || distribution == nil || strings.TrimSpace(stageDomain) == "" {
-		return
-	}
-
-	param := awsssm.StringParameter_FromStringParameterName(
-		stack,
-		jsii.String("SoulOrchestratorOriginDomainParam"),
-		jsii.String(fmt.Sprintf("/soul/%s/exports/v1/orchestrator_origin_domain", stageDomain)),
-	)
-
-	origin := awscloudfrontorigins.NewHttpOrigin(param.StringValue(), &awscloudfrontorigins.HttpOriginProps{
-		ProtocolPolicy: awscloudfront.OriginProtocolPolicy_HTTPS_ONLY,
-	})
-
-	options := &awscloudfront.AddBehaviorOptions{
-		AllowedMethods: awscloudfront.AllowedMethods_ALLOW_ALL(),
-		CachePolicy:    awscloudfront.CachePolicy_CACHING_DISABLED(),
-		// Forward Authorization + all query strings for orchestrator requests; exclude Host to prevent origin mismatch issues.
-		OriginRequestPolicy:  awscloudfront.OriginRequestPolicy_ALL_VIEWER_EXCEPT_HOST_HEADER(),
-		ViewerProtocolPolicy: awscloudfront.ViewerProtocolPolicy_REDIRECT_TO_HTTPS,
-	}
-
-	distribution.AddBehavior(jsii.String("/soul"), origin, options)
-	distribution.AddBehavior(jsii.String("/soul/*"), origin, options)
 }
 
 func overridePathRoutedFrontendRewriteFunction(frontend apptheorycdk.AppTheoryPathRoutedFrontend) {
@@ -894,6 +863,7 @@ func (s *LesserApiStack) createAPIGateway(domain string) {
 		WebSocketCertificate: s.WebSocketCertificate,
 		Functions:            s.Functions,
 		HostedZone:           s.HostedZone,
+		SoulEnabled:          s.soulEnabled(),
 	})
 
 	apis := []awsapigatewayv2.WebSocketApi{s.API.WebSocketApi}
@@ -1023,6 +993,46 @@ func (s *LesserApiStack) createOutputs() {
 			Description: jsii.String("S3 bucket for the auth UI (served under /auth/*)"),
 		})
 	}
+
+	s.publishStageExportsToSSM()
+}
+
+func (s *LesserApiStack) publishStageExportsToSSM() {
+	if s.Stack == nil {
+		return
+	}
+
+	appName := strings.TrimSpace(s.AppName)
+	if appName == "" {
+		appName = naming.DefaultAppName
+	}
+	stage := naming.StageForEnvironment(s.Environment)
+	paramPrefix := fmt.Sprintf("/%s/%s/lesser/exports/v1", appName, stage)
+
+	if s.MainTable != nil {
+		awsssm.NewStringParameter(s.Stack, jsii.String("LesserStageTableNameParam"), &awsssm.StringParameterProps{
+			ParameterName: jsii.String(fmt.Sprintf("%s/table_name", paramPrefix)),
+			StringValue:   s.MainTable.TableName(),
+			Description:   jsii.String("Lesser stage DynamoDB table name"),
+			Tier:          awsssm.ParameterTier_STANDARD,
+		})
+	}
+
+	if s.MediaBucket != nil {
+		awsssm.NewStringParameter(s.Stack, jsii.String("LesserStageMediaBucketNameParam"), &awsssm.StringParameterProps{
+			ParameterName: jsii.String(fmt.Sprintf("%s/media_bucket_name", paramPrefix)),
+			StringValue:   s.MediaBucket.BucketName(),
+			Description:   jsii.String("Lesser stage media bucket name"),
+			Tier:          awsssm.ParameterTier_STANDARD,
+		})
+	}
+
+	awsssm.NewStringParameter(s.Stack, jsii.String("LesserStageDomainParam"), &awsssm.StringParameterProps{
+		ParameterName: jsii.String(fmt.Sprintf("%s/domain", paramPrefix)),
+		StringValue:   jsii.String(s.Domain),
+		Description:   jsii.String("Lesser stage domain"),
+		Tier:          awsssm.ParameterTier_STANDARD,
+	})
 }
 
 func loadEnvironmentConfig(environment string) map[string]interface{} {

--- a/infra/cdk/stacks/soul_routing_test.go
+++ b/infra/cdk/stacks/soul_routing_test.go
@@ -4,16 +4,15 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/aws/aws-cdk-go/awscdk/v2"
-	"github.com/aws/aws-cdk-go/awscdk/v2/awscloudfront"
-	"github.com/aws/aws-cdk-go/awscdk/v2/awscloudfrontorigins"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awsdynamodb"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awss3"
 	"github.com/aws/jsii-runtime-go"
 )
 
-func TestSoulRoutingAddsCloudFrontBehaviorsWhenEnabled(t *testing.T) {
+func TestStageExportsPublishedToSSM(t *testing.T) {
 	outdir := t.TempDir()
 	app := awscdk.NewApp(&awscdk.AppProps{Outdir: jsii.String(outdir)})
 	stack := awscdk.NewStack(app, jsii.String("TestStack"), &awscdk.StackProps{
@@ -23,15 +22,23 @@ func TestSoulRoutingAddsCloudFrontBehaviorsWhenEnabled(t *testing.T) {
 		},
 	})
 
-	dist := awscloudfront.NewDistribution(stack, jsii.String("ClientDistribution"), &awscloudfront.DistributionProps{
-		DefaultBehavior: &awscloudfront.BehaviorOptions{
-			Origin: awscloudfrontorigins.NewHttpOrigin(jsii.String("api.dev.example.com"), &awscloudfrontorigins.HttpOriginProps{
-				ProtocolPolicy: awscloudfront.OriginProtocolPolicy_HTTPS_ONLY,
-			}),
-		},
+	mainTable := awsdynamodb.NewTable(stack, jsii.String("MainTable"), &awsdynamodb.TableProps{
+		PartitionKey: &awsdynamodb.Attribute{Name: jsii.String("pk"), Type: awsdynamodb.AttributeType_STRING},
+		SortKey:      &awsdynamodb.Attribute{Name: jsii.String("sk"), Type: awsdynamodb.AttributeType_STRING},
+		BillingMode:  awsdynamodb.BillingMode_PAY_PER_REQUEST,
 	})
 
-	addSoulOrchestratorRouting(stack, dist, "dev.example.com")
+	mediaBucket := awss3.NewBucket(stack, jsii.String("MediaBucket"), nil)
+
+	apiStack := &LesserApiStack{
+		Stack:       stack,
+		MainTable:   mainTable,
+		MediaBucket: mediaBucket,
+		AppName:     "lesser",
+		Environment: "development",
+		Domain:      "dev.example.com",
+	}
+	apiStack.publishStageExportsToSSM()
 
 	app.Synth(nil)
 
@@ -46,55 +53,49 @@ func TestSoulRoutingAddsCloudFrontBehaviorsWhenEnabled(t *testing.T) {
 		t.Fatalf("unmarshal template: %v", err)
 	}
 
-	resources := mustResources(t, tpl)
-	distRes := findSingleCloudFrontDistribution(t, resources)
-
-	cacheBehaviors := extractCacheBehaviors(t, distRes)
-	wildcard := findCacheBehavior(t, cacheBehaviors, "/soul/*")
-	exact := findCacheBehavior(t, cacheBehaviors, "/soul")
-
-	wantCachePolicyID := awscloudfront.CachePolicy_CACHING_DISABLED().CachePolicyId()
-	if wantCachePolicyID == nil || strings.TrimSpace(*wantCachePolicyID) == "" {
-		t.Fatalf("managed caching-disabled CachePolicyId missing")
-	}
-	wantOriginRequestPolicyID := awscloudfront.OriginRequestPolicy_ALL_VIEWER_EXCEPT_HOST_HEADER().OriginRequestPolicyId()
-	if wantOriginRequestPolicyID == nil || strings.TrimSpace(*wantOriginRequestPolicyID) == "" {
-		t.Fatalf("managed ALL_VIEWER_EXCEPT_HOST_HEADER OriginRequestPolicyId missing")
+	gotNames := extractSSMParameterNames(t, tpl)
+	wantNames := []string{
+		"/lesser/dev/lesser/exports/v1/table_name",
+		"/lesser/dev/lesser/exports/v1/media_bucket_name",
+		"/lesser/dev/lesser/exports/v1/domain",
 	}
 
-	requireBehaviorPolicyIDs(t, wildcard, *wantCachePolicyID, *wantOriginRequestPolicyID)
-	requireBehaviorPolicyIDs(t, exact, *wantCachePolicyID, *wantOriginRequestPolicyID)
-}
-
-func findCacheBehavior(t *testing.T, behaviors []map[string]any, pathPattern string) map[string]any {
-	t.Helper()
-
-	for _, behavior := range behaviors {
-		got, _ := behavior["PathPattern"].(string)
-		if got == pathPattern {
-			return behavior
+	for _, want := range wantNames {
+		var found bool
+		for _, got := range gotNames {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("missing SSM parameter %q (got %v)", want, gotNames)
 		}
 	}
-	t.Fatalf("expected cache behavior for %q", pathPattern)
-	return nil
 }
 
-func requireBehaviorPolicyIDs(t *testing.T, behavior map[string]any, wantCachePolicyID string, wantOriginRequestPolicyID string) {
+func extractSSMParameterNames(t *testing.T, tpl map[string]any) []string {
 	t.Helper()
 
-	gotCachePolicyID, ok := behavior["CachePolicyId"].(string)
-	if !ok || strings.TrimSpace(gotCachePolicyID) == "" {
-		t.Fatalf("behavior %q missing CachePolicyId", behavior["PathPattern"])
+	resources := mustResources(t, tpl)
+	out := make([]string, 0)
+	for _, raw := range resources {
+		res, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if res["Type"] != "AWS::SSM::Parameter" {
+			continue
+		}
+		props, ok := res["Properties"].(map[string]any)
+		if !ok {
+			continue
+		}
+		name, ok := props["Name"].(string)
+		if !ok || name == "" {
+			continue
+		}
+		out = append(out, name)
 	}
-	if gotCachePolicyID != wantCachePolicyID {
-		t.Fatalf("behavior %q unexpected CachePolicyId: got %q want %q", behavior["PathPattern"], gotCachePolicyID, wantCachePolicyID)
-	}
-
-	gotOriginRequestPolicyID, ok := behavior["OriginRequestPolicyId"].(string)
-	if !ok || strings.TrimSpace(gotOriginRequestPolicyID) == "" {
-		t.Fatalf("behavior %q missing OriginRequestPolicyId", behavior["PathPattern"])
-	}
-	if gotOriginRequestPolicyID != wantOriginRequestPolicyID {
-		t.Fatalf("behavior %q unexpected OriginRequestPolicyId: got %q want %q", behavior["PathPattern"], gotOriginRequestPolicyID, wantOriginRequestPolicyID)
-	}
+	return out
 }


### PR DESCRIPTION
Closes #136.

- Removes legacy CloudFront `/soul` behaviors + SSM lookup (Lambda URL remnant)
- Adds `POST /mcp` on the existing REST API when `soulEnabled=true`, integrating the lesser-body MCP Lambda ARN via SSM `/${app}/${stage}/lesser-body/exports/v1/mcp_lambda_arn` (streaming enabled)
- Publishes stage exports to SSM: `/${app}/${stage}/lesser/exports/v1/{table_name,media_bucket_name,domain}`
- Pins `infra/cdk` AppTheory to `v0.10.0`

Test: `cd infra/cdk && go test ./...`