### PR TITLE
Prevent verify ci host OOMs

### DIFF
--- a/cmd/lesser/env_defaults.go
+++ b/cmd/lesser/env_defaults.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	defaultCLIStage        = "dev"
-	defaultCLIMaxToolJobs  = 8
+	defaultCLIMaxToolJobs  = 4
 	lesserToolJobsEnvVar   = "LESSER_JOBS"
 	goMaxProcsEnvVar       = "GOMAXPROCS"
 	goFlagsEnvVar          = "GOFLAGS"
@@ -59,6 +59,9 @@ func resolveToolJobs() int {
 
 	if v := strings.TrimSpace(os.Getenv(goMaxProcsEnvVar)); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			if n > defaultCLIMaxToolJobs {
+				return defaultCLIMaxToolJobs
+			}
 			return n
 		}
 	}

--- a/cmd/lesser/env_defaults_test.go
+++ b/cmd/lesser/env_defaults_test.go
@@ -26,7 +26,7 @@ func TestResolveToolJobs_PrefersLesserJobsThenGOMAXPROCS(t *testing.T) {
 
 	t.Setenv(lesserToolJobsEnvVar, "nope")
 	t.Setenv(goMaxProcsEnvVar, "5")
-	require.Equal(t, 5, resolveToolJobs())
+	require.Equal(t, defaultCLIMaxToolJobs, resolveToolJobs())
 }
 
 func TestApplyToolParallelismDefaults_SetsGOMAXPROCSAndGOFLAGSWhenUnset(t *testing.T) {

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -61,7 +61,7 @@ go build -o lesser ./cmd/lesser
 Notes:
 
 - `./lesser verify ci` is stricter than `./lesser verify` (adds lint, security scans, supply chain verification, strict OpenAPI, and coverage gates).
-- By default, the `./lesser` CLI caps Go/lint parallelism on high-core machines to avoid host OOMs (sets `GOMAXPROCS` and `GOFLAGS=-p` up to 8). Override with `LESSER_JOBS` (or your own `GOMAXPROCS` / `GOFLAGS`).
+- By default, the `./lesser` CLI caps Go/lint parallelism on high-core machines to avoid host OOMs (sets `GOMAXPROCS` and `GOFLAGS=-p` up to 4). Override with `LESSER_JOBS` (or your own `GOMAXPROCS` / `GOFLAGS`).
 - CI runs coverage in short mode and skips HTML generation to keep runtime down (`./lesser test coverage --scope overall --short --verbose=false --exclude-generated=false --html=false`).
 - Coverage gates are strict (for example, `89.999%` fails even if it rounds to `90.0%` in a 1-decimal summary). If debugging drift, run with `GOFLAGS=-count=1` to force fresh test runs.
 


### PR DESCRIPTION
Reduces default Go/lint parallelism to lower peak memory during `./lesser verify ci` on high-core machines.

- Default cap now 4 (was 8) for inferred jobs when `LESSER_JOBS` is unset
- Caps jobs derived from `GOMAXPROCS` to the same default max to avoid accidentally inheriting huge global values
- Updates docs

Test:
- `go test ./...`
- `go build -o lesser ./cmd/lesser && ./lesser verify ci`