### PR TITLE
chore(auth-ui): bump svelte + devalue

### DIFF
--- a/auth-ui/package.json
+++ b/auth-ui/package.json
@@ -37,7 +37,7 @@
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
     "shiki": "^3.20.0",
-    "svelte": "^5.0.0",
+    "svelte": "^5.53.1",
     "tabbable": "^6.3.0",
     "unified": "^11.0.5",
     "vite": "^6.0.6",
@@ -50,7 +50,7 @@
   "pnpm": {
     "overrides": {
       "mdast-util-to-hast": "13.2.1",
-      "devalue": "5.6.2",
+      "devalue": "5.6.3",
       "h3": "1.15.5",
       "diff": "5.2.2"
     }

--- a/auth-ui/pnpm-lock.yaml
+++ b/auth-ui/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   mdast-util-to-hast: 13.2.1
-  devalue: 5.6.2
+  devalue: 5.6.3
   h3: 1.15.5
   diff: 5.2.2
 
@@ -22,7 +22,7 @@ importers:
         version: 0.14.3(@apollo/client@4.0.11(graphql-ws@6.0.6(crossws@0.3.5)(graphql@16.12.0))(graphql@16.12.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rxjs@7.8.2))(@types/react@19.2.7)(graphql@16.12.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rxjs@7.8.2)
       '@astrojs/svelte':
         specifier: ^7.2.1
-        version: 7.2.1(@types/node@24.9.2)(astro@5.16.3(@types/node@24.9.2)(rollup@4.52.5)(typescript@5.9.3))(svelte@5.43.2)(typescript@5.9.3)
+        version: 7.2.1(@types/node@24.9.2)(astro@5.16.3(@types/node@24.9.2)(rollup@4.52.5)(typescript@5.9.3))(svelte@5.53.1)(typescript@5.9.3)
       '@graphql-typed-document-node/core':
         specifier: ^3.2.0
         version: 3.2.0(graphql@16.12.0)
@@ -84,8 +84,8 @@ importers:
         specifier: ^3.20.0
         version: 3.20.0
       svelte:
-        specifier: ^5.0.0
-        version: 5.43.2
+        specifier: ^5.53.1
+        version: 5.53.1
       tabbable:
         specifier: ^6.3.0
         version: 6.3.0
@@ -686,6 +686,9 @@ packages:
   '@types/react@19.2.7':
     resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
@@ -899,8 +902,8 @@ packages:
     resolution: {integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==}
     engines: {node: '>=18'}
 
-  devalue@5.6.2:
-    resolution: {integrity: sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==}
+  devalue@5.6.3:
+    resolution: {integrity: sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -961,8 +964,8 @@ packages:
   esm-env@1.2.2:
     resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
-  esrap@2.1.2:
-    resolution: {integrity: sha512-DgvlIQeowRNyvLPWW4PT7Gu13WznY288Du086E751mwwbsgr29ytBiYeLzAGIo0qk3Ujob0SDk8TiSaM5WQzNg==}
+  esrap@2.2.3:
+    resolution: {integrity: sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ==}
 
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
@@ -1551,8 +1554,8 @@ packages:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0
 
-  svelte@5.43.2:
-    resolution: {integrity: sha512-ro1umEzX8rT5JpCmlf0PPv7ncD8MdVob9e18bhwqTKNoLjS8kDvhVpaoYVPc+qMwDAOfcwJtyY7ZFSDbOaNPgA==}
+  svelte@5.53.1:
+    resolution: {integrity: sha512-WzxFHZhhD23Qzu7JCYdvm1rxvRSzdt9HtHO8TScMBX51bLRFTcJmATVqjqXG+6Ln6hrViGCo9DzwOhAasxwC/w==}
     engines: {node: '>=18'}
 
   svgo@4.0.0:
@@ -1896,12 +1899,12 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/svelte@7.2.1(@types/node@24.9.2)(astro@5.16.3(@types/node@24.9.2)(rollup@4.52.5)(typescript@5.9.3))(svelte@5.43.2)(typescript@5.9.3)':
+  '@astrojs/svelte@7.2.1(@types/node@24.9.2)(astro@5.16.3(@types/node@24.9.2)(rollup@4.52.5)(typescript@5.9.3))(svelte@5.53.1)(typescript@5.9.3)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.43.2)(vite@6.4.1(@types/node@24.9.2))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.53.1)(vite@6.4.1(@types/node@24.9.2))
       astro: 5.16.3(@types/node@24.9.2)(rollup@4.52.5)(typescript@5.9.3)
-      svelte: 5.43.2
-      svelte2tsx: 0.7.45(svelte@5.43.2)(typescript@5.9.3)
+      svelte: 5.53.1
+      svelte2tsx: 0.7.45(svelte@5.53.1)(typescript@5.9.3)
       typescript: 5.9.3
       vite: 6.4.1(@types/node@24.9.2)
     transitivePeerDependencies:
@@ -2255,23 +2258,23 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.43.2)(vite@6.4.1(@types/node@24.9.2)))(svelte@5.43.2)(vite@6.4.1(@types/node@24.9.2))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.1)(vite@6.4.1(@types/node@24.9.2)))(svelte@5.53.1)(vite@6.4.1(@types/node@24.9.2))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.43.2)(vite@6.4.1(@types/node@24.9.2))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.53.1)(vite@6.4.1(@types/node@24.9.2))
       debug: 4.4.3
-      svelte: 5.43.2
+      svelte: 5.53.1
       vite: 6.4.1(@types/node@24.9.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.43.2)(vite@6.4.1(@types/node@24.9.2))':
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.1)(vite@6.4.1(@types/node@24.9.2))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.43.2)(vite@6.4.1(@types/node@24.9.2)))(svelte@5.43.2)(vite@6.4.1(@types/node@24.9.2))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.1)(vite@6.4.1(@types/node@24.9.2)))(svelte@5.53.1)(vite@6.4.1(@types/node@24.9.2))
       debug: 4.4.3
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.21
-      svelte: 5.43.2
+      svelte: 5.53.1
       vite: 6.4.1(@types/node@24.9.2)
       vitefu: 1.1.1(vite@6.4.1(@types/node@24.9.2))
     transitivePeerDependencies:
@@ -2316,6 +2319,8 @@ snapshots:
   '@types/react@19.2.7':
     dependencies:
       csstype: 3.2.3
+
+  '@types/trusted-types@2.0.7': {}
 
   '@types/unist@3.0.3': {}
 
@@ -2382,7 +2387,7 @@ snapshots:
       cssesc: 3.0.0
       debug: 4.4.3
       deterministic-object-hash: 2.0.2
-      devalue: 5.6.2
+      devalue: 5.6.3
       diff: 5.2.2
       dlv: 1.1.3
       dset: 3.1.4
@@ -2580,7 +2585,7 @@ snapshots:
     dependencies:
       base-64: 1.0.0
 
-  devalue@5.6.2: {}
+  devalue@5.6.3: {}
 
   devlop@1.1.0:
     dependencies:
@@ -2655,7 +2660,7 @@ snapshots:
 
   esm-env@1.2.2: {}
 
-  esrap@2.1.2:
+  esrap@2.2.3:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
@@ -3584,25 +3589,27 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
-  svelte2tsx@0.7.45(svelte@5.43.2)(typescript@5.9.3):
+  svelte2tsx@0.7.45(svelte@5.53.1)(typescript@5.9.3):
     dependencies:
       dedent-js: 1.0.1
       scule: 1.3.0
-      svelte: 5.43.2
+      svelte: 5.53.1
       typescript: 5.9.3
 
-  svelte@5.43.2:
+  svelte@5.53.1:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
       '@sveltejs/acorn-typescript': 1.0.6(acorn@8.15.0)
       '@types/estree': 1.0.8
+      '@types/trusted-types': 2.0.7
       acorn: 8.15.0
       aria-query: 5.3.2
       axobject-query: 4.1.0
       clsx: 2.1.1
+      devalue: 5.6.3
       esm-env: 1.2.2
-      esrap: 2.1.2
+      esrap: 2.2.3
       is-reference: 3.0.3
       locate-character: 3.0.0
       magic-string: 0.30.21


### PR DESCRIPTION
Bumps auth-ui lockfile to resolve current Dependabot alerts in auth-ui/pnpm-lock.yaml:
- svelte -> 5.53.1 (patched >= 5.51.5)
- devalue -> 5.6.3 (patched >= 5.6.3)

Verification:
- ./lesser verify ci