### PR TITLE
fix: publish /.well-known/mcp.json

### DIFF
--- a/docs/security-public-surface.md
+++ b/docs/security-public-surface.md
@@ -27,6 +27,7 @@ Legend:
 
 - **Public** `GET /.well-known/webfinger` (service: `cmd/webfinger`)
 - **Public** `GET /.well-known/nodeinfo` (service: `cmd/api`)
+- **Public** `GET /.well-known/mcp.json` (service: `lesser-body` MCP Lambda)
 - **Public** `GET /nodeinfo/2.0` (service: `cmd/api`)
 - **Public** `GET /users/:username` (service: `cmd/actor`)
   - Content negotiation:

--- a/infra/cdk/constructs/api_routes.go
+++ b/infra/cdk/constructs/api_routes.go
@@ -143,6 +143,7 @@ func addMcpRoute(scope constructs.Construct, api apptheorycdk.AppTheoryRestApiRo
 		Streaming: jsii.Bool(true),
 	}
 	api.AddLambdaIntegration(jsii.String("/mcp"), &[]*string{jsii.String("POST")}, mcpLambda, options)
+	api.AddLambdaIntegration(jsii.String("/.well-known/mcp.json"), &[]*string{jsii.String("GET")}, mcpLambda, nil)
 }
 
 func addRestApiGatewayResponses(scope constructs.Construct, api awsapigateway.RestApi) {

--- a/infra/cdk/constructs/api_routes_test.go
+++ b/infra/cdk/constructs/api_routes_test.go
@@ -200,6 +200,7 @@ func TestSoulEnabledAddsMcpRoute(t *testing.T) {
 	}
 
 	gotRoutes := extractHttpRouteToIntegrationURI(t, tpl)
+
 	uri, ok := gotRoutes["POST /mcp"]
 	if !ok {
 		t.Fatalf("expected POST /mcp route to exist when soulEnabled=true")
@@ -212,6 +213,18 @@ func TestSoulEnabledAddsMcpRoute(t *testing.T) {
 			t.Fatalf("marshal integration uri: %v", err)
 		}
 		t.Fatalf("expected POST /mcp integration to reference SSM param %q (got %s)", wantParamName, string(uriJSON))
+	}
+
+	uri, ok = gotRoutes["GET /.well-known/mcp.json"]
+	if !ok {
+		t.Fatalf("expected GET /.well-known/mcp.json route to exist when soulEnabled=true")
+	}
+	if !integrationURIReferencesSSMParameterDefault(t, tpl, uri, wantParamName) {
+		uriJSON, err := json.Marshal(uri)
+		if err != nil {
+			t.Fatalf("marshal integration uri: %v", err)
+		}
+		t.Fatalf("expected GET /.well-known/mcp.json integration to reference SSM param %q (got %s)", wantParamName, string(uriJSON))
 	}
 }
 
@@ -264,6 +277,9 @@ func TestSoulDisabledDoesNotAddMcpRoute(t *testing.T) {
 	gotRoutes := extractHttpRouteToIntegrationURI(t, tpl)
 	if _, ok := gotRoutes["POST /mcp"]; ok {
 		t.Fatalf("unexpected POST /mcp route present when soulEnabled=false")
+	}
+	if _, ok := gotRoutes["GET /.well-known/mcp.json"]; ok {
+		t.Fatalf("unexpected GET /.well-known/mcp.json route present when soulEnabled=false")
 	}
 }
 


### PR DESCRIPTION
Closes #141.

- Adds GET /.well-known/mcp.json on the existing API custom domain.
- Routes it to the imported lesser-body MCP Lambda (same SSM param as POST /mcp).
- Updates CDK route tests and public-surface docs.

Verification:
- ./lesser verify ci