### PR TITLE
bump apptheory to v0.15.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/spruceid/siwe-go v0.2.1
 	github.com/stretchr/testify v1.11.1
-	github.com/theory-cloud/apptheory v0.14.0
+	github.com/theory-cloud/apptheory v0.15.1
 	github.com/theory-cloud/tabletheory v1.4.1
 	github.com/tyler-smith/go-bip32 v1.0.0
 	github.com/tyler-smith/go-bip39 v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -249,8 +249,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/supranational/blst v0.3.16 h1:bTDadT+3fK497EvLdWRQEjiGnUtzJ7jjIUMF0jqwYhE=
 github.com/supranational/blst v0.3.16/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
-github.com/theory-cloud/apptheory v0.14.0 h1:6jp0ipfqvBdKTxihoWVnaAnleeoHhdTzr3rUA5jNf7o=
-github.com/theory-cloud/apptheory v0.14.0/go.mod h1:xIXtJJe0/JUNkSbPPYDACDsdaWCss/ukH+DVjVteJxw=
+github.com/theory-cloud/apptheory v0.15.1 h1:Ml69bKnHey2T/J6vGy1G5ilGKfI83XuOTwNgfzSjHIU=
+github.com/theory-cloud/apptheory v0.15.1/go.mod h1:xIXtJJe0/JUNkSbPPYDACDsdaWCss/ukH+DVjVteJxw=
 github.com/theory-cloud/tabletheory v1.4.1 h1:q4mdKhL0PSswfHuZwo2H8LWK5pLPQrrPJ4GRjoQovCs=
 github.com/theory-cloud/tabletheory v1.4.1/go.mod h1:jMKVL5t4b1M+9s5YT2lWxJIU3y4hlklrVpu4zqxxEsg=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=

--- a/infra/cdk/go.mod
+++ b/infra/cdk/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/constructs-go/constructs/v10 v10.5.1
 	github.com/aws/jsii-runtime-go v1.127.0
 	github.com/equaltoai/lesser v1.1.17
-	github.com/theory-cloud/apptheory v0.14.0
+	github.com/theory-cloud/apptheory v0.15.1
 )
 
 require (

--- a/infra/cdk/go.sum
+++ b/infra/cdk/go.sum
@@ -26,8 +26,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/theory-cloud/apptheory v0.14.0 h1:6jp0ipfqvBdKTxihoWVnaAnleeoHhdTzr3rUA5jNf7o=
-github.com/theory-cloud/apptheory v0.14.0/go.mod h1:xIXtJJe0/JUNkSbPPYDACDsdaWCss/ukH+DVjVteJxw=
+github.com/theory-cloud/apptheory v0.15.1 h1:Ml69bKnHey2T/J6vGy1G5ilGKfI83XuOTwNgfzSjHIU=
+github.com/theory-cloud/apptheory v0.15.1/go.mod h1:xIXtJJe0/JUNkSbPPYDACDsdaWCss/ukH+DVjVteJxw=
 github.com/yuin/goldmark v1.7.16 h1:n+CJdUxaFMiDUNnWC3dMWCIQJSkxH4uz3ZwQBkAlVNE=
 github.com/yuin/goldmark v1.7.16/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
- Upgrade github.com/theory-cloud/apptheory to v0.15.1 (root + infra/cdk)\n- SSE handlers already use apptheory.SSEStreamResponse + CDK Streaming integrations; this picks up upstream SSE/streaming fixes\n\nCommands:\n- make rubric\n