### PR TITLE
add graphql parity for souls

### DIFF
--- a/docs/contracts/graphql-schema.graphql
+++ b/docs/contracts/graphql-schema.graphql
@@ -4276,6 +4276,41 @@ input AdminVerifyAgentInput {
   exitQuarantine: Boolean
 }
 
+enum SoulBindingState {
+  UNBOUND
+  BOUND
+}
+
+type SoulAgentIdentity {
+  agentId: ID!
+  domain: String!
+  localId: String!
+  ensName: String
+  wallet: String!
+  principalAddress: String
+  status: String!
+  lifecycleStatus: String
+  selfDescriptionVersion: Int
+  capabilities: [String!]!
+  mintTxHash: String
+  mintedAt: Time
+  updatedAt: Time
+}
+
+type SoulBodyBinding {
+  username: String!
+  principalAddress: String
+  boundAt: Time!
+  updatedAt: Time!
+}
+
+type SoulInventoryItem {
+  agent: SoulAgentIdentity!
+  bindingState: SoulBindingState!
+  availableForIncorporation: Boolean!
+  binding: SoulBodyBinding
+}
+
 extend type Query {
   agent(username: String!): Agent
   agents(first: Int = 20, after: Cursor, type: AgentType, query: String, verified: Boolean, ownerUsername: String): AgentConnection!
@@ -4283,6 +4318,7 @@ extend type Query {
   agentActivity(username: String!, first: Int = 20, after: Cursor): AgentActivityConnection!
   adminAgentPolicy: AdminAgentPolicy!
   agentMemorySearch(query: String!, tags: [String!], dateRange: DateRangeInput, first: Int = 20, after: Cursor): ObjectConnection!
+  mySouls: [SoulInventoryItem!]!
 }
 
 extend type Mutation {
@@ -4297,6 +4333,7 @@ extend type Mutation {
   adminVerifyAgent(username: String!, input: AdminVerifyAgentInput): Agent!
   adminUnverifyAgent(username: String!, input: AdminVerifyAgentInput): Agent!
   adminSuspendAgent(username: String!): Agent!
+  incorporateSoul(agentId: ID!): SoulInventoryItem!
 }
 
 extend type Subscription {

--- a/docs/specs/graphql_coverage.yaml
+++ b/docs/specs/graphql_coverage.yaml
@@ -53,13 +53,11 @@ exemptions:
         prefixes:
             - /api/v1/trust
     - id: lesser_soul
-      reason: lesser-soul proof, discovery, and incorporation endpoints are REST-only internal surfaces.
+      reason: lesser-soul proof publication and internal notification delivery remain REST-only.
       match:
         exact:
             - /api/v1/admin/soul/well-known
             - /api/v1/notifications/deliver
-        prefixes:
-            - /api/v1/souls
 routes:
     - method: GET
       path: /
@@ -1067,12 +1065,16 @@ routes:
         - Query.search
     - method: GET
       path: /api/v1/souls/mine
-      policy: rest_only
-      exemptedBy: lesser_soul
+      policy: graphql_required
+      status: covered
+      graphql:
+        - Query.mySouls
     - method: POST
       path: /api/v1/souls/{agentId}/incorporate
-      policy: rest_only
-      exemptedBy: lesser_soul
+      policy: graphql_required
+      status: covered
+      graphql:
+        - Mutation.incorporateSoul
     - method: POST
       path: /api/v1/statuses
       policy: graphql_required

--- a/graph/agents.graphql
+++ b/graph/agents.graphql
@@ -175,6 +175,41 @@ input AdminVerifyAgentInput {
   exitQuarantine: Boolean
 }
 
+enum SoulBindingState {
+  UNBOUND
+  BOUND
+}
+
+type SoulAgentIdentity {
+  agentId: ID!
+  domain: String!
+  localId: String!
+  ensName: String
+  wallet: String!
+  principalAddress: String
+  status: String!
+  lifecycleStatus: String
+  selfDescriptionVersion: Int
+  capabilities: [String!]!
+  mintTxHash: String
+  mintedAt: Time
+  updatedAt: Time
+}
+
+type SoulBodyBinding {
+  username: String!
+  principalAddress: String
+  boundAt: Time!
+  updatedAt: Time!
+}
+
+type SoulInventoryItem {
+  agent: SoulAgentIdentity!
+  bindingState: SoulBindingState!
+  availableForIncorporation: Boolean!
+  binding: SoulBodyBinding
+}
+
 extend type Query {
   agent(username: String!): Agent
   agents(first: Int = 20, after: Cursor, type: AgentType, query: String, verified: Boolean, ownerUsername: String): AgentConnection!
@@ -182,6 +217,7 @@ extend type Query {
   agentActivity(username: String!, first: Int = 20, after: Cursor): AgentActivityConnection!
   adminAgentPolicy: AdminAgentPolicy!
   agentMemorySearch(query: String!, tags: [String!], dateRange: DateRangeInput, first: Int = 20, after: Cursor): ObjectConnection!
+  mySouls: [SoulInventoryItem!]!
 }
 
 extend type Mutation {
@@ -196,6 +232,7 @@ extend type Mutation {
   adminVerifyAgent(username: String!, input: AdminVerifyAgentInput): Agent!
   adminUnverifyAgent(username: String!, input: AdminVerifyAgentInput): Agent!
   adminSuspendAgent(username: String!): Agent!
+  incorporateSoul(agentId: ID!): SoulInventoryItem!
 }
 
 extend type Subscription {

--- a/graph/generated.go
+++ b/graph/generated.go
@@ -1802,6 +1802,7 @@ type ComplexityRoot struct {
 		FollowActor                        func(childComplexity int, id string) int
 		FollowHashtag                      func(childComplexity int, hashtag string, notifyLevel *model.NotificationLevel) int
 		ImportReputation                   func(childComplexity int, document string) int
+		IncorporateSoul                    func(childComplexity int, agentID string) int
 		InvitePublicationMember            func(childComplexity int, publicationID string, userID string, role model.PublicationRole) int
 		LikeObject                         func(childComplexity int, id string) int
 		MarkConversationAsRead             func(childComplexity int, id string) int
@@ -2257,6 +2258,7 @@ type ComplexityRoot struct {
 		MyAgents                  func(childComplexity int) int
 		MyDrafts                  func(childComplexity int, contentType *model.ObjectType, status *model.DraftStatus, first *int, after *model.Cursor) int
 		MyPublications            func(childComplexity int) int
+		MySouls                   func(childComplexity int) int
 		Notification              func(childComplexity int, id string) int
 		Notifications             func(childComplexity int, types []string, excludeTypes []string, first *int, after *model.Cursor) int
 		Object                    func(childComplexity int, id string) int
@@ -2566,6 +2568,36 @@ type ComplexityRoot struct {
 	SeveredRelationshipEdge struct {
 		Cursor func(childComplexity int) int
 		Node   func(childComplexity int) int
+	}
+
+	SoulAgentIdentity struct {
+		AgentID                func(childComplexity int) int
+		Capabilities           func(childComplexity int) int
+		Domain                 func(childComplexity int) int
+		EnsName                func(childComplexity int) int
+		LifecycleStatus        func(childComplexity int) int
+		LocalID                func(childComplexity int) int
+		MintTxHash             func(childComplexity int) int
+		MintedAt               func(childComplexity int) int
+		PrincipalAddress       func(childComplexity int) int
+		SelfDescriptionVersion func(childComplexity int) int
+		Status                 func(childComplexity int) int
+		UpdatedAt              func(childComplexity int) int
+		Wallet                 func(childComplexity int) int
+	}
+
+	SoulBodyBinding struct {
+		BoundAt          func(childComplexity int) int
+		PrincipalAddress func(childComplexity int) int
+		UpdatedAt        func(childComplexity int) int
+		Username         func(childComplexity int) int
+	}
+
+	SoulInventoryItem struct {
+		Agent                     func(childComplexity int) int
+		AvailableForIncorporation func(childComplexity int) int
+		Binding                   func(childComplexity int) int
+		BindingState              func(childComplexity int) int
 	}
 
 	SpamAnalysis struct {
@@ -3130,6 +3162,7 @@ type MutationResolver interface {
 	AdminVerifyAgent(ctx context.Context, username string, input *model.AdminVerifyAgentInput) (*model.Agent, error)
 	AdminUnverifyAgent(ctx context.Context, username string, input *model.AdminVerifyAgentInput) (*model.Agent, error)
 	AdminSuspendAgent(ctx context.Context, username string) (*model.Agent, error)
+	IncorporateSoul(ctx context.Context, agentID string) (*model.SoulInventoryItem, error)
 }
 type ObjectResolver interface {
 	ViewerFavourited(ctx context.Context, obj *model.Object) (bool, error)
@@ -3281,6 +3314,7 @@ type QueryResolver interface {
 	AgentActivity(ctx context.Context, username string, first *int, after *model.Cursor) (*model.AgentActivityConnection, error)
 	AdminAgentPolicy(ctx context.Context) (*model.AdminAgentPolicy, error)
 	AgentMemorySearch(ctx context.Context, query string, tags []string, dateRange *model.DateRangeInput, first *int, after *model.Cursor) (*model.ObjectConnection, error)
+	MySouls(ctx context.Context) ([]*model.SoulInventoryItem, error)
 }
 type QuoteContextResolver interface {
 	OriginalAuthor(ctx context.Context, obj *activitypub.QuoteContext) (*activitypub.Actor, error)
@@ -11840,6 +11874,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.ImportReputation(childComplexity, args["document"].(string)), true
 
+	case "Mutation.incorporateSoul":
+		if e.complexity.Mutation.IncorporateSoul == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_incorporateSoul_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.IncorporateSoul(childComplexity, args["agentId"].(string)), true
+
 	case "Mutation.invitePublicationMember":
 		if e.complexity.Mutation.InvitePublicationMember == nil {
 			break
@@ -15198,6 +15244,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Query.MyPublications(childComplexity), true
 
+	case "Query.mySouls":
+		if e.complexity.Query.MySouls == nil {
+			break
+		}
+
+		return e.complexity.Query.MySouls(childComplexity), true
+
 	case "Query.notification":
 		if e.complexity.Query.Notification == nil {
 			break
@@ -16857,6 +16910,153 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.SeveredRelationshipEdge.Node(childComplexity), true
+
+	case "SoulAgentIdentity.agentId":
+		if e.complexity.SoulAgentIdentity.AgentID == nil {
+			break
+		}
+
+		return e.complexity.SoulAgentIdentity.AgentID(childComplexity), true
+
+	case "SoulAgentIdentity.capabilities":
+		if e.complexity.SoulAgentIdentity.Capabilities == nil {
+			break
+		}
+
+		return e.complexity.SoulAgentIdentity.Capabilities(childComplexity), true
+
+	case "SoulAgentIdentity.domain":
+		if e.complexity.SoulAgentIdentity.Domain == nil {
+			break
+		}
+
+		return e.complexity.SoulAgentIdentity.Domain(childComplexity), true
+
+	case "SoulAgentIdentity.ensName":
+		if e.complexity.SoulAgentIdentity.EnsName == nil {
+			break
+		}
+
+		return e.complexity.SoulAgentIdentity.EnsName(childComplexity), true
+
+	case "SoulAgentIdentity.lifecycleStatus":
+		if e.complexity.SoulAgentIdentity.LifecycleStatus == nil {
+			break
+		}
+
+		return e.complexity.SoulAgentIdentity.LifecycleStatus(childComplexity), true
+
+	case "SoulAgentIdentity.localId":
+		if e.complexity.SoulAgentIdentity.LocalID == nil {
+			break
+		}
+
+		return e.complexity.SoulAgentIdentity.LocalID(childComplexity), true
+
+	case "SoulAgentIdentity.mintTxHash":
+		if e.complexity.SoulAgentIdentity.MintTxHash == nil {
+			break
+		}
+
+		return e.complexity.SoulAgentIdentity.MintTxHash(childComplexity), true
+
+	case "SoulAgentIdentity.mintedAt":
+		if e.complexity.SoulAgentIdentity.MintedAt == nil {
+			break
+		}
+
+		return e.complexity.SoulAgentIdentity.MintedAt(childComplexity), true
+
+	case "SoulAgentIdentity.principalAddress":
+		if e.complexity.SoulAgentIdentity.PrincipalAddress == nil {
+			break
+		}
+
+		return e.complexity.SoulAgentIdentity.PrincipalAddress(childComplexity), true
+
+	case "SoulAgentIdentity.selfDescriptionVersion":
+		if e.complexity.SoulAgentIdentity.SelfDescriptionVersion == nil {
+			break
+		}
+
+		return e.complexity.SoulAgentIdentity.SelfDescriptionVersion(childComplexity), true
+
+	case "SoulAgentIdentity.status":
+		if e.complexity.SoulAgentIdentity.Status == nil {
+			break
+		}
+
+		return e.complexity.SoulAgentIdentity.Status(childComplexity), true
+
+	case "SoulAgentIdentity.updatedAt":
+		if e.complexity.SoulAgentIdentity.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.SoulAgentIdentity.UpdatedAt(childComplexity), true
+
+	case "SoulAgentIdentity.wallet":
+		if e.complexity.SoulAgentIdentity.Wallet == nil {
+			break
+		}
+
+		return e.complexity.SoulAgentIdentity.Wallet(childComplexity), true
+
+	case "SoulBodyBinding.boundAt":
+		if e.complexity.SoulBodyBinding.BoundAt == nil {
+			break
+		}
+
+		return e.complexity.SoulBodyBinding.BoundAt(childComplexity), true
+
+	case "SoulBodyBinding.principalAddress":
+		if e.complexity.SoulBodyBinding.PrincipalAddress == nil {
+			break
+		}
+
+		return e.complexity.SoulBodyBinding.PrincipalAddress(childComplexity), true
+
+	case "SoulBodyBinding.updatedAt":
+		if e.complexity.SoulBodyBinding.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.SoulBodyBinding.UpdatedAt(childComplexity), true
+
+	case "SoulBodyBinding.username":
+		if e.complexity.SoulBodyBinding.Username == nil {
+			break
+		}
+
+		return e.complexity.SoulBodyBinding.Username(childComplexity), true
+
+	case "SoulInventoryItem.agent":
+		if e.complexity.SoulInventoryItem.Agent == nil {
+			break
+		}
+
+		return e.complexity.SoulInventoryItem.Agent(childComplexity), true
+
+	case "SoulInventoryItem.availableForIncorporation":
+		if e.complexity.SoulInventoryItem.AvailableForIncorporation == nil {
+			break
+		}
+
+		return e.complexity.SoulInventoryItem.AvailableForIncorporation(childComplexity), true
+
+	case "SoulInventoryItem.binding":
+		if e.complexity.SoulInventoryItem.Binding == nil {
+			break
+		}
+
+		return e.complexity.SoulInventoryItem.Binding(childComplexity), true
+
+	case "SoulInventoryItem.bindingState":
+		if e.complexity.SoulInventoryItem.BindingState == nil {
+			break
+		}
+
+		return e.complexity.SoulInventoryItem.BindingState(childComplexity), true
 
 	case "SpamAnalysis.accountAgeDays":
 		if e.complexity.SpamAnalysis.AccountAgeDays == nil {
@@ -19565,6 +19765,17 @@ func (ec *executionContext) field_Mutation_importReputation_args(ctx context.Con
 		return nil, err
 	}
 	args["document"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_incorporateSoul_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "agentId", ec.unmarshalNID2string)
+	if err != nil {
+		return nil, err
+	}
+	args["agentId"] = arg0
 	return args, nil
 }
 
@@ -85317,6 +85528,71 @@ func (ec *executionContext) fieldContext_Mutation_adminSuspendAgent(ctx context.
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_incorporateSoul(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_incorporateSoul(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().IncorporateSoul(rctx, fc.Args["agentId"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.SoulInventoryItem)
+	fc.Result = res
+	return ec.marshalNSoulInventoryItem2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulInventoryItem(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_incorporateSoul(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "agent":
+				return ec.fieldContext_SoulInventoryItem_agent(ctx, field)
+			case "bindingState":
+				return ec.fieldContext_SoulInventoryItem_bindingState(ctx, field)
+			case "availableForIncorporation":
+				return ec.fieldContext_SoulInventoryItem_availableForIncorporation(ctx, field)
+			case "binding":
+				return ec.fieldContext_SoulInventoryItem_binding(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SoulInventoryItem", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_incorporateSoul_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _MuteHashtagPayload_success(ctx context.Context, field graphql.CollectedField, obj *model.MuteHashtagPayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_MuteHashtagPayload_success(ctx, field)
 	if err != nil {
@@ -104057,6 +104333,60 @@ func (ec *executionContext) fieldContext_Query_agentMemorySearch(ctx context.Con
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_mySouls(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_mySouls(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().MySouls(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.SoulInventoryItem)
+	fc.Result = res
+	return ec.marshalNSoulInventoryItem2ᚕᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulInventoryItemᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_mySouls(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "agent":
+				return ec.fieldContext_SoulInventoryItem_agent(ctx, field)
+			case "bindingState":
+				return ec.fieldContext_SoulInventoryItem_bindingState(ctx, field)
+			case "availableForIncorporation":
+				return ec.fieldContext_SoulInventoryItem_availableForIncorporation(ctx, field)
+			case "binding":
+				return ec.fieldContext_SoulInventoryItem_binding(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SoulInventoryItem", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query___type(ctx, field)
 	if err != nil {
@@ -112460,6 +112790,941 @@ func (ec *executionContext) fieldContext_SeveredRelationshipEdge_cursor(_ contex
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Cursor does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulAgentIdentity_agentId(ctx context.Context, field graphql.CollectedField, obj *model.SoulAgentIdentity) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulAgentIdentity_agentId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AgentID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulAgentIdentity_agentId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulAgentIdentity",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulAgentIdentity_domain(ctx context.Context, field graphql.CollectedField, obj *model.SoulAgentIdentity) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulAgentIdentity_domain(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Domain, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulAgentIdentity_domain(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulAgentIdentity",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulAgentIdentity_localId(ctx context.Context, field graphql.CollectedField, obj *model.SoulAgentIdentity) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulAgentIdentity_localId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LocalID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulAgentIdentity_localId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulAgentIdentity",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulAgentIdentity_ensName(ctx context.Context, field graphql.CollectedField, obj *model.SoulAgentIdentity) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulAgentIdentity_ensName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.EnsName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulAgentIdentity_ensName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulAgentIdentity",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulAgentIdentity_wallet(ctx context.Context, field graphql.CollectedField, obj *model.SoulAgentIdentity) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulAgentIdentity_wallet(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Wallet, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulAgentIdentity_wallet(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulAgentIdentity",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulAgentIdentity_principalAddress(ctx context.Context, field graphql.CollectedField, obj *model.SoulAgentIdentity) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulAgentIdentity_principalAddress(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PrincipalAddress, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulAgentIdentity_principalAddress(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulAgentIdentity",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulAgentIdentity_status(ctx context.Context, field graphql.CollectedField, obj *model.SoulAgentIdentity) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulAgentIdentity_status(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Status, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulAgentIdentity_status(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulAgentIdentity",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulAgentIdentity_lifecycleStatus(ctx context.Context, field graphql.CollectedField, obj *model.SoulAgentIdentity) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulAgentIdentity_lifecycleStatus(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LifecycleStatus, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulAgentIdentity_lifecycleStatus(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulAgentIdentity",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulAgentIdentity_selfDescriptionVersion(ctx context.Context, field graphql.CollectedField, obj *model.SoulAgentIdentity) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulAgentIdentity_selfDescriptionVersion(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SelfDescriptionVersion, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulAgentIdentity_selfDescriptionVersion(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulAgentIdentity",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulAgentIdentity_capabilities(ctx context.Context, field graphql.CollectedField, obj *model.SoulAgentIdentity) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulAgentIdentity_capabilities(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Capabilities, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulAgentIdentity_capabilities(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulAgentIdentity",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulAgentIdentity_mintTxHash(ctx context.Context, field graphql.CollectedField, obj *model.SoulAgentIdentity) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulAgentIdentity_mintTxHash(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.MintTxHash, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulAgentIdentity_mintTxHash(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulAgentIdentity",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulAgentIdentity_mintedAt(ctx context.Context, field graphql.CollectedField, obj *model.SoulAgentIdentity) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulAgentIdentity_mintedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.MintedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulAgentIdentity_mintedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulAgentIdentity",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulAgentIdentity_updatedAt(ctx context.Context, field graphql.CollectedField, obj *model.SoulAgentIdentity) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulAgentIdentity_updatedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulAgentIdentity_updatedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulAgentIdentity",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBodyBinding_username(ctx context.Context, field graphql.CollectedField, obj *model.SoulBodyBinding) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBodyBinding_username(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Username, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBodyBinding_username(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBodyBinding",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBodyBinding_principalAddress(ctx context.Context, field graphql.CollectedField, obj *model.SoulBodyBinding) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBodyBinding_principalAddress(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PrincipalAddress, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBodyBinding_principalAddress(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBodyBinding",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBodyBinding_boundAt(ctx context.Context, field graphql.CollectedField, obj *model.SoulBodyBinding) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBodyBinding_boundAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BoundAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.Time)
+	fc.Result = res
+	return ec.marshalNTime2githubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBodyBinding_boundAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBodyBinding",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBodyBinding_updatedAt(ctx context.Context, field graphql.CollectedField, obj *model.SoulBodyBinding) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBodyBinding_updatedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.Time)
+	fc.Result = res
+	return ec.marshalNTime2githubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBodyBinding_updatedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBodyBinding",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulInventoryItem_agent(ctx context.Context, field graphql.CollectedField, obj *model.SoulInventoryItem) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulInventoryItem_agent(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Agent, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.SoulAgentIdentity)
+	fc.Result = res
+	return ec.marshalNSoulAgentIdentity2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulAgentIdentity(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulInventoryItem_agent(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulInventoryItem",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "agentId":
+				return ec.fieldContext_SoulAgentIdentity_agentId(ctx, field)
+			case "domain":
+				return ec.fieldContext_SoulAgentIdentity_domain(ctx, field)
+			case "localId":
+				return ec.fieldContext_SoulAgentIdentity_localId(ctx, field)
+			case "ensName":
+				return ec.fieldContext_SoulAgentIdentity_ensName(ctx, field)
+			case "wallet":
+				return ec.fieldContext_SoulAgentIdentity_wallet(ctx, field)
+			case "principalAddress":
+				return ec.fieldContext_SoulAgentIdentity_principalAddress(ctx, field)
+			case "status":
+				return ec.fieldContext_SoulAgentIdentity_status(ctx, field)
+			case "lifecycleStatus":
+				return ec.fieldContext_SoulAgentIdentity_lifecycleStatus(ctx, field)
+			case "selfDescriptionVersion":
+				return ec.fieldContext_SoulAgentIdentity_selfDescriptionVersion(ctx, field)
+			case "capabilities":
+				return ec.fieldContext_SoulAgentIdentity_capabilities(ctx, field)
+			case "mintTxHash":
+				return ec.fieldContext_SoulAgentIdentity_mintTxHash(ctx, field)
+			case "mintedAt":
+				return ec.fieldContext_SoulAgentIdentity_mintedAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_SoulAgentIdentity_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SoulAgentIdentity", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulInventoryItem_bindingState(ctx context.Context, field graphql.CollectedField, obj *model.SoulInventoryItem) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulInventoryItem_bindingState(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BindingState, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.SoulBindingState)
+	fc.Result = res
+	return ec.marshalNSoulBindingState2githubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBindingState(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulInventoryItem_bindingState(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulInventoryItem",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type SoulBindingState does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulInventoryItem_availableForIncorporation(ctx context.Context, field graphql.CollectedField, obj *model.SoulInventoryItem) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulInventoryItem_availableForIncorporation(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AvailableForIncorporation, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulInventoryItem_availableForIncorporation(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulInventoryItem",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulInventoryItem_binding(ctx context.Context, field graphql.CollectedField, obj *model.SoulInventoryItem) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulInventoryItem_binding(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Binding, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.SoulBodyBinding)
+	fc.Result = res
+	return ec.marshalOSoulBodyBinding2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBodyBinding(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulInventoryItem_binding(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulInventoryItem",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "username":
+				return ec.fieldContext_SoulBodyBinding_username(ctx, field)
+			case "principalAddress":
+				return ec.fieldContext_SoulBodyBinding_principalAddress(ctx, field)
+			case "boundAt":
+				return ec.fieldContext_SoulBodyBinding_boundAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_SoulBodyBinding_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SoulBodyBinding", field.Name)
 		},
 	}
 	return fc, nil
@@ -144298,6 +145563,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "incorporateSoul":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_incorporateSoul(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -149369,6 +150641,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "mySouls":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_mySouls(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "__type":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Query___type(ctx, field)
@@ -151359,6 +152653,186 @@ func (ec *executionContext) _SeveredRelationshipEdge(ctx context.Context, sel as
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var soulAgentIdentityImplementors = []string{"SoulAgentIdentity"}
+
+func (ec *executionContext) _SoulAgentIdentity(ctx context.Context, sel ast.SelectionSet, obj *model.SoulAgentIdentity) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, soulAgentIdentityImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("SoulAgentIdentity")
+		case "agentId":
+			out.Values[i] = ec._SoulAgentIdentity_agentId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "domain":
+			out.Values[i] = ec._SoulAgentIdentity_domain(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "localId":
+			out.Values[i] = ec._SoulAgentIdentity_localId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "ensName":
+			out.Values[i] = ec._SoulAgentIdentity_ensName(ctx, field, obj)
+		case "wallet":
+			out.Values[i] = ec._SoulAgentIdentity_wallet(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "principalAddress":
+			out.Values[i] = ec._SoulAgentIdentity_principalAddress(ctx, field, obj)
+		case "status":
+			out.Values[i] = ec._SoulAgentIdentity_status(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "lifecycleStatus":
+			out.Values[i] = ec._SoulAgentIdentity_lifecycleStatus(ctx, field, obj)
+		case "selfDescriptionVersion":
+			out.Values[i] = ec._SoulAgentIdentity_selfDescriptionVersion(ctx, field, obj)
+		case "capabilities":
+			out.Values[i] = ec._SoulAgentIdentity_capabilities(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "mintTxHash":
+			out.Values[i] = ec._SoulAgentIdentity_mintTxHash(ctx, field, obj)
+		case "mintedAt":
+			out.Values[i] = ec._SoulAgentIdentity_mintedAt(ctx, field, obj)
+		case "updatedAt":
+			out.Values[i] = ec._SoulAgentIdentity_updatedAt(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var soulBodyBindingImplementors = []string{"SoulBodyBinding"}
+
+func (ec *executionContext) _SoulBodyBinding(ctx context.Context, sel ast.SelectionSet, obj *model.SoulBodyBinding) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, soulBodyBindingImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("SoulBodyBinding")
+		case "username":
+			out.Values[i] = ec._SoulBodyBinding_username(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "principalAddress":
+			out.Values[i] = ec._SoulBodyBinding_principalAddress(ctx, field, obj)
+		case "boundAt":
+			out.Values[i] = ec._SoulBodyBinding_boundAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "updatedAt":
+			out.Values[i] = ec._SoulBodyBinding_updatedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var soulInventoryItemImplementors = []string{"SoulInventoryItem"}
+
+func (ec *executionContext) _SoulInventoryItem(ctx context.Context, sel ast.SelectionSet, obj *model.SoulInventoryItem) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, soulInventoryItemImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("SoulInventoryItem")
+		case "agent":
+			out.Values[i] = ec._SoulInventoryItem_agent(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "bindingState":
+			out.Values[i] = ec._SoulInventoryItem_bindingState(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "availableForIncorporation":
+			out.Values[i] = ec._SoulInventoryItem_availableForIncorporation(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "binding":
+			out.Values[i] = ec._SoulInventoryItem_binding(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -162517,6 +163991,84 @@ func (ec *executionContext) marshalNSeveredRelationshipEdge2ᚖgithubᚗcomᚋeq
 	return ec._SeveredRelationshipEdge(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNSoulAgentIdentity2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulAgentIdentity(ctx context.Context, sel ast.SelectionSet, v *model.SoulAgentIdentity) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._SoulAgentIdentity(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNSoulBindingState2githubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBindingState(ctx context.Context, v any) (model.SoulBindingState, error) {
+	var res model.SoulBindingState
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNSoulBindingState2githubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBindingState(ctx context.Context, sel ast.SelectionSet, v model.SoulBindingState) graphql.Marshaler {
+	return v
+}
+
+func (ec *executionContext) marshalNSoulInventoryItem2githubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulInventoryItem(ctx context.Context, sel ast.SelectionSet, v model.SoulInventoryItem) graphql.Marshaler {
+	return ec._SoulInventoryItem(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNSoulInventoryItem2ᚕᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulInventoryItemᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.SoulInventoryItem) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNSoulInventoryItem2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulInventoryItem(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNSoulInventoryItem2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulInventoryItem(ctx context.Context, sel ast.SelectionSet, v *model.SoulInventoryItem) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._SoulInventoryItem(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNSpamIndicator2ᚕᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSpamIndicatorᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.SpamIndicator) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
@@ -165392,6 +166944,13 @@ func (ec *executionContext) marshalOSeveranceDetails2ᚖgithubᚗcomᚋequaltoai
 		return graphql.Null
 	}
 	return ec._SeveranceDetails(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOSoulBodyBinding2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBodyBinding(ctx context.Context, sel ast.SelectionSet, v *model.SoulBodyBinding) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._SoulBodyBinding(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOSpamAnalysis2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSpamAnalysis(ctx context.Context, sel ast.SelectionSet, v *model.SpamAnalysis) graphql.Marshaler {

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -2329,6 +2329,36 @@ type SeveredRelationshipEdge struct {
 	Cursor Cursor               `json:"cursor"`
 }
 
+type SoulAgentIdentity struct {
+	AgentID                string   `json:"agentId"`
+	Domain                 string   `json:"domain"`
+	LocalID                string   `json:"localId"`
+	EnsName                *string  `json:"ensName,omitempty"`
+	Wallet                 string   `json:"wallet"`
+	PrincipalAddress       *string  `json:"principalAddress,omitempty"`
+	Status                 string   `json:"status"`
+	LifecycleStatus        *string  `json:"lifecycleStatus,omitempty"`
+	SelfDescriptionVersion *int     `json:"selfDescriptionVersion,omitempty"`
+	Capabilities           []string `json:"capabilities"`
+	MintTxHash             *string  `json:"mintTxHash,omitempty"`
+	MintedAt               *Time    `json:"mintedAt,omitempty"`
+	UpdatedAt              *Time    `json:"updatedAt,omitempty"`
+}
+
+type SoulBodyBinding struct {
+	Username         string  `json:"username"`
+	PrincipalAddress *string `json:"principalAddress,omitempty"`
+	BoundAt          Time    `json:"boundAt"`
+	UpdatedAt        Time    `json:"updatedAt"`
+}
+
+type SoulInventoryItem struct {
+	Agent                     *SoulAgentIdentity `json:"agent"`
+	BindingState              SoulBindingState   `json:"bindingState"`
+	AvailableForIncorporation bool               `json:"availableForIncorporation"`
+	Binding                   *SoulBodyBinding   `json:"binding,omitempty"`
+}
+
 type SpamAnalysis struct {
 	SpamScore       float64          `json:"spamScore"`
 	SpamIndicators  []*SpamIndicator `json:"spamIndicators"`
@@ -5483,6 +5513,61 @@ func (e *SeveranceReason) UnmarshalJSON(b []byte) error {
 }
 
 func (e SeveranceReason) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
+type SoulBindingState string
+
+const (
+	SoulBindingStateUnbound SoulBindingState = "UNBOUND"
+	SoulBindingStateBound   SoulBindingState = "BOUND"
+)
+
+var AllSoulBindingState = []SoulBindingState{
+	SoulBindingStateUnbound,
+	SoulBindingStateBound,
+}
+
+func (e SoulBindingState) IsValid() bool {
+	switch e {
+	case SoulBindingStateUnbound, SoulBindingStateBound:
+		return true
+	}
+	return false
+}
+
+func (e SoulBindingState) String() string {
+	return string(e)
+}
+
+func (e *SoulBindingState) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = SoulBindingState(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid SoulBindingState", str)
+	}
+	return nil
+}
+
+func (e SoulBindingState) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *SoulBindingState) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e SoulBindingState) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
 	e.MarshalGQL(&buf)
 	return buf.Bytes(), nil

--- a/graph/mutation_resolvers_souls.go
+++ b/graph/mutation_resolvers_souls.go
@@ -1,0 +1,48 @@
+package graph
+
+import (
+	"context"
+	"strings"
+
+	"github.com/equaltoai/lesser/graph/model"
+	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/common"
+	apperrors "github.com/equaltoai/lesser/pkg/errors"
+	"go.uber.org/zap"
+)
+
+// IncorporateSoul covers POST /api/v1/souls/{agentId}/incorporate.
+func (r *mutationResolver) IncorporateSoul(ctx context.Context, agentID string) (*model.SoulInventoryItem, error) {
+	claims, err := r.requireAuthClaims(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !claims.HasScope(auth.ScopeWrite) {
+		return nil, apperrors.InsufficientScope(auth.ScopeWrite)
+	}
+
+	agentID = strings.TrimSpace(agentID)
+	if err := common.ValidateRequiredParam("agentId", agentID); err != nil {
+		return nil, err
+	}
+
+	service, err := r.getSoulService()
+	if err != nil {
+		return nil, err
+	}
+
+	soul, err := service.Incorporate(ctx, claims.Username, agentID)
+	if err != nil {
+		if r.Logger != nil {
+			r.Logger.Error(
+				"failed to incorporate soul",
+				zap.String("username", claims.Username),
+				zap.String("agent_id", agentID),
+				zap.Error(err),
+			)
+		}
+		return nil, mapSoulServiceError(err)
+	}
+
+	return toGraphQLSoulInventoryItem(claims.Username, *soul), nil
+}

--- a/graph/query_resolvers_souls.go
+++ b/graph/query_resolvers_souls.go
@@ -1,0 +1,44 @@
+package graph
+
+import (
+	"context"
+
+	"github.com/equaltoai/lesser/graph/model"
+	"github.com/equaltoai/lesser/pkg/auth"
+	apperrors "github.com/equaltoai/lesser/pkg/errors"
+	"go.uber.org/zap"
+)
+
+// MySouls covers GET /api/v1/souls/mine.
+func (r *queryResolver) MySouls(ctx context.Context) ([]*model.SoulInventoryItem, error) {
+	claims, err := r.requireAuthClaims(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !claims.HasScope(auth.ScopeRead) && !claims.HasScope(auth.ScopeWrite) {
+		return nil, apperrors.NewAuthError(
+			apperrors.CodeInsufficientScope,
+			"insufficient scope: requires one of read, write",
+		)
+	}
+
+	service, err := r.getSoulService()
+	if err != nil {
+		return nil, err
+	}
+
+	souls, err := service.ListMine(ctx, claims.Username)
+	if err != nil {
+		if r.Logger != nil {
+			r.Logger.Error("failed to list souls", zap.String("username", claims.Username), zap.Error(err))
+		}
+		return nil, mapSoulServiceError(err)
+	}
+
+	items := make([]*model.SoulInventoryItem, 0, len(souls))
+	for _, soul := range souls {
+		items = append(items, toGraphQLSoulInventoryItem(claims.Username, soul))
+	}
+
+	return items, nil
+}

--- a/graph/resolver.go
+++ b/graph/resolver.go
@@ -9,6 +9,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/mastodon"
 	"github.com/equaltoai/lesser/pkg/services"
 	"github.com/equaltoai/lesser/pkg/services/notes"
+	soulservice "github.com/equaltoai/lesser/pkg/services/souls"
 	"github.com/equaltoai/lesser/pkg/storage/core"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"go.uber.org/zap"
@@ -22,6 +23,11 @@ type notesService interface {
 	HasReblogged(context.Context, string, string) (bool, error)
 }
 
+type soulInventoryService interface {
+	ListMine(context.Context, string) ([]soulservice.Soul, error)
+	Incorporate(context.Context, string, string) (*soulservice.Soul, error)
+}
+
 // This file will not be regenerated automatically.
 //
 // It serves as dependency injection for your app, add any dependencies you require here.
@@ -33,6 +39,8 @@ type Resolver struct {
 	Registry *services.Registry
 	// Optional override used in tests to bypass the service registry
 	notesClient notesService
+	// Optional override used in tests for the souls inventory/incorporation service
+	soulsClient soulInventoryService
 
 	// Legacy fields (to be phased out)
 	Config              *config.Config

--- a/graph/souls_graphql_helpers.go
+++ b/graph/souls_graphql_helpers.go
@@ -1,0 +1,62 @@
+package graph
+
+import (
+	"strings"
+	"time"
+
+	"github.com/equaltoai/lesser/graph/model"
+	soulservice "github.com/equaltoai/lesser/pkg/services/souls"
+)
+
+func toGraphQLSoulInventoryItem(currentUsername string, soul soulservice.Soul) *model.SoulInventoryItem {
+	bindingState := model.SoulBindingStateUnbound
+	available := true
+	var binding *model.SoulBodyBinding
+
+	if soul.Bound {
+		bindingState = model.SoulBindingStateBound
+		available = strings.EqualFold(strings.TrimSpace(soul.BoundUsername), strings.TrimSpace(currentUsername))
+		binding = &model.SoulBodyBinding{
+			Username:         strings.TrimSpace(soul.BoundUsername),
+			PrincipalAddress: optionalString(soul.BoundPrincipalAddress),
+			BoundAt:          model.Time(soul.BoundAt),
+			UpdatedAt:        model.Time(soul.BoundUpdatedAt),
+		}
+	}
+
+	return &model.SoulInventoryItem{
+		Agent: &model.SoulAgentIdentity{
+			AgentID:                strings.TrimSpace(soul.AgentID),
+			Domain:                 strings.TrimSpace(soul.Domain),
+			LocalID:                strings.TrimSpace(soul.LocalID),
+			EnsName:                optionalTrimmedStringPtr(soul.ENSName),
+			Wallet:                 strings.TrimSpace(soul.Wallet),
+			PrincipalAddress:       optionalString(soul.PrincipalAddress),
+			Status:                 strings.TrimSpace(soul.Status),
+			LifecycleStatus:        optionalString(soul.LifecycleStatus),
+			SelfDescriptionVersion: soul.SelfDescriptionVersion,
+			Capabilities:           append([]string{}, soul.Capabilities...),
+			MintTxHash:             optionalString(soul.MintTxHash),
+			MintedAt:               optionalTimePtr(soul.MintedAt),
+			UpdatedAt:              optionalTimePtr(soul.UpdatedAt),
+		},
+		BindingState:              bindingState,
+		AvailableForIncorporation: available,
+		Binding:                   binding,
+	}
+}
+
+func optionalTrimmedStringPtr(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	return optionalString(*value)
+}
+
+func optionalTimePtr(value *time.Time) *model.Time {
+	if value == nil || value.IsZero() {
+		return nil
+	}
+	t := model.Time(*value)
+	return &t
+}

--- a/graph/souls_round12_test.go
+++ b/graph/souls_round12_test.go
@@ -1,0 +1,254 @@
+package graph
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/common"
+	apperrors "github.com/equaltoai/lesser/pkg/errors"
+	soulservice "github.com/equaltoai/lesser/pkg/services/souls"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type stubSoulService struct {
+	listMineFunc    func(context.Context, string) ([]soulservice.Soul, error)
+	incorporateFunc func(context.Context, string, string) (*soulservice.Soul, error)
+}
+
+func (s *stubSoulService) ListMine(ctx context.Context, username string) ([]soulservice.Soul, error) {
+	if s.listMineFunc == nil {
+		return nil, nil
+	}
+	return s.listMineFunc(ctx, username)
+}
+
+func (s *stubSoulService) Incorporate(ctx context.Context, username string, agentID string) (*soulservice.Soul, error) {
+	if s.incorporateFunc == nil {
+		return nil, nil
+	}
+	return s.incorporateFunc(ctx, username, agentID)
+}
+
+func soulAuthContext(username string, scopes ...string) context.Context {
+	return context.WithValue(context.Background(), common.ContextKeyClaims, &auth.Claims{
+		Username: username,
+		Scopes:   scopes,
+	})
+}
+
+func TestRound12SoulServiceHelpers_GetSoulService(t *testing.T) {
+	var nilResolver *Resolver
+	_, err := nilResolver.getSoulService()
+	require.Error(t, err)
+
+	resolver := &Resolver{}
+	_, err = resolver.getSoulService()
+	require.Error(t, err)
+
+	withOverride := &Resolver{
+		soulsClient: &stubSoulService{},
+	}
+	svc, err := withOverride.getSoulService()
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+
+	fullResolver, _ := newRound12GraphResolver(t)
+	svc, err = fullResolver.getSoulService()
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+}
+
+func TestRound12SoulsGraphQLHelpers_ConvertInventoryItem(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	ensName := "alice.eth"
+	blankENS := "   "
+
+	bound := toGraphQLSoulInventoryItem("alice", soulservice.Soul{
+		AgentID:                "0x123",
+		Domain:                 "souls.example",
+		LocalID:                "alice-soul",
+		ENSName:                &ensName,
+		Wallet:                 "0xabc",
+		PrincipalAddress:       "0xabc",
+		Status:                 "active",
+		LifecycleStatus:        "active",
+		SelfDescriptionVersion: intPtr(7),
+		Capabilities:           nil,
+		MintTxHash:             "0xmint",
+		MintedAt:               &now,
+		UpdatedAt:              &now,
+		Bound:                  true,
+		BoundUsername:          "alice",
+		BoundPrincipalAddress:  "0xabc",
+		BoundAt:                now,
+		BoundUpdatedAt:         now,
+	})
+	require.NotNil(t, bound)
+	require.Equal(t, "alice.eth", *bound.Agent.EnsName)
+	require.Equal(t, "0xabc", *bound.Agent.PrincipalAddress)
+	require.NotNil(t, bound.Agent.MintedAt)
+	require.NotNil(t, bound.Agent.UpdatedAt)
+	require.NotNil(t, bound.Binding)
+	require.Equal(t, "alice", bound.Binding.Username)
+	require.Equal(t, "0xabc", *bound.Binding.PrincipalAddress)
+	require.True(t, bound.AvailableForIncorporation)
+	require.Equal(t, "BOUND", bound.BindingState.String())
+	require.NotNil(t, bound.Agent.Capabilities)
+	require.Empty(t, bound.Agent.Capabilities)
+
+	unbound := toGraphQLSoulInventoryItem("alice", soulservice.Soul{
+		AgentID:         "0x456",
+		Domain:          "souls.example",
+		LocalID:         "blank-ens",
+		ENSName:         &blankENS,
+		Wallet:          "0xdef",
+		Status:          "active",
+		LifecycleStatus: "   ",
+		MintTxHash:      "   ",
+		Capabilities:    []string{"chat"},
+	})
+	require.NotNil(t, unbound)
+	require.Nil(t, unbound.Agent.EnsName)
+	require.Nil(t, unbound.Agent.PrincipalAddress)
+	require.Nil(t, unbound.Agent.LifecycleStatus)
+	require.Nil(t, unbound.Agent.MintTxHash)
+	require.Nil(t, unbound.Binding)
+	require.True(t, unbound.AvailableForIncorporation)
+	require.Equal(t, "UNBOUND", unbound.BindingState.String())
+	require.Equal(t, []string{"chat"}, unbound.Agent.Capabilities)
+}
+
+func TestRound12SoulsQuery_MySouls(t *testing.T) {
+	resolver := &Resolver{
+		Logger: zap.NewNop(),
+		soulsClient: &stubSoulService{
+			listMineFunc: func(_ context.Context, username string) ([]soulservice.Soul, error) {
+				require.Equal(t, "alice", username)
+				ensName := "alice.eth"
+				return []soulservice.Soul{
+					{
+						AgentID:       "0x1",
+						Domain:        "souls.example",
+						LocalID:       "bound-to-viewer",
+						ENSName:       &ensName,
+						Wallet:        "0xabc",
+						Status:        "active",
+						Bound:         true,
+						BoundUsername: "alice",
+					},
+					{
+						AgentID:       "0x2",
+						Domain:        "souls.example",
+						LocalID:       "bound-away",
+						Wallet:        "0xdef",
+						Status:        "active",
+						Bound:         true,
+						BoundUsername: "bob",
+					},
+				}, nil
+			},
+		},
+	}
+
+	items, err := (&queryResolver{resolver}).MySouls(soulAuthContext("alice", auth.ScopeRead))
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	require.True(t, items[0].AvailableForIncorporation)
+	require.False(t, items[1].AvailableForIncorporation)
+	require.Equal(t, "alice.eth", *items[0].Agent.EnsName)
+}
+
+func TestRound12SoulsQuery_MySouls_AuthAndErrors(t *testing.T) {
+	resolver := &Resolver{
+		Logger: zap.NewNop(),
+		soulsClient: &stubSoulService{
+			listMineFunc: func(context.Context, string) ([]soulservice.Soul, error) {
+				return nil, soulservice.ErrTrustNotConfigured
+			},
+		},
+	}
+	query := &queryResolver{resolver}
+
+	_, err := query.MySouls(context.Background())
+	require.Error(t, err)
+	require.True(t, apperrors.HasCode(err, apperrors.CodeUnauthorized))
+
+	_, err = query.MySouls(soulAuthContext("alice"))
+	require.Error(t, err)
+	require.True(t, apperrors.HasCode(err, apperrors.CodeInsufficientScope))
+
+	_, err = query.MySouls(soulAuthContext("alice", auth.ScopeWrite))
+	require.Error(t, err)
+	require.True(t, apperrors.HasCode(err, apperrors.CodeUnprocessableEntity))
+}
+
+func TestRound12SoulsMutation_IncorporateSoul(t *testing.T) {
+	resolver := &Resolver{
+		Logger: zap.NewNop(),
+		soulsClient: &stubSoulService{
+			incorporateFunc: func(_ context.Context, username string, agentID string) (*soulservice.Soul, error) {
+				require.Equal(t, "alice", username)
+				require.Equal(t, "0xabc", agentID)
+				now := time.Now().UTC().Truncate(time.Second)
+				return &soulservice.Soul{
+					AgentID:        agentID,
+					Domain:         "souls.example",
+					LocalID:        "alice-soul",
+					Wallet:         "0xwallet",
+					Status:         "active",
+					Bound:          true,
+					BoundUsername:  username,
+					BoundAt:        now,
+					BoundUpdatedAt: now,
+				}, nil
+			},
+		},
+	}
+	mut := &mutationResolver{resolver}
+
+	item, err := mut.IncorporateSoul(soulAuthContext("alice", auth.ScopeWrite), "0xabc")
+	require.NoError(t, err)
+	require.NotNil(t, item)
+	require.Equal(t, "alice-soul", item.Agent.LocalID)
+	require.Equal(t, "BOUND", item.BindingState.String())
+	require.True(t, item.AvailableForIncorporation)
+
+	_, err = mut.IncorporateSoul(soulAuthContext("alice", auth.ScopeRead), "0xabc")
+	require.Error(t, err)
+	require.True(t, apperrors.HasCode(err, apperrors.CodeInsufficientScope))
+
+	_, err = mut.IncorporateSoul(soulAuthContext("alice", auth.ScopeWrite), "   ")
+	require.Error(t, err)
+}
+
+func TestRound12SoulsMutation_IncorporateSoul_ErrorMapping(t *testing.T) {
+	resolver := &Resolver{
+		Logger: zap.NewNop(),
+		soulsClient: &stubSoulService{
+			incorporateFunc: func(context.Context, string, string) (*soulservice.Soul, error) {
+				return nil, soulservice.ErrSoulAlreadyBound
+			},
+		},
+	}
+
+	_, err := (&mutationResolver{resolver}).IncorporateSoul(soulAuthContext("alice", auth.ScopeWrite), "0xabc")
+	require.Error(t, err)
+	require.True(t, apperrors.HasCode(err, apperrors.CodeConflict))
+
+	resolver.soulsClient = &stubSoulService{
+		incorporateFunc: func(context.Context, string, string) (*soulservice.Soul, error) {
+			return nil, soulservice.ErrSoulNotAvailable
+		},
+	}
+
+	_, err = (&mutationResolver{resolver}).IncorporateSoul(soulAuthContext("alice", auth.ScopeWrite), "0xabc")
+	require.Error(t, err)
+	require.True(t, apperrors.HasCode(err, apperrors.CodeNotFound))
+}
+
+func intPtr(value int) *int {
+	return &value
+}

--- a/graph/souls_service_helpers.go
+++ b/graph/souls_service_helpers.go
@@ -1,0 +1,66 @@
+package graph
+
+import (
+	"errors"
+
+	apperrors "github.com/equaltoai/lesser/pkg/errors"
+	soulservice "github.com/equaltoai/lesser/pkg/services/souls"
+	"go.uber.org/zap"
+)
+
+func (r *Resolver) getSoulService() (soulInventoryService, error) {
+	if r == nil {
+		return nil, errors.New("resolver is nil")
+	}
+	if r.soulsClient != nil {
+		return r.soulsClient, nil
+	}
+	if r.Config == nil {
+		return nil, errors.New("config is not available")
+	}
+
+	storage := r.Storage
+	if storage == nil && r.Registry != nil {
+		storage = r.Registry.GetStorage()
+	}
+	if storage == nil {
+		return nil, ErrStorageUnavailable
+	}
+
+	logger := r.Logger
+	if logger == nil && r.Registry != nil {
+		logger = r.Registry.GetLogger()
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	return soulservice.NewService(storage.Account(), storage.Instance(), r.Config, logger), nil
+}
+
+func mapSoulServiceError(err error) error {
+	switch {
+	case errors.Is(err, soulservice.ErrTrustNotConfigured):
+		return apperrors.NewAppError(
+			apperrors.CodeUnprocessableEntity,
+			apperrors.CategoryBusiness,
+			"trust not configured",
+		)
+	case errors.Is(err, soulservice.ErrSoulNotAvailable):
+		return apperrors.NotFound("soul")
+	case errors.Is(err, soulservice.ErrSoulAlreadyBound):
+		return apperrors.NewAppError(
+			apperrors.CodeConflict,
+			apperrors.CategoryBusiness,
+			"soul already bound to another local body",
+		)
+	case errors.Is(err, soulservice.ErrBodyAlreadyHasSoul):
+		return apperrors.NewAppError(
+			apperrors.CodeConflict,
+			apperrors.CategoryBusiness,
+			"local body already has a soul",
+		)
+	default:
+		return err
+	}
+}


### PR DESCRIPTION
## Summary
- add GraphQL souls inventory and incorporation operations with the same auth/scope expectations as the REST surface
- expose souls through generated GraphQL server/schema artifacts, including ENS and binding state
- update GraphQL coverage inventory so `/api/v1/souls/*` is enforced as GraphQL-covered instead of REST-only

## Verification
- GOTOOLCHAIN=auto GOCACHE=/home/aron/ai-workspace/codebases/equaltoai/lesser/tmp/go-cache go test ./graph
- bash scripts/verify_schema.sh
- GOTOOLCHAIN=auto GOCACHE=/home/aron/ai-workspace/codebases/equaltoai/lesser/tmp/go-cache go run ./tools/graphql_coverage --check --strict
- GOTOOLCHAIN=auto GOCACHE=/home/aron/ai-workspace/codebases/equaltoai/lesser/tmp/go-cache go run ./cmd/lesser verify ci