### PR TITLE
update github actions for node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -17,11 +20,11 @@ jobs:
       STAGE: dev
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
         id: setup-go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -36,7 +39,7 @@ jobs:
         run: bash scripts/install_ci_tools.sh
 
       - name: Cache Lesser XDG caches
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             tmp/xdg-cache/go${{ steps.setup-go.outputs.go-version }}
@@ -65,7 +68,7 @@ jobs:
 
       - name: Upload reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: reports
           path: report/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   publish:
     # Prevent duplicate releases when a workflow_dispatch run creates + pushes a tag.
@@ -24,12 +27,12 @@ jobs:
       RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.ref_name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -69,13 +72,22 @@ jobs:
         run: bash scripts/build_release_assets.sh "${RELEASE_VERSION}" dist/release
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ env.RELEASE_VERSION }}
-          files: |
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          assets=(
             dist/release/lesser-linux-amd64
             dist/release/lesser-linux-arm64
             dist/release/lesser-darwin-amd64
             dist/release/lesser-darwin-arm64
             dist/release/checksums.txt
             dist/release/lesser-release.json
+          )
+
+          if gh release view "${RELEASE_VERSION}" >/dev/null 2>&1; then
+            gh release upload "${RELEASE_VERSION}" "${assets[@]}" --clobber
+          else
+            gh release create "${RELEASE_VERSION}" "${assets[@]}" --verify-tag
+          fi


### PR DESCRIPTION
## Summary
- upgrade first-party GitHub Actions in CI and release workflows to Node 24 compatible majors
- replace `softprops/action-gh-release@v2` with an equivalent `gh release` step because the latest `v2` still runs on Node 20
- opt both workflows into Node 24 now with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`

## Validation
- `env GOTOOLCHAIN=go1.26.1 go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml .github/workflows/release.yml`
