### PR TITLE
fix issues 176-179 and stabilize verify ci

### DIFF
--- a/cmd/api/agent_safety_middleware.go
+++ b/cmd/api/agent_safety_middleware.go
@@ -179,15 +179,15 @@ func maybeApplyAgentErrorRateLockout(ctx *apptheory.Context, rateRepo *storageRe
 		return
 	}
 
-	_ = rateRepo.CheckAPIRateLimit(ctx.Context(), "agent:"+claims.Username, "agent_request_total", agentErrorRateCounterCap, agentErrorRateWindow)
+	_ = rateRepo.CheckAPIRateLimit(ctx.Context(), agentRateLimitUserID(claims.Username), "agent_request_total", agentErrorRateCounterCap, agentErrorRateWindow)
 	if !agentResponseCountsTowardLockout(ctx, resp, handlerErr) {
 		return
 	}
 
-	_ = rateRepo.CheckAPIRateLimit(ctx.Context(), "agent:"+claims.Username, "agent_request_error", agentErrorRateCounterCap, agentErrorRateWindow)
+	_ = rateRepo.CheckAPIRateLimit(ctx.Context(), agentRateLimitUserID(claims.Username), "agent_request_error", agentErrorRateCounterCap, agentErrorRateWindow)
 
-	totalRemaining, _, _ := rateRepo.GetAPIRateLimitInfo(ctx.Context(), "agent:"+claims.Username, "agent_request_total", agentErrorRateCounterCap, agentErrorRateWindow)
-	errorRemaining, _, _ := rateRepo.GetAPIRateLimitInfo(ctx.Context(), "agent:"+claims.Username, "agent_request_error", agentErrorRateCounterCap, agentErrorRateWindow)
+	totalRemaining, _, _ := rateRepo.GetAPIRateLimitInfo(ctx.Context(), agentRateLimitUserID(claims.Username), "agent_request_total", agentErrorRateCounterCap, agentErrorRateWindow)
+	errorRemaining, _, _ := rateRepo.GetAPIRateLimitInfo(ctx.Context(), agentRateLimitUserID(claims.Username), "agent_request_error", agentErrorRateCounterCap, agentErrorRateWindow)
 
 	totalCount := agentErrorRateCounterCap - totalRemaining
 	errorCount := agentErrorRateCounterCap - errorRemaining
@@ -342,6 +342,14 @@ func agentClaimsFromContext(ctx *apptheory.Context) *auth.Claims {
 }
 
 func agentLockoutIdentifier(username string) string {
+	username = strings.TrimSpace(username)
+	if username == "" {
+		return "agent:unknown"
+	}
+	return agentRateLimitUserID(username)
+}
+
+func agentRateLimitUserID(username string) string {
 	username = strings.TrimSpace(username)
 	if username == "" {
 		return "agent:unknown"

--- a/cmd/api/agent_safety_middleware_round21_error_rate_lockout_test.go
+++ b/cmd/api/agent_safety_middleware_round21_error_rate_lockout_test.go
@@ -322,6 +322,7 @@ func TestAgentSafetyHelpers_Round21(t *testing.T) {
 	t.Run("identifier helpers", func(t *testing.T) {
 		require.Equal(t, "agent:unknown", agentLockoutIdentifier(""))
 		require.Equal(t, "agent:alice", agentLockoutIdentifier("Alice"))
+		require.Equal(t, "agent:alice", agentRateLimitUserID("Alice"))
 		require.Equal(t, "cli:unknown", cliAutomationLockoutIdentifier(""))
 		require.Equal(t, "cli:sid", cliAutomationLockoutIdentifier("SID"))
 	})

--- a/cmd/api/handlers/accounts.go
+++ b/cmd/api/handlers/accounts.go
@@ -169,6 +169,158 @@ func (h *Handler) mastodonAccountFromStorageAccount(account *storage.Account) (m
 	return out, nil
 }
 
+func (h *Handler) publicAccountFromStorageAccount(account *storage.Account) models.Account {
+	if mastodonAccount, err := h.mastodonAccountFromStorageAccount(account); err == nil {
+		return mastodonAccount
+	}
+
+	if account != nil && account.Actor != nil {
+		out := transformations.ActorToAccountBase(account.Actor, handlerBaseURL(h))
+		ensureMastodonAccountCollections(&out)
+		return out
+	}
+
+	return models.Account{}
+}
+
+func (h *Handler) publicAccountFromActor(ctx context.Context, actor *activitypub.Actor) models.Account {
+	if actor == nil {
+		return models.Account{}
+	}
+
+	if localAccount, err := h.localStorageAccountForActor(ctx, actor); err == nil && localAccount != nil {
+		return h.publicAccountFromStorageAccount(localAccount)
+	}
+
+	out := transformations.ActorToAccountBase(actor, handlerBaseURL(h))
+	ensureMastodonAccountCollections(&out)
+	return out
+}
+
+func (h *Handler) lookupStorageAccountByID(ctx context.Context, accountID string) (*storage.Account, error) {
+	if h != nil && h.registry != nil && h.registry.Accounts() != nil {
+		account, err := h.registry.Accounts().GetAccount(ctx, accountID)
+		if err == nil && account != nil {
+			return account, nil
+		}
+		if !shouldFallbackAccountResolution(accountID) {
+			if err != nil {
+				return nil, err
+			}
+			return nil, fmt.Errorf("account not found")
+		}
+	}
+
+	if h != nil && (h.registry == nil || h.registry.Accounts() == nil) && h.repos != nil && h.repos.Account() != nil {
+		normalizedID := strings.TrimSpace(accountID)
+		if normalizedID != "" {
+			account, err := h.repos.Account().GetAccount(ctx, normalizedID)
+			if err == nil && account != nil {
+				return account, nil
+			}
+		}
+	}
+
+	if h == nil || h.repos == nil {
+		return nil, fmt.Errorf("account not found")
+	}
+
+	actor, err := h.resolveAccountID(ctx, accountID)
+	if err != nil {
+		return nil, err
+	}
+	if actor == nil {
+		return nil, fmt.Errorf("account not found")
+	}
+
+	if localAccount, err := h.localStorageAccountForActor(ctx, actor); err == nil && localAccount != nil {
+		return localAccount, nil
+	}
+
+	return storageAccountFromActor(actor), nil
+}
+
+func shouldFallbackAccountResolution(accountID string) bool {
+	normalized := normalizeResolvedAccountID(accountID)
+	normalized = strings.TrimSpace(normalized)
+	if normalized == "" {
+		return false
+	}
+	if strings.HasPrefix(normalized, "https://") || strings.HasPrefix(normalized, "http://") {
+		return true
+	}
+	if strings.Contains(normalized, "@") {
+		return true
+	}
+	return common.ValidateNumericID("account_id", normalized) == nil && len(normalized) >= 10
+}
+
+func (h *Handler) localStorageAccountForActor(ctx context.Context, actor *activitypub.Actor) (*storage.Account, error) {
+	if actor == nil || !h.actorAppearsLocal(actor) {
+		return nil, nil
+	}
+
+	username := strings.TrimSpace(actor.PreferredUsername)
+	if username == "" {
+		return nil, nil
+	}
+
+	if h != nil && h.registry != nil && h.registry.Accounts() != nil {
+		account, err := h.registry.Accounts().GetAccount(ctx, username)
+		if err == nil && account != nil {
+			if account.Actor == nil {
+				account.Actor = actor
+			}
+			return account, nil
+		}
+	}
+
+	if h != nil && h.repos != nil && h.repos.Account() != nil {
+		account, err := h.repos.Account().GetAccount(ctx, username)
+		if err == nil && account != nil {
+			if account.Actor == nil {
+				account.Actor = actor
+			}
+			return account, nil
+		}
+	}
+
+	return storageAccountFromActor(actor), nil
+}
+
+func (h *Handler) actorAppearsLocal(actor *activitypub.Actor) bool {
+	if actor == nil {
+		return false
+	}
+
+	baseURL := handlerBaseURL(h)
+	if baseURL != "" && strings.HasPrefix(strings.TrimSpace(actor.ID), baseURL+"/users/") {
+		return true
+	}
+
+	return !strings.Contains(strings.TrimSpace(actor.PreferredUsername), "@")
+}
+
+func storageAccountFromActor(actor *activitypub.Actor) *storage.Account {
+	if actor == nil {
+		return nil
+	}
+
+	username := strings.TrimSpace(actor.PreferredUsername)
+	if username == "" {
+		return nil
+	}
+
+	displayName := strings.TrimSpace(actor.Name)
+	return &storage.Account{
+		User: &storage.User{
+			Username:    username,
+			DisplayName: displayName,
+		},
+		Actor: actor,
+	}
+}
+
 func handlerBaseURL(h *Handler) string {
 	if h == nil || h.cfg == nil {
 		return ""
@@ -408,8 +560,7 @@ func (h *Handler) HandleGetAccountLift(ctx *apptheory.Context) (*apptheory.Respo
 		return common.RespondValidationError(ctx, err)
 	}
 
-	// Call Accounts service
-	account, err := h.registry.Accounts().GetAccount(ctx.Context(), accountID)
+	account, err := h.lookupStorageAccountByID(ctx.Context(), accountID)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			return common.RespondAccountNotFound(ctx)
@@ -418,7 +569,7 @@ func (h *Handler) HandleGetAccountLift(ctx *apptheory.Context) (*apptheory.Respo
 		return common.RespondInternalServerError(ctx)
 	}
 
-	return okJSON(account)
+	return okJSON(h.publicAccountFromStorageAccount(account))
 }
 
 // HandleAccountLookupLift looks up an account by username@domain
@@ -442,10 +593,7 @@ func (h *Handler) HandleAccountLookupLift(ctx *apptheory.Context) (*apptheory.Re
 		return common.RespondInternalServerError(ctx)
 	}
 
-	// Convert to Mastodon account format
-	mastodonAccount := transformations.ActorToAccountWithCounts(account.Actor, h.cfg.BaseURL(), 0, 0, 0)
-
-	return okJSON(mastodonAccount)
+	return okJSON(h.publicAccountFromStorageAccount(account))
 }
 
 // relationshipType represents the type of relationship being queried
@@ -505,9 +653,7 @@ func (h *Handler) handleAccountRelationshipsList(ctx *apptheory.Context, relType
 			continue
 		}
 
-		// Convert to account using the Actor from the account we already have
-		account := transformations.ActorToAccountBase(relatedAccount.Actor, h.cfg.BaseURL())
-		accounts = append(accounts, account)
+		accounts = append(accounts, h.publicAccountFromStorageAccount(relatedAccount))
 	}
 
 	resp, err := okJSON(accounts)
@@ -525,25 +671,22 @@ func (h *Handler) handleAccountRelationshipsList(ctx *apptheory.Context, relType
 }
 
 func (h *Handler) resolveRelationshipUsername(ctx context.Context, accountID string) (string, error) {
-	if h != nil && h.registry != nil && h.registry.Accounts() != nil {
-		account, err := h.registry.Accounts().GetAccount(ctx, accountID)
-		if err == nil && account != nil && account.Actor != nil {
-			username := strings.TrimSpace(account.Actor.PreferredUsername)
-			if username != "" {
-				return username, nil
-			}
-		}
-	}
-
-	actor, err := h.resolveAccountID(ctx, accountID)
+	account, err := h.lookupStorageAccountByID(ctx, accountID)
 	if err != nil {
 		return "", err
 	}
-	if actor == nil {
-		return "", errors.New("relationship not found")
+
+	if account != nil && account.User != nil {
+		username := strings.TrimSpace(account.User.Username)
+		if username != "" {
+			return username, nil
+		}
 	}
 
-	username := strings.TrimSpace(actor.PreferredUsername)
+	var username string
+	if account != nil && account.Actor != nil {
+		username = strings.TrimSpace(account.Actor.PreferredUsername)
+	}
 	if username == "" {
 		return "", errors.New("relationship not found")
 	}
@@ -606,7 +749,7 @@ func (h *Handler) HandleGetFamiliarFollowersLift(ctx *apptheory.Context) (*appth
 		apiAccounts := make([]models.Account, 0, len(familiarResult.Accounts))
 		for _, storageAccount := range familiarResult.Accounts {
 			if storageAccount.Actor != nil {
-				apiAccount := transformations.ActorToAccountBase(storageAccount.Actor, h.cfg.BaseURL())
+				apiAccount := h.publicAccountFromStorageAccount(storageAccount)
 				apiAccounts = append(apiAccounts, apiAccount)
 			}
 		}

--- a/cmd/api/handlers/accounts_round12_test.go
+++ b/cmd/api/handlers/accounts_round12_test.go
@@ -11,6 +11,7 @@ import (
 
 	apimodels "github.com/equaltoai/lesser/cmd/api/models"
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/services/accounts"
 	"github.com/equaltoai/lesser/pkg/storage"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
@@ -398,6 +399,58 @@ func TestAccountsRound12_AccountHandlers_ErrorBranches(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("HandleGetAccountLift_and_lookup_return_mastodon_identity", func(t *testing.T) {
+		createdAt := time.Date(2026, time.March, 1, 12, 0, 0, 0, time.UTC)
+		account := &storage.Account{
+			User: &storage.User{
+				Username:    "alice",
+				DisplayName: "Alice",
+				CreatedAt:   createdAt,
+			},
+			Actor: &activitypub.Actor{
+				BaseObject: activitypub.BaseObject{
+					ID:   cfg.ActorURL("alice"),
+					Type: "Person",
+				},
+				PreferredUsername: "alice",
+				Name:              "Alice",
+			},
+		}
+
+		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{}, &RegistryStub{
+			AccountsSvc: &AccountsServiceStub{
+				GetAccountFunc: func(context.Context, string) (*storage.Account, error) {
+					return account, nil
+				},
+				LookupAccountFunc: func(context.Context, *accounts.LookupAccountQuery) (*storage.Account, error) {
+					return account, nil
+				},
+			},
+		})
+
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/accounts/alice", nil, nil, nil)
+		require.NoError(t, err)
+		ctx.Params["id"] = "alice"
+
+		resp := requireStatus(t, http.StatusOK)(h.HandleGetAccountLift(ctx))
+		var got apimodels.Account
+		require.NoError(t, json.Unmarshal(resp.Body, &got))
+		require.Equal(t, common.GenerateNumericID("alice"), got.ID)
+		require.Equal(t, "alice", got.Username)
+		require.Equal(t, "alice", got.Acct)
+		require.Equal(t, "Alice", got.DisplayName)
+		require.Equal(t, cfg.BaseURL()+"/@alice", got.URL)
+
+		ctxLookup, err := round10NewLiftContext(http.MethodGet, "/api/v1/accounts/lookup", nil, map[string]string{"acct": "alice@example.com"}, nil)
+		require.NoError(t, err)
+
+		respLookup := requireStatus(t, http.StatusOK)(h.HandleAccountLookupLift(ctxLookup))
+		var lookedUp apimodels.Account
+		require.NoError(t, json.Unmarshal(respLookup.Body, &lookedUp))
+		require.Equal(t, common.GenerateNumericID("alice"), lookedUp.ID)
+		require.Equal(t, "alice", lookedUp.Username)
+	})
 }
 
 func TestAccountsRound12_RelationshipsAndActions(t *testing.T) {
@@ -460,7 +513,7 @@ func TestAccountsRound12_RelationshipsAndActions(t *testing.T) {
 	t.Run("handleAccountRelationshipsList_resolves_numeric_account_id", func(t *testing.T) {
 		const numericID = "446117837104852"
 
-		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{}, &RegistryStub{
+		h, baseRepos, _ := round11NewHandler(t, cfg, &round10QueryState{}, &RegistryStub{
 			AccountsSvc: &AccountsServiceStub{
 				GetAccountFunc: func(context.Context, string) (*storage.Account, error) {
 					return nil, errors.New("not found")
@@ -478,6 +531,7 @@ func TestAccountsRound12_RelationshipsAndActions(t *testing.T) {
 		actorRepo.On("GetActorByNumericID", mock.Anything, numericID).Return(actorAccount.Actor, nil).Once()
 
 		repos := &MockRepositoryStorage{}
+		repos.On("Account").Return(baseRepos.Account()).Maybe()
 		repos.On("Actor").Return(actorRepo).Maybe()
 		h.repos = repos
 

--- a/cmd/api/handlers/accounts_round20_helper_coverage_test.go
+++ b/cmd/api/handlers/accounts_round20_helper_coverage_test.go
@@ -1,0 +1,114 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountsRound20_PublicAccountFallbackHelpers(t *testing.T) {
+	cfg := round10TestConfig()
+	h := &Handler{cfg: cfg}
+
+	t.Run("public account helpers handle nil inputs", func(t *testing.T) {
+		require.Empty(t, h.publicAccountFromStorageAccount(nil))
+		require.Empty(t, h.publicAccountFromActor(context.Background(), nil))
+	})
+
+	t.Run("publicAccountFromStorageAccount falls back to actor conversion when user is missing", func(t *testing.T) {
+		actor := &activitypub.Actor{
+			BaseObject:        activitypub.BaseObject{ID: "https://remote.example/users/alice", Type: "Person"},
+			PreferredUsername: "alice@example.net",
+			Name:              "Alice",
+			URL:               "https://remote.example/@alice",
+		}
+
+		account := h.publicAccountFromStorageAccount(&storage.Account{Actor: actor})
+		require.Equal(t, actor.PreferredUsername, account.Username)
+		require.Equal(t, actor.Name, account.DisplayName)
+		require.Equal(t, actor.URL, account.URL)
+		require.NotNil(t, account.Emojis)
+		require.NotNil(t, account.Fields)
+	})
+
+	t.Run("publicAccountFromActor synthesizes local storage account data", func(t *testing.T) {
+		actor := &activitypub.Actor{
+			BaseObject:        activitypub.BaseObject{ID: cfg.BaseURL() + "/users/alice", Type: "Person"},
+			PreferredUsername: "alice",
+			Name:              "Alice",
+		}
+
+		account := h.publicAccountFromActor(context.Background(), actor)
+		require.Equal(t, "alice", account.Username)
+		require.Equal(t, "Alice", account.DisplayName)
+		require.Equal(t, cfg.BaseURL()+"/@alice", account.URL)
+		require.NotEmpty(t, account.ID)
+		require.NotNil(t, account.Emojis)
+		require.NotNil(t, account.Fields)
+	})
+
+	t.Run("publicAccountFromActor preserves remote actor fallback", func(t *testing.T) {
+		actor := &activitypub.Actor{
+			BaseObject:        activitypub.BaseObject{ID: "https://remote.example/users/bob", Type: "Person"},
+			PreferredUsername: "bob@example.net",
+			Name:              "Bob",
+			URL:               "https://remote.example/@bob",
+		}
+
+		account := h.publicAccountFromActor(context.Background(), actor)
+		require.Equal(t, actor.PreferredUsername, account.Username)
+		require.Equal(t, actor.Name, account.DisplayName)
+		require.Equal(t, actor.URL, account.URL)
+		require.NotNil(t, account.Emojis)
+		require.NotNil(t, account.Fields)
+	})
+}
+
+func TestAccountsRound20_AccountResolutionHelpers(t *testing.T) {
+	t.Run("storageAccountFromActor handles nil empty and valid actors", func(t *testing.T) {
+		require.Nil(t, storageAccountFromActor(nil))
+		require.Nil(t, storageAccountFromActor(&activitypub.Actor{PreferredUsername: "   "}))
+
+		actor := &activitypub.Actor{
+			BaseObject:        activitypub.BaseObject{ID: "https://example.com/users/alice", Type: "Person"},
+			PreferredUsername: "alice",
+			Name:              "Alice",
+		}
+
+		account := storageAccountFromActor(actor)
+		require.NotNil(t, account)
+		require.Equal(t, "alice", account.User.Username)
+		require.Equal(t, "Alice", account.User.DisplayName)
+		require.Same(t, actor, account.Actor)
+	})
+
+	t.Run("shouldFallbackAccountResolution recognizes public id shapes", func(t *testing.T) {
+		require.False(t, shouldFallbackAccountResolution(""))
+		require.False(t, shouldFallbackAccountResolution("alice"))
+		require.True(t, shouldFallbackAccountResolution("1234567890"))
+		require.True(t, shouldFallbackAccountResolution("https://example.com/users/alice"))
+		require.True(t, shouldFallbackAccountResolution("alice@example.com"))
+	})
+
+	t.Run("actorAppearsLocal honors base url and username style", func(t *testing.T) {
+		cfg := round10TestConfig()
+		h := &Handler{cfg: cfg}
+
+		require.False(t, h.actorAppearsLocal(nil))
+		require.True(t, h.actorAppearsLocal(&activitypub.Actor{
+			BaseObject:        activitypub.BaseObject{ID: cfg.BaseURL() + "/users/alice", Type: "Person"},
+			PreferredUsername: "alice@example.com",
+		}))
+		require.True(t, h.actorAppearsLocal(&activitypub.Actor{
+			BaseObject:        activitypub.BaseObject{ID: "https://remote.example/users/alice", Type: "Person"},
+			PreferredUsername: "alice",
+		}))
+		require.False(t, h.actorAppearsLocal(&activitypub.Actor{
+			BaseObject:        activitypub.BaseObject{ID: "https://remote.example/users/alice", Type: "Person"},
+			PreferredUsername: "alice@example.com",
+		}))
+	})
+}

--- a/cmd/api/handlers/agent_governance.go
+++ b/cmd/api/handlers/agent_governance.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"time"
@@ -223,6 +224,72 @@ func (h *Handler) HandleAdminUnverifyAgentLift(ctx *apptheory.Context) (*apptheo
 	})
 
 	return okJSON(agentFromStorageUser(account.User))
+}
+
+// HandleAdminUnlockAgentLift handles POST /api/v1/admin/agents/:username/unlock.
+func (h *Handler) HandleAdminUnlockAgentLift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	claims, err := h.authenticateWithScope(ctx, auth.ScopeAdmin)
+	if err != nil {
+		if isInsufficientScopeError(err) {
+			return common.RespondInsufficientScope(ctx, auth.ScopeAdmin)
+		}
+		return common.RespondUnauthorized(ctx)
+	}
+
+	if h.repos == nil || h.repos.Account() == nil || h.repos.RateLimit() == nil {
+		return common.RespondInternalServerError(ctx)
+	}
+
+	username := ctx.Param("username")
+	if err := common.ValidateUsernameParamID(username); err != nil {
+		return common.RespondValidationError(ctx, err)
+	}
+
+	var req apimodels.AdminUnlockAgentRequest
+	if err := common.ParseRequestWithFallback(ctx, &req); err != nil {
+		return common.RespondBadRequest(ctx, "invalid request body")
+	}
+
+	account, err := h.repos.Account().GetAccount(ctx.Context(), username)
+	if err != nil || account == nil || account.User == nil || !account.User.IsAgent {
+		return common.RespondNotFound(ctx, "agent")
+	}
+
+	if err := h.clearAgentSafetyState(ctx.Context(), account.User.Username); err != nil {
+		return common.RespondInternalServerError(ctx)
+	}
+
+	reason := strings.TrimSpace(req.Reason)
+	h.recordAgentGovernanceEvent(ctx, account.User.Username, "agent.unlocked", map[string]any{
+		"unlocked_by":         claims.Username,
+		"reason":              reason,
+		"rate_limit_subjects": agentRateLimitUserIDVariants(account.User.Username),
+	})
+
+	return okJSON(apimodels.AdminUnlockAgentResponse{
+		Username:   strings.TrimSpace(account.User.Username),
+		Unlocked:   true,
+		UnlockedBy: claims.Username,
+		Reason:     reason,
+		UnlockedAt: time.Now().UTC(),
+	})
+}
+
+func (h *Handler) clearAgentSafetyState(ctx context.Context, username string) error {
+	if h == nil || h.repos == nil || h.repos.RateLimit() == nil {
+		return nil
+	}
+
+	for _, subject := range agentRateLimitUserIDVariants(username) {
+		if err := h.repos.RateLimit().ClearLockout(ctx, subject); err != nil {
+			return err
+		}
+		if err := h.repos.RateLimit().ClearAPIRateLimitsForUser(ctx, subject); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (h *Handler) recordAgentGovernanceEvent(ctx *apptheory.Context, username string, eventType string, metadata map[string]any) {

--- a/cmd/api/handlers/agent_governance_round19_more_coverage_test.go
+++ b/cmd/api/handlers/agent_governance_round19_more_coverage_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"errors"
 	"math"
 	"net/http"
@@ -176,6 +177,101 @@ func TestAgentGovernanceRound19_AdminVerifyAndUnverify_ErrorBranches(t *testing.
 		unverifyCtx.Params["username"] = "agent"
 
 		requireStatus(t, http.StatusForbidden)(h.HandleAdminUnverifyAgentLift(unverifyCtx))
+	})
+}
+
+func TestAgentGovernanceRound19_AdminUnlockAgent_SuccessAndErrors(t *testing.T) {
+	cfg := round10TestConfig()
+	adminToken := round11SignAccessToken(t, cfg.JWTSecret, "admin", []string{auth.ScopeAdmin})
+	headers := map[string]string{"Authorization": "Bearer " + adminToken}
+
+	t.Run("invalid username returns 400", func(t *testing.T) {
+		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
+
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/admin/agents/not a username/unlock", headers, nil, apimodels.AdminUnlockAgentRequest{})
+		require.NoError(t, err)
+		ctx.Params["username"] = "not a username"
+
+		requireStatus(t, http.StatusBadRequest)(h.HandleAdminUnlockAgentLift(ctx))
+	})
+
+	t.Run("missing token returns 401", func(t *testing.T) {
+		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
+
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/admin/agents/agent/unlock", nil, nil, apimodels.AdminUnlockAgentRequest{})
+		require.NoError(t, err)
+		ctx.Params["username"] = "agent"
+
+		requireStatus(t, http.StatusUnauthorized)(h.HandleAdminUnlockAgentLift(ctx))
+	})
+
+	t.Run("agent not found returns 404", func(t *testing.T) {
+		state := &round10QueryState{
+			notFoundPKSK: map[string]bool{"USER#missing#METADATA": true},
+		}
+		h, _, _ := round11NewHandler(t, cfg, state)
+
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/admin/agents/missing/unlock", headers, nil, apimodels.AdminUnlockAgentRequest{})
+		require.NoError(t, err)
+		ctx.Params["username"] = "missing"
+
+		requireStatus(t, http.StatusNotFound)(h.HandleAdminUnlockAgentLift(ctx))
+	})
+
+	t.Run("rate limit clear failures return 500", func(t *testing.T) {
+		state := &round10QueryState{
+			usersByUsername: map[string]storagemodels.User{
+				"Agent-0": {
+					PK:       "USER#Agent-0",
+					SK:       storagemodels.SKMetadata,
+					Username: "Agent-0",
+					Role:     "user",
+					Approved: true,
+					Version:  1,
+					IsAgent:  true,
+				},
+			},
+			allErrorOnce: errors.New("boom"),
+		}
+		h, _, _ := round11NewHandler(t, cfg, state)
+
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/admin/agents/Agent-0/unlock", headers, nil, apimodels.AdminUnlockAgentRequest{})
+		require.NoError(t, err)
+		ctx.Params["username"] = "Agent-0"
+
+		requireStatus(t, http.StatusInternalServerError)(h.HandleAdminUnlockAgentLift(ctx))
+	})
+
+	t.Run("success returns unlock metadata", func(t *testing.T) {
+		state := &round10QueryState{
+			usersByUsername: map[string]storagemodels.User{
+				"Agent-0": {
+					PK:       "USER#Agent-0",
+					SK:       storagemodels.SKMetadata,
+					Username: "Agent-0",
+					Role:     "user",
+					Approved: true,
+					Version:  1,
+					IsAgent:  true,
+				},
+			},
+		}
+		h, _, _ := round11NewHandler(t, cfg, state)
+
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/admin/agents/Agent-0/unlock", headers, nil, apimodels.AdminUnlockAgentRequest{
+			Reason: "resume testing",
+		})
+		require.NoError(t, err)
+		ctx.Params["username"] = "Agent-0"
+
+		resp := requireStatus(t, http.StatusOK)(h.HandleAdminUnlockAgentLift(ctx))
+		var out apimodels.AdminUnlockAgentResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &out))
+		require.Equal(t, "Agent-0", out.Username)
+		require.True(t, out.Unlocked)
+		require.Equal(t, "admin", out.UnlockedBy)
+		require.Equal(t, "resume testing", out.Reason)
+		require.False(t, out.UnlockedAt.IsZero())
 	})
 }
 

--- a/cmd/api/handlers/agent_safety.go
+++ b/cmd/api/handlers/agent_safety.go
@@ -21,15 +21,15 @@ const (
 	agentMaxTagsPerPost = 5
 	agentMaxPostChars   = 500
 
-	agentRapidFireMaxPosts = 5
-	agentRapidFireWindow   = 10 * time.Second
+	agentRapidFireMaxPosts = 10
+	agentRapidFireWindow   = 30 * time.Second
 
-	agentRepetitionMax    = 3
-	agentRepetitionWindow = time.Hour
+	agentRepetitionMax    = 5
+	agentRepetitionWindow = 30 * time.Minute
 
 	agentDefaultMaxPostsPerHour         = 50
 	agentVerifiedDefaultMaxPostsPerHour = 200
-	agentLockoutDuration                = time.Hour
+	agentLockoutDuration                = 10 * time.Minute
 )
 
 func (h *Handler) enforceAgentStatusCreateRails(ctx *apptheory.Context, claims *auth.Claims, req *models.CreateStatusRequest) (*apptheory.Response, error) {
@@ -80,15 +80,15 @@ func (h *Handler) enforceAgentStatusCreateRails(ctx *apptheory.Context, claims *
 	if h.repos != nil && h.repos.RateLimit() != nil {
 		// Enforce per-hour posting cap (capability-driven, conservative default).
 		maxPerHour := h.agentMaxPostsPerHourLimit(ctx.Context(), agentUser)
-		if err := h.repos.RateLimit().CheckAPIRateLimit(ctx.Context(), "agent:"+claims.Username, "agent_posts_per_hour", maxPerHour, time.Hour); err != nil {
+		if err := h.repos.RateLimit().CheckAPIRateLimit(ctx.Context(), agentRateLimitUserID(claims.Username), "agent_posts_per_hour", maxPerHour, time.Hour); err != nil {
 			return apptheory.JSON(http.StatusTooManyRequests, map[string]any{
 				"error":             "too_many_requests",
 				"error_description": "agent post limit exceeded",
 			})
 		}
 
-		// Rapid-fire breaker: >5 posts in 10s => lockout.
-		if err := h.repos.RateLimit().CheckAPIRateLimit(ctx.Context(), "agent:"+claims.Username, "agent_posts_10s", agentRapidFireMaxPosts, agentRapidFireWindow); err != nil {
+		// Rapid-fire breaker: sustained bursts beyond the short testing envelope trigger a temporary lockout.
+		if err := h.repos.RateLimit().CheckAPIRateLimit(ctx.Context(), agentRateLimitUserID(claims.Username), "agent_posts_10s", agentRapidFireMaxPosts, agentRapidFireWindow); err != nil {
 			h.imposeAgentLockout(ctx.Context(), claims.Username, "rapid_fire")
 			return apptheory.JSON(http.StatusTooManyRequests, map[string]any{
 				"error":             "agent_locked",
@@ -96,10 +96,10 @@ func (h *Handler) enforceAgentStatusCreateRails(ctx *apptheory.Context, claims *
 			})
 		}
 
-		// Repetition breaker: identical content >3 times => lockout.
+		// Repetition breaker: repeated identical content within the short window triggers a temporary lockout.
 		hash := hashAgentContent(req.Status)
 		if hash != "" {
-			if err := h.repos.RateLimit().CheckAPIRateLimit(ctx.Context(), "agent:"+claims.Username, "agent_repeat:"+hash, agentRepetitionMax, agentRepetitionWindow); err != nil {
+			if err := h.repos.RateLimit().CheckAPIRateLimit(ctx.Context(), agentRateLimitUserID(claims.Username), "agent_repeat:"+hash, agentRepetitionMax, agentRepetitionWindow); err != nil {
 				h.imposeAgentLockout(ctx.Context(), claims.Username, "repetition")
 				return apptheory.JSON(http.StatusTooManyRequests, map[string]any{
 					"error":             "agent_locked",
@@ -235,5 +235,28 @@ func agentLockoutIdentifier(username string) string {
 	if username == "" {
 		return "agent:unknown"
 	}
+	return agentRateLimitUserID(username)
+}
+
+func agentRateLimitUserID(username string) string {
+	username = strings.TrimSpace(username)
+	if username == "" {
+		return "agent:unknown"
+	}
 	return "agent:" + strings.ToLower(username)
+}
+
+func agentRateLimitUserIDVariants(username string) []string {
+	normalized := agentRateLimitUserID(username)
+	rawUsername := strings.TrimSpace(username)
+	if rawUsername == "" {
+		return []string{normalized}
+	}
+
+	legacy := "agent:" + rawUsername
+	if legacy == normalized {
+		return []string{normalized}
+	}
+
+	return []string{normalized, legacy}
 }

--- a/cmd/api/handlers/agent_safety_round13_more_test.go
+++ b/cmd/api/handlers/agent_safety_round13_more_test.go
@@ -56,5 +56,9 @@ func TestAgentSafetyRound13_EnforceRails_AndLockout(t *testing.T) {
 		h.imposeAgentLockout(ctx.Context(), "agent", "rapid_fire")
 		h.imposeAgentLockout(ctx.Context(), "", "noop")
 		require.Equal(t, "agent:unknown", agentLockoutIdentifier(""))
+		require.Equal(t, "agent:agent", agentRateLimitUserID("Agent"))
+		require.Equal(t, []string{"agent:agent-0", "agent:Agent-0"}, agentRateLimitUserIDVariants("Agent-0"))
+		require.Equal(t, []string{"agent:unknown"}, agentRateLimitUserIDVariants(""))
+		require.Equal(t, []string{"agent:agent"}, agentRateLimitUserIDVariants("agent"))
 	})
 }

--- a/cmd/api/handlers/helpers.go
+++ b/cmd/api/handlers/helpers.go
@@ -253,6 +253,16 @@ func (h *Handler) convertStorageStatusToAPI(storageStatus *storageModels.Status,
 	interactions := h.statusInteractionState(ctx, storageStatus, currentUsername)
 	reblogStatus := h.loadReblogStatus(ctx, storageStatus, currentUsername)
 	baseStatus := h.transformStatusBase(ctx, storageStatus)
+	baseURL := handlerBaseURL(h)
+	statusID := url.PathEscape(storageStatus.StatusID)
+	statusURI := ""
+	if actorURL := strings.TrimSpace(h.cfg.ActorURL(storageStatus.AuthorUsername)); actorURL != "" {
+		statusURI = strings.TrimSuffix(actorURL, "/") + "/statuses/" + statusID
+	}
+	statusURL := ""
+	if baseURL != "" {
+		statusURL = fmt.Sprintf("%s/@%s/%s", baseURL, storageStatus.AuthorUsername, statusID)
+	}
 
 	apiStatus := &models.Status{
 		ID:                 baseStatus.ID,
@@ -278,8 +288,8 @@ func (h *Handler) convertStorageStatusToAPI(storageStatus *storageModels.Status,
 		Muted:              interactions.muted,
 		Pinned:             interactions.pinned,
 		Reblog:             reblogStatus,
-		URI:                fmt.Sprintf("https://%s/users/%s/statuses/%s", h.cfg.BaseURL(), storageStatus.AuthorUsername, storageStatus.StatusID),
-		URL:                fmt.Sprintf("https://%s/@%s/%s", h.cfg.BaseURL(), storageStatus.AuthorUsername, storageStatus.StatusID),
+		URI:                statusURI,
+		URL:                statusURL,
 	}
 
 	apiStatus.AgentAttribution = h.buildStatusAgentAttribution(authorAccount, storageStatus)
@@ -525,29 +535,47 @@ func (h *Handler) statusMediaAttachments(storageStatus *storageModels.Status) []
 }
 
 func (h *Handler) statusAccount(storageStatus *storageModels.Status, authorAccount *storage.Account) models.Account {
-	if authorAccount != nil && authorAccount.Actor != nil {
-		account := transformations.ActorToAccountBase(authorAccount.Actor, h.cfg.BaseURL())
-		account.ID = storageStatus.AuthorID
-		account.Username = storageStatus.AuthorUsername
-		account.Acct = storageStatus.AuthorUsername
-		account.DisplayName = authorAccount.User.DisplayName
-		account.CreatedAt = authorAccount.User.CreatedAt.Format("2006-01-02T15:04:05.000Z")
-		return withZeroAccountCounts(account)
+	if storageStatus == nil {
+		return models.Account{}
 	}
 
-	fakeActor := &activitypub.Actor{
-		BaseObject: activitypub.BaseObject{
-			ID:   storageStatus.AuthorID,
-			Type: "Person",
-		},
-		PreferredUsername: storageStatus.AuthorUsername,
-		Name:              authorAccount.User.DisplayName,
-		URL:               fmt.Sprintf("https://%s/@%s", h.cfg.BaseURL(), storageStatus.AuthorUsername),
+	baseURL := handlerBaseURL(h)
+	account := authorAccount
+	if account == nil {
+		account = &storage.Account{}
+	}
+	if account.User == nil {
+		account.User = &storage.User{}
+	}
+	if strings.TrimSpace(account.User.Username) == "" {
+		account.User.Username = storageStatus.AuthorUsername
+	}
+	if strings.TrimSpace(account.User.DisplayName) == "" {
+		account.User.DisplayName = storageStatus.AuthorUsername
 	}
 
-	account := transformations.ActorToAccountBase(fakeActor, h.cfg.BaseURL())
-	account.CreatedAt = authorAccount.User.CreatedAt.Format("2006-01-02T15:04:05.000Z")
-	return withZeroAccountCounts(account)
+	if account.Actor == nil {
+		account.Actor = &activitypub.Actor{
+			BaseObject: activitypub.BaseObject{
+				ID:   storageStatus.AuthorID,
+				Type: "Person",
+			},
+			PreferredUsername: storageStatus.AuthorUsername,
+			Name:              account.User.DisplayName,
+			URL:               fmt.Sprintf("%s/@%s", baseURL, storageStatus.AuthorUsername),
+		}
+	}
+
+	if account.Actor != nil && !h.actorAppearsLocal(account.Actor) {
+		remote := transformations.ActorToAccountBase(account.Actor, baseURL)
+		if displayName := strings.TrimSpace(account.User.DisplayName); displayName != "" {
+			remote.DisplayName = displayName
+		}
+		ensureMastodonAccountCollections(&remote)
+		return withZeroAccountCounts(remote)
+	}
+
+	return withZeroAccountCounts(h.publicAccountFromStorageAccount(account))
 }
 
 func withZeroAccountCounts(account models.Account) models.Account {

--- a/cmd/api/handlers/helpers_round18_more_coverage_test.go
+++ b/cmd/api/handlers/helpers_round18_more_coverage_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/agents"
+	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/storage"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/require"
@@ -186,11 +187,11 @@ func TestHelpersRound18_StatusAccountUsesActorData(t *testing.T) {
 		},
 	})
 
-	require.Equal(t, cfg.ActorURL("alice"), account.ID)
+	require.Equal(t, common.GenerateNumericID("alice"), account.ID)
 	require.Equal(t, "alice", account.Username)
 	require.Equal(t, "alice", account.Acct)
 	require.Equal(t, "Alice", account.DisplayName)
-	require.Equal(t, createdAt.Format("2006-01-02T15:04:05.000Z"), account.CreatedAt)
+	require.Equal(t, createdAt.Format(time.RFC3339), account.CreatedAt)
 }
 
 func TestHelpersRound18_StatusReblogTargetID(t *testing.T) {

--- a/cmd/api/handlers/interactions.go
+++ b/cmd/api/handlers/interactions.go
@@ -12,7 +12,6 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/services/notes"
 	"github.com/equaltoai/lesser/pkg/services/relationships"
-	"github.com/equaltoai/lesser/pkg/transformations"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	"go.uber.org/zap"
 )
@@ -23,6 +22,11 @@ const (
 
 	relationshipOpFollow   = "follow"
 	relationshipOpUnfollow = "unfollow"
+
+	statusOpFavorite   = "favorite"
+	statusOpUnfavorite = "unfavorite"
+	statusOpReblog     = "reblog"
+	statusOpUnreblog   = "unreblog"
 )
 
 // relationshipOperation performs common relationship operations (follow/unfollow/block/unblock)
@@ -61,6 +65,11 @@ func (h *Handler) relationshipOperation(ctx *apptheory.Context, operation string
 		return common.RespondInternalServerError(ctx, err.Error())
 	}
 
+	targetPublicID := ""
+	if targetAccount, lookupErr := h.lookupStorageAccountByID(ctx.Context(), accountID); lookupErr == nil && targetAccount != nil {
+		targetPublicID = h.publicAccountFromStorageAccount(targetAccount).ID
+	}
+
 	switch operation {
 	case relationshipOpFollow:
 		var req models.FollowRequest
@@ -81,7 +90,7 @@ func (h *Handler) relationshipOperation(ctx *apptheory.Context, operation string
 		if err != nil {
 			return common.RespondInternalServerError(ctx, err.Error())
 		}
-		return okJSON(h.relationshipFromService(r.Relationship))
+		return okJSON(h.relationshipFromServiceWithPublicID(r.Relationship, targetPublicID))
 	case relationshipOpUnfollow:
 		r, err := h.registry.Relationships().Unfollow(ctx.Context(), &relationships.UnfollowCommand{
 			FollowerID:  claims.Username,
@@ -90,7 +99,7 @@ func (h *Handler) relationshipOperation(ctx *apptheory.Context, operation string
 		if err != nil {
 			return common.RespondInternalServerError(ctx, err.Error())
 		}
-		return okJSON(h.relationshipFromService(r.Relationship))
+		return okJSON(h.relationshipFromServiceWithPublicID(r.Relationship, targetPublicID))
 	case "block":
 		r, err := h.registry.Relationships().Block(ctx.Context(), &relationships.BlockCommand{
 			BlockerID: claims.Username,
@@ -99,7 +108,7 @@ func (h *Handler) relationshipOperation(ctx *apptheory.Context, operation string
 		if err != nil {
 			return common.RespondInternalServerError(ctx, err.Error())
 		}
-		return okJSON(h.relationshipFromService(r.Relationship))
+		return okJSON(h.relationshipFromServiceWithPublicID(r.Relationship, targetPublicID))
 	case "unblock":
 		r, err := h.registry.Relationships().Unblock(ctx.Context(), &relationships.UnblockCommand{
 			BlockerID: claims.Username,
@@ -108,7 +117,7 @@ func (h *Handler) relationshipOperation(ctx *apptheory.Context, operation string
 		if err != nil {
 			return common.RespondInternalServerError(ctx, err.Error())
 		}
-		return okJSON(h.relationshipFromService(r.Relationship))
+		return okJSON(h.relationshipFromServiceWithPublicID(r.Relationship, targetPublicID))
 	default:
 		return common.RespondBadRequest(ctx, "invalid operation")
 	}
@@ -166,7 +175,7 @@ func (h *Handler) enforceAgentFollowRails(ctx *apptheory.Context, username strin
 		return nil, nil
 	}
 
-	if err := h.repos.RateLimit().CheckAPIRateLimit(ctx.Context(), "agent:"+username, "agent_follows_per_hour", allowed, time.Hour); err != nil {
+	if err := h.repos.RateLimit().CheckAPIRateLimit(ctx.Context(), agentRateLimitUserID(username), "agent_follows_per_hour", allowed, time.Hour); err != nil {
 		return apptheory.JSON(http.StatusTooManyRequests, map[string]any{
 			"error":             "too_many_requests",
 			"error_description": "agent follow limit exceeded",
@@ -224,8 +233,7 @@ func (h *Handler) HandleGetBlocksLift(ctx *apptheory.Context) (*apptheory.Respon
 	accounts := []models.Account{}
 	for _, blockedAccount := range result.BlockedUsers {
 		if blockedAccount.Actor != nil {
-			account := transformations.ActorToAccountBase(blockedAccount.Actor, h.cfg.BaseURL())
-			accounts = append(accounts, account)
+			accounts = append(accounts, h.publicAccountFromStorageAccount(blockedAccount))
 		}
 	}
 
@@ -259,84 +267,112 @@ func (h *Handler) statusInteraction(ctx *apptheory.Context, operation string) (*
 		return common.RespondUnauthorized(ctx)
 	}
 
-	switch operation {
-	case "favorite":
-		r, err := h.registry.Notes().LikeNote(ctx.Context(), &notes.LikeNoteCommand{
-			StatusID: statusID,
-			LikerID:  claims.Username,
-		})
-		if err != nil {
-			if strings.Contains(err.Error(), "not found") {
-				return common.RespondNotFound(ctx, "status not found")
-			}
-			return common.RespondInternalServerError(ctx, "failed to like status")
-		}
-		mastodonStatus := transformations.NotesToStatusAny(r.Status, h.cfg.BaseURL())
-		mastodonStatus.Favourited = true
-		return okJSON(mastodonStatus)
-	case "unfavorite":
-		r, err := h.registry.Notes().UnlikeNote(ctx.Context(), &notes.UnlikeNoteCommand{
-			StatusID:  statusID,
-			UnlikerID: claims.Username,
-		})
-		if err != nil {
-			if strings.Contains(err.Error(), "not found") {
-				return common.RespondNotFound(ctx, "status not found")
-			}
-			return common.RespondInternalServerError(ctx, "failed to unlike status")
-		}
-		mastodonStatus := transformations.NotesToStatusAny(r.Status, h.cfg.BaseURL())
-		mastodonStatus.Favourited = false
-		return okJSON(mastodonStatus)
-	case "reblog":
-		r, err := h.registry.Notes().ReblogNote(ctx.Context(), &notes.ReblogNoteCommand{
-			StatusID:    statusID,
-			RebloggerID: claims.Username,
-		})
-		if err != nil {
-			if strings.Contains(err.Error(), "not found") {
-				return common.RespondNotFound(ctx, "status not found")
-			}
-			return common.RespondInternalServerError(ctx, "failed to reblog status")
-		}
-		mastodonStatus := transformations.NotesToStatusAny(r.Status, h.cfg.BaseURL())
-		mastodonStatus.Reblogged = true
-		return okJSON(mastodonStatus)
-	case "unreblog":
-		r, err := h.registry.Notes().UnreblogNote(ctx.Context(), &notes.UnreblogNoteCommand{
-			StatusID:      statusID,
-			UnrebloggerID: claims.Username,
-		})
-		if err != nil {
-			if strings.Contains(err.Error(), "not found") {
-				return common.RespondNotFound(ctx, "status not found")
-			}
-			return common.RespondInternalServerError(ctx, "failed to unreblog status")
-		}
-		mastodonStatus := transformations.NotesToStatusAny(r.Status, h.cfg.BaseURL())
-		mastodonStatus.Reblogged = false
-		return okJSON(mastodonStatus)
-	default:
+	if !isSupportedStatusInteraction(operation) {
 		return common.RespondBadRequest(ctx, "invalid operation")
+	}
+
+	result, err := h.executeStatusInteraction(ctx.Context(), operation, statusID, claims.Username)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return common.RespondNotFound(ctx, "status not found")
+		}
+		return common.RespondInternalServerError(ctx, statusInteractionFailureMessage(operation))
+	}
+
+	mastodonStatus, convErr := h.convertStorageStatusToAPI(result.Status, claims.Username)
+	if convErr != nil {
+		h.logger.Error("failed to serialize interacted status", zap.String("operation", operation), zap.Error(convErr))
+		return common.RespondInternalServerError(ctx, "failed to serialize status")
+	}
+
+	applyStatusInteractionState(mastodonStatus, operation)
+	return okJSON(mastodonStatus)
+}
+
+func isSupportedStatusInteraction(operation string) bool {
+	switch operation {
+	case statusOpFavorite, statusOpUnfavorite, statusOpReblog, statusOpUnreblog:
+		return true
+	default:
+		return false
+	}
+}
+
+func (h *Handler) executeStatusInteraction(ctx context.Context, operation string, statusID string, username string) (*notes.LikeResult, error) {
+	switch operation {
+	case statusOpFavorite:
+		return h.registry.Notes().LikeNote(ctx, &notes.LikeNoteCommand{
+			StatusID: statusID,
+			LikerID:  username,
+		})
+	case statusOpUnfavorite:
+		return h.registry.Notes().UnlikeNote(ctx, &notes.UnlikeNoteCommand{
+			StatusID:  statusID,
+			UnlikerID: username,
+		})
+	case statusOpReblog:
+		return h.registry.Notes().ReblogNote(ctx, &notes.ReblogNoteCommand{
+			StatusID:    statusID,
+			RebloggerID: username,
+		})
+	case statusOpUnreblog:
+		return h.registry.Notes().UnreblogNote(ctx, &notes.UnreblogNoteCommand{
+			StatusID:      statusID,
+			UnrebloggerID: username,
+		})
+	default:
+		return nil, fmt.Errorf("unsupported status interaction: %s", operation)
+	}
+}
+
+func statusInteractionFailureMessage(operation string) string {
+	switch operation {
+	case statusOpFavorite:
+		return "failed to like status"
+	case statusOpUnfavorite:
+		return "failed to unlike status"
+	case statusOpReblog:
+		return "failed to reblog status"
+	case statusOpUnreblog:
+		return "failed to unreblog status"
+	default:
+		return "failed to update status"
+	}
+}
+
+func applyStatusInteractionState(status *models.Status, operation string) {
+	if status == nil {
+		return
+	}
+
+	switch operation {
+	case statusOpFavorite:
+		status.Favourited = true
+	case statusOpUnfavorite:
+		status.Favourited = false
+	case statusOpReblog:
+		status.Reblogged = true
+	case statusOpUnreblog:
+		status.Reblogged = false
 	}
 }
 
 // HandleFavoriteLift handles POST /api/v1/statuses/:id/favourite
 func (h *Handler) HandleFavoriteLift(ctx *apptheory.Context) (*apptheory.Response, error) {
-	return h.statusInteraction(ctx, "favorite")
+	return h.statusInteraction(ctx, statusOpFavorite)
 }
 
 // HandleUnfavoriteLift handles POST /api/v1/statuses/:id/unfavourite
 func (h *Handler) HandleUnfavoriteLift(ctx *apptheory.Context) (*apptheory.Response, error) {
-	return h.statusInteraction(ctx, "unfavorite")
+	return h.statusInteraction(ctx, statusOpUnfavorite)
 }
 
 // HandleReblogLift handles POST /api/v1/statuses/:id/reblog
 func (h *Handler) HandleReblogLift(ctx *apptheory.Context) (*apptheory.Response, error) {
-	return h.statusInteraction(ctx, "reblog")
+	return h.statusInteraction(ctx, statusOpReblog)
 }
 
 // HandleUnreblogLift handles POST /api/v1/statuses/:id/unreblog
 func (h *Handler) HandleUnreblogLift(ctx *apptheory.Context) (*apptheory.Response, error) {
-	return h.statusInteraction(ctx, "unreblog")
+	return h.statusInteraction(ctx, statusOpUnreblog)
 }

--- a/cmd/api/handlers/interactions_round19_more_coverage_test.go
+++ b/cmd/api/handlers/interactions_round19_more_coverage_test.go
@@ -2,16 +2,20 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
 
+	apimodels "github.com/equaltoai/lesser/cmd/api/models"
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/services/notes"
 	"github.com/equaltoai/lesser/pkg/services/relationships"
+	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 	repomocks "github.com/equaltoai/lesser/pkg/testing/mocks"
@@ -112,13 +116,28 @@ func TestInteractionsRound19_followResolvesNumericAndEncodedTargets(t *testing.T
 		BaseObject:        activitypub.BaseObject{ID: cfg.ActorURL("simulacrum"), Type: "Person"},
 		PreferredUsername: "simulacrum",
 	}
+	targetAccount := &storage.Account{
+		User: &storage.User{
+			ID:       "319442693566094",
+			Username: "simulacrum",
+		},
+		Actor: targetActor,
+	}
 	actorRepo := repomocks.NewMockActorRepository()
-	actorRepo.On("GetActorByNumericID", mock.Anything, "3133216004869690").Return(targetActor, nil).Once()
-	actorRepo.On("GetActor", mock.Anything, "simulacrum").Return(targetActor, nil).Once()
+	actorRepo.On("GetActorByNumericID", mock.Anything, "3133216004869690").Return(targetActor, nil).Twice()
+	actorRepo.On("GetActor", mock.Anything, "simulacrum").Return(targetActor, nil).Twice()
 	h.repos = &interactionsRound19Repos{MockRepositoryStorage: repos, actor: actorRepo}
 
 	var followCalls int
 	h.registry = &RegistryStub{
+		AccountsSvc: &AccountsServiceStub{
+			GetAccountFunc: func(_ context.Context, accountID string) (*storage.Account, error) {
+				if accountID == "simulacrum" {
+					return targetAccount, nil
+				}
+				return nil, errors.New("not found")
+			},
+		},
 		RelationshipsSvc: &RelationshipsServiceStub{
 			FollowFunc: func(_ context.Context, cmd *relationships.FollowCommand) (*relationships.FollowResult, error) {
 				followCalls++
@@ -137,13 +156,19 @@ func TestInteractionsRound19_followResolvesNumericAndEncodedTargets(t *testing.T
 	ctxNumeric, err := round10NewLiftContext(http.MethodPost, "/api/v1/accounts/3133216004869690/follow", headers, nil, nil)
 	require.NoError(t, err)
 	ctxNumeric.Params["id"] = "3133216004869690"
-	requireStatus(t, http.StatusOK)(h.HandleFollowLift(ctxNumeric))
+	respNumeric := requireStatus(t, http.StatusOK)(h.HandleFollowLift(ctxNumeric))
+	var numericBody apimodels.Relationship
+	require.NoError(t, json.Unmarshal(respNumeric.Body, &numericBody))
+	require.Equal(t, targetAccount.User.ID, numericBody.ID)
 
 	doubleEscapedTarget := "https:%252F%252F" + strings.ReplaceAll(strings.TrimPrefix(cfg.ActorURL("simulacrum"), "https://"), "/", "%252F")
 	ctxEscaped, err := round10NewLiftContext(http.MethodPost, "/api/v1/accounts/encoded/follow", headers, nil, nil)
 	require.NoError(t, err)
 	ctxEscaped.Params["id"] = doubleEscapedTarget
-	requireStatus(t, http.StatusOK)(h.HandleFollowLift(ctxEscaped))
+	respEscaped := requireStatus(t, http.StatusOK)(h.HandleFollowLift(ctxEscaped))
+	var escapedBody apimodels.Relationship
+	require.NoError(t, json.Unmarshal(respEscaped.Body, &escapedBody))
+	require.Equal(t, targetAccount.User.ID, escapedBody.ID)
 
 	require.Equal(t, 2, followCalls)
 	actorRepo.AssertExpectations(t)
@@ -179,6 +204,55 @@ func TestInteractionsRound19_statusInteraction_ErrorBranches(t *testing.T) {
 	require.NoError(t, err)
 	ctxInvalid.Params["id"] = "1"
 	requireStatus(t, http.StatusBadRequest)(h.statusInteraction(ctxInvalid, "invalid"))
+}
+
+func TestInteractionsRound19_statusInteraction_UsesStorageBackedSerialization(t *testing.T) {
+	cfg := round11TestConfig()
+	now := time.Now().UTC()
+	state := &round10QueryState{
+		usersByUsername: map[string]storagemodels.User{
+			"alice": {PK: "USER#alice", SK: storagemodels.SKMetadata, Username: "alice", Role: "user", Approved: true, Version: 1, CreatedAt: now.Add(-2 * time.Hour)},
+			"bob":   {PK: "USER#bob", SK: storagemodels.SKMetadata, Username: "bob", Role: "user", Approved: true, Version: 1, CreatedAt: now.Add(-3 * time.Hour)},
+		},
+		actorsByUser: map[string]storagemodels.Actor{
+			"alice": {Username: "alice", Actor: &activitypub.Actor{BaseObject: activitypub.BaseObject{ID: cfg.ActorURL("alice"), Type: "Person"}, PreferredUsername: "alice"}},
+			"bob":   {Username: "bob", Actor: &activitypub.Actor{BaseObject: activitypub.BaseObject{ID: cfg.ActorURL("bob"), Type: "Person"}, PreferredUsername: "bob", Name: "Bob"}},
+		},
+	}
+
+	notesSvc := &NotesServiceStub{
+		LikeNoteFunc: func(context.Context, *notes.LikeNoteCommand) (*notes.LikeResult, error) {
+			return &notes.LikeResult{
+				Status: &storagemodels.Status{
+					StatusID:       "status-1",
+					AuthorUsername: "bob",
+					AuthorID:       cfg.ActorURL("bob"),
+					Content:        "hello world",
+					PublishedAt:    now.Add(-time.Minute),
+					CreatedAt:      now.Add(-time.Minute),
+				},
+			}, nil
+		},
+	}
+
+	h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{NotesSvc: notesSvc})
+
+	token := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{auth.ScopeWrite})
+	ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses/status-1/favourite", map[string]string{"Authorization": "Bearer " + token}, nil, nil)
+	require.NoError(t, err)
+	ctx.Params["id"] = "status-1"
+
+	resp := requireStatus(t, http.StatusOK)(h.HandleFavoriteLift(ctx))
+
+	var body apimodels.Status
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Equal(t, "status-1", body.ID)
+	require.Equal(t, "hello world", body.Content)
+	require.Equal(t, cfg.ActorURL("bob")+"/statuses/status-1", body.URI)
+	require.Equal(t, cfg.BaseURL()+"/@bob/status-1", body.URL)
+	require.Equal(t, common.GenerateNumericID("bob"), body.Account.ID)
+	require.Equal(t, "bob", body.Account.Username)
+	require.True(t, body.Favourited)
 }
 
 func TestInteractionsRound19_agentFollowRails_AllowsFollowWhenUnderLimit(t *testing.T) {

--- a/cmd/api/handlers/misc.go
+++ b/cmd/api/handlers/misc.go
@@ -127,7 +127,7 @@ func (h *Handler) executeAccountSearch(ctx *apptheory.Context, params *SearchPar
 
 	// Convert actors to accounts
 	for _, actor := range actors {
-		account := h.convertActorToAccount(actor)
+		account := h.convertActorToAccount(ctx.Context(), actor)
 		result.Accounts = append(result.Accounts, account)
 	}
 }
@@ -167,15 +167,9 @@ func (h *Handler) executeHashtagSearch(ctx *apptheory.Context, params *SearchPar
 	h.addPlaceholderHashtag(params.Query, result)
 }
 
-// convertActorToAccount converts an ActivityPub actor to API account using transformation framework
-func (h *Handler) convertActorToAccount(actor *activitypub.Actor) models.Account {
-	// Use centralized transformation framework - ELIMINATES 25+ LINES OF DUPLICATE CODE
-	account := transformations.ActorToAccountBase(actor, h.cfg.BaseURL())
-
-	// Override ID to use PreferredUsername instead of numeric ID for this specific use case
-	account.ID = actor.PreferredUsername
-
-	return account
+// convertActorToAccount converts an ActivityPub actor to a public Mastodon account payload.
+func (h *Handler) convertActorToAccount(ctx context.Context, actor *activitypub.Actor) models.Account {
+	return h.publicAccountFromActor(ctx, actor)
 }
 
 // searchStatusByURL searches for a status by direct URL

--- a/cmd/api/handlers/misc_round12_coverage_test.go
+++ b/cmd/api/handlers/misc_round12_coverage_test.go
@@ -96,6 +96,13 @@ func TestMisc_Search_StatusURL_And_Params_Round12(t *testing.T) {
 
 		requireStatus(t, http.StatusBadRequest)(handler.HandleSearchLift(ctxInvalidQuery))
 	})
+
+	t.Run("convertActorToAccount uses stored public identity for local actors", func(t *testing.T) {
+		actor := state.actorsByUser["alice"].Actor
+		account := handler.convertActorToAccount(context.Background(), actor)
+		require.Equal(t, common.GenerateNumericID("alice"), account.ID)
+		require.Equal(t, "alice", account.Username)
+	})
 }
 
 func TestMisc_Search_HashtagPlaceholder_And_TagHistory_Round12(t *testing.T) {

--- a/cmd/api/handlers/mutes.go
+++ b/cmd/api/handlers/mutes.go
@@ -1,13 +1,15 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/equaltoai/lesser/cmd/api/models"
 	"github.com/equaltoai/lesser/pkg/common"
 	relationshipsvc "github.com/equaltoai/lesser/pkg/services/relationships"
-	"github.com/equaltoai/lesser/pkg/transformations"
+	"github.com/equaltoai/lesser/pkg/storage"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	"go.uber.org/zap"
 )
@@ -29,6 +31,46 @@ func (h *Handler) relationshipFromService(relationship *relationshipsvc.Relation
 		Endorsed:            relationship.Endorsed,
 		Note:                relationship.Note,
 	}
+}
+
+func (h *Handler) relationshipFromServiceWithPublicID(relationship *relationshipsvc.RelationshipData, publicID string) models.Relationship {
+	out := h.relationshipFromService(relationship)
+	if normalizedID := strings.TrimSpace(publicID); normalizedID != "" {
+		out.ID = normalizedID
+	}
+	return out
+}
+
+func (h *Handler) relationshipFromServiceForAccount(ctx context.Context, relationship *relationshipsvc.RelationshipData, accountID string) models.Relationship {
+	if h == nil || h.repos == nil {
+		return h.relationshipFromService(relationship)
+	}
+
+	account, err := h.lookupStorageAccountByID(ctx, accountID)
+	if err != nil || account == nil {
+		return h.relationshipFromService(relationship)
+	}
+
+	return h.relationshipFromServiceWithPublicID(relationship, h.publicAccountFromStorageAccount(account).ID)
+}
+
+func relationshipLookupTargetID(account *storage.Account, fallback string) string {
+	if account != nil && account.Actor != nil {
+		if actorID := strings.TrimSpace(account.Actor.ID); actorID != "" {
+			return actorID
+		}
+		if username := strings.TrimSpace(account.Actor.PreferredUsername); username != "" {
+			return username
+		}
+	}
+
+	if account != nil && account.User != nil {
+		if username := strings.TrimSpace(account.User.Username); username != "" {
+			return username
+		}
+	}
+
+	return strings.TrimSpace(fallback)
 }
 
 // HandleMuteAccountLift handles POST /api/v1/accounts/:id/mute
@@ -82,7 +124,7 @@ func (h *Handler) HandleMuteAccountLift(ctx *apptheory.Context) (*apptheory.Resp
 			return common.RespondInternalServerError(ctx)
 		}
 
-		return okJSON(h.relationshipFromService(result.Relationship))
+		return okJSON(h.relationshipFromServiceForAccount(ctx.Context(), result.Relationship, accountID))
 	}
 
 	// If we reach here, service is not available - return error
@@ -116,7 +158,7 @@ func (h *Handler) HandleUnmuteAccountLift(ctx *apptheory.Context) (*apptheory.Re
 			return common.RespondInternalServerError(ctx)
 		}
 
-		return okJSON(h.relationshipFromService(result.Relationship))
+		return okJSON(h.relationshipFromServiceForAccount(ctx.Context(), result.Relationship, accountID))
 	}
 
 	// If we reach here, service is not available - return error
@@ -159,9 +201,7 @@ func (h *Handler) HandleGetMutedAccountsLift(ctx *apptheory.Context) (*apptheory
 			accounts := make([]models.Account, 0, len(result.MutedUsers))
 			for _, mutedUser := range result.MutedUsers {
 				if mutedUser.Actor != nil {
-					// Get follower/following counts (simplified for service response)
-					account := transformations.ActorToAccountWithCounts(mutedUser.Actor, h.cfg.BaseURL(), 0, 0, 0)
-					accounts = append(accounts, account)
+					accounts = append(accounts, h.publicAccountFromStorageAccount(mutedUser))
 				}
 			}
 

--- a/cmd/api/handlers/notification_delivery.go
+++ b/cmd/api/handlers/notification_delivery.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	apiModels "github.com/equaltoai/lesser/cmd/api/models"
+	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/common"
 	apperrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/services/notifications"
@@ -43,11 +44,6 @@ func (h *Handler) HandleDeliverNotificationLift(ctx *apptheory.Context) (*appthe
 		return common.RespondForbidden(ctx, "invalid instance api key")
 	}
 
-	recipient := h.notificationDeliveryRecipient(ctx.Context())
-	if recipient == "" {
-		return common.RespondServiceUnavailable(ctx, "notification delivery")
-	}
-
 	var req apiModels.NotificationDeliveryRequest
 	if resp, err := common.ParseRequestStrictWithValidation(ctx, &req); resp != nil || err != nil {
 		return resp, err
@@ -56,6 +52,11 @@ func (h *Handler) HandleDeliverNotificationLift(ctx *apptheory.Context) (*appthe
 	delivery, err := normalizeCommNotificationDeliveryRequest(&req)
 	if err != nil {
 		return common.RespondValidationError(ctx, err)
+	}
+
+	recipient := h.resolveNotificationDeliveryRecipient(ctx.Context(), delivery)
+	if recipient == "" {
+		return common.RespondServiceUnavailable(ctx, "notification delivery")
 	}
 
 	notificationID, err := commNotificationID(recipient, delivery.MessageID)
@@ -136,6 +137,48 @@ func (h *Handler) HandleDeliverNotificationLift(ctx *apptheory.Context) (*appthe
 	return noContent(), nil
 }
 
+func (h *Handler) resolveNotificationDeliveryRecipient(ctx context.Context, delivery *commNotificationDelivery) string {
+	if username := h.notificationDeliveryAddressedRecipient(ctx, delivery); username != "" {
+		return username
+	}
+	return h.notificationDeliveryRecipient(ctx)
+}
+
+func (h *Handler) notificationDeliveryAddressedRecipient(ctx context.Context, delivery *commNotificationDelivery) string {
+	if delivery == nil {
+		return ""
+	}
+
+	localPart, domain, ok := splitNotificationDeliveryAddress(delivery.ToAddress)
+	if !ok || !h.isNotificationDeliveryLocalDomain(domain) {
+		return ""
+	}
+
+	if bindingUsername := h.notificationDeliveryBoundUsername(ctx, localPart); bindingUsername != "" {
+		return bindingUsername
+	}
+
+	canonicalUsername := h.notificationDeliveryCanonicalUsername(ctx, localPart)
+	if canonicalUsername == "" {
+		return ""
+	}
+
+	if bindingUsername := h.notificationDeliveryBoundUsername(ctx, canonicalUsername); bindingUsername != "" {
+		return bindingUsername
+	}
+
+	if h == nil || h.repos == nil || h.repos.Account() == nil {
+		return ""
+	}
+
+	account, err := h.repos.Account().GetAccount(ctx, canonicalUsername)
+	if err != nil || account == nil || account.User == nil || !account.User.IsAgent {
+		return ""
+	}
+
+	return strings.TrimSpace(account.User.Username)
+}
+
 func (h *Handler) notificationDeliveryRecipient(ctx context.Context) string {
 	if h == nil || h.cfg == nil {
 		return ""
@@ -155,6 +198,101 @@ func (h *Handler) notificationDeliveryRecipient(ctx context.Context) string {
 	}
 
 	return strings.TrimSpace(state.PrimaryAdminUsername)
+}
+
+func (h *Handler) notificationDeliveryBoundUsername(ctx context.Context, username string) string {
+	if h == nil || h.repos == nil || h.repos.Instance() == nil {
+		return ""
+	}
+
+	binding, err := h.repos.Instance().GetSoulBodyBindingByUsername(ctx, username)
+	if err != nil || binding == nil {
+		return ""
+	}
+
+	return strings.TrimSpace(binding.Username)
+}
+
+func (h *Handler) notificationDeliveryCanonicalUsername(ctx context.Context, username string) string {
+	if h == nil || h.repos == nil {
+		return ""
+	}
+
+	if h.repos.Account() != nil {
+		account, err := h.repos.Account().GetAccount(ctx, username)
+		if err == nil && account != nil && account.User != nil && account.User.IsAgent {
+			return strings.TrimSpace(account.User.Username)
+		}
+	}
+
+	if h.repos.Actor() != nil {
+		results, err := h.repos.Actor().SearchAccounts(ctx, username, 10, false, 0)
+		if err == nil {
+			if canonical := h.notificationDeliveryMatchingLocalUsername(username, results); canonical != "" {
+				return canonical
+			}
+		}
+	}
+
+	if h.repos.Search() != nil {
+		results, err := h.repos.Search().SearchAccounts(ctx, username, 10, false, 0)
+		if err == nil {
+			if canonical := h.notificationDeliveryMatchingLocalUsername(username, results); canonical != "" {
+				return canonical
+			}
+		}
+	}
+
+	return ""
+}
+
+func (h *Handler) notificationDeliveryMatchingLocalUsername(username string, actors []*activitypub.Actor) string {
+	for _, actor := range actors {
+		if actor == nil || !h.actorAppearsLocal(actor) {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(actor.PreferredUsername), username) {
+			return strings.TrimSpace(actor.PreferredUsername)
+		}
+	}
+
+	return ""
+}
+
+func (h *Handler) isNotificationDeliveryLocalDomain(domain string) bool {
+	domain = strings.ToLower(strings.TrimSpace(domain))
+	if domain == "" {
+		return false
+	}
+
+	if domain == "lessersoul.ai" {
+		return true
+	}
+	if h == nil || h.cfg == nil {
+		return false
+	}
+
+	return domain == strings.ToLower(strings.TrimSpace(h.cfg.Domain))
+}
+
+func splitNotificationDeliveryAddress(address string) (string, string, bool) {
+	address = strings.TrimSpace(address)
+	if address == "" {
+		return "", "", false
+	}
+
+	at := strings.LastIndex(address, "@")
+	if at <= 0 || at == len(address)-1 {
+		return "", "", false
+	}
+
+	localPart := strings.TrimSpace(address[:at])
+	domain := strings.TrimSpace(address[at+1:])
+	if localPart == "" || domain == "" {
+		return "", "", false
+	}
+
+	return localPart, domain, true
 }
 
 func (h *Handler) notificationDeliveryKeys() []string {

--- a/cmd/api/handlers/notification_delivery_round28_test.go
+++ b/cmd/api/handlers/notification_delivery_round28_test.go
@@ -2,12 +2,15 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	apiModels "github.com/equaltoai/lesser/cmd/api/models"
+	"github.com/equaltoai/lesser/pkg/activitypub"
 	apperrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/services/notifications"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
@@ -149,6 +152,65 @@ func TestNotificationDelivery_Round28_AuthAndIdempotency(t *testing.T) {
 
 		headers := map[string]string{"Authorization": "Bearer " + managedCfg.LesserHostInstanceKey}
 		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/api/v1/notifications/deliver", headers, nil, payload)
+		requireStatus(t, http.StatusNoContent)(managedHandler.HandleDeliverNotificationLift(ctx))
+	})
+
+	t.Run("addressed local agents receive the notification before admin fallback", func(t *testing.T) {
+		managedCfg := round11TestConfig()
+		managedCfg.AdminUsername = "admin"
+		managedCfg.LesserHostInstanceKey = "managed-instance-key"
+
+		state := &round10QueryState{
+			usersByUsername: map[string]storagemodels.User{
+				"Agent-0": {
+					PK:        "USER#Agent-0",
+					SK:        storagemodels.SKMetadata,
+					Username:  "Agent-0",
+					Role:      "user",
+					Approved:  true,
+					Version:   1,
+					IsAgent:   true,
+					CreatedAt: time.Date(2026, time.March, 1, 12, 0, 0, 0, time.UTC),
+				},
+			},
+			actorsByUser: map[string]storagemodels.Actor{
+				"Agent-0": {
+					Username: "Agent-0",
+					Actor: &activitypub.Actor{
+						BaseObject: activitypub.BaseObject{
+							ID:   managedCfg.ActorURL("Agent-0"),
+							Type: "Person",
+						},
+						PreferredUsername: "Agent-0",
+					},
+				},
+			},
+		}
+
+		managedHandler, _, _ := round11NewHandler(t, managedCfg, state)
+		managedHandler.registry = &RegistryStub{
+			NotificationsSvc: &NotificationsServiceStub{
+				CreateNotificationFunc: func(_ context.Context, cmd *notifications.CreateNotificationCommand) (*notifications.NotificationResult, error) {
+					require.Equal(t, "Agent-0", cmd.UserID)
+					return &notifications.NotificationResult{}, nil
+				},
+			},
+		}
+
+		body, err := json.Marshal(apiModels.NotificationDeliveryRequest{
+			Type:       "communication:inbound",
+			Channel:    "email",
+			From:       apiModels.NotificationDeliveryFrom{Address: "alice@example.com", DisplayName: "Alice"},
+			To:         &apiModels.NotificationDeliveryTo{Address: "agent-0@lessersoul.ai"},
+			Subject:    "hello",
+			Body:       "test message",
+			ReceivedAt: time.Date(2026, time.March, 4, 12, 0, 0, 0, time.UTC).Format(time.RFC3339),
+			MessageID:  "comm-msg-agent-0",
+		})
+		require.NoError(t, err)
+
+		headers := map[string]string{"Authorization": "Bearer " + managedCfg.LesserHostInstanceKey}
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/api/v1/notifications/deliver", headers, nil, body)
 		requireStatus(t, http.StatusNoContent)(managedHandler.HandleDeliverNotificationLift(ctx))
 	})
 }

--- a/cmd/api/handlers/relationships.go
+++ b/cmd/api/handlers/relationships.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"strings"
+
 	"github.com/equaltoai/lesser/cmd/api/models"
 	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/common"
@@ -43,9 +45,8 @@ func (h *Handler) handleRelationshipsLogic(ctx *apptheory.Context, username stri
 			continue
 		}
 
-		// Check if account exists (basic validation)
-		_, err := h.registry.Accounts().GetAccount(ctx.Context(), accountID)
-		if err != nil {
+		targetAccount, err := h.lookupStorageAccountByID(ctx.Context(), accountID)
+		if err != nil || targetAccount == nil {
 			// Skip accounts that don't exist
 			h.logger.Warn("account not found for relationship",
 				zap.String("account_id", accountID),
@@ -53,31 +54,21 @@ func (h *Handler) handleRelationshipsLogic(ctx *apptheory.Context, username stri
 			continue
 		}
 
+		targetLookupID := relationshipLookupTargetID(targetAccount, accountID)
+
 		// Use the Relationships service to get relationship data
-		relationshipData, err := h.registry.Relationships().GetRelationship(ctx.Context(), username, accountID)
+		relationshipData, err := h.registry.Relationships().GetRelationship(ctx.Context(), username, targetLookupID)
 		if err != nil {
 			h.logger.Error("failed to get relationship from service",
 				zap.String("requester", username),
-				zap.String("target", accountID),
+				zap.String("target", targetLookupID),
 				zap.Error(err))
 			return common.RespondInternalServerError(ctx, "failed to get relationships")
 		}
 
-		// Convert service relationship data to API model
-		relationship := models.Relationship{
-			ID:                  relationshipData.ID,
-			Following:           relationshipData.Following,
-			ShowingReblogs:      relationshipData.ShowingReblogs,
-			Notifying:           relationshipData.Notifying,
-			FollowedBy:          relationshipData.FollowedBy,
-			Blocking:            relationshipData.Blocking,
-			BlockedBy:           relationshipData.BlockedBy,
-			Muting:              relationshipData.Muting,
-			MutingNotifications: relationshipData.MutingNotifications,
-			Requested:           relationshipData.Requested,
-			DomainBlocking:      relationshipData.DomainBlocking,
-			Endorsed:            relationshipData.Endorsed,
-			Note:                relationshipData.Note,
+		relationship := h.relationshipFromService(relationshipData)
+		if publicID := strings.TrimSpace(h.publicAccountFromStorageAccount(targetAccount).ID); publicID != "" {
+			relationship.ID = publicID
 		}
 		relationships = append(relationships, relationship)
 	}

--- a/cmd/api/handlers/relationships_round12_test.go
+++ b/cmd/api/handlers/relationships_round12_test.go
@@ -9,9 +9,13 @@ import (
 	"testing"
 
 	apimodels "github.com/equaltoai/lesser/cmd/api/models"
+	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/services/relationships"
 	"github.com/equaltoai/lesser/pkg/storage"
+	repomocks "github.com/equaltoai/lesser/pkg/testing/mocks"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -87,7 +91,56 @@ func TestRelationshipsRound12(t *testing.T) {
 		var body []apimodels.Relationship
 		require.NoError(t, json.Unmarshal(resp.Body, &body))
 		require.Len(t, body, 1)
-		require.Equal(t, "bob", body[0].ID)
+		require.Equal(t, common.GenerateNumericID("bob"), body[0].ID)
 		require.True(t, body[0].Following)
+	})
+
+	t.Run("numeric account ids resolve to canonical public ids", func(t *testing.T) {
+		targetActor := &activitypub.Actor{
+			BaseObject:        activitypub.BaseObject{ID: cfg.ActorURL("bob"), Type: "Person"},
+			PreferredUsername: "bob",
+		}
+		targetAccount := &storage.Account{
+			User:  &storage.User{Username: "bob"},
+			Actor: targetActor,
+		}
+
+		accountsSvc := &AccountsServiceStub{
+			GetAccountFunc: func(_ context.Context, accountID string) (*storage.Account, error) {
+				if accountID == "3133216004869690" {
+					return nil, errors.New("not found")
+				}
+				if accountID == "bob" {
+					return targetAccount, nil
+				}
+				return nil, errors.New("not found")
+			},
+		}
+		relationshipsSvc := &RelationshipsServiceStub{
+			GetRelationshipFunc: func(_ context.Context, requesterID, targetID string) (*relationships.RelationshipData, error) {
+				require.Equal(t, "alice", requesterID)
+				require.Equal(t, cfg.ActorURL("bob"), targetID)
+				return &relationships.RelationshipData{ID: "bob", Following: true}, nil
+			},
+		}
+
+		h, repos, _ := round11NewHandler(t, cfg, &round10QueryState{}, &RegistryStub{AccountsSvc: accountsSvc, RelationshipsSvc: relationshipsSvc})
+		actorRepo := repomocks.NewMockActorRepository()
+		actorRepo.On("GetActorByNumericID", mock.Anything, "3133216004869690").Return(targetActor, nil).Once()
+		h.repos = &interactionsRound19Repos{MockRepositoryStorage: repos, actor: actorRepo}
+
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/accounts/relationships", map[string]string{
+			"Authorization": "Bearer " + readToken,
+		}, map[string]string{"id[0]": "3133216004869690"}, nil)
+		require.NoError(t, err)
+
+		resp := requireStatus(t, http.StatusOK)(h.HandleGetRelationshipsLift(ctx))
+
+		var body []apimodels.Relationship
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Len(t, body, 1)
+		require.Equal(t, common.GenerateNumericID("bob"), body[0].ID)
+		require.True(t, body[0].Following)
+		actorRepo.AssertExpectations(t)
 	})
 }

--- a/cmd/api/handlers/round11_helpers_test.go
+++ b/cmd/api/handlers/round11_helpers_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
 	apimodels "github.com/equaltoai/lesser/cmd/api/models"
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/common"
 	storage "github.com/equaltoai/lesser/pkg/storage"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/golang-jwt/jwt/v5"
@@ -238,14 +238,15 @@ func TestConvertStorageStatusToAPI(t *testing.T) {
 
 	apiStatus, err := handler.convertStorageStatusToAPI(status, "alice")
 	require.NoError(t, err)
-	require.True(t, strings.Contains(apiStatus.URI, "/statuses/s1"))
-	require.True(t, strings.Contains(apiStatus.URL, "/@alice/s1"))
+	require.Equal(t, cfg.ActorURL("alice")+"/statuses/s1", apiStatus.URI)
+	require.Equal(t, cfg.BaseURL()+"/@alice/s1", apiStatus.URL)
 	require.NotNil(t, apiStatus.InReplyToID)
 	require.Len(t, apiStatus.MediaAttachments, 1)
 	require.Len(t, apiStatus.Tags, 1)
 	require.NotNil(t, apiStatus.Reblog)
 	require.Equal(t, 4, apiStatus.FavouritesCount)
 	require.Equal(t, 3, apiStatus.ReblogsCount)
+	require.Equal(t, common.GenerateNumericID("alice"), apiStatus.Account.ID)
 
 	serialized, err := json.Marshal(apiStatus)
 	require.NoError(t, err)

--- a/cmd/api/models/agent_governance.go
+++ b/cmd/api/models/agent_governance.go
@@ -8,6 +8,20 @@ type AdminVerifyAgentRequest struct {
 	ExitQuarantine bool   `json:"exit_quarantine,omitempty"`
 }
 
+// AdminUnlockAgentRequest is the request payload for operator unlock actions.
+type AdminUnlockAgentRequest struct {
+	Reason string `json:"reason,omitempty"`
+}
+
+// AdminUnlockAgentResponse is the REST response for a successful operator unlock.
+type AdminUnlockAgentResponse struct {
+	Username   string    `json:"username"`
+	Unlocked   bool      `json:"unlocked"`
+	UnlockedBy string    `json:"unlocked_by"`
+	Reason     string    `json:"reason,omitempty"`
+	UnlockedAt time.Time `json:"unlocked_at"`
+}
+
 // AdminAgentPolicy is the REST representation of instance-level agent policy.
 type AdminAgentPolicy struct {
 	AllowAgents            bool `json:"allow_agents"`

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -463,6 +463,7 @@ func configureRoutes(app *apptheory.App) {
 	// Agent governance (Admin only)
 	app.Get("/api/v1/admin/agents/policy", apiHandler.HandleAdminGetAgentPolicyLift)
 	app.Put("/api/v1/admin/agents/policy", apiHandler.HandleAdminUpdateAgentPolicyLift)
+	app.Post("/api/v1/admin/agents/{username}/unlock", apiHandler.HandleAdminUnlockAgentLift)
 	app.Post("/api/v1/admin/agents/{username}/verify", apiHandler.HandleAdminVerifyAgentLift)
 	app.Post("/api/v1/admin/agents/{username}/unverify", apiHandler.HandleAdminUnverifyAgentLift)
 

--- a/cmd/api/testdata/routes_manifest.txt
+++ b/cmd/api/testdata/routes_manifest.txt
@@ -220,6 +220,7 @@ POST /api/v1/admin/accounts/{id}/reject
 POST /api/v1/admin/accounts/{id}/unsensitive
 POST /api/v1/admin/accounts/{id}/unsilence
 POST /api/v1/admin/accounts/{id}/unsuspend
+POST /api/v1/admin/agents/{username}/unlock
 POST /api/v1/admin/agents/{username}/unverify
 POST /api/v1/admin/agents/{username}/verify
 POST /api/v1/admin/announcements

--- a/cmd/lesser/verify_cmd.go
+++ b/cmd/lesser/verify_cmd.go
@@ -6,7 +6,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+)
+
+const (
+	defaultVerifyCIJobs   = 2
+	lesserVerifyCIJobsEnv = "LESSER_VERIFY_CI_JOBS"
 )
 
 func runVerify(argv []string) error {
@@ -159,17 +165,35 @@ func runVerifyCI(argv []string) error {
 		return err
 	}
 
-	repoRoot, err := findRepoRootFn()
-	if err != nil {
-		return err
-	}
-	modulePath, err := readModulePath(repoRoot)
+	modulePath, err := readVerifyCIModulePath()
 	if err != nil {
 		return err
 	}
 	cmdPrefix := modulePath + "/cmd"
 	pkgPrefix := modulePath + "/pkg"
+	run := func() error { return runVerifyCIWorkflow(includeSecurity, cmdPrefix, pkgPrefix) }
 
+	if jobs := resolveVerifyCIJobs(); jobs > 0 {
+		return withTemporaryEnv(map[string]string{
+			lesserToolJobsEnvVar: fmt.Sprintf("%d", jobs),
+			goMaxProcsEnvVar:     fmt.Sprintf("%d", jobs),
+			goFlagsEnvVar:        goFlagsWithBuildParallelism(os.Getenv(goFlagsEnvVar), jobs),
+		}, run)
+	}
+
+	return run()
+}
+
+func readVerifyCIModulePath() (string, error) {
+	repoRoot, err := findRepoRootFn()
+	if err != nil {
+		return "", err
+	}
+
+	return readModulePath(repoRoot)
+}
+
+func runVerifyCIWorkflow(includeSecurity bool, cmdPrefix, pkgPrefix string) error {
 	// CI should not run formatting because it mutates the working tree.
 	// Prefer fast failure: lint first, then security, then the full verify suite.
 	if err := runLint([]string{"--disable-gosec"}); err != nil {
@@ -189,6 +213,15 @@ func runVerifyCI(argv []string) error {
 	if err := runVerifySupplyChain(nil); err != nil {
 		return err
 	}
+	if err := runVerifyCIContractsAndCoverage(cmdPrefix, pkgPrefix); err != nil {
+		return err
+	}
+
+	fmt.Println("✓ verify ci complete (lint, security, supply chain, verify suite, strict contracts, overall/pkg/cmd coverage gates)")
+	return nil
+}
+
+func runVerifyCIContractsAndCoverage(cmdPrefix, pkgPrefix string) error {
 	// Verify suite, but skip redundant work:
 	// - `runVerifyAll` includes non-strict OpenAPI + unit tests, which CI supersedes with strict OpenAPI + coverage runs.
 	if err := runVerifyLambdaSet(nil); err != nil {
@@ -225,8 +258,91 @@ func runVerifyCI(argv []string) error {
 		return err
 	}
 
-	fmt.Println("✓ verify ci complete (lint, security, supply chain, verify suite, strict contracts, overall/pkg/cmd coverage gates)")
 	return nil
+}
+
+func resolveVerifyCIJobs() int {
+	if raw := strings.TrimSpace(os.Getenv(lesserVerifyCIJobsEnv)); raw != "" {
+		if jobs, err := strconv.Atoi(raw); err == nil && jobs > 0 {
+			return jobs
+		}
+	}
+
+	if strings.TrimSpace(os.Getenv(lesserToolJobsEnvVar)) != "" ||
+		strings.TrimSpace(os.Getenv(goMaxProcsEnvVar)) != "" ||
+		goFlagsHasBuildParallelism(strings.TrimSpace(os.Getenv(goFlagsEnvVar))) {
+		return 0
+	}
+
+	jobs := resolveToolJobs()
+	if jobs <= 0 {
+		return defaultVerifyCIJobs
+	}
+	if jobs > defaultVerifyCIJobs {
+		return defaultVerifyCIJobs
+	}
+	return jobs
+}
+
+func withTemporaryEnv(overrides map[string]string, fn func() error) error {
+	type envValue struct {
+		value string
+		ok    bool
+	}
+
+	previous := make(map[string]envValue, len(overrides))
+	for key, value := range overrides {
+		current, ok := os.LookupEnv(key)
+		previous[key] = envValue{value: current, ok: ok}
+		if err := os.Setenv(key, value); err != nil {
+			return err
+		}
+	}
+	defer func() {
+		for key, current := range previous {
+			if current.ok {
+				_ = os.Setenv(key, current.value)
+				continue
+			}
+			_ = os.Unsetenv(key)
+		}
+	}()
+
+	return fn()
+}
+
+func goFlagsWithBuildParallelism(goFlags string, jobs int) string {
+	fields := strings.Fields(strings.TrimSpace(goFlags))
+	if jobs <= 0 {
+		return strings.Join(fields, " ")
+	}
+
+	replacement := fmt.Sprintf("%s=%d", goBuildParallelismFlag, jobs)
+	out := make([]string, 0, len(fields)+1)
+	replaced := false
+
+	for i := 0; i < len(fields); i++ {
+		field := fields[i]
+		switch {
+		case field == goBuildParallelismFlag:
+			out = append(out, replacement)
+			replaced = true
+			if i+1 < len(fields) {
+				i++
+			}
+		case strings.HasPrefix(field, goBuildParallelismFlag+"="):
+			out = append(out, replacement)
+			replaced = true
+		default:
+			out = append(out, field)
+		}
+	}
+
+	if !replaced {
+		out = append(out, replacement)
+	}
+
+	return strings.Join(out, " ")
 }
 
 func runVerifyDocs(_ []string) error {

--- a/cmd/lesser/verify_cmd_round20_more_coverage_test.go
+++ b/cmd/lesser/verify_cmd_round20_more_coverage_test.go
@@ -126,3 +126,394 @@ func TestRunVerifyCI_Round20_PropagatesInventoryFailure(t *testing.T) {
 
 	require.ErrorIs(t, runVerifyCI(nil), errSentinel)
 }
+
+func TestResolveVerifyCIJobs_Round20(t *testing.T) {
+	t.Run("explicit verify ci override wins", func(t *testing.T) {
+		t.Setenv(lesserVerifyCIJobsEnv, "3")
+		t.Setenv(lesserToolJobsEnvVar, "8")
+		require.Equal(t, 3, resolveVerifyCIJobs())
+	})
+
+	t.Run("explicit tool env disables automatic override", func(t *testing.T) {
+		t.Setenv(lesserVerifyCIJobsEnv, "")
+		t.Setenv(lesserToolJobsEnvVar, "8")
+		require.Zero(t, resolveVerifyCIJobs())
+	})
+
+	t.Run("default cap stays at or below two", func(t *testing.T) {
+		t.Setenv(lesserVerifyCIJobsEnv, "")
+		t.Setenv(lesserToolJobsEnvVar, "")
+		t.Setenv(goMaxProcsEnvVar, "")
+		t.Setenv(goFlagsEnvVar, "")
+
+		jobs := resolveVerifyCIJobs()
+		require.GreaterOrEqual(t, jobs, 1)
+		require.LessOrEqual(t, jobs, defaultVerifyCIJobs)
+	})
+
+	t.Run("goflags build parallelism disables automatic override", func(t *testing.T) {
+		t.Setenv(lesserVerifyCIJobsEnv, "")
+		t.Setenv(lesserToolJobsEnvVar, "")
+		t.Setenv(goMaxProcsEnvVar, "")
+		t.Setenv(goFlagsEnvVar, "-trimpath -p=8")
+
+		require.Zero(t, resolveVerifyCIJobs())
+	})
+}
+
+func TestRunVerifyCI_Round20_UsesVerifyCIJobsOverride(t *testing.T) {
+	repoRoot := setupVerifyCIRound20Harness(t)
+
+	t.Setenv(lesserVerifyCIJobsEnv, "2")
+	t.Setenv(lesserToolJobsEnvVar, "8")
+	t.Setenv(goMaxProcsEnvVar, "")
+	t.Setenv(goFlagsEnvVar, "-trimpath")
+
+	var lintCall string
+	var coverageEnv map[string]string
+
+	runCommandFn = func(_ context.Context, name string, args []string, _ execOptions) error {
+		joinedArgs := strings.Join(args, " ")
+		switch {
+		case name == "golangci-lint":
+			lintCall = name + " " + joinedArgs
+		case name == "go" && firstArgOrEmpty(args) == "test" && strings.Contains(joinedArgs, "-coverprofile=coverage_overall.out"):
+			coverageEnv = map[string]string{
+				lesserToolJobsEnvVar: os.Getenv(lesserToolJobsEnvVar),
+				goMaxProcsEnvVar:     os.Getenv(goMaxProcsEnvVar),
+				goFlagsEnvVar:        os.Getenv(goFlagsEnvVar),
+			}
+			coveragePath := filepath.Join(repoRoot, "coverage_overall.out")
+			coverageData := "mode: set\n" + "github.com/equaltoai/lesser/pkg/common/errors.go:1.1,1.2 1 1\n"
+			return os.WriteFile(coveragePath, []byte(coverageData), 0o644)
+		}
+		return nil
+	}
+
+	require.NoError(t, runVerifyCI(nil))
+	require.Contains(t, lintCall, "--concurrency 2")
+	require.Equal(t, "2", coverageEnv[lesserToolJobsEnvVar])
+	require.Equal(t, "2", coverageEnv[goMaxProcsEnvVar])
+	require.Equal(t, "-trimpath -p=2", coverageEnv[goFlagsEnvVar])
+
+	require.Equal(t, "8", os.Getenv(lesserToolJobsEnvVar))
+	require.Equal(t, "", os.Getenv(goMaxProcsEnvVar))
+	require.Equal(t, "-trimpath", os.Getenv(goFlagsEnvVar))
+}
+
+func TestRunVerifyCI_Round20_SkipsSecurityWhenDisabled(t *testing.T) {
+	_ = setupVerifyCIRound20Harness(t)
+
+	t.Setenv(lesserToolJobsEnvVar, "8")
+
+	var sawSecScan bool
+	var sawVulnCheck bool
+
+	runCommandFn = func(_ context.Context, name string, _ []string, _ execOptions) error {
+		switch name {
+		case "gosec":
+			sawSecScan = true
+		case "govulncheck":
+			sawVulnCheck = true
+		}
+		return nil
+	}
+
+	require.NoError(t, runVerifyCI([]string{"--security=false"}))
+	require.False(t, sawSecScan)
+	require.False(t, sawVulnCheck)
+}
+
+func TestRunVerifyCIContractsAndCoverage_Round20_PropagatesRemainingFailures(t *testing.T) {
+	_ = setupVerifyCIRound20Harness(t)
+
+	const (
+		cmdPrefix = "github.com/equaltoai/lesser/cmd"
+		pkgPrefix = "github.com/equaltoai/lesser/pkg"
+	)
+
+	tests := []struct {
+		name       string
+		shouldFail func(name string, args []string) bool
+	}{
+		{
+			name: "docs",
+			shouldFail: func(name string, args []string) bool {
+				return name == "bash" && firstArgOrEmpty(args) == "scripts/verify_docs.sh"
+			},
+		},
+		{
+			name: "ai training",
+			shouldFail: func(name string, args []string) bool {
+				return name == "bash" && firstArgOrEmpty(args) == "scripts/verify_ai_training.sh"
+			},
+		},
+		{
+			name: "schema",
+			shouldFail: func(name string, args []string) bool {
+				return name == "bash" && firstArgOrEmpty(args) == "scripts/verify_schema.sh"
+			},
+		},
+		{
+			name: "graphql coverage",
+			shouldFail: func(name string, args []string) bool {
+				return name == "go" && len(args) >= 2 && args[0] == "run" && args[1] == "./tools/graphql_coverage"
+			},
+		},
+		{
+			name: "openapi",
+			shouldFail: func(name string, args []string) bool {
+				return name == "go" && len(args) >= 2 && args[0] == "run" && args[1] == "./tools/openapi"
+			},
+		},
+		{
+			name: "coverage run",
+			shouldFail: func(name string, args []string) bool {
+				return name == "go" && firstArgOrEmpty(args) == "test" && strings.Contains(strings.Join(args, " "), "-coverprofile=coverage_overall.out")
+			},
+		},
+		{
+			name: "overall scoreboard",
+			shouldFail: func(name string, args []string) bool {
+				joined := strings.Join(args, " ")
+				return name == "go" &&
+					len(args) >= 2 &&
+					args[0] == "run" &&
+					args[1] == "./tools/coverage_scoreboard" &&
+					!strings.Contains(joined, "--package")
+			},
+		},
+		{
+			name: "pkg scoreboard",
+			shouldFail: func(name string, args []string) bool {
+				joined := strings.Join(args, " ")
+				return name == "go" &&
+					len(args) >= 2 &&
+					args[0] == "run" &&
+					args[1] == "./tools/coverage_scoreboard" &&
+					strings.Contains(joined, "--package "+pkgPrefix)
+			},
+		},
+		{
+			name: "cmd scoreboard",
+			shouldFail: func(name string, args []string) bool {
+				joined := strings.Join(args, " ")
+				return name == "go" &&
+					len(args) >= 2 &&
+					args[0] == "run" &&
+					args[1] == "./tools/coverage_scoreboard" &&
+					strings.Contains(joined, "--package "+cmdPrefix)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runCommandFn = func(_ context.Context, name string, args []string, _ execOptions) error {
+				if tt.shouldFail(name, args) {
+					return errSentinel
+				}
+				return nil
+			}
+
+			require.ErrorIs(t, runVerifyCIContractsAndCoverage(cmdPrefix, pkgPrefix), errSentinel)
+		})
+	}
+}
+
+func TestReadVerifyCIModulePath_Round20_PropagatesRepoRootError(t *testing.T) {
+	previousRepoRoot := findRepoRootFn
+	t.Cleanup(func() {
+		findRepoRootFn = previousRepoRoot
+	})
+
+	findRepoRootFn = func() (string, error) { return "", errSentinel }
+
+	_, err := readVerifyCIModulePath()
+	require.ErrorIs(t, err, errSentinel)
+}
+
+func TestWithTemporaryEnv_Round20_RestoresAfterError(t *testing.T) {
+	t.Setenv("ROUND20_EXISTING_ENV", "before")
+	require.NoError(t, os.Unsetenv("ROUND20_NEW_ENV"))
+
+	err := withTemporaryEnv(map[string]string{
+		"ROUND20_EXISTING_ENV": "after",
+		"ROUND20_NEW_ENV":      "during",
+	}, func() error {
+		require.Equal(t, "after", os.Getenv("ROUND20_EXISTING_ENV"))
+		require.Equal(t, "during", os.Getenv("ROUND20_NEW_ENV"))
+		return errSentinel
+	})
+
+	require.ErrorIs(t, err, errSentinel)
+	require.Equal(t, "before", os.Getenv("ROUND20_EXISTING_ENV"))
+	_, ok := os.LookupEnv("ROUND20_NEW_ENV")
+	require.False(t, ok)
+}
+
+func TestGoFlagsWithBuildParallelism_Round20(t *testing.T) {
+	t.Run("no jobs trims existing flags", func(t *testing.T) {
+		require.Equal(t, "-trimpath -race", goFlagsWithBuildParallelism("  -trimpath   -race  ", 0))
+	})
+
+	t.Run("replaces inline p flag", func(t *testing.T) {
+		require.Equal(t, "-trimpath -p=2", goFlagsWithBuildParallelism("-trimpath -p=9", 2))
+	})
+
+	t.Run("replaces split p flag", func(t *testing.T) {
+		require.Equal(t, "-trimpath -p=4 -mod=readonly", goFlagsWithBuildParallelism("-trimpath -p 9 -mod=readonly", 4))
+	})
+
+	t.Run("appends p flag when missing", func(t *testing.T) {
+		require.Equal(t, "-trimpath -p=3", goFlagsWithBuildParallelism("-trimpath", 3))
+	})
+}
+
+func TestRunVerifySupportCommands_Round20_ErrorPaths(t *testing.T) {
+	t.Run("openapi propagates repo root error", func(t *testing.T) {
+		previousRepoRoot := findRepoRootFn
+		t.Cleanup(func() {
+			findRepoRootFn = previousRepoRoot
+		})
+
+		findRepoRootFn = func() (string, error) { return "", errSentinel }
+		require.ErrorIs(t, runVerifyOpenAPI(nil), errSentinel)
+	})
+
+	t.Run("openapi propagates missing go tool", func(t *testing.T) {
+		_ = setupVerifyCIRound20Harness(t)
+
+		ensureToolAvailableFn = func(name string) error {
+			if name == "go" {
+				return errSentinel
+			}
+			return nil
+		}
+
+		require.ErrorIs(t, runVerifyOpenAPI(nil), errSentinel)
+	})
+
+	t.Run("openapi propagates go cache error", func(t *testing.T) {
+		repoRoot := setupVerifyCIRound20Harness(t)
+		t.Setenv("GOCACHE", "")
+		require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "tmp"), []byte("x"), 0o644))
+
+		require.Error(t, runVerifyOpenAPI(nil))
+	})
+
+	t.Run("openapi propagates command failure", func(t *testing.T) {
+		_ = setupVerifyCIRound20Harness(t)
+
+		runCommandFn = func(_ context.Context, name string, args []string, _ execOptions) error {
+			if name == "go" && len(args) >= 2 && args[0] == "run" && args[1] == "./tools/openapi" {
+				return errSentinel
+			}
+			return nil
+		}
+
+		require.ErrorIs(t, runVerifyOpenAPI(nil), errSentinel)
+	})
+
+	t.Run("inventory propagates repo root error", func(t *testing.T) {
+		previousRepoRoot := findRepoRootFn
+		t.Cleanup(func() {
+			findRepoRootFn = previousRepoRoot
+		})
+
+		findRepoRootFn = func() (string, error) { return "", errSentinel }
+		require.ErrorIs(t, runVerifyInventory(nil), errSentinel)
+	})
+
+	t.Run("inventory propagates command failure", func(t *testing.T) {
+		_ = setupVerifyCIRound20Harness(t)
+
+		runCommandFn = func(_ context.Context, name string, args []string, _ execOptions) error {
+			if name == "bash" && firstArgOrEmpty(args) == "scripts/verify_inventory.sh" {
+				return errSentinel
+			}
+			return nil
+		}
+
+		require.ErrorIs(t, runVerifyInventory(nil), errSentinel)
+	})
+
+	t.Run("lambda set propagates repo root error", func(t *testing.T) {
+		previousRepoRoot := findRepoRootFn
+		t.Cleanup(func() {
+			findRepoRootFn = previousRepoRoot
+		})
+
+		findRepoRootFn = func() (string, error) { return "", errSentinel }
+		require.ErrorIs(t, runVerifyLambdaSet(nil), errSentinel)
+	})
+
+	t.Run("lambda set propagates command failure", func(t *testing.T) {
+		_ = setupVerifyCIRound20Harness(t)
+
+		runCommandFn = func(_ context.Context, name string, args []string, _ execOptions) error {
+			if name == "bash" && firstArgOrEmpty(args) == "scripts/verify_lambda_set.sh" {
+				return errSentinel
+			}
+			return nil
+		}
+
+		require.ErrorIs(t, runVerifyLambdaSet(nil), errSentinel)
+	})
+}
+
+func TestRunVerifySupportCommands_Round20_SupplyChainAndAuditErrors(t *testing.T) {
+	t.Run("supply chain propagates repo root error", func(t *testing.T) {
+		previousRepoRoot := findRepoRootFn
+		t.Cleanup(func() {
+			findRepoRootFn = previousRepoRoot
+		})
+
+		findRepoRootFn = func() (string, error) { return "", errSentinel }
+		require.ErrorIs(t, runVerifySupplyChain(nil), errSentinel)
+	})
+
+	t.Run("supply chain propagates command failure", func(t *testing.T) {
+		_ = setupVerifyCIRound20Harness(t)
+
+		runCommandFn = func(_ context.Context, name string, args []string, _ execOptions) error {
+			if name == "bash" && firstArgOrEmpty(args) == "scripts/verify_supply_chain.sh" {
+				return errSentinel
+			}
+			return nil
+		}
+
+		require.ErrorIs(t, runVerifySupplyChain(nil), errSentinel)
+	})
+
+	t.Run("audit propagates repo root error", func(t *testing.T) {
+		previousRepoRoot := findRepoRootFn
+		t.Cleanup(func() {
+			findRepoRootFn = previousRepoRoot
+		})
+
+		findRepoRootFn = func() (string, error) { return "", errSentinel }
+		require.ErrorIs(t, runVerifyAudit(nil), errSentinel)
+	})
+
+	t.Run("audit propagates command failure", func(t *testing.T) {
+		_ = setupVerifyCIRound20Harness(t)
+
+		runCommandFn = func(_ context.Context, name string, args []string, _ execOptions) error {
+			if name == "go" && len(args) >= 2 && args[0] == "run" && args[1] == "./tools/audit_gates" {
+				return errSentinel
+			}
+			return nil
+		}
+
+		require.ErrorIs(t, runVerifyAudit(nil), errSentinel)
+	})
+
+	t.Run("audit propagates go cache error", func(t *testing.T) {
+		repoRoot := setupVerifyCIRound20Harness(t)
+		t.Setenv("GOCACHE", "")
+		require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "tmp"), []byte("x"), 0o644))
+
+		require.Error(t, runVerifyAudit(nil))
+	})
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -94,6 +94,7 @@ Admin agent governance endpoints:
 
 - `GET /api/v1/admin/agents/policy` (view instance policy)
 - `PUT /api/v1/admin/agents/policy` (update instance policy)
+- `POST /api/v1/admin/agents/:username/unlock` (clear agent safety lockouts/counters for operator recovery)
 - `POST /api/v1/admin/agents/:username/verify` / `.../unverify` (set verified trust tier)
 
 Enablement is **off by default**; deployments must explicitly allow agents via configuration/policy before these routes

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -794,6 +794,31 @@ components:
                 - total_edges
                 - total_nodes
             type: object
+        AdminUnlockAgentRequest:
+            additionalProperties: false
+            properties:
+                reason:
+                    type: string
+            type: object
+        AdminUnlockAgentResponse:
+            additionalProperties: false
+            properties:
+                reason:
+                    type: string
+                unlocked:
+                    type: boolean
+                unlocked_at:
+                    $ref: '#/components/schemas/RFC3339DateTime'
+                unlocked_by:
+                    type: string
+                username:
+                    type: string
+            required:
+                - unlocked
+                - unlocked_at
+                - unlocked_by
+                - username
+            type: object
         AdminUpdateTrustRequest:
             additionalProperties: false
             properties:
@@ -8822,6 +8847,49 @@ paths:
                 - cmd/api/routes.go
             x-oauth-scopes:
                 - admin:write
+    /api/v1/admin/agents/{username}/unlock:
+        post:
+            operationId: post_api_v1_admin_agents_by_username_unlock
+            tags:
+                - admin
+            security:
+                - bearerAuth: []
+            parameters:
+                - name: username
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AdminUnlockAgentRequest'
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AdminUnlockAgentResponse'
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "401":
+                    $ref: '#/components/responses/Unauthorized'
+                "403":
+                    $ref: '#/components/responses/Forbidden'
+                "404":
+                    $ref: '#/components/responses/NotFound'
+                "422":
+                    $ref: '#/components/responses/UnprocessableEntity'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+            x-lesser-handler: HandleAdminUnlockAgentLift
+            x-lesser-lambda: api
+            x-lesser-routeSources:
+                - cmd/api/routes.go
+            x-oauth-scopes:
+                - admin
     /api/v1/admin/agents/{username}/unverify:
         post:
             operationId: post_api_v1_admin_agents_by_username_unverify

--- a/docs/specs/graphql_coverage.yaml
+++ b/docs/specs/graphql_coverage.yaml
@@ -58,6 +58,11 @@ exemptions:
         exact:
             - /api/v1/admin/soul/well-known
             - /api/v1/notifications/deliver
+    - id: admin_agent_unlock
+      reason: Agent operator unlock is currently exposed as a REST-only admin operation.
+      match:
+        exact:
+            - /api/v1/admin/agents/{username}/unlock
 routes:
     - method: GET
       path: /
@@ -259,6 +264,10 @@ routes:
       status: covered
       graphql:
         - Mutation.updateAdminAgentPolicy
+    - method: POST
+      path: /api/v1/admin/agents/{username}/unlock
+      policy: rest_only
+      exemptedBy: admin_agent_unlock
     - method: POST
       path: /api/v1/admin/agents/{username}/unverify
       policy: graphql_required

--- a/pkg/storage/repositories/rate_limit_repository.go
+++ b/pkg/storage/repositories/rate_limit_repository.go
@@ -186,6 +186,81 @@ func (r *RateLimitRepository) ImposeLockout(ctx context.Context, identifier stri
 	return r.rateLimitLockouts.Create(ctx, lockout)
 }
 
+// ClearLockout removes an active lockout record for the given identifier.
+func (r *RateLimitRepository) ClearLockout(ctx context.Context, identifier string) error {
+	if r == nil || r.rateLimitLockouts == nil {
+		return ErrorHandler.HandleCreateError(storage.ErrDatabaseConnectionFailed, EntityRateLimit, "lockout")
+	}
+
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return ErrorHandler.HandleCreateError(storage.ErrInvalidInput, EntityRateLimit, "lockout")
+	}
+
+	pk := fmt.Sprintf("RATELIMIT#%s", identifier)
+	err := r.rateLimitLockouts.Delete(ctx, pk, "LOCKOUT")
+	if err != nil && !errors.IsNotFound(err) {
+		r.logger.Error("failed to clear rate limit lockout",
+			zap.String("identifier", identifier),
+			zap.Error(err))
+		return err
+	}
+
+	return nil
+}
+
+// ClearAPIRateLimitsForUser removes all API rate-limit counters tracked for a user identifier.
+func (r *RateLimitRepository) ClearAPIRateLimitsForUser(ctx context.Context, userID string) error {
+	if r == nil || r.apiRateLimits == nil || r.db == nil {
+		return ErrorHandler.HandleCreateError(storage.ErrDatabaseConnectionFailed, EntityRateLimit, "api rate limits")
+	}
+
+	userID = strings.TrimSpace(userID)
+	if userID == "" {
+		return ErrorHandler.HandleCreateError(storage.ErrInvalidInput, EntityRateLimit, "api rate limits")
+	}
+
+	prefix := fmt.Sprintf("RATELIMIT#%s:", userID)
+	var rateLimits []models.APIRateLimit
+	if err := r.db.WithContext(ctx).Model(&models.APIRateLimit{}).
+		Filter("PK", "begins_with", prefix).
+		All(&rateLimits); err != nil {
+		r.logger.Error("failed to query api rate limits for clearing",
+			zap.String("user_id", userID),
+			zap.Error(err))
+		return err
+	}
+
+	if len(rateLimits) == 0 {
+		return nil
+	}
+
+	keys := make([]struct{ PK, SK string }, 0, len(rateLimits))
+	for _, rateLimit := range rateLimits {
+		if strings.TrimSpace(rateLimit.PK) == "" || strings.TrimSpace(rateLimit.SK) == "" {
+			continue
+		}
+		keys = append(keys, struct{ PK, SK string }{
+			PK: rateLimit.PK,
+			SK: rateLimit.SK,
+		})
+	}
+
+	if len(keys) == 0 {
+		return nil
+	}
+
+	if err := r.apiRateLimits.BatchDelete(ctx, keys); err != nil {
+		r.logger.Error("failed to clear api rate limits",
+			zap.String("user_id", userID),
+			zap.Int("count", len(keys)),
+			zap.Error(err))
+		return err
+	}
+
+	return nil
+}
+
 // ClearLoginAttempts clears all login attempts for an identifier using BaseRepository
 func (r *RateLimitRepository) ClearLoginAttempts(ctx context.Context, identifier string) error {
 	pk := fmt.Sprintf("RATELIMIT#%s", identifier)

--- a/pkg/storage/repositories/rate_limit_repository_round08_unlock_test.go
+++ b/pkg/storage/repositories/rate_limit_repository_round08_unlock_test.go
@@ -1,0 +1,61 @@
+package repositories
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	dynamormErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	"github.com/theory-cloud/tabletheory/pkg/mocks"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestRound08_RateLimitRepository_ClearLockoutAndAPICounters(t *testing.T) {
+	baseTime := time.Now().UTC()
+	ctx := context.Background()
+
+	t.Run("ClearLockout ignores missing lockouts", func(t *testing.T) {
+		mockDB := new(mocks.MockDB)
+		mockQuery := new(mocks.MockQuery)
+		mockQuery.On("Delete").Return(dynamormErrors.ErrItemNotFound).Once()
+		setupPermissiveRound08Mocks(mockDB, mockQuery, nil, baseTime)
+
+		repo := NewRateLimitRepository(mockDB, "test-table", zaptest.NewLogger(t), nil)
+		require.NoError(t, repo.ClearLockout(ctx, "agent:agent-0"))
+	})
+
+	t.Run("ClearAPIRateLimitsForUser deletes matching counters", func(t *testing.T) {
+		mockDB := new(mocks.MockDB)
+		mockQuery := new(mocks.MockQuery)
+		mockQuery.On("All", mock.AnythingOfType("*[]models.APIRateLimit")).Run(func(args mock.Arguments) {
+			dst := args.Get(0).(*[]models.APIRateLimit)
+			*dst = []models.APIRateLimit{
+				{PK: "RATELIMIT#agent:agent-0:agent_posts_10s", SK: "WINDOW#2026-03-11T15:00:00Z"},
+				{PK: "RATELIMIT#agent:agent-0:agent_request_total", SK: "WINDOW#2026-03-11T15:00:00Z"},
+			}
+		}).Return(nil).Once()
+		mockQuery.On("BatchDelete", mock.MatchedBy(func(keys []struct{ PK, SK string }) bool {
+			return len(keys) == 2 &&
+				keys[0].PK == "RATELIMIT#agent:agent-0:agent_posts_10s" &&
+				keys[1].PK == "RATELIMIT#agent:agent-0:agent_request_total"
+		})).Return(nil).Once()
+		setupPermissiveRound08Mocks(mockDB, mockQuery, nil, baseTime)
+
+		repo := NewRateLimitRepository(mockDB, "test-table", zaptest.NewLogger(t), nil)
+		require.NoError(t, repo.ClearAPIRateLimitsForUser(ctx, "agent:agent-0"))
+	})
+
+	t.Run("ClearAPIRateLimitsForUser returns query errors", func(t *testing.T) {
+		mockDB := new(mocks.MockDB)
+		mockQuery := new(mocks.MockQuery)
+		mockQuery.On("All", mock.AnythingOfType("*[]models.APIRateLimit")).Return(errors.New("boom")).Once()
+		setupPermissiveRound08Mocks(mockDB, mockQuery, nil, baseTime)
+
+		repo := NewRateLimitRepository(mockDB, "test-table", zaptest.NewLogger(t), nil)
+		require.Error(t, repo.ClearAPIRateLimitsForUser(ctx, "agent:agent-0"))
+	})
+}


### PR DESCRIPTION
## Summary
- fix account ID normalization, relationship resolution, and status serialization regressions behind issues #176 and #177
- route managed notification delivery by addressed local agent inboxes, add admin unlock support, and soften/testing-proof agent lockout handling for issues #178 and #179
- lower default verifier parallelism during verify ci unless operators already set their own job controls, and add coverage to keep the command rubric green

## Testing
- env GOTOOLCHAIN=auto go test ./cmd/api
- env GOTOOLCHAIN=auto go test ./cmd/api/handlers
- env GOTOOLCHAIN=auto go test ./cmd/lesser
- env GOTOOLCHAIN=auto go run ./tools/graphql_coverage --check --strict
- env GOTOOLCHAIN=auto go run ./tools/openapi --check --strict
- env PATH=/home/aron/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.1.linux-amd64/bin:$PATH GOTOOLCHAIN=go1.26.1 ./lesser verify ci