### PR TITLE
fix numeric managed account relationship lookups

### DIFF
--- a/cmd/api/handlers/accounts.go
+++ b/cmd/api/handlers/accounts.go
@@ -202,7 +202,7 @@ func (h *Handler) publicAccountFromActor(ctx context.Context, actor *activitypub
 func (h *Handler) lookupStorageAccountByID(ctx context.Context, accountID string) (*storage.Account, error) {
 	if h != nil && h.registry != nil && h.registry.Accounts() != nil {
 		account, err := h.registry.Accounts().GetAccount(ctx, accountID)
-		if err == nil && account != nil {
+		if err == nil && account != nil && h.accountLookupMatchesRequestedID(account, accountID) {
 			return account, nil
 		}
 		if !shouldFallbackAccountResolution(accountID) {
@@ -217,7 +217,7 @@ func (h *Handler) lookupStorageAccountByID(ctx context.Context, accountID string
 		normalizedID := strings.TrimSpace(accountID)
 		if normalizedID != "" {
 			account, err := h.repos.Account().GetAccount(ctx, normalizedID)
-			if err == nil && account != nil {
+			if err == nil && account != nil && h.accountLookupMatchesRequestedID(account, accountID) {
 				return account, nil
 			}
 		}
@@ -240,6 +240,19 @@ func (h *Handler) lookupStorageAccountByID(ctx context.Context, accountID string
 	}
 
 	return storageAccountFromActor(actor), nil
+}
+
+func (h *Handler) accountLookupMatchesRequestedID(account *storage.Account, accountID string) bool {
+	if account == nil {
+		return false
+	}
+
+	normalizedID := normalizeResolvedAccountID(accountID)
+	if common.ValidateNumericID("account_id", normalizedID) == nil && len(normalizedID) >= 10 {
+		return strings.TrimSpace(h.publicAccountFromStorageAccount(account).ID) == normalizedID
+	}
+
+	return true
 }
 
 func shouldFallbackAccountResolution(accountID string) bool {

--- a/cmd/api/handlers/accounts_full.go
+++ b/cmd/api/handlers/accounts_full.go
@@ -299,6 +299,12 @@ func (h *Handler) HandleGetAccountFollowingFull(ctx *apptheory.Context) (*appthe
 // Helper methods
 
 func (h *Handler) resolveAccountIDFull(ctx context.Context, accountID string) (*activitypub.Actor, error) {
+	accountID = normalizeResolvedAccountID(accountID)
+
+	if common.ValidateNumericID("account_id", accountID) == nil && len(accountID) >= 10 {
+		return h.resolveAccountID(ctx, accountID)
+	}
+
 	// Check if it's a local username or full actor ID
 	if strings.HasPrefix(accountID, schemeHTTP) {
 		// Full actor ID - extract username from URL

--- a/cmd/api/handlers/accounts_round21_numeric_recovery_test.go
+++ b/cmd/api/handlers/accounts_round21_numeric_recovery_test.go
@@ -1,0 +1,207 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/services/relationships"
+	"github.com/equaltoai/lesser/pkg/storage"
+	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+func round21LocalUser(username string) storagemodels.User {
+	return storagemodels.User{
+		PK:        "USER#" + username,
+		SK:        storagemodels.SKMetadata,
+		Username:  username,
+		Role:      "user",
+		Approved:  true,
+		Version:   1,
+		CreatedAt: time.Now().Add(-24 * time.Hour),
+		UpdatedAt: time.Now().Add(-1 * time.Hour),
+	}
+}
+
+func round21LocalActor(baseURL, username string) storagemodels.Actor {
+	actor := storagemodels.Actor{
+		PK:        "ACTOR#" + username,
+		SK:        storagemodels.SKProfile,
+		Username:  username,
+		NumericID: common.GenerateNumericID(username),
+		Actor: &activitypub.Actor{
+			BaseObject: activitypub.BaseObject{
+				ID:   baseURL + "/users/" + username,
+				Type: activitypub.PersonType,
+			},
+			PreferredUsername: username,
+			Name:              username,
+		},
+		CreatedAt: time.Now().Add(-24 * time.Hour),
+		UpdatedAt: time.Now().Add(-1 * time.Hour),
+	}
+	actor.GSI3PK = "DOMAIN#example.com"
+	actor.GSI3SK = username
+	return actor
+}
+
+func TestAccountsRound21_RelationshipListsRecoverMissingNumericIDMapping(t *testing.T) {
+	cfg := round10TestConfig()
+	username := "Agent-0"
+	numericID := common.GenerateNumericID(username)
+
+	state := &round10QueryState{
+		usersByUsername: map[string]storagemodels.User{
+			username: round21LocalUser(username),
+		},
+		actorsByUser: map[string]storagemodels.Actor{
+			username: round21LocalActor(cfg.BaseURL(), username),
+		},
+		notFoundPKs: map[string]bool{
+			"NUMERIC_ID#" + numericID: true,
+		},
+	}
+
+	var followersUsername string
+	var followingUsername string
+
+	h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{
+		RelationshipsSvc: &RelationshipsServiceStub{
+			GetFollowersFunc: func(_ context.Context, resolvedUsername string, limit int, cursor string) ([]*storage.Account, string, error) {
+				followersUsername = resolvedUsername
+				return []*storage.Account{}, "", nil
+			},
+			GetFollowingFunc: func(_ context.Context, resolvedUsername string, limit int, cursor string) ([]*storage.Account, string, error) {
+				followingUsername = resolvedUsername
+				return []*storage.Account{}, "", nil
+			},
+		},
+	})
+
+	ctxFollowers, err := round10NewLiftContext(http.MethodGet, "/api/v1/accounts/"+numericID+"/followers", nil, nil, nil)
+	require.NoError(t, err)
+	ctxFollowers.Params["id"] = numericID
+	requireStatus(t, http.StatusOK)(h.HandleGetAccountFollowersLift(ctxFollowers))
+
+	ctxFollowing, err := round10NewLiftContext(http.MethodGet, "/api/v1/accounts/"+numericID+"/following", nil, nil, nil)
+	require.NoError(t, err)
+	ctxFollowing.Params["id"] = numericID
+	requireStatus(t, http.StatusOK)(h.HandleGetAccountFollowingLift(ctxFollowing))
+
+	require.Equal(t, username, followersUsername)
+	require.Equal(t, username, followingUsername)
+}
+
+func TestInteractionsRound21_FollowRecoversMissingNumericIDMapping(t *testing.T) {
+	cfg := round10TestConfig()
+	followerUsername := "Agent-0"
+	targetUsername := "simulacrum"
+	targetNumericID := common.GenerateNumericID(targetUsername)
+	targetActorID := cfg.BaseURL() + "/users/" + targetUsername
+
+	state := &round10QueryState{
+		usersByUsername: map[string]storagemodels.User{
+			followerUsername: round21LocalUser(followerUsername),
+			targetUsername:   round21LocalUser(targetUsername),
+		},
+		actorsByUser: map[string]storagemodels.Actor{
+			followerUsername: round21LocalActor(cfg.BaseURL(), followerUsername),
+			targetUsername:   round21LocalActor(cfg.BaseURL(), targetUsername),
+		},
+		notFoundPKs: map[string]bool{
+			"NUMERIC_ID#" + targetNumericID: true,
+		},
+	}
+
+	var gotFollowerID string
+	var gotFollowingID string
+
+	h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{
+		RelationshipsSvc: &RelationshipsServiceStub{
+			FollowFunc: func(_ context.Context, cmd *relationships.FollowCommand) (*relationships.FollowResult, error) {
+				gotFollowerID = cmd.FollowerID
+				gotFollowingID = cmd.FollowingID
+				return &relationships.FollowResult{
+					Relationship: &relationships.RelationshipData{
+						ID:        cmd.FollowingID,
+						Following: true,
+					},
+				}, nil
+			},
+		},
+	})
+
+	token := round11SignAccessToken(t, cfg.JWTSecret, followerUsername, []string{"follow"})
+	ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/accounts/"+targetNumericID+"/follow", map[string]string{
+		"Authorization": "Bearer " + token,
+	}, nil, nil)
+	require.NoError(t, err)
+	ctx.Params["id"] = targetNumericID
+
+	requireStatus(t, http.StatusOK)(h.HandleFollowLift(ctx))
+	require.Equal(t, followerUsername, gotFollowerID)
+	require.Equal(t, targetActorID, gotFollowingID)
+}
+
+func TestAccountsFullRound21_ResolveAccountIDFull_RecoversMissingNumericIDMapping(t *testing.T) {
+	cfg := round10TestConfig()
+	username := "simulacrum"
+	numericID := common.GenerateNumericID(username)
+
+	state := &round10QueryState{
+		usersByUsername: map[string]storagemodels.User{
+			username: round21LocalUser(username),
+		},
+		actorsByUser: map[string]storagemodels.Actor{
+			username: round21LocalActor(cfg.BaseURL(), username),
+		},
+		notFoundPKs: map[string]bool{
+			"NUMERIC_ID#" + numericID: true,
+		},
+	}
+
+	h, _, _ := round11NewHandler(t, cfg, state)
+	actor, err := h.resolveAccountIDFull(context.Background(), numericID)
+	require.NoError(t, err)
+	require.NotNil(t, actor)
+	require.Equal(t, username, actor.PreferredUsername)
+}
+
+func TestAccountsRound21_VerifyCredentialsEnsuresOwnNumericIDStillWorks(t *testing.T) {
+	cfg := round10TestConfig()
+	username := "Agent-0"
+
+	state := &round10QueryState{
+		usersByUsername: map[string]storagemodels.User{
+			username: round21LocalUser(username),
+		},
+		actorsByUser: map[string]storagemodels.Actor{
+			username: round21LocalActor(cfg.BaseURL(), username),
+		},
+	}
+
+	h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{
+		AccountsSvc: &AccountsServiceStub{
+			GetAccountFunc: func(_ context.Context, gotUsername string) (*storage.Account, error) {
+				require.Equal(t, username, gotUsername)
+				return &storage.Account{
+					User:  &storage.User{Username: username},
+					Actor: round21LocalActor(cfg.BaseURL(), username).Actor,
+				}, nil
+			},
+		},
+	})
+
+	token := round11SignAccessToken(t, cfg.JWTSecret, username, []string{auth.ScopeRead})
+	ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/accounts/verify_credentials", map[string]string{
+		"Authorization": "Bearer " + token,
+	}, nil, nil)
+	require.NoError(t, err)
+
+	requireStatus(t, http.StatusOK)(h.HandleVerifyCredentialsLift(ctx))
+}

--- a/cmd/api/handlers/helpers.go
+++ b/cmd/api/handlers/helpers.go
@@ -82,8 +82,7 @@ func (h *Handler) resolveAccountID(ctx context.Context, accountID string) (*acti
 
 	// Check if it's a numeric ID (Mastodon compatibility)
 	if common.ValidateNumericID("account_id", accountID) == nil && len(accountID) >= 10 {
-		// It's a numeric ID - use the dedicated lookup method
-		return h.repos.Actor().GetActorByNumericID(ctx, accountID)
+		return h.resolveNumericAccountID(ctx, accountID)
 	}
 
 	// Support federated handles in addition to local usernames.
@@ -119,6 +118,107 @@ func normalizeResolvedAccountID(accountID string) string {
 		normalized = decoded
 	}
 	return normalized
+}
+
+func (h *Handler) resolveNumericAccountID(ctx context.Context, accountID string) (*activitypub.Actor, error) {
+	actor, err := h.repos.Actor().GetActorByNumericID(ctx, accountID)
+	if err == nil || !isMissingAccountLookup(err) {
+		return actor, err
+	}
+
+	recovered, recoverErr := h.recoverLocalActorByNumericID(ctx, accountID)
+	if recoverErr == nil {
+		return recovered, nil
+	}
+	if !isMissingAccountLookup(recoverErr) {
+		return nil, recoverErr
+	}
+	return nil, err
+}
+
+func isMissingAccountLookup(err error) bool {
+	if err == nil {
+		return false
+	}
+	if common.IsNotFound(err) {
+		return true
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "not found")
+}
+
+func (h *Handler) recoverLocalActorByNumericID(ctx context.Context, numericID string) (*activitypub.Actor, error) {
+	if h == nil || h.repos == nil || h.repos.GetDB() == nil || h.cfg == nil {
+		return nil, common.ActorNotFoundError{Username: numericID}
+	}
+
+	domain := normalizeLocalActorDomain(h.cfg.Domain)
+	if domain == "" {
+		return nil, common.ActorNotFoundError{Username: numericID}
+	}
+
+	var actorModels []storageModels.Actor
+	err := h.repos.GetDB().WithContext(ctx).
+		Model(&storageModels.Actor{}).
+		Index("gsi3").
+		Where("gsi3PK", "=", fmt.Sprintf("DOMAIN#%s", domain)).
+		All(&actorModels)
+	if err != nil {
+		return nil, err
+	}
+
+	trimmedNumericID := strings.TrimSpace(numericID)
+	for _, actorModel := range actorModels {
+		if strings.TrimSpace(actorModel.NumericID) != trimmedNumericID {
+			continue
+		}
+
+		username := strings.TrimSpace(actorModel.Username)
+		if username == "" && actorModel.Actor != nil {
+			username = strings.TrimSpace(actorModel.Actor.PreferredUsername)
+		}
+		if username == "" {
+			continue
+		}
+
+		h.ensureLocalNumericIDMapping(ctx, username)
+
+		actor, err := h.repos.Actor().GetActor(ctx, username)
+		if err == nil && actor != nil {
+			return actor, nil
+		}
+		if err != nil && !isMissingAccountLookup(err) {
+			return nil, err
+		}
+
+		actor = actorModel.Actor
+		if actor == nil {
+			continue
+		}
+		if strings.TrimSpace(actor.PreferredUsername) == "" {
+			actor.PreferredUsername = username
+		}
+		if strings.TrimSpace(actor.ID) == "" {
+			baseURL := handlerBaseURL(h)
+			if baseURL != "" {
+				actor.ID = baseURL + "/users/" + username
+			}
+		}
+		return actor, nil
+	}
+
+	return nil, common.ActorNotFoundError{Username: numericID}
+}
+
+func normalizeLocalActorDomain(domain string) string {
+	domain = strings.TrimSpace(domain)
+	domain = strings.TrimPrefix(strings.TrimPrefix(domain, "https://"), "http://")
+	if idx := strings.Index(domain, "/"); idx >= 0 {
+		domain = domain[:idx]
+	}
+	if idx := strings.Index(domain, ":"); idx >= 0 {
+		domain = domain[:idx]
+	}
+	return strings.ToLower(strings.TrimSpace(domain))
 }
 
 // authenticateUser handles the common pattern of extracting and validating user authentication


### PR DESCRIPTION
## Summary
- repair local numeric account ID resolution when the reverse NUMERIC_ID mapping row is missing
- only trust direct account lookups for numeric requests when the returned public account ID actually matches
- add regression coverage for followers, following, follow, and full-account numeric resolution

## Issue
- closes #176

## Verification
- env GOTOOLCHAIN=auto go test ./cmd/api/handlers ./pkg/storage/repositories ./cmd/api
- env PATH=/home/aron/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.1.linux-amd64/bin:/home/aron/go/bin:$PATH GOTOOLCHAIN=go1.26.1 golangci-lint run --config .golangci.yml --disable gosec --concurrency 2
- env PATH=/home/aron/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.1.linux-amd64/bin:$PATH GOTOOLCHAIN=go1.26.1 GOMAXPROCS=2 ./lesser build lambdas
- env PATH=/home/aron/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.1.linux-amd64/bin:$PATH GOTOOLCHAIN=go1.26.1 GOMAXPROCS=2 ./lesser verify ci