### PR TITLE
fix local follow relationship indexes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ bootstrap*
 .gomodcache/
 /bootstrap_*/
 .pai/
+.codex/
 lint-report.json
 
 /*/.astro/

--- a/pkg/storage/models/relationship.go
+++ b/pkg/storage/models/relationship.go
@@ -93,7 +93,7 @@ func (r *RelationshipRecord) UpdateKeys() error {
 	if followerDomain, ok := extractRelationshipDomain(followerUsername); ok {
 		r.GSI2PK = fmt.Sprintf("FOLLOWER_DOMAIN#%s", followerDomain)
 		r.GSI2SK = r.SK // FOLLOWING#{username}
-	} else {
+	} else if strings.TrimSpace(r.GSI2PK) == "" || strings.TrimSpace(r.GSI2SK) == "" {
 		r.GSI2PK = ""
 		r.GSI2SK = ""
 	}
@@ -103,7 +103,7 @@ func (r *RelationshipRecord) UpdateKeys() error {
 	if followingDomain, ok := extractRelationshipDomain(followingUsername); ok {
 		r.GSI3PK = fmt.Sprintf("FOLLOWING_DOMAIN#%s", followingDomain)
 		r.GSI3SK = r.GSI1SK // FOLLOWER#{username}
-	} else {
+	} else if strings.TrimSpace(r.GSI3PK) == "" || strings.TrimSpace(r.GSI3SK) == "" {
 		r.GSI3PK = ""
 		r.GSI3SK = ""
 	}

--- a/pkg/storage/models/relationship_test.go
+++ b/pkg/storage/models/relationship_test.go
@@ -147,6 +147,28 @@ func TestRelationshipRecord_UpdateKeys(t *testing.T) {
 		assert.Empty(t, record.GSI3PK)
 		assert.Empty(t, record.GSI3SK)
 	})
+
+	t.Run("preserves prepopulated local domain GSIs", func(t *testing.T) {
+		record := &RelationshipRecord{
+			PK:     "FOLLOW#alice",
+			SK:     "FOLLOWING#bob",
+			GSI1PK: "FOLLOW#bob",
+			GSI1SK: "FOLLOWER#alice",
+			GSI2PK: "FOLLOWER_DOMAIN#dev.simulacrum.greater.website",
+			GSI2SK: "FOLLOWING#bob",
+			GSI3PK: "FOLLOWING_DOMAIN#dev.simulacrum.greater.website",
+			GSI3SK: "FOLLOWER#alice",
+			State:  RelationshipAccepted,
+		}
+
+		err := record.UpdateKeys()
+		require.NoError(t, err)
+
+		assert.Equal(t, "FOLLOWER_DOMAIN#dev.simulacrum.greater.website", record.GSI2PK)
+		assert.Equal(t, "FOLLOWING#bob", record.GSI2SK)
+		assert.Equal(t, "FOLLOWING_DOMAIN#dev.simulacrum.greater.website", record.GSI3PK)
+		assert.Equal(t, "FOLLOWER#alice", record.GSI3SK)
+	})
 }
 
 func TestNewRelationshipRecord(t *testing.T) {


### PR DESCRIPTION
## Summary
- preserve repository-provided local-domain follow GSIs during relationship key updates
- add a regression test covering prepopulated local-domain relationship GSIs
- ignore local .codex tooling state in git

## Testing
- GOTOOLCHAIN=auto go test ./pkg/storage/models -run TestRelationship
- GOTOOLCHAIN=auto go test ./pkg/storage/repositories -run TestRelationshipRepository
- PATH="/home/aron/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.1.linux-amd64/bin:/home/aron/.local/bin:/home/aron/.codex/tmp/arg0/codex-arg0dBoLhd:/home/aron/.nvm/versions/node/v24.11.1/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/aron/.cargo/bin:/home/aron/.local/share/pnpm:/home/aron/.nvm/versions/node/v24.11.1/bin:/home/aron/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/snap/bin:/home/aron/.lmstudio/bin:/usr/local/go/bin:/home/aron/.lmstudio/bin:/usr/local/go/bin:/home/aron/.lmstudio/bin:/usr/local/go/bin" ./lesser verify ci