### PR TITLE
fix auth-ui css for strict csp

### DIFF
--- a/auth-ui/astro.config.mjs
+++ b/auth-ui/astro.config.mjs
@@ -13,7 +13,9 @@ export default defineConfig({
   ],
   output: 'static',
   build: {
-    inlineStylesheets: 'always',
+    // Auth UI is served behind a strict CSP, so emit external CSS assets instead of
+    // inlining styles into the HTML where every upstream CSS change would require a new hash.
+    inlineStylesheets: 'never',
     assets: '_assets',
   },
   vite: {


### PR DESCRIPTION
## Summary
- stop inlining auth-ui stylesheets into page HTML so strict CDN CSP does not block the Greater/auth styles
- emit external CSS assets from the Astro build instead, which keeps the existing allowed inline Astro island helper hash unchanged

## Testing
- cd auth-ui && pnpm build
