### PR TITLE
fix agent auth persistence boundary

### DIFF
--- a/cmd/api/handlers/agent_access_leases.go
+++ b/cmd/api/handlers/agent_access_leases.go
@@ -18,6 +18,7 @@ import (
 	soulservice "github.com/equaltoai/lesser/pkg/services/souls"
 	"github.com/equaltoai/lesser/pkg/storage"
 	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
+	storageRepos "github.com/equaltoai/lesser/pkg/storage/repositories"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
@@ -56,6 +57,14 @@ type agentAccessLeaseOptions struct {
 	DeviceLabel       string
 	IdleTimeoutHours  int
 	AbsoluteTTLHours  int
+}
+
+func (h *Handler) agentAccessLeaseRepo() *storageRepos.AgentAccessLeaseRepository {
+	if h == nil || h.repos == nil {
+		return nil
+	}
+
+	return storageRepos.NewAgentAccessLeaseRepository(h.repos.GetDB(), h.repos.GetTableName(), h.logger)
 }
 
 // HandleCreateAgentAccessLeasePrincipalChallengeLift issues the owner approval challenge.
@@ -211,7 +220,11 @@ func (h *Handler) HandleCreateAgentAccessLeaseLift(ctx *apptheory.Context) (*app
 		return common.RespondInternalServerError(ctx)
 	}
 
-	if err := h.repos.GetDB().Model(model).WithContext(ctx.Context()).IfNotExists().Create(); err != nil {
+	repo := h.agentAccessLeaseRepo()
+	if repo == nil {
+		return common.RespondInternalServerError(ctx)
+	}
+	if err := repo.CreateLease(ctx.Context(), model); err != nil {
 		if dynamormErrors.IsConditionFailed(err) {
 			return common.RespondConflict(ctx, "lease already exists")
 		}
@@ -787,7 +800,8 @@ func (h *Handler) requireManagedAgentAccount(ctx *apptheory.Context, username st
 }
 
 func (h *Handler) createAgentAccessLeaseChallenge(ctx *apptheory.Context, opts agentAccessLeaseOptions, action string) (*storageModels.AgentAccessLeaseChallenge, error) {
-	if h == nil || h.repos == nil || h.repos.GetDB() == nil {
+	repo := h.agentAccessLeaseRepo()
+	if repo == nil {
 		return nil, errors.New("storage not initialized")
 	}
 
@@ -832,25 +846,20 @@ func (h *Handler) createAgentAccessLeaseChallenge(ctx *apptheory.Context, opts a
 		Used:              false,
 	}
 
-	if err := h.repos.GetDB().Model(model).WithContext(ctx.Context()).IfNotExists().Create(); err != nil {
+	if err := repo.CreateChallenge(ctx.Context(), model); err != nil {
 		return nil, err
 	}
 	return model, nil
 }
 
 func (h *Handler) loadAgentAccessLeaseChallenge(ctx *apptheory.Context, challengeID string) (*storageModels.AgentAccessLeaseChallenge, *apptheory.Response, error) {
-	if h == nil || h.repos == nil || h.repos.GetDB() == nil {
+	repo := h.agentAccessLeaseRepo()
+	if repo == nil {
 		resp, respErr := common.RespondInternalServerError(ctx)
 		return nil, resp, respErr
 	}
 
-	pk := fmt.Sprintf("AGENT_ACCESS_CHALLENGE#%s", strings.TrimSpace(challengeID))
-	challenge := &storageModels.AgentAccessLeaseChallenge{}
-	err := h.repos.GetDB().WithContext(ctx.Context()).
-		Model(&storageModels.AgentAccessLeaseChallenge{}).
-		Where("PK", "=", pk).
-		Where("SK", "=", "CHALLENGE").
-		First(challenge)
+	challenge, err := repo.GetChallenge(ctx.Context(), challengeID)
 	if err != nil {
 		if dynamormErrors.IsNotFound(err) {
 			resp, respErr := apptheory.JSON(http.StatusUnauthorized, map[string]any{
@@ -883,15 +892,12 @@ func (h *Handler) loadAgentAccessLeaseChallenge(ctx *apptheory.Context, challeng
 }
 
 func (h *Handler) markAgentAccessLeaseChallengeUsed(ctx *apptheory.Context, challengeID string) error {
-	now := time.Now().UTC()
-	pk := fmt.Sprintf("AGENT_ACCESS_CHALLENGE#%s", strings.TrimSpace(challengeID))
-	existing := &storageModels.AgentAccessLeaseChallenge{PK: pk, SK: "CHALLENGE"}
+	repo := h.agentAccessLeaseRepo()
+	if repo == nil {
+		return errors.New("storage not initialized")
+	}
 
-	return h.repos.GetDB().Model(existing).WithContext(ctx.Context()).UpdateBuilder().
-		Set("Used", true).
-		Condition("Used", "=", false).
-		Condition("TTL", ">", now.Unix()).
-		Execute()
+	return repo.MarkChallengeUsed(ctx.Context(), challengeID, time.Now().UTC())
 }
 
 func (h *Handler) verifyLeaseChallengeSignature(_ *apptheory.Context, challenge *storageModels.AgentAccessLeaseChallenge, signature string) error {
@@ -910,14 +916,13 @@ func (h *Handler) verifyLeaseChallengeSignature(_ *apptheory.Context, challenge 
 }
 
 func (h *Handler) loadAgentAccessLease(ctx *apptheory.Context, username, leaseID string) (*storageModels.AgentAccessLease, *apptheory.Response, error) {
-	pk := fmt.Sprintf("AGENT_ACCESS_LEASE#%s", strings.TrimSpace(username))
-	sk := fmt.Sprintf("LEASE#%s", strings.TrimSpace(leaseID))
-	lease := &storageModels.AgentAccessLease{}
-	err := h.repos.GetDB().WithContext(ctx.Context()).
-		Model(&storageModels.AgentAccessLease{}).
-		Where("PK", "=", pk).
-		Where("SK", "=", sk).
-		First(lease)
+	repo := h.agentAccessLeaseRepo()
+	if repo == nil {
+		resp, respErr := common.RespondInternalServerError(ctx)
+		return nil, resp, respErr
+	}
+
+	lease, err := repo.GetLease(ctx.Context(), username, leaseID)
 	if err != nil {
 		if dynamormErrors.IsNotFound(err) {
 			resp, respErr := common.RespondNotFound(ctx, "agent access lease")
@@ -930,13 +935,12 @@ func (h *Handler) loadAgentAccessLease(ctx *apptheory.Context, username, leaseID
 }
 
 func (h *Handler) listAgentAccessLeases(ctx *apptheory.Context, username string) ([]storageModels.AgentAccessLease, error) {
-	var leases []storageModels.AgentAccessLease
-	err := h.repos.GetDB().WithContext(ctx.Context()).
-		Model(&storageModels.AgentAccessLease{}).
-		Where("PK", "=", fmt.Sprintf("AGENT_ACCESS_LEASE#%s", strings.TrimSpace(username))).
-		Where("SK", "BEGINS_WITH", "LEASE#").
-		All(&leases)
-	return leases, err
+	repo := h.agentAccessLeaseRepo()
+	if repo == nil {
+		return nil, errors.New("storage not initialized")
+	}
+
+	return repo.ListLeases(ctx.Context(), username)
 }
 
 func (h *Handler) userHasWallet(ctx *apptheory.Context, username, address string) (bool, error) {

--- a/cmd/api/handlers/agent_access_leases_additional_test.go
+++ b/cmd/api/handlers/agent_access_leases_additional_test.go
@@ -14,6 +14,7 @@ import (
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
 )
 
 func TestAgentAccessLeaseAdditionalHelpers_ValidationBranches(t *testing.T) {
@@ -188,6 +189,14 @@ func TestAgentAccessLeaseAdditionalHelpers_StateAndDomainBranches(t *testing.T) 
 	var nilHandler *Handler
 	_, err := nilHandler.createAgentAccessLeaseChallenge(nil, agentAccessLeaseOptions{}, agentAccessLeaseActionPrincipal)
 	require.ErrorContains(t, err, "storage not initialized")
+	require.ErrorContains(t, nilHandler.markAgentAccessLeaseChallengeUsed(nil, "challenge-1"), "storage not initialized")
+	leases, err := nilHandler.listAgentAccessLeases(nil, "agent1")
+	require.Nil(t, leases)
+	require.ErrorContains(t, err, "storage not initialized")
+	lease, resp, err := nilHandler.loadAgentAccessLease(&apptheory.Context{}, "agent1", "lease-1")
+	require.Nil(t, lease)
+	require.NotNil(t, resp)
+	require.NoError(t, err)
 
 	ok, err := nilHandler.userHasWallet(nil, "owner", "0x1111111111111111111111111111111111111111")
 	require.False(t, ok)
@@ -357,7 +366,7 @@ func TestAgentAccessLeaseAdditionalHelpers_HandlerErrorBranches(t *testing.T) {
 			DeviceLabel:       "local-agent",
 			IdleTimeoutHours:  24,
 			AbsoluteTTLHours:  48,
-		}, agentAccessLeaseActionRenewSession)
+		}, agentAccessLeaseActionAgent)
 		require.ErrorContains(t, err, "boom")
 	})
 }

--- a/cmd/api/handlers/agent_access_leases_internal_test.go
+++ b/cmd/api/handlers/agent_access_leases_internal_test.go
@@ -161,6 +161,9 @@ func TestAgentAccessLeasesRound20_InternalHelpers(t *testing.T) {
 	}, agentAccessLeaseActionAgent)
 	require.NoError(t, err)
 	require.Equal(t, "agent1", createdChallenge.Username)
+	require.Equal(t, "AGENT_ACCESS_CHALLENGE#"+createdChallenge.ID, createdChallenge.PK)
+	require.Equal(t, "CHALLENGE", createdChallenge.SK)
+	require.Equal(t, createdChallenge.ExpiresAt.Unix(), createdChallenge.TTL)
 
 	badCtx, err := round10NewLiftContext(http.MethodGet, "/api/v1/agents/agent1/access-leases", map[string]string{"Authorization": "Bearer " + round11SignAccessToken(t, cfg.JWTSecret, "intruder", []string{"write"})}, nil, nil)
 	require.NoError(t, err)

--- a/cmd/api/handlers/agent_self_sovereign.go
+++ b/cmd/api/handlers/agent_self_sovereign.go
@@ -16,6 +16,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/federation"
 	"github.com/equaltoai/lesser/pkg/storage"
 	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
+	storageRepos "github.com/equaltoai/lesser/pkg/storage/repositories"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	dynamormErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 )
@@ -29,6 +30,14 @@ const (
 	agentKeyActionAuth      = "auth"
 	agentKeyActionRotateKey = "rotate_key"
 )
+
+func (h *Handler) agentKeyChallengeRepo() *storageRepos.AgentKeyChallengeRepository {
+	if h == nil || h.repos == nil {
+		return nil
+	}
+
+	return storageRepos.NewAgentKeyChallengeRepository(h.repos.GetDB(), h.repos.GetTableName(), h.logger)
+}
 
 // HandleAgentRegisterChallengeLift issues a one-time challenge for self-sovereign agent registration.
 func (h *Handler) HandleAgentRegisterChallengeLift(ctx *apptheory.Context) (*apptheory.Response, error) {
@@ -590,7 +599,8 @@ func (h *Handler) HandleAgentRotateKeyLift(ctx *apptheory.Context) (*apptheory.R
 }
 
 func (h *Handler) createAgentKeyChallenge(ctx *apptheory.Context, username string, action string, ttl time.Duration) (*storageModels.AgentKeyChallenge, error) {
-	if h == nil || h.repos == nil || h.repos.GetDB() == nil {
+	repo := h.agentKeyChallengeRepo()
+	if repo == nil {
 		return nil, fmt.Errorf("storage not initialized")
 	}
 
@@ -623,7 +633,7 @@ func (h *Handler) createAgentKeyChallenge(ctx *apptheory.Context, username strin
 		Used:      false,
 	}
 
-	if err := h.repos.GetDB().Model(model).WithContext(ctx.Context()).IfNotExists().Create(); err != nil {
+	if err := repo.Create(ctx.Context(), model); err != nil {
 		return nil, err
 	}
 
@@ -631,7 +641,8 @@ func (h *Handler) createAgentKeyChallenge(ctx *apptheory.Context, username strin
 }
 
 func (h *Handler) loadAndValidateAgentKeyChallenge(ctx *apptheory.Context, challengeID string, username string, action string) (*storageModels.AgentKeyChallenge, *apptheory.Response, error) {
-	if h == nil || h.repos == nil || h.repos.GetDB() == nil {
+	repo := h.agentKeyChallengeRepo()
+	if repo == nil {
 		resp, respErr := apptheory.JSON(http.StatusServiceUnavailable, map[string]any{
 			"error":             "service_unavailable",
 			"error_description": "storage is not initialized",
@@ -647,13 +658,7 @@ func (h *Handler) loadAndValidateAgentKeyChallenge(ctx *apptheory.Context, chall
 		return nil, resp, respErr
 	}
 
-	pk := fmt.Sprintf("AGENT_KEY_CHALLENGE#%s", challengeID)
-	challenge := &storageModels.AgentKeyChallenge{}
-	err := h.repos.GetDB().WithContext(ctx.Context()).
-		Model(&storageModels.AgentKeyChallenge{}).
-		Where("PK", "=", pk).
-		Where("SK", "=", "CHALLENGE").
-		First(challenge)
+	challenge, err := repo.Get(ctx.Context(), challengeID)
 	if err != nil {
 		if dynamormErrors.IsNotFound(err) {
 			resp, respErr := apptheory.JSON(http.StatusUnauthorized, map[string]any{
@@ -695,7 +700,8 @@ func (h *Handler) loadAndValidateAgentKeyChallenge(ctx *apptheory.Context, chall
 }
 
 func (h *Handler) markAgentKeyChallengeUsed(ctx *apptheory.Context, challengeID string) error {
-	if h == nil || h.repos == nil || h.repos.GetDB() == nil {
+	repo := h.agentKeyChallengeRepo()
+	if repo == nil {
 		return fmt.Errorf("storage not initialized")
 	}
 
@@ -704,15 +710,7 @@ func (h *Handler) markAgentKeyChallengeUsed(ctx *apptheory.Context, challengeID 
 		return fmt.Errorf("challenge id is empty")
 	}
 
-	now := time.Now().UTC()
-	pk := fmt.Sprintf("AGENT_KEY_CHALLENGE#%s", challengeID)
-	existing := &storageModels.AgentKeyChallenge{PK: pk, SK: "CHALLENGE"}
-
-	return h.repos.GetDB().Model(existing).WithContext(ctx.Context()).UpdateBuilder().
-		Set("Used", true).
-		Condition("Used", "=", false).
-		Condition("TTL", ">", now.Unix()).
-		Execute()
+	return repo.MarkUsed(ctx.Context(), challengeID, time.Now().UTC())
 }
 
 func buildAgentKeyChallengeMessage(id string, action string, username string, nonce string, issuedAt time.Time, expiresAt time.Time) string {

--- a/cmd/api/handlers/agent_self_sovereign_round14_more_branches_test.go
+++ b/cmd/api/handlers/agent_self_sovereign_round14_more_branches_test.go
@@ -82,6 +82,9 @@ func TestAgentSelfSovereignRound14_CreateAndConsumeChallengeBranches(t *testing.
 		require.Equal(t, agentKeyActionRegister, challenge.Action)
 		require.False(t, challenge.Used)
 		require.False(t, challenge.ExpiresAt.IsZero())
+		require.Equal(t, "AGENT_KEY_CHALLENGE#"+challenge.ID, challenge.PK)
+		require.Equal(t, "CHALLENGE", challenge.SK)
+		require.Equal(t, challenge.ExpiresAt.Unix(), challenge.TTL)
 	})
 
 	t.Run("markAgentKeyChallengeUsed rejects empty id", func(t *testing.T) {

--- a/cmd/api/handlers/round10_test_helpers_test.go
+++ b/cmd/api/handlers/round10_test_helpers_test.go
@@ -308,7 +308,6 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 			if m == nil {
 				return
 			}
-			_ = m.BeforeCreate()
 			if state.agentAccessLeasesByKey == nil {
 				state.agentAccessLeasesByKey = map[string]storagemodels.AgentAccessLease{}
 			}
@@ -317,11 +316,18 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 			if m == nil {
 				return
 			}
-			_ = m.BeforeCreate()
 			if state.agentAccessChallengesByID == nil {
 				state.agentAccessChallengesByID = map[string]storagemodels.AgentAccessLeaseChallenge{}
 			}
 			state.agentAccessChallengesByID[m.ID] = *m
+		case *storagemodels.AgentKeyChallenge:
+			if m == nil {
+				return
+			}
+			if state.agentKeyChallengesByID == nil {
+				state.agentKeyChallengesByID = map[string]storagemodels.AgentKeyChallenge{}
+			}
+			state.agentKeyChallengesByID[m.ID] = *m
 		}
 	}).Maybe()
 

--- a/graph/agent_access_lease_resolvers.go
+++ b/graph/agent_access_lease_resolvers.go
@@ -20,6 +20,7 @@ import (
 	soulservice "github.com/equaltoai/lesser/pkg/services/souls"
 	"github.com/equaltoai/lesser/pkg/storage"
 	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
+	storageRepos "github.com/equaltoai/lesser/pkg/storage/repositories"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
@@ -57,6 +58,14 @@ type graphAgentAccessLeaseOptions struct {
 	DeviceLabel       string
 	IdleTimeoutHours  int
 	AbsoluteTTLHours  int
+}
+
+func (r *Resolver) agentAccessLeaseRepo() *storageRepos.AgentAccessLeaseRepository {
+	if r == nil || r.Storage == nil {
+		return nil
+	}
+
+	return storageRepos.NewAgentAccessLeaseRepository(r.Storage.GetDB(), r.Storage.GetTableName(), r.Logger)
 }
 
 // AgentAccessLeases is the resolver for the agentAccessLeases field.
@@ -174,7 +183,11 @@ func (r *mutationResolver) CreateAgentAccessLease(ctx context.Context, username 
 		}
 		return nil, apperrors.InternalWithCause(err, "failed to mark agent challenge used")
 	}
-	if err := r.Storage.GetDB().Model(lease).WithContext(ctx).IfNotExists().Create(); err != nil {
+	repo := r.agentAccessLeaseRepo()
+	if repo == nil {
+		return nil, ErrStorageUnavailable
+	}
+	if err := repo.CreateLease(ctx, lease); err != nil {
 		if dynamormErrors.IsConditionFailed(err) {
 			return nil, apperrors.NewAppError(apperrors.CodeConflict, apperrors.CategoryBusiness, "lease already exists")
 		}
@@ -652,25 +665,20 @@ func graphBoundSoulLeasePrincipalWallet(soul *soulservice.Soul) string {
 }
 
 func (r *Resolver) listGraphAgentAccessLeases(ctx context.Context, username string) ([]storageModels.AgentAccessLease, error) {
-	var leases []storageModels.AgentAccessLease
-	err := r.Storage.GetDB().WithContext(ctx).
-		Model(&storageModels.AgentAccessLease{}).
-		Where("PK", "=", fmt.Sprintf("AGENT_ACCESS_LEASE#%s", strings.TrimSpace(username))).
-		Where("SK", "BEGINS_WITH", "LEASE#").
-		All(&leases)
-	return leases, err
+	repo := r.agentAccessLeaseRepo()
+	if repo == nil {
+		return nil, ErrStorageUnavailable
+	}
+
+	return repo.ListLeases(ctx, username)
 }
 
 func (r *Resolver) loadGraphAgentAccessLease(ctx context.Context, username, leaseID string) (*storageModels.AgentAccessLease, error) {
-	if r == nil || r.Storage == nil || r.Storage.GetDB() == nil {
+	repo := r.agentAccessLeaseRepo()
+	if repo == nil {
 		return nil, ErrStorageUnavailable
 	}
-	lease := &storageModels.AgentAccessLease{}
-	err := r.Storage.GetDB().WithContext(ctx).
-		Model(&storageModels.AgentAccessLease{}).
-		Where("PK", "=", fmt.Sprintf("AGENT_ACCESS_LEASE#%s", strings.TrimSpace(username))).
-		Where("SK", "=", fmt.Sprintf("LEASE#%s", strings.TrimSpace(leaseID))).
-		First(lease)
+	lease, err := repo.GetLease(ctx, username, leaseID)
 	if err != nil {
 		if dynamormErrors.IsNotFound(err) {
 			return nil, apperrors.NewAppError(apperrors.CodeNotFound, apperrors.CategoryBusiness, "agent access lease not found")
@@ -681,7 +689,8 @@ func (r *Resolver) loadGraphAgentAccessLease(ctx context.Context, username, leas
 }
 
 func (r *Resolver) createGraphAgentAccessLeaseChallengeRecord(ctx context.Context, opts graphAgentAccessLeaseOptions, action string) (*storageModels.AgentAccessLeaseChallenge, error) {
-	if r == nil || r.Storage == nil || r.Storage.GetDB() == nil {
+	repo := r.agentAccessLeaseRepo()
+	if repo == nil {
 		return nil, ErrStorageUnavailable
 	}
 	now := time.Now().UTC()
@@ -721,22 +730,18 @@ func (r *Resolver) createGraphAgentAccessLeaseChallengeRecord(ctx context.Contex
 		ExpiresAt:         expiresAt,
 		Used:              false,
 	}
-	if err := r.Storage.GetDB().Model(model).WithContext(ctx).IfNotExists().Create(); err != nil {
+	if err := repo.CreateChallenge(ctx, model); err != nil {
 		return nil, err
 	}
 	return model, nil
 }
 
 func (r *Resolver) loadGraphAgentAccessLeaseChallenge(ctx context.Context, challengeID string) (*storageModels.AgentAccessLeaseChallenge, error) {
-	if r == nil || r.Storage == nil || r.Storage.GetDB() == nil {
+	repo := r.agentAccessLeaseRepo()
+	if repo == nil {
 		return nil, ErrStorageUnavailable
 	}
-	challenge := &storageModels.AgentAccessLeaseChallenge{}
-	err := r.Storage.GetDB().WithContext(ctx).
-		Model(&storageModels.AgentAccessLeaseChallenge{}).
-		Where("PK", "=", fmt.Sprintf("AGENT_ACCESS_CHALLENGE#%s", strings.TrimSpace(challengeID))).
-		Where("SK", "=", "CHALLENGE").
-		First(challenge)
+	challenge, err := repo.GetChallenge(ctx, challengeID)
 	if err != nil {
 		if dynamormErrors.IsNotFound(err) {
 			return nil, apperrors.Unauthorized("challenge not found")
@@ -754,16 +759,11 @@ func (r *Resolver) loadGraphAgentAccessLeaseChallenge(ctx context.Context, chall
 }
 
 func (r *Resolver) markGraphAgentAccessLeaseChallengeUsed(ctx context.Context, challengeID string) error {
-	if r == nil || r.Storage == nil || r.Storage.GetDB() == nil {
+	repo := r.agentAccessLeaseRepo()
+	if repo == nil {
 		return ErrStorageUnavailable
 	}
-	now := time.Now().UTC()
-	existing := &storageModels.AgentAccessLeaseChallenge{PK: fmt.Sprintf("AGENT_ACCESS_CHALLENGE#%s", strings.TrimSpace(challengeID)), SK: "CHALLENGE"}
-	return r.Storage.GetDB().Model(existing).WithContext(ctx).UpdateBuilder().
-		Set("Used", true).
-		Condition("Used", "=", false).
-		Condition("TTL", ">", now.Unix()).
-		Execute()
+	return repo.MarkChallengeUsed(ctx, challengeID, time.Now().UTC())
 }
 
 func normalizeGraphAgentAccessLeaseOptions(

--- a/pkg/storage/models/agent_key_challenge.go
+++ b/pkg/storage/models/agent_key_challenge.go
@@ -46,6 +46,25 @@ func (c *AgentKeyChallenge) BeforeCreate() error {
 		c.IssuedAt = now
 	}
 
+	return c.UpdateKeys()
+}
+
+// GetPK returns the partition key.
+func (c *AgentKeyChallenge) GetPK() string {
+	return c.PK
+}
+
+// GetSK returns the sort key.
+func (c *AgentKeyChallenge) GetSK() string {
+	return c.SK
+}
+
+// UpdateKeys derives keys and TTL.
+func (c *AgentKeyChallenge) UpdateKeys() error {
+	if c == nil {
+		return fmt.Errorf("nil model")
+	}
+
 	c.ID = strings.TrimSpace(c.ID)
 	c.Username = strings.TrimSpace(c.Username)
 	c.Action = strings.TrimSpace(c.Action)

--- a/pkg/storage/repositories/agent_access_lease_repository.go
+++ b/pkg/storage/repositories/agent_access_lease_repository.go
@@ -1,0 +1,182 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	"go.uber.org/zap"
+)
+
+// AgentAccessLeaseRepository persists agent access lease challenges and leases.
+type AgentAccessLeaseRepository struct {
+	db        core.DB
+	tableName string
+	logger    *zap.Logger
+}
+
+// NewAgentAccessLeaseRepository creates a new AgentAccessLeaseRepository.
+func NewAgentAccessLeaseRepository(db core.DB, tableName string, logger *zap.Logger) *AgentAccessLeaseRepository {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	return &AgentAccessLeaseRepository{
+		db:        db,
+		tableName: tableName,
+		logger:    logger,
+	}
+}
+
+// CreateChallenge stores a new access lease challenge after preparing its keys and defaults.
+func (r *AgentAccessLeaseRepository) CreateChallenge(ctx context.Context, challenge *models.AgentAccessLeaseChallenge) error {
+	if r == nil {
+		return storage.ErrDatabaseConnectionFailed
+	}
+
+	return createPreparedModel(
+		ctx,
+		r.db,
+		r.logger,
+		challenge,
+		"failed to prepare agent access lease challenge",
+		"failed to create agent access lease challenge",
+		func(challenge *models.AgentAccessLeaseChallenge) []zap.Field {
+			if challenge == nil {
+				return nil
+			}
+			return []zap.Field{
+				zap.String("challenge_id", strings.TrimSpace(challenge.ID)),
+				zap.String("lease_id", strings.TrimSpace(challenge.LeaseID)),
+			}
+		},
+	)
+}
+
+// GetChallenge loads an access lease challenge by ID.
+func (r *AgentAccessLeaseRepository) GetChallenge(ctx context.Context, challengeID string) (*models.AgentAccessLeaseChallenge, error) {
+	if r == nil || r.db == nil {
+		return nil, storage.ErrDatabaseConnectionFailed
+	}
+
+	challengeID = strings.TrimSpace(challengeID)
+	if challengeID == "" {
+		return nil, storage.ErrInvalidInput
+	}
+
+	challenge := &models.AgentAccessLeaseChallenge{}
+	if err := r.db.WithContext(ctx).
+		Model(&models.AgentAccessLeaseChallenge{}).
+		Where("PK", "=", fmt.Sprintf("AGENT_ACCESS_CHALLENGE#%s", challengeID)).
+		Where("SK", "=", "CHALLENGE").
+		First(challenge); err != nil {
+		r.logger.Warn("failed to load agent access lease challenge",
+			zap.String("challenge_id", challengeID),
+			zap.Error(err))
+		return nil, err
+	}
+
+	return challenge, nil
+}
+
+// MarkChallengeUsed marks an access lease challenge as used when it is still valid.
+func (r *AgentAccessLeaseRepository) MarkChallengeUsed(ctx context.Context, challengeID string, now time.Time) error {
+	if r == nil {
+		return storage.ErrDatabaseConnectionFailed
+	}
+	return markChallengeUsed(
+		ctx,
+		r.db,
+		r.logger,
+		challengeID,
+		now,
+		&models.AgentAccessLeaseChallenge{
+			PK: fmt.Sprintf("AGENT_ACCESS_CHALLENGE#%s", strings.TrimSpace(challengeID)),
+			SK: "CHALLENGE",
+		},
+		"failed to mark agent access lease challenge used",
+	)
+}
+
+// CreateLease stores a new access lease after preparing its keys and defaults.
+func (r *AgentAccessLeaseRepository) CreateLease(ctx context.Context, lease *models.AgentAccessLease) error {
+	if r == nil {
+		return storage.ErrDatabaseConnectionFailed
+	}
+
+	return createPreparedModel(
+		ctx,
+		r.db,
+		r.logger,
+		lease,
+		"failed to prepare agent access lease",
+		"failed to create agent access lease",
+		func(lease *models.AgentAccessLease) []zap.Field {
+			if lease == nil {
+				return nil
+			}
+			return []zap.Field{
+				zap.String("lease_id", strings.TrimSpace(lease.ID)),
+				zap.String("username", strings.TrimSpace(lease.Username)),
+			}
+		},
+	)
+}
+
+// GetLease loads a single agent access lease.
+func (r *AgentAccessLeaseRepository) GetLease(ctx context.Context, username, leaseID string) (*models.AgentAccessLease, error) {
+	if r == nil || r.db == nil {
+		return nil, storage.ErrDatabaseConnectionFailed
+	}
+
+	username = strings.TrimSpace(username)
+	leaseID = strings.TrimSpace(leaseID)
+	if username == "" || leaseID == "" {
+		return nil, storage.ErrInvalidInput
+	}
+
+	lease := &models.AgentAccessLease{}
+	if err := r.db.WithContext(ctx).
+		Model(&models.AgentAccessLease{}).
+		Where("PK", "=", fmt.Sprintf("AGENT_ACCESS_LEASE#%s", username)).
+		Where("SK", "=", fmt.Sprintf("LEASE#%s", leaseID)).
+		First(lease); err != nil {
+		r.logger.Warn("failed to load agent access lease",
+			zap.String("username", username),
+			zap.String("lease_id", leaseID),
+			zap.Error(err))
+		return nil, err
+	}
+
+	return lease, nil
+}
+
+// ListLeases loads all access leases for an agent username.
+func (r *AgentAccessLeaseRepository) ListLeases(ctx context.Context, username string) ([]models.AgentAccessLease, error) {
+	if r == nil || r.db == nil {
+		return nil, storage.ErrDatabaseConnectionFailed
+	}
+
+	username = strings.TrimSpace(username)
+	if username == "" {
+		return nil, storage.ErrInvalidInput
+	}
+
+	var leases []models.AgentAccessLease
+	if err := r.db.WithContext(ctx).
+		Model(&models.AgentAccessLease{}).
+		Where("PK", "=", fmt.Sprintf("AGENT_ACCESS_LEASE#%s", username)).
+		Where("SK", "BEGINS_WITH", "LEASE#").
+		All(&leases); err != nil {
+		r.logger.Warn("failed to list agent access leases",
+			zap.String("username", username),
+			zap.Error(err))
+		return nil, err
+	}
+
+	return leases, nil
+}

--- a/pkg/storage/repositories/agent_auth_repositories_test.go
+++ b/pkg/storage/repositories/agent_auth_repositories_test.go
@@ -1,0 +1,502 @@
+package repositories
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	dynamormcore "github.com/theory-cloud/tabletheory/pkg/core"
+	dynamormmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
+	"go.uber.org/zap"
+)
+
+func TestAgentAccessLeaseRepository_CreateChallenge_PreparesModel(t *testing.T) {
+	mockDB := new(dynamormmocks.MockDB)
+	mockQuery := new(dynamormmocks.MockQuery)
+	mockDB.On("WithContext", mock.Anything).Return(mockDB).Once()
+	mockQuery.On("IfNotExists").Return(mockQuery).Once()
+	mockQuery.On("Create").Return(nil).Once()
+
+	expiresAt := time.Now().UTC().Add(5 * time.Minute)
+	challenge := &models.AgentAccessLeaseChallenge{
+		ID:                " challenge-1 ",
+		LeaseID:           " lease-1 ",
+		Username:          " agent-1 ",
+		Action:            " principal_approve ",
+		Address:           "0xABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD",
+		PrincipalUsername: " owner ",
+		PrincipalWallet:   "0xABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD",
+		AgentWallet:       "0x0123456789012345678901234567890123456789",
+		Message:           "sign me",
+		ExpiresAt:         expiresAt,
+	}
+
+	mockDB.On("Model", mock.MatchedBy(func(model any) bool {
+		m, ok := model.(*models.AgentAccessLeaseChallenge)
+		if !ok {
+			return false
+		}
+		return m.PK == "AGENT_ACCESS_CHALLENGE#challenge-1" &&
+			m.SK == "CHALLENGE" &&
+			m.TTL == expiresAt.Unix() &&
+			m.Address == "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd" &&
+			m.PrincipalWallet == "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd" &&
+			m.AgentWallet == "0x0123456789012345678901234567890123456789"
+	})).Return(mockQuery).Once()
+
+	repo := NewAgentAccessLeaseRepository(mockDB, "table", zap.NewNop())
+	require.NoError(t, repo.CreateChallenge(context.Background(), challenge))
+	require.Equal(t, "AGENT_ACCESS_CHALLENGE#challenge-1", challenge.PK)
+	require.Equal(t, "CHALLENGE", challenge.SK)
+	require.Equal(t, expiresAt.Unix(), challenge.TTL)
+	require.False(t, challenge.IssuedAt.IsZero())
+	mockDB.AssertExpectations(t)
+	mockQuery.AssertExpectations(t)
+}
+
+func TestAgentAccessLeaseRepository_CreateLease_PreparesModel(t *testing.T) {
+	mockDB := new(dynamormmocks.MockDB)
+	mockQuery := new(dynamormmocks.MockQuery)
+	mockDB.On("WithContext", mock.Anything).Return(mockDB).Once()
+	mockQuery.On("IfNotExists").Return(mockQuery).Once()
+	mockQuery.On("Create").Return(nil).Once()
+
+	now := time.Now().UTC()
+	lease := &models.AgentAccessLease{
+		ID:                " lease-1 ",
+		Username:          " agent-1 ",
+		PrincipalUsername: "owner",
+		PrincipalWallet:   "0x1111111111111111111111111111111111111111",
+		AgentWallet:       "0x2222222222222222222222222222222222222222",
+		Scopes:            []string{"read", "write"},
+		DeviceLabel:       "local-agent",
+		IdleTimeoutHours:  24,
+		IdleExpiresAt:     now.Add(24 * time.Hour),
+		AbsoluteExpiresAt: now.Add(48 * time.Hour),
+	}
+
+	mockDB.On("Model", mock.MatchedBy(func(model any) bool {
+		m, ok := model.(*models.AgentAccessLease)
+		if !ok {
+			return false
+		}
+		return m.PK == "AGENT_ACCESS_LEASE#agent-1" &&
+			m.SK == "LEASE#lease-1" &&
+			m.TTL == lease.AbsoluteExpiresAt.Unix() &&
+			m.Status == "active" &&
+			m.LeaseVersion == 1 &&
+			!m.CreatedAt.IsZero() &&
+			!m.LastUsedAt.IsZero()
+	})).Return(mockQuery).Once()
+
+	repo := NewAgentAccessLeaseRepository(mockDB, "table", zap.NewNop())
+	require.NoError(t, repo.CreateLease(context.Background(), lease))
+	require.Equal(t, "AGENT_ACCESS_LEASE#agent-1", lease.PK)
+	require.Equal(t, "LEASE#lease-1", lease.SK)
+	require.Equal(t, lease.AbsoluteExpiresAt.Unix(), lease.TTL)
+	require.Equal(t, "active", lease.Status)
+	require.Equal(t, 1, lease.LeaseVersion)
+	mockDB.AssertExpectations(t)
+	mockQuery.AssertExpectations(t)
+}
+
+func TestAgentAccessLeaseRepository_MarkChallengeUsed_UsesConditionalUpdate(t *testing.T) {
+	mockDB := new(dynamormmocks.MockDB)
+	mockQuery := new(dynamormmocks.MockQuery)
+	mockUpdate := new(dynamormmocks.MockUpdateBuilder)
+
+	mockDB.On("Model", mock.MatchedBy(func(model any) bool {
+		m, ok := model.(*models.AgentAccessLeaseChallenge)
+		return ok && m.PK == "AGENT_ACCESS_CHALLENGE#challenge-1" && m.SK == "CHALLENGE"
+	})).Return(mockQuery).Once()
+	mockQuery.On("WithContext", mock.Anything).Return(mockQuery).Once()
+	mockQuery.On("UpdateBuilder").Return(mockUpdate).Once()
+	mockUpdate.On("Set", "Used", true).Return(mockUpdate).Once()
+	mockUpdate.On("Condition", "Used", "=", false).Return(mockUpdate).Once()
+	mockUpdate.On("Condition", "TTL", ">", mock.AnythingOfType("int64")).Return(mockUpdate).Once()
+	mockUpdate.On("Execute").Return(nil).Once()
+
+	repo := NewAgentAccessLeaseRepository(mockDB, "table", zap.NewNop())
+	require.NoError(t, repo.MarkChallengeUsed(context.Background(), "challenge-1", time.Now().UTC()))
+	mockDB.AssertExpectations(t)
+	mockQuery.AssertExpectations(t)
+	mockUpdate.AssertExpectations(t)
+}
+
+func TestAgentAccessLeaseRepository_ReadPaths(t *testing.T) {
+	t.Run("GetChallenge", func(t *testing.T) {
+		mockDB := new(dynamormmocks.MockDB)
+		mockQuery := new(dynamormmocks.MockQuery)
+		mockDB.On("WithContext", mock.Anything).Return(mockDB).Once()
+		mockDB.On("Model", mock.AnythingOfType("*models.AgentAccessLeaseChallenge")).Return(mockQuery).Once()
+		mockQuery.On("Where", "PK", "=", "AGENT_ACCESS_CHALLENGE#challenge-1").Return(mockQuery).Once()
+		mockQuery.On("Where", "SK", "=", "CHALLENGE").Return(mockQuery).Once()
+		mockQuery.On("First", mock.AnythingOfType("*models.AgentAccessLeaseChallenge")).
+			Run(func(args mock.Arguments) {
+				dest := args.Get(0).(*models.AgentAccessLeaseChallenge)
+				*dest = models.AgentAccessLeaseChallenge{
+					ID:       "challenge-1",
+					LeaseID:  "lease-1",
+					Username: "agent-1",
+				}
+			}).
+			Return(nil).Once()
+
+		repo := NewAgentAccessLeaseRepository(mockDB, "table", zap.NewNop())
+		challenge, err := repo.GetChallenge(context.Background(), "challenge-1")
+		require.NoError(t, err)
+		require.Equal(t, "challenge-1", challenge.ID)
+		require.Equal(t, "lease-1", challenge.LeaseID)
+		require.Equal(t, "agent-1", challenge.Username)
+		mockDB.AssertExpectations(t)
+		mockQuery.AssertExpectations(t)
+	})
+
+	t.Run("GetLease", func(t *testing.T) {
+		mockDB := new(dynamormmocks.MockDB)
+		mockQuery := new(dynamormmocks.MockQuery)
+		mockDB.On("WithContext", mock.Anything).Return(mockDB).Once()
+		mockDB.On("Model", mock.AnythingOfType("*models.AgentAccessLease")).Return(mockQuery).Once()
+		mockQuery.On("Where", "PK", "=", "AGENT_ACCESS_LEASE#agent-1").Return(mockQuery).Once()
+		mockQuery.On("Where", "SK", "=", "LEASE#lease-1").Return(mockQuery).Once()
+		mockQuery.On("First", mock.AnythingOfType("*models.AgentAccessLease")).
+			Run(func(args mock.Arguments) {
+				dest := args.Get(0).(*models.AgentAccessLease)
+				*dest = models.AgentAccessLease{
+					ID:       "lease-1",
+					Username: "agent-1",
+					Status:   "active",
+				}
+			}).
+			Return(nil).Once()
+
+		repo := NewAgentAccessLeaseRepository(mockDB, "table", zap.NewNop())
+		lease, err := repo.GetLease(context.Background(), "agent-1", "lease-1")
+		require.NoError(t, err)
+		require.Equal(t, "lease-1", lease.ID)
+		require.Equal(t, "agent-1", lease.Username)
+		require.Equal(t, "active", lease.Status)
+		mockDB.AssertExpectations(t)
+		mockQuery.AssertExpectations(t)
+	})
+
+	t.Run("ListLeases", func(t *testing.T) {
+		mockDB := new(dynamormmocks.MockDB)
+		mockQuery := new(dynamormmocks.MockQuery)
+		mockDB.On("WithContext", mock.Anything).Return(mockDB).Once()
+		mockDB.On("Model", mock.AnythingOfType("*models.AgentAccessLease")).Return(mockQuery).Once()
+		mockQuery.On("Where", "PK", "=", "AGENT_ACCESS_LEASE#agent-1").Return(mockQuery).Once()
+		mockQuery.On("Where", "SK", "BEGINS_WITH", "LEASE#").Return(mockQuery).Once()
+		mockQuery.On("All", mock.AnythingOfType("*[]models.AgentAccessLease")).
+			Run(func(args mock.Arguments) {
+				dest := args.Get(0).(*[]models.AgentAccessLease)
+				*dest = []models.AgentAccessLease{
+					{ID: "lease-1", Username: "agent-1"},
+					{ID: "lease-2", Username: "agent-1"},
+				}
+			}).
+			Return(nil).Once()
+
+		repo := NewAgentAccessLeaseRepository(mockDB, "table", zap.NewNop())
+		leases, err := repo.ListLeases(context.Background(), "agent-1")
+		require.NoError(t, err)
+		require.Len(t, leases, 2)
+		require.Equal(t, "lease-1", leases[0].ID)
+		require.Equal(t, "lease-2", leases[1].ID)
+		mockDB.AssertExpectations(t)
+		mockQuery.AssertExpectations(t)
+	})
+
+	t.Run("query errors surface", func(t *testing.T) {
+		t.Run("GetChallenge", func(t *testing.T) {
+			mockDB := new(dynamormmocks.MockDB)
+			mockQuery := new(dynamormmocks.MockQuery)
+			mockDB.On("WithContext", mock.Anything).Return(mockDB).Once()
+			mockDB.On("Model", mock.AnythingOfType("*models.AgentAccessLeaseChallenge")).Return(mockQuery).Once()
+			mockQuery.On("Where", "PK", "=", "AGENT_ACCESS_CHALLENGE#challenge-1").Return(mockQuery).Once()
+			mockQuery.On("Where", "SK", "=", "CHALLENGE").Return(mockQuery).Once()
+			mockQuery.On("First", mock.AnythingOfType("*models.AgentAccessLeaseChallenge")).Return(errors.New("boom")).Once()
+
+			repo := NewAgentAccessLeaseRepository(mockDB, "table", zap.NewNop())
+			_, err := repo.GetChallenge(context.Background(), "challenge-1")
+			require.ErrorContains(t, err, "boom")
+			mockDB.AssertExpectations(t)
+			mockQuery.AssertExpectations(t)
+		})
+
+		t.Run("GetLease", func(t *testing.T) {
+			mockDB := new(dynamormmocks.MockDB)
+			mockQuery := new(dynamormmocks.MockQuery)
+			mockDB.On("WithContext", mock.Anything).Return(mockDB).Once()
+			mockDB.On("Model", mock.AnythingOfType("*models.AgentAccessLease")).Return(mockQuery).Once()
+			mockQuery.On("Where", "PK", "=", "AGENT_ACCESS_LEASE#agent-1").Return(mockQuery).Once()
+			mockQuery.On("Where", "SK", "=", "LEASE#lease-1").Return(mockQuery).Once()
+			mockQuery.On("First", mock.AnythingOfType("*models.AgentAccessLease")).Return(errors.New("boom")).Once()
+
+			repo := NewAgentAccessLeaseRepository(mockDB, "table", zap.NewNop())
+			_, err := repo.GetLease(context.Background(), "agent-1", "lease-1")
+			require.ErrorContains(t, err, "boom")
+			mockDB.AssertExpectations(t)
+			mockQuery.AssertExpectations(t)
+		})
+
+		t.Run("ListLeases", func(t *testing.T) {
+			mockDB := new(dynamormmocks.MockDB)
+			mockQuery := new(dynamormmocks.MockQuery)
+			mockDB.On("WithContext", mock.Anything).Return(mockDB).Once()
+			mockDB.On("Model", mock.AnythingOfType("*models.AgentAccessLease")).Return(mockQuery).Once()
+			mockQuery.On("Where", "PK", "=", "AGENT_ACCESS_LEASE#agent-1").Return(mockQuery).Once()
+			mockQuery.On("Where", "SK", "BEGINS_WITH", "LEASE#").Return(mockQuery).Once()
+			mockQuery.On("All", mock.AnythingOfType("*[]models.AgentAccessLease")).Return(errors.New("boom")).Once()
+
+			repo := NewAgentAccessLeaseRepository(mockDB, "table", zap.NewNop())
+			_, err := repo.ListLeases(context.Background(), "agent-1")
+			require.ErrorContains(t, err, "boom")
+			mockDB.AssertExpectations(t)
+			mockQuery.AssertExpectations(t)
+		})
+	})
+}
+
+func TestAgentKeyChallengeRepository_Create_PreparesModel(t *testing.T) {
+	mockDB := new(dynamormmocks.MockDB)
+	mockQuery := new(dynamormmocks.MockQuery)
+	mockDB.On("WithContext", mock.Anything).Return(mockDB).Once()
+	mockQuery.On("IfNotExists").Return(mockQuery).Once()
+	mockQuery.On("Create").Return(nil).Once()
+
+	expiresAt := time.Now().UTC().Add(5 * time.Minute)
+	challenge := &models.AgentKeyChallenge{
+		ID:        " challenge-1 ",
+		Username:  " alice ",
+		Action:    " register ",
+		Nonce:     "nonce",
+		Message:   "hello",
+		ExpiresAt: expiresAt,
+	}
+
+	mockDB.On("Model", mock.MatchedBy(func(model any) bool {
+		m, ok := model.(*models.AgentKeyChallenge)
+		if !ok {
+			return false
+		}
+		return m.PK == "AGENT_KEY_CHALLENGE#challenge-1" &&
+			m.SK == "CHALLENGE" &&
+			m.TTL == expiresAt.Unix()
+	})).Return(mockQuery).Once()
+
+	repo := NewAgentKeyChallengeRepository(mockDB, "table", zap.NewNop())
+	require.NoError(t, repo.Create(context.Background(), challenge))
+	require.Equal(t, "AGENT_KEY_CHALLENGE#challenge-1", challenge.PK)
+	require.Equal(t, "CHALLENGE", challenge.SK)
+	require.Equal(t, expiresAt.Unix(), challenge.TTL)
+	require.False(t, challenge.IssuedAt.IsZero())
+	mockDB.AssertExpectations(t)
+	mockQuery.AssertExpectations(t)
+}
+
+func TestAgentKeyChallengeRepository_Get_Success(t *testing.T) {
+	mockDB := new(dynamormmocks.MockDB)
+	mockQuery := new(dynamormmocks.MockQuery)
+	mockDB.On("WithContext", mock.Anything).Return(mockDB).Once()
+	mockDB.On("Model", mock.AnythingOfType("*models.AgentKeyChallenge")).Return(mockQuery).Once()
+	mockQuery.On("Where", "PK", "=", "AGENT_KEY_CHALLENGE#challenge-1").Return(mockQuery).Once()
+	mockQuery.On("Where", "SK", "=", "CHALLENGE").Return(mockQuery).Once()
+	mockQuery.On("First", mock.AnythingOfType("*models.AgentKeyChallenge")).
+		Run(func(args mock.Arguments) {
+			dest := args.Get(0).(*models.AgentKeyChallenge)
+			*dest = models.AgentKeyChallenge{
+				ID:       "challenge-1",
+				Username: "alice",
+				Action:   "register",
+			}
+		}).
+		Return(nil).Once()
+
+	repo := NewAgentKeyChallengeRepository(mockDB, "table", zap.NewNop())
+	challenge, err := repo.Get(context.Background(), "challenge-1")
+	require.NoError(t, err)
+	require.Equal(t, "challenge-1", challenge.ID)
+	require.Equal(t, "alice", challenge.Username)
+	require.Equal(t, "register", challenge.Action)
+	mockDB.AssertExpectations(t)
+	mockQuery.AssertExpectations(t)
+}
+
+func TestAgentKeyChallengeRepository_Get_Error(t *testing.T) {
+	mockDB := new(dynamormmocks.MockDB)
+	mockQuery := new(dynamormmocks.MockQuery)
+	mockDB.On("WithContext", mock.Anything).Return(mockDB).Once()
+	mockDB.On("Model", mock.AnythingOfType("*models.AgentKeyChallenge")).Return(mockQuery).Once()
+	mockQuery.On("Where", "PK", "=", "AGENT_KEY_CHALLENGE#challenge-1").Return(mockQuery).Once()
+	mockQuery.On("Where", "SK", "=", "CHALLENGE").Return(mockQuery).Once()
+	mockQuery.On("First", mock.AnythingOfType("*models.AgentKeyChallenge")).Return(errors.New("boom")).Once()
+
+	repo := NewAgentKeyChallengeRepository(mockDB, "table", zap.NewNop())
+	_, err := repo.Get(context.Background(), "challenge-1")
+	require.ErrorContains(t, err, "boom")
+	mockDB.AssertExpectations(t)
+	mockQuery.AssertExpectations(t)
+}
+
+func TestAgentAuthRepositoryHelpers(t *testing.T) {
+	t.Run("constructors default nil logger", func(t *testing.T) {
+		leaseRepo := NewAgentAccessLeaseRepository(new(dynamormmocks.MockDB), "table", nil)
+		require.NotNil(t, leaseRepo.logger)
+
+		keyRepo := NewAgentKeyChallengeRepository(new(dynamormmocks.MockDB), "table", nil)
+		require.NotNil(t, keyRepo.logger)
+	})
+
+	t.Run("create helper rejects nil pointer models", func(t *testing.T) {
+		mockDB := new(dynamormmocks.MockDB)
+		var nilChallenge *models.AgentKeyChallenge
+		err := createPreparedModel(
+			context.Background(),
+			mockDB,
+			zap.NewNop(),
+			nilChallenge,
+			"failed to prepare",
+			"failed to create",
+			func(*models.AgentKeyChallenge) []zap.Field { return nil },
+		)
+		require.ErrorIs(t, err, storage.ErrInvalidInput)
+	})
+
+	t.Run("isNilModel handles value types", func(t *testing.T) {
+		require.False(t, isNilModel(models.AgentKeyChallenge{}))
+	})
+
+	t.Run("mark helper rejects nil db", func(t *testing.T) {
+		var nilCoreDB dynamormcore.DB
+		err := markChallengeUsed(
+			context.Background(),
+			nilCoreDB,
+			zap.NewNop(),
+			"challenge-1",
+			time.Time{},
+			&models.AgentKeyChallenge{PK: "AGENT_KEY_CHALLENGE#challenge-1", SK: "CHALLENGE"},
+			"failed to mark",
+		)
+		require.ErrorIs(t, err, storage.ErrDatabaseConnectionFailed)
+	})
+
+	t.Run("create helper surfaces preparation errors", func(t *testing.T) {
+		mockDB := new(dynamormmocks.MockDB)
+		err := createPreparedModel(
+			context.Background(),
+			mockDB,
+			zap.NewNop(),
+			&models.AgentKeyChallenge{},
+			"failed to prepare",
+			"failed to create",
+			func(*models.AgentKeyChallenge) []zap.Field { return nil },
+		)
+		require.ErrorContains(t, err, "missing required fields")
+		mockDB.AssertNotCalled(t, "WithContext", mock.Anything)
+	})
+
+	t.Run("create helper surfaces storage errors", func(t *testing.T) {
+		mockDB := new(dynamormmocks.MockDB)
+		mockQuery := new(dynamormmocks.MockQuery)
+		mockDB.On("WithContext", mock.Anything).Return(mockDB).Once()
+		mockDB.On("Model", mock.MatchedBy(func(model any) bool {
+			challenge, ok := model.(*models.AgentKeyChallenge)
+			return ok && challenge.PK == "AGENT_KEY_CHALLENGE#challenge-1" && challenge.SK == "CHALLENGE"
+		})).Return(mockQuery).Once()
+		mockQuery.On("IfNotExists").Return(mockQuery).Once()
+		mockQuery.On("Create").Return(errors.New("boom")).Once()
+
+		err := createPreparedModel(
+			context.Background(),
+			mockDB,
+			zap.NewNop(),
+			&models.AgentKeyChallenge{
+				ID:        "challenge-1",
+				Username:  "alice",
+				Action:    "register",
+				Message:   "hello",
+				ExpiresAt: time.Now().UTC().Add(5 * time.Minute),
+			},
+			"failed to prepare",
+			"failed to create",
+			func(challenge *models.AgentKeyChallenge) []zap.Field {
+				return []zap.Field{zap.String("challenge_id", challenge.ID)}
+			},
+		)
+		require.ErrorContains(t, err, "boom")
+		mockDB.AssertExpectations(t)
+		mockQuery.AssertExpectations(t)
+	})
+
+	t.Run("mark helper surfaces update errors", func(t *testing.T) {
+		mockDB := new(dynamormmocks.MockDB)
+		mockQuery := new(dynamormmocks.MockQuery)
+		mockUpdate := new(dynamormmocks.MockUpdateBuilder)
+		mockDB.On("Model", mock.AnythingOfType("*models.AgentKeyChallenge")).Return(mockQuery).Once()
+		mockQuery.On("WithContext", mock.Anything).Return(mockQuery).Once()
+		mockQuery.On("UpdateBuilder").Return(mockUpdate).Once()
+		mockUpdate.On("Set", "Used", true).Return(mockUpdate).Once()
+		mockUpdate.On("Condition", "Used", "=", false).Return(mockUpdate).Once()
+		mockUpdate.On("Condition", "TTL", ">", mock.AnythingOfType("int64")).Return(mockUpdate).Once()
+		mockUpdate.On("Execute").Return(errors.New("boom")).Once()
+
+		err := markChallengeUsed(
+			context.Background(),
+			mockDB,
+			zap.NewNop(),
+			"challenge-1",
+			time.Time{},
+			&models.AgentKeyChallenge{PK: "AGENT_KEY_CHALLENGE#challenge-1", SK: "CHALLENGE"},
+			"failed to mark",
+		)
+		require.ErrorContains(t, err, "boom")
+		mockDB.AssertExpectations(t)
+		mockQuery.AssertExpectations(t)
+		mockUpdate.AssertExpectations(t)
+	})
+}
+
+func TestAgentAuthRepositories_InvalidInputAndStorage(t *testing.T) {
+	var nilCoreDB dynamormcore.DB
+
+	leaseRepo := NewAgentAccessLeaseRepository(nilCoreDB, "table", zap.NewNop())
+	_, err := leaseRepo.GetLease(context.Background(), "agent", "lease")
+	require.ErrorIs(t, err, storage.ErrDatabaseConnectionFailed)
+	require.ErrorIs(t, leaseRepo.CreateChallenge(context.Background(), nil), storage.ErrDatabaseConnectionFailed)
+
+	keyRepo := NewAgentKeyChallengeRepository(nilCoreDB, "table", zap.NewNop())
+	_, err = keyRepo.Get(context.Background(), "challenge")
+	require.ErrorIs(t, err, storage.ErrDatabaseConnectionFailed)
+
+	mockDB := new(dynamormmocks.MockDB)
+	_, err = NewAgentAccessLeaseRepository(mockDB, "table", zap.NewNop()).GetChallenge(context.Background(), " ")
+	require.ErrorIs(t, err, storage.ErrInvalidInput)
+	_, err = NewAgentAccessLeaseRepository(mockDB, "table", zap.NewNop()).GetLease(context.Background(), " ", "lease")
+	require.ErrorIs(t, err, storage.ErrInvalidInput)
+	_, err = NewAgentAccessLeaseRepository(mockDB, "table", zap.NewNop()).ListLeases(context.Background(), " ")
+	require.ErrorIs(t, err, storage.ErrInvalidInput)
+	require.ErrorIs(t, NewAgentAccessLeaseRepository(mockDB, "table", zap.NewNop()).MarkChallengeUsed(context.Background(), " ", time.Time{}), storage.ErrInvalidInput)
+	require.ErrorIs(t, NewAgentKeyChallengeRepository(mockDB, "table", zap.NewNop()).Create(context.Background(), nil), storage.ErrInvalidInput)
+	_, err = NewAgentKeyChallengeRepository(mockDB, "table", zap.NewNop()).Get(context.Background(), " ")
+	require.ErrorIs(t, err, storage.ErrInvalidInput)
+	require.ErrorIs(t, NewAgentKeyChallengeRepository(mockDB, "table", zap.NewNop()).MarkUsed(context.Background(), " ", time.Time{}), storage.ErrInvalidInput)
+}
+
+func TestAgentAuthRepositories_NilReceivers(t *testing.T) {
+	var leaseRepo *AgentAccessLeaseRepository
+	require.ErrorIs(t, leaseRepo.CreateChallenge(context.Background(), &models.AgentAccessLeaseChallenge{}), storage.ErrDatabaseConnectionFailed)
+	require.ErrorIs(t, leaseRepo.CreateLease(context.Background(), &models.AgentAccessLease{}), storage.ErrDatabaseConnectionFailed)
+	require.ErrorIs(t, leaseRepo.MarkChallengeUsed(context.Background(), "challenge-1", time.Time{}), storage.ErrDatabaseConnectionFailed)
+
+	var keyRepo *AgentKeyChallengeRepository
+	require.ErrorIs(t, keyRepo.Create(context.Background(), &models.AgentKeyChallenge{}), storage.ErrDatabaseConnectionFailed)
+	_, err := keyRepo.Get(context.Background(), "challenge-1")
+	require.ErrorIs(t, err, storage.ErrDatabaseConnectionFailed)
+	require.ErrorIs(t, keyRepo.MarkUsed(context.Background(), "challenge-1", time.Time{}), storage.ErrDatabaseConnectionFailed)
+}

--- a/pkg/storage/repositories/agent_auth_repository_helpers.go
+++ b/pkg/storage/repositories/agent_auth_repository_helpers.go
@@ -1,0 +1,101 @@
+package repositories
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	"go.uber.org/zap"
+)
+
+type keyedPreparableModel interface {
+	BeforeCreate() error
+	GetPK() string
+	GetSK() string
+}
+
+func createPreparedModel[T keyedPreparableModel](
+	ctx context.Context,
+	db core.DB,
+	logger *zap.Logger,
+	model T,
+	prepareMessage string,
+	createMessage string,
+	logFields func(T) []zap.Field,
+) error {
+	if db == nil {
+		return storage.ErrDatabaseConnectionFailed
+	}
+	if isNilModel(model) {
+		return storage.ErrInvalidInput
+	}
+
+	fields := logFields(model)
+	if err := model.BeforeCreate(); err != nil {
+		logger.Error(prepareMessage, append(fields, zap.Error(err))...)
+		return err
+	}
+
+	fields = append(fields,
+		zap.String("pk", model.GetPK()),
+		zap.String("sk", model.GetSK()),
+	)
+	if err := db.WithContext(ctx).Model(model).IfNotExists().Create(); err != nil {
+		logger.Error(createMessage, append(fields, zap.Error(err))...)
+		return err
+	}
+
+	return nil
+}
+
+func isNilModel[T any](model T) bool {
+	value := reflect.ValueOf(model)
+	if !value.IsValid() {
+		return true
+	}
+
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func markChallengeUsed(
+	ctx context.Context,
+	db core.DB,
+	logger *zap.Logger,
+	challengeID string,
+	now time.Time,
+	existing interface{},
+	warnMessage string,
+) error {
+	if db == nil {
+		return storage.ErrDatabaseConnectionFailed
+	}
+
+	challengeID = strings.TrimSpace(challengeID)
+	if challengeID == "" {
+		return storage.ErrInvalidInput
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	if err := db.Model(existing).WithContext(ctx).UpdateBuilder().
+		Set("Used", true).
+		Condition("Used", "=", false).
+		Condition("TTL", ">", now.Unix()).
+		Execute(); err != nil {
+		logger.Warn(warnMessage,
+			zap.String("challenge_id", challengeID),
+			zap.Error(err))
+		return err
+	}
+
+	return nil
+}

--- a/pkg/storage/repositories/agent_key_challenge_repository.go
+++ b/pkg/storage/repositories/agent_key_challenge_repository.go
@@ -1,0 +1,103 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	"go.uber.org/zap"
+)
+
+// AgentKeyChallengeRepository persists self-sovereign agent key challenges.
+type AgentKeyChallengeRepository struct {
+	db        core.DB
+	tableName string
+	logger    *zap.Logger
+}
+
+// NewAgentKeyChallengeRepository creates a new AgentKeyChallengeRepository.
+func NewAgentKeyChallengeRepository(db core.DB, tableName string, logger *zap.Logger) *AgentKeyChallengeRepository {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	return &AgentKeyChallengeRepository{
+		db:        db,
+		tableName: tableName,
+		logger:    logger,
+	}
+}
+
+// Create stores a new key challenge after preparing its keys and defaults.
+func (r *AgentKeyChallengeRepository) Create(ctx context.Context, challenge *models.AgentKeyChallenge) error {
+	if r == nil {
+		return storage.ErrDatabaseConnectionFailed
+	}
+
+	return createPreparedModel(
+		ctx,
+		r.db,
+		r.logger,
+		challenge,
+		"failed to prepare agent key challenge",
+		"failed to create agent key challenge",
+		func(challenge *models.AgentKeyChallenge) []zap.Field {
+			if challenge == nil {
+				return nil
+			}
+			return []zap.Field{
+				zap.String("challenge_id", strings.TrimSpace(challenge.ID)),
+				zap.String("username", strings.TrimSpace(challenge.Username)),
+			}
+		},
+	)
+}
+
+// Get loads a key challenge by ID.
+func (r *AgentKeyChallengeRepository) Get(ctx context.Context, challengeID string) (*models.AgentKeyChallenge, error) {
+	if r == nil || r.db == nil {
+		return nil, storage.ErrDatabaseConnectionFailed
+	}
+
+	challengeID = strings.TrimSpace(challengeID)
+	if challengeID == "" {
+		return nil, storage.ErrInvalidInput
+	}
+
+	challenge := &models.AgentKeyChallenge{}
+	if err := r.db.WithContext(ctx).
+		Model(&models.AgentKeyChallenge{}).
+		Where("PK", "=", fmt.Sprintf("AGENT_KEY_CHALLENGE#%s", challengeID)).
+		Where("SK", "=", "CHALLENGE").
+		First(challenge); err != nil {
+		r.logger.Warn("failed to load agent key challenge",
+			zap.String("challenge_id", challengeID),
+			zap.Error(err))
+		return nil, err
+	}
+
+	return challenge, nil
+}
+
+// MarkUsed marks a key challenge as used when it is still valid.
+func (r *AgentKeyChallengeRepository) MarkUsed(ctx context.Context, challengeID string, now time.Time) error {
+	if r == nil {
+		return storage.ErrDatabaseConnectionFailed
+	}
+	return markChallengeUsed(
+		ctx,
+		r.db,
+		r.logger,
+		challengeID,
+		now,
+		&models.AgentKeyChallenge{
+			PK: fmt.Sprintf("AGENT_KEY_CHALLENGE#%s", strings.TrimSpace(challengeID)),
+			SK: "CHALLENGE",
+		},
+		"failed to mark agent key challenge used",
+	)
+}


### PR DESCRIPTION
## Summary
- move agent access lease and agent key challenge persistence into dedicated repositories
- prepare keys and ttl before create operations instead of relying on transport-layer direct writes
- align REST, GraphQL, and self-sovereign handler tests with real repository behavior and raise coverage for the affected storage and handler paths

## Testing
- GOTOOLCHAIN=go1.26.1 go build -o lesser ./cmd/lesser
- GOTOOLCHAIN=go1.26.1 ./lesser build lambdas
- GOTOOLCHAIN=go1.26.1 ./lesser verify ci

## Issues
- closes #190