### PR TITLE
fix agent lease keyed updates

### DIFF
--- a/cmd/api/handlers/agent_access_leases.go
+++ b/cmd/api/handlers/agent_access_leases.go
@@ -305,15 +305,9 @@ func (h *Handler) HandleRevokeAgentAccessLeaseLift(ctx *apptheory.Context) (*app
 	if effectiveAgentAccessLeaseStatus(lease, now) == agentAccessLeaseStatusRevoked {
 		return okJSON(agentAccessLeaseResponse(lease, now))
 	}
-
-	update := h.repos.GetDB().Model(&storageModels.AgentAccessLease{PK: lease.PK, SK: lease.SK}).WithContext(ctx.Context()).UpdateBuilder().
-		Set("Status", agentAccessLeaseStatusRevoked).
-		Set("UpdatedAt", now).
-		Set("RevokedAt", now).
-		Set("RevokedBy", claims.Username).
-		Set("RevokedReason", strings.TrimSpace(req.Reason))
-
-	if err := update.Execute(); err != nil {
+	reason := strings.TrimSpace(req.Reason)
+	repo := h.agentAccessLeaseRepo()
+	if err := repo.RevokeLease(ctx.Context(), lease, claims.Username, reason, now); err != nil {
 		return common.RespondInternalServerError(ctx)
 	}
 
@@ -321,10 +315,10 @@ func (h *Handler) HandleRevokeAgentAccessLeaseLift(ctx *apptheory.Context) (*app
 	lease.UpdatedAt = now
 	lease.RevokedAt = now
 	lease.RevokedBy = claims.Username
-	lease.RevokedReason = strings.TrimSpace(req.Reason)
+	lease.RevokedReason = reason
 	h.recordAgentGovernanceEvent(ctx, username, "agent.access_lease.revoked", map[string]any{
 		"lease_id": lease.ID,
-		"reason":   strings.TrimSpace(req.Reason),
+		"reason":   reason,
 	})
 	return okJSON(agentAccessLeaseResponse(lease, now))
 }
@@ -452,13 +446,8 @@ func (h *Handler) HandleAuthorizeAgentAccessLeaseSessionKeyLift(ctx *apptheory.C
 		}
 		return common.RespondInternalServerError(ctx)
 	}
-
-	update := h.repos.GetDB().Model(&storageModels.AgentAccessLease{PK: lease.PK, SK: lease.SK}).WithContext(ctx.Context()).UpdateBuilder().
-		Set("SessionPublicKey", challenge.SessionPublicKey).
-		Set("SessionKeyType", agentAccessLeaseSessionKeyType).
-		Set("SessionKeyCreatedAt", now).
-		Set("UpdatedAt", now)
-	if err := update.Execute(); err != nil {
+	repo := h.agentAccessLeaseRepo()
+	if err := repo.AuthorizeSessionKey(ctx.Context(), lease, challenge.SessionPublicKey, agentAccessLeaseSessionKeyType, now); err != nil {
 		return common.RespondInternalServerError(ctx)
 	}
 
@@ -636,15 +625,8 @@ func (h *Handler) HandleExchangeAgentAccessLeaseTokenLift(ctx *apptheory.Context
 	if err != nil {
 		return common.RespondInternalServerError(ctx)
 	}
-
-	update := h.repos.GetDB().Model(&storageModels.AgentAccessLease{PK: lease.PK, SK: lease.SK}).WithContext(ctx.Context()).UpdateBuilder().
-		Set("LastUsedAt", now).
-		Set("IdleExpiresAt", newIdleExpiresAt).
-		Set("UpdatedAt", now)
-	if challenge.Action == agentAccessLeaseActionRenewSession {
-		update = update.Set("SessionKeyLastUsedAt", now)
-	}
-	if err := update.Execute(); err != nil {
+	repo := h.agentAccessLeaseRepo()
+	if err := repo.RecordLeaseUse(ctx.Context(), lease, newIdleExpiresAt, now, challenge.Action == agentAccessLeaseActionRenewSession); err != nil {
 		return common.RespondInternalServerError(ctx)
 	}
 

--- a/graph/agent_access_lease_resolvers.go
+++ b/graph/agent_access_lease_resolvers.go
@@ -226,13 +226,8 @@ func (r *mutationResolver) RevokeAgentAccessLease(ctx context.Context, username 
 	if input != nil && input.Reason != nil {
 		reason = strings.TrimSpace(*input.Reason)
 	}
-	update := r.Storage.GetDB().Model(&storageModels.AgentAccessLease{PK: lease.PK, SK: lease.SK}).WithContext(ctx).UpdateBuilder().
-		Set("Status", graphAgentAccessLeaseStatusRevoked).
-		Set("UpdatedAt", now).
-		Set("RevokedAt", now).
-		Set("RevokedBy", claims.Username).
-		Set("RevokedReason", reason)
-	if err := update.Execute(); err != nil {
+	repo := r.agentAccessLeaseRepo()
+	if err := repo.RevokeLease(ctx, lease, claims.Username, reason, now); err != nil {
 		return nil, apperrors.InternalWithCause(err, "failed to revoke agent access lease")
 	}
 	lease.Status = graphAgentAccessLeaseStatusRevoked
@@ -324,12 +319,8 @@ func (r *mutationResolver) AuthorizeAgentAccessLeaseSessionKey(ctx context.Conte
 		}
 		return nil, apperrors.InternalWithCause(err, "failed to mark session key challenge used")
 	}
-	update := r.Storage.GetDB().Model(&storageModels.AgentAccessLease{PK: lease.PK, SK: lease.SK}).WithContext(ctx).UpdateBuilder().
-		Set("SessionPublicKey", challenge.SessionPublicKey).
-		Set("SessionKeyType", graphAgentAccessLeaseSessionKeyType).
-		Set("SessionKeyCreatedAt", now).
-		Set("UpdatedAt", now)
-	if err := update.Execute(); err != nil {
+	repo := r.agentAccessLeaseRepo()
+	if err := repo.AuthorizeSessionKey(ctx, lease, challenge.SessionPublicKey, graphAgentAccessLeaseSessionKeyType, now); err != nil {
 		return nil, apperrors.InternalWithCause(err, "failed to authorize session key")
 	}
 	lease.SessionPublicKey = challenge.SessionPublicKey
@@ -447,14 +438,8 @@ func (r *mutationResolver) ExchangeAgentAccessLeaseToken(ctx context.Context, us
 	if err != nil {
 		return nil, apperrors.InternalWithCause(err, "failed to mint lease access token")
 	}
-	update := r.Storage.GetDB().Model(&storageModels.AgentAccessLease{PK: lease.PK, SK: lease.SK}).WithContext(ctx).UpdateBuilder().
-		Set("LastUsedAt", now).
-		Set("IdleExpiresAt", newIdleExpiresAt).
-		Set("UpdatedAt", now)
-	if challenge.Action == graphAgentAccessLeaseActionRenewSession {
-		update = update.Set("SessionKeyLastUsedAt", now)
-	}
-	if err := update.Execute(); err != nil {
+	repo := r.agentAccessLeaseRepo()
+	if err := repo.RecordLeaseUse(ctx, lease, newIdleExpiresAt, now, challenge.Action == graphAgentAccessLeaseActionRenewSession); err != nil {
 		return nil, apperrors.InternalWithCause(err, "failed to update lease activity")
 	}
 	return &model.AgentAccessLeaseTokenPayload{

--- a/pkg/storage/repositories/agent_access_lease_repository.go
+++ b/pkg/storage/repositories/agent_access_lease_repository.go
@@ -127,6 +127,117 @@ func (r *AgentAccessLeaseRepository) CreateLease(ctx context.Context, lease *mod
 	)
 }
 
+func (r *AgentAccessLeaseRepository) updateLease(
+	ctx context.Context,
+	lease *models.AgentAccessLease,
+	warnMessage string,
+	build func(core.UpdateBuilder) core.UpdateBuilder,
+) error {
+	if r == nil || r.db == nil {
+		return storage.ErrDatabaseConnectionFailed
+	}
+	if lease == nil {
+		return storage.ErrInvalidInput
+	}
+	if build == nil {
+		return storage.ErrInvalidInput
+	}
+
+	update, err := keyedUpdateBuilder(ctx, r.db, lease)
+	if err != nil {
+		return err
+	}
+
+	if err := build(update).Execute(); err != nil {
+		r.logger.Warn(warnMessage,
+			zap.String("lease_id", strings.TrimSpace(lease.ID)),
+			zap.String("username", strings.TrimSpace(lease.Username)),
+			zap.String("pk", strings.TrimSpace(lease.GetPK())),
+			zap.String("sk", strings.TrimSpace(lease.GetSK())),
+			zap.Error(err))
+		return err
+	}
+
+	return nil
+}
+
+// RevokeLease updates a lease to the revoked state.
+func (r *AgentAccessLeaseRepository) RevokeLease(
+	ctx context.Context,
+	lease *models.AgentAccessLease,
+	revokedBy string,
+	reason string,
+	now time.Time,
+) error {
+	revokedBy = strings.TrimSpace(revokedBy)
+	reason = strings.TrimSpace(reason)
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	return r.updateLease(ctx, lease, "failed to revoke agent access lease", func(update core.UpdateBuilder) core.UpdateBuilder {
+		return update.
+			Set("Status", "revoked").
+			Set("UpdatedAt", now).
+			Set("RevokedAt", now).
+			Set("RevokedBy", revokedBy).
+			Set("RevokedReason", reason)
+	})
+}
+
+// AuthorizeSessionKey stores the active session key metadata for a lease.
+func (r *AgentAccessLeaseRepository) AuthorizeSessionKey(
+	ctx context.Context,
+	lease *models.AgentAccessLease,
+	sessionPublicKey string,
+	sessionKeyType string,
+	now time.Time,
+) error {
+	sessionPublicKey = strings.TrimSpace(sessionPublicKey)
+	sessionKeyType = strings.TrimSpace(sessionKeyType)
+	if sessionPublicKey == "" || sessionKeyType == "" {
+		return storage.ErrInvalidInput
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	return r.updateLease(ctx, lease, "failed to authorize agent access lease session key", func(update core.UpdateBuilder) core.UpdateBuilder {
+		return update.
+			Set("SessionPublicKey", sessionPublicKey).
+			Set("SessionKeyType", sessionKeyType).
+			Set("SessionKeyCreatedAt", now).
+			Set("UpdatedAt", now)
+	})
+}
+
+// RecordLeaseUse refreshes lease activity timestamps after successful token exchange.
+func (r *AgentAccessLeaseRepository) RecordLeaseUse(
+	ctx context.Context,
+	lease *models.AgentAccessLease,
+	idleExpiresAt time.Time,
+	now time.Time,
+	sessionKeyUsed bool,
+) error {
+	if idleExpiresAt.IsZero() {
+		return storage.ErrInvalidInput
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	return r.updateLease(ctx, lease, "failed to update agent access lease activity", func(update core.UpdateBuilder) core.UpdateBuilder {
+		update = update.
+			Set("LastUsedAt", now).
+			Set("IdleExpiresAt", idleExpiresAt).
+			Set("UpdatedAt", now)
+		if sessionKeyUsed {
+			update = update.Set("SessionKeyLastUsedAt", now)
+		}
+		return update
+	})
+}
+
 // GetLease loads a single agent access lease.
 func (r *AgentAccessLeaseRepository) GetLease(ctx context.Context, username, leaseID string) (*models.AgentAccessLease, error) {
 	if r == nil || r.db == nil {

--- a/pkg/storage/repositories/agent_auth_repositories_test.go
+++ b/pkg/storage/repositories/agent_auth_repositories_test.go
@@ -110,11 +110,13 @@ func TestAgentAccessLeaseRepository_MarkChallengeUsed_UsesConditionalUpdate(t *t
 	mockQuery := new(dynamormmocks.MockQuery)
 	mockUpdate := new(dynamormmocks.MockUpdateBuilder)
 
+	mockDB.On("WithContext", mock.Anything).Return(mockDB).Once()
 	mockDB.On("Model", mock.MatchedBy(func(model any) bool {
 		m, ok := model.(*models.AgentAccessLeaseChallenge)
 		return ok && m.PK == "AGENT_ACCESS_CHALLENGE#challenge-1" && m.SK == "CHALLENGE"
 	})).Return(mockQuery).Once()
-	mockQuery.On("WithContext", mock.Anything).Return(mockQuery).Once()
+	mockQuery.On("Where", "PK", "=", "AGENT_ACCESS_CHALLENGE#challenge-1").Return(mockQuery).Once()
+	mockQuery.On("Where", "SK", "=", "CHALLENGE").Return(mockQuery).Once()
 	mockQuery.On("UpdateBuilder").Return(mockUpdate).Once()
 	mockUpdate.On("Set", "Used", true).Return(mockUpdate).Once()
 	mockUpdate.On("Condition", "Used", "=", false).Return(mockUpdate).Once()
@@ -126,6 +128,93 @@ func TestAgentAccessLeaseRepository_MarkChallengeUsed_UsesConditionalUpdate(t *t
 	mockDB.AssertExpectations(t)
 	mockQuery.AssertExpectations(t)
 	mockUpdate.AssertExpectations(t)
+}
+
+func TestAgentAccessLeaseRepository_UpdatePaths_UseKeyConditions(t *testing.T) {
+	t.Run("RevokeLease", func(t *testing.T) {
+		mockDB := new(dynamormmocks.MockDB)
+		mockQuery := new(dynamormmocks.MockQuery)
+		mockUpdate := new(dynamormmocks.MockUpdateBuilder)
+		now := time.Now().UTC()
+		lease := &models.AgentAccessLease{
+			ID:       "lease-1",
+			Username: "agent-1",
+		}
+
+		mockDB.On("WithContext", mock.Anything).Return(mockDB).Once()
+		mockDB.On("Model", mock.MatchedBy(func(model any) bool {
+			m, ok := model.(*models.AgentAccessLease)
+			return ok && m.PK == "AGENT_ACCESS_LEASE#agent-1" && m.SK == "LEASE#lease-1"
+		})).Return(mockQuery).Once()
+		mockQuery.On("Where", "PK", "=", "AGENT_ACCESS_LEASE#agent-1").Return(mockQuery).Once()
+		mockQuery.On("Where", "SK", "=", "LEASE#lease-1").Return(mockQuery).Once()
+		mockQuery.On("UpdateBuilder").Return(mockUpdate).Once()
+		mockUpdate.On("Set", "Status", "revoked").Return(mockUpdate).Once()
+		mockUpdate.On("Set", "UpdatedAt", now).Return(mockUpdate).Once()
+		mockUpdate.On("Set", "RevokedAt", now).Return(mockUpdate).Once()
+		mockUpdate.On("Set", "RevokedBy", "owner").Return(mockUpdate).Once()
+		mockUpdate.On("Set", "RevokedReason", "expired").Return(mockUpdate).Once()
+		mockUpdate.On("Execute").Return(nil).Once()
+
+		repo := NewAgentAccessLeaseRepository(mockDB, "table", zap.NewNop())
+		require.NoError(t, repo.RevokeLease(context.Background(), lease, "owner", "expired", now))
+		require.Equal(t, "AGENT_ACCESS_LEASE#agent-1", lease.PK)
+		require.Equal(t, "LEASE#lease-1", lease.SK)
+		mockDB.AssertExpectations(t)
+		mockQuery.AssertExpectations(t)
+		mockUpdate.AssertExpectations(t)
+	})
+
+	t.Run("AuthorizeSessionKey", func(t *testing.T) {
+		mockDB := new(dynamormmocks.MockDB)
+		mockQuery := new(dynamormmocks.MockQuery)
+		mockUpdate := new(dynamormmocks.MockUpdateBuilder)
+		now := time.Now().UTC()
+		lease := &models.AgentAccessLease{PK: "AGENT_ACCESS_LEASE#agent-1", SK: "LEASE#lease-1", ID: "lease-1", Username: "agent-1"}
+
+		mockDB.On("WithContext", mock.Anything).Return(mockDB).Once()
+		mockDB.On("Model", lease).Return(mockQuery).Once()
+		mockQuery.On("Where", "PK", "=", "AGENT_ACCESS_LEASE#agent-1").Return(mockQuery).Once()
+		mockQuery.On("Where", "SK", "=", "LEASE#lease-1").Return(mockQuery).Once()
+		mockQuery.On("UpdateBuilder").Return(mockUpdate).Once()
+		mockUpdate.On("Set", "SessionPublicKey", "pub").Return(mockUpdate).Once()
+		mockUpdate.On("Set", "SessionKeyType", "ed25519").Return(mockUpdate).Once()
+		mockUpdate.On("Set", "SessionKeyCreatedAt", now).Return(mockUpdate).Once()
+		mockUpdate.On("Set", "UpdatedAt", now).Return(mockUpdate).Once()
+		mockUpdate.On("Execute").Return(nil).Once()
+
+		repo := NewAgentAccessLeaseRepository(mockDB, "table", zap.NewNop())
+		require.NoError(t, repo.AuthorizeSessionKey(context.Background(), lease, "pub", "ed25519", now))
+		mockDB.AssertExpectations(t)
+		mockQuery.AssertExpectations(t)
+		mockUpdate.AssertExpectations(t)
+	})
+
+	t.Run("RecordLeaseUse", func(t *testing.T) {
+		mockDB := new(dynamormmocks.MockDB)
+		mockQuery := new(dynamormmocks.MockQuery)
+		mockUpdate := new(dynamormmocks.MockUpdateBuilder)
+		now := time.Now().UTC()
+		idleExpiresAt := now.Add(time.Hour)
+		lease := &models.AgentAccessLease{PK: "AGENT_ACCESS_LEASE#agent-1", SK: "LEASE#lease-1", ID: "lease-1", Username: "agent-1"}
+
+		mockDB.On("WithContext", mock.Anything).Return(mockDB).Once()
+		mockDB.On("Model", lease).Return(mockQuery).Once()
+		mockQuery.On("Where", "PK", "=", "AGENT_ACCESS_LEASE#agent-1").Return(mockQuery).Once()
+		mockQuery.On("Where", "SK", "=", "LEASE#lease-1").Return(mockQuery).Once()
+		mockQuery.On("UpdateBuilder").Return(mockUpdate).Once()
+		mockUpdate.On("Set", "LastUsedAt", now).Return(mockUpdate).Once()
+		mockUpdate.On("Set", "IdleExpiresAt", idleExpiresAt).Return(mockUpdate).Once()
+		mockUpdate.On("Set", "UpdatedAt", now).Return(mockUpdate).Once()
+		mockUpdate.On("Set", "SessionKeyLastUsedAt", now).Return(mockUpdate).Once()
+		mockUpdate.On("Execute").Return(nil).Once()
+
+		repo := NewAgentAccessLeaseRepository(mockDB, "table", zap.NewNop())
+		require.NoError(t, repo.RecordLeaseUse(context.Background(), lease, idleExpiresAt, now, true))
+		mockDB.AssertExpectations(t)
+		mockQuery.AssertExpectations(t)
+		mockUpdate.AssertExpectations(t)
+	})
 }
 
 func TestAgentAccessLeaseRepository_ReadPaths(t *testing.T) {
@@ -438,8 +527,10 @@ func TestAgentAuthRepositoryHelpers(t *testing.T) {
 		mockDB := new(dynamormmocks.MockDB)
 		mockQuery := new(dynamormmocks.MockQuery)
 		mockUpdate := new(dynamormmocks.MockUpdateBuilder)
+		mockDB.On("WithContext", mock.Anything).Return(mockDB).Once()
 		mockDB.On("Model", mock.AnythingOfType("*models.AgentKeyChallenge")).Return(mockQuery).Once()
-		mockQuery.On("WithContext", mock.Anything).Return(mockQuery).Once()
+		mockQuery.On("Where", "PK", "=", "AGENT_KEY_CHALLENGE#challenge-1").Return(mockQuery).Once()
+		mockQuery.On("Where", "SK", "=", "CHALLENGE").Return(mockQuery).Once()
 		mockQuery.On("UpdateBuilder").Return(mockUpdate).Once()
 		mockUpdate.On("Set", "Used", true).Return(mockUpdate).Once()
 		mockUpdate.On("Condition", "Used", "=", false).Return(mockUpdate).Once()
@@ -459,6 +550,33 @@ func TestAgentAuthRepositoryHelpers(t *testing.T) {
 		mockDB.AssertExpectations(t)
 		mockQuery.AssertExpectations(t)
 		mockUpdate.AssertExpectations(t)
+	})
+
+	t.Run("keyed update builder derives missing keys", func(t *testing.T) {
+		mockDB := new(dynamormmocks.MockDB)
+		mockQuery := new(dynamormmocks.MockQuery)
+		mockUpdate := new(dynamormmocks.MockUpdateBuilder)
+		lease := &models.AgentAccessLease{
+			ID:       "lease-1",
+			Username: "agent-1",
+		}
+
+		mockDB.On("WithContext", mock.Anything).Return(mockDB).Once()
+		mockDB.On("Model", mock.MatchedBy(func(model any) bool {
+			m, ok := model.(*models.AgentAccessLease)
+			return ok && m.PK == "AGENT_ACCESS_LEASE#agent-1" && m.SK == "LEASE#lease-1"
+		})).Return(mockQuery).Once()
+		mockQuery.On("Where", "PK", "=", "AGENT_ACCESS_LEASE#agent-1").Return(mockQuery).Once()
+		mockQuery.On("Where", "SK", "=", "LEASE#lease-1").Return(mockQuery).Once()
+		mockQuery.On("UpdateBuilder").Return(mockUpdate).Once()
+
+		update, err := keyedUpdateBuilder(context.Background(), mockDB, lease)
+		require.NoError(t, err)
+		require.NotNil(t, update)
+		require.Equal(t, "AGENT_ACCESS_LEASE#agent-1", lease.PK)
+		require.Equal(t, "LEASE#lease-1", lease.SK)
+		mockDB.AssertExpectations(t)
+		mockQuery.AssertExpectations(t)
 	})
 }
 
@@ -486,6 +604,9 @@ func TestAgentAuthRepositories_InvalidInputAndStorage(t *testing.T) {
 	_, err = NewAgentKeyChallengeRepository(mockDB, "table", zap.NewNop()).Get(context.Background(), " ")
 	require.ErrorIs(t, err, storage.ErrInvalidInput)
 	require.ErrorIs(t, NewAgentKeyChallengeRepository(mockDB, "table", zap.NewNop()).MarkUsed(context.Background(), " ", time.Time{}), storage.ErrInvalidInput)
+	require.ErrorIs(t, NewAgentAccessLeaseRepository(mockDB, "table", zap.NewNop()).AuthorizeSessionKey(context.Background(), &models.AgentAccessLease{}, " ", "ed25519", time.Time{}), storage.ErrInvalidInput)
+	require.ErrorIs(t, NewAgentAccessLeaseRepository(mockDB, "table", zap.NewNop()).AuthorizeSessionKey(context.Background(), &models.AgentAccessLease{}, "pub", " ", time.Time{}), storage.ErrInvalidInput)
+	require.ErrorIs(t, NewAgentAccessLeaseRepository(mockDB, "table", zap.NewNop()).RecordLeaseUse(context.Background(), &models.AgentAccessLease{}, time.Time{}, time.Time{}, false), storage.ErrInvalidInput)
 }
 
 func TestAgentAuthRepositories_NilReceivers(t *testing.T) {
@@ -493,6 +614,9 @@ func TestAgentAuthRepositories_NilReceivers(t *testing.T) {
 	require.ErrorIs(t, leaseRepo.CreateChallenge(context.Background(), &models.AgentAccessLeaseChallenge{}), storage.ErrDatabaseConnectionFailed)
 	require.ErrorIs(t, leaseRepo.CreateLease(context.Background(), &models.AgentAccessLease{}), storage.ErrDatabaseConnectionFailed)
 	require.ErrorIs(t, leaseRepo.MarkChallengeUsed(context.Background(), "challenge-1", time.Time{}), storage.ErrDatabaseConnectionFailed)
+	require.ErrorIs(t, leaseRepo.RevokeLease(context.Background(), &models.AgentAccessLease{}, "owner", "reason", time.Time{}), storage.ErrDatabaseConnectionFailed)
+	require.ErrorIs(t, leaseRepo.AuthorizeSessionKey(context.Background(), &models.AgentAccessLease{}, "pub", "ed25519", time.Time{}), storage.ErrDatabaseConnectionFailed)
+	require.ErrorIs(t, leaseRepo.RecordLeaseUse(context.Background(), &models.AgentAccessLease{}, time.Now().UTC(), time.Time{}, false), storage.ErrDatabaseConnectionFailed)
 
 	var keyRepo *AgentKeyChallengeRepository
 	require.ErrorIs(t, keyRepo.Create(context.Background(), &models.AgentKeyChallenge{}), storage.ErrDatabaseConnectionFailed)

--- a/pkg/storage/repositories/agent_auth_repository_helpers.go
+++ b/pkg/storage/repositories/agent_auth_repository_helpers.go
@@ -17,6 +17,11 @@ type keyedPreparableModel interface {
 	GetSK() string
 }
 
+type keyedStoredModel interface {
+	GetPK() string
+	GetSK() string
+}
+
 func createPreparedModel[T keyedPreparableModel](
 	ctx context.Context,
 	db core.DB,
@@ -65,19 +70,44 @@ func isNilModel[T any](model T) bool {
 	}
 }
 
+func keyedUpdateBuilder[T keyedStoredModel](ctx context.Context, db core.DB, model T) (core.UpdateBuilder, error) {
+	if db == nil {
+		return nil, storage.ErrDatabaseConnectionFailed
+	}
+	if isNilModel(model) {
+		return nil, storage.ErrInvalidInput
+	}
+
+	if updater, ok := any(model).(interface{ UpdateKeys() error }); ok {
+		if strings.TrimSpace(model.GetPK()) == "" || strings.TrimSpace(model.GetSK()) == "" {
+			if err := updater.UpdateKeys(); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	pk := strings.TrimSpace(model.GetPK())
+	sk := strings.TrimSpace(model.GetSK())
+	if pk == "" || sk == "" {
+		return nil, storage.ErrInvalidInput
+	}
+
+	return db.WithContext(ctx).
+		Model(model).
+		Where("PK", "=", pk).
+		Where("SK", "=", sk).
+		UpdateBuilder(), nil
+}
+
 func markChallengeUsed(
 	ctx context.Context,
 	db core.DB,
 	logger *zap.Logger,
 	challengeID string,
 	now time.Time,
-	existing interface{},
+	existing keyedStoredModel,
 	warnMessage string,
 ) error {
-	if db == nil {
-		return storage.ErrDatabaseConnectionFailed
-	}
-
 	challengeID = strings.TrimSpace(challengeID)
 	if challengeID == "" {
 		return storage.ErrInvalidInput
@@ -86,7 +116,12 @@ func markChallengeUsed(
 		now = time.Now().UTC()
 	}
 
-	if err := db.Model(existing).WithContext(ctx).UpdateBuilder().
+	update, err := keyedUpdateBuilder(ctx, db, existing)
+	if err != nil {
+		return err
+	}
+
+	if err := update.
 		Set("Used", true).
 		Condition("Used", "=", false).
 		Condition("TTL", ">", now.Unix()).


### PR DESCRIPTION
## Summary
- fix agent auth repository updates to bind PK/SK through explicit key conditions before using UpdateBuilder
- move agent lease revoke/session-key/lease-activity mutations behind the lease repository so REST and GraphQL share the same safe persistence path
- add regression coverage for challenge-consume and lease mutation update wiring

## Verification
- GOTOOLCHAIN=go1.26.1 go test ./pkg/storage/repositories ./cmd/api/handlers ./graph -count=1
- GOTOOLCHAIN=go1.26.1 golangci-lint run --config .golangci.yml --disable gosec --concurrency 4 ./pkg/storage/repositories ./cmd/api/handlers ./graph
- GOTOOLCHAIN=go1.26.1 go build -o lesser ./cmd/lesser
- GOTOOLCHAIN=go1.26.1 ./lesser verify ci

Closes #192