### PR TITLE
restore delegated agent creation

### DIFF
--- a/cmd/api/handlers/agents.go
+++ b/cmd/api/handlers/agents.go
@@ -14,6 +14,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/agents"
 	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/common"
+	apperrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/federation"
 	"github.com/equaltoai/lesser/pkg/storage"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
@@ -177,7 +178,7 @@ func (h *Handler) resolveDelegatedAgentAccount(
 
 	account, err := h.repos.Account().GetAccount(ctx.Context(), agentUsername)
 	if err != nil {
-		if common.IsNotFound(err) {
+		if apperrors.HasCode(err, apperrors.CodeNotFound) {
 			resp, respErr := common.RespondNotFound(ctx, "agent")
 			return nil, resp, respErr
 		}

--- a/graph/agent_delegation_round32_test.go
+++ b/graph/agent_delegation_round32_test.go
@@ -14,9 +14,11 @@ import (
 	apperrors "github.com/equaltoai/lesser/pkg/errors"
 	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
+	"github.com/equaltoai/lesser/pkg/storage/theorydb/marshalers"
 	pkgtesting "github.com/equaltoai/lesser/pkg/testing"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	dynamormerrors "github.com/theory-cloud/tabletheory/pkg/errors"
 	dynamormmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
 	"go.uber.org/zap"
 )
@@ -37,52 +39,154 @@ func delegatedAgentAuthContext(username string, scopes ...string) context.Contex
 	})
 }
 
-func newDelegationResolver(t *testing.T, storedScopes []string, allowAgentRegistration bool) *Resolver {
+type passthroughEncryptor struct{}
+
+func (passthroughEncryptor) Encrypt(plaintext []byte) ([]byte, error) {
+	return append([]byte(nil), plaintext...), nil
+}
+func (passthroughEncryptor) Decrypt(ciphertext []byte) ([]byte, error) {
+	return append([]byte(nil), ciphertext...), nil
+}
+
+type delegationGraphState struct {
+	users              map[string]*storageModels.User
+	actors             map[string]*storageModels.Actor
+	createConflictOnce bool
+}
+
+func newDelegationGraphState(username string, storedScopes []string) *delegationGraphState {
+	now := time.Now().UTC()
+	user := &storageModels.User{
+		Username:     username,
+		DisplayName:  "Agent One",
+		IsAgent:      true,
+		AgentType:    "CUSTOM",
+		AgentVersion: "v1",
+		AgentOwner:   "@owner",
+		Metadata: map[string]any{
+			"agent_delegated_scopes": append([]string(nil), storedScopes...),
+		},
+		CreatedAt: now.Add(-time.Hour),
+		UpdatedAt: now,
+	}
+	_ = user.UpdateKeys()
+
+	actor := &storageModels.Actor{
+		Username:  username,
+		NumericID: common.GenerateNumericID(username),
+		CreatedAt: now.Add(-time.Hour),
+		UpdatedAt: now,
+		Actor: &activitypub.Actor{
+			BaseObject: activitypub.BaseObject{
+				ID:   "https://localhost/users/" + username,
+				Type: activitypub.ServiceType,
+			},
+			PreferredUsername: username,
+		},
+	}
+	_ = actor.UpdateKeys()
+
+	return &delegationGraphState{
+		users:  map[string]*storageModels.User{username: user},
+		actors: map[string]*storageModels.Actor{username: actor},
+	}
+}
+
+func (s *delegationGraphState) user(username string) *storageModels.User {
+	if s == nil || s.users == nil {
+		return nil
+	}
+	return s.users[username]
+}
+
+func (s *delegationGraphState) actor(username string) *storageModels.Actor {
+	if s == nil || s.actors == nil {
+		return nil
+	}
+	return s.actors[username]
+}
+
+func (s *delegationGraphState) storeCreate(model any) {
+	switch v := model.(type) {
+	case *storageModels.User:
+		if s.users == nil {
+			s.users = map[string]*storageModels.User{}
+		}
+		copyUser := *v
+		s.users[v.Username] = &copyUser
+	case *storageModels.Actor:
+		if s.actors == nil {
+			s.actors = map[string]*storageModels.Actor{}
+		}
+		copyActor := *v
+		s.actors[v.Username] = &copyActor
+	}
+}
+
+func newDelegationResolver(t *testing.T, state *delegationGraphState, allowAgentRegistration bool) *Resolver {
 	t.Helper()
+
+	if state == nil {
+		state = &delegationGraphState{}
+	}
 
 	mockDB := new(dynamormmocks.MockDB)
 	mockQuery := new(dynamormmocks.MockQuery)
+	var currentModel any
+	var lastPK string
 
 	mockDB.On("WithContext", mock.Anything).Return(mockDB).Maybe()
-	mockDB.On("Model", mock.Anything).Return(mockQuery).Maybe()
+	mockDB.On("Model", mock.Anything).Run(func(args mock.Arguments) {
+		currentModel = args.Get(0)
+	}).Return(mockQuery).Maybe()
 
 	mockQuery.On("WithContext", mock.Anything).Return(mockQuery).Maybe()
-	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery).Maybe()
+	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		field, _ := args.Get(0).(string)
+		value, _ := args.Get(2).(string)
+		if field == "PK" {
+			lastPK = value
+		}
+	}).Return(mockQuery).Maybe()
 	mockQuery.On("Index", mock.Anything).Return(mockQuery).Maybe()
 	mockQuery.On("ConsistentRead").Return(mockQuery).Maybe()
-	mockQuery.On("Create").Return(nil).Maybe()
-	mockQuery.On("First", mock.Anything).Run(func(args mock.Arguments) {
-		switch v := args.Get(0).(type) {
-		case *storageModels.User:
-			v.Username = "agent1"
-			v.DisplayName = "Agent One"
-			v.IsAgent = true
-			v.AgentType = "CUSTOM"
-			v.AgentVersion = "v1"
-			v.AgentOwner = "@owner"
-			v.Metadata = map[string]any{
-				"agent_delegated_scopes": append([]string(nil), storedScopes...),
-			}
-			v.CreatedAt = time.Now().Add(-time.Hour)
-			v.UpdatedAt = time.Now()
-			_ = v.UpdateKeys()
-		case *storageModels.Actor:
-			v.Username = "agent1"
-			v.NumericID = common.GenerateNumericID("agent1")
-			v.CreatedAt = time.Now().Add(-time.Hour)
-			v.UpdatedAt = time.Now()
-			v.Actor = &activitypub.Actor{
-				BaseObject: activitypub.BaseObject{
-					ID:   "https://localhost/users/agent1",
-					Type: activitypub.ServiceType,
-				},
-				PreferredUsername: "agent1",
-			}
-			_ = v.UpdateKeys()
-		}
+	if state.createConflictOnce {
+		mockQuery.On("Create").Return(dynamormerrors.ErrConditionFailed).Once()
+	}
+	mockQuery.On("Create").Run(func(mock.Arguments) {
+		state.storeCreate(currentModel)
 	}).Return(nil).Maybe()
 
+	mockQuery.On("First", mock.MatchedBy(func(dest any) bool {
+		_, ok := dest.(*storageModels.User)
+		username := strings.TrimPrefix(lastPK, "USER#")
+		return ok && state.user(username) == nil
+	})).Return(dynamormerrors.ErrItemNotFound).Maybe()
+	mockQuery.On("First", mock.MatchedBy(func(dest any) bool {
+		_, ok := dest.(*storageModels.User)
+		username := strings.TrimPrefix(lastPK, "USER#")
+		return ok && state.user(username) != nil
+	})).Run(func(args mock.Arguments) {
+		dest := args.Get(0).(*storageModels.User)
+		*dest = *state.user(strings.TrimPrefix(lastPK, "USER#"))
+	}).Return(nil).Maybe()
+	mockQuery.On("First", mock.MatchedBy(func(dest any) bool {
+		_, ok := dest.(*storageModels.Actor)
+		username := strings.TrimPrefix(lastPK, "ACTOR#")
+		return ok && state.actor(username) == nil
+	})).Return(dynamormerrors.ErrItemNotFound).Maybe()
+	mockQuery.On("First", mock.MatchedBy(func(dest any) bool {
+		_, ok := dest.(*storageModels.Actor)
+		username := strings.TrimPrefix(lastPK, "ACTOR#")
+		return ok && state.actor(username) != nil
+	})).Run(func(args mock.Arguments) {
+		dest := args.Get(0).(*storageModels.Actor)
+		*dest = *state.actor(strings.TrimPrefix(lastPK, "ACTOR#"))
+	}).Return(nil).Maybe()
+	mockQuery.On("First", mock.Anything).Return(nil).Maybe()
+
 	accountRepo := repositories.NewAccountRepository(mockDB, "test-table", "localhost", zap.NewNop())
+	accountRepo.SetEncryptor(marshalers.Encryptor(passthroughEncryptor{}))
 	storage := &agentDelegationGraphStorage{
 		MockRepositoryStorage: pkgtesting.NewMockRepositoryStorage(),
 		accountRepo:           accountRepo,
@@ -103,7 +207,7 @@ func newDelegationResolver(t *testing.T, storedScopes []string, allowAgentRegist
 }
 
 func TestDelegateToAgent_AllowsExistingAgentWhenRegistrationDisabled(t *testing.T) {
-	resolver := newDelegationResolver(t, []string{"read", "write:statuses"}, false)
+	resolver := newDelegationResolver(t, newDelegationGraphState("agent1", []string{"read", "write:statuses"}), false)
 	ctx := delegatedAgentAuthContext("owner", auth.ScopeRead, auth.ScopeWrite)
 
 	result, err := resolver.Mutation().DelegateToAgent(ctx, model.DelegateToAgentInput{
@@ -123,8 +227,100 @@ func TestDelegateToAgent_AllowsExistingAgentWhenRegistrationDisabled(t *testing.
 	require.Equal(t, "agent1", result.Agent.Username)
 }
 
+func TestDelegateToAgent_CreatesMissingAgentWhenRegistrationEnabled(t *testing.T) {
+	resolver := newDelegationResolver(t, &delegationGraphState{}, true)
+	ctx := delegatedAgentAuthContext("owner", auth.ScopeRead, auth.ScopeWrite, "follow")
+	bio := "Market intelligence advisor"
+
+	result, err := resolver.Mutation().DelegateToAgent(ctx, model.DelegateToAgentInput{
+		AgentUsername: "scout",
+		DisplayName:   "Scout",
+		Bio:           &bio,
+		Scopes:        []string{"read", "write", "follow"},
+		AgentType:     model.AgentTypeResearcher,
+		Version:       "1.0.0",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "scout", result.Agent.Username)
+	require.Equal(t, "Scout", result.Agent.DisplayName)
+	require.NotNil(t, result.Agent.Bio)
+	require.Equal(t, bio, *result.Agent.Bio)
+	require.Equal(t, model.AgentTypeResearcher, result.Agent.AgentType)
+	require.Equal(t, "1.0.0", result.Agent.AgentVersion)
+	require.Equal(t, "@owner", *result.Agent.AgentOwner)
+	require.ElementsMatch(t, []string{"read", "write", "follow"}, result.Agent.DelegatedScopes)
+	require.True(t, result.Agent.AgentCapabilities.CanPost)
+	require.True(t, result.Agent.AgentCapabilities.CanFollow)
+}
+
+func TestDelegateToAgent_CreateMissingAgentRespectsRegistrationPolicy(t *testing.T) {
+	resolver := newDelegationResolver(t, &delegationGraphState{}, false)
+	ctx := delegatedAgentAuthContext("owner", auth.ScopeRead, auth.ScopeWrite)
+
+	_, err := resolver.Mutation().DelegateToAgent(ctx, model.DelegateToAgentInput{
+		AgentUsername: "scout",
+		DisplayName:   "Scout",
+		Scopes:        []string{"read"},
+		AgentType:     model.AgentTypeResearcher,
+		Version:       "1.0.0",
+	})
+	require.Error(t, err)
+	require.True(t, apperrors.HasCode(err, apperrors.CodeForbidden))
+}
+
+func TestDelegateToAgent_CreateConflictFallsBackToExistingAgent(t *testing.T) {
+	state := &delegationGraphState{
+		users: map[string]*storageModels.User{
+			"scout": {
+				Username:     "scout",
+				DisplayName:  "Scout",
+				IsAgent:      true,
+				AgentType:    "RESEARCHER",
+				AgentVersion: "1.0.0",
+				AgentOwner:   "@owner",
+				Metadata: map[string]any{
+					"agent_delegated_scopes": []string{"read", "write"},
+				},
+				CreatedAt: time.Now().Add(-time.Hour),
+				UpdatedAt: time.Now(),
+			},
+		},
+		actors: map[string]*storageModels.Actor{
+			"scout": {
+				Username:  "scout",
+				NumericID: common.GenerateNumericID("scout"),
+				CreatedAt: time.Now().Add(-time.Hour),
+				UpdatedAt: time.Now(),
+				Actor: &activitypub.Actor{
+					BaseObject: activitypub.BaseObject{
+						ID:   "https://localhost/users/scout",
+						Type: activitypub.ServiceType,
+					},
+					PreferredUsername: "scout",
+				},
+			},
+		},
+		createConflictOnce: true,
+	}
+
+	resolver := newDelegationResolver(t, state, true)
+	ctx := delegatedAgentAuthContext("owner", auth.ScopeRead, auth.ScopeWrite)
+
+	result, err := resolver.Mutation().DelegateToAgent(ctx, model.DelegateToAgentInput{
+		AgentUsername: "scout",
+		DisplayName:   "Scout",
+		Scopes:        []string{"read"},
+		AgentType:     model.AgentTypeResearcher,
+		Version:       "1.0.0",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "scout", result.Agent.Username)
+}
+
 func TestDelegateToAgent_EnforcesStoredAgentScopeEnvelope(t *testing.T) {
-	resolver := newDelegationResolver(t, []string{"read"}, true)
+	resolver := newDelegationResolver(t, newDelegationGraphState("agent1", []string{"read"}), true)
 	ctx := delegatedAgentAuthContext("owner", auth.ScopeRead, auth.ScopeWrite, "follow")
 
 	_, err := resolver.Mutation().DelegateToAgent(ctx, model.DelegateToAgentInput{

--- a/graph/agent_resolvers_stubs.go
+++ b/graph/agent_resolvers_stubs.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/common"
 	apperrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/federation"
 	"github.com/equaltoai/lesser/pkg/storage"
 	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
 )
@@ -636,7 +638,7 @@ func (r *mutationResolver) DelegateToAgent(ctx context.Context, input model.Dele
 	}
 
 	now := time.Now().UTC()
-	account, err := r.resolveDelegatedAgentAccount(ctx, claims, agentUsername, requestedScopes)
+	account, err := r.resolveOrCreateDelegatedAgentAccount(ctx, claims, input, requestedScopes, now)
 	if err != nil {
 		return nil, err
 	}
@@ -671,10 +673,32 @@ func (r *mutationResolver) DelegateToAgent(ctx context.Context, input model.Dele
 	}, nil
 }
 
+func (r *mutationResolver) resolveOrCreateDelegatedAgentAccount(
+	ctx context.Context,
+	claims *auth.Claims,
+	input model.DelegateToAgentInput,
+	requestedScopes []string,
+	now time.Time,
+) (*storage.Account, error) {
+	account, err := r.resolveDelegatedAgentAccount(ctx, claims, input.AgentUsername, requestedScopes)
+	if err == nil {
+		return account, nil
+	}
+	if !apperrors.HasCode(err, apperrors.CodeNotFound) {
+		return nil, err
+	}
+
+	if regErr := r.ensureAgentRegistrationEnabled(ctx); regErr != nil {
+		return nil, regErr
+	}
+
+	return r.createDelegatedAgentAccount(ctx, claims, input, requestedScopes, now)
+}
+
 func (r *mutationResolver) resolveDelegatedAgentAccount(ctx context.Context, claims *auth.Claims, agentUsername string, requestedScopes []string) (*storage.Account, error) {
 	account, err := r.Storage.Account().GetAccount(ctx, agentUsername)
 	if err != nil {
-		if common.IsNotFound(err) {
+		if apperrors.HasCode(err, apperrors.CodeNotFound) {
 			return nil, apperrors.NewAppError(apperrors.CodeNotFound, apperrors.CategoryBusiness, "agent not found")
 		}
 		return nil, apperrors.InternalWithCause(err, "failed to load agent account")
@@ -687,6 +711,119 @@ func (r *mutationResolver) resolveDelegatedAgentAccount(ctx context.Context, cla
 	}
 	if err := validateDelegationAgainstAgentEnvelope(account.User, requestedScopes); err != nil {
 		return nil, err
+	}
+
+	return account, nil
+}
+
+func (r *mutationResolver) createDelegatedAgentAccount(
+	ctx context.Context,
+	claims *auth.Claims,
+	input model.DelegateToAgentInput,
+	requestedScopes []string,
+	now time.Time,
+) (*storage.Account, error) {
+	if r == nil || r.Storage == nil || r.Storage.Account() == nil || r.Config == nil {
+		return nil, ErrStorageUnavailable
+	}
+
+	agentUsername := strings.TrimSpace(input.AgentUsername)
+	displayName := strings.TrimSpace(input.DisplayName)
+	if displayName == "" {
+		displayName = agentUsername
+	} else if err := common.ValidateDisplayName(displayName); err != nil {
+		return nil, err
+	}
+
+	bio := strings.TrimSpace(derefString(input.Bio))
+	if bio != "" {
+		if err := common.ValidateAccountBio(bio); err != nil {
+			return nil, err
+		}
+	}
+
+	agentType := strings.TrimSpace(string(input.AgentType))
+	if agentType == "" {
+		agentType = string(model.AgentTypeCustom)
+	}
+
+	agentVersion := strings.TrimSpace(derefString(input.AgentVersion))
+	if agentVersion == "" {
+		agentVersion = strings.TrimSpace(input.Version)
+	}
+	if agentVersion == "" {
+		agentVersion = agentVersionUnknown
+	}
+
+	quarantineDays, maxPostsPerHourAllowed := r.agentRegistrationLimits(ctx)
+	capabilities := deriveAgentCapabilitiesFromScopes(requestedScopes)
+	clampMaxPostsPerHour(&capabilities, maxPostsPerHourAllowed)
+	quarantineEnd := now.AddDate(0, 0, quarantineDays)
+	ownerIdentifier := "@" + strings.TrimSpace(claims.Username)
+
+	user := &storage.User{
+		Username:          agentUsername,
+		DisplayName:       displayName,
+		Note:              bio,
+		Approved:          true,
+		Suspended:         false,
+		Silenced:          false,
+		Role:              "user",
+		Locked:            false,
+		Discoverable:      true,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+		IsAgent:           true,
+		AgentType:         agentType,
+		AgentVersion:      agentVersion,
+		AgentOwner:        ownerIdentifier,
+		AgentCreatedBy:    strings.TrimSpace(claims.Username),
+		AgentCapabilities: &capabilities,
+		Metadata: map[string]any{
+			"agent_quarantine_status": "quarantined",
+			"agent_quarantine_start":  now.Format(time.RFC3339),
+			"agent_quarantine_end":    quarantineEnd.Format(time.RFC3339),
+			"agent_delegated_scopes":  append([]string(nil), requestedScopes...),
+		},
+	}
+
+	privateKey, err := federation.GenerateRSAKeyPair(2048)
+	if err != nil {
+		return nil, apperrors.InternalWithCause(err, "failed to generate agent keypair")
+	}
+	publicKeyPEM, err := federation.EncodePublicKeyPEM(&privateKey.PublicKey)
+	if err != nil {
+		return nil, apperrors.InternalWithCause(err, "failed to encode agent public key")
+	}
+	privateKeyPEM, err := federation.EncodePrivateKeyPEM(privateKey)
+	if err != nil {
+		return nil, apperrors.InternalWithCause(err, "failed to encode agent private key")
+	}
+
+	actorID := r.Config.ActorURL(agentUsername)
+	actor := activitypub.NewActor(activitypub.ServiceType, actorID, agentUsername)
+	actor.Name = displayName
+	actor.Summary = bio
+	actor.URL = fmt.Sprintf("%s/@%s", r.Config.BaseURL(), agentUsername)
+	actor.CreatedAt = &now
+	actor.PublicKey = &activitypub.PublicKey{
+		ID:           actorID + "#main-key",
+		Owner:        actorID,
+		PublicKeyPem: string(publicKeyPEM),
+	}
+	actor = activitypubutil.BuildLocalActor(agentUsername, r.Config.BaseURL(), user, actor)
+
+	account := &storage.Account{
+		User:       user,
+		Actor:      actor,
+		PrivateKey: string(privateKeyPEM),
+	}
+
+	if err := r.Storage.Account().CreateAccount(ctx, account); err != nil {
+		if common.IsConflict(err) {
+			return r.resolveDelegatedAgentAccount(ctx, claims, agentUsername, requestedScopes)
+		}
+		return nil, apperrors.InternalWithCause(err, "failed to create agent account")
 	}
 
 	return account, nil


### PR DESCRIPTION
## Summary
- restore `delegateToAgent` as a resolve-or-create mutation for first-time delegated agents
- fix missing-agent not-found handling so account lookups do not surface as internal errors
- add GraphQL regression coverage for first-create, registration-disabled, and create-conflict delegation flows

## Verification
- `GOTOOLCHAIN=go1.26.1 go test ./graph ./cmd/api/handlers -run 'TestDelegateToAgent|TestAgentsRound20_ResolveDelegatedAgentAccount_Branches' -count=1`
- `GOTOOLCHAIN=go1.26.1 golangci-lint run --config .golangci.yml --disable gosec --concurrency 4 ./graph ./cmd/api/handlers`
