### PR TITLE
fix delegated agent actor persistence

### DIFF
--- a/pkg/storage/repositories/account_repository.go
+++ b/pkg/storage/repositories/account_repository.go
@@ -244,6 +244,15 @@ func (r *AccountRepository) createActorWithRollback(ctx context.Context, actor i
 			r.logger.Warn("failed to rollback user creation after actor failure",
 				zap.Error(delErr),
 				zap.String("username", userModel.Username))
+			rawDeleteErr := r.db.WithContext(ctx).Model(&models.User{}).
+				Where("PK", "=", pk).
+				Where("SK", "=", models.SKMetadata).
+				Delete()
+			if rawDeleteErr != nil {
+				r.logger.Warn("failed raw rollback delete after actor failure",
+					zap.Error(rawDeleteErr),
+					zap.String("username", userModel.Username))
+			}
 		}
 		return ErrorHandler.HandleCreateError(err, EntityActor, userModel.Username)
 	}
@@ -478,6 +487,9 @@ func (r *AccountRepository) ensureNumericIDMapping(ctx context.Context, numericI
 		Username:  strings.TrimSpace(username),
 		ActorID:   strings.TrimSpace(actorID),
 	}
+	if err := mapping.BeforeCreate(); err != nil {
+		return ErrorHandler.HandleCreateError(err, "numeric ID mapping", numericID)
+	}
 
 	err := r.db.WithContext(ctx).Model(mapping).Create()
 	if err == nil {
@@ -558,20 +570,10 @@ func (r *AccountRepository) createActor(ctx context.Context, actor *activitypub.
 		FollowerCount:  0,
 		FollowingCount: 0,
 		StatusCount:    0,
+		CreatedAt:      time.Now().UTC(),
 	}
+	actorModel.UpdatedAt = actorModel.CreatedAt
 
-	// Set domain for GSI3
-	if r.domain != "" {
-		actorModel.GSI3PK = fmt.Sprintf("DOMAIN#%s", r.domain)
-		actorModel.GSI3SK = username
-	}
-
-	r.logger.Info("actor model before UpdateKeys",
-		zap.String("username", actorModel.Username),
-		zap.String("pk", actorModel.PK),
-		zap.String("sk", actorModel.SK))
-
-	// Explicitly call UpdateKeys to ensure PK/SK are set
 	if err := actorModel.UpdateKeys(); err != nil {
 		r.logger.Error("failed to update actor keys",
 			zap.String("username", username),
@@ -579,10 +581,10 @@ func (r *AccountRepository) createActor(ctx context.Context, actor *activitypub.
 		return err
 	}
 
-	r.logger.Info("actor model after UpdateKeys",
-		zap.String("username", actorModel.Username),
-		zap.String("pk", actorModel.PK),
-		zap.String("sk", actorModel.SK))
+	if r.domain != "" {
+		actorModel.GSI3PK = fmt.Sprintf("DOMAIN#%s", r.domain)
+		actorModel.GSI3SK = username
+	}
 
 	// Create using DynamORM
 	if err := r.db.WithContext(ctx).Model(actorModel).Create(); err != nil {

--- a/pkg/storage/repositories/account_repository_encryptor_coverage_test.go
+++ b/pkg/storage/repositories/account_repository_encryptor_coverage_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/mock"
@@ -77,6 +78,56 @@ func TestAccountRepository_CreateActor_EncryptorSuccessAndConflict(t *testing.T)
 		}, "private-key")
 		require.Error(t, err)
 	})
+}
+
+func TestAccountRepository_CreateActor_PreparesActorAndNumericIDMapping(t *testing.T) {
+	ctx := context.Background()
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+	var currentModel any
+	var createdActor *models.Actor
+	var createdMapping *models.NumericIDMapping
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB).Maybe()
+	mockDB.On("Model", mock.Anything).Run(func(args mock.Arguments) {
+		currentModel = args.Get(0)
+	}).Return(mockQuery).Maybe()
+
+	mockQuery.On("Create").Run(func(mock.Arguments) {
+		switch model := currentModel.(type) {
+		case *models.Actor:
+			copyActor := *model
+			createdActor = &copyActor
+		case *models.NumericIDMapping:
+			copyMapping := *model
+			createdMapping = &copyMapping
+		}
+	}).Return(nil).Maybe()
+
+	repo := NewAccountRepository(mockDB, "test-table", "example.com", zaptest.NewLogger(t))
+	repo.SetEncryptor(testEncryptor{})
+
+	err := repo.createActor(ctx, &activitypub.Actor{
+		PreferredUsername: "alice",
+		BaseObject:        activitypub.BaseObject{ID: "https://example.com/users/alice"},
+		Name:              "Alice",
+	}, "private-key")
+	require.NoError(t, err)
+
+	require.NotNil(t, createdActor)
+	require.Equal(t, "ACTOR#alice", createdActor.PK)
+	require.Equal(t, models.SKProfile, createdActor.SK)
+	require.Equal(t, "DOMAIN#example.com", createdActor.GSI3PK)
+	require.Equal(t, "alice", createdActor.GSI3SK)
+	require.False(t, createdActor.CreatedAt.IsZero())
+	require.False(t, createdActor.UpdatedAt.IsZero())
+
+	require.NotNil(t, createdMapping)
+	require.Equal(t, "NUMERIC_ID#"+common.GenerateNumericID("alice"), createdMapping.PK)
+	require.Equal(t, models.SKMetadata, createdMapping.SK)
+	require.Equal(t, "NumericIDMapping", createdMapping.Type)
+	require.Equal(t, "alice", createdMapping.Username)
+	require.False(t, createdMapping.CreatedAt.IsZero())
 }
 
 func TestAccountRepository_GetActorPrivateKey_DecryptPaths(t *testing.T) {


### PR DESCRIPTION
## Summary
- prepare delegated-agent actor records before direct DynamoDB creates so timestamps and keys are present
- prepare numeric ID mappings before direct creates and add a raw rollback fallback if actor creation fails after the user row is written
- add repository regression coverage that inspects the actor and numeric mapping models passed to DynamoDB

## Verification
- `GOTOOLCHAIN=go1.26.1 go test ./pkg/storage/repositories -run 'TestAccountRepository_CreateActor|TestAccountRepository_CreateAccount_WithActorAndEncryptor' -count=1`
- `GOTOOLCHAIN=go1.26.1 golangci-lint run --config .golangci.yml --disable gosec --concurrency 4 ./pkg/storage/repositories`

## Live validation
- confirmed and deleted the orphaned `USER#Scout` record in `simulacrum-dev-main-table`
- verified there was no matching `ACTOR#Scout` or numeric ID mapping, matching the actor-side persistence failure this change fixes
