### PR TITLE
make lease token ttl policy explicit

### DIFF
--- a/cmd/api/handlers/agent_access_leases.go
+++ b/cmd/api/handlers/agent_access_leases.go
@@ -57,6 +57,7 @@ type agentAccessLeaseOptions struct {
 	DeviceLabel       string
 	IdleTimeoutHours  int
 	AbsoluteTTLHours  int
+	TokenTTLHours     int
 }
 
 func (h *Handler) agentAccessLeaseRepo() *storageRepos.AgentAccessLeaseRepository {
@@ -193,6 +194,7 @@ func (h *Handler) HandleCreateAgentAccessLeaseLift(ctx *apptheory.Context) (*app
 		DeviceLabel:       principalChallenge.DeviceLabel,
 		Status:            agentAccessLeaseStatusActive,
 		IdleTimeoutHours:  principalChallenge.IdleTimeoutHours,
+		TokenTTLHours:     principalChallenge.EffectiveTokenTTLHours(),
 		IdleExpiresAt:     idleExpiresAt,
 		AbsoluteExpiresAt: absoluteExpiresAt,
 		LastUsedAt:        now,
@@ -237,6 +239,7 @@ func (h *Handler) HandleCreateAgentAccessLeaseLift(ctx *apptheory.Context) (*app
 		"agent_wallet":     model.AgentWallet,
 		"scopes":           model.Scopes,
 		"idle_hours":       model.IdleTimeoutHours,
+		"token_ttl_hours":  model.EffectiveTokenTTLHours(),
 		"absolute_expires": model.AbsoluteExpiresAt.Format(time.RFC3339),
 	})
 	h.ensureAgentActor(username, account)
@@ -596,17 +599,15 @@ func (h *Handler) HandleExchangeAgentAccessLeaseTokenLift(ctx *apptheory.Context
 	if newIdleExpiresAt.After(lease.AbsoluteExpiresAt) {
 		newIdleExpiresAt = lease.AbsoluteExpiresAt
 	}
-	accessTTL := auth.AccessTokenDuration
-	remaining := time.Until(newIdleExpiresAt)
+	tokenExpiresAt := storageModels.AgentAccessLeaseTokenExpiresAt(now, lease, newIdleExpiresAt)
+	remaining := time.Until(tokenExpiresAt)
 	if remaining <= 0 {
 		return apptheory.JSON(http.StatusUnauthorized, map[string]any{
 			"error":             "invalid_lease",
 			"error_description": "lease expired",
 		})
 	}
-	if remaining < accessTTL {
-		accessTTL = remaining
-	}
+	accessTTL := remaining
 
 	if h.cfg == nil || h.cfg.JWTSecret == "" {
 		return common.RespondInternalServerError(ctx)
@@ -640,6 +641,7 @@ func (h *Handler) HandleExchangeAgentAccessLeaseTokenLift(ctx *apptheory.Context
 		"lease_id":    lease.ID,
 		"signer_kind": challenge.Action,
 		"expires_in":  int(accessTTL.Seconds()),
+		"token_hours": lease.EffectiveTokenTTLHours(),
 	})
 	return okJSON(apimodels.AgentAccessLeaseTokenResponse{
 		LeaseID: lease.ID,
@@ -692,6 +694,7 @@ func (h *Handler) handleCreateAgentAccessLeaseChallenge(ctx *apptheory.Context, 
 		req.DeviceLabel,
 		req.IdleTimeoutHours,
 		req.AbsoluteTTLHours,
+		req.TokenTTLHours,
 		action == agentAccessLeaseActionAgent,
 	)
 	if err != nil {
@@ -821,6 +824,7 @@ func (h *Handler) createAgentAccessLeaseChallenge(ctx *apptheory.Context, opts a
 		DeviceLabel:       opts.DeviceLabel,
 		IdleTimeoutHours:  opts.IdleTimeoutHours,
 		AbsoluteTTLHours:  opts.AbsoluteTTLHours,
+		TokenTTLHours:     opts.TokenTTLHours,
 		Nonce:             nonce,
 		Message:           message,
 		IssuedAt:          now,
@@ -997,6 +1001,7 @@ func normalizeAgentAccessLeaseOptions(
 	deviceLabel string,
 	idleTimeoutHours int,
 	absoluteTTLHours int,
+	tokenTTLHours int,
 	requireLeaseID bool,
 ) (agentAccessLeaseOptions, error) {
 	leaseID = strings.TrimSpace(leaseID)
@@ -1041,6 +1046,7 @@ func normalizeAgentAccessLeaseOptions(
 	if absoluteTTLHours < idleTimeoutHours {
 		absoluteTTLHours = idleTimeoutHours
 	}
+	tokenTTLHours = storageModels.NormalizeAgentAccessLeaseTokenTTLHours(idleTimeoutHours, absoluteTTLHours, tokenTTLHours)
 	normalizedScopes := append([]string(nil), scopes...)
 	sort.Strings(normalizedScopes)
 
@@ -1056,6 +1062,7 @@ func normalizeAgentAccessLeaseOptions(
 		DeviceLabel:       deviceLabel,
 		IdleTimeoutHours:  idleTimeoutHours,
 		AbsoluteTTLHours:  absoluteTTLHours,
+		TokenTTLHours:     tokenTTLHours,
 	}, nil
 }
 
@@ -1091,7 +1098,7 @@ func normalizeAgentAccessSessionPublicKey(raw string) (string, error) {
 
 func buildAgentAccessLeaseChallengeMessage(id string, opts agentAccessLeaseOptions, action string, nonce string, issuedAt, expiresAt time.Time) string {
 	return fmt.Sprintf(
-		"LESSER AGENT ACCESS LEASE\nid: %s\nlease_id: %s\naction: %s\ndomain: %s\nprincipal_username: %s\nagent_username: %s\nprincipal_wallet: %s\nagent_wallet: %s\nsession_public_key: %s\nscopes: %s\ndevice_label: %s\nidle_timeout_hours: %d\nabsolute_ttl_hours: %d\nnonce: %s\nissued_at: %s\nexpires_at: %s",
+		"LESSER AGENT ACCESS LEASE\nid: %s\nlease_id: %s\naction: %s\ndomain: %s\nprincipal_username: %s\nagent_username: %s\nprincipal_wallet: %s\nagent_wallet: %s\nsession_public_key: %s\nscopes: %s\ndevice_label: %s\nidle_timeout_hours: %d\nabsolute_ttl_hours: %d\ntoken_ttl_hours: %d\nnonce: %s\nissued_at: %s\nexpires_at: %s",
 		strings.TrimSpace(id),
 		strings.TrimSpace(opts.LeaseID),
 		strings.TrimSpace(action),
@@ -1105,6 +1112,7 @@ func buildAgentAccessLeaseChallengeMessage(id string, opts agentAccessLeaseOptio
 		strings.TrimSpace(opts.DeviceLabel),
 		opts.IdleTimeoutHours,
 		opts.AbsoluteTTLHours,
+		opts.TokenTTLHours,
 		strings.TrimSpace(nonce),
 		issuedAt.UTC().Format(time.RFC3339),
 		expiresAt.UTC().Format(time.RFC3339),
@@ -1145,6 +1153,7 @@ func buildAgentAccessLeaseTypedData(challenge *storageModels.AgentAccessLeaseCha
 		"deviceLabel":       strings.TrimSpace(challenge.DeviceLabel),
 		"idleTimeoutHours":  fmt.Sprintf("%d", challenge.IdleTimeoutHours),
 		"absoluteTTLHours":  fmt.Sprintf("%d", challenge.AbsoluteTTLHours),
+		"tokenTTLHours":     fmt.Sprintf("%d", challenge.EffectiveTokenTTLHours()),
 		"nonce":             strings.TrimSpace(challenge.Nonce),
 		"issuedAt":          challenge.IssuedAt.UTC().Format(time.RFC3339),
 		"expiresAt":         challenge.ExpiresAt.UTC().Format(time.RFC3339),
@@ -1169,6 +1178,7 @@ func buildAgentAccessLeaseTypedData(challenge *storageModels.AgentAccessLeaseCha
 				{Name: "deviceLabel", Type: "string"},
 				{Name: "idleTimeoutHours", Type: "string"},
 				{Name: "absoluteTTLHours", Type: "string"},
+				{Name: "tokenTTLHours", Type: "string"},
 				{Name: "nonce", Type: "string"},
 				{Name: "issuedAt", Type: "string"},
 				{Name: "expiresAt", Type: "string"},
@@ -1272,7 +1282,8 @@ func agentAccessLeaseChallengesMatch(a, b *storageModels.AgentAccessLeaseChallen
 		strings.EqualFold(strings.Join(a.Scopes, " "), strings.Join(b.Scopes, " ")) &&
 		a.DeviceLabel == b.DeviceLabel &&
 		a.IdleTimeoutHours == b.IdleTimeoutHours &&
-		a.AbsoluteTTLHours == b.AbsoluteTTLHours
+		a.AbsoluteTTLHours == b.AbsoluteTTLHours &&
+		a.EffectiveTokenTTLHours() == b.EffectiveTokenTTLHours()
 }
 
 func agentAccessLeaseResponse(model *storageModels.AgentAccessLease, now time.Time) apimodels.AgentAccessLease {
@@ -1306,6 +1317,7 @@ func agentAccessLeaseResponse(model *storageModels.AgentAccessLease, now time.Ti
 		DeviceLabel:          strings.TrimSpace(model.DeviceLabel),
 		Status:               effectiveAgentAccessLeaseStatus(model, now),
 		IdleTimeoutHours:     model.IdleTimeoutHours,
+		TokenTTLHours:        model.EffectiveTokenTTLHours(),
 		IdleExpiresAt:        model.IdleExpiresAt,
 		AbsoluteExpiresAt:    model.AbsoluteExpiresAt,
 		LastUsedAt:           model.LastUsedAt,
@@ -1341,6 +1353,7 @@ func agentAccessLeaseChallengeResponse(model *storageModels.AgentAccessLeaseChal
 		DeviceLabel:      strings.TrimSpace(model.DeviceLabel),
 		IdleTimeoutHours: model.IdleTimeoutHours,
 		AbsoluteTTLHours: model.AbsoluteTTLHours,
+		TokenTTLHours:    model.EffectiveTokenTTLHours(),
 		Message:          model.Message,
 		TypedData:        challengeTypedDataResponse(model),
 		IssuedAt:         model.IssuedAt,

--- a/cmd/api/handlers/agent_access_leases_additional_test.go
+++ b/cmd/api/handlers/agent_access_leases_additional_test.go
@@ -30,6 +30,7 @@ func TestAgentAccessLeaseAdditionalHelpers_ValidationBranches(t *testing.T) {
 			"",
 			0,
 			0,
+			0,
 			true,
 		)
 		require.ErrorContains(t, err, "lease_id is required")
@@ -45,6 +46,7 @@ func TestAgentAccessLeaseAdditionalHelpers_ValidationBranches(t *testing.T) {
 			"",
 			0,
 			0,
+			0,
 			true,
 		)
 		require.ErrorContains(t, err, "principal_wallet")
@@ -58,6 +60,7 @@ func TestAgentAccessLeaseAdditionalHelpers_ValidationBranches(t *testing.T) {
 			"",
 			[]string{"read"},
 			"",
+			0,
 			0,
 			0,
 			true,
@@ -81,6 +84,7 @@ func TestAgentAccessLeaseAdditionalHelpers_ValidationBranches(t *testing.T) {
 			" desktop ",
 			agentAccessLeaseMaxIdleHrs+10,
 			1,
+			48,
 			true,
 		)
 		require.NoError(t, err)
@@ -89,6 +93,7 @@ func TestAgentAccessLeaseAdditionalHelpers_ValidationBranches(t *testing.T) {
 		require.Equal(t, "desktop", opts.DeviceLabel)
 		require.Equal(t, agentAccessLeaseMaxIdleHrs, opts.IdleTimeoutHours)
 		require.Equal(t, agentAccessLeaseMaxIdleHrs, opts.AbsoluteTTLHours)
+		require.Equal(t, 48, opts.TokenTTLHours)
 		require.Equal(t, agentAccessLeaseSessionKeyType, opts.SessionKeyType)
 		require.Equal(t, pubBase64, opts.SessionPublicKey)
 		require.Equal(t, []string{"read", "write"}, opts.Scopes)

--- a/cmd/api/handlers/agent_access_leases_flow_test.go
+++ b/cmd/api/handlers/agent_access_leases_flow_test.go
@@ -101,6 +101,7 @@ func TestAgentAccessLeasesRound20_FlowAndRenewal(t *testing.T) {
 			DeviceLabel:      "local-agent",
 			IdleTimeoutHours: 168,
 			AbsoluteTTLHours: 720,
+			TokenTTLHours:    12,
 		}
 		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/agents/agent1/access-leases/challenge/principal", headers, nil, principalChallengeReq)
 		require.NoError(t, err)
@@ -110,6 +111,7 @@ func TestAgentAccessLeasesRound20_FlowAndRenewal(t *testing.T) {
 		var principalChallengeResp apimodels.AgentAccessLeaseChallengeResponse
 		require.NoError(t, json.Unmarshal(resp.Body, &principalChallengeResp))
 		require.NotEmpty(t, principalChallengeResp.LeaseID)
+		require.Equal(t, 12, principalChallengeResp.TokenTTLHours)
 
 		agentChallengeReq := principalChallengeReq
 		agentChallengeReq.LeaseID = principalChallengeResp.LeaseID
@@ -143,6 +145,7 @@ func TestAgentAccessLeasesRound20_FlowAndRenewal(t *testing.T) {
 		require.Equal(t, "active", lease.Status)
 		require.Equal(t, ownerAddr, strings.ToLower(lease.PrincipalWallet))
 		require.Equal(t, agentAddr, strings.ToLower(lease.AgentWallet))
+		require.Equal(t, 12, lease.TokenTTLHours)
 
 		ctx, err = round10NewLiftContext(http.MethodGet, "/api/v1/agents/agent1/access-leases", headers, nil, nil)
 		require.NoError(t, err)
@@ -195,6 +198,7 @@ func TestAgentAccessLeasesRound20_FlowAndRenewal(t *testing.T) {
 			DeviceLabel:         "local-agent",
 			Status:              "active",
 			IdleTimeoutHours:    168,
+			TokenTTLHours:       12,
 			IdleExpiresAt:       now.Add(168 * time.Hour),
 			AbsoluteExpiresAt:   now.Add(720 * time.Hour),
 			LastUsedAt:          now,
@@ -235,6 +239,7 @@ func TestAgentAccessLeasesRound20_FlowAndRenewal(t *testing.T) {
 			DeviceLabel:         "local-agent",
 			Status:              "active",
 			IdleTimeoutHours:    168,
+			TokenTTLHours:       12,
 			IdleExpiresAt:       now.Add(168 * time.Hour),
 			AbsoluteExpiresAt:   now.Add(720 * time.Hour),
 			LastUsedAt:          now,
@@ -259,6 +264,7 @@ func TestAgentAccessLeasesRound20_FlowAndRenewal(t *testing.T) {
 		require.NoError(t, json.Unmarshal(resp.Body, &tokenResp))
 		require.NotEmpty(t, tokenResp.Token.AccessToken)
 		require.Empty(t, tokenResp.Token.RefreshToken)
+		require.InDelta(t, 12*60*60, tokenResp.Token.ExpiresIn, 5)
 
 		ctx, err = round10NewLiftContext(http.MethodPost, "/api/v1/agents/agent1/access-leases/"+lease.ID+"/revoke", headers, nil, apimodels.RevokeAgentAccessLeaseRequest{
 			Reason: "operator request",
@@ -319,7 +325,10 @@ func TestAgentAccessLeasesRound20_FlowAndRenewal(t *testing.T) {
 		require.NoError(t, err)
 		ctx.Params["username"] = "agent1"
 		ctx.Params["leaseID"] = leaseID
-		requireStatus(t, http.StatusOK)(h.HandleExchangeAgentAccessLeaseTokenLift(ctx))
+		resp = requireStatus(t, http.StatusOK)(h.HandleExchangeAgentAccessLeaseTokenLift(ctx))
+		var tokenResp apimodels.AgentAccessLeaseTokenResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &tokenResp))
+		require.InDelta(t, 168*60*60, tokenResp.Token.ExpiresIn, 5)
 	})
 
 	t.Run("bound_soul_agent_enrollment_does_not_require_wallet_auth_credentials", func(t *testing.T) {

--- a/cmd/api/handlers/agent_access_leases_helpers_test.go
+++ b/cmd/api/handlers/agent_access_leases_helpers_test.go
@@ -20,6 +20,7 @@ func TestNormalizeAgentAccessLeaseOptions_DefaultsAndSorting(t *testing.T) {
 		"",
 		0,
 		0,
+		0,
 		false,
 	)
 	require.NoError(t, err)
@@ -27,6 +28,7 @@ func TestNormalizeAgentAccessLeaseOptions_DefaultsAndSorting(t *testing.T) {
 	require.Equal(t, "local-agent", opts.DeviceLabel)
 	require.Equal(t, agentAccessLeaseDefaultIdleHrs, opts.IdleTimeoutHours)
 	require.Equal(t, agentAccessLeaseDefaultAbsHrs, opts.AbsoluteTTLHours)
+	require.Equal(t, agentAccessLeaseDefaultIdleHrs, opts.TokenTTLHours)
 	require.Equal(t, []string{"follow", "read", "write"}, opts.Scopes)
 }
 
@@ -42,11 +44,13 @@ func TestNormalizeAgentAccessLeaseOptions_ClampsAbsoluteToIdle(t *testing.T) {
 		"mac-mini",
 		72,
 		24,
+		36,
 		true,
 	)
 	require.NoError(t, err)
 	require.Equal(t, 72, opts.IdleTimeoutHours)
 	require.Equal(t, 72, opts.AbsoluteTTLHours)
+	require.Equal(t, 36, opts.TokenTTLHours)
 }
 
 func TestComputeLeaseExpiries_ClampsIdleToAbsolute(t *testing.T) {

--- a/cmd/api/handlers/agent_access_leases_internal_test.go
+++ b/cmd/api/handlers/agent_access_leases_internal_test.go
@@ -73,6 +73,7 @@ func TestAgentAccessLeasesRound20_InternalHelpers(t *testing.T) {
 				DeviceLabel:       "local-agent",
 				Status:            "active",
 				IdleTimeoutHours:  24,
+				TokenTTLHours:     12,
 				IdleExpiresAt:     now.Add(24 * time.Hour),
 				AbsoluteExpiresAt: now.Add(48 * time.Hour),
 				LastUsedAt:        now,
@@ -97,6 +98,7 @@ func TestAgentAccessLeasesRound20_InternalHelpers(t *testing.T) {
 				DeviceLabel:       "local-agent",
 				IdleTimeoutHours:  24,
 				AbsoluteTTLHours:  48,
+				TokenTTLHours:     12,
 				Message:           "challenge",
 				IssuedAt:          now,
 				ExpiresAt:         now.Add(time.Minute),
@@ -158,12 +160,14 @@ func TestAgentAccessLeasesRound20_InternalHelpers(t *testing.T) {
 		DeviceLabel:       "local-agent",
 		IdleTimeoutHours:  24,
 		AbsoluteTTLHours:  48,
+		TokenTTLHours:     12,
 	}, agentAccessLeaseActionAgent)
 	require.NoError(t, err)
 	require.Equal(t, "agent1", createdChallenge.Username)
 	require.Equal(t, "AGENT_ACCESS_CHALLENGE#"+createdChallenge.ID, createdChallenge.PK)
 	require.Equal(t, "CHALLENGE", createdChallenge.SK)
 	require.Equal(t, createdChallenge.ExpiresAt.Unix(), createdChallenge.TTL)
+	require.Equal(t, 12, createdChallenge.EffectiveTokenTTLHours())
 
 	badCtx, err := round10NewLiftContext(http.MethodGet, "/api/v1/agents/agent1/access-leases", map[string]string{"Authorization": "Bearer " + round11SignAccessToken(t, cfg.JWTSecret, "intruder", []string{"write"})}, nil, nil)
 	require.NoError(t, err)

--- a/cmd/api/handlers/agent_self_sovereign.go
+++ b/cmd/api/handlers/agent_self_sovereign.go
@@ -313,14 +313,15 @@ func (h *Handler) createSelfSovereignAgentAccount(ctx *apptheory.Context, user *
 }
 
 func (h *Handler) mintSelfSovereignTokens(ctx *apptheory.Context, username string, requestedScopes []string) (apimodels.OAuthTokenResponse, error) {
+	accessTTL := auth.AgentAccessTokenTTL(h.cfg)
 	oauthSvc := createOAuthService(h.cfg.JWTSecret, h.cfg, h.repos, h.logger)
-	accessToken, refreshToken, err := oauthSvc.GenerateTokens(ctx.Context(), username, selfSovereignAgentClientID, "", requestedScopes)
+	accessToken, refreshToken, err := oauthSvc.GenerateTokensWithAccessTokenTTL(ctx.Context(), username, selfSovereignAgentClientID, "", requestedScopes, accessTTL)
 	if err != nil {
 		return apimodels.OAuthTokenResponse{}, err
 	}
 
 	now := time.Now()
-	refreshExpiry := now.Add(auth.AccessTokenDuration)
+	refreshExpiry := now.Add(auth.RefreshTokenDuration)
 	oauthRefreshToken := &storage.RefreshToken{
 		Token:     refreshToken,
 		Username:  username,
@@ -336,7 +337,7 @@ func (h *Handler) mintSelfSovereignTokens(ctx *apptheory.Context, username strin
 		TokenType:    "Bearer",
 		Scope:        strings.Join(requestedScopes, " "),
 		CreatedAt:    now.Unix(),
-		ExpiresIn:    int(auth.AccessTokenDuration.Seconds()),
+		ExpiresIn:    int(accessTTL.Seconds()),
 		RefreshToken: refreshToken,
 	}, nil
 }
@@ -429,19 +430,21 @@ func (h *Handler) HandleAgentAuthTokenLift(ctx *apptheory.Context) (*apptheory.R
 	}
 
 	scopes := agentSelfSovereignScopes(agentUser)
+	accessTTL := auth.AgentAccessTokenTTL(h.cfg)
 	oauthSvc := createOAuthService(h.cfg.JWTSecret, h.cfg, h.repos, h.logger)
-	accessToken, refreshToken, err := oauthSvc.GenerateTokens(ctx.Context(), req.Username, selfSovereignAgentClientID, "", scopes)
+	accessToken, refreshToken, err := oauthSvc.GenerateTokensWithAccessTokenTTL(ctx.Context(), req.Username, selfSovereignAgentClientID, "", scopes, accessTTL)
 	if err != nil {
 		return common.RespondInternalServerError(ctx)
 	}
 
-	refreshExpiry := time.Now().Add(auth.AccessTokenDuration)
+	now := time.Now()
+	refreshExpiry := now.Add(auth.RefreshTokenDuration)
 	oauthRefreshToken := &storage.RefreshToken{
 		Token:     refreshToken,
 		Username:  req.Username,
 		ClientID:  selfSovereignAgentClientID,
 		Scopes:    scopes,
-		CreatedAt: time.Now(),
+		CreatedAt: now,
 		ExpiresAt: refreshExpiry,
 	}
 	_ = h.repos.Account().CreateRefreshToken(ctx.Context(), oauthRefreshToken)
@@ -450,8 +453,8 @@ func (h *Handler) HandleAgentAuthTokenLift(ctx *apptheory.Context) (*apptheory.R
 		AccessToken:  accessToken,
 		TokenType:    "Bearer",
 		Scope:        strings.Join(scopes, " "),
-		CreatedAt:    time.Now().Unix(),
-		ExpiresIn:    int(auth.AccessTokenDuration.Seconds()),
+		CreatedAt:    now.Unix(),
+		ExpiresIn:    int(accessTTL.Seconds()),
 		RefreshToken: refreshToken,
 	})
 }

--- a/cmd/api/handlers/agents.go
+++ b/cmd/api/handlers/agents.go
@@ -14,6 +14,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/agents"
 	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/config"
 	apperrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/federation"
 	"github.com/equaltoai/lesser/pkg/storage"
@@ -100,7 +101,7 @@ func (h *Handler) HandleDelegateAgentLift(ctx *apptheory.Context) (*apptheory.Re
 		return resp, err
 	}
 
-	accessTTL, resp, err := validateAgentAccessTokenTTL(ctx, req.ExpiresIn)
+	accessTTL, resp, err := validateAgentAccessTokenTTLWithConfig(ctx, h.cfg, req.ExpiresIn)
 	if resp != nil || err != nil {
 		return resp, err
 	}
@@ -965,9 +966,14 @@ func scopesAreSubset(ownerScopes, requested []string) bool {
 	return true
 }
 
+//nolint:unused // Retained as the config-free helper for callers and tests that do not inject runtime config.
 func validateAgentAccessTokenTTL(ctx *apptheory.Context, expiresIn int) (time.Duration, *apptheory.Response, error) {
+	return validateAgentAccessTokenTTLWithConfig(ctx, nil, expiresIn)
+}
+
+func validateAgentAccessTokenTTLWithConfig(ctx *apptheory.Context, cfg *config.Config, expiresIn int) (time.Duration, *apptheory.Response, error) {
 	if expiresIn == 0 {
-		return auth.AccessTokenDuration, nil, nil
+		return auth.AgentAccessTokenTTL(cfg), nil, nil
 	}
 
 	if expiresIn < 60 {

--- a/cmd/api/models/agent_access_leases.go
+++ b/cmd/api/models/agent_access_leases.go
@@ -13,6 +13,7 @@ type AgentAccessLeaseChallengeRequest struct {
 
 	IdleTimeoutHours int `json:"idle_timeout_hours,omitempty"`
 	AbsoluteTTLHours int `json:"absolute_ttl_hours,omitempty"`
+	TokenTTLHours    int `json:"token_ttl_hours,omitempty"`
 }
 
 // AgentAccessLeaseChallengeResponse returns a one-time signing challenge.
@@ -30,6 +31,7 @@ type AgentAccessLeaseChallengeResponse struct {
 	DeviceLabel      string    `json:"device_label"`
 	IdleTimeoutHours int       `json:"idle_timeout_hours"`
 	AbsoluteTTLHours int       `json:"absolute_ttl_hours"`
+	TokenTTLHours    int       `json:"token_ttl_hours"`
 	Message          string    `json:"message"`
 	TypedData        any       `json:"typed_data,omitempty"`
 	IssuedAt         time.Time `json:"issued_at"`
@@ -60,6 +62,7 @@ type AgentAccessLease struct {
 	DeviceLabel          string     `json:"device_label"`
 	Status               string     `json:"status"`
 	IdleTimeoutHours     int        `json:"idle_timeout_hours"`
+	TokenTTLHours        int        `json:"token_ttl_hours"`
 	IdleExpiresAt        time.Time  `json:"idle_expires_at"`
 	AbsoluteExpiresAt    time.Time  `json:"absolute_expires_at"`
 	LastUsedAt           time.Time  `json:"last_used_at"`

--- a/docs/contracts/graphql-schema.graphql
+++ b/docs/contracts/graphql-schema.graphql
@@ -4226,6 +4226,7 @@ type AgentAccessLease {
   deviceLabel: String!
   status: String!
   idleTimeoutHours: Int!
+  tokenTTLHours: Int!
   idleExpiresAt: Time!
   absoluteExpiresAt: Time!
   lastUsedAt: Time!
@@ -4255,6 +4256,7 @@ type AgentAccessLeaseChallenge {
   deviceLabel: String!
   idleTimeoutHours: Int!
   absoluteTTLHours: Int!
+  tokenTTLHours: Int!
   message: String!
   typedDataJson: String
   issuedAt: Time!
@@ -4279,6 +4281,7 @@ input AgentAccessLeaseChallengeInput {
   leaseID: ID
   idleTimeoutHours: Int
   absoluteTTLHours: Int
+  tokenTTLHours: Int
 }
 
 input CreateAgentAccessLeaseInput {

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -956,6 +956,8 @@ components:
                     type: string
                 status:
                     type: string
+                token_ttl_hours:
+                    type: integer
                 updated_at:
                     $ref: '#/components/schemas/RFC3339DateTime'
                 username:
@@ -974,6 +976,7 @@ components:
                 - principal_wallet
                 - scopes
                 - status
+                - token_ttl_hours
                 - updated_at
                 - username
             type: object
@@ -998,6 +1001,8 @@ components:
                     type: array
                 session_public_key:
                     type: string
+                token_ttl_hours:
+                    type: integer
             required:
                 - agent_wallet
                 - device_label
@@ -1037,6 +1042,8 @@ components:
                     type: string
                 session_public_key:
                     type: string
+                token_ttl_hours:
+                    type: integer
                 typed_data: {}
                 username:
                     type: string
@@ -1055,6 +1062,7 @@ components:
                 - message
                 - principal_wallet
                 - scopes
+                - token_ttl_hours
                 - username
                 - wallet_address
             type: object

--- a/docs/specs/graphql_coverage.yaml
+++ b/docs/specs/graphql_coverage.yaml
@@ -1660,3 +1660,4 @@ routes:
       path: /setup/status
       policy: rest_only
       exemptedBy: auth_setup
+

--- a/graph/agent_access_lease_resolvers.go
+++ b/graph/agent_access_lease_resolvers.go
@@ -58,6 +58,7 @@ type graphAgentAccessLeaseOptions struct {
 	DeviceLabel       string
 	IdleTimeoutHours  int
 	AbsoluteTTLHours  int
+	TokenTTLHours     int
 }
 
 func (r *Resolver) agentAccessLeaseRepo() *storageRepos.AgentAccessLeaseRepository {
@@ -161,6 +162,7 @@ func (r *mutationResolver) CreateAgentAccessLease(ctx context.Context, username 
 		DeviceLabel:       principalChallenge.DeviceLabel,
 		Status:            graphAgentAccessLeaseStatusActive,
 		IdleTimeoutHours:  principalChallenge.IdleTimeoutHours,
+		TokenTTLHours:     principalChallenge.EffectiveTokenTTLHours(),
 		IdleExpiresAt:     idleExpiresAt,
 		AbsoluteExpiresAt: absoluteExpiresAt,
 		LastUsedAt:        now,
@@ -422,14 +424,12 @@ func (r *mutationResolver) ExchangeAgentAccessLeaseToken(ctx context.Context, us
 	if newIdleExpiresAt.After(lease.AbsoluteExpiresAt) {
 		newIdleExpiresAt = lease.AbsoluteExpiresAt
 	}
-	accessTTL := auth.AccessTokenDuration
-	remaining := time.Until(newIdleExpiresAt)
+	tokenExpiresAt := storageModels.AgentAccessLeaseTokenExpiresAt(now, lease, newIdleExpiresAt)
+	remaining := time.Until(tokenExpiresAt)
 	if remaining <= 0 {
 		return nil, apperrors.Unauthorized("lease expired")
 	}
-	if remaining < accessTTL {
-		accessTTL = remaining
-	}
+	accessTTL := remaining
 	if r.Config == nil || r.Config.JWTSecret == "" {
 		return nil, apperrors.Internal("jwt secret not configured")
 	}
@@ -494,6 +494,10 @@ func (r *mutationResolver) createGraphAgentAccessLeaseChallenge(ctx context.Cont
 	if input.AbsoluteTTLHours != nil {
 		absoluteTTLHours = *input.AbsoluteTTLHours
 	}
+	tokenTTLHours := 0
+	if input.TokenTTLHours != nil {
+		tokenTTLHours = *input.TokenTTLHours
+	}
 	opts, err := normalizeGraphAgentAccessLeaseOptions(
 		leaseID,
 		username,
@@ -505,6 +509,7 @@ func (r *mutationResolver) createGraphAgentAccessLeaseChallenge(ctx context.Cont
 		deviceLabel,
 		idleTimeoutHours,
 		absoluteTTLHours,
+		tokenTTLHours,
 		action == graphAgentAccessLeaseActionAgent,
 	)
 	if err != nil {
@@ -709,6 +714,7 @@ func (r *Resolver) createGraphAgentAccessLeaseChallengeRecord(ctx context.Contex
 		DeviceLabel:       opts.DeviceLabel,
 		IdleTimeoutHours:  opts.IdleTimeoutHours,
 		AbsoluteTTLHours:  opts.AbsoluteTTLHours,
+		TokenTTLHours:     opts.TokenTTLHours,
 		Nonce:             nonce,
 		Message:           message,
 		IssuedAt:          now,
@@ -762,6 +768,7 @@ func normalizeGraphAgentAccessLeaseOptions(
 	deviceLabel string,
 	idleTimeoutHours int,
 	absoluteTTLHours int,
+	tokenTTLHours int,
 	requireLeaseID bool,
 ) (graphAgentAccessLeaseOptions, error) {
 	leaseID = strings.TrimSpace(leaseID)
@@ -806,6 +813,7 @@ func normalizeGraphAgentAccessLeaseOptions(
 	if absoluteTTLHours < idleTimeoutHours {
 		absoluteTTLHours = idleTimeoutHours
 	}
+	tokenTTLHours = storageModels.NormalizeAgentAccessLeaseTokenTTLHours(idleTimeoutHours, absoluteTTLHours, tokenTTLHours)
 	normalizedScopes := append([]string(nil), scopes...)
 	sort.Strings(normalizedScopes)
 	return graphAgentAccessLeaseOptions{
@@ -820,6 +828,7 @@ func normalizeGraphAgentAccessLeaseOptions(
 		DeviceLabel:       deviceLabel,
 		IdleTimeoutHours:  idleTimeoutHours,
 		AbsoluteTTLHours:  absoluteTTLHours,
+		TokenTTLHours:     tokenTTLHours,
 	}, nil
 }
 
@@ -855,7 +864,7 @@ func normalizeGraphAgentAccessSessionPublicKey(raw string) (string, error) {
 
 func buildGraphAgentAccessLeaseChallengeMessage(id string, opts graphAgentAccessLeaseOptions, action string, nonce string, issuedAt time.Time, expiresAt time.Time) string {
 	return fmt.Sprintf(
-		"LESSER AGENT ACCESS LEASE\nid: %s\nlease_id: %s\naction: %s\ndomain: %s\nprincipal_username: %s\nagent_username: %s\nprincipal_wallet: %s\nagent_wallet: %s\nsession_public_key: %s\nscopes: %s\ndevice_label: %s\nidle_timeout_hours: %d\nabsolute_ttl_hours: %d\nnonce: %s\nissued_at: %s\nexpires_at: %s",
+		"LESSER AGENT ACCESS LEASE\nid: %s\nlease_id: %s\naction: %s\ndomain: %s\nprincipal_username: %s\nagent_username: %s\nprincipal_wallet: %s\nagent_wallet: %s\nsession_public_key: %s\nscopes: %s\ndevice_label: %s\nidle_timeout_hours: %d\nabsolute_ttl_hours: %d\ntoken_ttl_hours: %d\nnonce: %s\nissued_at: %s\nexpires_at: %s",
 		strings.TrimSpace(id),
 		strings.TrimSpace(opts.LeaseID),
 		strings.TrimSpace(action),
@@ -869,6 +878,7 @@ func buildGraphAgentAccessLeaseChallengeMessage(id string, opts graphAgentAccess
 		strings.TrimSpace(opts.DeviceLabel),
 		opts.IdleTimeoutHours,
 		opts.AbsoluteTTLHours,
+		opts.TokenTTLHours,
 		strings.TrimSpace(nonce),
 		issuedAt.UTC().Format(time.RFC3339),
 		expiresAt.UTC().Format(time.RFC3339),
@@ -928,7 +938,8 @@ func graphAgentAccessLeaseChallengesMatch(a, b *storageModels.AgentAccessLeaseCh
 		strings.EqualFold(strings.Join(a.Scopes, " "), strings.Join(b.Scopes, " ")) &&
 		a.DeviceLabel == b.DeviceLabel &&
 		a.IdleTimeoutHours == b.IdleTimeoutHours &&
-		a.AbsoluteTTLHours == b.AbsoluteTTLHours
+		a.AbsoluteTTLHours == b.AbsoluteTTLHours &&
+		a.EffectiveTokenTTLHours() == b.EffectiveTokenTTLHours()
 }
 
 func buildGraphAgentAccessLeaseTypedData(challenge *storageModels.AgentAccessLeaseChallenge) apitypes.TypedData {
@@ -952,6 +963,7 @@ func buildGraphAgentAccessLeaseTypedData(challenge *storageModels.AgentAccessLea
 				{Name: "deviceLabel", Type: "string"},
 				{Name: "idleTimeoutHours", Type: "string"},
 				{Name: "absoluteTTLHours", Type: "string"},
+				{Name: "tokenTTLHours", Type: "string"},
 				{Name: "nonce", Type: "string"},
 				{Name: "issuedAt", Type: "string"},
 				{Name: "expiresAt", Type: "string"},
@@ -976,6 +988,7 @@ func buildGraphAgentAccessLeaseTypedData(challenge *storageModels.AgentAccessLea
 			"deviceLabel":       strings.TrimSpace(challenge.DeviceLabel),
 			"idleTimeoutHours":  fmt.Sprintf("%d", challenge.IdleTimeoutHours),
 			"absoluteTTLHours":  fmt.Sprintf("%d", challenge.AbsoluteTTLHours),
+			"tokenTTLHours":     fmt.Sprintf("%d", challenge.EffectiveTokenTTLHours()),
 			"nonce":             strings.TrimSpace(challenge.Nonce),
 			"issuedAt":          challenge.IssuedAt.UTC().Format(time.RFC3339),
 			"expiresAt":         challenge.ExpiresAt.UTC().Format(time.RFC3339),
@@ -1082,6 +1095,7 @@ func graphAgentAccessLeaseModel(lease *storageModels.AgentAccessLease, now time.
 		DeviceLabel:          strings.TrimSpace(lease.DeviceLabel),
 		Status:               graphEffectiveAgentAccessLeaseStatus(lease, now),
 		IdleTimeoutHours:     lease.IdleTimeoutHours,
+		TokenTTLHours:        lease.EffectiveTokenTTLHours(),
 		IdleExpiresAt:        model.Time(lease.IdleExpiresAt),
 		AbsoluteExpiresAt:    model.Time(lease.AbsoluteExpiresAt),
 		LastUsedAt:           model.Time(lease.LastUsedAt),
@@ -1126,6 +1140,7 @@ func graphAgentAccessLeaseChallengeModel(challenge *storageModels.AgentAccessLea
 		DeviceLabel:      strings.TrimSpace(challenge.DeviceLabel),
 		IdleTimeoutHours: challenge.IdleTimeoutHours,
 		AbsoluteTTLHours: challenge.AbsoluteTTLHours,
+		TokenTTLHours:    challenge.EffectiveTokenTTLHours(),
 		Message:          challenge.Message,
 		TypedDataJSON:    typedDataJSON,
 		IssuedAt:         model.Time(challenge.IssuedAt),

--- a/graph/agent_access_lease_round32_test.go
+++ b/graph/agent_access_lease_round32_test.go
@@ -1,0 +1,92 @@
+package graph
+
+import (
+	"testing"
+	"time"
+
+	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeGraphAgentAccessLeaseOptions_TokenTTLPolicy(t *testing.T) {
+	opts, err := normalizeGraphAgentAccessLeaseOptions(
+		"",
+		"agent1",
+		"owner",
+		"0x1111111111111111111111111111111111111111",
+		"0x2222222222222222222222222222222222222222",
+		"",
+		[]string{"write", "read"},
+		"",
+		24,
+		72,
+		0,
+		false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 24, opts.TokenTTLHours)
+
+	opts, err = normalizeGraphAgentAccessLeaseOptions(
+		"",
+		"agent1",
+		"owner",
+		"0x1111111111111111111111111111111111111111",
+		"0x2222222222222222222222222222222222222222",
+		"",
+		[]string{"write", "read"},
+		"",
+		24,
+		72,
+		12,
+		false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 12, opts.TokenTTLHours)
+
+	opts, err = normalizeGraphAgentAccessLeaseOptions(
+		"",
+		"agent1",
+		"owner",
+		"0x1111111111111111111111111111111111111111",
+		"0x2222222222222222222222222222222222222222",
+		"",
+		[]string{"write", "read"},
+		"",
+		24,
+		72,
+		36,
+		false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 24, opts.TokenTTLHours)
+}
+
+func TestGraphAgentAccessLeaseModel_UsesEffectiveTokenTTL(t *testing.T) {
+	now := time.Now().UTC()
+	lease := &storageModels.AgentAccessLease{
+		ID:                "lease-1",
+		Username:          "agent1",
+		PrincipalUsername: "owner",
+		PrincipalWallet:   "0x1111111111111111111111111111111111111111",
+		AgentWallet:       "0x2222222222222222222222222222222222222222",
+		Scopes:            []string{"read", "write"},
+		DeviceLabel:       "local-agent",
+		Status:            graphAgentAccessLeaseStatusActive,
+		IdleTimeoutHours:  24,
+		IdleExpiresAt:     now.Add(24 * time.Hour),
+		AbsoluteExpiresAt: now.Add(72 * time.Hour),
+		LastUsedAt:        now,
+		LeaseVersion:      1,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+
+	model := graphAgentAccessLeaseModel(lease, now)
+	require.NotNil(t, model)
+	require.Equal(t, 24, model.TokenTTLHours)
+
+	lease.TokenTTLHours = 12
+	model = graphAgentAccessLeaseModel(lease, now)
+	require.NotNil(t, model)
+	require.Equal(t, 12, model.TokenTTLHours)
+}

--- a/graph/agent_resolvers_stubs.go
+++ b/graph/agent_resolvers_stubs.go
@@ -14,6 +14,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/agents"
 	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/config"
 	apperrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/federation"
 	"github.com/equaltoai/lesser/pkg/storage"
@@ -632,7 +633,7 @@ func (r *mutationResolver) DelegateToAgent(ctx context.Context, input model.Dele
 		return nil, err
 	}
 
-	accessTTL, err := validateAccessTokenTTL(input.ExpiresIn)
+	accessTTL, err := validateAccessTokenTTL(r.Config, input.ExpiresIn)
 	if err != nil {
 		return nil, err
 	}
@@ -1171,9 +1172,9 @@ func agentDelegationEnvelope(user *storage.User) ([]string, bool) {
 	return agentDelegatedScopes(user), true
 }
 
-func validateAccessTokenTTL(expiresIn *int) (time.Duration, error) {
+func validateAccessTokenTTL(cfg *config.Config, expiresIn *int) (time.Duration, error) {
 	if expiresIn == nil || *expiresIn == 0 {
-		return auth.AccessTokenDuration, nil
+		return auth.AgentAccessTokenTTL(cfg), nil
 	}
 
 	if *expiresIn < 60 {

--- a/graph/agents.graphql
+++ b/graph/agents.graphql
@@ -125,6 +125,7 @@ type AgentAccessLease {
   deviceLabel: String!
   status: String!
   idleTimeoutHours: Int!
+  tokenTTLHours: Int!
   idleExpiresAt: Time!
   absoluteExpiresAt: Time!
   lastUsedAt: Time!
@@ -154,6 +155,7 @@ type AgentAccessLeaseChallenge {
   deviceLabel: String!
   idleTimeoutHours: Int!
   absoluteTTLHours: Int!
+  tokenTTLHours: Int!
   message: String!
   typedDataJson: String
   issuedAt: Time!
@@ -178,6 +180,7 @@ input AgentAccessLeaseChallengeInput {
   leaseID: ID
   idleTimeoutHours: Int
   absoluteTTLHours: Int
+  tokenTTLHours: Int
 }
 
 input CreateAgentAccessLeaseInput {

--- a/graph/generated.go
+++ b/graph/generated.go
@@ -575,6 +575,7 @@ type ComplexityRoot struct {
 		SessionKeyType       func(childComplexity int) int
 		SessionPublicKey     func(childComplexity int) int
 		Status               func(childComplexity int) int
+		TokenTTLHours        func(childComplexity int) int
 		UpdatedAt            func(childComplexity int) int
 		Username             func(childComplexity int) int
 	}
@@ -594,6 +595,7 @@ type ComplexityRoot struct {
 		Scopes           func(childComplexity int) int
 		SessionKeyType   func(childComplexity int) int
 		SessionPublicKey func(childComplexity int) int
+		TokenTTLHours    func(childComplexity int) int
 		TypedDataJSON    func(childComplexity int) int
 		Username         func(childComplexity int) int
 		WalletAddress    func(childComplexity int) int
@@ -5781,6 +5783,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.AgentAccessLease.Status(childComplexity), true
 
+	case "AgentAccessLease.tokenTTLHours":
+		if e.complexity.AgentAccessLease.TokenTTLHours == nil {
+			break
+		}
+
+		return e.complexity.AgentAccessLease.TokenTTLHours(childComplexity), true
+
 	case "AgentAccessLease.updatedAt":
 		if e.complexity.AgentAccessLease.UpdatedAt == nil {
 			break
@@ -5892,6 +5901,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.AgentAccessLeaseChallenge.SessionPublicKey(childComplexity), true
+
+	case "AgentAccessLeaseChallenge.tokenTTLHours":
+		if e.complexity.AgentAccessLeaseChallenge.TokenTTLHours == nil {
+			break
+		}
+
+		return e.complexity.AgentAccessLeaseChallenge.TokenTTLHours(childComplexity), true
 
 	case "AgentAccessLeaseChallenge.typedDataJson":
 		if e.complexity.AgentAccessLeaseChallenge.TypedDataJSON == nil {
@@ -39097,6 +39113,50 @@ func (ec *executionContext) fieldContext_AgentAccessLease_idleTimeoutHours(_ con
 	return fc, nil
 }
 
+func (ec *executionContext) _AgentAccessLease_tokenTTLHours(ctx context.Context, field graphql.CollectedField, obj *model.AgentAccessLease) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AgentAccessLease_tokenTTLHours(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TokenTTLHours, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AgentAccessLease_tokenTTLHours(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AgentAccessLease",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _AgentAccessLease_idleExpiresAt(ctx context.Context, field graphql.CollectedField, obj *model.AgentAccessLease) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_AgentAccessLease_idleExpiresAt(ctx, field)
 	if err != nil {
@@ -40202,6 +40262,50 @@ func (ec *executionContext) _AgentAccessLeaseChallenge_absoluteTTLHours(ctx cont
 }
 
 func (ec *executionContext) fieldContext_AgentAccessLeaseChallenge_absoluteTTLHours(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AgentAccessLeaseChallenge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AgentAccessLeaseChallenge_tokenTTLHours(ctx context.Context, field graphql.CollectedField, obj *model.AgentAccessLeaseChallenge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AgentAccessLeaseChallenge_tokenTTLHours(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TokenTTLHours, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AgentAccessLeaseChallenge_tokenTTLHours(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "AgentAccessLeaseChallenge",
 		Field:      field,
@@ -87842,6 +87946,8 @@ func (ec *executionContext) fieldContext_Mutation_createAgentAccessLeasePrincipa
 				return ec.fieldContext_AgentAccessLeaseChallenge_idleTimeoutHours(ctx, field)
 			case "absoluteTTLHours":
 				return ec.fieldContext_AgentAccessLeaseChallenge_absoluteTTLHours(ctx, field)
+			case "tokenTTLHours":
+				return ec.fieldContext_AgentAccessLeaseChallenge_tokenTTLHours(ctx, field)
 			case "message":
 				return ec.fieldContext_AgentAccessLeaseChallenge_message(ctx, field)
 			case "typedDataJson":
@@ -87933,6 +88039,8 @@ func (ec *executionContext) fieldContext_Mutation_createAgentAccessLeaseAgentCha
 				return ec.fieldContext_AgentAccessLeaseChallenge_idleTimeoutHours(ctx, field)
 			case "absoluteTTLHours":
 				return ec.fieldContext_AgentAccessLeaseChallenge_absoluteTTLHours(ctx, field)
+			case "tokenTTLHours":
+				return ec.fieldContext_AgentAccessLeaseChallenge_tokenTTLHours(ctx, field)
 			case "message":
 				return ec.fieldContext_AgentAccessLeaseChallenge_message(ctx, field)
 			case "typedDataJson":
@@ -88016,6 +88124,8 @@ func (ec *executionContext) fieldContext_Mutation_createAgentAccessLease(ctx con
 				return ec.fieldContext_AgentAccessLease_status(ctx, field)
 			case "idleTimeoutHours":
 				return ec.fieldContext_AgentAccessLease_idleTimeoutHours(ctx, field)
+			case "tokenTTLHours":
+				return ec.fieldContext_AgentAccessLease_tokenTTLHours(ctx, field)
 			case "idleExpiresAt":
 				return ec.fieldContext_AgentAccessLease_idleExpiresAt(ctx, field)
 			case "absoluteExpiresAt":
@@ -88117,6 +88227,8 @@ func (ec *executionContext) fieldContext_Mutation_revokeAgentAccessLease(ctx con
 				return ec.fieldContext_AgentAccessLease_status(ctx, field)
 			case "idleTimeoutHours":
 				return ec.fieldContext_AgentAccessLease_idleTimeoutHours(ctx, field)
+			case "tokenTTLHours":
+				return ec.fieldContext_AgentAccessLease_tokenTTLHours(ctx, field)
 			case "idleExpiresAt":
 				return ec.fieldContext_AgentAccessLease_idleExpiresAt(ctx, field)
 			case "absoluteExpiresAt":
@@ -88226,6 +88338,8 @@ func (ec *executionContext) fieldContext_Mutation_createAgentAccessLeaseSessionK
 				return ec.fieldContext_AgentAccessLeaseChallenge_idleTimeoutHours(ctx, field)
 			case "absoluteTTLHours":
 				return ec.fieldContext_AgentAccessLeaseChallenge_absoluteTTLHours(ctx, field)
+			case "tokenTTLHours":
+				return ec.fieldContext_AgentAccessLeaseChallenge_tokenTTLHours(ctx, field)
 			case "message":
 				return ec.fieldContext_AgentAccessLeaseChallenge_message(ctx, field)
 			case "typedDataJson":
@@ -88309,6 +88423,8 @@ func (ec *executionContext) fieldContext_Mutation_authorizeAgentAccessLeaseSessi
 				return ec.fieldContext_AgentAccessLease_status(ctx, field)
 			case "idleTimeoutHours":
 				return ec.fieldContext_AgentAccessLease_idleTimeoutHours(ctx, field)
+			case "tokenTTLHours":
+				return ec.fieldContext_AgentAccessLease_tokenTTLHours(ctx, field)
 			case "idleExpiresAt":
 				return ec.fieldContext_AgentAccessLease_idleExpiresAt(ctx, field)
 			case "absoluteExpiresAt":
@@ -88418,6 +88534,8 @@ func (ec *executionContext) fieldContext_Mutation_createAgentAccessLeaseRenewCha
 				return ec.fieldContext_AgentAccessLeaseChallenge_idleTimeoutHours(ctx, field)
 			case "absoluteTTLHours":
 				return ec.fieldContext_AgentAccessLeaseChallenge_absoluteTTLHours(ctx, field)
+			case "tokenTTLHours":
+				return ec.fieldContext_AgentAccessLeaseChallenge_tokenTTLHours(ctx, field)
 			case "message":
 				return ec.fieldContext_AgentAccessLeaseChallenge_message(ctx, field)
 			case "typedDataJson":
@@ -107602,6 +107720,8 @@ func (ec *executionContext) fieldContext_Query_agentAccessLeases(ctx context.Con
 				return ec.fieldContext_AgentAccessLease_status(ctx, field)
 			case "idleTimeoutHours":
 				return ec.fieldContext_AgentAccessLease_idleTimeoutHours(ctx, field)
+			case "tokenTTLHours":
+				return ec.fieldContext_AgentAccessLease_tokenTTLHours(ctx, field)
 			case "idleExpiresAt":
 				return ec.fieldContext_AgentAccessLease_idleExpiresAt(ctx, field)
 			case "absoluteExpiresAt":
@@ -130754,7 +130874,7 @@ func (ec *executionContext) unmarshalInputAgentAccessLeaseChallengeInput(ctx con
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"principalWallet", "agentWallet", "sessionPublicKey", "scopes", "deviceLabel", "leaseID", "idleTimeoutHours", "absoluteTTLHours"}
+	fieldsInOrder := [...]string{"principalWallet", "agentWallet", "sessionPublicKey", "scopes", "deviceLabel", "leaseID", "idleTimeoutHours", "absoluteTTLHours", "tokenTTLHours"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -130817,6 +130937,13 @@ func (ec *executionContext) unmarshalInputAgentAccessLeaseChallengeInput(ctx con
 				return it, err
 			}
 			it.AbsoluteTTLHours = data
+		case "tokenTTLHours":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("tokenTTLHours"))
+			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.TokenTTLHours = data
 		}
 	}
 
@@ -139188,6 +139315,11 @@ func (ec *executionContext) _AgentAccessLease(ctx context.Context, sel ast.Selec
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "tokenTTLHours":
+			out.Values[i] = ec._AgentAccessLease_tokenTTLHours(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "idleExpiresAt":
 			out.Values[i] = ec._AgentAccessLease_idleExpiresAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -139322,6 +139454,11 @@ func (ec *executionContext) _AgentAccessLeaseChallenge(ctx context.Context, sel 
 			}
 		case "absoluteTTLHours":
 			out.Values[i] = ec._AgentAccessLeaseChallenge_absoluteTTLHours(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "tokenTTLHours":
+			out.Values[i] = ec._AgentAccessLeaseChallenge_tokenTTLHours(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/graph/model/agent_access_leases.go
+++ b/graph/model/agent_access_leases.go
@@ -11,6 +11,7 @@ type AgentAccessLease struct {
 	DeviceLabel          string   `json:"deviceLabel"`
 	Status               string   `json:"status"`
 	IdleTimeoutHours     int      `json:"idleTimeoutHours"`
+	TokenTTLHours        int      `json:"tokenTTLHours"`
 	IdleExpiresAt        Time     `json:"idleExpiresAt"`
 	AbsoluteExpiresAt    Time     `json:"absoluteExpiresAt"`
 	LastUsedAt           Time     `json:"lastUsedAt"`
@@ -41,6 +42,7 @@ type AgentAccessLeaseChallenge struct {
 	DeviceLabel      string   `json:"deviceLabel"`
 	IdleTimeoutHours int      `json:"idleTimeoutHours"`
 	AbsoluteTTLHours int      `json:"absoluteTTLHours"`
+	TokenTTLHours    int      `json:"tokenTTLHours"`
 	Message          string   `json:"message"`
 	TypedDataJSON    *string  `json:"typedDataJson,omitempty"`
 	IssuedAt         Time     `json:"issuedAt"`
@@ -67,6 +69,7 @@ type AgentAccessLeaseChallengeInput struct {
 	LeaseID          *string  `json:"leaseID,omitempty"`
 	IdleTimeoutHours *int     `json:"idleTimeoutHours,omitempty"`
 	AbsoluteTTLHours *int     `json:"absoluteTTLHours,omitempty"`
+	TokenTTLHours    *int     `json:"tokenTTLHours,omitempty"`
 }
 
 // CreateAgentAccessLeaseInput is the GraphQL input for finalizing a lease.

--- a/infra/cdk/constructs/lambda_functions.go
+++ b/infra/cdk/constructs/lambda_functions.go
@@ -151,6 +151,9 @@ func CreateLambdaFunctions(stack awscdk.Stack, props *LambdaFunctionsProps) *Lam
 	if v := getConfigString("translationEnabled"); v != "" {
 		commonEnv["TRANSLATION_ENABLED"] = jsii.String(v)
 	}
+	if v := getConfigString("agentAccessTokenDuration"); v != "" {
+		commonEnv["AGENT_ACCESS_TOKEN_DURATION"] = jsii.String(v)
+	}
 
 	// Set JWT secret ARN from SharedStack (securely passed, never synthesized)
 	if props.JwtSecret != nil {

--- a/infra/cdk/stacks/lesser_api_stack.go
+++ b/infra/cdk/stacks/lesser_api_stack.go
@@ -1048,9 +1048,10 @@ func loadEnvironmentConfig(environment string) map[string]interface{} {
 	// Default environment tuning used by the CDK app.
 	// Note: `infra/cdk/config/` contains reference templates and is not loaded at deploy time.
 	config := map[string]interface{}{
-		"logLevel":   "INFO",
-		"memorySize": 3008.0, // ARM64 Lambda optimized default
-		"timeout":    30.0,
+		"logLevel":                 "INFO",
+		"memorySize":               3008.0, // ARM64 Lambda optimized default
+		"timeout":                  30.0,
+		"agentAccessTokenDuration": "24h",
 		"features": map[string]interface{}{
 			"enableMonitoring": true,
 		},

--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -71,6 +71,15 @@ const (
 	ClientClassAgent = "agent"
 )
 
+// AgentAccessTokenTTL returns the configured default lifetime for agent access tokens.
+// When no agent-specific override is configured, Lesser falls back to the shared OAuth default.
+func AgentAccessTokenTTL(cfg *config.Config) time.Duration {
+	if cfg != nil && cfg.AgentAccessTokenDuration > 0 {
+		return cfg.AgentAccessTokenDuration
+	}
+	return AccessTokenDuration
+}
+
 // Claims represents the JWT claims for access tokens with enhanced security
 type Claims struct {
 	jwt.RegisteredClaims

--- a/pkg/auth/oauth_client_context_test.go
+++ b/pkg/auth/oauth_client_context_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
 	"github.com/stretchr/testify/require"
@@ -99,4 +100,12 @@ func TestNormalizeDelegatedBy(t *testing.T) {
 	require.Equal(t, "@owner", normalizeDelegatedBy("owner"))
 	require.Equal(t, "@owner", normalizeDelegatedBy("@owner"))
 	require.Equal(t, "@owner", normalizeDelegatedBy(" @owner "))
+}
+
+func TestAgentAccessTokenTTL(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, AccessTokenDuration, AgentAccessTokenTTL(nil))
+	require.Equal(t, AccessTokenDuration, AgentAccessTokenTTL(&config.Config{}))
+	require.Equal(t, 6*time.Hour, AgentAccessTokenTTL(&config.Config{AgentAccessTokenDuration: 6 * time.Hour}))
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -101,12 +101,13 @@ type Config struct {
 	FollowingURL string // Following URL pattern
 
 	// Features
-	MaxUploadSize          int64 // Maximum file upload size in bytes
-	PageSize               int   // Default pagination size
-	AllowRegistration      bool  // Whether new users can register
-	AllowAgents            bool  // Whether agent accounts are enabled
-	AllowAgentRegistration bool  // Whether new agent accounts can be registered/delegated
-	AllowDeviceFlow        bool  // Whether OAuth device authorization is enabled
+	MaxUploadSize            int64         // Maximum file upload size in bytes
+	PageSize                 int           // Default pagination size
+	AllowRegistration        bool          // Whether new users can register
+	AllowAgents              bool          // Whether agent accounts are enabled
+	AllowAgentRegistration   bool          // Whether new agent accounts can be registered/delegated
+	AllowDeviceFlow          bool          // Whether OAuth device authorization is enabled
+	AgentAccessTokenDuration time.Duration // Default lifetime for agent-minted access tokens
 
 	// CLI automation safety rails (device-flow tokens classified as client_class=cli)
 	CLIAutomationConcurrencyLimit   int           // Max concurrent in-flight requests per CLI session (sid)
@@ -371,6 +372,7 @@ func loadConfig() *Config {
 		AllowAgents:                     getEnvAsBoolOrDefault("ALLOW_AGENTS", false),
 		AllowAgentRegistration:          getEnvAsBoolOrDefault("ALLOW_AGENT_REGISTRATION", false),
 		AllowDeviceFlow:                 getEnvAsBoolOrDefault("ALLOW_DEVICE_FLOW", false),
+		AgentAccessTokenDuration:        getEnvAsDurationOrDefault("AGENT_ACCESS_TOKEN_DURATION", time.Hour),
 		CLIAutomationConcurrencyLimit:   getEnvAsIntOrDefault("CLI_AUTOMATION_CONCURRENCY_LIMIT", 2),
 		CLIAutomationBurstLimit:         getEnvAsIntOrDefault("CLI_AUTOMATION_BURST_LIMIT", 20),
 		CLIAutomationBurstWindow:        getEnvAsDurationOrDefault("CLI_AUTOMATION_BURST_WINDOW", 10*time.Second),

--- a/pkg/storage/models/agent_access_lease.go
+++ b/pkg/storage/models/agent_access_lease.go
@@ -33,6 +33,7 @@ type AgentAccessLease struct {
 	DeviceLabel          string    `theorydb:"attr:deviceLabel" json:"device_label"`
 	Status               string    `theorydb:"attr:status" json:"status"`
 	IdleTimeoutHours     int       `theorydb:"attr:idleTimeoutHours" json:"idle_timeout_hours"`
+	TokenTTLHours        int       `theorydb:"attr:tokenTTLHours" json:"token_ttl_hours"`
 	IdleExpiresAt        time.Time `theorydb:"attr:idleExpiresAt" json:"idle_expires_at"`
 	AbsoluteExpiresAt    time.Time `theorydb:"attr:absoluteExpiresAt" json:"absolute_expires_at"`
 	LastUsedAt           time.Time `theorydb:"attr:lastUsedAt" json:"last_used_at"`
@@ -139,6 +140,7 @@ type AgentAccessLeaseChallenge struct {
 	Scopes            []string  `theorydb:"attr:scopes" json:"scopes"`
 	DeviceLabel       string    `theorydb:"attr:deviceLabel" json:"device_label"`
 	IdleTimeoutHours  int       `theorydb:"attr:idleTimeoutHours" json:"idle_timeout_hours"`
+	TokenTTLHours     int       `theorydb:"attr:tokenTTLHours" json:"token_ttl_hours"`
 	AbsoluteTTLHours  int       `theorydb:"attr:absoluteTTLHours" json:"absolute_ttl_hours"`
 	Nonce             string    `theorydb:"attr:nonce" json:"nonce"`
 	Message           string    `theorydb:"attr:message" json:"message"`
@@ -204,4 +206,70 @@ func (c *AgentAccessLeaseChallenge) UpdateKeys() error {
 	c.SK = agentAccessChallengeSK
 	c.TTL = c.ExpiresAt.UTC().Unix()
 	return nil
+}
+
+// NormalizeAgentAccessLeaseTokenTTLHours clamps a lease token TTL policy to the
+// lease bounds so it remains meaningful to clients.
+func NormalizeAgentAccessLeaseTokenTTLHours(idleTimeoutHours, absoluteTTLHours, tokenTTLHours int) int {
+	if idleTimeoutHours < 0 {
+		idleTimeoutHours = 0
+	}
+	if absoluteTTLHours < 0 {
+		absoluteTTLHours = 0
+	}
+	if absoluteTTLHours > 0 && (idleTimeoutHours == 0 || absoluteTTLHours < idleTimeoutHours) {
+		idleTimeoutHours = absoluteTTLHours
+	}
+	if tokenTTLHours <= 0 {
+		tokenTTLHours = idleTimeoutHours
+	}
+	if idleTimeoutHours > 0 && tokenTTLHours > idleTimeoutHours {
+		tokenTTLHours = idleTimeoutHours
+	}
+	if absoluteTTLHours > 0 && tokenTTLHours > absoluteTTLHours {
+		tokenTTLHours = absoluteTTLHours
+	}
+	if tokenTTLHours < 0 {
+		return 0
+	}
+	return tokenTTLHours
+}
+
+// EffectiveTokenTTLHours returns the lease token TTL policy after applying
+// lease-safe defaults and clamps.
+func (l *AgentAccessLease) EffectiveTokenTTLHours() int {
+	if l == nil {
+		return 0
+	}
+	return NormalizeAgentAccessLeaseTokenTTLHours(l.IdleTimeoutHours, l.IdleTimeoutHours, l.TokenTTLHours)
+}
+
+// EffectiveTokenTTLHours returns the challenge token TTL policy after applying
+// lease-safe defaults and clamps.
+func (c *AgentAccessLeaseChallenge) EffectiveTokenTTLHours() int {
+	if c == nil {
+		return 0
+	}
+	return NormalizeAgentAccessLeaseTokenTTLHours(c.IdleTimeoutHours, c.AbsoluteTTLHours, c.TokenTTLHours)
+}
+
+// AgentAccessLeaseTokenExpiresAt returns the effective bearer-token expiry for
+// a lease renewal after combining lease policy, idle-window renewal, and the
+// absolute lease expiry.
+func AgentAccessLeaseTokenExpiresAt(now time.Time, lease *AgentAccessLease, idleExpiresAt time.Time) time.Time {
+	expiresAt := idleExpiresAt
+	if lease == nil {
+		return expiresAt
+	}
+
+	if tokenTTLHours := lease.EffectiveTokenTTLHours(); tokenTTLHours > 0 {
+		candidate := now.Add(time.Duration(tokenTTLHours) * time.Hour)
+		if expiresAt.IsZero() || candidate.Before(expiresAt) {
+			expiresAt = candidate
+		}
+	}
+	if !lease.AbsoluteExpiresAt.IsZero() && (expiresAt.IsZero() || lease.AbsoluteExpiresAt.Before(expiresAt)) {
+		expiresAt = lease.AbsoluteExpiresAt
+	}
+	return expiresAt
 }

--- a/pkg/storage/models/agent_access_lease_test.go
+++ b/pkg/storage/models/agent_access_lease_test.go
@@ -19,6 +19,7 @@ func TestAgentAccessLease_BeforeCreateDefaultsAndKeys(t *testing.T) {
 		Scopes:            []string{"read", "write"},
 		DeviceLabel:       "local-agent",
 		IdleTimeoutHours:  24,
+		TokenTTLHours:     12,
 		IdleExpiresAt:     now.Add(24 * time.Hour),
 		AbsoluteExpiresAt: now.Add(48 * time.Hour),
 	}
@@ -29,6 +30,7 @@ func TestAgentAccessLease_BeforeCreateDefaultsAndKeys(t *testing.T) {
 	require.Equal(t, lease.AbsoluteExpiresAt.Unix(), lease.TTL)
 	require.Equal(t, agentAccessLeaseStatusActive, lease.Status)
 	require.Equal(t, 1, lease.LeaseVersion)
+	require.Equal(t, 12, lease.EffectiveTokenTTLHours())
 	require.False(t, lease.CreatedAt.IsZero())
 	require.False(t, lease.UpdatedAt.IsZero())
 	require.False(t, lease.LastUsedAt.IsZero())
@@ -73,6 +75,7 @@ func TestAgentAccessLeaseChallenge_BeforeCreateAndKeys(t *testing.T) {
 		SessionKeyType:    "  ed25519  ",
 		Scopes:            []string{"read"},
 		DeviceLabel:       " local-agent ",
+		TokenTTLHours:     12,
 		Message:           "typed-data-payload",
 		ExpiresAt:         now.Add(5 * time.Minute),
 	}
@@ -87,6 +90,7 @@ func TestAgentAccessLeaseChallenge_BeforeCreateAndKeys(t *testing.T) {
 	require.Equal(t, "pubkey", challenge.SessionPublicKey)
 	require.Equal(t, "ed25519", challenge.SessionKeyType)
 	require.Equal(t, "local-agent", challenge.DeviceLabel)
+	require.Equal(t, 12, challenge.EffectiveTokenTTLHours())
 	require.False(t, challenge.IssuedAt.IsZero())
 }
 
@@ -121,4 +125,40 @@ func TestAgentAccessLeaseChallenge_UpdateKeysRequiresSigner(t *testing.T) {
 	var nilChallenge *AgentAccessLeaseChallenge
 	require.Error(t, nilChallenge.UpdateKeys())
 	require.Error(t, nilChallenge.BeforeCreate())
+}
+
+func TestNormalizeAgentAccessLeaseTokenTTLHours(t *testing.T) {
+	require.Equal(t, 24, NormalizeAgentAccessLeaseTokenTTLHours(24, 72, 0))
+	require.Equal(t, 12, NormalizeAgentAccessLeaseTokenTTLHours(24, 72, 12))
+	require.Equal(t, 24, NormalizeAgentAccessLeaseTokenTTLHours(24, 72, 48))
+	require.Equal(t, 6, NormalizeAgentAccessLeaseTokenTTLHours(24, 6, 12))
+	require.Equal(t, 0, NormalizeAgentAccessLeaseTokenTTLHours(0, 0, 0))
+}
+
+func TestAgentAccessLeaseTokenExpiresAt(t *testing.T) {
+	now := time.Now().UTC()
+	lease := &AgentAccessLease{
+		IdleTimeoutHours:  24,
+		TokenTTLHours:     6,
+		AbsoluteExpiresAt: now.Add(72 * time.Hour),
+	}
+
+	expiresAt := AgentAccessLeaseTokenExpiresAt(now, lease, now.Add(24*time.Hour))
+	require.WithinDuration(t, now.Add(6*time.Hour), expiresAt, time.Second)
+
+	lease.TokenTTLHours = 48
+	expiresAt = AgentAccessLeaseTokenExpiresAt(now, lease, now.Add(24*time.Hour))
+	require.WithinDuration(t, now.Add(24*time.Hour), expiresAt, time.Second)
+
+	lease.TokenTTLHours = 12
+	lease.AbsoluteExpiresAt = now.Add(2 * time.Hour)
+	expiresAt = AgentAccessLeaseTokenExpiresAt(now, lease, now.Add(24*time.Hour))
+	require.WithinDuration(t, now.Add(2*time.Hour), expiresAt, time.Second)
+
+	var nilLease *AgentAccessLease
+	require.Equal(t, 0, nilLease.EffectiveTokenTTLHours())
+	require.WithinDuration(t, now.Add(time.Hour), AgentAccessLeaseTokenExpiresAt(now, nilLease, now.Add(time.Hour)), time.Second)
+
+	var nilChallenge *AgentAccessLeaseChallenge
+	require.Equal(t, 0, nilChallenge.EffectiveTokenTTLHours())
 }


### PR DESCRIPTION
## Summary
- make agent access lease bearer TTL a lease-level policy via `tokenTTLHours`, exposed in REST and GraphQL
- remove the hidden `AgentAccessTokenTTL` cap from lease renewals so lease-minted tokens honor the lease policy and remaining lease window
- keep an instance-level `AGENT_ACCESS_TOKEN_DURATION` override for non-lease agent token flows, plus regression coverage and refreshed contracts

Closes #197.

## Verification
- `GOTOOLCHAIN=go1.26.1 go test ./pkg/storage/models -run 'TestAgentAccessLease' -count=1`
- `GOTOOLCHAIN=go1.26.1 go test ./cmd/api/handlers -run 'TestAgentAccessLeasesRound20_(FlowAndRenewal|InternalHelpers)|TestAgentAccessLeaseAdditionalHelpers_ValidationBranches|TestNormalizeAgentAccessLeaseOptions_' -count=1`
- `GOTOOLCHAIN=go1.26.1 go test ./graph -run 'TestNormalizeGraphAgentAccessLeaseOptions_TokenTTLPolicy|TestGraphAgentAccessLeaseModel_UsesEffectiveTokenTTL' -count=1`
- `GOTOOLCHAIN=go1.26.1 go test ./cmd/api/handlers ./graph ./pkg/storage/models ./pkg/auth ./cmd/lesser -count=1`
- `cd infra/cdk && GOTOOLCHAIN=go1.26.1 go test ./... -count=1`
- `GOTOOLCHAIN=go1.26.1 golangci-lint run --config .golangci.yml --disable gosec --concurrency 4 ./cmd/api/handlers ./graph ./pkg/storage/models ./pkg/auth ./cmd/lesser`
- `cd infra/cdk && GOTOOLCHAIN=go1.26.1 golangci-lint run --disable gosec --concurrency 4 ./...`
- `GOTOOLCHAIN=go1.26.1 ./lesser verify ci`
