### PR TITLE
fix dm conversation gsi omitempty

### DIFF
--- a/pkg/storage/models/activity.go
+++ b/pkg/storage/models/activity.go
@@ -17,12 +17,12 @@ type Activity struct {
 	SK string `theorydb:"sk,attr:SK" json:"SK"` // Format: "ACTIVITY#{timestamp}#{activity_id}"
 
 	// GSI for inbox activities - MUST match legacy patterns exactly
-	GSI1PK string `theorydb:"index:gsi1,pk,attr:gsi1PK" json:"gsi1PK,omitempty"` // Format: "INBOX#{username}" (only for inbox activities)
-	GSI1SK string `theorydb:"index:gsi1,sk,attr:gsi1SK" json:"gsi1SK,omitempty"` // Format: timestamp (only for inbox activities)
+	GSI1PK string `theorydb:"index:gsi1,pk,attr:gsi1PK,omitempty" json:"gsi1PK,omitempty"` // Format: "INBOX#{username}" (only for inbox activities)
+	GSI1SK string `theorydb:"index:gsi1,sk,attr:gsi1SK,omitempty" json:"gsi1SK,omitempty"` // Format: timestamp (only for inbox activities)
 
 	// GSI for direct activity lookup by Activity.ID
-	GSI2PK string `theorydb:"index:gsi2,pk,attr:gsi2PK" json:"gsi2PK,omitempty"` // Format: "ACTIVITYID#{activity_id}"
-	GSI2SK string `theorydb:"index:gsi2,sk,attr:gsi2SK" json:"gsi2SK,omitempty"` // Format: "ACTIVITY#{timestamp}#{activity_id}"
+	GSI2PK string `theorydb:"index:gsi2,pk,attr:gsi2PK,omitempty" json:"gsi2PK,omitempty"` // Format: "ACTIVITYID#{activity_id}"
+	GSI2SK string `theorydb:"index:gsi2,sk,attr:gsi2SK,omitempty" json:"gsi2SK,omitempty"` // Format: "ACTIVITY#{timestamp}#{activity_id}"
 
 	// Activity data
 	Activity  *activitypub.Activity `theorydb:"attr:activity" json:"Activity"`

--- a/pkg/storage/models/conversation.go
+++ b/pkg/storage/models/conversation.go
@@ -13,7 +13,7 @@ type DmRequestState string
 
 const (
 	// DmRequestStatePending indicates the participant has not yet accepted or declined the request.
-	DmRequestStatePending  DmRequestState = "PENDING"
+	DmRequestStatePending DmRequestState = "PENDING"
 	// DmRequestStateAccepted indicates the participant has accepted the request.
 	DmRequestStateAccepted DmRequestState = "ACCEPTED"
 	// DmRequestStateDeclined indicates the participant has declined the request.
@@ -30,8 +30,8 @@ type Conversation struct {
 
 	// GSI1 is used for participant records (additional records per participant)
 	// Note: The main conversation record doesn't use GSI1, only participant records do
-	GSI1PK string `theorydb:"index:gsi1,pk,attr:gsi1PK" json:"gsi1PK,omitempty"`
-	GSI1SK string `theorydb:"index:gsi1,sk,attr:gsi1SK" json:"gsi1SK,omitempty"`
+	GSI1PK string `theorydb:"index:gsi1,pk,attr:gsi1PK,omitempty" json:"gsi1PK,omitempty"`
+	GSI1SK string `theorydb:"index:gsi1,sk,attr:gsi1SK,omitempty" json:"gsi1SK,omitempty"`
 
 	// Core fields from legacy
 	ID           string    `theorydb:"attr:id" json:"id"`
@@ -172,7 +172,7 @@ type ConversationParticipantKey struct {
 	PK     string `theorydb:"pk,attr:PK" json:"PK"`
 	SK     string `theorydb:"sk,attr:SK" json:"SK"`
 	GSI1PK string `theorydb:"index:gsi1,pk,attr:gsi1PK" json:"gsi1PK"`
-	GSI1SK string `theorydb:"index:gsi1,sk,attr:gsi1SK" json:"gsi1SK,omitempty"`
+	GSI1SK string `theorydb:"index:gsi1,sk,attr:gsi1SK,omitempty" json:"gsi1SK,omitempty"`
 
 	ConversationID string `theorydb:"attr:conversationID" json:"conversation_id"`
 }

--- a/pkg/storage/models/conversation_activity_omitempty_test.go
+++ b/pkg/storage/models/conversation_activity_omitempty_test.go
@@ -1,0 +1,159 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ttcore "github.com/theory-cloud/tabletheory/pkg/core"
+	ttmodel "github.com/theory-cloud/tabletheory/pkg/model"
+	ttquery "github.com/theory-cloud/tabletheory/pkg/query"
+)
+
+type theorydbPutCapture struct {
+	item map[string]types.AttributeValue
+}
+
+func (c *theorydbPutCapture) ExecuteQuery(*ttcore.CompiledQuery, any) error {
+	return nil
+}
+
+func (c *theorydbPutCapture) ExecuteScan(*ttcore.CompiledQuery, any) error {
+	return nil
+}
+
+func (c *theorydbPutCapture) ExecutePutItem(_ *ttcore.CompiledQuery, item map[string]types.AttributeValue) error {
+	c.item = item
+	return nil
+}
+
+type rawRegistryMetadataAdapter struct {
+	meta *ttmodel.Metadata
+}
+
+func (a *rawRegistryMetadataAdapter) TableName() string {
+	return a.meta.TableName
+}
+
+func (a *rawRegistryMetadataAdapter) PrimaryKey() ttcore.KeySchema {
+	schema := ttcore.KeySchema{
+		PartitionKey: a.meta.PrimaryKey.PartitionKey.Name,
+	}
+	if a.meta.PrimaryKey.SortKey != nil {
+		schema.SortKey = a.meta.PrimaryKey.SortKey.Name
+	}
+	return schema
+}
+
+func (a *rawRegistryMetadataAdapter) Indexes() []ttcore.IndexSchema {
+	indexes := make([]ttcore.IndexSchema, len(a.meta.Indexes))
+	for i, idx := range a.meta.Indexes {
+		indexes[i] = ttcore.IndexSchema{
+			Name:            idx.Name,
+			Type:            string(idx.Type),
+			ProjectionType:  idx.ProjectionType,
+			ProjectedFields: idx.ProjectedFields,
+		}
+		if idx.PartitionKey != nil {
+			indexes[i].PartitionKey = idx.PartitionKey.Name
+		}
+		if idx.SortKey != nil {
+			indexes[i].SortKey = idx.SortKey.Name
+		}
+	}
+	return indexes
+}
+
+func (a *rawRegistryMetadataAdapter) AttributeMetadata(field string) *ttcore.AttributeMetadata {
+	if meta, ok := a.meta.Fields[field]; ok {
+		return &ttcore.AttributeMetadata{Name: meta.Name, Type: meta.Type.String(), DynamoDBName: meta.DBName}
+	}
+	if meta, ok := a.meta.FieldsByDBName[field]; ok {
+		return &ttcore.AttributeMetadata{Name: meta.Name, Type: meta.Type.String(), DynamoDBName: meta.DBName}
+	}
+	return nil
+}
+
+func (a *rawRegistryMetadataAdapter) VersionFieldName() string {
+	if a.meta.VersionField == nil {
+		return ""
+	}
+	if a.meta.VersionField.DBName != "" {
+		return a.meta.VersionField.DBName
+	}
+	return a.meta.VersionField.Name
+}
+
+func (a *rawRegistryMetadataAdapter) RawMetadata() *ttmodel.Metadata {
+	return a.meta
+}
+
+func marshalWithTableTheory(t *testing.T, item any) map[string]types.AttributeValue {
+	t.Helper()
+
+	registry := ttmodel.NewRegistry()
+	require.NoError(t, registry.Register(item))
+
+	meta, err := registry.GetMetadata(item)
+	require.NoError(t, err)
+
+	executor := &theorydbPutCapture{}
+	query := ttquery.New(item, &rawRegistryMetadataAdapter{meta: meta}, executor)
+	require.NoError(t, query.Create())
+	require.NotNil(t, executor.item)
+
+	return executor.item
+}
+
+func TestConversationCreateOmitsEmptyConversationGSIKeys(t *testing.T) {
+	conversation := &Conversation{
+		ID:        "conv-1",
+		CreatedAt: time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC),
+	}
+	require.NoError(t, conversation.BeforeCreate())
+
+	item := marshalWithTableTheory(t, conversation)
+
+	assert.NotContains(t, item, "gsi1PK")
+	assert.NotContains(t, item, "gsi1SK")
+	assert.Contains(t, item, "PK")
+	assert.Contains(t, item, "SK")
+}
+
+func TestConversationParticipantKeyOmitsEmptyReverseLookupSortKey(t *testing.T) {
+	lookupKey := &ConversationParticipantKey{
+		PK:             "CONVERSATION_PARTICIPANTS#alice,bob",
+		SK:             "LOOKUP",
+		GSI1PK:         "CONVERSATION_PARTICIPANTS#alice,bob",
+		ConversationID: "conv-1",
+	}
+
+	item := marshalWithTableTheory(t, lookupKey)
+
+	assert.Contains(t, item, "gsi1PK")
+	assert.NotContains(t, item, "gsi1SK")
+}
+
+func TestActivityCreateOmitsEmptyOptionalGSIKeys(t *testing.T) {
+	activity := &Activity{
+		Activity: &activitypub.Activity{
+			BaseObject: activitypub.BaseObject{ID: "act-1"},
+			Actor:      "https://example.com/users/alice",
+		},
+		CreatedAt: time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC),
+	}
+	require.NoError(t, activity.UpdateKeys())
+
+	item := marshalWithTableTheory(t, activity)
+
+	assert.NotContains(t, item, "gsi1PK")
+	assert.NotContains(t, item, "gsi1SK")
+	assert.NotContains(t, item, "gsi2PK")
+	assert.NotContains(t, item, "gsi2SK")
+	assert.Contains(t, item, "PK")
+	assert.Contains(t, item, "SK")
+}


### PR DESCRIPTION
## Summary
- omit empty `gsi1` attributes from the main conversation record so DM creation no longer writes invalid empty index keys
- omit the latent empty `gsi1SK` on conversation participant lookup keys and align optional activity GSIs with the same TableTheory contract
- add TableTheory marshaling regression tests that assert the emitted DynamoDB item really skips these empty index attributes

## Testing
- `GOTOOLCHAIN=go1.26.1 go test ./pkg/storage/models -run 'TestConversation(CreateOmitsEmptyConversationGSIKeys|ParticipantKeyOmitsEmptyReverseLookupSortKey)|TestActivityCreateOmitsEmptyOptionalGSIKeys|TestConversationModels|TestInstanceConfig_TimelineEntry_InstanceMetrics_Article_Activity' -count=1`
- `GOTOOLCHAIN=go1.26.1 go test ./pkg/storage/models ./pkg/storage/repositories ./pkg/services/conversations ./graph -count=1`
- `GOTOOLCHAIN=go1.26.1 ./lesser verify ci`

Closes #199