### PR TITLE
finish issue 205 attribution migration

### DIFF
--- a/cmd/api/handlers/agent_feature_round12_coverage_test.go
+++ b/cmd/api/handlers/agent_feature_round12_coverage_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	apimodels "github.com/equaltoai/lesser/cmd/api/models"
+	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/auth"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/golang-jwt/jwt/v5"
@@ -340,7 +341,8 @@ func TestAgentFeaturesRound12_StatusAttributionAndMemoryEvents(t *testing.T) {
 	require.Nil(t, resp)
 	require.NotNil(t, attribution)
 	require.Equal(t, "mention", attribution.TriggerType)
-	require.Equal(t, "@owner", attribution.DelegatedBy)
+	require.Equal(t, cfg.ActorURL("owner"), attribution.DelegatedBy)
+	require.Equal(t, activitypub.AgentAttributionSchemaVersion, attribution.SchemaVersion)
 	require.Len(t, attribution.MemoryCitations, 1)
 }
 

--- a/cmd/api/handlers/agent_status_metadata.go
+++ b/cmd/api/handlers/agent_status_metadata.go
@@ -163,10 +163,11 @@ func (h *Handler) buildAgentStatusAttribution(ctx *apptheory.Context, claims *au
 	if delegatedBy == "" {
 		delegatedBy = strings.TrimSpace(agentUser.AgentOwner)
 	}
+	delegatedBy = h.normalizeDelegatedByActorURI(delegatedBy)
 
-	modelVersion := strings.TrimSpace(agentUser.AgentVersion)
-	if modelVersion == "" {
-		modelVersion = agentVersionUnknown
+	modelID := strings.TrimSpace(agentUser.AgentVersion)
+	if modelID == "" {
+		modelID = agentVersionUnknown
 	}
 
 	attribution := &activitypub.AgentPostAttribution{
@@ -176,7 +177,8 @@ func (h *Handler) buildAgentStatusAttribution(ctx *apptheory.Context, claims *au
 		DelegatedBy:     delegatedBy,
 		Scopes:          append([]string(nil), claims.Scopes...),
 		Constraints:     buildAgentCapabilityConstraints(agentUser.AgentCapabilities),
-		ModelVersion:    modelVersion,
+		SchemaVersion:   activitypub.AgentAttributionSchemaVersion,
+		ModelID:         modelID,
 	}
 
 	return attribution, nil, nil

--- a/cmd/api/handlers/agent_status_metadata_round18_more_coverage_test.go
+++ b/cmd/api/handlers/agent_status_metadata_round18_more_coverage_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	apimodels "github.com/equaltoai/lesser/cmd/api/models"
+	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/agents"
 	"github.com/equaltoai/lesser/pkg/auth"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
@@ -257,8 +258,9 @@ func TestAgentStatusMetadataRound18_BuildAgentStatusAttribution(t *testing.T) {
 		require.Nil(t, resp)
 		require.NotNil(t, attribution)
 		require.Equal(t, "manual", attribution.TriggerType)
-		require.Equal(t, "owner", attribution.DelegatedBy)
-		require.Equal(t, agentVersionUnknown, attribution.ModelVersion)
+		require.Equal(t, cfg.ActorURL("owner"), attribution.DelegatedBy)
+		require.Equal(t, activitypub.AgentAttributionSchemaVersion, attribution.SchemaVersion)
+		require.Equal(t, agentVersionUnknown, attribution.ModelID)
 		require.Equal(t, []string{"write:statuses"}, attribution.Scopes)
 	})
 }

--- a/cmd/api/handlers/helpers.go
+++ b/cmd/api/handlers/helpers.go
@@ -41,6 +41,18 @@ const MaxPaginationLimit = 80
 
 // Legacy authentication function removed - use auth.RequireAuthWithScope() instead
 
+func (h *Handler) normalizeDelegatedByActorURI(value string) string {
+	delegatedBy := strings.TrimSpace(value)
+	if delegatedBy == "" || h == nil || h.cfg == nil {
+		return delegatedBy
+	}
+	lowerValue := strings.ToLower(delegatedBy)
+	if strings.HasPrefix(lowerValue, "http://") || strings.HasPrefix(lowerValue, "https://") {
+		return delegatedBy
+	}
+	return h.cfg.ActorURL(strings.TrimPrefix(delegatedBy, "@"))
+}
+
 // resolveAccountID resolves an account ID (which can be a username, numeric ID, or URL) to an actor
 func (h *Handler) resolveAccountID(ctx context.Context, accountID string) (*activitypub.Actor, error) {
 	accountID = normalizeResolvedAccountID(accountID)
@@ -786,25 +798,30 @@ func (h *Handler) buildStatusAgentAttribution(authorAccount *storage.Account, st
 	}
 
 	out := &models.AgentPostAttribution{
-		ModelVersion: agentVersionUnknown,
+		SchemaVersion: activitypub.AgentAttributionSchemaVersion,
+		ModelID:       agentVersionUnknown,
 	}
 
 	if noteAttr != nil {
 		out.TriggerType = strings.TrimSpace(noteAttr.TriggerType)
 		out.TriggerDetails = strings.TrimSpace(noteAttr.TriggerDetails)
 		out.MemoryCitations = append([]string(nil), noteAttr.MemoryCitations...)
-		out.DelegatedBy = strings.TrimSpace(noteAttr.DelegatedBy)
+		out.DelegatedBy = h.normalizeDelegatedByActorURI(noteAttr.DelegatedBy)
+		out.DelegatedByDID = strings.TrimSpace(noteAttr.DelegatedByDID)
 		out.Scopes = append([]string(nil), noteAttr.Scopes...)
 		out.Constraints = append([]string(nil), noteAttr.Constraints...)
-		if v := strings.TrimSpace(noteAttr.ModelVersion); v != "" {
-			out.ModelVersion = v
+		if v := strings.TrimSpace(noteAttr.SchemaVersion); v != "" {
+			out.SchemaVersion = v
+		}
+		if v := strings.TrimSpace(noteAttr.ModelID); v != "" {
+			out.ModelID = v
 		}
 	}
 
 	if out.DelegatedBy == "" {
-		out.DelegatedBy = strings.TrimSpace(authorAccount.User.AgentOwner)
+		out.DelegatedBy = h.normalizeDelegatedByActorURI(authorAccount.User.AgentOwner)
 		if out.DelegatedBy == "" && authorAccount.Actor != nil && authorAccount.Actor.AgentManifest != nil {
-			out.DelegatedBy = strings.TrimSpace(authorAccount.Actor.AgentManifest.OperatedBy)
+			out.DelegatedBy = h.normalizeDelegatedByActorURI(authorAccount.Actor.AgentManifest.OperatedBy)
 		}
 	}
 
@@ -816,12 +833,12 @@ func (h *Handler) buildStatusAgentAttribution(authorAccount *storage.Account, st
 		out.Constraints = buildAgentCapabilityConstraints(authorAccount.User.AgentCapabilities)
 	}
 
-	if out.ModelVersion == agentVersionUnknown {
+	if out.ModelID == agentVersionUnknown {
 		if v := strings.TrimSpace(authorAccount.User.AgentVersion); v != "" {
-			out.ModelVersion = v
+			out.ModelID = v
 		} else if authorAccount.Actor != nil && authorAccount.Actor.AgentManifest != nil {
 			if v := strings.TrimSpace(authorAccount.Actor.AgentManifest.Version); v != "" {
-				out.ModelVersion = v
+				out.ModelID = v
 			}
 		}
 	}

--- a/cmd/api/handlers/helpers_round18_more_coverage_test.go
+++ b/cmd/api/handlers/helpers_round18_more_coverage_test.go
@@ -87,6 +87,30 @@ func TestHelpersRound18_ResolveAccountID_InvalidURLBranches(t *testing.T) {
 	})
 }
 
+func TestHelpersRound18_NormalizeDelegatedByActorURI(t *testing.T) {
+	cfg := round11TestConfig()
+
+	t.Run("returns empty string unchanged", func(t *testing.T) {
+		var h *Handler
+		require.Empty(t, h.normalizeDelegatedByActorURI("   "))
+	})
+
+	t.Run("returns trimmed value when handler config missing", func(t *testing.T) {
+		h := &Handler{}
+		require.Equal(t, "owner", h.normalizeDelegatedByActorURI("  owner  "))
+	})
+
+	t.Run("passes through actor urls", func(t *testing.T) {
+		h := &Handler{cfg: cfg}
+		require.Equal(t, "HTTPS://remote.example/users/owner", h.normalizeDelegatedByActorURI("HTTPS://remote.example/users/owner"))
+	})
+
+	t.Run("normalizes local usernames to actor urls", func(t *testing.T) {
+		h := &Handler{cfg: cfg}
+		require.Equal(t, cfg.ActorURL("owner"), h.normalizeDelegatedByActorURI("@owner"))
+	})
+}
+
 func TestHelpersRound18_BuildStatusAgentAttribution(t *testing.T) {
 	cfg := round11TestConfig()
 	h := &Handler{cfg: cfg}
@@ -106,7 +130,8 @@ func TestHelpersRound18_BuildStatusAgentAttribution(t *testing.T) {
 					DelegatedBy:     "operator",
 					Scopes:          []string{"read"},
 					Constraints:     []string{"requires_approval"},
-					ModelVersion:    "v2",
+					SchemaVersion:   activitypub.AgentAttributionSchemaVersion,
+					ModelID:         "v2",
 				},
 			},
 		}
@@ -120,10 +145,11 @@ func TestHelpersRound18_BuildStatusAgentAttribution(t *testing.T) {
 		require.Equal(t, "mention", out.TriggerType)
 		require.Equal(t, "test", out.TriggerDetails)
 		require.Equal(t, []string{"m1"}, out.MemoryCitations)
-		require.Equal(t, "operator", out.DelegatedBy)
+		require.Equal(t, cfg.ActorURL("operator"), out.DelegatedBy)
 		require.Equal(t, []string{"read"}, out.Scopes)
 		require.Equal(t, []string{"requires_approval"}, out.Constraints)
-		require.Equal(t, "v2", out.ModelVersion)
+		require.Equal(t, activitypub.AgentAttributionSchemaVersion, out.SchemaVersion)
+		require.Equal(t, "v2", out.ModelID)
 	})
 
 	t.Run("agent falls back to stored delegation and constraints", func(t *testing.T) {
@@ -154,12 +180,43 @@ func TestHelpersRound18_BuildStatusAgentAttribution(t *testing.T) {
 
 		out := h.buildStatusAgentAttribution(account, &storagemodels.Status{Note: &activitypub.Note{}})
 		require.NotNil(t, out)
-		require.Equal(t, "manifest-owner", out.DelegatedBy)
+		require.Equal(t, cfg.ActorURL("manifest-owner"), out.DelegatedBy)
 		require.Equal(t, []string{"read", "write:statuses"}, out.Scopes)
 		require.Contains(t, out.Constraints, "max_posts_per_hour:5")
 		require.Contains(t, out.Constraints, "requires_approval")
 		require.Contains(t, out.Constraints, "restricted_domains:example.org")
-		require.Equal(t, "manifest-v1", out.ModelVersion)
+		require.Equal(t, activitypub.AgentAttributionSchemaVersion, out.SchemaVersion)
+		require.Equal(t, "manifest-v1", out.ModelID)
+	})
+
+	t.Run("agent keeps delegated did and falls back to account metadata", func(t *testing.T) {
+		account := &storage.Account{
+			User: &storage.User{
+				Username:     "bot",
+				IsAgent:      true,
+				AgentOwner:   "https://remote.example/users/owner",
+				AgentVersion: "user-v2",
+				Metadata: map[string]any{
+					"agent_delegated_scopes": []any{"read"},
+				},
+			},
+		}
+
+		status := &storagemodels.Status{
+			Note: &activitypub.Note{
+				AgentAttribution: &activitypub.AgentPostAttribution{
+					DelegatedByDID: "did:key:z6Mkexample",
+				},
+			},
+		}
+
+		out := h.buildStatusAgentAttribution(account, status)
+		require.NotNil(t, out)
+		require.Equal(t, "https://remote.example/users/owner", out.DelegatedBy)
+		require.Equal(t, "did:key:z6Mkexample", out.DelegatedByDID)
+		require.Equal(t, []string{"read"}, out.Scopes)
+		require.Equal(t, activitypub.AgentAttributionSchemaVersion, out.SchemaVersion)
+		require.Equal(t, "user-v2", out.ModelID)
 	})
 }
 
@@ -192,6 +249,49 @@ func TestHelpersRound18_StatusAccountUsesActorData(t *testing.T) {
 	require.Equal(t, "alice", account.Acct)
 	require.Equal(t, "Alice", account.DisplayName)
 	require.Equal(t, createdAt.Format(time.RFC3339), account.CreatedAt)
+}
+
+func TestHelpersRound18_StatusAccountFallbackBranches(t *testing.T) {
+	cfg := round11TestConfig()
+	h := &Handler{cfg: cfg}
+
+	t.Run("builds local fallback account when author account missing", func(t *testing.T) {
+		account := h.statusAccount(&storagemodels.Status{
+			StatusID:       "status-2",
+			AuthorUsername: "bot",
+			AuthorID:       cfg.ActorURL("bot"),
+		}, nil)
+
+		require.Equal(t, "bot", account.Username)
+		require.Equal(t, "bot", account.DisplayName)
+		require.Equal(t, "bot", account.Acct)
+	})
+
+	t.Run("returns remote actor account when actor is not local", func(t *testing.T) {
+		account := h.statusAccount(&storagemodels.Status{
+			StatusID:       "status-3",
+			AuthorUsername: "alice",
+			AuthorID:       "https://remote.example/users/alice",
+		}, &storage.Account{
+			User: &storage.User{
+				Username:    "alice",
+				DisplayName: "Alice Remote",
+			},
+			Actor: &activitypub.Actor{
+				BaseObject: activitypub.BaseObject{
+					ID:   "https://remote.example/users/alice",
+					Type: "Person",
+				},
+				PreferredUsername: "alice",
+				Name:              "Alice Remote",
+				URL:               "https://remote.example/@alice",
+			},
+		})
+
+		require.Equal(t, "alice", account.Username)
+		require.Equal(t, "alice", account.Acct)
+		require.Equal(t, "Alice Remote", account.DisplayName)
+	})
 }
 
 func TestHelpersRound18_StatusReblogTargetID(t *testing.T) {

--- a/cmd/api/models/agent_attribution.go
+++ b/cmd/api/models/agent_attribution.go
@@ -9,9 +9,11 @@ type AgentPostAttribution struct {
 
 	MemoryCitations []string `json:"memory_citations,omitempty"`
 
-	DelegatedBy string   `json:"delegated_by,omitempty"`
-	Scopes      []string `json:"scopes,omitempty"`
+	DelegatedBy    string   `json:"delegated_by,omitempty"`
+	DelegatedByDID string   `json:"delegated_by_did,omitempty"`
+	Scopes         []string `json:"scopes,omitempty"`
 
-	Constraints  []string `json:"constraints,omitempty"`
-	ModelVersion string   `json:"model_version,omitempty"`
+	Constraints   []string `json:"constraints,omitempty"`
+	SchemaVersion string   `json:"schema_version,omitempty"`
+	ModelID       string   `json:"model_id,omitempty"`
 }

--- a/cmd/lesser/test_cmd.go
+++ b/cmd/lesser/test_cmd.go
@@ -9,7 +9,13 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
+)
+
+const (
+	defaultCoverageBatchSize = 25
+	coverageBatchSizeEnvVar  = "LESSER_TEST_COVERAGE_BATCH_SIZE"
 )
 
 func runTest(argv []string) error {
@@ -192,10 +198,7 @@ func runTestCoverage(argv []string) error {
 	if verbose {
 		goArgs = append(goArgs, "-v")
 	}
-	goArgs = append(goArgs, "-coverprofile="+profileName)
-	goArgs = append(goArgs, pkgPaths...)
-
-	if err := runGoTests(args, goArgs, nil); err != nil {
+	if err := runGoCoverageTests(args, repoRoot, profileName, goArgs, pkgPaths); err != nil {
 		return err
 	}
 
@@ -214,6 +217,127 @@ func runTestCoverage(argv []string) error {
 			"GOCACHE": goCache,
 		},
 	})
+}
+
+func runGoCoverageTests(args testArgs, repoRoot, profileName string, baseGoArgs, pkgPaths []string) error {
+	batchSize := resolveCoverageBatchSize()
+	if batchSize <= 0 || len(pkgPaths) <= batchSize {
+		goArgs := append(append([]string{}, baseGoArgs...), "-coverprofile="+profileName)
+		goArgs = append(goArgs, pkgPaths...)
+		return runGoTests(args, goArgs, nil)
+	}
+
+	tmpProfiles := make([]string, 0, (len(pkgPaths)+batchSize-1)/batchSize)
+	for i := 0; i < len(pkgPaths); i += batchSize {
+		end := i + batchSize
+		if end > len(pkgPaths) {
+			end = len(pkgPaths)
+		}
+
+		tmpProfile, err := os.CreateTemp(repoRoot, filepath.Base(profileName)+".batch-*.out")
+		if err != nil {
+			return fmt.Errorf("create temp coverprofile: %w", err)
+		}
+		tmpPath := tmpProfile.Name()
+		if err := tmpProfile.Close(); err != nil {
+			_ = os.Remove(tmpPath)
+			return fmt.Errorf("close temp coverprofile: %w", err)
+		}
+		defer func(path string) { _ = os.Remove(path) }(tmpPath)
+
+		goArgs := append(append([]string{}, baseGoArgs...), "-coverprofile="+tmpPath)
+		goArgs = append(goArgs, pkgPaths[i:end]...)
+		if err := runGoTests(args, goArgs, nil); err != nil {
+			return err
+		}
+		tmpProfiles = append(tmpProfiles, tmpPath)
+	}
+
+	return mergeCoverageProfiles(profileName, tmpProfiles)
+}
+
+func resolveCoverageBatchSize() int {
+	if raw := strings.TrimSpace(os.Getenv(coverageBatchSizeEnvVar)); raw != "" {
+		if size, err := strconv.Atoi(raw); err == nil {
+			return size
+		}
+	}
+	return defaultCoverageBatchSize
+}
+
+func mergeCoverageProfiles(destPath string, profilePaths []string) error {
+	// #nosec G304 -- destination is a repo-owned coverage artifact path.
+	out, err := os.Create(filepath.Clean(destPath))
+	if err != nil {
+		return fmt.Errorf("create merged coverprofile: %w", err)
+	}
+	defer func() {
+		if err := out.Close(); err != nil {
+			fmt.Fprintln(os.Stderr, "warning: close merged coverprofile:", err)
+		}
+	}()
+
+	writer := bufio.NewWriter(out)
+	defer func() {
+		if err := writer.Flush(); err != nil {
+			fmt.Fprintln(os.Stderr, "warning: flush merged coverprofile:", err)
+		}
+	}()
+
+	mode := ""
+	for _, profilePath := range profilePaths {
+		if err := appendCoverageProfile(writer, profilePath, &mode); err != nil {
+			return err
+		}
+	}
+
+	if mode == "" {
+		if _, err := writer.WriteString("mode: set\n"); err != nil {
+			return fmt.Errorf("write default coverage mode: %w", err)
+		}
+	}
+
+	if err := writer.Flush(); err != nil {
+		return fmt.Errorf("flush merged coverprofile: %w", err)
+	}
+	return nil
+}
+
+func appendCoverageProfile(writer *bufio.Writer, profilePath string, mode *string) error {
+	in, err := os.Open(filepath.Clean(profilePath))
+	if err != nil {
+		return fmt.Errorf("open temp coverprofile: %w", err)
+	}
+	defer func() {
+		if err := in.Close(); err != nil {
+			fmt.Fprintln(os.Stderr, "warning: close temp coverprofile:", err)
+		}
+	}()
+
+	scanner := bufio.NewScanner(in)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "mode:") {
+			if *mode == "" {
+				*mode = line
+				if _, err := writer.WriteString(line + "\n"); err != nil {
+					return fmt.Errorf("write coverage mode: %w", err)
+				}
+				continue
+			}
+			if line != *mode {
+				return fmt.Errorf("mismatched coverage mode %q (expected %q)", line, *mode)
+			}
+			continue
+		}
+		if _, err := writer.WriteString(line + "\n"); err != nil {
+			return fmt.Errorf("write merged coverprofile: %w", err)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("read temp coverprofile: %w", err)
+	}
+	return nil
 }
 
 func filterGeneratedFilesFromCoverProfile(repoRoot string, coverProfilePath string) error {

--- a/cmd/lesser/test_cmd_test.go
+++ b/cmd/lesser/test_cmd_test.go
@@ -222,3 +222,117 @@ func TestRunTestCoverage_PropagatesRepoRootAndCacheErrors(t *testing.T) {
 	t.Setenv("GOCACHE", goCacheFile)
 	require.Error(t, runTestCoverage([]string{"--scope", "all"}))
 }
+
+func TestRunGoCoverageTests_BatchesAndMergesProfiles(t *testing.T) {
+	previousRunCommand := runCommandFn
+	previousRepoRoot := findRepoRootFn
+	previousEnsureTool := ensureToolAvailableFn
+	t.Cleanup(func() {
+		runCommandFn = previousRunCommand
+		findRepoRootFn = previousRepoRoot
+		ensureToolAvailableFn = previousEnsureTool
+	})
+
+	repoRoot := t.TempDir()
+	findRepoRootFn = func() (string, error) { return repoRoot, nil }
+	ensureToolAvailableFn = func(string) error { return nil }
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "go.mod"), []byte("module github.com/equaltoai/lesser\n"), 0o644))
+
+	t.Setenv(coverageBatchSizeEnvVar, "2")
+
+	var goTestCalls [][]string
+	runCommandFn = func(_ context.Context, name string, args []string, _ execOptions) error {
+		if name != "go" || len(args) == 0 || args[0] != "test" {
+			return nil
+		}
+		goTestCalls = append(goTestCalls, append([]string(nil), args...))
+
+		profileArg := ""
+		for _, arg := range args {
+			if strings.HasPrefix(arg, "-coverprofile=") {
+				profileArg = strings.TrimPrefix(arg, "-coverprofile=")
+				break
+			}
+		}
+		require.NotEmpty(t, profileArg)
+
+		lastPkg := args[len(args)-1]
+		content := "mode: set\n" + lastPkg + ".go:1.1,1.2 1 1\n"
+		return os.WriteFile(profileArg, []byte(content), 0o644)
+	}
+
+	err := runGoCoverageTests(testArgs{}, repoRoot, filepath.Join(repoRoot, "coverage.out"), []string{"test"}, []string{
+		"github.com/equaltoai/lesser/pkg/a",
+		"github.com/equaltoai/lesser/pkg/b",
+		"github.com/equaltoai/lesser/pkg/c",
+	})
+	require.NoError(t, err)
+	require.Len(t, goTestCalls, 2)
+
+	merged, err := os.ReadFile(filepath.Join(repoRoot, "coverage.out"))
+	require.NoError(t, err)
+	require.Equal(t, "mode: set\ngithub.com/equaltoai/lesser/pkg/b.go:1.1,1.2 1 1\ngithub.com/equaltoai/lesser/pkg/c.go:1.1,1.2 1 1\n", string(merged))
+}
+
+func TestRunGoCoverageTests_UsesSingleBatchProfileWhenWithinLimit(t *testing.T) {
+	previousRunCommand := runCommandFn
+	previousRepoRoot := findRepoRootFn
+	previousEnsureTool := ensureToolAvailableFn
+	t.Cleanup(func() {
+		runCommandFn = previousRunCommand
+		findRepoRootFn = previousRepoRoot
+		ensureToolAvailableFn = previousEnsureTool
+	})
+
+	repoRoot := t.TempDir()
+	findRepoRootFn = func() (string, error) { return repoRoot, nil }
+	ensureToolAvailableFn = func(string) error { return nil }
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "go.mod"), []byte("module github.com/equaltoai/lesser\n"), 0o644))
+
+	t.Setenv(coverageBatchSizeEnvVar, "10")
+
+	var profileArg string
+	runCommandFn = func(_ context.Context, name string, args []string, _ execOptions) error {
+		if name != "go" || len(args) == 0 || args[0] != "test" {
+			return nil
+		}
+		for _, arg := range args {
+			if strings.HasPrefix(arg, "-coverprofile=") {
+				profileArg = strings.TrimPrefix(arg, "-coverprofile=")
+				break
+			}
+		}
+		require.Equal(t, filepath.Join(repoRoot, "coverage.out"), profileArg)
+		return os.WriteFile(profileArg, []byte("mode: set\npkg.go:1.1,1.2 1 1\n"), 0o644)
+	}
+
+	err := runGoCoverageTests(testArgs{}, repoRoot, filepath.Join(repoRoot, "coverage.out"), []string{"test"}, []string{
+		"github.com/equaltoai/lesser/pkg/a",
+		"github.com/equaltoai/lesser/pkg/b",
+	})
+	require.NoError(t, err)
+}
+
+func TestMergeCoverageProfiles_RejectsMismatchedModes(t *testing.T) {
+	repoRoot := t.TempDir()
+	first := filepath.Join(repoRoot, "first.out")
+	second := filepath.Join(repoRoot, "second.out")
+
+	require.NoError(t, os.WriteFile(first, []byte("mode: set\none.go:1.1,1.2 1 1\n"), 0o644))
+	require.NoError(t, os.WriteFile(second, []byte("mode: count\ntwo.go:1.1,1.2 1 1\n"), 0o644))
+
+	err := mergeCoverageProfiles(filepath.Join(repoRoot, "merged.out"), []string{first, second})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mismatched coverage mode")
+}
+
+func TestMergeCoverageProfiles_WritesDefaultModeWhenNoProfilesProvided(t *testing.T) {
+	repoRoot := t.TempDir()
+	mergedPath := filepath.Join(repoRoot, "merged.out")
+
+	require.NoError(t, mergeCoverageProfiles(mergedPath, nil))
+
+	merged, err := os.ReadFile(mergedPath)
+	require.NoError(t, err)
+	require.Equal(t, "mode: set\n", string(merged))
+}

--- a/cmd/lesser/verify_cmd_test.go
+++ b/cmd/lesser/verify_cmd_test.go
@@ -97,7 +97,10 @@ func TestRunVerifyCI_RunsLintSecurityAndVerifySuite(t *testing.T) {
 	})
 
 	ensureToolAvailableFn = func(string) error { return nil }
+	t.Setenv(lesserVerifyCIJobsEnv, "")
 	t.Setenv("LESSER_JOBS", "8")
+	t.Setenv(goMaxProcsEnvVar, "")
+	t.Setenv(goFlagsEnvVar, "")
 
 	repoRoot := t.TempDir()
 	findRepoRootFn = func() (string, error) { return repoRoot, nil }

--- a/docs/contracts/graphql-schema.graphql
+++ b/docs/contracts/graphql-schema.graphql
@@ -158,9 +158,11 @@ type AgentPostAttribution {
   triggerDetails: String
   memoryCitations: [String!]
   delegatedBy: String
+  delegatedByDid: String
   scopes: [String!]
   constraints: [String!]
-  modelVersion: String
+  schemaVersion: String
+  modelId: String
 }
 
 input AgentPostAttributionInput {
@@ -168,9 +170,11 @@ input AgentPostAttributionInput {
   triggerDetails: String
   memoryCitations: [String!]
   delegatedBy: String
+  delegatedByDid: String
   scopes: [String!]
   constraints: [String!]
-  modelVersion: String
+  schemaVersion: String
+  modelId: String
 }
 
 type ContentMap {

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -1311,11 +1311,15 @@ components:
                     type: array
                 delegated_by:
                     type: string
+                delegated_by_did:
+                    type: string
                 memory_citations:
                     items:
                         type: string
                     type: array
-                model_version:
+                model_id:
+                    type: string
+                schema_version:
                     type: string
                 scopes:
                     items:
@@ -6232,32 +6236,6 @@ components:
                     anyOf:
                         - additionalProperties: false
                           properties:
-                            _:agentAttribution:
-                                anyOf:
-                                    - additionalProperties: false
-                                      properties:
-                                        constraints:
-                                            items:
-                                                type: string
-                                            type: array
-                                        delegated_by:
-                                            type: string
-                                        memory_citations:
-                                            items:
-                                                type: string
-                                            type: array
-                                        model_version:
-                                            type: string
-                                        scopes:
-                                            items:
-                                                type: string
-                                            type: array
-                                        trigger_details:
-                                            type: string
-                                        trigger_type:
-                                            type: string
-                                      type: object
-                                    - type: "null"
                             _:quoteContext:
                                 anyOf:
                                     - additionalProperties: false
@@ -6334,6 +6312,36 @@ components:
                                     - id
                                     - type
                                 type: object
+                            agentAttribution:
+                                anyOf:
+                                    - additionalProperties: false
+                                      properties:
+                                        constraints:
+                                            items:
+                                                type: string
+                                            type: array
+                                        delegated_by:
+                                            type: string
+                                        delegated_by_did:
+                                            type: string
+                                        memory_citations:
+                                            items:
+                                                type: string
+                                            type: array
+                                        model_id:
+                                            type: string
+                                        schema_version:
+                                            type: string
+                                        scopes:
+                                            items:
+                                                type: string
+                                            type: array
+                                        trigger_details:
+                                            type: string
+                                        trigger_type:
+                                            type: string
+                                      type: object
+                                    - type: "null"
                             attachment:
                                 items:
                                     additionalProperties: false

--- a/graph/core.graphql
+++ b/graph/core.graphql
@@ -155,9 +155,11 @@ type AgentPostAttribution {
   triggerDetails: String
   memoryCitations: [String!]
   delegatedBy: String
+  delegatedByDid: String
   scopes: [String!]
   constraints: [String!]
-  modelVersion: String
+  schemaVersion: String
+  modelId: String
 }
 
 input AgentPostAttributionInput {
@@ -165,9 +167,11 @@ input AgentPostAttributionInput {
   triggerDetails: String
   memoryCitations: [String!]
   delegatedBy: String
+  delegatedByDid: String
   scopes: [String!]
   constraints: [String!]
-  modelVersion: String
+  schemaVersion: String
+  modelId: String
 }
 
 type ContentMap {

--- a/graph/generated.go
+++ b/graph/generated.go
@@ -655,8 +655,10 @@ type ComplexityRoot struct {
 	AgentPostAttribution struct {
 		Constraints     func(childComplexity int) int
 		DelegatedBy     func(childComplexity int) int
+		DelegatedByDID  func(childComplexity int) int
 		MemoryCitations func(childComplexity int) int
-		ModelVersion    func(childComplexity int) int
+		ModelID         func(childComplexity int) int
+		SchemaVersion   func(childComplexity int) int
 		Scopes          func(childComplexity int) int
 		TriggerDetails  func(childComplexity int) int
 		TriggerType     func(childComplexity int) int
@@ -6154,6 +6156,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.AgentPostAttribution.DelegatedBy(childComplexity), true
 
+	case "AgentPostAttribution.delegatedByDid":
+		if e.complexity.AgentPostAttribution.DelegatedByDID == nil {
+			break
+		}
+
+		return e.complexity.AgentPostAttribution.DelegatedByDID(childComplexity), true
+
 	case "AgentPostAttribution.memoryCitations":
 		if e.complexity.AgentPostAttribution.MemoryCitations == nil {
 			break
@@ -6161,12 +6170,19 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.AgentPostAttribution.MemoryCitations(childComplexity), true
 
-	case "AgentPostAttribution.modelVersion":
-		if e.complexity.AgentPostAttribution.ModelVersion == nil {
+	case "AgentPostAttribution.modelId":
+		if e.complexity.AgentPostAttribution.ModelID == nil {
 			break
 		}
 
-		return e.complexity.AgentPostAttribution.ModelVersion(childComplexity), true
+		return e.complexity.AgentPostAttribution.ModelID(childComplexity), true
+
+	case "AgentPostAttribution.schemaVersion":
+		if e.complexity.AgentPostAttribution.SchemaVersion == nil {
+			break
+		}
+
+		return e.complexity.AgentPostAttribution.SchemaVersion(childComplexity), true
 
 	case "AgentPostAttribution.scopes":
 		if e.complexity.AgentPostAttribution.Scopes == nil {
@@ -42050,6 +42066,47 @@ func (ec *executionContext) fieldContext_AgentPostAttribution_delegatedBy(_ cont
 	return fc, nil
 }
 
+func (ec *executionContext) _AgentPostAttribution_delegatedByDid(ctx context.Context, field graphql.CollectedField, obj *activitypub.AgentPostAttribution) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AgentPostAttribution_delegatedByDid(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DelegatedByDID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AgentPostAttribution_delegatedByDid(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AgentPostAttribution",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _AgentPostAttribution_scopes(ctx context.Context, field graphql.CollectedField, obj *activitypub.AgentPostAttribution) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_AgentPostAttribution_scopes(ctx, field)
 	if err != nil {
@@ -42132,8 +42189,8 @@ func (ec *executionContext) fieldContext_AgentPostAttribution_constraints(_ cont
 	return fc, nil
 }
 
-func (ec *executionContext) _AgentPostAttribution_modelVersion(ctx context.Context, field graphql.CollectedField, obj *activitypub.AgentPostAttribution) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_AgentPostAttribution_modelVersion(ctx, field)
+func (ec *executionContext) _AgentPostAttribution_schemaVersion(ctx context.Context, field graphql.CollectedField, obj *activitypub.AgentPostAttribution) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AgentPostAttribution_schemaVersion(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -42146,7 +42203,7 @@ func (ec *executionContext) _AgentPostAttribution_modelVersion(ctx context.Conte
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.ModelVersion, nil
+		return obj.SchemaVersion, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -42160,7 +42217,48 @@ func (ec *executionContext) _AgentPostAttribution_modelVersion(ctx context.Conte
 	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_AgentPostAttribution_modelVersion(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_AgentPostAttribution_schemaVersion(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AgentPostAttribution",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AgentPostAttribution_modelId(ctx context.Context, field graphql.CollectedField, obj *activitypub.AgentPostAttribution) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AgentPostAttribution_modelId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ModelID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AgentPostAttribution_modelId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "AgentPostAttribution",
 		Field:      field,
@@ -91704,12 +91802,16 @@ func (ec *executionContext) fieldContext_Object_agentAttribution(_ context.Conte
 				return ec.fieldContext_AgentPostAttribution_memoryCitations(ctx, field)
 			case "delegatedBy":
 				return ec.fieldContext_AgentPostAttribution_delegatedBy(ctx, field)
+			case "delegatedByDid":
+				return ec.fieldContext_AgentPostAttribution_delegatedByDid(ctx, field)
 			case "scopes":
 				return ec.fieldContext_AgentPostAttribution_scopes(ctx, field)
 			case "constraints":
 				return ec.fieldContext_AgentPostAttribution_constraints(ctx, field)
-			case "modelVersion":
-				return ec.fieldContext_AgentPostAttribution_modelVersion(ctx, field)
+			case "schemaVersion":
+				return ec.fieldContext_AgentPostAttribution_schemaVersion(ctx, field)
+			case "modelId":
+				return ec.fieldContext_AgentPostAttribution_modelId(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type AgentPostAttribution", field.Name)
 		},
@@ -131060,7 +131162,7 @@ func (ec *executionContext) unmarshalInputAgentPostAttributionInput(ctx context.
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"triggerType", "triggerDetails", "memoryCitations", "delegatedBy", "scopes", "constraints", "modelVersion"}
+	fieldsInOrder := [...]string{"triggerType", "triggerDetails", "memoryCitations", "delegatedBy", "delegatedByDid", "scopes", "constraints", "schemaVersion", "modelId"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -131095,6 +131197,13 @@ func (ec *executionContext) unmarshalInputAgentPostAttributionInput(ctx context.
 				return it, err
 			}
 			it.DelegatedBy = data
+		case "delegatedByDid":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("delegatedByDid"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DelegatedByDid = data
 		case "scopes":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("scopes"))
 			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
@@ -131109,13 +131218,20 @@ func (ec *executionContext) unmarshalInputAgentPostAttributionInput(ctx context.
 				return it, err
 			}
 			it.Constraints = data
-		case "modelVersion":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("modelVersion"))
+		case "schemaVersion":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("schemaVersion"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.ModelVersion = data
+			it.SchemaVersion = data
+		case "modelId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("modelId"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ModelID = data
 		}
 	}
 
@@ -139900,12 +140016,16 @@ func (ec *executionContext) _AgentPostAttribution(ctx context.Context, sel ast.S
 			out.Values[i] = ec._AgentPostAttribution_memoryCitations(ctx, field, obj)
 		case "delegatedBy":
 			out.Values[i] = ec._AgentPostAttribution_delegatedBy(ctx, field, obj)
+		case "delegatedByDid":
+			out.Values[i] = ec._AgentPostAttribution_delegatedByDid(ctx, field, obj)
 		case "scopes":
 			out.Values[i] = ec._AgentPostAttribution_scopes(ctx, field, obj)
 		case "constraints":
 			out.Values[i] = ec._AgentPostAttribution_constraints(ctx, field, obj)
-		case "modelVersion":
-			out.Values[i] = ec._AgentPostAttribution_modelVersion(ctx, field, obj)
+		case "schemaVersion":
+			out.Values[i] = ec._AgentPostAttribution_schemaVersion(ctx, field, obj)
+		case "modelId":
+			out.Values[i] = ec._AgentPostAttribution_modelId(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graph/helpers.go
+++ b/graph/helpers.go
@@ -62,6 +62,18 @@ func deriveUsernameFromIRI(iri string) string {
 	return candidate
 }
 
+func (r *Resolver) normalizeDelegatedByActorURI(value string) string {
+	delegatedBy := strings.TrimSpace(value)
+	if delegatedBy == "" || r == nil || r.Config == nil {
+		return delegatedBy
+	}
+	lowerValue := strings.ToLower(delegatedBy)
+	if strings.HasPrefix(lowerValue, "http://") || strings.HasPrefix(lowerValue, "https://") {
+		return delegatedBy
+	}
+	return r.Config.ActorURL(strings.TrimPrefix(delegatedBy, "@"))
+}
+
 // generateID generates a unique ID for objects
 func generateID() string {
 	b := make([]byte, 16)

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -624,9 +624,11 @@ type AgentPostAttributionInput struct {
 	TriggerDetails  *string  `json:"triggerDetails,omitempty"`
 	MemoryCitations []string `json:"memoryCitations,omitempty"`
 	DelegatedBy     *string  `json:"delegatedBy,omitempty"`
+	DelegatedByDid  *string  `json:"delegatedByDid,omitempty"`
 	Scopes          []string `json:"scopes,omitempty"`
 	Constraints     []string `json:"constraints,omitempty"`
-	ModelVersion    *string  `json:"modelVersion,omitempty"`
+	SchemaVersion   *string  `json:"schemaVersion,omitempty"`
+	ModelID         *string  `json:"modelId,omitempty"`
 }
 
 type Announcement struct {

--- a/graph/mutation_resolvers_notes.go
+++ b/graph/mutation_resolvers_notes.go
@@ -132,7 +132,7 @@ const (
 	agentAttributionMaxTriggerDetails  = 500
 
 	agentAttributionDefaultTriggerType = "manual"
-	agentAttributionUnknownVersion     = "unknown"
+	agentAttributionUnknownModelID     = "unknown"
 )
 
 var allowedAgentAttributionTriggerTypes = map[string]struct{}{
@@ -191,10 +191,11 @@ func (r *mutationResolver) buildAgentPostAttribution(ctx context.Context, claims
 	if delegatedBy == "" {
 		delegatedBy = strings.TrimSpace(agentUser.AgentOwner)
 	}
+	delegatedBy = r.normalizeDelegatedByActorURI(delegatedBy)
 
-	modelVersion := strings.TrimSpace(agentUser.AgentVersion)
-	if modelVersion == "" {
-		modelVersion = agentAttributionUnknownVersion
+	modelID := strings.TrimSpace(agentUser.AgentVersion)
+	if modelID == "" {
+		modelID = agentAttributionUnknownModelID
 	}
 
 	return &activitypub.AgentPostAttribution{
@@ -204,7 +205,8 @@ func (r *mutationResolver) buildAgentPostAttribution(ctx context.Context, claims
 		DelegatedBy:     delegatedBy,
 		Scopes:          append([]string(nil), claims.Scopes...),
 		Constraints:     buildAgentCapabilityConstraints(agentUser.AgentCapabilities),
-		ModelVersion:    modelVersion,
+		SchemaVersion:   activitypub.AgentAttributionSchemaVersion,
+		ModelID:         modelID,
 	}, nil
 }
 

--- a/graph/mutation_resolvers_notes_round12_test.go
+++ b/graph/mutation_resolvers_notes_round12_test.go
@@ -6,8 +6,15 @@ import (
 	"time"
 
 	"github.com/equaltoai/lesser/graph/model"
+	"github.com/equaltoai/lesser/pkg/agents"
+	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/services/notes"
+	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/models"
+	pkgtesting "github.com/equaltoai/lesser/pkg/testing"
+	"github.com/equaltoai/lesser/pkg/testing/mocks"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -99,4 +106,46 @@ func TestRound12MutationResolvers_Notes_CreateDeleteAndSchedule(t *testing.T) {
 
 	// Ensure status repo remains usable for other tests.
 	require.NotNil(t, storageRepo.Status())
+}
+
+func TestRound12MutationResolvers_Notes_BuildAgentPostAttribution(t *testing.T) {
+	mockUserRepo := mocks.NewMockUserRepositoryInterface()
+	mockUserRepo.On("GetUser", mock.Anything, "agent").Return(&storage.User{
+		Username:     "agent",
+		IsAgent:      true,
+		AgentOwner:   "owner",
+		AgentVersion: "claude-3",
+		AgentCapabilities: &agents.Capabilities{
+			RequiresApproval: true,
+		},
+	}, nil).Once()
+
+	resolver := &mutationResolver{&Resolver{
+		Config:  &config.Config{Domain: "example.com"},
+		Storage: pkgtesting.NewMockRepositoryStorage(pkgtesting.WithUserRepository(mockUserRepo)),
+	}}
+
+	triggerType := "mention"
+	triggerDetails := "test"
+	got, err := resolver.buildAgentPostAttribution(context.Background(), &auth.Claims{
+		Username:    "agent",
+		IsAgent:     true,
+		DelegatedBy: "@owner",
+		Scopes:      []string{"write"},
+	}, &model.AgentPostAttributionInput{
+		TriggerType:     &triggerType,
+		TriggerDetails:  &triggerDetails,
+		MemoryCitations: []string{"status-1", "status-1"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "mention", got.TriggerType)
+	require.Equal(t, "test", got.TriggerDetails)
+	require.Equal(t, []string{"status-1"}, got.MemoryCitations)
+	require.Equal(t, "https://example.com/users/owner", got.DelegatedBy)
+	require.Equal(t, "1.0", got.SchemaVersion)
+	require.Equal(t, "claude-3", got.ModelID)
+	require.Equal(t, []string{"write"}, got.Scopes)
+	require.Contains(t, got.Constraints, "requires_approval")
+	mockUserRepo.AssertExpectations(t)
 }

--- a/pkg/activitypub/agent_post_attribution.go
+++ b/pkg/activitypub/agent_post_attribution.go
@@ -1,5 +1,16 @@
 package activitypub
 
+import (
+	"encoding/json"
+	"strings"
+)
+
+const (
+	// AgentAttributionSchemaVersion identifies the current Lesser agent attribution schema.
+	AgentAttributionSchemaVersion       = "1.0"
+	legacyAgentAttributionSchemaVersion = "0.9"
+)
+
 // AgentPostAttribution captures transparency metadata for an agent-authored post.
 //
 // This is a Lesser extension. It is stored on the underlying Note and exposed via the REST
@@ -10,9 +21,38 @@ type AgentPostAttribution struct {
 
 	MemoryCitations []string `json:"memory_citations,omitempty"`
 
-	DelegatedBy string   `json:"delegated_by,omitempty"`
-	Scopes      []string `json:"scopes,omitempty"`
+	DelegatedBy    string   `json:"delegated_by,omitempty"`
+	DelegatedByDID string   `json:"delegated_by_did,omitempty"`
+	Scopes         []string `json:"scopes,omitempty"`
 
-	Constraints  []string `json:"constraints,omitempty"`
-	ModelVersion string   `json:"model_version,omitempty"`
+	Constraints   []string `json:"constraints,omitempty"`
+	SchemaVersion string   `json:"schema_version,omitempty"`
+	ModelID       string   `json:"model_id,omitempty"`
+}
+
+type agentPostAttributionAlias AgentPostAttribution
+
+type legacyAgentPostAttribution struct {
+	agentPostAttributionAlias
+	ModelVersion string `json:"model_version,omitempty"`
+}
+
+// UnmarshalJSON preserves backward compatibility with stored records that still carry the
+// legacy model_version field.
+func (a *AgentPostAttribution) UnmarshalJSON(data []byte) error {
+	var legacy legacyAgentPostAttribution
+	if err := json.Unmarshal(data, &legacy); err != nil {
+		return err
+	}
+
+	*a = AgentPostAttribution(legacy.agentPostAttributionAlias)
+
+	if strings.TrimSpace(a.ModelID) == "" && strings.TrimSpace(legacy.ModelVersion) != "" {
+		a.ModelID = strings.TrimSpace(legacy.ModelVersion)
+	}
+	if strings.TrimSpace(a.SchemaVersion) == "" && strings.TrimSpace(legacy.ModelVersion) != "" {
+		a.SchemaVersion = legacyAgentAttributionSchemaVersion
+	}
+
+	return nil
 }

--- a/pkg/activitypub/types.go
+++ b/pkg/activitypub/types.go
@@ -100,6 +100,8 @@ var Context = ContextValue{
 		"schema":                    "http://schema.org#",
 		"PropertyValue":             "schema:PropertyValue",
 		"value":                     "schema:value",
+		"lessersoul":                "https://lessersoul.ai/ns/agent-attribution/v1#",
+		"agentAttribution":          "lessersoul:agentAttribution",
 		"agentManifest":             "https://lesser.social/ns/agentManifest",
 	},
 }
@@ -190,7 +192,30 @@ type Note struct {
 	QuoteContext       *QuoteContext `json:"_:quoteContext,omitempty"`
 
 	// Lesser extension: per-status attribution for agent-authored content.
-	AgentAttribution *AgentPostAttribution `json:"_:agentAttribution,omitempty"`
+	AgentAttribution *AgentPostAttribution `json:"agentAttribution,omitempty"`
+}
+
+type noteAlias Note
+
+type legacyNote struct {
+	noteAlias
+	LegacyAgentAttribution *AgentPostAttribution `json:"_:agentAttribution,omitempty"`
+}
+
+// UnmarshalJSON accepts both the new namespaced agentAttribution key and the legacy
+// _:agentAttribution key stored in older records.
+func (n *Note) UnmarshalJSON(data []byte) error {
+	var legacy legacyNote
+	if err := json.Unmarshal(data, &legacy); err != nil {
+		return err
+	}
+
+	*n = Note(legacy.noteAlias)
+	if n.AgentAttribution == nil && legacy.LegacyAgentAttribution != nil {
+		n.AgentAttribution = legacy.LegacyAgentAttribution
+	}
+
+	return nil
 }
 
 // QuoteNote is retained for backwards compatibility; it now simply aliases Note.

--- a/pkg/activitypub/types_test.go
+++ b/pkg/activitypub/types_test.go
@@ -90,3 +90,63 @@ func TestActor_MarshalJSON_UsesContextValue(t *testing.T) {
 	_, ok := decoded["@context"].([]any)
 	assert.True(t, ok)
 }
+
+func TestNoteAgentAttributionJSONCompatibility(t *testing.T) {
+	t.Run("legacy key unmarshals", func(t *testing.T) {
+		var note Note
+		err := json.Unmarshal([]byte(`{
+			"id":"https://example.com/notes/1",
+			"type":"Note",
+			"content":"hi",
+			"attributedTo":"https://example.com/users/alice",
+			"_:agentAttribution":{"delegated_by":"https://example.com/users/owner","model_version":"claude-3"}
+		}`), &note)
+		require.NoError(t, err)
+		require.NotNil(t, note.AgentAttribution)
+		require.Equal(t, "https://example.com/users/owner", note.AgentAttribution.DelegatedBy)
+		require.Equal(t, legacyAgentAttributionSchemaVersion, note.AgentAttribution.SchemaVersion)
+		require.Equal(t, "claude-3", note.AgentAttribution.ModelID)
+	})
+
+	t.Run("new key unmarshals", func(t *testing.T) {
+		var note Note
+		err := json.Unmarshal([]byte(`{
+			"id":"https://example.com/notes/1",
+			"type":"Note",
+			"content":"hi",
+			"attributedTo":"https://example.com/users/alice",
+			"agentAttribution":{"delegated_by":"https://example.com/users/owner","schema_version":"1.0","model_id":"claude-3"}
+		}`), &note)
+		require.NoError(t, err)
+		require.NotNil(t, note.AgentAttribution)
+		require.Equal(t, AgentAttributionSchemaVersion, note.AgentAttribution.SchemaVersion)
+		require.Equal(t, "claude-3", note.AgentAttribution.ModelID)
+	})
+
+	t.Run("marshal uses new key", func(t *testing.T) {
+		data, err := json.Marshal(Note{
+			BaseObject:   BaseObject{ID: "https://example.com/notes/1", Type: NoteType},
+			Content:      "hi",
+			AttributedTo: "https://example.com/users/alice",
+			AgentAttribution: &AgentPostAttribution{
+				SchemaVersion: AgentAttributionSchemaVersion,
+				ModelID:       "claude-3",
+			},
+		})
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"agentAttribution"`)
+		assert.NotContains(t, string(data), `"_:agentAttribution"`)
+	})
+
+	t.Run("note without attribution still works", func(t *testing.T) {
+		var note Note
+		err := json.Unmarshal([]byte(`{
+			"id":"https://example.com/notes/1",
+			"type":"Note",
+			"content":"hi",
+			"attributedTo":"https://example.com/users/alice"
+		}`), &note)
+		require.NoError(t, err)
+		require.Nil(t, note.AgentAttribution)
+	})
+}

--- a/pkg/transformations/converters.go
+++ b/pkg/transformations/converters.go
@@ -176,12 +176,13 @@ func buildAgentPostAttribution(actor *activitypub.Actor) *models.AgentPostAttrib
 	}
 
 	attribution := &models.AgentPostAttribution{
-		ModelVersion: "unknown",
+		SchemaVersion: activitypub.AgentAttributionSchemaVersion,
+		ModelID:       "unknown",
 	}
 
 	if actor.AgentManifest != nil {
 		if v := strings.TrimSpace(actor.AgentManifest.Version); v != "" {
-			attribution.ModelVersion = v
+			attribution.ModelID = v
 		}
 		if operatedBy := strings.TrimSpace(actor.AgentManifest.OperatedBy); operatedBy != "" {
 			attribution.DelegatedBy = operatedBy

--- a/pkg/transformations/converters_test.go
+++ b/pkg/transformations/converters_test.go
@@ -285,7 +285,8 @@ func TestBuildAgentPostAttribution_Branches(t *testing.T) {
 		BaseObject: activitypub.BaseObject{Type: activitypub.ServiceType},
 	})
 	require.NotNil(t, attribution)
-	require.Equal(t, "unknown", attribution.ModelVersion)
+	require.Equal(t, activitypub.AgentAttributionSchemaVersion, attribution.SchemaVersion)
+	require.Equal(t, "unknown", attribution.ModelID)
 	require.Nil(t, attribution.Constraints)
 
 	attribution = buildAgentPostAttribution(&activitypub.Actor{
@@ -299,7 +300,8 @@ func TestBuildAgentPostAttribution_Branches(t *testing.T) {
 		},
 	})
 	require.NotNil(t, attribution)
-	require.Equal(t, "m1", attribution.ModelVersion)
+	require.Equal(t, activitypub.AgentAttributionSchemaVersion, attribution.SchemaVersion)
+	require.Equal(t, "m1", attribution.ModelID)
 	require.Equal(t, "@delegator", attribution.DelegatedBy)
 	require.Contains(t, attribution.Constraints, "requires_approval")
 }


### PR DESCRIPTION
## Summary
- complete the issue #205 agent attribution schema migration across REST, GraphQL, ActivityPub, and transformers
- preserve backward compatibility for stored legacy attribution payloads while normalizing delegated actor URIs and exposing the new schema/model fields
- stabilize low-memory local verification by batching coverage runs and add focused tests to clear the cmd coverage gate

## Verification
- `env LESSER_VERIFY_CI_JOBS=1 LESSER_JOBS=1 GOMAXPROCS=1 GOFLAGS=-p=1 LESSER_TEST_COVERAGE_BATCH_SIZE=25 GOMEMLIMIT=3GiB ./lesser verify ci`
- `env GOTOOLCHAIN=go1.26.1 go test ./cmd/api/handlers -count=1`
- `env GOMAXPROCS=1 GOFLAGS=-p=1 GOTOOLCHAIN=go1.26.1 go test ./cmd/lesser -count=1`

Closes #205