### PR TITLE
fix auth ui csp hash

### DIFF
--- a/infra/cdk/constructs/frontend_response_headers.go
+++ b/infra/cdk/constructs/frontend_response_headers.go
@@ -91,7 +91,7 @@ func buildFrontendStaticCSP(domainName *string) string {
 func authUIInlineScriptHashes() []string {
 	return []string{
 		"'sha256-QzWFZi+FLIx23tnm9SBU4aEgx4x8DsuASP07mfqol/c='",
-		"'sha256-U7a72oKuFFz8D7GUHLA1NZ0ciymHmDOc9T9aVDg2rWU='",
+		"'sha256-QJZDUlo/qa5AJCrG6vHyWcatjwCeWidEHQfJc601lzw='",
 		"'sha256-eIXWvAmxkr251LJZkjniEK5LcPF3NkapbJepohwYRIc='",
 		"'sha256-IV0HjYu959C/EiJIL2l/9Ty8PA4757JXhA/g112YXVE='",
 	}

--- a/infra/cdk/stacks/frontend_csp_test.go
+++ b/infra/cdk/stacks/frontend_csp_test.go
@@ -100,7 +100,7 @@ func TestFrontendStaticCSPIsStrictAndBehaviorScoped(t *testing.T) {
 	}
 	requireContainsAll(t, csp, []string{
 		"'sha256-QzWFZi+FLIx23tnm9SBU4aEgx4x8DsuASP07mfqol/c='",
-		"'sha256-U7a72oKuFFz8D7GUHLA1NZ0ciymHmDOc9T9aVDg2rWU='",
+		"'sha256-QJZDUlo/qa5AJCrG6vHyWcatjwCeWidEHQfJc601lzw='",
 		"'sha256-eIXWvAmxkr251LJZkjniEK5LcPF3NkapbJepohwYRIc='",
 		"'sha256-IV0HjYu959C/EiJIL2l/9Ty8PA4757JXhA/g112YXVE='",
 		"'sha256-vv9IoKo7BSLbWcUHr3tNmfNVmm5L/9Cfn2H6LMk7/ow='",


### PR DESCRIPTION
## Summary
- update the auth UI inline script CSP hash to match the current Astro login hydration output
- keep the frontend CDK CSP test aligned with the shipped auth bundle

## Verification
- cd auth-ui && pnpm build
- cd infra/cdk && env GOTOOLCHAIN=auto go test ./stacks -run TestFrontendStaticCSPIsStrictAndBehaviorScoped -count=1