### PR TITLE
Fix: update hardcoded namespace URL in AP @context to spec.lessersoul.ai

### DIFF
--- a/pkg/activitypub/types.go
+++ b/pkg/activitypub/types.go
@@ -100,7 +100,7 @@ var Context = ContextValue{
 		"schema":                    "http://schema.org#",
 		"PropertyValue":             "schema:PropertyValue",
 		"value":                     "schema:value",
-		"lessersoul":                "https://lessersoul.ai/ns/agent-attribution/v1#",
+		"lessersoul":                "https://spec.lessersoul.ai/ns/agent-attribution/v1#",
 		"agentAttribution":          "lessersoul:agentAttribution",
 		"agentManifest":             "https://lesser.social/ns/agentManifest",
 	},

--- a/pkg/activitypub/types_test.go
+++ b/pkg/activitypub/types_test.go
@@ -89,6 +89,14 @@ func TestActor_MarshalJSON_UsesContextValue(t *testing.T) {
 	require.Contains(t, decoded, "@context")
 	_, ok := decoded["@context"].([]any)
 	assert.True(t, ok)
+
+	contextEntries, ok := decoded["@context"].([]any)
+	require.True(t, ok)
+	require.Len(t, contextEntries, 2)
+
+	contextMap, ok := contextEntries[1].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "https://spec.lessersoul.ai/ns/agent-attribution/v1#", contextMap["lessersoul"])
 }
 
 func TestNoteAgentAttributionJSONCompatibility(t *testing.T) {


### PR DESCRIPTION
## Summary
- update the hardcoded lessersoul JSON-LD namespace in ActivityPub @context to https://spec.lessersoul.ai/ns/agent-attribution/v1#
- add a serialization test that asserts federated payloads now emit the spec host in @context

## Testing
- GOTOOLCHAIN=auto go test ./pkg/activitypub

Closes #235