### PR TITLE
Embed notification post snapshots in notifications API

### DIFF
--- a/cmd/api/handlers/misc.go
+++ b/cmd/api/handlers/misc.go
@@ -40,6 +40,8 @@ const (
 
 	// API path components
 	pathComponentStatuses = "statuses"
+
+	notificationPostSnapshotKey = "postSnapshot"
 )
 
 // SearchParams holds search request parameters
@@ -731,17 +733,31 @@ func (h *Handler) convertSingleNotification(ctx *apptheory.Context, notif *stora
 
 // shouldIncludeStatus checks if a status should be included in the notification
 func (h *Handler) shouldIncludeStatus(notif *storage.Notification) bool {
-	if err := common.ValidateMastodonStatusID(notif.StatusID); err != nil {
+	if notif == nil {
 		return false
 	}
-	return notif.Type == models.NotificationTypeMention ||
-		notif.Type == models.NotificationTypeReply ||
-		notif.Type == models.NotificationTypeFavourite ||
-		notif.Type == models.NotificationTypeReblog
+
+	if notif.Type != models.NotificationTypeMention &&
+		notif.Type != models.NotificationTypeReply &&
+		notif.Type != models.NotificationTypeFavourite &&
+		notif.Type != models.NotificationTypeReblog {
+		return false
+	}
+
+	if _, ok := h.notificationPostSnapshot(notif); ok {
+		return true
+	}
+
+	return common.ValidateMastodonStatusID(notif.StatusID) == nil
 }
 
 // attachStatusToNotification attaches status information to a notification
 func (h *Handler) attachStatusToNotification(ctx *apptheory.Context, notif *storage.Notification, apiNotif *models.Notification) {
+	if snapshotStatus := h.statusFromNotificationSnapshot(ctx, notif); snapshotStatus != nil {
+		apiNotif.Status = snapshotStatus
+		return
+	}
+
 	// Get the status
 	obj, err := h.repos.Object().GetObject(ctx.Context(), notif.StatusID)
 	if err != nil {
@@ -764,6 +780,94 @@ func (h *Handler) attachStatusToNotification(ctx *apptheory.Context, notif *stor
 		status := transformations.ObjectToStatusAny(obj, statusActor, h.cfg.BaseURL())
 		apiNotif.Status = &status
 	}
+}
+
+func (h *Handler) notificationPostSnapshot(notif *storage.Notification) (map[string]interface{}, bool) {
+	if notif == nil || len(notif.Data) == 0 {
+		return nil, false
+	}
+
+	rawSnapshot, ok := notif.Data[notificationPostSnapshotKey]
+	if !ok {
+		return nil, false
+	}
+
+	snapshot, ok := rawSnapshot.(map[string]interface{})
+	if !ok || len(snapshot) == 0 {
+		return nil, false
+	}
+
+	return snapshot, true
+}
+
+func (h *Handler) statusFromNotificationSnapshot(ctx *apptheory.Context, notif *storage.Notification) *models.Status {
+	snapshot, ok := h.notificationPostSnapshot(notif)
+	if !ok {
+		return nil
+	}
+
+	statusActor := h.notificationSnapshotActor(ctx, snapshot)
+	status := transformations.ObjectToStatusBase(notificationSnapshotObjectMap(snapshot), statusActor, h.cfg.BaseURL())
+	if status.ID == "" {
+		return nil
+	}
+
+	if url := strings.TrimSpace(notificationSnapshotString(snapshot, "url")); url != "" {
+		status.URL = url
+	}
+	if visibility := strings.TrimSpace(notificationSnapshotString(snapshot, "visibility")); visibility != "" {
+		status.Visibility = visibility
+	}
+
+	return &status
+}
+
+func (h *Handler) notificationSnapshotActor(ctx *apptheory.Context, snapshot map[string]interface{}) *activitypub.Actor {
+	attributedTo := strings.TrimSpace(notificationSnapshotString(snapshot, "attributedTo"))
+	if attributedTo == "" {
+		return nil
+	}
+
+	fallbackActor := h.fallbackNotificationActor(attributedTo)
+	username := extractUsernameFromNotificationActorID(attributedTo)
+	if username == "" {
+		return fallbackActor
+	}
+
+	statusActor, err := h.repos.Actor().GetActor(ctx.Context(), username)
+	if err != nil {
+		return fallbackActor
+	}
+
+	return statusActor
+}
+
+func notificationSnapshotObjectMap(snapshot map[string]interface{}) map[string]interface{} {
+	objectMap := map[string]interface{}{
+		"id":        notificationSnapshotString(snapshot, "id"),
+		"content":   notificationSnapshotString(snapshot, "content"),
+		"published": notificationSnapshotString(snapshot, "createdAt"),
+	}
+
+	if inReplyToID := strings.TrimSpace(notificationSnapshotString(snapshot, "inReplyToId")); inReplyToID != "" {
+		objectMap["inReplyTo"] = inReplyToID
+	}
+
+	return objectMap
+}
+
+func notificationSnapshotString(snapshot map[string]interface{}, key string) string {
+	rawValue, ok := snapshot[key]
+	if !ok {
+		return ""
+	}
+
+	value, ok := rawValue.(string)
+	if !ok {
+		return ""
+	}
+
+	return value
 }
 
 // extractStatusAuthor extracts the author actor from a status object

--- a/cmd/api/handlers/misc_round12_coverage_test.go
+++ b/cmd/api/handlers/misc_round12_coverage_test.go
@@ -233,6 +233,40 @@ func TestMisc_Notifications_AttachStatusAndAuthor_Round12(t *testing.T) {
 		require.Nil(t, apiNotif.Status)
 	})
 
+	t.Run("snapshot attaches status without object fetch", func(t *testing.T) {
+		errState := &round10QueryState{
+			actorsByUser: state.actorsByUser,
+			firstErrorPK: map[string]error{
+				"object#status-snapshot": errors.New("unexpected object fetch"),
+			},
+		}
+		snapshotHandler, _, _ := round11NewHandler(t, cfg, errState)
+
+		apiNotif := snapshotHandler.convertSingleNotification(ctx, &storage.Notification{
+			ID:        "n-snapshot",
+			Type:      models.NotificationTypeMention,
+			AccountID: "alice",
+			StatusID:  "status-snapshot",
+			CreatedAt: now,
+			Data: map[string]interface{}{
+				"postSnapshot": map[string]interface{}{
+					"id":           "https://example.com/objects/status-snapshot",
+					"url":          "https://example.com/@bob/status-snapshot",
+					"content":      "<p>snapshot body</p>",
+					"createdAt":    now.Add(-30 * time.Minute).Format(time.RFC3339),
+					"visibility":   "private",
+					"inReplyToId":  "https://example.com/objects/root",
+					"attributedTo": cfg.BaseURL() + "/users/bob",
+				},
+			},
+		})
+		require.NotNil(t, apiNotif)
+		require.NotNil(t, apiNotif.Status)
+		require.Equal(t, "<p>snapshot body</p>", apiNotif.Status.Content)
+		require.Equal(t, "https://example.com/@bob/status-snapshot", apiNotif.Status.URL)
+		require.Equal(t, "private", apiNotif.Status.Visibility)
+	})
+
 	t.Run("object fetch error leaves status unset", func(t *testing.T) {
 		errState := &round10QueryState{
 			actorsByUser: map[string]storagemodels.Actor{

--- a/cmd/api/handlers/misc_round29_snapshot_helpers_test.go
+++ b/cmd/api/handlers/misc_round29_snapshot_helpers_test.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/equaltoai/lesser/cmd/api/models"
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMisc_NotificationSnapshotHelpers_Round29(t *testing.T) {
+	cfg := round11TestConfig()
+
+	handler, _, _ := round11NewHandler(t, cfg, &round10QueryState{
+		firstErrorPK: map[string]error{
+			"ACTOR#missing": errors.New("boom"),
+		},
+	})
+
+	t.Run("shouldIncludeStatus handles snapshot and unsupported types", func(t *testing.T) {
+		require.False(t, handler.shouldIncludeStatus(nil))
+		require.False(t, handler.shouldIncludeStatus(&storage.Notification{Type: models.NotificationTypeFollow, StatusID: "123"}))
+		require.False(t, handler.shouldIncludeStatus(&storage.Notification{Type: models.NotificationTypeMention, StatusID: "not valid"}))
+		require.True(t, handler.shouldIncludeStatus(&storage.Notification{
+			Type: models.NotificationTypeMention,
+			Data: map[string]interface{}{
+				"postSnapshot": map[string]interface{}{"id": "https://example.com/objects/s1"},
+			},
+		}))
+	})
+
+	t.Run("notificationPostSnapshot rejects invalid payloads", func(t *testing.T) {
+		_, ok := handler.notificationPostSnapshot(&storage.Notification{})
+		require.False(t, ok)
+
+		_, ok = handler.notificationPostSnapshot(&storage.Notification{
+			Data: map[string]interface{}{"postSnapshot": "bad"},
+		})
+		require.False(t, ok)
+	})
+
+	t.Run("statusFromNotificationSnapshot returns nil for malformed snapshots", func(t *testing.T) {
+		ctx, err := round10NewLiftContext("GET", "/test", nil, nil, nil)
+		require.NoError(t, err)
+
+		status := handler.statusFromNotificationSnapshot(ctx, &storage.Notification{
+			Data: map[string]interface{}{
+				"postSnapshot": map[string]interface{}{
+					"id": 123,
+				},
+			},
+		})
+		require.Nil(t, status)
+	})
+
+	t.Run("notificationSnapshotActor falls back when actor lookup fails", func(t *testing.T) {
+		ctx, err := round10NewLiftContext("GET", "/test", nil, nil, nil)
+		require.NoError(t, err)
+
+		actor := handler.notificationSnapshotActor(ctx, map[string]interface{}{
+			"attributedTo": "https://remote.example/users/missing",
+		})
+		require.NotNil(t, actor)
+		require.Equal(t, "missing", actor.PreferredUsername)
+		require.Equal(t, "https://remote.example/users/missing", actor.ID)
+	})
+
+	t.Run("notificationSnapshotString ignores non-string values", func(t *testing.T) {
+		require.Equal(t, "", notificationSnapshotString(map[string]interface{}{"createdAt": 123}, "createdAt"))
+	})
+}

--- a/cmd/api/handlers/notifications_comm_list_round28_test.go
+++ b/cmd/api/handlers/notifications_comm_list_round28_test.go
@@ -196,3 +196,104 @@ func TestNotifications_ListIncludesReplyNotifications_Round28(t *testing.T) {
 	require.NotEmpty(t, out[0].Status.ID)
 	require.Equal(t, "reply body", out[0].Status.Content)
 }
+
+func TestNotifications_ListHandlesSnapshotAndLegacyStatuses_Round28(t *testing.T) {
+	cfg := round11TestConfig()
+	now := time.Date(2026, time.March, 17, 9, 0, 0, 0, time.UTC)
+
+	state := &round10QueryState{
+		actorsByUser: map[string]storageModels.Actor{
+			"alice": {
+				Username: "alice",
+				Actor: &activitypub.Actor{
+					BaseObject:        activitypub.BaseObject{ID: cfg.BaseURL() + "/users/alice", Type: "Person"},
+					PreferredUsername: "alice",
+					Name:              "Alice",
+				},
+			},
+			"bob": {
+				Username: "bob",
+				Actor: &activitypub.Actor{
+					BaseObject:        activitypub.BaseObject{ID: cfg.BaseURL() + "/users/bob", Type: "Person"},
+					PreferredUsername: "bob",
+					Name:              "Bob",
+				},
+			},
+		},
+		objectsByID: map[string]storageModels.Object{
+			"status-legacy": {
+				ID:           "status-legacy",
+				Type:         activitypub.NoteType,
+				Content:      "legacy body",
+				Published:    now.Add(-2 * time.Minute),
+				AttributedTo: cfg.BaseURL() + "/users/bob",
+			},
+		},
+		firstErrorPK: map[string]error{
+			"object#status-snapshot": context.DeadlineExceeded,
+		},
+	}
+
+	h, _, _ := round11NewHandler(t, cfg, state)
+	h.registry = &RegistryStub{
+		NotificationsSvc: &NotificationsServiceStub{
+			ListNotificationsFunc: func(_ context.Context, query *notifications.ListNotificationsQuery) (*notifications.NotificationListResult, error) {
+				require.NotNil(t, query)
+				require.Equal(t, "alice", query.UserID)
+
+				return &notifications.NotificationListResult{
+					Notifications: []*storageModels.Notification{
+						{
+							ID:         "notif-snapshot-1",
+							Type:       apiModels.NotificationTypeReply,
+							ActorID:    "bob",
+							UserID:     "alice",
+							TargetID:   "status-snapshot",
+							TargetType: "status",
+							CreatedAt:  now,
+							Data: map[string]interface{}{
+								"postSnapshot": map[string]interface{}{
+									"id":           "https://example.com/objects/status-snapshot",
+									"url":          "https://example.com/@bob/status-snapshot",
+									"content":      "snapshot body",
+									"createdAt":    now.Add(-1 * time.Minute).Format(time.RFC3339),
+									"visibility":   "unlisted",
+									"attributedTo": cfg.BaseURL() + "/users/bob",
+								},
+							},
+						},
+						{
+							ID:         "notif-legacy-1",
+							Type:       apiModels.NotificationTypeReply,
+							ActorID:    "bob",
+							UserID:     "alice",
+							TargetID:   "status-legacy",
+							TargetType: "status",
+							CreatedAt:  now.Add(-3 * time.Minute),
+						},
+					},
+				}, nil
+			},
+		},
+	}
+
+	readToken := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{"read:notifications", auth.ScopeRead})
+	headers := map[string]string{
+		"Authorization": "Bearer " + readToken,
+		"Host":          "example.com",
+	}
+
+	ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/notifications", headers, nil, nil)
+	require.NoError(t, err)
+
+	resp := requireStatus(t, http.StatusOK)(h.HandleGetNotificationsLift(ctx))
+
+	var out []apiModels.Notification
+	require.NoError(t, json.Unmarshal(resp.Body, &out))
+	require.Len(t, out, 2)
+	require.NotNil(t, out[0].Status)
+	require.Equal(t, "snapshot body", out[0].Status.Content)
+	require.Equal(t, "https://example.com/@bob/status-snapshot", out[0].Status.URL)
+	require.NotNil(t, out[1].Status)
+	require.Equal(t, "legacy body", out[1].Status.Content)
+}

--- a/pkg/services/constants.go
+++ b/pkg/services/constants.go
@@ -1,0 +1,3 @@
+package services
+
+const unknownValue = "unknown"

--- a/pkg/services/core_services_round27_coverage_test.go
+++ b/pkg/services/core_services_round27_coverage_test.go
@@ -42,6 +42,10 @@ type capturingNotificationRepo struct {
 	err     error
 }
 
+func ptrTime(t time.Time) *time.Time {
+	return &t
+}
+
 func (r *capturingNotificationRepo) CreateNotification(_ context.Context, notification *models.Notification) error {
 	r.created = append(r.created, notification)
 	return r.err
@@ -381,6 +385,7 @@ func TestNotificationService_round27_coverage(t *testing.T) {
 		assert.Equal(t, "follow", captureRepo.created[0].Type)
 		assert.Equal(t, "alice", captureRepo.created[0].UserID)
 		assert.Equal(t, "bob", captureRepo.created[0].ActorID)
+		assert.Nil(t, captureRepo.created[0].Data)
 	})
 
 	t.Run("CreateLikeNotification_swallows_storage_errors", func(t *testing.T) {
@@ -423,8 +428,16 @@ func TestNotificationService_round27_coverage(t *testing.T) {
 
 	t.Run("CreateLikeNotification_success", func(t *testing.T) {
 		captureRepo := &capturingNotificationRepo{}
+		publishedAt := time.Date(2026, time.March, 19, 10, 0, 0, 0, time.UTC)
 		storage := &repositoryStorageAdapter{repos: fakeStorageAdapterRepos{
-			object:       fakeObjectRepo{getValue: map[string]any{"attributedTo": "https://local.example/users/alice"}},
+			object: fakeObjectRepo{getValue: map[string]any{
+				"id":           "https://local.example/objects/n1",
+				"url":          "https://local.example/@alice/n1",
+				"content":      "<p>liked post</p>",
+				"published":    publishedAt,
+				"visibility":   "unlisted",
+				"attributedTo": "https://local.example/users/alice",
+			}},
 			notification: captureRepo,
 			logger:       zap.NewNop(),
 			table:        "tbl",
@@ -440,6 +453,13 @@ func TestNotificationService_round27_coverage(t *testing.T) {
 		require.Len(t, captureRepo.created, 1)
 		assert.Equal(t, "favourite", captureRepo.created[0].Type)
 		assert.Equal(t, "alice", captureRepo.created[0].UserID)
+		snapshot, ok := captureRepo.created[0].Data[notificationPostSnapshotKey].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "https://local.example/objects/n1", snapshot["id"])
+		assert.Equal(t, "https://local.example/@alice/n1", snapshot["url"])
+		assert.Equal(t, "<p>liked post</p>", snapshot["content"])
+		assert.Equal(t, publishedAt.Format(time.RFC3339), snapshot["createdAt"])
+		assert.Equal(t, "unlisted", snapshot["visibility"])
 	})
 
 	t.Run("CreateReplyNotification_requires_in_reply_to", func(t *testing.T) {
@@ -521,12 +541,27 @@ func TestNotificationService_round27_coverage(t *testing.T) {
 		err := svc.CreateReplyNotification(ctx, &activitypub.Activity{
 			BaseObject: activitypub.BaseObject{ID: "reply-1"},
 			Actor:      "https://remote.example/users/bob",
-			Object:     &activitypub.Note{BaseObject: activitypub.BaseObject{InReplyTo: "https://local.example/objects/n1"}},
+			Object: &activitypub.Note{
+				BaseObject: activitypub.BaseObject{
+					ID:        "https://local.example/objects/reply-1",
+					Published: ptrTime(time.Date(2026, time.March, 19, 12, 30, 0, 0, time.UTC)),
+					InReplyTo: "https://local.example/objects/n1",
+					To:        []string{activitypub.PublicAddress},
+				},
+				Content:      "<p>reply content</p>",
+				AttributedTo: "https://remote.example/users/bob",
+			},
 		})
 		require.NoError(t, err)
 		require.Len(t, captureRepo.created, 1)
 		assert.Equal(t, "reply", captureRepo.created[0].Type)
 		assert.Equal(t, "alice", captureRepo.created[0].UserID)
+		snapshot, ok := captureRepo.created[0].Data[notificationPostSnapshotKey].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "https://local.example/objects/reply-1", snapshot["id"])
+		assert.Equal(t, "<p>reply content</p>", snapshot["content"])
+		assert.Equal(t, "public", snapshot["visibility"])
+		assert.Equal(t, "https://local.example/objects/n1", snapshot["inReplyToId"])
 	})
 
 	t.Run("CreateMentionNotification_skips_self_and_continues_on_error", func(t *testing.T) {
@@ -544,6 +579,43 @@ func TestNotificationService_round27_coverage(t *testing.T) {
 		assert.Equal(t, "bob", captureRepo.created[0].UserID)
 	})
 
+	t.Run("CreateMentionNotification_embeds_post_snapshot", func(t *testing.T) {
+		captureRepo := &capturingNotificationRepo{}
+		storage := &repositoryStorageAdapter{repos: fakeStorageAdapterRepos{
+			notification: captureRepo,
+			logger:       zap.NewNop(),
+			table:        "tbl",
+		}}
+		svc := &notificationService{storage: storage, logger: zap.NewNop()}
+
+		publishedAt := time.Date(2026, time.March, 19, 13, 0, 0, 0, time.UTC)
+		err := svc.CreateMentionNotification(ctx, []string{"https://remote.example/users/bob"}, &activitypub.Activity{
+			BaseObject: activitypub.BaseObject{
+				ID:        "https://local.example/activities/create-1",
+				Published: ptrTime(publishedAt),
+				To:        []string{"https://www.w3.org/ns/activitystreams#Public"},
+			},
+			Actor: "https://local.example/users/alice",
+			Object: &activitypub.Note{
+				BaseObject: activitypub.BaseObject{
+					ID:        "https://local.example/objects/n1",
+					Published: ptrTime(publishedAt),
+					To:        []string{"https://www.w3.org/ns/activitystreams#Public"},
+				},
+				Content:      "<p>@bob hi</p>",
+				AttributedTo: "https://local.example/users/alice",
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, captureRepo.created, 1)
+		snapshot, ok := captureRepo.created[0].Data[notificationPostSnapshotKey].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "https://local.example/objects/n1", snapshot["id"])
+		assert.Equal(t, "<p>@bob hi</p>", snapshot["content"])
+		assert.Equal(t, publishedAt.Format(time.RFC3339), snapshot["createdAt"])
+		assert.Equal(t, "public", snapshot["visibility"])
+	})
+
 	t.Run("createNotification_handles_reblog_and_custom_types", func(t *testing.T) {
 		captureRepo := &capturingNotificationRepo{}
 		storage := &repositoryStorageAdapter{repos: fakeStorageAdapterRepos{
@@ -554,8 +626,8 @@ func TestNotificationService_round27_coverage(t *testing.T) {
 
 		svc := &notificationService{storage: storage, logger: zap.NewNop()}
 
-		require.NoError(t, svc.createNotification(ctx, "https://local.example/users/alice", "https://remote.example/users/bob", "reblog", "obj-1"))
-		require.NoError(t, svc.createNotification(ctx, "https://local.example/users/alice", "https://remote.example/users/bob", "custom.type", "obj-1"))
+		require.NoError(t, svc.createNotification(ctx, "https://local.example/users/alice", "https://remote.example/users/bob", "reblog", "obj-1", nil))
+		require.NoError(t, svc.createNotification(ctx, "https://local.example/users/alice", "https://remote.example/users/bob", "custom.type", "obj-1", nil))
 		require.Len(t, captureRepo.created, 2)
 		assert.Equal(t, "reblog", captureRepo.created[0].Type)
 		assert.Equal(t, "custom.type", captureRepo.created[1].Type)
@@ -570,8 +642,8 @@ func TestNotificationService_round27_coverage(t *testing.T) {
 		}}
 		svc := &notificationService{storage: storage, logger: zap.NewNop()}
 
-		require.NoError(t, svc.createNotification(ctx, "alice", "https://remote.example/users/bob", "follow", "obj-1"))
-		require.NoError(t, svc.createNotification(ctx, "https://local.example/users/alice", "bob", "follow", "obj-1"))
+		require.NoError(t, svc.createNotification(ctx, "alice", "https://remote.example/users/bob", "follow", "obj-1", nil))
+		require.NoError(t, svc.createNotification(ctx, "https://local.example/users/alice", "bob", "follow", "obj-1", nil))
 		assert.Empty(t, captureRepo.created)
 	})
 

--- a/pkg/services/file_validation.go
+++ b/pkg/services/file_validation.go
@@ -186,7 +186,7 @@ func (fv *FileValidationService) detectContentType(data []byte, result *FileVali
 		case strings.Contains(contentType, "text"):
 			result.DetectedFormat = "text"
 		default:
-			result.DetectedFormat = "unknown"
+			result.DetectedFormat = unknownValue
 		}
 	}
 

--- a/pkg/services/notifications.go
+++ b/pkg/services/notifications.go
@@ -3,12 +3,15 @@ package services
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"go.uber.org/zap"
 )
+
+const notificationPostSnapshotKey = "postSnapshot"
 
 // notificationService implements NotificationService
 type notificationService struct {
@@ -39,7 +42,7 @@ func (n *notificationService) CreateFollowNotification(ctx context.Context, foll
 	followerActorID := followActivity.Actor
 
 	// Create follow notification
-	return n.createNotification(ctx, targetActorID, followerActorID, "follow", followActivity.ID)
+	return n.createNotification(ctx, targetActorID, followerActorID, "follow", followActivity.ID, nil)
 }
 
 // CreateLikeNotification creates a notification when someone likes a post
@@ -74,7 +77,7 @@ func (n *notificationService) CreateLikeNotification(ctx context.Context, likeAc
 	}
 
 	// Create like notification
-	return n.createNotification(ctx, authorActorID, likerActorID, "favourite", likeActivity.ID)
+	return n.createNotification(ctx, authorActorID, likerActorID, "favourite", likeActivity.ID, n.buildPostSnapshotFromObject(object, objectID, ""))
 }
 
 // CreateReplyNotification creates a notification when someone replies to a post
@@ -114,12 +117,13 @@ func (n *notificationService) CreateReplyNotification(ctx context.Context, reply
 	}
 
 	// Create reply notification
-	return n.createNotification(ctx, parentAuthorActorID, replierActorID, "reply", replyActivity.ID)
+	return n.createNotification(ctx, parentAuthorActorID, replierActorID, "reply", replyActivity.ID, n.buildPostSnapshotFromObject(note, firstNonEmptyString(note.ID, replyActivity.ID), n.snapshotVisibilityFromActivity(replyActivity)))
 }
 
 // CreateMentionNotification creates notifications for mentioned users
 func (n *notificationService) CreateMentionNotification(ctx context.Context, mentions []string, activity *activitypub.Activity) error {
 	mentionerActorID := activity.Actor
+	postSnapshot := n.postSnapshotForActivity(ctx, activity)
 
 	for _, mentionedActorID := range mentions {
 		// Don't notify if user mentioned themselves
@@ -128,7 +132,7 @@ func (n *notificationService) CreateMentionNotification(ctx context.Context, men
 		}
 
 		// Create mention notification
-		if err := n.createNotification(ctx, mentionedActorID, mentionerActorID, "mention", activity.ID); err != nil {
+		if err := n.createNotification(ctx, mentionedActorID, mentionerActorID, "mention", activity.ID, postSnapshot); err != nil {
 			n.logger.Warn("failed to create mention notification",
 				zap.String("mentioned_actor", mentionedActorID),
 				zap.Error(err))
@@ -140,7 +144,7 @@ func (n *notificationService) CreateMentionNotification(ctx context.Context, men
 
 // Helper methods
 
-func (n *notificationService) createNotification(ctx context.Context, recipientActorID, fromActorID, notificationType, activityID string) error {
+func (n *notificationService) createNotification(ctx context.Context, recipientActorID, fromActorID, notificationType, activityID string, postSnapshot map[string]interface{}) error {
 	// Extract username from actor ID for storage
 	recipientUsername := n.extractUsernameFromActorID(recipientActorID)
 	fromUsername := n.extractUsernameFromActorID(fromActorID)
@@ -172,6 +176,10 @@ func (n *notificationService) createNotification(ctx context.Context, recipientA
 			OfType(notificationType).
 			FromActor(fromUsername, "user").
 			Build()
+	}
+
+	if len(postSnapshot) > 0 {
+		notification.SetData(notificationPostSnapshotKey, cloneNotificationPostSnapshot(postSnapshot))
 	}
 
 	// Create the notification
@@ -217,5 +225,239 @@ func (n *notificationService) extractUsernameFromActorID(actorID string) string 
 			return parts[1]
 		}
 	}
+	return ""
+}
+
+func (n *notificationService) postSnapshotForActivity(ctx context.Context, activity *activitypub.Activity) map[string]interface{} {
+	if activity == nil {
+		return nil
+	}
+
+	fallbackVisibility := n.snapshotVisibilityFromActivity(activity)
+
+	switch object := activity.Object.(type) {
+	case nil:
+		return nil
+	case string:
+		storedObject, err := n.storage.GetObject(ctx, object)
+		if err != nil {
+			n.logger.Warn("failed to load activity object for notification snapshot",
+				zap.String("object_id", object),
+				zap.Error(err))
+			return nil
+		}
+		return n.buildPostSnapshotFromObject(storedObject, object, fallbackVisibility)
+	default:
+		return n.buildPostSnapshotFromObject(object, activity.ID, fallbackVisibility)
+	}
+}
+
+func (n *notificationService) buildPostSnapshotFromObject(object interface{}, fallbackID, fallbackVisibility string) map[string]interface{} {
+	switch obj := object.(type) {
+	case *activitypub.Note:
+		return buildNotificationPostSnapshot(
+			firstNonEmptyString(obj.ID, fallbackID),
+			firstNonEmptyString(obj.ID, fallbackID),
+			obj.Content,
+			timestampString(obj.Published),
+			n.resolveSnapshotVisibility(obj.Visibility, obj.To, obj.CC, obj.BTo, obj.BCC, fallbackVisibility),
+			obj.InReplyTo,
+			obj.AttributedTo,
+		)
+	case *activitypub.QuoteNote:
+		return n.buildPostSnapshotFromObject(&obj.Note, fallbackID, fallbackVisibility)
+	case *activitypub.Article:
+		return n.buildPostSnapshotFromObject(&obj.Note, fallbackID, fallbackVisibility)
+	case *models.Object:
+		return buildNotificationPostSnapshot(
+			firstNonEmptyString(obj.ID, fallbackID),
+			firstNonEmptyString(obj.URL, obj.ID, fallbackID),
+			obj.Content,
+			timestampString(&obj.Published),
+			n.resolveSnapshotVisibility(obj.Visibility, obj.To, obj.CC, obj.BTo, obj.BCC, fallbackVisibility),
+			derefString(obj.InReplyTo),
+			obj.AttributedTo,
+		)
+	case map[string]interface{}:
+		return n.buildPostSnapshotFromMap(obj, fallbackID, fallbackVisibility)
+	default:
+		return nil
+	}
+}
+
+func (n *notificationService) buildPostSnapshotFromMap(object map[string]interface{}, fallbackID, fallbackVisibility string) map[string]interface{} {
+	id := stringValueFromMap(object, "id")
+	url := stringValueFromMap(object, "url")
+	content := stringValueFromMap(object, "content")
+	createdAt := firstNonEmptyString(timestampString(anyTimePointerFromMap(object, "createdAt")), timestampString(anyTimePointerFromMap(object, "published")))
+	visibility := n.resolveSnapshotVisibility(
+		stringValueFromMap(object, "visibility"),
+		stringSliceFromAny(object["to"]),
+		stringSliceFromAny(object["cc"]),
+		stringSliceFromAny(object["bto"]),
+		stringSliceFromAny(object["bcc"]),
+		fallbackVisibility,
+	)
+	inReplyTo := firstNonEmptyString(stringValueFromMap(object, "inReplyTo"), stringValueFromMap(object, "inReplyToId"))
+	attributedTo := stringValueFromMap(object, "attributedTo")
+
+	return buildNotificationPostSnapshot(
+		firstNonEmptyString(id, fallbackID),
+		firstNonEmptyString(url, id, fallbackID),
+		content,
+		createdAt,
+		visibility,
+		inReplyTo,
+		attributedTo,
+	)
+}
+
+func (n *notificationService) snapshotVisibilityFromActivity(activity *activitypub.Activity) string {
+	if activity == nil {
+		return ""
+	}
+
+	visibility := activitypub.NewAddressingValidator().GetVisibilityLevel(activity)
+	if visibility == unknownValue {
+		return ""
+	}
+
+	return visibility
+}
+
+func (n *notificationService) resolveSnapshotVisibility(explicit string, to, cc, bto, bcc []string, fallback string) string {
+	if trimmed := strings.TrimSpace(explicit); trimmed != "" {
+		return trimmed
+	}
+
+	derived := activitypub.NewAddressingValidator().GetVisibilityLevel(&activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			To:  to,
+			CC:  cc,
+			BTo: bto,
+			BCC: bcc,
+		},
+	})
+	if derived != "" && derived != unknownValue {
+		return derived
+	}
+
+	if trimmed := strings.TrimSpace(fallback); trimmed != "" {
+		return trimmed
+	}
+
+	return models.VisibilityPublic
+}
+
+func buildNotificationPostSnapshot(id, url, content, createdAt, visibility, inReplyToID, attributedTo string) map[string]interface{} {
+	if strings.TrimSpace(id) == "" {
+		return nil
+	}
+
+	snapshot := map[string]interface{}{
+		"id":         id,
+		"url":        firstNonEmptyString(url, id),
+		"content":    content,
+		"createdAt":  createdAt,
+		"visibility": firstNonEmptyString(visibility, models.VisibilityPublic),
+	}
+
+	if trimmed := strings.TrimSpace(inReplyToID); trimmed != "" {
+		snapshot["inReplyToId"] = trimmed
+	}
+	if trimmed := strings.TrimSpace(attributedTo); trimmed != "" {
+		snapshot["attributedTo"] = trimmed
+	}
+
+	return snapshot
+}
+
+func cloneNotificationPostSnapshot(snapshot map[string]interface{}) map[string]interface{} {
+	if len(snapshot) == 0 {
+		return nil
+	}
+
+	cloned := make(map[string]interface{}, len(snapshot))
+	for key, value := range snapshot {
+		cloned[key] = value
+	}
+
+	return cloned
+}
+
+func stringValueFromMap(values map[string]interface{}, key string) string {
+	raw, ok := values[key]
+	if !ok {
+		return ""
+	}
+
+	switch value := raw.(type) {
+	case string:
+		return strings.TrimSpace(value)
+	default:
+		return ""
+	}
+}
+
+func anyTimePointerFromMap(values map[string]interface{}, key string) *time.Time {
+	raw, ok := values[key]
+	if !ok {
+		return nil
+	}
+
+	switch value := raw.(type) {
+	case time.Time:
+		return &value
+	case *time.Time:
+		return value
+	case string:
+		if parsed, err := time.Parse(time.RFC3339, value); err == nil {
+			return &parsed
+		}
+	}
+
+	return nil
+}
+
+func stringSliceFromAny(value interface{}) []string {
+	switch typed := value.(type) {
+	case []string:
+		return typed
+	case []interface{}:
+		out := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if str, ok := item.(string); ok && strings.TrimSpace(str) != "" {
+				out = append(out, strings.TrimSpace(str))
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func timestampString(value *time.Time) string {
+	if value == nil || value.IsZero() {
+		return ""
+	}
+
+	return value.UTC().Format(time.RFC3339)
+}
+
+func derefString(value *string) string {
+	if value == nil {
+		return ""
+	}
+
+	return *value
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+
 	return ""
 }

--- a/pkg/services/notifications_round32_snapshot_test.go
+++ b/pkg/services/notifications_round32_snapshot_test.go
@@ -1,0 +1,126 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestNotificationService_PostSnapshotHelpers_Round32(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	publishedAt := time.Date(2026, time.March, 19, 15, 0, 0, 0, time.UTC)
+
+	t.Run("postSnapshotForActivity fetches stored string object", func(t *testing.T) {
+		parentID := "https://local.example/objects/root"
+		svc := &notificationService{
+			storage: &repositoryStorageAdapter{repos: fakeStorageAdapterRepos{
+				object: fakeObjectRepo{getValue: &models.Object{
+					ID:           "https://local.example/objects/n1",
+					URL:          "https://local.example/@alice/n1",
+					Content:      "<p>stored body</p>",
+					Published:    publishedAt,
+					InReplyTo:    &parentID,
+					Visibility:   models.VisibilityPrivate,
+					AttributedTo: "https://local.example/users/alice",
+				}},
+				logger: zap.NewNop(),
+				table:  "tbl",
+			}},
+			logger: zap.NewNop(),
+		}
+
+		snapshot := svc.postSnapshotForActivity(ctx, &activitypub.Activity{
+			BaseObject: activitypub.BaseObject{ID: "https://local.example/activities/create-1"},
+			Object:     "https://local.example/objects/n1",
+		})
+
+		require.NotNil(t, snapshot)
+		assert.Equal(t, "https://local.example/objects/n1", snapshot["id"])
+		assert.Equal(t, "https://local.example/@alice/n1", snapshot["url"])
+		assert.Equal(t, "<p>stored body</p>", snapshot["content"])
+		assert.Equal(t, publishedAt.Format(time.RFC3339), snapshot["createdAt"])
+		assert.Equal(t, models.VisibilityPrivate, snapshot["visibility"])
+		assert.Equal(t, parentID, snapshot["inReplyToId"])
+	})
+
+	t.Run("postSnapshotForActivity returns nil when lookup fails", func(t *testing.T) {
+		svc := &notificationService{
+			storage: &repositoryStorageAdapter{repos: fakeStorageAdapterRepos{
+				object: fakeObjectRepo{getErr: errors.New("boom")},
+				logger: zap.NewNop(),
+				table:  "tbl",
+			}},
+			logger: zap.NewNop(),
+		}
+
+		snapshot := svc.postSnapshotForActivity(ctx, &activitypub.Activity{
+			BaseObject: activitypub.BaseObject{ID: "https://local.example/activities/create-2"},
+			Object:     "https://local.example/objects/missing",
+		})
+
+		require.Nil(t, snapshot)
+	})
+
+	t.Run("buildPostSnapshotFromObject supports article and quote note", func(t *testing.T) {
+		svc := &notificationService{logger: zap.NewNop()}
+
+		article := &activitypub.Article{
+			Note: activitypub.Note{
+				BaseObject: activitypub.BaseObject{
+					ID:        "https://local.example/articles/a1",
+					Published: ptrTime(publishedAt),
+					To:        []string{activitypub.PublicAddress},
+				},
+				Content:      "<p>article body</p>",
+				AttributedTo: "https://local.example/users/alice",
+			},
+			Name: "Article",
+		}
+		quote := &activitypub.QuoteNote{
+			Note: activitypub.Note{
+				BaseObject: activitypub.BaseObject{
+					ID:        "https://local.example/objects/q1",
+					Published: ptrTime(publishedAt.Add(time.Minute)),
+					BTo:       []string{"https://local.example/users/bob"},
+				},
+				Content:      "<p>quote body</p>",
+				AttributedTo: "https://local.example/users/alice",
+			},
+		}
+
+		articleSnapshot := svc.buildPostSnapshotFromObject(article, "", "")
+		quoteSnapshot := svc.buildPostSnapshotFromObject(quote, "", "")
+
+		require.NotNil(t, articleSnapshot)
+		require.NotNil(t, quoteSnapshot)
+		assert.Equal(t, "<p>article body</p>", articleSnapshot["content"])
+		assert.Equal(t, models.VisibilityPublic, articleSnapshot["visibility"])
+		assert.Equal(t, "<p>quote body</p>", quoteSnapshot["content"])
+		assert.Equal(t, models.VisibilityDirect, quoteSnapshot["visibility"])
+	})
+
+	t.Run("map and scalar helpers cover time parsing and slice extraction", func(t *testing.T) {
+		createdAt := anyTimePointerFromMap(map[string]interface{}{
+			"createdAt": publishedAt.Format(time.RFC3339),
+		}, "createdAt")
+		require.NotNil(t, createdAt)
+		assert.Equal(t, publishedAt, createdAt.UTC())
+
+		assert.Equal(t, []string{"one", "two"}, stringSliceFromAny([]interface{}{" one ", 2, "two"}))
+		assert.Nil(t, stringSliceFromAny("nope"))
+		assert.Equal(t, "", derefString(nil))
+
+		value := "parent"
+		assert.Equal(t, "parent", derefString(&value))
+		assert.Nil(t, buildNotificationPostSnapshot("", "", "", "", "", "", ""))
+	})
+}


### PR DESCRIPTION
## Summary
- embed `postSnapshot` data for mention, reply, and favourite notifications at creation time
- prefer embedded snapshots in the notifications API and fall back to legacy object lookups when absent
- add targeted service and handler coverage to keep local `verify ci` green, including the small package and command coverage margin fixes

## Issues
Closes #243
Closes #244

## Verification
- `GOTOOLCHAIN=auto go test ./pkg/services ./cmd/api/handlers -count=1`
- `GOTOOLCHAIN=auto go build -o lesser ./cmd/lesser`
- `./lesser build lambdas --rebuild`
- `PATH="$(GOTOOLCHAIN=auto go env GOROOT)/bin:$PATH" LESSER_VERIFY_CI_JOBS=1 LESSER_TEST_COVERAGE_BATCH_SIZE=5 ./lesser verify ci`
