### PR TITLE
Fix MCP protected-resource route wiring

### DIFF
--- a/infra/cdk/constructs/api_routes.go
+++ b/infra/cdk/constructs/api_routes.go
@@ -167,7 +167,7 @@ func addMcpRoute(scope constructs.Construct, api apptheorycdk.AppTheoryRestApiRo
 	api.AddLambdaIntegration(jsii.String("/mcp"), &[]*string{jsii.String("GET")}, mcpLambda, options)
 	api.AddLambdaIntegration(jsii.String("/mcp"), &[]*string{jsii.String("DELETE")}, mcpLambda, nil)
 	api.AddLambdaIntegration(jsii.String("/.well-known/mcp.json"), &[]*string{jsii.String("GET")}, mcpLambda, nil)
-	api.AddLambdaIntegration(jsii.String("/.well-known/oauth-protected-resource"), &[]*string{jsii.String("GET")}, mcpLambda, nil)
+	api.AddLambdaIntegration(jsii.String("/.well-known/oauth-protected-resource/mcp/{actor}"), &[]*string{jsii.String("GET")}, mcpLambda, nil)
 }
 
 func addRestApiGatewayResponses(scope constructs.Construct, api awsapigateway.RestApi) {

--- a/infra/cdk/constructs/api_routes_test.go
+++ b/infra/cdk/constructs/api_routes_test.go
@@ -218,7 +218,7 @@ func TestBodyEnabledAddsMcpRoute(t *testing.T) {
 
 	for _, routeKey := range []string{
 		"GET /.well-known/mcp.json",
-		"GET /.well-known/oauth-protected-resource",
+		"GET /.well-known/oauth-protected-resource/mcp/{actor}",
 	} {
 		uri, ok := gotRoutes[routeKey]
 		if !ok {
@@ -312,7 +312,7 @@ func TestBodyDisabledDoesNotAddMcpRoute(t *testing.T) {
 	}
 	for _, routeKey := range []string{
 		"GET /.well-known/mcp.json",
-		"GET /.well-known/oauth-protected-resource",
+		"GET /.well-known/oauth-protected-resource/mcp/{actor}",
 	} {
 		if _, ok := gotRoutes[routeKey]; ok {
 			t.Fatalf("unexpected %s route present when bodyEnabled=false", routeKey)


### PR DESCRIPTION
## Summary
- wire the MCP Lambda to the per-actor protected-resource metadata route
- update the CDK route contract tests to assert the new API Gateway path
- remove the stale shared protected-resource route expectation

## Verification
- env GOTOOLCHAIN=auto go test ./constructs/...  # from infra/cdk
- env GOTOOLCHAIN=auto go run ./cmd/lesser verify ci

Closes #313