### PR TITLE
Patch auth-ui h3 Dependabot alerts

### DIFF
--- a/auth-ui/package.json
+++ b/auth-ui/package.json
@@ -53,7 +53,7 @@
     "overrides": {
       "mdast-util-to-hast": "13.2.1",
       "devalue": "5.6.4",
-      "h3": "1.15.6",
+      "h3": "1.15.9",
       "diff": "5.2.2",
       "svgo": "4.0.1"
     }

--- a/auth-ui/pnpm-lock.yaml
+++ b/auth-ui/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   mdast-util-to-hast: 13.2.1
   devalue: 5.6.4
-  h3: 1.15.6
+  h3: 1.15.9
   diff: 5.2.2
   svgo: 4.0.1
 
@@ -1053,8 +1053,8 @@ packages:
     resolution: {integrity: sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
-  h3@1.15.6:
-    resolution: {integrity: sha512-oi15ESLW5LRthZ+qPCi5GNasY/gvynSKUQxgiovrY63bPAtG59wtM+LSrlcwvOHAXzGrXVLnI97brbkdPF9WoQ==}
+  h3@1.15.9:
+    resolution: {integrity: sha512-H7UPnyIupUOYUQu7f2x7ABVeMyF/IbJjqn20WSXpMdnQB260luADUkSgJU7QTWLutq8h3tUayMQ1DdbSYX5LkA==}
 
   hast-util-embedded@3.0.0:
     resolution: {integrity: sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==}
@@ -2729,7 +2729,7 @@ snapshots:
 
   graphql@16.13.1: {}
 
-  h3@1.15.6:
+  h3@1.15.9:
     dependencies:
       cookie-es: 1.2.2
       crossws: 0.3.5
@@ -3756,7 +3756,7 @@ snapshots:
       anymatch: 3.1.3
       chokidar: 5.0.0
       destr: 2.0.5
-      h3: 1.15.6
+      h3: 1.15.9
       lru-cache: 11.2.7
       node-fetch-native: 1.6.7
       ofetch: 1.5.1


### PR DESCRIPTION
## Summary
- bump the auth-ui pnpm override for `h3` from `1.15.6` to `1.15.9`
- refresh `auth-ui/pnpm-lock.yaml` so the transitive graph resolves to the first patched `h3` version
- keep the change scoped to the two open Dependabot alerts on `auth-ui/pnpm-lock.yaml`

## Addresses
- Dependabot alert [#45](https://github.com/equaltoai/lesser/security/dependabot/45) (`GHSA-4hxc-9384-m385`)
- Dependabot alert [#46](https://github.com/equaltoai/lesser/security/dependabot/46) (`GHSA-72gr-qfp7-vwhw`)

## Verification
- `pnpm install --frozen-lockfile` in `auth-ui`
- `pnpm build` in `auth-ui`
- `env GOTOOLCHAIN=auto go run ./cmd/lesser verify ci`
