### PR TITLE
Wire per-actor MCP gateway routes

### DIFF
--- a/infra/cdk/constructs/api_routes.go
+++ b/infra/cdk/constructs/api_routes.go
@@ -166,6 +166,9 @@ func addMcpRoute(scope constructs.Construct, api apptheorycdk.AppTheoryRestApiRo
 	api.AddLambdaIntegration(jsii.String("/mcp"), &[]*string{jsii.String("POST")}, mcpLambda, options)
 	api.AddLambdaIntegration(jsii.String("/mcp"), &[]*string{jsii.String("GET")}, mcpLambda, options)
 	api.AddLambdaIntegration(jsii.String("/mcp"), &[]*string{jsii.String("DELETE")}, mcpLambda, nil)
+	api.AddLambdaIntegration(jsii.String("/mcp/{actor}"), &[]*string{jsii.String("POST")}, mcpLambda, options)
+	api.AddLambdaIntegration(jsii.String("/mcp/{actor}"), &[]*string{jsii.String("GET")}, mcpLambda, options)
+	api.AddLambdaIntegration(jsii.String("/mcp/{actor}"), &[]*string{jsii.String("DELETE")}, mcpLambda, nil)
 	api.AddLambdaIntegration(jsii.String("/.well-known/mcp.json"), &[]*string{jsii.String("GET")}, mcpLambda, nil)
 	api.AddLambdaIntegration(jsii.String("/.well-known/oauth-protected-resource/mcp/{actor}"), &[]*string{jsii.String("GET")}, mcpLambda, nil)
 }

--- a/infra/cdk/constructs/api_routes_test.go
+++ b/infra/cdk/constructs/api_routes_test.go
@@ -202,7 +202,14 @@ func TestBodyEnabledAddsMcpRoute(t *testing.T) {
 	gotRoutes := extractHttpRouteToIntegrationURI(t, tpl)
 
 	wantParamName := "/lesser/dev/lesser-body/exports/v1/mcp_lambda_arn"
-	for _, routeKey := range []string{"POST /mcp", "GET /mcp", "DELETE /mcp"} {
+	for _, routeKey := range []string{
+		"POST /mcp",
+		"GET /mcp",
+		"DELETE /mcp",
+		"POST /mcp/{actor}",
+		"GET /mcp/{actor}",
+		"DELETE /mcp/{actor}",
+	} {
 		uri, ok := gotRoutes[routeKey]
 		if !ok {
 			t.Fatalf("expected %s route to exist when bodyEnabled=true", routeKey)
@@ -304,11 +311,20 @@ func TestBodyDisabledDoesNotAddMcpRoute(t *testing.T) {
 	if _, ok := gotRoutes["POST /mcp"]; ok {
 		t.Fatalf("unexpected POST /mcp route present when bodyEnabled=false")
 	}
+	if _, ok := gotRoutes["POST /mcp/{actor}"]; ok {
+		t.Fatalf("unexpected POST /mcp/{actor} route present when bodyEnabled=false")
+	}
 	if _, ok := gotRoutes["GET /mcp"]; ok {
 		t.Fatalf("unexpected GET /mcp route present when bodyEnabled=false")
 	}
+	if _, ok := gotRoutes["GET /mcp/{actor}"]; ok {
+		t.Fatalf("unexpected GET /mcp/{actor} route present when bodyEnabled=false")
+	}
 	if _, ok := gotRoutes["DELETE /mcp"]; ok {
 		t.Fatalf("unexpected DELETE /mcp route present when bodyEnabled=false")
+	}
+	if _, ok := gotRoutes["DELETE /mcp/{actor}"]; ok {
+		t.Fatalf("unexpected DELETE /mcp/{actor} route present when bodyEnabled=false")
 	}
 	for _, routeKey := range []string{
 		"GET /.well-known/mcp.json",


### PR DESCRIPTION
## Summary
- add the missing `/mcp/{actor}` POST/GET/DELETE integrations to the main API Gateway MCP wiring
- keep the shared `/mcp` routes in place so lesser-body can continue returning its migration `410`
- extend the CDK route-contract tests to assert the per-actor routes when body routing is enabled and absent when disabled

## Verification
- `env GOTOOLCHAIN=auto go test ./constructs/...` in `infra/cdk`
- `env GOTOOLCHAIN=auto go run ./cmd/lesser verify ci`

Closes #316