### PR TITLE
Accept comm-worker notification delivery fields

### DIFF
--- a/cmd/api/handlers/notification_delivery.go
+++ b/cmd/api/handlers/notification_delivery.go
@@ -69,49 +69,14 @@ func (h *Handler) HandleDeliverNotificationLift(ctx *apptheory.Context) (*appthe
 		return common.RespondServiceUnavailable(ctx, "notification")
 	}
 
-	from := map[string]interface{}{
-		"address":     delivery.FromAddress,
-		"displayName": delivery.FromDisplayName,
-		"soulAgentId": nil,
-	}
-	if delivery.FromSoulAgentID != "" {
-		from["soulAgentId"] = delivery.FromSoulAgentID
-	}
-
-	data := map[string]interface{}{
-		"channel":    delivery.Channel,
-		"from":       from,
-		"receivedAt": delivery.ReceivedAt.Format(time.RFC3339Nano),
-		"messageId":  delivery.MessageID,
-	}
-	if delivery.ToAddress != "" {
-		data["to"] = map[string]interface{}{
-			"address": delivery.ToAddress,
-		}
-	}
-	if delivery.InReplyTo != "" {
-		data["inReplyTo"] = delivery.InReplyTo
-	}
-	if len(delivery.Attachments) > 0 {
-		attachments := make([]map[string]interface{}, 0, len(delivery.Attachments))
-		for _, attachment := range delivery.Attachments {
-			attachments = append(attachments, map[string]interface{}{
-				"id":          attachment.ID,
-				"filename":    attachment.Filename,
-				"contentType": attachment.ContentType,
-				"sizeBytes":   attachment.SizeBytes,
-				"sha256":      attachment.SHA256,
-			})
-		}
-		data["attachments"] = attachments
-	}
+	data := commNotificationData(delivery)
 
 	cmd := &notifications.CreateNotificationCommand{
 		ID:        notificationID,
 		CreatedAt: &delivery.ReceivedAt,
 		UserID:    recipient,
 		Type:      delivery.NotificationType,
-		ActorID:   delivery.FromAddress,
+		ActorID:   delivery.FromIdentifier,
 		ActorType: "external",
 		Title:     delivery.Subject,
 		Body:      delivery.Body,
@@ -135,6 +100,64 @@ func (h *Handler) HandleDeliverNotificationLift(ctx *apptheory.Context) (*appthe
 	h.recordCommDeliveryAuditEvent(ctx, recipient, delivery, true, "", idempotent)
 
 	return noContent(), nil
+}
+
+func commNotificationData(delivery *commNotificationDelivery) map[string]interface{} {
+	data := map[string]interface{}{
+		"channel":    delivery.Channel,
+		"from":       commNotificationParty(delivery.FromAddress, delivery.FromNumber, delivery.FromDisplayName, delivery.FromSoulAgentID),
+		"receivedAt": delivery.ReceivedAt.Format(time.RFC3339Nano),
+		"messageId":  delivery.MessageID,
+	}
+	if to := commNotificationParty(delivery.ToAddress, delivery.ToNumber, "", ""); len(to) > 0 {
+		data["to"] = to
+	}
+	if delivery.InReplyTo != "" {
+		data["inReplyTo"] = delivery.InReplyTo
+	}
+	if delivery.BodyMimeType != "" {
+		data["bodyMimeType"] = delivery.BodyMimeType
+	}
+	if attachments := commNotificationAttachmentsData(delivery.Attachments); len(attachments) > 0 {
+		data["attachments"] = attachments
+	}
+	return data
+}
+
+func commNotificationParty(address, number, displayName, soulAgentID string) map[string]interface{} {
+	party := map[string]interface{}{}
+	if address != "" {
+		party["address"] = address
+	}
+	if number != "" {
+		party["number"] = number
+	}
+	if displayName != "" {
+		party["displayName"] = displayName
+	}
+	if soulAgentID != "" {
+		party["soulAgentId"] = soulAgentID
+	}
+	return party
+}
+
+func commNotificationAttachmentsData(attachments []commNotificationAttachment) []map[string]interface{} {
+	if len(attachments) == 0 {
+		return nil
+	}
+
+	data := make([]map[string]interface{}, 0, len(attachments))
+	for _, attachment := range attachments {
+		data = append(data, map[string]interface{}{
+			"id":          attachment.ID,
+			"filename":    attachment.Filename,
+			"contentType": attachment.ContentType,
+			"sizeBytes":   attachment.SizeBytes,
+			"sha256":      attachment.SHA256,
+		})
+	}
+
+	return data
 }
 
 func (h *Handler) resolveNotificationDeliveryRecipient(ctx context.Context, delivery *commNotificationDelivery) string {

--- a/cmd/api/handlers/notification_delivery_contract.go
+++ b/cmd/api/handlers/notification_delivery_contract.go
@@ -21,17 +21,19 @@ const (
 )
 
 const (
-	commNotificationMaxTypeLen        = 64
-	commNotificationMaxChannelLen     = 16
-	commNotificationMaxFromAddressLen = 320
-	commNotificationMaxToAddressLen   = 320
-	commNotificationMaxDisplayNameLen = 200
-	commNotificationMaxSubjectLen     = 500
-	commNotificationMaxBodyLen        = 25_000
-	commNotificationMaxMessageIDLen   = 200
-	commNotificationMaxInReplyToLen   = 200
-	commNotificationMaxSoulAgentIDLen = 128
-	commNotificationMaxAttachments    = 20
+	commNotificationMaxTypeLen         = 64
+	commNotificationMaxChannelLen      = 16
+	commNotificationMaxFromAddressLen  = 320
+	commNotificationMaxToAddressLen    = 320
+	commNotificationMaxPhoneNumberLen  = 32
+	commNotificationMaxDisplayNameLen  = 200
+	commNotificationMaxSubjectLen      = 500
+	commNotificationMaxBodyLen         = 25_000
+	commNotificationMaxBodyMimeTypeLen = 128
+	commNotificationMaxMessageIDLen    = 200
+	commNotificationMaxInReplyToLen    = 200
+	commNotificationMaxSoulAgentIDLen  = 128
+	commNotificationMaxAttachments     = 20
 
 	commNotificationMaxAttachmentIDLen          = 128
 	commNotificationMaxAttachmentFilenameLen    = 255
@@ -45,13 +47,18 @@ type commNotificationDelivery struct {
 	NotificationType string
 	Channel          string
 
+	FromIdentifier  string
 	FromAddress     string
+	FromNumber      string
 	FromSoulAgentID string
 	FromDisplayName string
+	ToIdentifier    string
 	ToAddress       string
+	ToNumber        string
 
-	Subject string
-	Body    string
+	Subject      string
+	Body         string
+	BodyMimeType string
 
 	ReceivedAt time.Time
 	MessageID  string
@@ -83,17 +90,22 @@ func normalizeCommNotificationDeliveryRequest(req *apiModels.NotificationDeliver
 		return nil, err
 	}
 
-	fromAddress, displayName, soulAgentID, err := normalizeCommNotificationSender(req.From)
+	fromIdentifier, fromAddress, fromNumber, displayName, soulAgentID, err := normalizeCommNotificationSender(channel, req.From)
 	if err != nil {
 		return nil, err
 	}
 
-	toAddress, err := normalizeCommNotificationRecipient(channel, req.To)
+	toIdentifier, toAddress, toNumber, err := normalizeCommNotificationRecipient(channel, req.To)
 	if err != nil {
 		return nil, err
 	}
 
 	subject, body, err := normalizeCommNotificationContent(channel, req.Subject, req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	bodyMimeType, err := normalizeCommNotificationBodyMimeType(req.BodyMimeType)
 	if err != nil {
 		return nil, err
 	}
@@ -121,12 +133,17 @@ func normalizeCommNotificationDeliveryRequest(req *apiModels.NotificationDeliver
 	return &commNotificationDelivery{
 		NotificationType: typ,
 		Channel:          channel,
+		FromIdentifier:   fromIdentifier,
 		FromAddress:      fromAddress,
+		FromNumber:       fromNumber,
 		FromSoulAgentID:  soulAgentID,
 		FromDisplayName:  displayName,
+		ToIdentifier:     toIdentifier,
 		ToAddress:        toAddress,
+		ToNumber:         toNumber,
 		Subject:          subject,
 		Body:             body,
+		BodyMimeType:     bodyMimeType,
 		ReceivedAt:       receivedAt.UTC(),
 		MessageID:        messageID,
 		InReplyTo:        inReplyTo,
@@ -163,42 +180,62 @@ func normalizeCommNotificationChannel(raw string) (string, error) {
 	}
 }
 
-func normalizeCommNotificationSender(from apiModels.NotificationDeliveryFrom) (string, string, string, error) {
-	fromAddress, err := common.ValidateAndSanitizeString("from.address", from.Address, 1, commNotificationMaxFromAddressLen)
+func normalizeCommNotificationSender(channel string, from apiModels.NotificationDeliveryFrom) (string, string, string, string, string, error) {
+	fromAddress, err := normalizeCommNotificationOptionalAddress("from.address", from.Address, commNotificationMaxFromAddressLen)
 	if err != nil {
-		return "", "", "", apperrors.ValidationFailed("from.address", err.Error())
+		return "", "", "", "", "", err
+	}
+
+	fromNumber, err := normalizeCommNotificationOptionalAddress("from.number", from.Number, commNotificationMaxPhoneNumberLen)
+	if err != nil {
+		return "", "", "", "", "", err
 	}
 
 	displayName, err := common.ValidateAndSanitizeString("from.displayName", from.DisplayName, 0, commNotificationMaxDisplayNameLen)
 	if err != nil {
-		return "", "", "", apperrors.ValidationFailed("from.displayName", err.Error())
+		return "", "", "", "", "", apperrors.ValidationFailed("from.displayName", err.Error())
 	}
 
 	soulAgentID := ""
 	if from.SoulAgentID != nil {
 		soulAgentID, err = common.ValidateAndSanitizeString("from.soulAgentId", *from.SoulAgentID, 0, commNotificationMaxSoulAgentIDLen)
 		if err != nil {
-			return "", "", "", apperrors.ValidationFailed("from.soulAgentId", err.Error())
+			return "", "", "", "", "", apperrors.ValidationFailed("from.soulAgentId", err.Error())
 		}
 	}
 
-	return fromAddress, common.EscapeHTML(displayName), soulAgentID, nil
+	identifier, field, err := normalizeCommNotificationIdentity(channel, "from", fromAddress, fromNumber)
+	if err != nil {
+		return "", "", "", "", "", apperrors.ValidationFailed(field, err.Error())
+	}
+
+	return identifier, fromAddress, fromNumber, common.EscapeHTML(displayName), soulAgentID, nil
 }
 
-func normalizeCommNotificationRecipient(channel string, to *apiModels.NotificationDeliveryTo) (string, error) {
+func normalizeCommNotificationRecipient(channel string, to *apiModels.NotificationDeliveryTo) (string, string, string, error) {
 	if to == nil {
 		if channel == commNotificationChannelEmail {
-			return "", apperrors.ValidationFailed("to.address", "email recipient is required")
+			return "", "", "", apperrors.ValidationFailed("to.address", "email recipient is required")
 		}
-		return "", nil
+		return "", "", "", nil
 	}
 
-	address, err := common.ValidateAndSanitizeString("to.address", to.Address, 1, commNotificationMaxToAddressLen)
+	address, err := normalizeCommNotificationOptionalAddress("to.address", to.Address, commNotificationMaxToAddressLen)
 	if err != nil {
-		return "", apperrors.ValidationFailed("to.address", err.Error())
+		return "", "", "", err
 	}
 
-	return address, nil
+	number, err := normalizeCommNotificationOptionalAddress("to.number", to.Number, commNotificationMaxPhoneNumberLen)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	identifier, field, identityErr := normalizeCommNotificationIdentity(channel, "to", address, number)
+	if identityErr != nil {
+		return "", "", "", apperrors.ValidationFailed(field, identityErr.Error())
+	}
+
+	return identifier, address, number, nil
 }
 
 func normalizeCommNotificationContent(channel, rawSubject, rawBody string) (string, string, error) {
@@ -223,6 +260,15 @@ func normalizeCommNotificationContent(channel, rawSubject, rawBody string) (stri
 	}
 
 	return subject, body, nil
+}
+
+func normalizeCommNotificationBodyMimeType(raw string) (string, error) {
+	bodyMimeType, err := common.ValidateAndSanitizeString("bodyMimeType", raw, 0, commNotificationMaxBodyMimeTypeLen)
+	if err != nil {
+		return "", apperrors.ValidationFailed("bodyMimeType", err.Error())
+	}
+
+	return strings.ToLower(strings.TrimSpace(bodyMimeType)), nil
 }
 
 func normalizeCommNotificationReceivedAt(raw string) (time.Time, error) {
@@ -283,6 +329,48 @@ func normalizeCommNotificationAttachments(raw []apiModels.NotificationDeliveryAt
 	}
 
 	return attachments, nil
+}
+
+func normalizeCommNotificationOptionalAddress(field, raw string, maxLen int) (string, error) {
+	value, err := common.ValidateAndSanitizeString(field, raw, 0, maxLen)
+	if err != nil {
+		return "", apperrors.ValidationFailed(field, err.Error())
+	}
+
+	return value, nil
+}
+
+func normalizeCommNotificationIdentity(channel, prefix, address, number string) (string, string, error) {
+	switch channel {
+	case commNotificationChannelEmail:
+		if address == "" {
+			return "", prefix + ".address", fmt.Errorf("email %s is required", identitySubject(prefix))
+		}
+		return address, "", nil
+	case commNotificationChannelSMS, commNotificationChannelVoice:
+		if number != "" {
+			return number, "", nil
+		}
+		if address != "" {
+			return address, "", nil
+		}
+		return "", prefix + ".number", fmt.Errorf("%s address or number is required", identitySubject(prefix))
+	default:
+		if address != "" {
+			return address, "", nil
+		}
+		if number != "" {
+			return number, "", nil
+		}
+		return "", prefix + ".address", fmt.Errorf("%s address is required", identitySubject(prefix))
+	}
+}
+
+func identitySubject(prefix string) string {
+	if prefix == "from" {
+		return "sender"
+	}
+	return "recipient"
 }
 
 func normalizeCommNotificationAttachment(idx int, attachment apiModels.NotificationDeliveryAttachment) (commNotificationAttachment, error) {

--- a/cmd/api/handlers/notification_delivery_contract_test.go
+++ b/cmd/api/handlers/notification_delivery_contract_test.go
@@ -72,19 +72,23 @@ func TestCommNotificationID_IsStable(t *testing.T) {
 func TestCommNotificationDeliveryContract_HelperCoverage(t *testing.T) {
 	t.Run("sender recipient and in-reply-to normalize", func(t *testing.T) {
 		soulAgentID := "agent-123"
-		fromAddress, displayName, normalizedSoulAgentID, err := normalizeCommNotificationSender(apiModels.NotificationDeliveryFrom{
+		fromIdentifier, fromAddress, fromNumber, displayName, normalizedSoulAgentID, err := normalizeCommNotificationSender(commNotificationChannelEmail, apiModels.NotificationDeliveryFrom{
 			Address:     "alice@example.com",
 			DisplayName: "Alice <Admin>",
 			SoulAgentID: &soulAgentID,
 		})
 		require.NoError(t, err)
+		require.Equal(t, "alice@example.com", fromIdentifier)
 		require.Equal(t, "alice@example.com", fromAddress)
+		require.Empty(t, fromNumber)
 		require.Equal(t, "Alice &lt;Admin&gt;", displayName)
 		require.Equal(t, soulAgentID, normalizedSoulAgentID)
 
-		toAddress, err := normalizeCommNotificationRecipient(commNotificationChannelSMS, nil)
+		toIdentifier, toAddress, toNumber, err := normalizeCommNotificationRecipient(commNotificationChannelSMS, nil)
 		require.NoError(t, err)
+		require.Empty(t, toIdentifier)
 		require.Empty(t, toAddress)
+		require.Empty(t, toNumber)
 
 		replyTo := "  parent-1  "
 		inReplyTo, err := normalizeCommNotificationInReplyTo(&replyTo)
@@ -101,6 +105,10 @@ func TestCommNotificationDeliveryContract_HelperCoverage(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, subject)
 		require.Equal(t, "hello &lt;b&gt;world&lt;/b&gt;", body)
+
+		bodyMimeType, err := normalizeCommNotificationBodyMimeType(" Text/Plain ")
+		require.NoError(t, err)
+		require.Equal(t, "text/plain", bodyMimeType)
 
 		_, _, err = normalizeCommNotificationContent(commNotificationChannelEmail, "", "hello")
 		require.Error(t, err)
@@ -152,8 +160,24 @@ func TestCommNotificationDeliveryContract_HelperCoverage(t *testing.T) {
 		_, err = normalizeCommNotificationChannel("pager")
 		require.Error(t, err)
 
-		_, err = normalizeCommNotificationRecipient(commNotificationChannelEmail, nil)
+		_, _, _, err = normalizeCommNotificationRecipient(commNotificationChannelEmail, nil)
 		require.Error(t, err)
+
+		fromIdentifier, fromAddress, fromNumber, _, _, err := normalizeCommNotificationSender(commNotificationChannelSMS, apiModels.NotificationDeliveryFrom{
+			Number: "+15551230000",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "+15551230000", fromIdentifier)
+		require.Empty(t, fromAddress)
+		require.Equal(t, "+15551230000", fromNumber)
+
+		toIdentifier, toAddress, toNumber, err := normalizeCommNotificationRecipient(commNotificationChannelSMS, &apiModels.NotificationDeliveryTo{
+			Number: "+15557654321",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "+15557654321", toIdentifier)
+		require.Empty(t, toAddress)
+		require.Equal(t, "+15557654321", toNumber)
 
 		var attachments []apiModels.NotificationDeliveryAttachment
 		for i := 0; i < commNotificationMaxAttachments+1; i++ {
@@ -167,5 +191,31 @@ func TestCommNotificationDeliveryContract_HelperCoverage(t *testing.T) {
 		}
 		_, err = normalizeCommNotificationAttachments(attachments)
 		require.Error(t, err)
+	})
+
+	t.Run("identity helpers cover email sms voice and fallback rules", func(t *testing.T) {
+		identifier, field, err := normalizeCommNotificationIdentity(commNotificationChannelEmail, "from", "alice@example.com", "")
+		require.NoError(t, err)
+		require.Equal(t, "alice@example.com", identifier)
+		require.Empty(t, field)
+
+		identifier, field, err = normalizeCommNotificationIdentity(commNotificationChannelEmail, "to", "", "")
+		require.Error(t, err)
+		require.Empty(t, identifier)
+		require.Equal(t, "to.address", field)
+		require.ErrorContains(t, err, "email recipient is required")
+
+		identifier, field, err = normalizeCommNotificationIdentity(commNotificationChannelVoice, "from", "sip:agent@example.com", "")
+		require.NoError(t, err)
+		require.Equal(t, "sip:agent@example.com", identifier)
+		require.Empty(t, field)
+
+		identifier, field, err = normalizeCommNotificationIdentity("push", "from", "", "token-123")
+		require.NoError(t, err)
+		require.Equal(t, "token-123", identifier)
+		require.Empty(t, field)
+
+		require.Equal(t, "sender", identitySubject("from"))
+		require.Equal(t, "recipient", identitySubject("to"))
 	})
 }

--- a/cmd/api/handlers/notification_delivery_round28_test.go
+++ b/cmd/api/handlers/notification_delivery_round28_test.go
@@ -213,4 +213,139 @@ func TestNotificationDelivery_Round28_AuthAndIdempotency(t *testing.T) {
 		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/api/v1/notifications/deliver", headers, nil, body)
 		requireStatus(t, http.StatusNoContent)(managedHandler.HandleDeliverNotificationLift(ctx))
 	})
+
+	t.Run("email body mime type is accepted and preserved", func(t *testing.T) {
+		mimeHandler, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
+
+		mimeHandler.registry = &RegistryStub{
+			NotificationsSvc: &NotificationsServiceStub{
+				CreateNotificationFunc: func(_ context.Context, cmd *notifications.CreateNotificationCommand) (*notifications.NotificationResult, error) {
+					require.Equal(t, "alice@example.com", cmd.ActorID)
+					require.NotNil(t, cmd.Data)
+					require.Equal(t, "text/plain", cmd.Data["bodyMimeType"])
+
+					from, ok := cmd.Data["from"].(map[string]interface{})
+					require.True(t, ok)
+					require.Equal(t, "alice@example.com", from["address"])
+					_, hasNumber := from["number"]
+					require.False(t, hasNumber)
+
+					return &notifications.NotificationResult{}, nil
+				},
+			},
+		}
+
+		body, err := json.Marshal(apiModels.NotificationDeliveryRequest{
+			Type:         "communication:inbound",
+			Channel:      "email",
+			From:         apiModels.NotificationDeliveryFrom{Address: "alice@example.com", DisplayName: "Alice"},
+			To:           &apiModels.NotificationDeliveryTo{Address: "agent-0@lessersoul.ai"},
+			Subject:      "hello",
+			Body:         "plain text body",
+			BodyMimeType: "text/plain",
+			ReceivedAt:   time.Date(2026, time.March, 4, 12, 0, 0, 0, time.UTC).Format(time.RFC3339),
+			MessageID:    "comm-msg-body-mime",
+		})
+		require.NoError(t, err)
+
+		headers := map[string]string{"Authorization": "Bearer " + cfg.InstanceAPIKey}
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/api/v1/notifications/deliver", headers, nil, body)
+		requireStatus(t, http.StatusNoContent)(mimeHandler.HandleDeliverNotificationLift(ctx))
+	})
+
+	t.Run("sms number payload is accepted and preserved", func(t *testing.T) {
+		smsHandler, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
+
+		smsHandler.registry = &RegistryStub{
+			NotificationsSvc: &NotificationsServiceStub{
+				CreateNotificationFunc: func(_ context.Context, cmd *notifications.CreateNotificationCommand) (*notifications.NotificationResult, error) {
+					require.Equal(t, "+15551230000", cmd.ActorID)
+					require.NotNil(t, cmd.Data)
+					require.Equal(t, "sms", cmd.Data["channel"])
+
+					from, ok := cmd.Data["from"].(map[string]interface{})
+					require.True(t, ok)
+					require.Equal(t, "+15551230000", from["number"])
+					_, hasAddress := from["address"]
+					require.False(t, hasAddress)
+
+					to, ok := cmd.Data["to"].(map[string]interface{})
+					require.True(t, ok)
+					require.Equal(t, "+15557654321", to["number"])
+					_, hasToAddress := to["address"]
+					require.False(t, hasToAddress)
+
+					return &notifications.NotificationResult{}, nil
+				},
+			},
+		}
+
+		body, err := json.Marshal(apiModels.NotificationDeliveryRequest{
+			Type:       "communication:inbound",
+			Channel:    "sms",
+			From:       apiModels.NotificationDeliveryFrom{Number: "+15551230000", DisplayName: "Alice"},
+			To:         &apiModels.NotificationDeliveryTo{Number: "+15557654321"},
+			Body:       "test message",
+			ReceivedAt: time.Date(2026, time.March, 4, 12, 5, 0, 0, time.UTC).Format(time.RFC3339),
+			MessageID:  "comm-msg-sms",
+		})
+		require.NoError(t, err)
+
+		headers := map[string]string{"Authorization": "Bearer " + cfg.InstanceAPIKey}
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/api/v1/notifications/deliver", headers, nil, body)
+		requireStatus(t, http.StatusNoContent)(smsHandler.HandleDeliverNotificationLift(ctx))
+	})
+}
+
+func TestNotificationDelivery_Round28_HelperPayloadBuilders(t *testing.T) {
+	t.Run("comm notification data includes optional fields", func(t *testing.T) {
+		delivery := &commNotificationDelivery{
+			Channel:         commNotificationChannelSMS,
+			FromAddress:     "fallback@example.com",
+			FromNumber:      "+15551230000",
+			FromDisplayName: "Alice",
+			FromSoulAgentID: "agent-1",
+			ToNumber:        "+15557654321",
+			BodyMimeType:    "text/plain",
+			ReceivedAt:      time.Date(2026, time.March, 4, 12, 5, 0, 0, time.UTC),
+			MessageID:       "comm-msg-sms",
+			InReplyTo:       "comm-msg-parent",
+			Attachments: []commNotificationAttachment{
+				{
+					ID:          "att-1",
+					Filename:    "note.txt",
+					ContentType: "text/plain",
+					SizeBytes:   42,
+					SHA256:      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				},
+			},
+		}
+
+		data := commNotificationData(delivery)
+
+		require.Equal(t, "sms", data["channel"])
+		require.Equal(t, "text/plain", data["bodyMimeType"])
+		require.Equal(t, "comm-msg-parent", data["inReplyTo"])
+
+		from, ok := data["from"].(map[string]interface{})
+		require.True(t, ok)
+		require.Equal(t, "fallback@example.com", from["address"])
+		require.Equal(t, "+15551230000", from["number"])
+		require.Equal(t, "Alice", from["displayName"])
+		require.Equal(t, "agent-1", from["soulAgentId"])
+
+		to, ok := data["to"].(map[string]interface{})
+		require.True(t, ok)
+		require.Equal(t, "+15557654321", to["number"])
+
+		attachments, ok := data["attachments"].([]map[string]interface{})
+		require.True(t, ok)
+		require.Len(t, attachments, 1)
+		require.Equal(t, "att-1", attachments[0]["id"])
+	})
+
+	t.Run("party and attachment helpers omit empty values", func(t *testing.T) {
+		require.Empty(t, commNotificationParty("", "", "", ""))
+		require.Nil(t, commNotificationAttachmentsData(nil))
+	})
 }

--- a/cmd/api/models/notification_delivery.go
+++ b/cmd/api/models/notification_delivery.go
@@ -6,21 +6,23 @@ package models
 // It is intentionally narrow (only the fields in the spec) so the instance side can
 // validate and persist notifications without guessing at provider-specific payloads.
 type NotificationDeliveryRequest struct {
-	Type        string                           `json:"type"`
-	Channel     string                           `json:"channel"`
-	From        NotificationDeliveryFrom         `json:"from"`
-	To          *NotificationDeliveryTo          `json:"to,omitempty"`
-	Subject     string                           `json:"subject"`
-	Body        string                           `json:"body"`
-	ReceivedAt  string                           `json:"receivedAt"`
-	MessageID   string                           `json:"messageId"`
-	InReplyTo   *string                          `json:"inReplyTo,omitempty"`
-	Attachments []NotificationDeliveryAttachment `json:"attachments,omitempty"`
+	Type         string                           `json:"type"`
+	Channel      string                           `json:"channel"`
+	From         NotificationDeliveryFrom         `json:"from"`
+	To           *NotificationDeliveryTo          `json:"to,omitempty"`
+	Subject      string                           `json:"subject"`
+	Body         string                           `json:"body"`
+	BodyMimeType string                           `json:"bodyMimeType,omitempty"`
+	ReceivedAt   string                           `json:"receivedAt"`
+	MessageID    string                           `json:"messageId"`
+	InReplyTo    *string                          `json:"inReplyTo,omitempty"`
+	Attachments  []NotificationDeliveryAttachment `json:"attachments,omitempty"`
 }
 
 // NotificationDeliveryFrom describes the sender for an inbound communication notification.
 type NotificationDeliveryFrom struct {
 	Address     string  `json:"address"`
+	Number      string  `json:"number,omitempty"`
 	SoulAgentID *string `json:"soulAgentId"`
 	DisplayName string  `json:"displayName"`
 }
@@ -28,6 +30,7 @@ type NotificationDeliveryFrom struct {
 // NotificationDeliveryTo describes the recipient for an inbound communication notification.
 type NotificationDeliveryTo struct {
 	Address string `json:"address"`
+	Number  string `json:"number,omitempty"`
 }
 
 // NotificationDeliveryAttachment carries metadata-only attachment information for inbound communication notifications.

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -3652,6 +3652,8 @@ components:
                     type: string
                 displayName:
                     type: string
+                number:
+                    type: string
                 soulAgentId:
                     anyOf:
                         - type: string
@@ -3668,6 +3670,8 @@ components:
                         $ref: '#/components/schemas/NotificationDeliveryAttachment'
                     type: array
                 body:
+                    type: string
+                bodyMimeType:
                     type: string
                 channel:
                     type: string
@@ -3702,6 +3706,8 @@ components:
             additionalProperties: false
             properties:
                 address:
+                    type: string
+                number:
                     type: string
             required:
                 - address


### PR DESCRIPTION
## Summary
- accept `bodyMimeType` plus `from.number`/`to.number` on the strict notification delivery contract
- normalize SMS and voice deliveries so numeric sender/recipient identities are valid and preserved in notification data
- add handler + normalization regression coverage and refresh the generated OpenAPI contract

## Verification
- `env GOTOOLCHAIN=auto go test ./cmd/api/handlers -coverprofile=/tmp/handlers322.out`
- `env GOTOOLCHAIN=auto go run ./cmd/lesser verify ci`

Closes #322