### PR TITLE
Fix notification delivery hardening regressions

### DIFF
--- a/pkg/services/notifications/service.go
+++ b/pkg/services/notifications/service.go
@@ -604,6 +604,15 @@ func (s *Service) ListNotifications(ctx context.Context, query *ListNotification
 	}
 
 	if err != nil {
+		s.logger.Error("notification query failed",
+			zap.String("user_id", query.UserID),
+			zap.Strings("types", query.Types),
+			zap.Strings("exclude_types", query.ExcludeTypes),
+			zap.Bool("only_unread", query.OnlyUnread),
+			zap.Bool("include_read", query.IncludeRead),
+			zap.String("actor_id", query.ActorID),
+			zap.String("target_type", query.TargetType),
+			zap.Error(err))
 		return nil, ErrNotificationQueryFailed
 	}
 

--- a/pkg/services/notifications/service_round27_more_coverage_test.go
+++ b/pkg/services/notifications/service_round27_more_coverage_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 type testStringer struct{ value string }
@@ -258,6 +260,42 @@ func TestService_ListNotifications_round27_error_paths(t *testing.T) {
 
 	_, err := service.ListNotifications(ctx, &ListNotificationsQuery{UserID: "alice"})
 	assert.ErrorIs(t, err, ErrNotificationQueryFailed)
+}
+
+func TestService_ListNotifications_logsUnderlyingQueryError_round27(t *testing.T) {
+	t.Parallel()
+
+	service, notificationRepo, _, _, _ := setupTestService()
+	ctx := context.Background()
+
+	core, observed := observer.New(zapcore.ErrorLevel)
+	service.logger = zap.New(core)
+
+	queryErr := errors.New("builder failed")
+	notificationRepo.On("GetUserNotifications", ctx, "alice", mock.AnythingOfType("interfaces.PaginationOptions")).Return(nil, queryErr).Once()
+
+	_, err := service.ListNotifications(ctx, &ListNotificationsQuery{
+		UserID:       "alice",
+		Types:        nil,
+		ExcludeTypes: []string{"follow"},
+		OnlyUnread:   false,
+		IncludeRead:  false,
+		ActorID:      "bob",
+		TargetType:   "status",
+	})
+	require.ErrorIs(t, err, ErrNotificationQueryFailed)
+
+	entries := observed.All()
+	require.Len(t, entries, 1)
+	assert.Equal(t, "notification query failed", entries[0].Message)
+	assert.Equal(t, "alice", entries[0].ContextMap()["user_id"])
+	assert.Empty(t, entries[0].ContextMap()["types"])
+	assert.Equal(t, []interface{}{"follow"}, entries[0].ContextMap()["exclude_types"])
+	assert.Equal(t, false, entries[0].ContextMap()["only_unread"])
+	assert.Equal(t, false, entries[0].ContextMap()["include_read"])
+	assert.Equal(t, "bob", entries[0].ContextMap()["actor_id"])
+	assert.Equal(t, "status", entries[0].ContextMap()["target_type"])
+	assert.Contains(t, entries[0].ContextMap()["error"], "builder failed")
 }
 
 func TestService_CreateNotification_round27_actor_optional_missing(t *testing.T) {

--- a/pkg/storage/models/audit_log.go
+++ b/pkg/storage/models/audit_log.go
@@ -49,14 +49,14 @@ type AuthAuditLog struct {
 	Metadata string `theorydb:"attr:metadata" json:"metadata,omitempty"`
 
 	// GSI keys for querying
-	GSI1PK string `theorydb:"attr:gsi1PK" json:"-"` // USER#username
-	GSI1SK string `theorydb:"attr:gsi1SK" json:"-"` // AUDIT#timestamp
-	GSI2PK string `theorydb:"attr:gsi2PK" json:"-"` // IP#address
-	GSI2SK string `theorydb:"attr:gsi2SK" json:"-"` // AUDIT#timestamp
-	GSI3PK string `theorydb:"attr:gsi3PK" json:"-"` // SESSION#id
-	GSI3SK string `theorydb:"attr:gsi3SK" json:"-"` // AUDIT#timestamp
-	GSI4PK string `theorydb:"attr:gsi4PK" json:"-"` // SEVERITY#level
-	GSI4SK string `theorydb:"attr:gsi4SK" json:"-"` // AUDIT#timestamp
+	GSI1PK string `theorydb:"index:gsi1,pk,attr:gsi1PK,omitempty" json:"-"` // USER#username
+	GSI1SK string `theorydb:"index:gsi1,sk,attr:gsi1SK,omitempty" json:"-"` // AUDIT#timestamp
+	GSI2PK string `theorydb:"index:gsi2,pk,attr:gsi2PK,omitempty" json:"-"` // IP#address
+	GSI2SK string `theorydb:"index:gsi2,sk,attr:gsi2SK,omitempty" json:"-"` // AUDIT#timestamp
+	GSI3PK string `theorydb:"index:gsi3,pk,attr:gsi3PK,omitempty" json:"-"` // SESSION#id
+	GSI3SK string `theorydb:"index:gsi3,sk,attr:gsi3SK,omitempty" json:"-"` // AUDIT#timestamp
+	GSI4PK string `theorydb:"index:gsi4,pk,attr:gsi4PK,omitempty" json:"-"` // SEVERITY#level
+	GSI4SK string `theorydb:"index:gsi4,sk,attr:gsi4SK,omitempty" json:"-"` // AUDIT#timestamp
 
 	// TTL for automatic deletion
 	TTL int64 `theorydb:"ttl,attr:ttl" json:"-"`

--- a/pkg/storage/models/round15_more_zero_coverage_models3_test.go
+++ b/pkg/storage/models/round15_more_zero_coverage_models3_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -103,6 +104,30 @@ func TestAuthAuditLog(t *testing.T) {
 		assert.InDelta(t, time.Now().Add(24*time.Hour).Unix(), a.TTL, 2)
 
 		require.NoError(t, a.BeforeSave())
+	})
+
+	t.Run("empty optional gsi sources stay unset and tags omit empty keys", func(t *testing.T) {
+		a := &AuthAuditLog{
+			ID:       "e2",
+			Severity: "info",
+		}
+
+		require.NoError(t, a.UpdateKeys())
+		assert.Empty(t, a.GSI1PK)
+		assert.Empty(t, a.GSI1SK)
+		assert.Empty(t, a.GSI2PK)
+		assert.Empty(t, a.GSI2SK)
+		assert.Empty(t, a.GSI3PK)
+		assert.Empty(t, a.GSI3SK)
+		assert.Equal(t, "SEVERITY#info", a.GSI4PK)
+		assert.NotEmpty(t, a.GSI4SK)
+
+		typ := reflect.TypeOf(AuthAuditLog{})
+		for _, fieldName := range []string{"GSI1PK", "GSI1SK", "GSI2PK", "GSI2SK", "GSI3PK", "GSI3SK", "GSI4PK", "GSI4SK"} {
+			field, ok := typ.FieldByName(fieldName)
+			require.True(t, ok)
+			assert.Contains(t, field.Tag.Get("theorydb"), "omitempty")
+		}
 	})
 }
 

--- a/pkg/storage/repositories/services.go
+++ b/pkg/storage/repositories/services.go
@@ -196,7 +196,7 @@ func (v *DefaultValidationService) isFieldEmpty(field reflect.Value) bool {
 // isCommonRequiredField checks if a field name indicates it should be required
 func (v *DefaultValidationService) isCommonRequiredField(fieldName string) bool {
 	commonRequired := []string{
-		"ID", "Id", "Username", "Name", "Title", "Type", "Status",
+		"ID", "Id", "Username", "Name", "Type", "Status",
 		// Note: Email is NOT in this list - email is optional for wallet-based auth
 	}
 

--- a/pkg/storage/repositories/services_round09_coverage_test.go
+++ b/pkg/storage/repositories/services_round09_coverage_test.go
@@ -63,6 +63,22 @@ func (m *testTaggedRequiredModel) UpdateKeys() error { return nil }
 func (m *testTaggedRequiredModel) GetPK() string     { return m.PK }
 func (m *testTaggedRequiredModel) GetSK() string     { return m.SK }
 
+type testOptionalTitleModel struct {
+	ID    string
+	Title string
+	PK    string
+	SK    string
+}
+
+func (m *testOptionalTitleModel) UpdateKeys() error {
+	m.PK = "PK#" + m.ID
+	m.SK = "SK#" + m.ID
+	return nil
+}
+
+func (m *testOptionalTitleModel) GetPK() string { return m.PK }
+func (m *testOptionalTitleModel) GetSK() string { return m.SK }
+
 type testEventHandler struct {
 	seen []Event
 	err  error
@@ -137,6 +153,16 @@ func TestServices_DefaultValidationService(t *testing.T) {
 		// Common required field name: ID.
 		err = svc.ValidateRequiredFields(context.Background(), &testServicesModel{})
 		assert.Error(t, err)
+	})
+
+	t.Run("title_is_not_treated_as_a_universal_required_field", func(t *testing.T) {
+		svc := NewDefaultValidationService()
+		model := &testOptionalTitleModel{ID: "notif-1"}
+		require.NoError(t, model.UpdateKeys())
+
+		err := svc.ValidateRequiredFields(context.Background(), model)
+		assert.NoError(t, err)
+		assert.False(t, svc.isCommonRequiredField("Title"))
 	})
 }
 


### PR DESCRIPTION
## Summary
- stop treating notification `Title` as a universal required field so SMS/voice inbound notifications can persist without synthetic subjects
- mark all `AuthAuditLog` GSI key attributes as indexed `omitempty` fields so best-effort audit writes no longer fail on empty secondary keys
- log the underlying notifications repository error before returning `ErrNotificationQueryFailed` so the live `GET /api/v1/notifications` failure can be diagnosed safely

## Verification
- `env GOTOOLCHAIN=auto go test ./cmd/api/handlers/... -run "TestCommNotificationDeliveryContract|TestNotificationDelivery_Round28|TestNotifications_ListIncludesCommNotifications_Round28"`
- `env GOTOOLCHAIN=auto go test ./pkg/storage/repositories/... ./pkg/storage/models/... ./pkg/services/notifications/...`
- `env GOTOOLCHAIN=auto go run ./cmd/lesser verify ci`

Closes #325
Closes #326
Closes #327