### PR TITLE
Fix notification cursor pagination query shape

### DIFF
--- a/pkg/storage/repositories/notification_repository.go
+++ b/pkg/storage/repositories/notification_repository.go
@@ -43,6 +43,15 @@ func (r *NotificationRepository) SetDispatcher(dispatcher interfaces.Notificatio
 	r.dispatcher = dispatcher
 }
 
+func applyNotificationSortKeyScope(query core.Query, cursor string) core.Query {
+	if cursor == "" {
+		return query.Where("SK", "begins_with", "notif#")
+	}
+
+	return query.Where("SK", "<", cursor).
+		Filter("SK", "begins_with", "notif#")
+}
+
 // CreateNotification creates a new notification using BaseRepository
 func (r *NotificationRepository) CreateNotification(ctx context.Context, notification *models.Notification) error {
 	if err := notification.BeforeCreate(); err != nil {
@@ -121,15 +130,12 @@ func (r *NotificationRepository) GetUserNotifications(ctx context.Context, userI
 		opts.Limit = 100
 	}
 	pk := "USER#" + userID
-	query := r.db.WithContext(ctx).Model(&models.Notification{}).
-		Where("PK", "=", pk).
-		Where("SK", "begins_with", "notif#").
-		OrderBy("SK", "DESC") // Most recent first
-
-	// Resume from the supplied cursor value when available
-	if opts.Cursor != "" {
-		query = query.Where("SK", "<", opts.Cursor)
-	}
+	query := applyNotificationSortKeyScope(
+		r.db.WithContext(ctx).Model(&models.Notification{}).
+			Where("PK", "=", pk).
+			OrderBy("SK", "DESC"), // Most recent first
+		opts.Cursor,
+	)
 
 	// Fetch limit+1 to detect if more results exist
 	query = query.Limit(opts.Limit + 1)
@@ -176,16 +182,12 @@ func (r *NotificationRepository) GetUnreadNotifications(ctx context.Context, use
 		opts.Limit = 100
 	}
 	pk := "USER#" + userID
-	query := r.db.WithContext(ctx).Model(&models.Notification{}).
-		Where("PK", "=", pk).
-		Where("SK", "begins_with", "notif#").
-		Filter("IsRead", "=", false).
-		OrderBy("SK", "DESC") // Most recent first
-
-	// Resume from the supplied cursor value when available
-	if opts.Cursor != "" {
-		query = query.Where("SK", "<", opts.Cursor)
-	}
+	query := applyNotificationSortKeyScope(
+		r.db.WithContext(ctx).Model(&models.Notification{}).
+			Where("PK", "=", pk).
+			OrderBy("SK", "DESC"), // Most recent first
+		opts.Cursor,
+	).Filter("IsRead", "=", false)
 
 	// Fetch limit+1 to detect if more results exist
 	query = query.Limit(opts.Limit + 1)
@@ -471,15 +473,12 @@ func (r *NotificationRepository) GetNotificationGroups(ctx context.Context, user
 	}
 
 	pk := "USER#" + userID
-	query := r.db.WithContext(ctx).Model(&models.Notification{}).
-		Where("PK", "=", pk).
-		Where("SK", "begins_with", "notif#").
-		OrderBy("SK", "DESC")
-
-	// Resume from the supplied cursor value when available
-	if opts.Cursor != "" {
-		query = query.Where("SK", "<", opts.Cursor)
-	}
+	query := applyNotificationSortKeyScope(
+		r.db.WithContext(ctx).Model(&models.Notification{}).
+			Where("PK", "=", pk).
+			OrderBy("SK", "DESC"),
+		opts.Cursor,
+	)
 
 	// Fetch extra items to account for grouping expansion and detect more results
 	query = query.Limit((opts.Limit * 3) + 1)
@@ -897,18 +896,16 @@ func (r *NotificationRepository) GetNotificationsAdvanced(ctx context.Context, u
 	}
 
 	pk := "USER#" + userID
-	query := r.db.WithContext(ctx).Model(&models.Notification{}).
-		Where("PK", "=", pk).
-		Where("SK", "begins_with", "notif#").
-		OrderBy("SK", "DESC")
+	query := applyNotificationSortKeyScope(
+		r.db.WithContext(ctx).Model(&models.Notification{}).
+			Where("PK", "=", pk).
+			OrderBy("SK", "DESC"),
+		pagination.Cursor,
+	)
 
 	// Apply additional filters
 	for key, value := range filters {
 		query = query.Filter(key, "=", value)
-	}
-
-	if pagination.Cursor != "" {
-		query = query.Where("SK", "<", pagination.Cursor)
 	}
 
 	query = query.Limit(pagination.Limit + 1)

--- a/pkg/storage/repositories/notification_repository_coverage_test.go
+++ b/pkg/storage/repositories/notification_repository_coverage_test.go
@@ -17,6 +17,24 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
+func countMockCalls(q *mocks.MockQuery, method, field, op string) int {
+	count := 0
+	for _, call := range q.Calls {
+		if call.Method != method || len(call.Arguments) < 2 {
+			continue
+		}
+		if gotField, ok := call.Arguments.Get(0).(string); !ok || gotField != field {
+			continue
+		}
+		if gotOp, ok := call.Arguments.Get(1).(string); !ok || gotOp != op {
+			continue
+		}
+		count++
+	}
+
+	return count
+}
+
 type fakeNotificationDispatcher struct {
 	calls int
 }
@@ -446,6 +464,8 @@ func TestRound07_NotificationRepository_UserNotifications_PaginationBranches(t *
 	require.NoError(t, err)
 	require.True(t, result.HasMore)
 	require.Equal(t, "notif#2", result.NextCursor)
+	require.Equal(t, 1, countMockCalls(mockQuery, "Where", "SK", "<"))
+	require.Equal(t, 1, countMockCalls(mockQuery, "Filter", "SK", "begins_with"))
 
 	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
 		ptr := args.Get(0).(*[]models.Notification)
@@ -458,6 +478,9 @@ func TestRound07_NotificationRepository_UserNotifications_PaginationBranches(t *
 	require.NoError(t, err)
 	require.True(t, result.HasMore)
 	require.Equal(t, "notif#2", result.NextCursor)
+	require.Equal(t, 2, countMockCalls(mockQuery, "Where", "SK", "<"))
+	require.Equal(t, 2, countMockCalls(mockQuery, "Filter", "SK", "begins_with"))
+	require.Equal(t, 1, countMockCalls(mockQuery, "Filter", "IsRead", "="))
 }
 
 func TestRound07_NotificationRepository_GetUserNotifications_LogsQueryError(t *testing.T) {
@@ -487,6 +510,35 @@ func TestRound07_NotificationRepository_GetUserNotifications_LogsQueryError(t *t
 	fields := entries[0].ContextMap()
 	require.Equal(t, "user-1", fields["user_id"])
 	require.Equal(t, queryErr.Error(), fields["error"])
+}
+
+func TestRound07_NotificationRepository_NotificationQueries_MovePrefixToFilterWhenCursorPresent(t *testing.T) {
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB).Maybe()
+	mockDB.On("Model", mock.Anything).Return(mockQuery).Maybe()
+	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery).Maybe()
+	mockQuery.On("Filter", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery).Maybe()
+	mockQuery.On("OrderBy", mock.Anything, mock.Anything).Return(mockQuery).Maybe()
+	mockQuery.On("Limit", mock.Anything).Return(mockQuery).Maybe()
+
+	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
+		ptr := args.Get(0).(*[]models.Notification)
+		*ptr = []models.Notification{{SK: "notif#2", UserID: "user-1"}}
+	}).Return(nil).Times(2)
+
+	repo := NewNotificationRepository(mockDB, "test-table", zap.NewNop(), nil)
+
+	_, err := repo.GetNotificationGroups(context.Background(), "user-1", interfaces.PaginationOptions{Limit: 1, Cursor: "notif#99"})
+	require.NoError(t, err)
+
+	_, err = repo.GetNotificationsAdvanced(context.Background(), "user-1", map[string]interface{}{"Type": "mention"}, interfaces.PaginationOptions{Limit: 1, Cursor: "notif#99"})
+	require.NoError(t, err)
+
+	require.Equal(t, 2, countMockCalls(mockQuery, "Where", "SK", "<"))
+	require.Equal(t, 2, countMockCalls(mockQuery, "Filter", "SK", "begins_with"))
+	require.Equal(t, 1, countMockCalls(mockQuery, "Filter", "Type", "="))
 }
 
 func TestRound07_NotificationRepository_MarkUnreadAndPush_GetErrorBranches(t *testing.T) {


### PR DESCRIPTION
## Summary
- move notification sort-key prefix matching into a filter when a pagination cursor is present
- reuse the same DynamoDB-safe sort-key scoping in user, unread, grouped, and advanced notification queries
- add repository regressions that assert the cursor path uses one SK key condition plus a prefix filter

## Verification
- `env GOTOOLCHAIN=auto go test ./pkg/storage/repositories/... -run 'TestRound07_NotificationRepository_(UserNotifications_PaginationBranches|GetUserNotifications_LogsQueryError|NotificationQueries_MovePrefixToFilterWhenCursorPresent)'`
- `env GOTOOLCHAIN=auto go run ./cmd/lesser verify ci`

Closes #333
