### PR TITLE
Fix comm recipient resolution by full contact identifier

### DIFF
--- a/cmd/api/handlers/notification_delivery.go
+++ b/cmd/api/handlers/notification_delivery.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	apiModels "github.com/equaltoai/lesser/cmd/api/models"
-	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/common"
 	apperrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/services/notifications"
@@ -172,41 +171,15 @@ func (h *Handler) notificationDeliveryAddressedRecipient(ctx context.Context, de
 		return ""
 	}
 
-	localPart, domain, ok := splitNotificationDeliveryAddress(delivery.ToAddress)
-	if !ok || !h.isNotificationDeliveryLocalDomain(domain) {
-		return ""
+	if username := h.notificationDeliveryBoundContactIdentifier(ctx, delivery.ToAddress); username != "" {
+		return username
 	}
 
-	lookupUsername := strings.TrimSpace(localPart)
-	canonicalUsername := h.notificationDeliveryCanonicalUsername(ctx, localPart)
-	if canonicalUsername != "" {
-		lookupUsername = canonicalUsername
+	if username := h.notificationDeliveryBoundContactIdentifier(ctx, delivery.ToNumber); username != "" {
+		return username
 	}
 
-	if bindingUsername := h.notificationDeliveryBoundUsername(ctx, lookupUsername); bindingUsername != "" {
-		return bindingUsername
-	}
-
-	if lookupUsername != localPart {
-		if bindingUsername := h.notificationDeliveryBoundUsername(ctx, localPart); bindingUsername != "" {
-			return bindingUsername
-		}
-	}
-
-	if canonicalUsername == "" {
-		return ""
-	}
-
-	if h == nil || h.repos == nil || h.repos.Account() == nil {
-		return ""
-	}
-
-	account, err := h.repos.Account().GetAccount(ctx, lookupUsername)
-	if err != nil || account == nil || account.User == nil || !account.User.IsAgent {
-		return ""
-	}
-
-	return strings.TrimSpace(account.User.Username)
+	return ""
 }
 
 func (h *Handler) notificationDeliveryRecipient(ctx context.Context) string {
@@ -242,100 +215,47 @@ func (h *Handler) notificationDeliveryBoundUsername(ctx context.Context, usernam
 
 	binding, err := h.repos.Instance().GetSoulBodyBindingByUsername(ctx, username)
 	if err != nil || binding == nil {
-		canonicalUsername := h.notificationDeliveryCanonicalUsername(ctx, username)
-		if canonicalUsername == "" || canonicalUsername == username {
-			return ""
-		}
-
-		binding, err = h.repos.Instance().GetSoulBodyBindingByUsername(ctx, canonicalUsername)
-		if err != nil || binding == nil {
-			return ""
-		}
+		return ""
 	}
 
 	return strings.TrimSpace(binding.Username)
 }
 
-func (h *Handler) notificationDeliveryCanonicalUsername(ctx context.Context, username string) string {
-	if h == nil || h.repos == nil {
+func (h *Handler) notificationDeliveryBoundContactIdentifier(ctx context.Context, identifier string) string {
+	username := h.notificationDeliveryUsernameForContactIdentifier(ctx, identifier)
+	if username == "" {
 		return ""
 	}
 
-	if h.repos.Account() != nil {
-		account, err := h.repos.Account().GetAccount(ctx, username)
-		if err == nil && account != nil && account.User != nil && account.User.IsAgent {
-			return strings.TrimSpace(account.User.Username)
-		}
+	if bindingUsername := h.notificationDeliveryBoundUsername(ctx, username); bindingUsername != "" {
+		return bindingUsername
 	}
 
-	if h.repos.Actor() != nil {
-		results, err := h.repos.Actor().SearchAccounts(ctx, username, 10, false, 0)
-		if err == nil {
-			if canonical := h.notificationDeliveryMatchingLocalUsername(username, results); canonical != "" {
-				return canonical
-			}
-		}
-	}
-
-	if h.repos.Search() != nil {
-		results, err := h.repos.Search().SearchAccounts(ctx, username, 10, false, 0)
-		if err == nil {
-			if canonical := h.notificationDeliveryMatchingLocalUsername(username, results); canonical != "" {
-				return canonical
-			}
-		}
-	}
-
-	return ""
+	return username
 }
 
-func (h *Handler) notificationDeliveryMatchingLocalUsername(username string, actors []*activitypub.Actor) string {
-	for _, actor := range actors {
-		if actor == nil || !h.actorAppearsLocal(actor) {
-			continue
-		}
-		if strings.EqualFold(strings.TrimSpace(actor.PreferredUsername), username) {
-			return strings.TrimSpace(actor.PreferredUsername)
-		}
+func (h *Handler) notificationDeliveryUsernameForContactIdentifier(ctx context.Context, identifier string) string {
+	if h == nil || h.repos == nil || h.repos.Account() == nil {
+		return ""
 	}
 
-	return ""
-}
-
-func (h *Handler) isNotificationDeliveryLocalDomain(domain string) bool {
-	domain = strings.ToLower(strings.TrimSpace(domain))
-	if domain == "" {
-		return false
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return ""
 	}
 
-	if domain == "lessersoul.ai" {
-		return true
-	}
-	if h == nil || h.cfg == nil {
-		return false
+	if !strings.Contains(identifier, "@") {
+		return ""
 	}
 
-	return domain == strings.ToLower(strings.TrimSpace(h.cfg.Domain))
-}
-
-func splitNotificationDeliveryAddress(address string) (string, string, bool) {
-	address = strings.TrimSpace(address)
-	if address == "" {
-		return "", "", false
+	actor, err := h.repos.Account().SearchByWebfinger(ctx, identifier)
+	if err != nil || actor == nil {
+		return ""
 	}
-
-	at := strings.LastIndex(address, "@")
-	if at <= 0 || at == len(address)-1 {
-		return "", "", false
+	if !h.actorAppearsLocal(actor) {
+		return ""
 	}
-
-	localPart := strings.TrimSpace(address[:at])
-	domain := strings.TrimSpace(address[at+1:])
-	if localPart == "" || domain == "" {
-		return "", "", false
-	}
-
-	return localPart, domain, true
+	return strings.TrimSpace(actor.PreferredUsername)
 }
 
 func (h *Handler) notificationDeliveryKeys() []string {

--- a/cmd/api/handlers/notification_delivery_round28_test.go
+++ b/cmd/api/handlers/notification_delivery_round28_test.go
@@ -69,7 +69,7 @@ func TestNotificationDelivery_Round28_AuthAndIdempotency(t *testing.T) {
 		require.GreaterOrEqual(t, len(seenCmds), 2)
 		cmd := seenCmds[len(seenCmds)-1]
 
-		expectedID, idErr := commNotificationID(cfg.AdminUsername, "comm-msg-001")
+		expectedID, idErr := commNotificationID("agent-bob", "comm-msg-001")
 		require.NoError(t, idErr)
 		require.Equal(t, expectedID, cmd.ID)
 
@@ -77,7 +77,7 @@ func TestNotificationDelivery_Round28_AuthAndIdempotency(t *testing.T) {
 		require.Equal(t, time.Date(2026, time.March, 4, 12, 0, 0, 0, time.UTC), cmd.CreatedAt.UTC())
 
 		require.Equal(t, commNotificationTypeInbound, cmd.Type)
-		require.Equal(t, cfg.AdminUsername, cmd.UserID)
+		require.Equal(t, "agent-bob", cmd.UserID)
 		require.Equal(t, "alice@example.com", cmd.ActorID)
 
 		require.NotNil(t, cmd.Data)
@@ -121,7 +121,7 @@ func TestNotificationDelivery_Round28_AuthAndIdempotency(t *testing.T) {
 		managedHandler.registry = &RegistryStub{
 			NotificationsSvc: &NotificationsServiceStub{
 				CreateNotificationFunc: func(_ context.Context, cmd *notifications.CreateNotificationCommand) (*notifications.NotificationResult, error) {
-					require.Equal(t, managedCfg.AdminUsername, cmd.UserID)
+					require.Equal(t, "agent-bob", cmd.UserID)
 					return &notifications.NotificationResult{}, nil
 				},
 			},
@@ -144,7 +144,7 @@ func TestNotificationDelivery_Round28_AuthAndIdempotency(t *testing.T) {
 		managedHandler.registry = &RegistryStub{
 			NotificationsSvc: &NotificationsServiceStub{
 				CreateNotificationFunc: func(_ context.Context, cmd *notifications.CreateNotificationCommand) (*notifications.NotificationResult, error) {
-					require.Equal(t, "simulacrum", cmd.UserID)
+					require.Equal(t, "agent-bob", cmd.UserID)
 					return &notifications.NotificationResult{}, nil
 				},
 			},

--- a/cmd/api/handlers/round10_test_helpers_test.go
+++ b/cmd/api/handlers/round10_test_helpers_test.go
@@ -643,6 +643,32 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 		return true
 	})).Return(dynamormerrors.ErrItemNotFound).Maybe()
 
+	mockQuery.On("First", mock.MatchedBy(func(dest any) bool {
+		if _, ok := dest.(*storagemodels.User); !ok {
+			return false
+		}
+		pk, ok := state.whereString("PK")
+		if !ok || !strings.HasPrefix(pk, "USER#") || state.usersByUsername == nil {
+			return false
+		}
+		username := strings.TrimPrefix(pk, "USER#")
+		_, exactExists := state.usersByUsername[username]
+		return !exactExists
+	})).Return(dynamormerrors.ErrItemNotFound).Maybe()
+
+	mockQuery.On("First", mock.MatchedBy(func(dest any) bool {
+		if _, ok := dest.(*storagemodels.Actor); !ok {
+			return false
+		}
+		pk, ok := state.whereString("PK")
+		if !ok || !strings.HasPrefix(pk, "ACTOR#") || state.actorsByUser == nil {
+			return false
+		}
+		username := strings.TrimPrefix(pk, "ACTOR#")
+		_, exactExists := state.actorsByUser[username]
+		return !exactExists
+	})).Return(dynamormerrors.ErrItemNotFound).Maybe()
+
 	mockQuery.On("First", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		dest := args.Get(0)
 		switch d := dest.(type) {
@@ -656,6 +682,15 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 			username := ""
 			if pk, ok := state.whereString("PK"); ok && strings.HasPrefix(pk, "USER#") {
 				username = strings.TrimPrefix(pk, "USER#")
+			} else if gsi5pk, ok := state.whereString("gsi5PK"); ok && strings.HasPrefix(gsi5pk, "USER_HANDLE_PREFIX#") {
+				if gsi5sk, ok := state.whereString("gsi5SK"); ok {
+					for candidate, user := range state.usersByUsername {
+						if strings.EqualFold(strings.TrimSpace(user.Username), gsi5sk) || strings.EqualFold(strings.TrimSpace(candidate), gsi5sk) {
+							*d = user
+							return
+						}
+					}
+				}
 			}
 			if user, ok := state.usersByUsername[username]; ok {
 				*d = user

--- a/pkg/storage/repositories/account_repository.go
+++ b/pkg/storage/repositories/account_repository.go
@@ -462,11 +462,15 @@ func (r *AccountRepository) isLocalDomain(domain string) bool {
 	if domain == "" {
 		return false
 	}
+	normalizedDomain := normalizeDomainValue(domain)
+	if normalizedDomain == "lessersoul.ai" || strings.HasSuffix(normalizedDomain, ".lessersoul.ai") {
+		return true
+	}
 	repoDomain := r.domain
 	if strings.TrimSpace(repoDomain) == "" {
 		repoDomain = config.Get().Domain
 	}
-	return normalizeDomainValue(domain) == normalizeDomainValue(repoDomain)
+	return normalizedDomain == normalizeDomainValue(repoDomain)
 }
 
 func normalizeDomainValue(domain string) string {

--- a/pkg/storage/repositories/account_repository_search.go
+++ b/pkg/storage/repositories/account_repository_search.go
@@ -306,8 +306,15 @@ func (r *AccountRepository) SearchByWebfinger(ctx context.Context, webfinger str
 	domain := parts[1]
 
 	// If local domain, search locally
-	if domain == r.domain {
-		return r.GetActor(ctx, username)
+	if r.isLocalDomain(domain) {
+		resolvedUsername, err := r.resolveLocalUsernameByHandle(ctx, username)
+		if err != nil {
+			return nil, err
+		}
+		if resolvedUsername == "" {
+			return nil, ErrorHandler.HandleGetError(errors.ErrItemNotFound, EntityActor, webfinger)
+		}
+		return r.GetActor(ctx, resolvedUsername)
 	}
 
 	// Search for remote actor
@@ -329,6 +336,43 @@ func (r *AccountRepository) SearchByWebfinger(ctx context.Context, webfinger str
 	}
 
 	return actor.Actor, nil
+}
+
+func (r *AccountRepository) resolveLocalUsernameByHandle(ctx context.Context, username string) (string, error) {
+	username = strings.TrimSpace(strings.TrimPrefix(username, "@"))
+	if username == "" {
+		return "", nil
+	}
+
+	user, err := r.GetUser(ctx, username)
+	if err == nil && user != nil {
+		return strings.TrimSpace(user.Username), nil
+	}
+
+	if r.db == nil {
+		return "", nil
+	}
+
+	normalizedUsername := strings.ToLower(username)
+	prefix := normalizedUsername
+	if len(prefix) > 2 {
+		prefix = prefix[:2]
+	}
+
+	var userModel models.User
+	err = r.db.WithContext(ctx).Model(&userModel).
+		Index("gsi5").
+		Where("gsi5PK", "=", fmt.Sprintf("USER_HANDLE_PREFIX#%s", prefix)).
+		Where("gsi5SK", "=", normalizedUsername).
+		First(&userModel)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", ErrorHandler.HandleQueryError(err, EntityActor, fmt.Sprintf("local webfinger search: %s", username))
+	}
+
+	return strings.TrimSpace(userModel.Username), nil
 }
 
 // CacheRemoteActor caches a remote actor for search

--- a/pkg/storage/repositories/account_repository_search_coverage_test.go
+++ b/pkg/storage/repositories/account_repository_search_coverage_test.go
@@ -119,6 +119,116 @@ func TestAccountRepository_SearchByWebfinger_RemoteNotFound(t *testing.T) {
 	mockQuery.AssertExpectations(t)
 }
 
+func TestAccountRepository_SearchByWebfinger_LocalDomainCanonicalizesMixedCaseUsername(t *testing.T) {
+	ctx := context.Background()
+	baseTime := time.Date(2025, 2, 3, 4, 5, 6, 0, time.UTC)
+
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+
+	mockQuery.On("First", mock.MatchedBy(func(dest any) bool {
+		_, ok := dest.(*models.User)
+		return ok
+	})).Return(errors.ErrItemNotFound).Once()
+
+	mockQuery.On("First", mock.MatchedBy(func(dest any) bool {
+		_, ok := dest.(*models.User)
+		return ok
+	})).Run(func(args mock.Arguments) {
+		user := args.Get(0).(*models.User)
+		user.Username = "Medic"
+		user.Role = "user"
+		user.CreatedAt = baseTime
+		user.UpdatedAt = baseTime
+		_ = user.UpdateKeys()
+	}).Return(nil).Once()
+
+	mockQuery.On("First", mock.MatchedBy(func(dest any) bool {
+		_, ok := dest.(*models.Actor)
+		return ok
+	})).Run(func(args mock.Arguments) {
+		actor := args.Get(0).(*models.Actor)
+		actor.Username = "Medic"
+		actor.CreatedAt = baseTime
+		actor.UpdatedAt = baseTime
+		actor.Actor = &activitypub.Actor{
+			PreferredUsername: "Medic",
+			Name:              "Medic",
+			BaseObject: activitypub.BaseObject{
+				ID: "https://example.com/users/Medic",
+			},
+		}
+		_ = actor.UpdateKeys()
+	}).Return(nil).Once()
+
+	setupPermissiveAccountRepositoryMocks(mockDB, mockQuery, nil, baseTime)
+
+	repo := NewAccountRepository(mockDB, "test-table", "example.com", zaptest.NewLogger(t))
+
+	actor, err := repo.SearchByWebfinger(ctx, "medic@example.com")
+	require.NoError(t, err)
+	require.NotNil(t, actor)
+	require.Equal(t, "Medic", actor.PreferredUsername)
+
+	mockDB.AssertExpectations(t)
+	mockQuery.AssertExpectations(t)
+}
+
+func TestAccountRepository_SearchByWebfinger_ManagedLesserSoulAliasIsLocal(t *testing.T) {
+	ctx := context.Background()
+	baseTime := time.Date(2025, 2, 3, 4, 5, 6, 0, time.UTC)
+
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+
+	mockQuery.On("First", mock.MatchedBy(func(dest any) bool {
+		_, ok := dest.(*models.User)
+		return ok
+	})).Return(errors.ErrItemNotFound).Once()
+
+	mockQuery.On("First", mock.MatchedBy(func(dest any) bool {
+		_, ok := dest.(*models.User)
+		return ok
+	})).Run(func(args mock.Arguments) {
+		user := args.Get(0).(*models.User)
+		user.Username = "Agent-0"
+		user.Role = "user"
+		user.CreatedAt = baseTime
+		user.UpdatedAt = baseTime
+		_ = user.UpdateKeys()
+	}).Return(nil).Once()
+
+	mockQuery.On("First", mock.MatchedBy(func(dest any) bool {
+		_, ok := dest.(*models.Actor)
+		return ok
+	})).Run(func(args mock.Arguments) {
+		actor := args.Get(0).(*models.Actor)
+		actor.Username = "Agent-0"
+		actor.CreatedAt = baseTime
+		actor.UpdatedAt = baseTime
+		actor.Actor = &activitypub.Actor{
+			PreferredUsername: "Agent-0",
+			Name:              "Agent-0",
+			BaseObject: activitypub.BaseObject{
+				ID: "https://example.com/users/Agent-0",
+			},
+		}
+		_ = actor.UpdateKeys()
+	}).Return(nil).Once()
+
+	setupPermissiveAccountRepositoryMocks(mockDB, mockQuery, nil, baseTime)
+
+	repo := NewAccountRepository(mockDB, "test-table", "example.com", zaptest.NewLogger(t))
+
+	actor, err := repo.SearchByWebfinger(ctx, "agent-0@lessersoul.ai")
+	require.NoError(t, err)
+	require.NotNil(t, actor)
+	require.Equal(t, "Agent-0", actor.PreferredUsername)
+
+	mockDB.AssertExpectations(t)
+	mockQuery.AssertExpectations(t)
+}
+
 func TestAccountRepository_SearchAllActors_FilteringAndErrorBranches(t *testing.T) {
 	ctx := context.Background()
 	baseTime := time.Date(2025, 2, 3, 4, 5, 6, 0, time.UTC)


### PR DESCRIPTION
## Summary
- route inbound comm recipient resolution through the full addressed contact identifier instead of calling `GetAccount()` on an extracted local-part username
- teach local webfinger lookup to canonicalize mixed-case local usernames through the handle index, including the managed `lessersoul.ai` alias path
- update the notification delivery regressions and Dynamo harness so addressed inbound comms resolve to the bound agent instead of the admin fallback

## Verification
- `env GOTOOLCHAIN=auto go test ./pkg/storage/repositories/... -run 'TestAccountRepository_SearchByWebfinger_(InvalidFormat|RemoteNotFound|LocalDomainCanonicalizesMixedCaseUsername|ManagedLesserSoulAliasIsLocal)'`
- `env GOTOOLCHAIN=auto go test ./cmd/api/handlers/... -run 'TestNotificationDelivery_Round28_AuthAndIdempotency'`
- `env GOTOOLCHAIN=auto go run ./cmd/lesser verify ci`

Closes #338
