### PR TITLE
fix numeric account id mappings (#374)

### DIFF
--- a/cmd/api/handlers/accounts_round21_numeric_recovery_test.go
+++ b/cmd/api/handlers/accounts_round21_numeric_recovery_test.go
@@ -205,3 +205,32 @@ func TestAccountsRound21_VerifyCredentialsEnsuresOwnNumericIDStillWorks(t *testi
 
 	requireStatus(t, http.StatusOK)(h.HandleVerifyCredentialsLift(ctx))
 }
+
+func TestAccountsFullRound21_ResolveAccountIDFull_RecoversLegacyMixedCaseNumericIDRows(t *testing.T) {
+	cfg := round10TestConfig()
+	username := "agent-0"
+	requestedNumericID := common.GenerateNumericID(username)
+
+	legacyActor := round21LocalActor(cfg.BaseURL(), "Agent-0")
+	legacyActor.PK = "ACTOR#" + username
+	legacyActor.Username = username
+	legacyActor.GSI3SK = username
+
+	state := &round10QueryState{
+		usersByUsername: map[string]storagemodels.User{
+			username: round21LocalUser(username),
+		},
+		actorsByUser: map[string]storagemodels.Actor{
+			username: legacyActor,
+		},
+		notFoundPKs: map[string]bool{
+			"NUMERIC_ID#" + requestedNumericID: true,
+		},
+	}
+
+	h, _, _ := round11NewHandler(t, cfg, state)
+	actor, err := h.resolveAccountIDFull(context.Background(), requestedNumericID)
+	require.NoError(t, err)
+	require.NotNil(t, actor)
+	require.Equal(t, username, actor.PreferredUsername)
+}

--- a/cmd/api/handlers/helpers.go
+++ b/cmd/api/handlers/helpers.go
@@ -181,45 +181,70 @@ func (h *Handler) recoverLocalActorByNumericID(ctx context.Context, numericID st
 
 	trimmedNumericID := strings.TrimSpace(numericID)
 	for _, actorModel := range actorModels {
-		if strings.TrimSpace(actorModel.NumericID) != trimmedNumericID {
+		canonicalUsername, ok := recoveredActorCanonicalUsername(actorModel, trimmedNumericID)
+		if !ok {
 			continue
 		}
-
-		username := strings.TrimSpace(actorModel.Username)
-		if username == "" && actorModel.Actor != nil {
-			username = strings.TrimSpace(actorModel.Actor.PreferredUsername)
-		}
-		if username == "" {
-			continue
-		}
-
-		h.ensureLocalNumericIDMapping(ctx, username)
-
-		actor, err := h.repos.Actor().GetActor(ctx, username)
+		actor, err := h.loadRecoveredLocalActor(ctx, canonicalUsername, actorModel.Actor)
 		if err == nil && actor != nil {
 			return actor, nil
 		}
 		if err != nil && !isMissingAccountLookup(err) {
 			return nil, err
 		}
-
-		actor = actorModel.Actor
-		if actor == nil {
-			continue
-		}
-		if strings.TrimSpace(actor.PreferredUsername) == "" {
-			actor.PreferredUsername = username
-		}
-		if strings.TrimSpace(actor.ID) == "" {
-			baseURL := handlerBaseURL(h)
-			if baseURL != "" {
-				actor.ID = baseURL + "/users/" + username
-			}
-		}
-		return actor, nil
 	}
 
 	return nil, common.ActorNotFoundError{Username: numericID}
+}
+
+func recoveredActorCanonicalUsername(actorModel storageModels.Actor, numericID string) (string, bool) {
+	username := strings.TrimSpace(actorModel.Username)
+	if username == "" && actorModel.Actor != nil {
+		username = strings.TrimSpace(actorModel.Actor.PreferredUsername)
+	}
+	if username == "" {
+		return "", false
+	}
+
+	canonicalUsername := strings.ToLower(username)
+	if strings.TrimSpace(actorModel.NumericID) != numericID && common.GenerateNumericID(canonicalUsername) != numericID {
+		return "", false
+	}
+
+	return canonicalUsername, true
+}
+
+func (h *Handler) loadRecoveredLocalActor(ctx context.Context, canonicalUsername string, fallback *activitypub.Actor) (*activitypub.Actor, error) {
+	h.ensureLocalNumericIDMapping(ctx, canonicalUsername)
+
+	actor, err := h.repos.Actor().GetActor(ctx, canonicalUsername)
+	if err == nil && actor != nil {
+		normalizeRecoveredLocalActor(h, actor, canonicalUsername)
+		return actor, nil
+	}
+	if err != nil && !isMissingAccountLookup(err) {
+		return nil, err
+	}
+	if fallback == nil {
+		return nil, nil
+	}
+
+	normalizeRecoveredLocalActor(h, fallback, canonicalUsername)
+	return fallback, nil
+}
+
+func normalizeRecoveredLocalActor(h *Handler, actor *activitypub.Actor, canonicalUsername string) {
+	if actor == nil {
+		return
+	}
+
+	actor.PreferredUsername = canonicalUsername
+	if strings.TrimSpace(actor.ID) == "" {
+		baseURL := handlerBaseURL(h)
+		if baseURL != "" {
+			actor.ID = baseURL + "/users/" + canonicalUsername
+		}
+	}
 }
 
 func normalizeLocalActorDomain(domain string) string {

--- a/cmd/lesser/main.go
+++ b/cmd/lesser/main.go
@@ -11,33 +11,34 @@ func main() {
 }
 
 var (
-	runUpFn              = runUp
-	runDownFn            = runDown
-	runClientDeployFn    = runClientDeploy
-	runInitAdminFn       = runInitAdmin
-	runBuildFn           = runBuild
-	runGenerateFn        = runGenerate
-	runVerifyFn          = runVerify
-	runTestFn            = runTest
-	runCoverageFn        = runCoverage
-	runDevFn             = runDev
-	runFmtFn             = runFmt
-	runLintFn            = runLint
-	runSecScanFn         = runSecScan
-	runVulnCheckFn       = runVulnCheck
-	runGqlgenFn          = runGqlgen
-	runTidyFn            = runTidy
-	runSchemaFn          = runSchema
-	runExportSchemaFn    = runExportSchema
-	runLogsFn            = runLogs
-	runMetricsFn         = runMetrics
-	runErrorsFn          = runErrors
-	runDashboardFn       = runDashboard
-	runSmokeFn           = runSmoke
-	runAuthFn            = runAuth
-	runAPIFn             = runAPI
-	runSoulFn            = runSoul
-	runMigrateUserKeysFn = runMigrateUserKeys
+	runUpFn                = runUp
+	runDownFn              = runDown
+	runClientDeployFn      = runClientDeploy
+	runInitAdminFn         = runInitAdmin
+	runBuildFn             = runBuild
+	runGenerateFn          = runGenerate
+	runVerifyFn            = runVerify
+	runTestFn              = runTest
+	runCoverageFn          = runCoverage
+	runDevFn               = runDev
+	runFmtFn               = runFmt
+	runLintFn              = runLint
+	runSecScanFn           = runSecScan
+	runVulnCheckFn         = runVulnCheck
+	runGqlgenFn            = runGqlgen
+	runTidyFn              = runTidy
+	runSchemaFn            = runSchema
+	runExportSchemaFn      = runExportSchema
+	runLogsFn              = runLogs
+	runMetricsFn           = runMetrics
+	runErrorsFn            = runErrors
+	runDashboardFn         = runDashboard
+	runSmokeFn             = runSmoke
+	runAuthFn              = runAuth
+	runAPIFn               = runAPI
+	runSoulFn              = runSoul
+	runMigrateUserKeysFn   = runMigrateUserKeys
+	runMigrateNumericIDsFn = runMigrateNumericIDs
 )
 
 func runCLI(args []string, stderr io.Writer) int {
@@ -71,33 +72,34 @@ func runCLI(args []string, stderr io.Writer) int {
 
 func commandRunner(cmd string) (func([]string) error, bool) {
 	runners := map[string]func([]string) error{
-		"up":                func(argv []string) error { return runUpFn(argv) },
-		"down":              func(argv []string) error { return runDownFn(argv) },
-		"destroy":           func(argv []string) error { return runDownFn(argv) },
-		"init-admin":        func(argv []string) error { return runInitAdminFn(argv) },
-		"build":             func(argv []string) error { return runBuildFn(argv) },
-		"generate":          func(argv []string) error { return runGenerateFn(argv) },
-		"verify":            func(argv []string) error { return runVerifyFn(argv) },
-		"test":              func(argv []string) error { return runTestFn(argv) },
-		"coverage":          func(argv []string) error { return runCoverageFn(argv) },
-		valueDev:            func(argv []string) error { return runDevFn(argv) },
-		"fmt":               func(argv []string) error { return runFmtFn(argv) },
-		"lint":              func(argv []string) error { return runLintFn(argv) },
-		"sec-scan":          func(argv []string) error { return runSecScanFn(argv) },
-		"vuln-check":        func(argv []string) error { return runVulnCheckFn(argv) },
-		"gqlgen":            func(argv []string) error { return runGqlgenFn(argv) },
-		"tidy":              func(argv []string) error { return runTidyFn(argv) },
-		valueSchema:         func(argv []string) error { return runSchemaFn(argv) },
-		"export-schema":     func(argv []string) error { return runExportSchemaFn(argv) },
-		"logs":              func(argv []string) error { return runLogsFn(argv) },
-		"metrics":           func(argv []string) error { return runMetricsFn(argv) },
-		"errors":            func(argv []string) error { return runErrorsFn(argv) },
-		"dashboard":         func(argv []string) error { return runDashboardFn(argv) },
-		"smoke":             func(argv []string) error { return runSmokeFn(argv) },
-		"auth":              func(argv []string) error { return runAuthFn(argv) },
-		"api":               func(argv []string) error { return runAPIFn(argv) },
-		"soul":              func(argv []string) error { return runSoulFn(argv) },
-		"migrate-user-keys": func(argv []string) error { return runMigrateUserKeysFn(argv) },
+		"up":                  func(argv []string) error { return runUpFn(argv) },
+		"down":                func(argv []string) error { return runDownFn(argv) },
+		"destroy":             func(argv []string) error { return runDownFn(argv) },
+		"init-admin":          func(argv []string) error { return runInitAdminFn(argv) },
+		"build":               func(argv []string) error { return runBuildFn(argv) },
+		"generate":            func(argv []string) error { return runGenerateFn(argv) },
+		"verify":              func(argv []string) error { return runVerifyFn(argv) },
+		"test":                func(argv []string) error { return runTestFn(argv) },
+		"coverage":            func(argv []string) error { return runCoverageFn(argv) },
+		valueDev:              func(argv []string) error { return runDevFn(argv) },
+		"fmt":                 func(argv []string) error { return runFmtFn(argv) },
+		"lint":                func(argv []string) error { return runLintFn(argv) },
+		"sec-scan":            func(argv []string) error { return runSecScanFn(argv) },
+		"vuln-check":          func(argv []string) error { return runVulnCheckFn(argv) },
+		"gqlgen":              func(argv []string) error { return runGqlgenFn(argv) },
+		"tidy":                func(argv []string) error { return runTidyFn(argv) },
+		valueSchema:           func(argv []string) error { return runSchemaFn(argv) },
+		"export-schema":       func(argv []string) error { return runExportSchemaFn(argv) },
+		"logs":                func(argv []string) error { return runLogsFn(argv) },
+		"metrics":             func(argv []string) error { return runMetricsFn(argv) },
+		"errors":              func(argv []string) error { return runErrorsFn(argv) },
+		"dashboard":           func(argv []string) error { return runDashboardFn(argv) },
+		"smoke":               func(argv []string) error { return runSmokeFn(argv) },
+		"auth":                func(argv []string) error { return runAuthFn(argv) },
+		"api":                 func(argv []string) error { return runAPIFn(argv) },
+		"soul":                func(argv []string) error { return runSoulFn(argv) },
+		"migrate-user-keys":   func(argv []string) error { return runMigrateUserKeysFn(argv) },
+		"migrate-numeric-ids": func(argv []string) error { return runMigrateNumericIDsFn(argv) },
 	}
 
 	runner, ok := runners[cmd]
@@ -154,6 +156,7 @@ func printUsageTo(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  lesser api request --method GET --path /api/v1/accounts/verify_credentials [flags...]")
 	_, _ = fmt.Fprintln(w, "  lesser soul ens set|preview|publish [flags...]")
 	_, _ = fmt.Fprintln(w, "  lesser migrate-user-keys [--app <slug>] [--env dev|staging|live] [--aws-profile <profile>] [--table <name>] [--limit <n>] [--apply]")
+	_, _ = fmt.Fprintln(w, "  lesser migrate-numeric-ids [--app <slug>] [--env dev|staging|live] [--aws-profile <profile>] [--table <name>] [--limit <n>] [--apply]")
 }
 
 func exitCodeFromErr(err error, stderr io.Writer) int {

--- a/cmd/lesser/main_test.go
+++ b/cmd/lesser/main_test.go
@@ -136,6 +136,7 @@ func TestRunCLI_DispatchesAllCommands(t *testing.T) {
 	prevAPI := runAPIFn
 	prevSoul := runSoulFn
 	prevMigrateUserKeys := runMigrateUserKeysFn
+	prevMigrateNumericIDs := runMigrateNumericIDsFn
 	t.Cleanup(func() {
 		runUpFn = prevUp
 		runDownFn = prevDown
@@ -164,6 +165,7 @@ func TestRunCLI_DispatchesAllCommands(t *testing.T) {
 		runAPIFn = prevAPI
 		runSoulFn = prevSoul
 		runMigrateUserKeysFn = prevMigrateUserKeys
+		runMigrateNumericIDsFn = prevMigrateNumericIDs
 	})
 
 	type call struct {
@@ -204,6 +206,7 @@ func TestRunCLI_DispatchesAllCommands(t *testing.T) {
 	runAPIFn = stub("api")
 	runSoulFn = stub("soul")
 	runMigrateUserKeysFn = stub("migrate-user-keys")
+	runMigrateNumericIDsFn = stub("migrate-numeric-ids")
 
 	var buf bytes.Buffer
 	require.Equal(t, 0, runCLI([]string{"lesser", helpFlagShort}, &buf))
@@ -296,6 +299,9 @@ func TestRunCLI_DispatchesAllCommands(t *testing.T) {
 
 	require.Equal(t, 0, runCLI([]string{"lesser", "migrate-user-keys", "--env", "dev"}, &buf))
 	require.Equal(t, []string{"--env", "dev"}, calls["migrate-user-keys"].argv)
+
+	require.Equal(t, 0, runCLI([]string{"lesser", "migrate-numeric-ids", "--env", "dev"}, &buf))
+	require.Equal(t, []string{"--env", "dev"}, calls["migrate-numeric-ids"].argv)
 }
 
 func TestExitCodeFromErr(t *testing.T) {

--- a/cmd/lesser/migrate_numeric_ids.go
+++ b/cmd/lesser/migrate_numeric_ids.go
@@ -1,0 +1,499 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/equaltoai/lesser/pkg/common"
+)
+
+const (
+	actorPartitionPrefix    = "ACTOR#"
+	numericMappingPartition = "NUMERIC_ID#"
+	numericMetadataSortKey  = "METADATA"
+	actorProfileSortKey     = "PROFILE"
+	numericMappingTypeName  = "NumericIDMapping"
+)
+
+type numericIDMigrationSummary struct {
+	ScannedActors         int
+	Candidates            int
+	ActorRowsUpdated      int
+	MappingsUpserted      int
+	LegacyMappingsDeleted int
+}
+
+type numericIDMigrationCandidate struct {
+	ActorPK         string
+	ActorSK         string
+	ActorItem       map[string]types.AttributeValue
+	PutActor        bool
+	MappingItem     map[string]types.AttributeValue
+	PutMapping      bool
+	LegacyMappingPK string
+	DeleteLegacy    bool
+}
+
+func runMigrateNumericIDs(argv []string) error {
+	fs := flag.NewFlagSet("lesser migrate-numeric-ids", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	var (
+		app        string
+		env        string
+		awsProfile string
+		tableName  string
+		limit      int
+		apply      bool
+	)
+	fs.StringVar(&app, "app", envOrDefault("LESSER_APP", ""), "app slug (default: lesser)")
+	fs.StringVar(&env, "env", valueDev, "deployment stage (dev|staging|live)")
+	fs.StringVar(&awsProfile, "aws-profile", os.Getenv("AWS_PROFILE"), "AWS profile name (optional; sets AWS_PROFILE)")
+	fs.StringVar(&tableName, "table", "", "explicit DynamoDB table name override")
+	fs.IntVar(&limit, "limit", 0, "maximum number of legacy actor rows to process (0 = all)")
+	fs.BoolVar(&apply, "apply", false, "rewrite actor numeric IDs and upsert lowercase NUMERIC_ID mappings")
+
+	if err := fs.Parse(argv); err != nil {
+		return err
+	}
+
+	resolvedTableName, err := resolveUserKeyMigrationTableName(app, env, tableName)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	awsCfg, resolvedProfile, err := loadAWSConfigForCLIFn(ctx, awsProfile)
+	if err != nil {
+		return err
+	}
+
+	summary, err := executeNumericIDMigration(ctx, newUserKeyMigrationClientFn(awsCfg), resolvedTableName, apply, limit)
+	if err != nil {
+		return err
+	}
+
+	mode := "dry-run"
+	if apply {
+		mode = "apply"
+	}
+
+	fmt.Printf("migrate-numeric-ids %s complete\n", mode)
+	fmt.Printf("table: %s\n", resolvedTableName)
+	if resolvedProfile != "" {
+		fmt.Printf("aws_profile: %s\n", resolvedProfile)
+	}
+	fmt.Printf("scanned_actors: %d\n", summary.ScannedActors)
+	fmt.Printf("candidates: %d\n", summary.Candidates)
+	fmt.Printf("actor_rows_updated: %d\n", summary.ActorRowsUpdated)
+	fmt.Printf("mappings_upserted: %d\n", summary.MappingsUpserted)
+	fmt.Printf("legacy_mappings_deleted: %d\n", summary.LegacyMappingsDeleted)
+
+	if !apply {
+		fmt.Println("no writes performed; re-run with --apply to rewrite actor numeric IDs and conformant NUMERIC_ID mappings")
+	}
+
+	return nil
+}
+
+func executeNumericIDMigration(
+	ctx context.Context,
+	client userKeyMigrationClient,
+	tableName string,
+	apply bool,
+	limit int,
+) (numericIDMigrationSummary, error) {
+	summary := numericIDMigrationSummary{}
+
+	if client == nil {
+		return summary, fmt.Errorf("migration client is required")
+	}
+	if strings.TrimSpace(tableName) == "" {
+		return summary, fmt.Errorf("table name is required")
+	}
+
+	actors, err := scanMigrationItems(ctx, client, tableName, actorPartitionPrefix, actorProfileSortKey)
+	if err != nil {
+		return summary, fmt.Errorf("scan actor profiles: %w", err)
+	}
+	mappings, err := scanMigrationItems(ctx, client, tableName, numericMappingPartition, numericMetadataSortKey)
+	if err != nil {
+		return summary, fmt.Errorf("scan numeric ID mappings: %w", err)
+	}
+
+	mappingsByPK := make(map[string]map[string]types.AttributeValue, len(mappings))
+	for _, item := range mappings {
+		if pk, ok := attributeString(item["PK"]); ok {
+			mappingsByPK[pk] = item
+		}
+	}
+
+	for _, actorItem := range actors {
+		summary.ScannedActors++
+
+		candidate, ok, err := buildNumericIDMigrationCandidate(actorItem, mappingsByPK)
+		if err != nil {
+			return summary, err
+		}
+		if !ok {
+			continue
+		}
+
+		summary.Candidates++
+		if apply {
+			if err := applyNumericIDMigrationCandidate(ctx, client, tableName, candidate, &summary); err != nil {
+				return summary, err
+			}
+		}
+
+		if limit > 0 && summary.Candidates >= limit {
+			break
+		}
+	}
+
+	return summary, nil
+}
+
+func scanMigrationItems(
+	ctx context.Context,
+	client userKeyMigrationClient,
+	tableName string,
+	pkPrefix string,
+	sk string,
+) ([]map[string]types.AttributeValue, error) {
+	scanInput := &dynamodb.ScanInput{
+		TableName:        aws.String(tableName),
+		FilterExpression: aws.String("begins_with(PK, :prefix) AND SK = :sk"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":prefix": &types.AttributeValueMemberS{Value: pkPrefix},
+			":sk":     &types.AttributeValueMemberS{Value: sk},
+		},
+	}
+
+	var items []map[string]types.AttributeValue
+	for {
+		out, err := client.Scan(ctx, scanInput)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, out.Items...)
+		if len(out.LastEvaluatedKey) == 0 {
+			return items, nil
+		}
+		scanInput.ExclusiveStartKey = out.LastEvaluatedKey
+	}
+}
+
+func buildNumericIDMigrationCandidate(
+	actorItem map[string]types.AttributeValue,
+	mappingsByPK map[string]map[string]types.AttributeValue,
+) (numericIDMigrationCandidate, bool, error) {
+	actorPK, ok := attributeString(actorItem["PK"])
+	if !ok || !strings.HasPrefix(actorPK, actorPartitionPrefix) {
+		return numericIDMigrationCandidate{}, false, nil
+	}
+	actorSK, ok := attributeString(actorItem["SK"])
+	if !ok || actorSK != actorProfileSortKey {
+		return numericIDMigrationCandidate{}, false, nil
+	}
+
+	canonicalUsername := canonicalMigrationUsername(actorItem, actorPK)
+	if canonicalUsername == "" {
+		return numericIDMigrationCandidate{}, false, fmt.Errorf("actor profile %q is missing username", actorPK)
+	}
+
+	desiredNumericID := common.GenerateNumericID(canonicalUsername)
+	currentNumericID, _ := attributeString(actorItem["numericID"])
+	updatedActorItem := cloneAttributeMap(actorItem)
+	putActor := false
+
+	if currentNumericID != desiredNumericID {
+		updatedActorItem["numericID"] = &types.AttributeValueMemberS{Value: desiredNumericID}
+		putActor = true
+	}
+	if usernameValue, ok := attributeString(updatedActorItem["username"]); !ok || usernameValue != canonicalUsername {
+		updatedActorItem["username"] = &types.AttributeValueMemberS{Value: canonicalUsername}
+		putActor = true
+	}
+	if normalizeActorPayloadIdentity(updatedActorItem, canonicalUsername) {
+		putActor = true
+	}
+
+	legacyMappingPK := ""
+	if strings.TrimSpace(currentNumericID) != "" && currentNumericID != desiredNumericID {
+		legacyMappingPK = numericMappingPartition + currentNumericID
+	}
+
+	desiredMappingPK := numericMappingPartition + desiredNumericID
+	existingDesiredMapping := mappingsByPK[desiredMappingPK]
+	legacyMapping := mappingsByPK[legacyMappingPK]
+	desiredActorID := desiredActorIDForMapping(updatedActorItem, existingDesiredMapping, legacyMapping, canonicalUsername)
+	desiredCreatedAt := desiredCreatedAtAttribute(existingDesiredMapping, legacyMapping)
+	desiredMappingItem := buildNumericIDMappingItem(desiredNumericID, canonicalUsername, desiredActorID, desiredCreatedAt)
+	putMapping := !mappingItemsEquivalent(existingDesiredMapping, desiredMappingItem)
+	deleteLegacy := legacyMappingPK != "" && legacyMapping != nil
+
+	if !putActor && !putMapping && !deleteLegacy {
+		return numericIDMigrationCandidate{}, false, nil
+	}
+
+	return numericIDMigrationCandidate{
+		ActorPK:         actorPK,
+		ActorSK:         actorSK,
+		ActorItem:       updatedActorItem,
+		PutActor:        putActor,
+		MappingItem:     desiredMappingItem,
+		PutMapping:      putMapping,
+		LegacyMappingPK: legacyMappingPK,
+		DeleteLegacy:    deleteLegacy,
+	}, true, nil
+}
+
+func applyNumericIDMigrationCandidate(
+	ctx context.Context,
+	client userKeyMigrationClient,
+	tableName string,
+	candidate numericIDMigrationCandidate,
+	summary *numericIDMigrationSummary,
+) error {
+	if candidate.PutActor {
+		if _, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+			TableName: aws.String(tableName),
+			Item:      candidate.ActorItem,
+		}); err != nil {
+			return fmt.Errorf("put actor profile %s %s: %w", candidate.ActorPK, candidate.ActorSK, err)
+		}
+		summary.ActorRowsUpdated++
+	}
+
+	if candidate.PutMapping {
+		if _, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+			TableName: aws.String(tableName),
+			Item:      candidate.MappingItem,
+		}); err != nil {
+			mappingPK, _ := attributeString(candidate.MappingItem["PK"])
+			return fmt.Errorf("put numeric ID mapping %s: %w", mappingPK, err)
+		}
+		summary.MappingsUpserted++
+	}
+
+	if candidate.DeleteLegacy {
+		if _, err := client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+			TableName: aws.String(tableName),
+			Key: map[string]types.AttributeValue{
+				"PK": &types.AttributeValueMemberS{Value: candidate.LegacyMappingPK},
+				"SK": &types.AttributeValueMemberS{Value: numericMetadataSortKey},
+			},
+		}); err != nil {
+			return fmt.Errorf("delete legacy numeric ID mapping %s: %w", candidate.LegacyMappingPK, err)
+		}
+		summary.LegacyMappingsDeleted++
+	}
+
+	return nil
+}
+
+func canonicalMigrationUsername(actorItem map[string]types.AttributeValue, actorPK string) string {
+	if username, ok := attributeString(actorItem["username"]); ok && strings.TrimSpace(username) != "" {
+		return strings.ToLower(strings.TrimSpace(username))
+	}
+
+	if actorValue, ok := actorItem["actor"].(*types.AttributeValueMemberM); ok {
+		if preferredUsername, ok := attributeString(actorValue.Value["preferredUsername"]); ok && strings.TrimSpace(preferredUsername) != "" {
+			return strings.ToLower(strings.TrimSpace(preferredUsername))
+		}
+	}
+
+	return strings.ToLower(strings.TrimSpace(strings.TrimPrefix(actorPK, actorPartitionPrefix)))
+}
+
+func normalizeActorPayloadIdentity(actorItem map[string]types.AttributeValue, canonicalUsername string) bool {
+	actorValue, ok := actorItem["actor"].(*types.AttributeValueMemberM)
+	if !ok || actorValue == nil {
+		return false
+	}
+
+	changed := setNestedStringAttribute(actorValue.Value, "preferredUsername", canonicalUsername)
+
+	for _, key := range []string{"id", "url", "inbox", "outbox", "followers", "following", "liked"} {
+		if normalizeNestedActorReference(actorValue.Value, key, canonicalUsername) {
+			changed = true
+		}
+	}
+
+	return changed
+}
+
+func desiredActorIDForMapping(
+	actorItem map[string]types.AttributeValue,
+	existingDesiredMapping map[string]types.AttributeValue,
+	legacyMapping map[string]types.AttributeValue,
+	canonicalUsername string,
+) string {
+	if actorValue, ok := actorItem["actor"].(*types.AttributeValueMemberM); ok && actorValue != nil {
+		if actorID, ok := attributeString(actorValue.Value["id"]); ok && strings.TrimSpace(actorID) != "" {
+			return normalizeActorReference(actorID, canonicalUsername)
+		}
+	}
+
+	for _, item := range []map[string]types.AttributeValue{existingDesiredMapping, legacyMapping} {
+		if item == nil {
+			continue
+		}
+		if actorID, ok := attributeString(item["actorID"]); ok && strings.TrimSpace(actorID) != "" {
+			return normalizeActorReference(actorID, canonicalUsername)
+		}
+	}
+
+	return ""
+}
+
+func desiredCreatedAtAttribute(existingDesiredMapping map[string]types.AttributeValue, legacyMapping map[string]types.AttributeValue) types.AttributeValue {
+	for _, item := range []map[string]types.AttributeValue{existingDesiredMapping, legacyMapping} {
+		if item == nil {
+			continue
+		}
+		if createdAt, ok := item["createdAt"]; ok {
+			return cloneAttributeValue(createdAt)
+		}
+	}
+
+	return &types.AttributeValueMemberS{Value: time.Now().UTC().Format(time.RFC3339Nano)}
+}
+
+func buildNumericIDMappingItem(
+	numericID string,
+	username string,
+	actorID string,
+	createdAt types.AttributeValue,
+) map[string]types.AttributeValue {
+	item := map[string]types.AttributeValue{
+		"PK":        &types.AttributeValueMemberS{Value: numericMappingPartition + numericID},
+		"SK":        &types.AttributeValueMemberS{Value: numericMetadataSortKey},
+		"numericID": &types.AttributeValueMemberS{Value: numericID},
+		"username":  &types.AttributeValueMemberS{Value: username},
+		"type":      &types.AttributeValueMemberS{Value: numericMappingTypeName},
+		"createdAt": cloneAttributeValue(createdAt),
+	}
+	if strings.TrimSpace(actorID) != "" {
+		item["actorID"] = &types.AttributeValueMemberS{Value: actorID}
+	}
+	return item
+}
+
+func mappingItemsEquivalent(existing map[string]types.AttributeValue, desired map[string]types.AttributeValue) bool {
+	if existing == nil {
+		return false
+	}
+
+	for _, key := range []string{"PK", "SK", "numericID", "username", "type", "actorID"} {
+		existingValue, existingOK := attributeString(existing[key])
+		desiredValue, desiredOK := attributeString(desired[key])
+		if existingOK != desiredOK {
+			return false
+		}
+		if existingValue != desiredValue {
+			return false
+		}
+	}
+
+	_, existingCreatedAt := attributeString(existing["createdAt"])
+	_, desiredCreatedAt := attributeString(desired["createdAt"])
+	return existingCreatedAt == desiredCreatedAt
+}
+
+func setNestedStringAttribute(item map[string]types.AttributeValue, key string, value string) bool {
+	current, ok := attributeString(item[key])
+	if ok && current == value {
+		return false
+	}
+	item[key] = &types.AttributeValueMemberS{Value: value}
+	return true
+}
+
+func normalizeNestedActorReference(item map[string]types.AttributeValue, key string, canonicalUsername string) bool {
+	current, ok := attributeString(item[key])
+	if !ok || strings.TrimSpace(current) == "" {
+		return false
+	}
+
+	normalized := normalizeActorReference(current, canonicalUsername)
+	if normalized == current {
+		return false
+	}
+	item[key] = &types.AttributeValueMemberS{Value: normalized}
+	return true
+}
+
+func normalizeActorReference(value string, canonicalUsername string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+
+	trimmed = strings.TrimRight(trimmed, "/")
+	lowerTrimmed := strings.ToLower(trimmed)
+	if idx := strings.LastIndex(lowerTrimmed, "/users/"); idx >= 0 {
+		suffix := trimmed[idx+len("/users/"):]
+		if suffix != "" && !strings.Contains(suffix, "/") {
+			return trimmed[:idx+len("/users/")] + canonicalUsername
+		}
+	}
+	if idx := strings.LastIndex(lowerTrimmed, "/@"); idx >= 0 {
+		suffix := trimmed[idx+len("/@"):]
+		if suffix != "" && !strings.Contains(suffix, "/") {
+			return trimmed[:idx+len("/@")] + canonicalUsername
+		}
+	}
+	return trimmed
+}
+
+func cloneAttributeMap(item map[string]types.AttributeValue) map[string]types.AttributeValue {
+	cloned := make(map[string]types.AttributeValue, len(item))
+	for key, value := range item {
+		cloned[key] = cloneAttributeValue(value)
+	}
+	return cloned
+}
+
+func cloneAttributeValue(value types.AttributeValue) types.AttributeValue {
+	switch typed := value.(type) {
+	case *types.AttributeValueMemberB:
+		return &types.AttributeValueMemberB{Value: append([]byte(nil), typed.Value...)}
+	case *types.AttributeValueMemberBOOL:
+		return &types.AttributeValueMemberBOOL{Value: typed.Value}
+	case *types.AttributeValueMemberBS:
+		cloned := make([][]byte, len(typed.Value))
+		for i := range typed.Value {
+			cloned[i] = append([]byte(nil), typed.Value[i]...)
+		}
+		return &types.AttributeValueMemberBS{Value: cloned}
+	case *types.AttributeValueMemberL:
+		cloned := make([]types.AttributeValue, len(typed.Value))
+		for i := range typed.Value {
+			cloned[i] = cloneAttributeValue(typed.Value[i])
+		}
+		return &types.AttributeValueMemberL{Value: cloned}
+	case *types.AttributeValueMemberM:
+		return &types.AttributeValueMemberM{Value: cloneAttributeMap(typed.Value)}
+	case *types.AttributeValueMemberN:
+		return &types.AttributeValueMemberN{Value: typed.Value}
+	case *types.AttributeValueMemberNS:
+		return &types.AttributeValueMemberNS{Value: append([]string(nil), typed.Value...)}
+	case *types.AttributeValueMemberNULL:
+		return &types.AttributeValueMemberNULL{Value: typed.Value}
+	case *types.AttributeValueMemberS:
+		return &types.AttributeValueMemberS{Value: typed.Value}
+	case *types.AttributeValueMemberSS:
+		return &types.AttributeValueMemberSS{Value: append([]string(nil), typed.Value...)}
+	default:
+		return value
+	}
+}

--- a/cmd/lesser/migrate_numeric_ids_test.go
+++ b/cmd/lesser/migrate_numeric_ids_test.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunMigrateNumericIDs_PrintsDryRunSummary(t *testing.T) {
+	previousLoadAWSConfig := loadAWSConfigForCLIFn
+	previousClientFactory := newUserKeyMigrationClientFn
+	t.Cleanup(func() {
+		loadAWSConfigForCLIFn = previousLoadAWSConfig
+		newUserKeyMigrationClientFn = previousClientFactory
+	})
+
+	legacyNumericID := common.GenerateNumericID("Medic")
+	client := &fakeUserKeyMigrationClient{
+		scanOutputs: []*dynamodb.ScanOutput{
+			{
+				Items: []map[string]types.AttributeValue{
+					legacyActorMigrationItem("medic", legacyNumericID, "Medic"),
+				},
+			},
+			{
+				Items: []map[string]types.AttributeValue{
+					legacyNumericMappingItem(legacyNumericID, "Medic", "https://example.com/users/Medic"),
+				},
+			},
+		},
+	}
+
+	var seenProfile string
+	loadAWSConfigForCLIFn = func(_ context.Context, awsProfile string) (aws.Config, string, error) {
+		seenProfile = awsProfile
+		return aws.Config{}, "Sim", nil
+	}
+	newUserKeyMigrationClientFn = func(aws.Config) userKeyMigrationClient { return client }
+
+	output := captureStdout(t, func() {
+		require.NoError(t, runMigrateNumericIDs([]string{
+			"--app", "simulacrum",
+			"--env", "dev",
+			"--aws-profile", "Sim",
+		}))
+	})
+
+	require.Equal(t, "Sim", seenProfile)
+	require.Contains(t, output, "migrate-numeric-ids dry-run complete")
+	require.Contains(t, output, "table: simulacrum-dev-main-table")
+	require.Contains(t, output, "aws_profile: Sim")
+	require.Contains(t, output, "scanned_actors: 1")
+	require.Contains(t, output, "candidates: 1")
+	require.Contains(t, output, "actor_rows_updated: 0")
+	require.Contains(t, output, "mappings_upserted: 0")
+	require.Contains(t, output, "legacy_mappings_deleted: 0")
+	require.Contains(t, output, "no writes performed; re-run with --apply")
+	require.Len(t, client.scanInputs, 2)
+	require.Equal(t, actorPartitionPrefix, strAttr(t, client.scanInputs[0].ExpressionAttributeValues[":prefix"]))
+	require.Equal(t, numericMappingPartition, strAttr(t, client.scanInputs[1].ExpressionAttributeValues[":prefix"]))
+}
+
+func TestExecuteNumericIDMigration_ApplyRewritesLegacyActorAndMapping(t *testing.T) {
+	legacyNumericID := common.GenerateNumericID("Pilot")
+	desiredNumericID := common.GenerateNumericID("pilot")
+	client := &fakeUserKeyMigrationClient{
+		scanOutputs: []*dynamodb.ScanOutput{
+			{
+				Items: []map[string]types.AttributeValue{
+					legacyActorMigrationItem("pilot", legacyNumericID, "Pilot"),
+				},
+			},
+			{
+				Items: []map[string]types.AttributeValue{
+					legacyNumericMappingItem(legacyNumericID, "Pilot", "https://example.com/users/Pilot"),
+				},
+			},
+		},
+	}
+
+	summary, err := executeNumericIDMigration(context.Background(), client, "simulacrum-dev-main-table", true, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, summary.ScannedActors)
+	require.Equal(t, 1, summary.Candidates)
+	require.Equal(t, 1, summary.ActorRowsUpdated)
+	require.Equal(t, 1, summary.MappingsUpserted)
+	require.Equal(t, 1, summary.LegacyMappingsDeleted)
+
+	require.Len(t, client.putInputs, 2)
+	actorPut := client.putInputs[0].Item
+	require.Equal(t, "ACTOR#pilot", strAttr(t, actorPut["PK"]))
+	require.Equal(t, desiredNumericID, strAttr(t, actorPut["numericID"]))
+	require.Equal(t, "pilot", strAttr(t, actorPut["username"]))
+	actorValue, ok := actorPut["actor"].(*types.AttributeValueMemberM)
+	require.True(t, ok)
+	require.Equal(t, "pilot", strAttr(t, actorValue.Value["preferredUsername"]))
+
+	mappingPut := client.putInputs[1].Item
+	require.Equal(t, "NUMERIC_ID#"+desiredNumericID, strAttr(t, mappingPut["PK"]))
+	require.Equal(t, desiredNumericID, strAttr(t, mappingPut["numericID"]))
+	require.Equal(t, "pilot", strAttr(t, mappingPut["username"]))
+	require.Equal(t, "https://example.com/users/pilot", strAttr(t, mappingPut["actorID"]))
+	require.Equal(t, numericMappingTypeName, strAttr(t, mappingPut["type"]))
+
+	require.Len(t, client.deleteInputs, 1)
+	require.Equal(t, "NUMERIC_ID#"+legacyNumericID, strAttr(t, client.deleteInputs[0].Key["PK"]))
+	require.Equal(t, numericMetadataSortKey, strAttr(t, client.deleteInputs[0].Key["SK"]))
+}
+
+func TestExecuteNumericIDMigration_SkipsConformantActor(t *testing.T) {
+	numericID := common.GenerateNumericID("scout")
+	client := &fakeUserKeyMigrationClient{
+		scanOutputs: []*dynamodb.ScanOutput{
+			{
+				Items: []map[string]types.AttributeValue{
+					legacyActorMigrationItem("scout", numericID, "scout"),
+				},
+			},
+			{
+				Items: []map[string]types.AttributeValue{
+					legacyNumericMappingItem(numericID, "scout", "https://example.com/users/scout"),
+				},
+			},
+		},
+	}
+
+	summary, err := executeNumericIDMigration(context.Background(), client, "simulacrum-dev-main-table", false, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, summary.ScannedActors)
+	require.Equal(t, 0, summary.Candidates)
+	require.Empty(t, client.putInputs)
+	require.Empty(t, client.deleteInputs)
+}
+
+func TestExecuteNumericIDMigration_ValidatesInputsAndScanErrors(t *testing.T) {
+	_, err := executeNumericIDMigration(context.Background(), nil, "simulacrum-dev-main-table", false, 0)
+	require.Error(t, err)
+
+	_, err = executeNumericIDMigration(context.Background(), &fakeUserKeyMigrationClient{}, "", false, 0)
+	require.Error(t, err)
+
+	client := &fakeUserKeyMigrationClient{scanErr: context.DeadlineExceeded}
+	_, err = executeNumericIDMigration(context.Background(), client, "simulacrum-dev-main-table", false, 0)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "scan actor profiles")
+}
+
+func TestNumericIDMigrationHelpers(t *testing.T) {
+	t.Run("canonical username falls back through item fields", func(t *testing.T) {
+		require.Equal(t, "alice", canonicalMigrationUsername(map[string]types.AttributeValue{
+			"username": sAttr("Alice"),
+		}, "ACTOR#ignored"))
+
+		require.Equal(t, "bob", canonicalMigrationUsername(map[string]types.AttributeValue{
+			"actor": &types.AttributeValueMemberM{Value: map[string]types.AttributeValue{
+				"preferredUsername": sAttr("Bob"),
+			}},
+		}, "ACTOR#ignored"))
+
+		require.Equal(t, "carol", canonicalMigrationUsername(map[string]types.AttributeValue{}, "ACTOR#Carol"))
+	})
+
+	t.Run("normalize actor payload identity rewrites canonical fields", func(t *testing.T) {
+		actorItem := map[string]types.AttributeValue{
+			"actor": &types.AttributeValueMemberM{Value: map[string]types.AttributeValue{
+				"preferredUsername": sAttr("Agent-0"),
+				"id":                sAttr("https://example.com/users/Agent-0"),
+				"url":               sAttr("https://example.com/@Agent-0"),
+				"inbox":             sAttr("https://example.com/users/Agent-0/inbox"),
+			}},
+		}
+
+		require.True(t, normalizeActorPayloadIdentity(actorItem, "agent-0"))
+		actorValue := actorItem["actor"].(*types.AttributeValueMemberM)
+		require.Equal(t, "agent-0", strAttr(t, actorValue.Value["preferredUsername"]))
+		require.Equal(t, "https://example.com/users/agent-0", strAttr(t, actorValue.Value["id"]))
+		require.Equal(t, "https://example.com/@agent-0", strAttr(t, actorValue.Value["url"]))
+		require.Equal(t, "https://example.com/users/Agent-0/inbox", strAttr(t, actorValue.Value["inbox"]))
+		require.False(t, normalizeActorPayloadIdentity(map[string]types.AttributeValue{}, "agent-0"))
+	})
+
+	t.Run("desired actor ID and mapping equivalence helpers", func(t *testing.T) {
+		actorItem := map[string]types.AttributeValue{
+			"actor": &types.AttributeValueMemberM{Value: map[string]types.AttributeValue{
+				"id": sAttr("https://example.com/users/Agent-0"),
+			}},
+		}
+		existingDesired := legacyNumericMappingItem(common.GenerateNumericID("agent-0"), "agent-0", "https://example.com/users/agent-0")
+		legacy := legacyNumericMappingItem(common.GenerateNumericID("Agent-0"), "Agent-0", "https://example.com/users/Agent-0")
+
+		require.Equal(t, "https://example.com/users/agent-0", desiredActorIDForMapping(actorItem, existingDesired, legacy, "agent-0"))
+		require.Equal(t, "https://example.com/users/agent-0", desiredActorIDForMapping(map[string]types.AttributeValue{}, existingDesired, nil, "agent-0"))
+		require.Equal(t, "https://example.com/users/agent-0", desiredActorIDForMapping(map[string]types.AttributeValue{}, nil, legacy, "agent-0"))
+		require.Empty(t, desiredActorIDForMapping(map[string]types.AttributeValue{}, nil, nil, "agent-0"))
+
+		createdAt := desiredCreatedAtAttribute(existingDesired, nil)
+		require.Equal(t, "2026-03-24T12:00:00Z", strAttr(t, createdAt))
+		newCreatedAt := desiredCreatedAtAttribute(nil, nil)
+		_, ok := newCreatedAt.(*types.AttributeValueMemberS)
+		require.True(t, ok)
+
+		desired := buildNumericIDMappingItem(common.GenerateNumericID("agent-0"), "agent-0", "https://example.com/users/agent-0", createdAt)
+		require.True(t, mappingItemsEquivalent(existingDesired, desired))
+		desired["username"] = sAttr("Agent-0")
+		require.False(t, mappingItemsEquivalent(existingDesired, desired))
+	})
+
+	t.Run("clone attribute helpers deep copy nested values", func(t *testing.T) {
+		original := map[string]types.AttributeValue{
+			"list": &types.AttributeValueMemberL{Value: []types.AttributeValue{sAttr("one")}},
+			"map": &types.AttributeValueMemberM{Value: map[string]types.AttributeValue{
+				"nested": sAttr("value"),
+			}},
+			"binary": &types.AttributeValueMemberB{Value: []byte("hi")},
+		}
+
+		cloned := cloneAttributeMap(original)
+		cloned["map"].(*types.AttributeValueMemberM).Value["nested"] = sAttr("changed")
+		cloned["list"].(*types.AttributeValueMemberL).Value[0] = sAttr("two")
+		cloned["binary"].(*types.AttributeValueMemberB).Value[0] = 'H'
+
+		require.Equal(t, "value", strAttr(t, original["map"].(*types.AttributeValueMemberM).Value["nested"]))
+		require.Equal(t, "one", strAttr(t, original["list"].(*types.AttributeValueMemberL).Value[0]))
+		require.Equal(t, byte('h'), original["binary"].(*types.AttributeValueMemberB).Value[0])
+
+		require.Equal(t, "https://example.com/@agent-0", normalizeActorReference("https://example.com/@Agent-0", "agent-0"))
+		require.Equal(t, "https://remote.example/actors/Agent-0", normalizeActorReference("https://remote.example/actors/Agent-0", "agent-0"))
+	})
+}
+
+func legacyActorMigrationItem(username, numericID, preferredUsername string) map[string]types.AttributeValue {
+	return map[string]types.AttributeValue{
+		"PK":        sAttr("ACTOR#" + username),
+		"SK":        sAttr(actorProfileSortKey),
+		"username":  sAttr(username),
+		"numericID": sAttr(numericID),
+		"actor": &types.AttributeValueMemberM{Value: map[string]types.AttributeValue{
+			"preferredUsername": sAttr(preferredUsername),
+		}},
+	}
+}
+
+func legacyNumericMappingItem(numericID, username, actorID string) map[string]types.AttributeValue {
+	return map[string]types.AttributeValue{
+		"PK":        sAttr(numericMappingPartition + numericID),
+		"SK":        sAttr(numericMetadataSortKey),
+		"numericID": sAttr(numericID),
+		"username":  sAttr(username),
+		"actorID":   sAttr(actorID),
+		"type":      sAttr(numericMappingTypeName),
+		"createdAt": sAttr("2026-03-24T12:00:00Z"),
+	}
+}

--- a/pkg/storage/repositories/account_repository.go
+++ b/pkg/storage/repositories/account_repository.go
@@ -614,18 +614,19 @@ func normalizeDomainValue(domain string) string {
 	return normalized
 }
 
-func (r *AccountRepository) ensureNumericIDMapping(ctx context.Context, numericID, username, actorID string) error {
-	if strings.TrimSpace(numericID) == "" || strings.TrimSpace(username) == "" {
+func (r *AccountRepository) ensureNumericIDMapping(ctx context.Context, _ string, username, actorID string) error {
+	normalizedNumericID, canonicalUsername, canonicalActorID := normalizedNumericIDMappingValues(username, actorID)
+	if canonicalUsername == "" {
 		return nil
 	}
 
 	mapping := &models.NumericIDMapping{
-		NumericID: strings.TrimSpace(numericID),
-		Username:  strings.TrimSpace(username),
-		ActorID:   strings.TrimSpace(actorID),
+		NumericID: normalizedNumericID,
+		Username:  canonicalUsername,
+		ActorID:   canonicalActorID,
 	}
 	if err := mapping.BeforeCreate(); err != nil {
-		return ErrorHandler.HandleCreateError(err, "numeric ID mapping", numericID)
+		return ErrorHandler.HandleCreateError(err, "numeric ID mapping", normalizedNumericID)
 	}
 
 	err := r.db.WithContext(ctx).Model(mapping).Create()
@@ -633,21 +634,21 @@ func (r *AccountRepository) ensureNumericIDMapping(ctx context.Context, numericI
 		return nil
 	}
 	if !dynamormErrors.IsConditionFailed(err) {
-		return ErrorHandler.HandleCreateError(err, "numeric ID mapping", numericID)
+		return ErrorHandler.HandleCreateError(err, "numeric ID mapping", normalizedNumericID)
 	}
 
 	var existing models.NumericIDMapping
 	lookupErr := r.db.WithContext(ctx).Model(&models.NumericIDMapping{}).
-		Where("PK", "=", "NUMERIC_ID#"+numericID).
+		Where("PK", "=", "NUMERIC_ID#"+normalizedNumericID).
 		Where("SK", "=", models.SKMetadata).
 		First(&existing)
 	if lookupErr == nil && strings.EqualFold(existing.Username, mapping.Username) {
 		return nil
 	}
 	if lookupErr == nil {
-		return ErrorHandler.HandleCreateError(err, "numeric ID mapping", numericID)
+		return ErrorHandler.HandleCreateError(err, "numeric ID mapping", normalizedNumericID)
 	}
-	return ErrorHandler.HandleCreateError(lookupErr, "numeric ID mapping", numericID)
+	return ErrorHandler.HandleCreateError(lookupErr, "numeric ID mapping", normalizedNumericID)
 }
 
 func (r *AccountRepository) deleteNumericIDMapping(ctx context.Context, numericID string) error {
@@ -863,40 +864,11 @@ func (r *AccountRepository) modelToStorageUser(model *models.User) *storage.User
 }
 
 func (r *AccountRepository) normalizeLocalActorIdentity(username string, actor *activitypub.Actor) *activitypub.Actor {
-	if actor == nil {
-		return nil
-	}
-
 	canonical := r.canonicalUsername(username)
-	if canonical == "" {
+	if canonical == "" && actor != nil {
 		canonical = r.canonicalUsername(actor.PreferredUsername)
 	}
-	if canonical == "" {
-		return actor
-	}
-
-	baseURL := r.actorBaseURL()
-	normalized := activitypubutil.BuildLocalActor(canonical, baseURL, nil, actor)
-	if normalized == nil {
-		return actor
-	}
-
-	normalized.PreferredUsername = canonical
-	if baseURL != "" {
-		normalized.ID = fmt.Sprintf("%s/users/%s", baseURL, canonical)
-		normalized.URL = fmt.Sprintf("%s/@%s", baseURL, canonical)
-		normalized.Inbox = fmt.Sprintf("%s/users/%s/inbox", baseURL, canonical)
-		normalized.Outbox = fmt.Sprintf("%s/users/%s/outbox", baseURL, canonical)
-		normalized.Followers = fmt.Sprintf("%s/users/%s/followers", baseURL, canonical)
-		normalized.Following = fmt.Sprintf("%s/users/%s/following", baseURL, canonical)
-		normalized.Liked = fmt.Sprintf("%s/users/%s/liked", baseURL, canonical)
-		if normalized.Endpoints == nil {
-			normalized.Endpoints = &activitypub.Endpoints{}
-		}
-		normalized.Endpoints.SharedInbox = fmt.Sprintf("%s/inbox", baseURL)
-	}
-
-	return normalized
+	return normalizeLocalActorIdentityForStorage(canonical, r.actorBaseURL(), actor)
 }
 
 // UserUpdatePayload captures mutable account fields accepted from federation updates.

--- a/pkg/storage/repositories/account_repository_encryptor_coverage_test.go
+++ b/pkg/storage/repositories/account_repository_encryptor_coverage_test.go
@@ -130,6 +130,53 @@ func TestAccountRepository_CreateActor_PreparesActorAndNumericIDMapping(t *testi
 	require.False(t, createdMapping.CreatedAt.IsZero())
 }
 
+func TestAccountRepository_CreateActor_NormalizesMixedCaseNumericIdentity(t *testing.T) {
+	ctx := context.Background()
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+	var currentModel any
+	var createdActor *models.Actor
+	var createdMapping *models.NumericIDMapping
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB).Maybe()
+	mockDB.On("Model", mock.Anything).Run(func(args mock.Arguments) {
+		currentModel = args.Get(0)
+	}).Return(mockQuery).Maybe()
+
+	mockQuery.On("Create").Run(func(mock.Arguments) {
+		switch model := currentModel.(type) {
+		case *models.Actor:
+			copyActor := *model
+			createdActor = &copyActor
+		case *models.NumericIDMapping:
+			copyMapping := *model
+			createdMapping = &copyMapping
+		}
+	}).Return(nil).Maybe()
+
+	repo := NewAccountRepository(mockDB, "test-table", "example.com", zaptest.NewLogger(t))
+	repo.SetEncryptor(testEncryptor{})
+
+	err := repo.createActor(ctx, &activitypub.Actor{
+		PreferredUsername: "Agent-0",
+		BaseObject:        activitypub.BaseObject{ID: "https://example.com/users/Agent-0"},
+		Name:              "Agent 0",
+	}, "private-key")
+	require.NoError(t, err)
+
+	require.NotNil(t, createdActor)
+	require.Equal(t, "ACTOR#agent-0", createdActor.PK)
+	require.Equal(t, common.GenerateNumericID("agent-0"), createdActor.NumericID)
+	require.NotNil(t, createdActor.Actor)
+	require.Equal(t, "agent-0", createdActor.Actor.PreferredUsername)
+	require.Equal(t, "https://example.com/users/agent-0", createdActor.Actor.ID)
+
+	require.NotNil(t, createdMapping)
+	require.Equal(t, common.GenerateNumericID("agent-0"), createdMapping.NumericID)
+	require.Equal(t, "agent-0", createdMapping.Username)
+	require.Equal(t, "https://example.com/users/agent-0", createdMapping.ActorID)
+}
+
 func TestAccountRepository_GetActorPrivateKey_DecryptPaths(t *testing.T) {
 	ctx := context.Background()
 	baseTime := time.Date(2025, 8, 9, 10, 11, 12, 0, time.UTC)

--- a/pkg/storage/repositories/actor_repository.go
+++ b/pkg/storage/repositories/actor_repository.go
@@ -80,7 +80,8 @@ func (r *ActorRepository) CreateActor(ctx context.Context, actor *activitypub.Ac
 		return err
 	}
 
-	username := actor.PreferredUsername
+	username := canonicalNumericMappingUsername(actor.PreferredUsername)
+	actor = normalizeLocalActorIdentityForStorage(username, actorRepositoryBaseURL(), actor)
 	numericID := common.GenerateNumericID(username)
 
 	// Encrypt private key - REQUIRED for security
@@ -204,12 +205,12 @@ func (r *ActorRepository) GetActorByNumericID(ctx context.Context, numericID str
 		return nil, ErrorHandler.HandleGetError(err, "numeric ID mapping", numericID)
 	}
 
-	return r.GetActor(ctx, mapping.Username)
+	return r.GetActor(ctx, canonicalNumericMappingUsername(mapping.Username))
 }
 
 // EnsureNumericIDMapping recreates the numeric ID lookup row for an existing actor when it is missing.
 func (r *ActorRepository) EnsureNumericIDMapping(ctx context.Context, username string) error {
-	username = strings.TrimSpace(username)
+	username = canonicalNumericMappingUsername(username)
 	if username == "" {
 		return nil
 	}
@@ -475,35 +476,47 @@ func (r *ActorRepository) lookupNumericIDMapping(ctx context.Context, numericID 
 	return &mapping, nil
 }
 
-func (r *ActorRepository) ensureNumericIDMapping(ctx context.Context, numericID, username, actorID string) error {
-	if strings.TrimSpace(numericID) == "" || strings.TrimSpace(username) == "" {
+func (r *ActorRepository) ensureNumericIDMapping(ctx context.Context, _ string, username, actorID string) error {
+	normalizedNumericID, canonicalUsername, canonicalActorID := normalizedNumericIDMappingValues(username, actorID)
+	if canonicalUsername == "" {
 		return nil
 	}
 
 	mapping := &models.NumericIDMapping{
-		NumericID: strings.TrimSpace(numericID),
-		Username:  strings.TrimSpace(username),
-		ActorID:   strings.TrimSpace(actorID),
+		NumericID: normalizedNumericID,
+		Username:  canonicalUsername,
+		ActorID:   canonicalActorID,
 	}
 	err := r.db.WithContext(ctx).Model(mapping).Create()
 	if err == nil {
 		return nil
 	}
 	if !dynamormerrors.IsConditionFailed(err) {
-		return ErrorHandler.HandleCreateError(err, "numeric ID mapping", numericID)
+		return ErrorHandler.HandleCreateError(err, "numeric ID mapping", normalizedNumericID)
 	}
 
-	existing, lookupErr := r.lookupNumericIDMapping(ctx, numericID)
+	existing, lookupErr := r.lookupNumericIDMapping(ctx, normalizedNumericID)
 	if lookupErr == nil && existing != nil && strings.EqualFold(existing.Username, mapping.Username) {
 		return nil
 	}
 	if lookupErr == nil {
-		return ErrorHandler.HandleCreateError(err, "numeric ID mapping", numericID)
+		return ErrorHandler.HandleCreateError(err, "numeric ID mapping", normalizedNumericID)
 	}
 	if dynamormerrors.IsNotFound(lookupErr) {
-		return ErrorHandler.HandleCreateError(err, "numeric ID mapping", numericID)
+		return ErrorHandler.HandleCreateError(err, "numeric ID mapping", normalizedNumericID)
 	}
-	return ErrorHandler.HandleCreateError(lookupErr, "numeric ID mapping", numericID)
+	return ErrorHandler.HandleCreateError(lookupErr, "numeric ID mapping", normalizedNumericID)
+}
+
+func actorRepositoryBaseURL() string {
+	domain := strings.TrimSpace(lesserconfig.Get().Domain)
+	if domain == "" {
+		return ""
+	}
+	if strings.HasPrefix(domain, "http://") || strings.HasPrefix(domain, "https://") {
+		return strings.TrimSuffix(domain, "/")
+	}
+	return "https://" + strings.TrimSuffix(domain, "/")
 }
 
 func (r *ActorRepository) deleteNumericIDMapping(ctx context.Context, numericID string) error {

--- a/pkg/storage/repositories/actor_repository_additional_coverage_test.go
+++ b/pkg/storage/repositories/actor_repository_additional_coverage_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/common"
 	lesserconfig "github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/models"
@@ -15,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/theory-cloud/tabletheory/pkg/core"
 	dynamormerrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	"github.com/theory-cloud/tabletheory/pkg/mocks"
 	"go.uber.org/zap"
 )
 
@@ -534,6 +536,42 @@ func TestActorRepository_EnsureNumericIDMapping_conditionFailedWithExistingMappi
 	}).Once()
 
 	require.NoError(t, repo.EnsureNumericIDMapping(ctx, "alice"))
+}
+
+func TestActorRepository_EnsureNumericIDMapping_normalizesMixedCaseIdentity(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+	var currentModel any
+	var createdMapping *models.NumericIDMapping
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB).Maybe()
+	mockDB.On("Model", mock.Anything).Run(func(args mock.Arguments) {
+		currentModel = args.Get(0)
+	}).Return(mockQuery).Maybe()
+	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery).Maybe()
+	mockQuery.On("First", mock.AnythingOfType("*models.NumericIDMapping")).Return(dynamormerrors.ErrItemNotFound).Once()
+	mockQuery.On("First", mock.AnythingOfType("*models.Actor")).Return(nil).Run(func(args mock.Arguments) {
+		m := args.Get(0).(*models.Actor)
+		m.Actor = &activitypub.Actor{
+			BaseObject:        activitypub.BaseObject{ID: "https://example.com/users/Agent-0"},
+			PreferredUsername: "Agent-0",
+		}
+	}).Once()
+	mockQuery.On("Create").Run(func(mock.Arguments) {
+		if mapping, ok := currentModel.(*models.NumericIDMapping); ok {
+			copyMapping := *mapping
+			createdMapping = &copyMapping
+		}
+	}).Return(nil).Once()
+
+	repo := NewActorRepository(mockDB, "test-table", logger)
+	require.NoError(t, repo.EnsureNumericIDMapping(ctx, "Agent-0"))
+	require.NotNil(t, createdMapping)
+	require.Equal(t, common.GenerateNumericID("agent-0"), createdMapping.NumericID)
+	require.Equal(t, "agent-0", createdMapping.Username)
+	require.Equal(t, "https://example.com/users/agent-0", createdMapping.ActorID)
 }
 
 func TestActorRepository_misc_methods(t *testing.T) {

--- a/pkg/storage/repositories/numeric_id_mapping_helpers.go
+++ b/pkg/storage/repositories/numeric_id_mapping_helpers.go
@@ -1,0 +1,97 @@
+package repositories
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/activitypubutil"
+	"github.com/equaltoai/lesser/pkg/common"
+)
+
+func canonicalNumericMappingUsername(username string) string {
+	return strings.ToLower(strings.TrimSpace(username))
+}
+
+func normalizedNumericIDMappingValues(username, actorID string) (numericID, canonicalUsername, canonicalActorID string) {
+	canonicalUsername = canonicalNumericMappingUsername(username)
+	if canonicalUsername == "" {
+		return "", "", strings.TrimSpace(actorID)
+	}
+
+	return common.GenerateNumericID(canonicalUsername), canonicalUsername, normalizeCanonicalActorReference(actorID, canonicalUsername)
+}
+
+func normalizeCanonicalActorReference(value, username string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+
+	canonical := canonicalNumericMappingUsername(username)
+	if canonical == "" {
+		return trimmed
+	}
+
+	trimmed = strings.TrimRight(trimmed, "/")
+	lowerTrimmed := strings.ToLower(trimmed)
+
+	if idx := strings.LastIndex(lowerTrimmed, "/users/"); idx >= 0 {
+		suffix := trimmed[idx+len("/users/"):]
+		if suffix != "" && !strings.Contains(suffix, "/") {
+			return trimmed[:idx+len("/users/")] + canonical
+		}
+	}
+
+	if idx := strings.LastIndex(lowerTrimmed, "/@"); idx >= 0 {
+		suffix := trimmed[idx+len("/@"):]
+		if suffix != "" && !strings.Contains(suffix, "/") {
+			return trimmed[:idx+len("/@")] + canonical
+		}
+	}
+
+	return trimmed
+}
+
+func normalizeLocalActorIdentityForStorage(username, baseURL string, actor *activitypub.Actor) *activitypub.Actor {
+	if actor == nil {
+		return nil
+	}
+
+	canonical := canonicalNumericMappingUsername(username)
+	if canonical == "" {
+		return actor
+	}
+
+	normalizedBaseURL := strings.TrimSuffix(strings.TrimSpace(baseURL), "/")
+	normalized := activitypubutil.BuildLocalActor(canonical, normalizedBaseURL, nil, actor)
+	if normalized == nil {
+		return actor
+	}
+
+	normalized.PreferredUsername = canonical
+	if normalizedBaseURL == "" {
+		normalized.ID = normalizeCanonicalActorReference(normalized.ID, canonical)
+		normalized.URL = normalizeCanonicalActorReference(normalized.URL, canonical)
+		normalized.Inbox = normalizeCanonicalActorReference(normalized.Inbox, canonical)
+		normalized.Outbox = normalizeCanonicalActorReference(normalized.Outbox, canonical)
+		normalized.Followers = normalizeCanonicalActorReference(normalized.Followers, canonical)
+		normalized.Following = normalizeCanonicalActorReference(normalized.Following, canonical)
+		normalized.Liked = normalizeCanonicalActorReference(normalized.Liked, canonical)
+		return normalized
+	}
+
+	normalized.ID = fmt.Sprintf("%s/users/%s", normalizedBaseURL, canonical)
+	normalized.URL = fmt.Sprintf("%s/@%s", normalizedBaseURL, canonical)
+	normalized.Inbox = fmt.Sprintf("%s/users/%s/inbox", normalizedBaseURL, canonical)
+	normalized.Outbox = fmt.Sprintf("%s/users/%s/outbox", normalizedBaseURL, canonical)
+	normalized.Followers = fmt.Sprintf("%s/users/%s/followers", normalizedBaseURL, canonical)
+	normalized.Following = fmt.Sprintf("%s/users/%s/following", normalizedBaseURL, canonical)
+	normalized.Liked = fmt.Sprintf("%s/users/%s/liked", normalizedBaseURL, canonical)
+	if normalized.Endpoints == nil {
+		normalized.Endpoints = &activitypub.Endpoints{}
+	}
+	normalized.Endpoints.SharedInbox = fmt.Sprintf("%s/inbox", normalizedBaseURL)
+
+	return normalized
+}

--- a/pkg/storage/repositories/numeric_id_mapping_helpers_test.go
+++ b/pkg/storage/repositories/numeric_id_mapping_helpers_test.go
@@ -1,0 +1,62 @@
+package repositories
+
+import (
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizedNumericIDMappingValues(t *testing.T) {
+	numericID, username, actorID := normalizedNumericIDMappingValues("Agent-0", "https://example.com/users/Agent-0")
+	require.Equal(t, common.GenerateNumericID("agent-0"), numericID)
+	require.Equal(t, "agent-0", username)
+	require.Equal(t, "https://example.com/users/agent-0", actorID)
+
+	numericID, username, actorID = normalizedNumericIDMappingValues("  ", "https://example.com/users/Agent-0")
+	require.Empty(t, numericID)
+	require.Empty(t, username)
+	require.Equal(t, "https://example.com/users/Agent-0", actorID)
+}
+
+func TestNormalizeCanonicalActorReference(t *testing.T) {
+	require.Equal(t, "https://example.com/users/agent-0", normalizeCanonicalActorReference("https://example.com/users/Agent-0/", "agent-0"))
+	require.Equal(t, "https://example.com/@agent-0", normalizeCanonicalActorReference("https://example.com/@Agent-0", "agent-0"))
+	require.Equal(t, "https://remote.example/actors/Agent-0", normalizeCanonicalActorReference("https://remote.example/actors/Agent-0", "agent-0"))
+}
+
+func TestNormalizeLocalActorIdentityForStorage(t *testing.T) {
+	baseURL := "https://example.com"
+	actor := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   baseURL + "/users/Agent-0",
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: "Agent-0",
+		URL:               baseURL + "/@Agent-0",
+		Inbox:             baseURL + "/users/Agent-0/inbox",
+		Outbox:            baseURL + "/users/Agent-0/outbox",
+		Followers:         baseURL + "/users/Agent-0/followers",
+		Following:         baseURL + "/users/Agent-0/following",
+		Liked:             baseURL + "/users/Agent-0/liked",
+	}
+
+	normalized := normalizeLocalActorIdentityForStorage("Agent-0", baseURL, actor)
+	require.NotNil(t, normalized)
+	require.Equal(t, "agent-0", normalized.PreferredUsername)
+	require.Equal(t, "https://example.com/users/agent-0", normalized.ID)
+	require.Equal(t, "https://example.com/@agent-0", normalized.URL)
+	require.Equal(t, "https://example.com/users/agent-0/inbox", normalized.Inbox)
+	require.Equal(t, "https://example.com/users/agent-0/outbox", normalized.Outbox)
+	require.Equal(t, "https://example.com/users/agent-0/followers", normalized.Followers)
+	require.Equal(t, "https://example.com/users/agent-0/following", normalized.Following)
+	require.Equal(t, "https://example.com/users/agent-0/liked", normalized.Liked)
+	require.NotNil(t, normalized.Endpoints)
+	require.Equal(t, "https://example.com/inbox", normalized.Endpoints.SharedInbox)
+
+	withoutBaseURL := normalizeLocalActorIdentityForStorage("Agent-0", "", actor)
+	require.Equal(t, "agent-0", withoutBaseURL.PreferredUsername)
+	require.Equal(t, "https://example.com/users/agent-0", withoutBaseURL.ID)
+	require.Equal(t, "https://example.com/@agent-0", withoutBaseURL.URL)
+}

--- a/tools/audit_gates/baseline.yml
+++ b/tools/audit_gates/baseline.yml
@@ -25,6 +25,7 @@ goInsecureSkipVerify:
 # Exact occurrences of TableTheory `Query.Scan(...)` in non-test Go code (tracked by count per file).
 # This gate exists to prevent adding new DynamoDB scans to production code paths.
 goDynamoDBQueryScan:
+  cmd/lesser/migrate_numeric_ids.go: 1
   cmd/lesser/migrate_user_keys.go: 1
   pkg/cost/dynamorm_tracker.go: 1
   pkg/federation/relationship_tracker.go: 4


### PR DESCRIPTION
## Summary
- add lowercase-conformant numeric ID normalization for actor and mapping writes, plus recovery hardening for legacy mixed-case-derived rows
- add `lesser migrate-numeric-ids` with tests so actor `numericID` fields and `NUMERIC_ID#` lookup rows can be backfilled repeatably
- run the backfill on `AWS_PROFILE=Sim` and verify the follow-up dry run reports zero remaining candidates

## Verification
- `GOTOOLCHAIN=auto go test ./cmd/lesser ./cmd/api/handlers ./pkg/storage/repositories`
- `./lesser test coverage --scope overall --short --verbose=false --exclude-generated=false --html=false`
- `./lesser coverage scoreboard --profile coverage_overall.out --mode package --package github.com/equaltoai/lesser/pkg --min-total 90.0`
- `./lesser coverage scoreboard --profile coverage_overall.out --mode package --package github.com/equaltoai/lesser/cmd --min-total 90.0`
- `./lesser verify ci`
- `./lesser migrate-numeric-ids --app simulacrum --env dev --aws-profile Sim`
- `./lesser migrate-numeric-ids --app simulacrum --env dev --aws-profile Sim --apply`
- `./lesser migrate-numeric-ids --app simulacrum --env dev --aws-profile Sim`

Closes #374
