### PR TITLE
clarify m0 deprecation contract

### DIFF
--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -2206,12 +2206,6 @@ components:
                 status:
                     type: string
                 visibility:
-                    description: Status visibility. `direct` messages must mention exactly one recipient using an @mention in the status content.
-                    enum:
-                        - public
-                        - unlisted
-                        - private
-                        - direct
                     type: string
             required:
                 - sensitive
@@ -11984,6 +11978,15 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/AppRegistrationResponse'
+                    headers:
+                        Deprecation:
+                            description: Present when legacy connector-era MCP registration semantics are used. Runtime value is `true`.
+                            schema:
+                                type: string
+                        Warning:
+                            description: HTTP warning emitted when legacy `client_class=agent` or `agent_username` registration semantics are used.
+                            schema:
+                                type: string
                 "400":
                     $ref: '#/components/responses/BadRequest'
                 "401":
@@ -18831,6 +18834,15 @@ paths:
             responses:
                 "200":
                     description: OK
+                    headers:
+                        Deprecation:
+                            description: Present when legacy connector-era MCP registration semantics are used. Runtime value is `true`.
+                            schema:
+                                type: string
+                        Warning:
+                            description: HTTP warning emitted when legacy `client_class=agent` or `agent_username` registration semantics are used.
+                            schema:
+                                type: string
                 "201":
                     description: Created
                     content:

--- a/docs/device-code-agent-auth.md
+++ b/docs/device-code-agent-auth.md
@@ -23,12 +23,17 @@ Device flow is the middle ground between browser-based `authorization_code` and 
 For public remote MCP access, the canonical contract is still the actor-scoped, resource-bound OAuth flow described in
 [docs/specs/mcp-actor-url-auth-contract.md](/home/aron/ai-workspace/codebases/equaltoai/lesser/docs/specs/mcp-actor-url-auth-contract.md).
 
-Device code can remain part of that public client toolbox when enabled, but the older agent-bound runtime session
-semantics described below are compatibility behavior rather than the canonical public MCP contract.
+Current device-code flow is outside that canonical actor-URL contract for now. `POST /oauth/device/code` currently
+accepts `client_id` and scopes only; it does not accept the actor-scoped `resource` value used by the canonical public
+MCP flow.
+
+Treat device code as a separate, non-canonical compatibility/bootstrap path until a later milestone rewires it around
+the actor-scoped resource contract.
 
 ## Lesser device-flow sequence
 
 1. The agent calls `POST /oauth/device/code` with its `client_id` and requested scopes.
+   This flow currently does not carry the actor-scoped MCP `resource`.
 2. Lesser returns:
    - `device_code`
    - `user_code`

--- a/docs/oauth-agent-clients.md
+++ b/docs/oauth-agent-clients.md
@@ -16,7 +16,7 @@ contract.
 - Prefer `POST /oauth/register` as the canonical public registration path.
 - Use standard RFC 7591 metadata as the source of truth for public clients.
 - Treat any published client profile, starter snippet, or copied example as derived guidance rather than a separate contract.
-- `POST /api/v1/apps` remains available as an operator-controlled compatibility path.
+- `POST /api/v1/apps` remains available as a non-canonical public compatibility path.
 - Request canonical scopes from the public catalog: `read`, `write`, `follow`, `push`.
 - Do not request `admin`; it is internal-only and rejected on public OAuth surfaces.
 - Store the returned `client_secret` because it is only shown once.
@@ -56,5 +56,5 @@ The current compatibility story is:
 - if device flow is enabled, dynamic `cli` clients also receive `device_code`
 - legacy agent-bound dynamic clients still require the existing ownership check before Lesser will bind them to an agent identity
 
-Manual `POST /api/v1/apps` registration remains available as an operator-controlled compatibility path, but RFC 7591 is
+Manual `POST /api/v1/apps` registration remains available as a non-canonical public compatibility path, but RFC 7591 is
 the canonical remote MCP path.

--- a/docs/specs/mcp-actor-url-auth-contract.md
+++ b/docs/specs/mcp-actor-url-auth-contract.md
@@ -75,7 +75,7 @@ That means:
 - any published public-client profile is derived from the RFC 7591 contract and must not replace it as the source of
   truth
 
-`POST /api/v1/apps` may continue to exist as an operator-controlled compatibility path, but it is not the canonical
+`POST /api/v1/apps` may continue to exist as a non-canonical public compatibility path, but it is not the canonical
 remote MCP contract for new public clients.
 
 ## Token model for public MCP access

--- a/tools/openapi/response_headers.go
+++ b/tools/openapi/response_headers.go
@@ -53,6 +53,17 @@ func ensureStandardResponseHeaders(op *operation, route routeDef) {
 		})
 	}
 
+	if route.Path == "/api/v1/apps" || route.Path == "/oauth/register" {
+		ensureHeader(resp.Headers, "Deprecation", responseHeader{
+			Description: "Present when legacy connector-era MCP registration semantics are used. Runtime value is `true`.",
+			Schema:      schemaRef{Type: "string"},
+		})
+		ensureHeader(resp.Headers, "Warning", responseHeader{
+			Description: "HTTP warning emitted when legacy `client_class=agent` or `agent_username` registration semantics are used.",
+			Schema:      schemaRef{Type: "string"},
+		})
+	}
+
 	op.Responses[respKey] = resp
 }
 

--- a/tools/openapi/route_schema_bindings.go
+++ b/tools/openapi/route_schema_bindings.go
@@ -15,6 +15,7 @@ func bindPayloadSchemas(repoRoot string, spec *openAPISpec, routes []routeDef) e
 	if err != nil {
 		return err
 	}
+	applySchemaOverrides(spec)
 
 	liftPkg := builder.pkgs[packagePathLift]
 	if liftPkg == nil {
@@ -32,7 +33,7 @@ func bindPayloadSchemas(repoRoot string, spec *openAPISpec, routes []routeDef) e
 		}
 	}
 
-	applySchemaOverrides(spec)
+	overrideOAuthClientSchemas(spec.Components.Schemas)
 	applyScopeDefaults(routes)
 
 	return nil


### PR DESCRIPTION
## Summary
- document Deprecation and Warning headers on the legacy registration paths in the generated OpenAPI contract
- make the device-code doc explicit that it is outside the canonical actor-scoped resource contract for now
- rename the legacy /api/v1/apps path as a non-canonical public compatibility path in the M0 docs

## Verification
- GOTOOLCHAIN=auto go run ./tools/openapi --check --strict
- GOTOOLCHAIN=auto go test ./cmd/api/handlers -run 'TestHandleAppRegistrationLift|TestHandleOAuthDynamicClientRegistrationLift_Round21|TestNormalizeDynamicClientRegistration_Round21' -count=1

Follow-up to #563 after the original PR merged before this commit landed.