### PR TITLE
add simple actor-scoped mcp access bundle

### DIFF
--- a/cmd/api/handlers/agent_governance.go
+++ b/cmd/api/handlers/agent_governance.go
@@ -178,7 +178,7 @@ func (h *Handler) HandleAdminVerifyAgentLift(ctx *apptheory.Context) (*apptheory
 		"reason":      strings.TrimSpace(req.Reason),
 	})
 
-	return okJSON(agentFromStorageUser(account.User, governance))
+	return okJSON(agentFromStorageUserWithBaseURL(account.User, governance, handlerBaseURL(h)))
 }
 
 // HandleAdminUnverifyAgentLift handles POST /api/v1/admin/agents/:username/unverify.
@@ -238,7 +238,7 @@ func (h *Handler) HandleAdminUnverifyAgentLift(ctx *apptheory.Context) (*apptheo
 		"reason":        strings.TrimSpace(req.Reason),
 	})
 
-	return okJSON(agentFromStorageUser(account.User, governance))
+	return okJSON(agentFromStorageUserWithBaseURL(account.User, governance, handlerBaseURL(h)))
 }
 
 // HandleAdminUnlockAgentLift handles POST /api/v1/admin/agents/:username/unlock.

--- a/cmd/api/handlers/agent_self_sovereign.go
+++ b/cmd/api/handlers/agent_self_sovereign.go
@@ -611,7 +611,7 @@ func (h *Handler) HandleAgentRotateKeyLift(ctx *apptheory.Context) (*apptheory.R
 		"key_type": account.User.AgentKeyType,
 	})
 
-	return okJSON(agentFromStorageUser(account.User, governance))
+	return okJSON(agentFromStorageUserWithBaseURL(account.User, governance, handlerBaseURL(h)))
 }
 
 func (h *Handler) createAgentKeyChallenge(ctx *apptheory.Context, username string, action string, ttl time.Duration) (*storageModels.AgentKeyChallenge, error) {

--- a/cmd/api/handlers/agents.go
+++ b/cmd/api/handlers/agents.go
@@ -438,6 +438,7 @@ func (h *Handler) HandleListAgentsLift(ctx *apptheory.Context) (*apptheory.Respo
 	if err != nil {
 		return common.RespondInternalServerError(ctx)
 	}
+	baseURL := handlerBaseURL(h)
 	for _, user := range users {
 		if user == nil || !user.IsAgent {
 			continue
@@ -445,7 +446,7 @@ func (h *Handler) HandleListAgentsLift(ctx *apptheory.Context) (*apptheory.Respo
 		if user.Suspended {
 			continue
 		}
-		agentsOut = append(agentsOut, agentFromStorageUser(user, governanceStates[strings.ToLower(strings.TrimSpace(user.Username))]))
+		agentsOut = append(agentsOut, agentFromStorageUserWithBaseURL(user, governanceStates[strings.ToLower(strings.TrimSpace(user.Username))], baseURL))
 	}
 
 	return okJSON(agentsOut)
@@ -473,7 +474,7 @@ func (h *Handler) HandleGetAgentLift(ctx *apptheory.Context) (*apptheory.Respons
 		return common.RespondInternalServerError(ctx)
 	}
 
-	return okJSON(agentFromStorageUser(user, governance))
+	return okJSON(agentFromStorageUserWithBaseURL(user, governance, handlerBaseURL(h)))
 }
 
 // HandleUpdateAgentLift handles PATCH /api/v1/agents/:username.
@@ -526,7 +527,7 @@ func (h *Handler) HandleUpdateAgentLift(ctx *apptheory.Context) (*apptheory.Resp
 		return respondAgentGovernanceWriteError(ctx, err)
 	}
 
-	return okJSON(agentFromStorageUser(account.User, governance))
+	return okJSON(agentFromStorageUserWithBaseURL(account.User, governance, handlerBaseURL(h)))
 }
 
 func parseUpdateAgentRequest(ctx *apptheory.Context) (*apimodels.UpdateAgentRequest, *apptheory.Response, error) {
@@ -700,7 +701,7 @@ func (h *Handler) HandleDeleteAgentLift(ctx *apptheory.Context) (*apptheory.Resp
 		return common.RespondInternalServerError(ctx)
 	}
 
-	return okJSON(agentFromStorageUser(account.User, governance))
+	return okJSON(agentFromStorageUserWithBaseURL(account.User, governance, handlerBaseURL(h)))
 }
 
 // HandleGetAgentActivityLift handles GET /api/v1/agents/:username/activity.
@@ -826,7 +827,7 @@ func (h *Handler) HandleSuspendAgentLift(ctx *apptheory.Context) (*apptheory.Res
 		return common.RespondInternalServerError(ctx)
 	}
 
-	return okJSON(agentFromStorageUser(account.User, governance))
+	return okJSON(agentFromStorageUserWithBaseURL(account.User, governance, handlerBaseURL(h)))
 }
 
 func (h *Handler) authenticateAgentOwner(ctx *apptheory.Context) (*auth.Claims, *apptheory.Response, error) {
@@ -981,7 +982,12 @@ func validateAgentAccessTokenTTLWithConfig(ctx *apptheory.Context, cfg *config.C
 	return time.Duration(expiresIn) * time.Second, nil, nil
 }
 
+//nolint:unused // Retained as the config-free helper for focused tests that only validate shape defaults.
 func agentFromStorageUser(user *storage.User, governance *storage.AgentGovernanceState) apimodels.Agent {
+	return agentFromStorageUserWithBaseURL(user, governance, "")
+}
+
+func agentFromStorageUserWithBaseURL(user *storage.User, governance *storage.AgentGovernanceState, baseURL string) apimodels.Agent {
 	out := apimodels.Agent{
 		Username:     user.Username,
 		DisplayName:  user.DisplayName,
@@ -1010,6 +1016,7 @@ func agentFromStorageUser(user *storage.User, governance *storage.AgentGovernanc
 	if strings.TrimSpace(out.AgentVersion) == "" {
 		out.AgentVersion = agentVersionUnknown
 	}
+	out.MCPAccess = apiAgentMCPAccess(auth.BuildPublicMCPAccessBundle(baseURL, out.Username))
 
 	return out
 }
@@ -1044,6 +1051,17 @@ func apiAgentCapabilitiesFromStorage(caps *agents.Capabilities) apimodels.AgentC
 		RestrictedDomains: append([]string(nil), caps.RestrictedDomains...),
 		MaxPostsPerHour:   caps.MaxPostsPerHour,
 		RequiresApproval:  caps.RequiresApproval,
+	}
+}
+
+func apiAgentMCPAccess(bundle auth.PublicMCPAccessBundle) apimodels.AgentMCPAccess {
+	return apimodels.AgentMCPAccess{
+		MCPURL:                 bundle.MCPURL,
+		ProtectedResourceURL:   bundle.ProtectedResourceURL,
+		AuthorizationServerURL: bundle.AuthorizationServerURL,
+		RegistrationURL:        bundle.RegistrationURL,
+		Scopes:                 append([]string(nil), bundle.SupportedScopes...),
+		Guidance:               append([]string(nil), bundle.Guidance...),
 	}
 }
 

--- a/cmd/api/handlers/agents_helpers_round20_test.go
+++ b/cmd/api/handlers/agents_helpers_round20_test.go
@@ -149,15 +149,22 @@ func TestAgentHelpersRound20(t *testing.T) {
 		require.Equal(t, []string{"read"}, unverified.DelegatedScopes)
 		require.NotNil(t, unverified.CreatedAt)
 		require.Equal(t, createdAt, *unverified.CreatedAt)
+		require.Empty(t, unverified.MCPAccess.MCPURL)
+		require.Equal(t, []string{auth.ScopeRead, auth.ScopeWrite, auth.ScopeFollow, auth.ScopePush}, unverified.MCPAccess.Scopes)
 
-		verified := agentFromStorageUser(user, &storage.AgentGovernanceState{
+		verified := agentFromStorageUserWithBaseURL(user, &storage.AgentGovernanceState{
 			Username:   "agent1",
 			Verified:   true,
 			VerifiedAt: &verifiedAt,
-		})
+		}, "https://example.com/")
 		require.True(t, verified.Verified)
 		require.NotNil(t, verified.VerifiedAt)
 		require.Equal(t, verifiedAt.UTC(), *verified.VerifiedAt)
+		require.Equal(t, "https://example.com/mcp/agent1", verified.MCPAccess.MCPURL)
+		require.Equal(t, "https://example.com/.well-known/oauth-protected-resource/mcp/agent1", verified.MCPAccess.ProtectedResourceURL)
+		require.Equal(t, "https://example.com/.well-known/oauth-authorization-server", verified.MCPAccess.AuthorizationServerURL)
+		require.Equal(t, "https://example.com/oauth/register", verified.MCPAccess.RegistrationURL)
+		require.Len(t, verified.MCPAccess.Guidance, 4)
 	})
 
 	t.Run("agent governance state helpers handle nil found and missing rows", func(t *testing.T) {

--- a/cmd/api/handlers/agents_management_round20_test.go
+++ b/cmd/api/handlers/agents_management_round20_test.go
@@ -89,6 +89,11 @@ func TestAgentManagementHandlersRound20(t *testing.T) {
 		var out apimodels.Agent
 		require.NoError(t, json.Unmarshal(resp.Body, &out))
 		require.Equal(t, "agent1", out.Username)
+		require.Equal(t, cfg.BaseURL()+"/mcp/agent1", out.MCPAccess.MCPURL)
+		require.Equal(t, cfg.BaseURL()+"/.well-known/oauth-protected-resource/mcp/agent1", out.MCPAccess.ProtectedResourceURL)
+		require.Equal(t, cfg.BaseURL()+"/.well-known/oauth-authorization-server", out.MCPAccess.AuthorizationServerURL)
+		require.Equal(t, cfg.BaseURL()+"/oauth/register", out.MCPAccess.RegistrationURL)
+		require.Len(t, out.MCPAccess.Guidance, 4)
 	})
 
 	t.Run("update agent success", func(t *testing.T) {

--- a/cmd/api/models/agents.go
+++ b/cmd/api/models/agents.go
@@ -16,6 +16,17 @@ type AgentCapabilities struct {
 	RequiresApproval  bool     `json:"requires_approval"`
 }
 
+// AgentMCPAccess describes the client-neutral actor-scoped MCP access surface
+// for an agent page.
+type AgentMCPAccess struct {
+	MCPURL                 string   `json:"mcp_url"`
+	ProtectedResourceURL   string   `json:"protected_resource_url"`
+	AuthorizationServerURL string   `json:"authorization_server_url"`
+	RegistrationURL        string   `json:"registration_url"`
+	Scopes                 []string `json:"scopes"`
+	Guidance               []string `json:"guidance"`
+}
+
 // Agent is the REST representation of a local agent account.
 type Agent struct {
 	Username          string            `json:"username"`
@@ -29,6 +40,7 @@ type Agent struct {
 	AgentOwner        string            `json:"agent_owner,omitempty"`
 	DelegatedScopes   []string          `json:"delegated_scopes,omitempty"`
 	AgentCapabilities AgentCapabilities `json:"agent_capabilities"`
+	MCPAccess         AgentMCPAccess    `json:"mcp_access"`
 }
 
 // AgentDelegationRequest is the request payload for POST /api/v1/agents/delegate.

--- a/docs/contracts/graphql-schema.graphql
+++ b/docs/contracts/graphql-schema.graphql
@@ -4143,6 +4143,15 @@ type AgentCapabilities {
   restrictedDomains: [String!]
 }
 
+type AgentMCPAccess {
+  mcpURL: String!
+  protectedResourceURL: String!
+  authorizationServerURL: String!
+  registrationURL: String!
+  scopes: [String!]!
+  guidance: [String!]!
+}
+
 type Agent {
   id: ID!
   username: String!
@@ -4155,6 +4164,7 @@ type Agent {
   agentCapabilities: AgentCapabilities!
   agentOwner: String
   delegatedScopes: [String!]!
+  mcpAccess: AgentMCPAccess!
   verified: Boolean!
   verifiedAt: Time
   ownerActor: Actor

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -889,6 +889,8 @@ components:
                     type: array
                 display_name:
                     type: string
+                mcp_access:
+                    $ref: '#/components/schemas/AgentMCPAccess'
                 username:
                     type: string
                 verified:
@@ -902,6 +904,7 @@ components:
                 - agent_type
                 - agent_version
                 - display_name
+                - mcp_access
                 - username
                 - verified
             type: object
@@ -1215,6 +1218,33 @@ components:
             items:
                 $ref: '#/components/schemas/Agent'
             type: array
+        AgentMCPAccess:
+            additionalProperties: false
+            properties:
+                authorization_server_url:
+                    type: string
+                guidance:
+                    items:
+                        type: string
+                    type: array
+                mcp_url:
+                    type: string
+                protected_resource_url:
+                    type: string
+                registration_url:
+                    type: string
+                scopes:
+                    items:
+                        type: string
+                    type: array
+            required:
+                - authorization_server_url
+                - guidance
+                - mcp_url
+                - protected_resource_url
+                - registration_url
+                - scopes
+            type: object
         AgentMemoryEventRequest:
             additionalProperties: false
             properties:

--- a/docs/oauth-agent-clients.md
+++ b/docs/oauth-agent-clients.md
@@ -9,6 +9,30 @@ Dedicated internal runtime clients such as `lesser-agent-delegation` and `lesser
 flows, and similar owned-client operations are compatibility/runtime surfaces, not the source of truth for public MCP
 access.
 
+## Simple MCP access panel
+
+The intended agent-page experience for public remote MCP access is a simple, actor-scoped access panel.
+
+That panel should surface:
+
+- the actor-scoped MCP URL
+- the actor-scoped protected-resource metadata URL
+- the shared OAuth authorization-server metadata URL
+- the canonical RFC 7591 registration URL
+- the supported public scope catalog
+- short client-neutral guidance for how to use those URLs together
+
+That panel should not depend on:
+
+- connector registration forms
+- pasted or copied client-secret recovery flows
+- browser-local connector inventories or cached connector metadata
+- connector session grouping or connector-specific transport packaging
+
+The panel contract is intentionally client-neutral. Lesser publishes the actor-scoped MCP access bundle; client-specific
+UI, local persistence, and onboarding affordances belong to the consuming product rather than to Lesser's canonical
+public MCP surface.
+
 ## Supported registration flow
 
 - Prefer `POST /oauth/register` as the canonical public registration path.
@@ -41,6 +65,9 @@ Legacy `read:*`, `write:*`, and `write:follows` aliases remain accepted for comp
 - Device-code and client-credentials tokens for agent clients are minted for the bound agent identity and carry `client_class`, `is_agent`, `agent_type`, and `delegated_by` claims.
 
 ## Secret recovery
+
+This is a compatibility/runtime concern for owned legacy clients. It is not part of the normal public remote MCP
+agent-page contract and should not be presented as the primary access path for new public clients.
 
 - Operators can rotate an owned legacy compatibility client secret in place with `POST /api/v1/apps/{id}/rotate_secret`.
 - Existing bearer access tokens remain valid until their normal expiry.

--- a/docs/specs/mcp-actor-url-auth-contract.md
+++ b/docs/specs/mcp-actor-url-auth-contract.md
@@ -5,6 +5,7 @@ This document freezes the client-consumable remote MCP access form owned by Less
 It is the single written contract for M0 and covers:
 
 - the canonical actor-scoped MCP access form
+- the simple access-panel shape that surfaces that form to users
 - the binding rule between actor URL, OAuth client, and access decision
 - the canonical public registration path
 - the resource-bound token model for public MCP access
@@ -27,6 +28,33 @@ New remote clients should treat that actor-scoped form as canonical.
 `/.well-known/mcp.json` remains part of public discovery, but it does not replace the actor-scoped protected-resource
 metadata. The MCP server URL a client ultimately connects to is the actor-specific resource URL, not a separate
 connector-specific endpoint.
+
+## Simple access-panel contract
+
+When Lesser surfaces public MCP access for an actor in its own UI, the canonical shape is a simple actor-scoped access
+bundle:
+
+- MCP URL:
+  `https://{domain}/mcp/{actor}`
+- protected-resource metadata URL:
+  `https://{domain}/.well-known/oauth-protected-resource/mcp/{actor}`
+- authorization-server metadata URL:
+  `https://{domain}/.well-known/oauth-authorization-server`
+- registration URL:
+  `https://{domain}/oauth/register`
+- supported scopes:
+  `read`, `write`, `follow`, `push`
+- client-neutral guidance that tells a consumer to use the actor-scoped MCP URL as the OAuth `resource` and to discover
+  OAuth metadata from the actor-scoped protected-resource document
+
+That access bundle is the intended public agent-page contract.
+
+The normal panel UX must not depend on:
+
+- connector registration forms
+- copied client secrets as the primary onboarding path
+- browser-local connector inventories or browser-local connector metadata
+- connector grouping, connector session management, or connector-specific transport packaging
 
 ## Discovery sequence
 

--- a/graph/agent_model_helpers.go
+++ b/graph/agent_model_helpers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/equaltoai/lesser/graph/model"
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/agents"
+	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/storage"
 )
 
@@ -23,8 +24,10 @@ func (r *Resolver) convertStorageUserToAgent(user *storage.User, governance *sto
 	}
 
 	id := username
+	baseURL := ""
 	if r != nil && r.Config != nil {
 		id = r.Config.ActorURL(username)
+		baseURL = r.Config.BaseURL()
 	}
 
 	displayName := strings.TrimSpace(user.DisplayName)
@@ -72,6 +75,7 @@ func (r *Resolver) convertStorageUserToAgent(user *storage.User, governance *sto
 		AgentCapabilities: capabilities,
 		AgentOwner:        agentOwner,
 		DelegatedScopes:   delegatedScopes,
+		McpAccess:         graphAgentMCPAccessModel(auth.BuildPublicMCPAccessBundle(baseURL, username)),
 		Verified:          verified,
 		VerifiedAt:        verifiedAt,
 		OwnerActor:        nil,
@@ -81,6 +85,17 @@ func (r *Resolver) convertStorageUserToAgent(user *storage.User, governance *sto
 		Owner:             nil,
 		CreatedAt:         model.Time(createdAt),
 		ActivityCount:     0,
+	}
+}
+
+func graphAgentMCPAccessModel(bundle auth.PublicMCPAccessBundle) *model.AgentMCPAccess {
+	return &model.AgentMCPAccess{
+		McpURL:                 bundle.MCPURL,
+		ProtectedResourceURL:   bundle.ProtectedResourceURL,
+		AuthorizationServerURL: bundle.AuthorizationServerURL,
+		RegistrationURL:        bundle.RegistrationURL,
+		Scopes:                 append([]string(nil), bundle.SupportedScopes...),
+		Guidance:               append([]string(nil), bundle.Guidance...),
 	}
 }
 

--- a/graph/agent_model_helpers_test.go
+++ b/graph/agent_model_helpers_test.go
@@ -5,12 +5,13 @@ import (
 	"time"
 
 	"github.com/equaltoai/lesser/pkg/agents"
+	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConvertStorageUserToAgent_HydratesMetadataAndCapabilities(t *testing.T) {
-	resolver := &Resolver{}
+	resolver := &Resolver{Config: &config.Config{Domain: "example.com"}}
 	createdAt := time.Date(2026, 2, 13, 12, 42, 10, 0, time.UTC)
 
 	user := &storage.User{
@@ -46,6 +47,12 @@ func TestConvertStorageUserToAgent_HydratesMetadataAndCapabilities(t *testing.T)
 	require.True(t, agent.AgentCapabilities.CanDM)
 	require.Equal(t, 0, agent.AgentCapabilities.MaxPostsPerHour)
 	require.True(t, agent.AgentCapabilities.RequiresApproval)
+	require.NotNil(t, agent.McpAccess)
+	require.Equal(t, "https://example.com/mcp/lowkey", agent.McpAccess.McpURL)
+	require.Equal(t, "https://example.com/.well-known/oauth-protected-resource/mcp/lowkey", agent.McpAccess.ProtectedResourceURL)
+	require.Equal(t, "https://example.com/.well-known/oauth-authorization-server", agent.McpAccess.AuthorizationServerURL)
+	require.Equal(t, "https://example.com/oauth/register", agent.McpAccess.RegistrationURL)
+	require.Len(t, agent.McpAccess.Guidance, 4)
 }
 
 func TestConvertStorageUserToAgent_HidesVerifiedAtWhenAgentIsNotVerified(t *testing.T) {

--- a/graph/agents.graphql
+++ b/graph/agents.graphql
@@ -20,6 +20,15 @@ type AgentCapabilities {
   restrictedDomains: [String!]
 }
 
+type AgentMCPAccess {
+  mcpURL: String!
+  protectedResourceURL: String!
+  authorizationServerURL: String!
+  registrationURL: String!
+  scopes: [String!]!
+  guidance: [String!]!
+}
+
 type Agent {
   id: ID!
   username: String!
@@ -32,6 +41,7 @@ type Agent {
   agentCapabilities: AgentCapabilities!
   agentOwner: String
   delegatedScopes: [String!]!
+  mcpAccess: AgentMCPAccess!
   verified: Boolean!
   verifiedAt: Time
   ownerActor: Actor

--- a/graph/generated.go
+++ b/graph/generated.go
@@ -545,6 +545,7 @@ type ComplexityRoot struct {
 		DelegatedScopes   func(childComplexity int) int
 		DisplayName       func(childComplexity int) int
 		ID                func(childComplexity int) int
+		McpAccess         func(childComplexity int) int
 		Owner             func(childComplexity int) int
 		OwnerActor        func(childComplexity int) int
 		Type              func(childComplexity int) int
@@ -552,6 +553,15 @@ type ComplexityRoot struct {
 		Verified          func(childComplexity int) int
 		VerifiedAt        func(childComplexity int) int
 		Version           func(childComplexity int) int
+	}
+
+	AgentMCPAccess struct {
+		AuthorizationServerURL func(childComplexity int) int
+		Guidance               func(childComplexity int) int
+		McpURL                 func(childComplexity int) int
+		ProtectedResourceURL   func(childComplexity int) int
+		RegistrationURL        func(childComplexity int) int
+		Scopes                 func(childComplexity int) int
 	}
 
 	AgentAccessLease struct {
@@ -5623,6 +5633,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Agent.ID(childComplexity), true
 
+	case "Agent.mcpAccess":
+		if e.complexity.Agent.McpAccess == nil {
+			break
+		}
+
+		return e.complexity.Agent.McpAccess(childComplexity), true
+
 	case "Agent.owner":
 		if e.complexity.Agent.Owner == nil {
 			break
@@ -5671,6 +5688,48 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Agent.Version(childComplexity), true
+
+	case "AgentMCPAccess.authorizationServerURL":
+		if e.complexity.AgentMCPAccess.AuthorizationServerURL == nil {
+			break
+		}
+
+		return e.complexity.AgentMCPAccess.AuthorizationServerURL(childComplexity), true
+
+	case "AgentMCPAccess.guidance":
+		if e.complexity.AgentMCPAccess.Guidance == nil {
+			break
+		}
+
+		return e.complexity.AgentMCPAccess.Guidance(childComplexity), true
+
+	case "AgentMCPAccess.mcpURL":
+		if e.complexity.AgentMCPAccess.McpURL == nil {
+			break
+		}
+
+		return e.complexity.AgentMCPAccess.McpURL(childComplexity), true
+
+	case "AgentMCPAccess.protectedResourceURL":
+		if e.complexity.AgentMCPAccess.ProtectedResourceURL == nil {
+			break
+		}
+
+		return e.complexity.AgentMCPAccess.ProtectedResourceURL(childComplexity), true
+
+	case "AgentMCPAccess.registrationURL":
+		if e.complexity.AgentMCPAccess.RegistrationURL == nil {
+			break
+		}
+
+		return e.complexity.AgentMCPAccess.RegistrationURL(childComplexity), true
+
+	case "AgentMCPAccess.scopes":
+		if e.complexity.AgentMCPAccess.Scopes == nil {
+			break
+		}
+
+		return e.complexity.AgentMCPAccess.Scopes(childComplexity), true
 
 	case "AgentAccessLease.absoluteExpiresAt":
 		if e.complexity.AgentAccessLease.AbsoluteExpiresAt == nil {
@@ -27838,6 +27897,8 @@ func (ec *executionContext) fieldContext_Actor_agentInfo(_ context.Context, fiel
 				return ec.fieldContext_Agent_agentOwner(ctx, field)
 			case "delegatedScopes":
 				return ec.fieldContext_Agent_delegatedScopes(ctx, field)
+			case "mcpAccess":
+				return ec.fieldContext_Agent_mcpAccess(ctx, field)
 			case "verified":
 				return ec.fieldContext_Agent_verified(ctx, field)
 			case "verifiedAt":
@@ -38488,6 +38549,64 @@ func (ec *executionContext) fieldContext_Agent_delegatedScopes(_ context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _Agent_mcpAccess(ctx context.Context, field graphql.CollectedField, obj *model.Agent) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Agent_mcpAccess(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.McpAccess, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.AgentMCPAccess)
+	fc.Result = res
+	return ec.marshalNAgentMCPAccess(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Agent_mcpAccess(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Agent",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "mcpURL":
+				return ec.fieldContext_AgentMCPAccess_mcpURL(ctx, field)
+			case "protectedResourceURL":
+				return ec.fieldContext_AgentMCPAccess_protectedResourceURL(ctx, field)
+			case "authorizationServerURL":
+				return ec.fieldContext_AgentMCPAccess_authorizationServerURL(ctx, field)
+			case "registrationURL":
+				return ec.fieldContext_AgentMCPAccess_registrationURL(ctx, field)
+			case "scopes":
+				return ec.fieldContext_AgentMCPAccess_scopes(ctx, field)
+			case "guidance":
+				return ec.fieldContext_AgentMCPAccess_guidance(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AgentMCPAccess", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Agent_verified(ctx context.Context, field graphql.CollectedField, obj *model.Agent) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Agent_verified(ctx, field)
 	if err != nil {
@@ -38980,6 +39099,270 @@ func (ec *executionContext) fieldContext_Agent_activityCount(_ context.Context, 
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AgentMCPAccess_mcpURL(ctx context.Context, field graphql.CollectedField, obj *model.AgentMCPAccess) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AgentMCPAccess_mcpURL(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx
+		return obj.McpURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AgentMCPAccess_mcpURL(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AgentMCPAccess",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AgentMCPAccess_protectedResourceURL(ctx context.Context, field graphql.CollectedField, obj *model.AgentMCPAccess) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AgentMCPAccess_protectedResourceURL(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx
+		return obj.ProtectedResourceURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AgentMCPAccess_protectedResourceURL(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AgentMCPAccess",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AgentMCPAccess_authorizationServerURL(ctx context.Context, field graphql.CollectedField, obj *model.AgentMCPAccess) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AgentMCPAccess_authorizationServerURL(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx
+		return obj.AuthorizationServerURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AgentMCPAccess_authorizationServerURL(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AgentMCPAccess",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AgentMCPAccess_registrationURL(ctx context.Context, field graphql.CollectedField, obj *model.AgentMCPAccess) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AgentMCPAccess_registrationURL(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx
+		return obj.RegistrationURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AgentMCPAccess_registrationURL(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AgentMCPAccess",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AgentMCPAccess_scopes(ctx context.Context, field graphql.CollectedField, obj *model.AgentMCPAccess) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AgentMCPAccess_scopes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx
+		return obj.Scopes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AgentMCPAccess_scopes(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AgentMCPAccess",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AgentMCPAccess_guidance(ctx context.Context, field graphql.CollectedField, obj *model.AgentMCPAccess) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AgentMCPAccess_guidance(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx
+		return obj.Guidance, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AgentMCPAccess_guidance(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AgentMCPAccess",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -140472,6 +140855,11 @@ func (ec *executionContext) _Agent(ctx context.Context, sel ast.SelectionSet, ob
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "mcpAccess":
+			out.Values[i] = ec._Agent_mcpAccess(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "verified":
 			out.Values[i] = ec._Agent_verified(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -140963,6 +141351,70 @@ func (ec *executionContext) _AgentActivityEvent(ctx context.Context, sel ast.Sel
 			out.Values[i] = ec._AgentActivityEvent_metadataJson(ctx, field, obj)
 		case "timestamp":
 			out.Values[i] = ec._AgentActivityEvent_timestamp(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var agentMCPAccessImplementors = []string{"AgentMCPAccess"}
+
+func (ec *executionContext) _AgentMCPAccess(ctx context.Context, sel ast.SelectionSet, obj *model.AgentMCPAccess) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, agentMCPAccessImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("AgentMCPAccess")
+		case "mcpURL":
+			out.Values[i] = ec._AgentMCPAccess_mcpURL(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "protectedResourceURL":
+			out.Values[i] = ec._AgentMCPAccess_protectedResourceURL(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "authorizationServerURL":
+			out.Values[i] = ec._AgentMCPAccess_authorizationServerURL(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "registrationURL":
+			out.Values[i] = ec._AgentMCPAccess_registrationURL(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "scopes":
+			out.Values[i] = ec._AgentMCPAccess_scopes(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "guidance":
+			out.Values[i] = ec._AgentMCPAccess_guidance(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -162841,6 +163293,16 @@ func (ec *executionContext) marshalNAgent2ᚖgithubᚗcomᚋequaltoaiᚋlesser�
 		return graphql.Null
 	}
 	return ec._Agent(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNAgentMCPAccess(ctx context.Context, sel ast.SelectionSet, v *model.AgentMCPAccess) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._AgentMCPAccess(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNAgentAccessLease2githubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐAgentAccessLease(ctx context.Context, sel ast.SelectionSet, v model.AgentAccessLease) graphql.Marshaler {

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -566,6 +566,7 @@ type Agent struct {
 	AgentCapabilities *activitypub.AgentCapabilities `json:"agentCapabilities"`
 	AgentOwner        *string                        `json:"agentOwner,omitempty"`
 	DelegatedScopes   []string                       `json:"delegatedScopes"`
+	McpAccess         *AgentMCPAccess                `json:"mcpAccess"`
 	Verified          bool                           `json:"verified"`
 	VerifiedAt        *Time                          `json:"verifiedAt,omitempty"`
 	OwnerActor        *activitypub.Actor             `json:"ownerActor,omitempty"`
@@ -575,6 +576,15 @@ type Agent struct {
 	Owner             *activitypub.Actor             `json:"owner,omitempty"`
 	CreatedAt         Time                           `json:"createdAt"`
 	ActivityCount     int                            `json:"activityCount"`
+}
+
+type AgentMCPAccess struct {
+	McpURL                 string   `json:"mcpURL"`
+	ProtectedResourceURL   string   `json:"protectedResourceURL"`
+	AuthorizationServerURL string   `json:"authorizationServerURL"`
+	RegistrationURL        string   `json:"registrationURL"`
+	Scopes                 []string `json:"scopes"`
+	Guidance               []string `json:"guidance"`
 }
 
 type AgentActivityConnection struct {

--- a/pkg/auth/mcp_access.go
+++ b/pkg/auth/mcp_access.go
@@ -1,0 +1,41 @@
+package auth
+
+import "strings"
+
+// PublicMCPAccessBundle describes the client-neutral actor-scoped MCP access
+// surface that can be shown by agent UIs without provisioning connector state.
+type PublicMCPAccessBundle struct {
+	MCPURL                 string
+	ProtectedResourceURL   string
+	AuthorizationServerURL string
+	RegistrationURL        string
+	SupportedScopes        []string
+	Guidance               []string
+}
+
+// BuildPublicMCPAccessBundle returns the canonical actor-scoped MCP discovery
+// bundle for a given local actor username.
+func BuildPublicMCPAccessBundle(baseURL, actorUsername string) PublicMCPAccessBundle {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	actorUsername = strings.TrimSpace(actorUsername)
+
+	bundle := PublicMCPAccessBundle{
+		SupportedScopes: []string{ScopeRead, ScopeWrite, ScopeFollow, ScopePush},
+		Guidance: []string{
+			"Start from the actor-specific MCP URL.",
+			"Use that same MCP URL as the OAuth resource parameter.",
+			"Discover OAuth metadata through the actor-scoped protected-resource document.",
+			"Register a generic OAuth client with /oauth/register when your client needs registration.",
+		},
+	}
+	if baseURL == "" || actorUsername == "" {
+		return bundle
+	}
+
+	bundle.MCPURL = baseURL + "/mcp/" + actorUsername
+	bundle.ProtectedResourceURL = baseURL + "/.well-known/oauth-protected-resource/mcp/" + actorUsername
+	bundle.AuthorizationServerURL = baseURL + "/.well-known/oauth-authorization-server"
+	bundle.RegistrationURL = baseURL + "/oauth/register"
+
+	return bundle
+}

--- a/pkg/auth/mcp_access_test.go
+++ b/pkg/auth/mcp_access_test.go
@@ -1,0 +1,32 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildPublicMCPAccessBundle(t *testing.T) {
+	t.Run("returns actor scoped urls and canonical guidance", func(t *testing.T) {
+		bundle := BuildPublicMCPAccessBundle("https://example.com/", "agent-one")
+
+		require.Equal(t, "https://example.com/mcp/agent-one", bundle.MCPURL)
+		require.Equal(t, "https://example.com/.well-known/oauth-protected-resource/mcp/agent-one", bundle.ProtectedResourceURL)
+		require.Equal(t, "https://example.com/.well-known/oauth-authorization-server", bundle.AuthorizationServerURL)
+		require.Equal(t, "https://example.com/oauth/register", bundle.RegistrationURL)
+		require.Equal(t, []string{ScopeRead, ScopeWrite, ScopeFollow, ScopePush}, bundle.SupportedScopes)
+		require.Len(t, bundle.Guidance, 4)
+		require.Contains(t, bundle.Guidance[1], "OAuth resource")
+	})
+
+	t.Run("preserves client neutral guidance without runtime base url", func(t *testing.T) {
+		bundle := BuildPublicMCPAccessBundle("", "agent-one")
+
+		require.Empty(t, bundle.MCPURL)
+		require.Empty(t, bundle.ProtectedResourceURL)
+		require.Empty(t, bundle.AuthorizationServerURL)
+		require.Empty(t, bundle.RegistrationURL)
+		require.Equal(t, []string{ScopeRead, ScopeWrite, ScopeFollow, ScopePush}, bundle.SupportedScopes)
+		require.Len(t, bundle.Guidance, 4)
+	})
+}


### PR DESCRIPTION
## Summary
- add a reusable public MCP access bundle and expose it on REST and GraphQL agent models
- update the Lesser-owned agent contract/docs around a simple actor-scoped MCP access panel instead of connector registration UX
- regenerate the OpenAPI and GraphQL contracts and cover the new access bundle with handler/graph/auth tests

## Scope
This PR completes Lesser's owned slice of M5 by publishing the actor-scoped MCP access bundle on Lesser surfaces.

Simulacrum can consume that contract in its own follow-up work, but this Lesser PR stands on its own for the Lesser-owned issues it implements.

## Verification
- GOTOOLCHAIN=auto go test ./pkg/auth -run 'TestBuildPublicMCPAccessBundle' -count=1
- GOTOOLCHAIN=auto go test ./cmd/api/handlers -run 'TestAgentHelpersRound20|TestAgentManagementHandlersRound20' -count=1
- GOTOOLCHAIN=auto go test ./graph -run 'TestConvertStorageUserToAgent' -count=1
- GOTOOLCHAIN=auto go run ./tools/openapi --check --strict
- PATH="$(GOTOOLCHAIN=auto go env GOROOT)/bin:$PATH" ./lesser verify ci

Closes #527
Closes #528
Closes #529
Closes #530
Closes #531
Closes #532
Closes #533
Closes #534