### PR TITLE
retire connector-era mcp auth state

### DIFF
--- a/cmd/api/handlers/oauth.go
+++ b/cmd/api/handlers/oauth.go
@@ -703,14 +703,16 @@ func (h *Handler) HandleOAuthTokenLift(ctx *apptheory.Context) (*apptheory.Respo
 		return h.handleOAuthAuthorizationCodeGrant(ctx.Context(), oauthSvc, req)
 	case oauthGrantTypeRefreshToken:
 		return h.handleOAuthRefreshTokenGrant(ctx, oauthSvc, req)
-	case oauthGrantTypeClientCredentials:
-		return h.handleOAuthClientCredentialsGrant(ctx.Context(), oauthSvc, req)
 	case oauthDeviceCodeGrantType:
 		return h.handleOAuthDeviceCodeGrant(ctx.Context(), oauthSvc, req)
 	default:
+		description := "Only authorization_code and refresh_token grant types are supported"
+		if oauthDeviceFlowEnabled(h.cfg) {
+			description = "Only authorization_code, refresh_token, and device_code grant types are supported"
+		}
 		return apptheory.JSON(http.StatusBadRequest, map[string]string{
 			"error":             "unsupported_grant_type",
-			"error_description": "Only authorization_code, refresh_token, client_credentials, and device_code grant types are supported",
+			"error_description": description,
 		})
 	}
 }
@@ -823,101 +825,6 @@ func (h *Handler) handleOAuthRefreshTokenGrant(ctx *apptheory.Context, oauthSvc 
 	})
 }
 
-func (h *Handler) handleOAuthClientCredentialsGrant(ctx context.Context, oauthSvc *auth.OAuthService, req *oauthTokenRequest) (*apptheory.Response, error) {
-	if err := common.ValidateMultipleRequiredParams(map[string]string{
-		"client_id":     req.clientID,
-		"client_secret": req.clientSecret,
-	}); err != nil {
-		return apptheory.JSON(http.StatusBadRequest, map[string]string{
-			"error":             "invalid_request",
-			"error_description": err.Error(),
-		})
-	}
-
-	client, err := h.repos.Account().GetOAuthClient(ctx, strings.TrimSpace(req.clientID))
-	if err != nil || client == nil {
-		return apptheory.JSON(http.StatusBadRequest, map[string]string{
-			"error":             "invalid_client",
-			"error_description": "Invalid client credentials",
-		})
-	}
-	if err := oauthSvc.ValidateClient(ctx, req.clientID, req.clientSecret); err != nil {
-		return apptheory.JSON(http.StatusBadRequest, map[string]string{
-			"error":             "invalid_client",
-			"error_description": "Invalid client credentials",
-		})
-	}
-	if !oauthClientSupportsGrantType(client, oauthGrantTypeClientCredentials) {
-		return apptheory.JSON(http.StatusBadRequest, map[string]string{
-			"error":             "unauthorized_client",
-			"error_description": "client_credentials is not allowed for this client",
-		})
-	}
-	if !strings.EqualFold(strings.TrimSpace(client.ClientClass), auth.ClientClassAgent) {
-		return apptheory.JSON(http.StatusBadRequest, map[string]string{
-			"error":             "unauthorized_client",
-			"error_description": "Only agent clients may use client_credentials",
-		})
-	}
-
-	agentUser, agentErr := h.getAgentUserForOAuthClient(ctx, client, client.OwnerID)
-	switch agentErr {
-	case nil:
-	case errOAuthAgentUsernameRequired, errOAuthAgentNotFound:
-		return apptheory.JSON(http.StatusBadRequest, map[string]string{
-			"error":             "invalid_client",
-			"error_description": agentErr.Error(),
-		})
-	case errOAuthAgentForbidden:
-		return apptheory.JSON(http.StatusBadRequest, map[string]string{
-			"error":             "invalid_client",
-			"error_description": "Client ownership no longer matches the bound agent",
-		})
-	default:
-		h.logger.Error("failed to resolve OAuth agent client_credentials binding", zap.Error(agentErr))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{
-			"error":             "server_error",
-			"error_description": "Failed to resolve bound agent",
-		})
-	}
-
-	scopes, err := resolveOAuthClientRequestedScopes(client, req.scope)
-	if err != nil {
-		return apptheory.JSON(http.StatusBadRequest, map[string]string{
-			"error":             "invalid_scope",
-			"error_description": "requested scopes exceed the client scope set",
-		})
-	}
-
-	accessTTL := auth.AgentAccessTokenTTL(h.cfg)
-	accessToken, _, err := oauthSvc.GenerateTokensWithAccessTokenTTLAndClientContextAndAudience(
-		ctx,
-		agentUser.Username,
-		client.ClientID,
-		"",
-		scopes,
-		accessTTL,
-		auth.ClientClassAgent,
-		common.GenerateSessionIDULID(),
-		req.resource,
-	)
-	if err != nil {
-		h.logger.Error("failed to generate client_credentials access token", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{
-			"error":             "server_error",
-			"error_description": "Failed to generate tokens",
-		})
-	}
-
-	return okJSON(apimodels.OAuthTokenResponse{
-		AccessToken: accessToken,
-		TokenType:   oauthTokenTypeBearer,
-		Scope:       strings.Join(scopes, " "),
-		CreatedAt:   time.Now().Unix(),
-		ExpiresIn:   int(accessTTL.Seconds()),
-	})
-}
-
 func (h *Handler) handleOAuthDeviceCodeGrant(ctx context.Context, oauthSvc *auth.OAuthService, req *oauthTokenRequest) (*apptheory.Response, error) {
 	if h.cfg == nil || !h.cfg.AllowDeviceFlow {
 		return apptheory.JSON(http.StatusForbidden, map[string]string{
@@ -987,12 +894,20 @@ func oauthClientSupportsGrantType(client *storage.OAuthClient, grantType string)
 	if client == nil {
 		return false
 	}
+	normalizedGrantType := strings.ToLower(strings.TrimSpace(grantType))
+	clientClass := strings.ToLower(strings.TrimSpace(client.ClientClass))
+	if normalizedGrantType == oauthGrantTypeClientCredentials {
+		return false
+	}
+	if normalizedGrantType == oauthDeviceCodeGrantType && clientClass == auth.ClientClassAgent {
+		return false
+	}
 	if len(client.GrantTypes) == 0 {
-		switch strings.ToLower(strings.TrimSpace(grantType)) {
-		case oauthGrantTypeAuthorizationCode, oauthGrantTypeRefreshToken, oauthDeviceCodeGrantType:
+		switch normalizedGrantType {
+		case oauthGrantTypeAuthorizationCode, oauthGrantTypeRefreshToken:
 			return true
-		case oauthGrantTypeClientCredentials:
-			return strings.EqualFold(strings.TrimSpace(client.ClientClass), auth.ClientClassAgent)
+		case oauthDeviceCodeGrantType:
+			return clientClass == auth.ClientClassCLI
 		default:
 			return false
 		}
@@ -1003,28 +918,6 @@ func oauthClientSupportsGrantType(client *storage.OAuthClient, grantType string)
 		}
 	}
 	return false
-}
-
-func resolveOAuthClientRequestedScopes(client *storage.OAuthClient, requestedScope string) ([]string, error) {
-	requested := splitOAuthSpaceDelimited(requestedScope)
-	if len(requested) == 0 {
-		if len(client.Scopes) > 0 {
-			requested = append([]string(nil), client.Scopes...)
-		} else {
-			requested = auth.DefaultScopes()
-		}
-	}
-	if err := auth.ValidatePublicOAuthScopes(requested); err != nil {
-		return nil, err
-	}
-	if len(client.Scopes) == 0 {
-		return requested, nil
-	}
-
-	if !auth.ScopeSetAllows(client.Scopes, requested) {
-		return nil, auth.ErrInvalidScope
-	}
-	return requested, nil
 }
 
 func (h *Handler) loadOAuthDeviceSessionForTokenGrant(ctx context.Context, deviceCode, clientID string) (*storage.OAuthDeviceSession, *apptheory.Response, error) {
@@ -1184,29 +1077,23 @@ func (h *Handler) oauthDeviceSessionApprovedTokenResponse(ctx context.Context, o
 	})
 }
 
-func (h *Handler) oauthDeviceApprovedTokenContext(ctx context.Context, client *storage.OAuthClient, approvedUsername string) (string, string, string, time.Duration, error) {
+func (h *Handler) oauthDeviceApprovedTokenContext(_ context.Context, client *storage.OAuthClient, approvedUsername string) (string, string, string, time.Duration, error) {
 	clientClass := strings.ToLower(strings.TrimSpace(client.ClientClass))
 	if clientClass == "" {
 		clientClass = auth.ClientClassCLI
+	}
+	if clientClass == auth.ClientClassAgent {
+		return "", "", "", 0, auth.ErrInvalidGrant
 	}
 
 	tokenUsername := strings.TrimSpace(approvedUsername)
 	sessionID := ""
 	accessTTL := auth.AccessTokenDuration
-	if clientClass == auth.ClientClassCLI || clientClass == auth.ClientClassAgent {
+	if clientClass == auth.ClientClassCLI {
 		sessionID = common.GenerateSessionIDULID()
 	}
 
-	if clientClass != auth.ClientClassAgent {
-		return tokenUsername, clientClass, sessionID, accessTTL, nil
-	}
-
-	agentUser, err := h.getAgentUserForOAuthClient(ctx, client, approvedUsername)
-	if err != nil || agentUser == nil {
-		return "", "", "", 0, auth.ErrInvalidGrant
-	}
-
-	return agentUser.Username, clientClass, sessionID, auth.AgentAccessTokenTTL(h.cfg), nil
+	return tokenUsername, clientClass, sessionID, accessTTL, nil
 }
 
 func (h *Handler) oauthDeviceApprovedTokenContextErrorResponse(err error) (*apptheory.Response, error) {
@@ -1347,11 +1234,7 @@ func oauthClientRequiresPKCE(client *storage.OAuthClient) bool {
 }
 
 func oauthAuthorizeRequiresResource(client *storage.OAuthClient) bool {
-	if client == nil {
-		return false
-	}
-	return usesDeprecatedMCPConnectorSemantics(client.ClientClass, client.AgentUsername) ||
-		oauthClientRequiresPKCE(client)
+	return oauthClientRequiresPKCE(client)
 }
 
 func requireOAuthPKCE(codeChallenge, codeChallengeMethod string) error {

--- a/cmd/api/handlers/oauth_client_helpers_round12_test.go
+++ b/cmd/api/handlers/oauth_client_helpers_round12_test.go
@@ -69,8 +69,9 @@ func TestOAuthClientHelperCoverage(t *testing.T) {
 	t.Run("oauth client supports grant type defaults and explicit lists", func(t *testing.T) {
 		require.False(t, oauthClientSupportsGrantType(nil, auth.GrantTypeAuthorizationCode))
 		require.True(t, oauthClientSupportsGrantType(&storagepkg.OAuthClient{}, auth.GrantTypeAuthorizationCode))
-		require.True(t, oauthClientSupportsGrantType(&storagepkg.OAuthClient{ClientClass: auth.ClientClassAgent}, auth.GrantTypeClientCredentials))
-		require.False(t, oauthClientSupportsGrantType(&storagepkg.OAuthClient{ClientClass: auth.ClientClassWeb}, auth.GrantTypeClientCredentials))
+		require.True(t, oauthClientSupportsGrantType(&storagepkg.OAuthClient{ClientClass: auth.ClientClassCLI}, oauthDeviceCodeGrantType))
+		require.False(t, oauthClientSupportsGrantType(&storagepkg.OAuthClient{ClientClass: auth.ClientClassAgent}, oauthDeviceCodeGrantType))
+		require.False(t, oauthClientSupportsGrantType(&storagepkg.OAuthClient{ClientClass: auth.ClientClassAgent}, auth.GrantTypeClientCredentials))
 		require.True(t, oauthClientSupportsGrantType(&storagepkg.OAuthClient{GrantTypes: []string{auth.GrantTypeRefreshToken}}, auth.GrantTypeRefreshToken))
 		require.False(t, oauthClientSupportsGrantType(&storagepkg.OAuthClient{GrantTypes: []string{auth.GrantTypeRefreshToken}}, auth.GrantTypeAuthorizationCode))
 	})

--- a/cmd/api/handlers/oauth_device.go
+++ b/cmd/api/handlers/oauth_device.go
@@ -68,10 +68,17 @@ func (h *Handler) HandleOAuthDeviceCodeLift(ctx *apptheory.Context) (*apptheory.
 	}
 
 	// Validate that the client exists (public clients are allowed; secret is not required here).
-	if _, err := h.repos.Account().GetOAuthClient(ctx.Context(), clientID); err != nil {
+	client, err := h.repos.Account().GetOAuthClient(ctx.Context(), clientID)
+	if err != nil || client == nil {
 		return apptheory.JSON(http.StatusBadRequest, apimodels.OAuthErrorResponse{
 			Error:            "invalid_client",
 			ErrorDescription: "unknown client",
+		})
+	}
+	if !oauthClientSupportsGrantType(client, oauthDeviceCodeGrantType) {
+		return apptheory.JSON(http.StatusBadRequest, apimodels.OAuthErrorResponse{
+			Error:            "unauthorized_client",
+			ErrorDescription: "device_code is not allowed for this client",
 		})
 	}
 

--- a/cmd/api/handlers/oauth_device_round12_test.go
+++ b/cmd/api/handlers/oauth_device_round12_test.go
@@ -5,8 +5,11 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	apimodels "github.com/equaltoai/lesser/cmd/api/models"
+	"github.com/equaltoai/lesser/pkg/auth"
+	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,6 +30,14 @@ func TestOAuthDeviceCodeLiftRound12(t *testing.T) {
 		cfgDevice := round11TestConfig()
 		cfgDevice.AllowDeviceFlow = true
 		state := &round10QueryState{
+			oauthClientsByID: map[string]storagemodels.OAuthClient{
+				"client-1": {
+					ClientID:    "client-1",
+					ClientClass: auth.ClientClassCLI,
+					GrantTypes:  []string{oauthDeviceCodeGrantType, auth.GrantTypeRefreshToken},
+					CreatedAt:   time.Now().Add(-1 * time.Hour),
+				},
+			},
 			createErrorOnce: errors.New("boom"),
 		}
 		h, _, _ := round11NewHandler(t, cfgDevice, state)
@@ -41,7 +52,16 @@ func TestOAuthDeviceCodeLiftRound12(t *testing.T) {
 	t.Run("success returns device and user codes", func(t *testing.T) {
 		cfgDevice := round11TestConfig()
 		cfgDevice.AllowDeviceFlow = true
-		h, _, _ := round11NewHandler(t, cfgDevice, &round10QueryState{})
+		h, _, _ := round11NewHandler(t, cfgDevice, &round10QueryState{
+			oauthClientsByID: map[string]storagemodels.OAuthClient{
+				"client-1": {
+					ClientID:    "client-1",
+					ClientClass: auth.ClientClassCLI,
+					GrantTypes:  []string{oauthDeviceCodeGrantType, auth.GrantTypeRefreshToken},
+					CreatedAt:   time.Now().Add(-1 * time.Hour),
+				},
+			},
+		})
 		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/device/code", nil, nil, []byte("client_id=client-1&scope=read%20write"))
 		resp := requireStatus(t, http.StatusOK)(h.HandleOAuthDeviceCodeLift(ctx))
 
@@ -53,5 +73,29 @@ func TestOAuthDeviceCodeLiftRound12(t *testing.T) {
 		require.NotEmpty(t, body.VerificationURIComplete)
 		require.Equal(t, oauthDeviceCodeTTLSeconds, body.ExpiresIn)
 		require.Equal(t, oauthDevicePollIntervalSeconds, body.Interval)
+	})
+
+	t.Run("connector-era agent clients are rejected", func(t *testing.T) {
+		cfgDevice := round11TestConfig()
+		cfgDevice.AllowDeviceFlow = true
+		h, _, _ := round11NewHandler(t, cfgDevice, &round10QueryState{
+			oauthClientsByID: map[string]storagemodels.OAuthClient{
+				"client-agent": {
+					ClientID:      "client-agent",
+					ClientClass:   auth.ClientClassAgent,
+					AgentUsername: "agent1",
+					GrantTypes:    []string{oauthDeviceCodeGrantType, auth.GrantTypeRefreshToken},
+					CreatedAt:     time.Now().Add(-1 * time.Hour),
+				},
+			},
+		})
+
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/device/code", nil, nil, []byte("client_id=client-agent"))
+		resp := requireStatus(t, http.StatusBadRequest)(h.HandleOAuthDeviceCodeLift(ctx))
+
+		var body apimodels.OAuthErrorResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "unauthorized_client", body.Error)
+		require.Equal(t, "device_code is not allowed for this client", body.ErrorDescription)
 	})
 }

--- a/cmd/api/handlers/oauth_device_round21_end_to_end_test.go
+++ b/cmd/api/handlers/oauth_device_round21_end_to_end_test.go
@@ -1,10 +1,8 @@
 package handlers
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
-	"net/url"
 	"testing"
 	"time"
 
@@ -14,10 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOAuthDeviceFlowAgentEndToEndRound21(t *testing.T) {
+func TestOAuthDeviceFlowConnectorAgentRejectedRound21(t *testing.T) {
 	cfg := round11TestConfig()
 	cfg.AllowDeviceFlow = true
-	cfg.AgentAccessTokenDuration = 8 * time.Hour
 
 	state := &round10QueryState{
 		oauthClientsByID: map[string]storagemodels.OAuthClient{
@@ -44,94 +41,11 @@ func TestOAuthDeviceFlowAgentEndToEndRound21(t *testing.T) {
 	h, _, _ := round11NewHandler(t, cfg, state)
 
 	deviceCtx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/device/code", nil, nil, []byte("client_id=client-agent&scope=read%20follow"))
-	deviceResp := requireStatus(t, http.StatusOK)(h.HandleOAuthDeviceCodeLift(deviceCtx))
+	deviceResp := requireStatus(t, http.StatusBadRequest)(h.HandleOAuthDeviceCodeLift(deviceCtx))
 
-	var deviceBody apimodels.OAuthDeviceCodeResponse
-	require.NoError(t, json.Unmarshal(deviceResp.Body, &deviceBody))
-	require.NotEmpty(t, deviceBody.DeviceCode)
-	require.NotEmpty(t, deviceBody.UserCode)
-	require.Equal(t, "https://example.com/auth/device", deviceBody.VerificationURI)
-	require.Equal(t, "https://example.com/auth/device?user_code="+url.QueryEscape(deviceBody.UserCode), deviceBody.VerificationURIComplete)
-
-	deviceHash := oauthDeviceCodeHash(deviceBody.DeviceCode)
-	storedSession, ok := state.oauthDeviceSessionsByHash[deviceHash]
-	require.True(t, ok)
-	require.Equal(t, []string{auth.ScopeRead, auth.ScopeFollow}, storedSession.Scopes)
-	require.Equal(t, oauthDeviceSessionStatusPending, storedSession.Status)
-
-	pageCtx, err := round10NewLiftContext(http.MethodGet, "/auth/device", nil, map[string]string{"user_code": deviceBody.UserCode}, nil)
-	require.NoError(t, err)
-	pageResp := requireStatus(t, http.StatusOK)(h.HandleOAuthDevicePageLift(pageCtx))
-	require.Contains(t, string(pageResp.Body), deviceBody.UserCode)
-
-	verifyCtx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/device/verify", nil, nil, []byte("user_code="+url.QueryEscape(deviceBody.UserCode)))
-	verifyResp := requireStatus(t, http.StatusOK)(h.HandleOAuthDeviceVerifyLift(verifyCtx))
-
-	var verifyBody apimodels.OAuthDeviceVerifyResponse
-	require.NoError(t, json.Unmarshal(verifyResp.Body, &verifyBody))
-	require.Equal(t, "client-agent", verifyBody.ClientID)
-	require.Equal(t, "Agent Device Connector", verifyBody.ClientName)
-	require.Equal(t, []string{auth.ScopeRead, auth.ScopeFollow}, verifyBody.Scopes)
-	require.Equal(t, oauthDeviceSessionStatusPending, verifyBody.Status)
-
-	oauthSvc := createOAuthService(cfg.JWTSecret, cfg, h.repos, h.logger)
-	operatorAccessToken, _, err := oauthSvc.GenerateTokens(context.Background(), "owner", "device-approver", "", []string{auth.ScopeRead})
-	require.NoError(t, err)
-
-	consentCtx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/device/consent", map[string]string{
-		"authorization": "Bearer " + operatorAccessToken,
-	}, nil, []byte("user_code="+url.QueryEscape(deviceBody.UserCode)+"&action=approve"))
-	consentResp := requireStatus(t, http.StatusOK)(h.HandleOAuthDeviceConsentLift(consentCtx))
-
-	var consentBody apimodels.OAuthDeviceConsentResponse
-	require.NoError(t, json.Unmarshal(consentResp.Body, &consentBody))
-	require.Equal(t, oauthDeviceSessionStatusApproved, consentBody.Status)
-
-	approvedSession := state.oauthDeviceSessionsByHash[deviceHash]
-	require.Equal(t, oauthDeviceSessionStatusApproved, approvedSession.Status)
-	require.Equal(t, "owner", approvedSession.ApprovedUsername)
-
-	tokenCtx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type="+oauthDeviceCodeGrantType+"&device_code="+url.QueryEscape(deviceBody.DeviceCode)+"&client_id=client-agent"))
-	tokenResp := requireStatus(t, http.StatusOK)(h.HandleOAuthTokenLift(tokenCtx))
-
-	var tokenBody apimodels.OAuthTokenResponse
-	require.NoError(t, json.Unmarshal(tokenResp.Body, &tokenBody))
-	require.Equal(t, "read follow", tokenBody.Scope)
-	require.Equal(t, int((8 * time.Hour).Seconds()), tokenBody.ExpiresIn)
-	require.NotEmpty(t, tokenBody.RefreshToken)
-
-	claims := round12DecodeJWTClaims(t, tokenBody.AccessToken)
-	require.Equal(t, "agent1", claims.Username)
-	require.True(t, claims.IsAgent)
-	require.Equal(t, auth.ClientClassAgent, claims.ClientClass)
-	require.Equal(t, "assistant", claims.AgentType)
-	require.Equal(t, "@owner", claims.DelegatedBy)
-	require.ElementsMatch(t, []string{auth.ScopeRead, auth.ScopeFollow}, claims.Scopes)
-
-	readCtx := round10NewLiftContextWithBodyBytes(http.MethodGet, "/api/v1/accounts/verify_credentials", map[string]string{
-		"authorization": "Bearer " + tokenBody.AccessToken,
-	}, nil, nil)
-	readClaims, err := h.authenticateWithScope(readCtx, auth.ScopeRead)
-	require.NoError(t, err)
-	require.Equal(t, "agent1", readClaims.Username)
-
-	followCtx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/api/v1/accounts/agent1/follow", map[string]string{
-		"authorization": "Bearer " + tokenBody.AccessToken,
-	}, nil, nil)
-	followClaims, err := h.authenticateRelationshipOperation(followCtx, relationshipOpFollow)
-	require.NoError(t, err)
-	require.Equal(t, "agent1", followClaims.Username)
-
-	finalSession := state.oauthDeviceSessionsByHash[deviceHash]
-	require.Equal(t, oauthDeviceSessionStatusConsumed, finalSession.Status)
-	require.Equal(t, []string{auth.ScopeRead, auth.ScopeFollow}, finalSession.Scopes)
-
-	storedRefresh, ok := state.refreshTokensByToken[tokenBody.RefreshToken]
-	require.True(t, ok)
-	require.Equal(t, auth.ClientClassAgent, storedRefresh.ClientClass)
-	require.Equal(t, "agent1", storedRefresh.Username)
-	require.Equal(t, []string{auth.ScopeRead, auth.ScopeFollow}, storedRefresh.Scopes)
-	require.Empty(t, storedRefresh.FamilyID)
-	require.False(t, storedRefresh.Current)
-	require.Zero(t, storedRefresh.AccessTTLSeconds)
+	var body apimodels.OAuthErrorResponse
+	require.NoError(t, json.Unmarshal(deviceResp.Body, &body))
+	require.Equal(t, "unauthorized_client", body.Error)
+	require.Equal(t, "device_code is not allowed for this client", body.ErrorDescription)
+	require.Empty(t, state.oauthDeviceSessionsByHash)
 }

--- a/cmd/api/handlers/oauth_mcp_deprecation.go
+++ b/cmd/api/handlers/oauth_mcp_deprecation.go
@@ -1,12 +1,1 @@
 package handlers
-
-import (
-	"strings"
-
-	"github.com/equaltoai/lesser/pkg/auth"
-)
-
-func usesDeprecatedMCPConnectorSemantics(clientClass, agentUsername string) bool {
-	return strings.EqualFold(strings.TrimSpace(clientClass), auth.ClientClassAgent) ||
-		strings.TrimSpace(agentUsername) != ""
-}

--- a/cmd/api/handlers/oauth_metadata.go
+++ b/cmd/api/handlers/oauth_metadata.go
@@ -42,7 +42,6 @@ func oauthGrantTypesSupported(cfg *config.Config) []string {
 	grantTypes := []string{
 		"authorization_code",
 		"refresh_token",
-		"client_credentials",
 	}
 	if oauthDeviceFlowEnabled(cfg) {
 		grantTypes = append(grantTypes, oauthDeviceCodeGrantType)

--- a/cmd/api/handlers/oauth_metadata_test.go
+++ b/cmd/api/handlers/oauth_metadata_test.go
@@ -30,7 +30,7 @@ func TestHandleOAuthAuthorizationServerMetadataLift(t *testing.T) {
 		require.Equal(t, "https://example.com/oauth/device/code", body["device_authorization_endpoint"])
 		require.Equal(t, false, body["client_id_metadata_document_supported"])
 		require.ElementsMatch(t, []any{"code"}, body["response_types_supported"].([]any))
-		require.ElementsMatch(t, []any{"authorization_code", "refresh_token", "client_credentials", oauthDeviceCodeGrantType}, body["grant_types_supported"].([]any))
+		require.ElementsMatch(t, []any{"authorization_code", "refresh_token", oauthDeviceCodeGrantType}, body["grant_types_supported"].([]any))
 		require.ElementsMatch(t, []any{"client_secret_basic", "client_secret_post", "none"}, body["token_endpoint_auth_methods_supported"].([]any))
 		require.ElementsMatch(t, []any{"S256"}, body["code_challenge_methods_supported"].([]any))
 		require.ElementsMatch(t, []any{auth.ScopeRead, auth.ScopeWrite, auth.ScopeFollow, auth.ScopePush}, body["scopes_supported"].([]any))
@@ -50,6 +50,6 @@ func TestHandleOAuthAuthorizationServerMetadataLift(t *testing.T) {
 		require.NoError(t, json.Unmarshal(resp.Body, &body))
 		require.Equal(t, false, body["client_id_metadata_document_supported"])
 		require.NotContains(t, body, "device_authorization_endpoint")
-		require.ElementsMatch(t, []any{"authorization_code", "refresh_token", "client_credentials"}, body["grant_types_supported"].([]any))
+		require.ElementsMatch(t, []any{"authorization_code", "refresh_token"}, body["grant_types_supported"].([]any))
 	})
 }

--- a/cmd/api/handlers/oauth_round12_test.go
+++ b/cmd/api/handlers/oauth_round12_test.go
@@ -252,7 +252,26 @@ func TestOAuthAuthorizeFlowRound12(t *testing.T) {
 		require.Equal(t, "alice", storedState.PrincipalUsername)
 	})
 
-	t.Run("agent-style authorize requests require canonical mcp resource", func(t *testing.T) {
+	t.Run("legacy agent-style authorize requests no longer bind actor metadata without resource", func(t *testing.T) {
+		var storedState *storage.OAuthState
+		accountsSvc := &AccountsServiceStub{
+			GetUserAppConsentFunc: func(context.Context, *accounts.GetUserAppConsentQuery) (*accounts.GetUserAppConsentResult, error) {
+				return &accounts.GetUserAppConsentResult{}, errors.New("no consent")
+			},
+			StoreOAuthStateFunc: func(_ context.Context, cmd *accounts.StoreOAuthStateCommand) (*accounts.StoreOAuthStateResult, error) {
+				storedState = cmd.OAuthState
+				return &accounts.StoreOAuthStateResult{}, nil
+			},
+			GetOAuthAppFunc: func(_ context.Context, query *accounts.GetOAuthAppQuery) (*accounts.GetOAuthAppResult, error) {
+				return &accounts.GetOAuthAppResult{
+					App: &storage.OAuthApp{
+						ClientID:    query.ClientID,
+						Name:        "Agent Connector",
+						ClientClass: auth.ClientClassAgent,
+					},
+				}, nil
+			},
+		}
 		state := &round10QueryState{
 			oauthClientsByID: map[string]storagemodels.OAuthClient{
 				"client-agent": {
@@ -267,7 +286,7 @@ func TestOAuthAuthorizeFlowRound12(t *testing.T) {
 			},
 		}
 
-		h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{AccountsSvc: &AccountsServiceStub{}})
+		h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{AccountsSvc: accountsSvc})
 		ctx, err := round10NewLiftContext(http.MethodGet, "/oauth/authorize", map[string]string{"Accept": "text/html"}, map[string]string{
 			"response_type": "code",
 			"client_id":     "client-agent",
@@ -276,10 +295,17 @@ func TestOAuthAuthorizeFlowRound12(t *testing.T) {
 			"state":         "state-agent-missing-resource",
 		}, nil)
 		require.NoError(t, err)
+		ctx.Set("username", "owner")
 		resp := requireStatus(t, http.StatusFound)(h.HandleOAuthAuthorizeLift(ctx))
 		redirectURL := firstStringValue(resp.Headers, "location")
-		require.Contains(t, redirectURL, "error=invalid_target")
-		require.Contains(t, redirectURL, "resource+is+required+for+remote+MCP+authorization")
+		require.Contains(t, redirectURL, "/auth/consent?")
+		require.NotContains(t, redirectURL, "resource=")
+		require.NotContains(t, redirectURL, "agent_username=")
+		require.NotNil(t, storedState)
+		require.Equal(t, "owner", storedState.Username)
+		require.Equal(t, "owner", storedState.PrincipalUsername)
+		require.Empty(t, storedState.Resource)
+		require.Empty(t, storedState.AgentUsername)
 	})
 
 	t.Run("dynamic public authorize requests require canonical mcp resource", func(t *testing.T) {
@@ -636,6 +662,16 @@ func TestOAuthAuthorizeHelpersRound12(t *testing.T) {
 
 func TestOAuthTokenLiftRound12(t *testing.T) {
 	cfg := round11TestConfig()
+	newDeviceFlowCLIClient := func() storagemodels.OAuthClient {
+		return storagemodels.OAuthClient{
+			ClientID:     "client-1",
+			Name:         "CLI App",
+			RedirectURIs: []string{"https://example.com/callback"},
+			GrantTypes:   []string{oauthDeviceCodeGrantType, auth.GrantTypeRefreshToken},
+			ClientClass:  auth.ClientClassCLI,
+			CreatedAt:    time.Now().Add(-24 * time.Hour),
+		}
+	}
 
 	t.Run("empty request body", func(t *testing.T) {
 		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
@@ -1311,278 +1347,26 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		require.Equal(t, "https://mcp.example/resource", storedRefresh.Resource)
 	})
 
-	t.Run("client_credentials issues access-only agent token with delegated claims", func(t *testing.T) {
-		state := &round10QueryState{
-			oauthClientsByID: map[string]storagemodels.OAuthClient{
-				"client-agent": {
-					ClientID:      "client-agent",
-					ClientSecret:  "secret",
-					Name:          "Agent Connector",
-					RedirectURIs:  []string{"https://example.com/callback"},
-					GrantTypes:    []string{auth.GrantTypeClientCredentials},
-					Scopes:        []string{auth.ScopeRead, auth.ScopeWrite},
-					ClientClass:   auth.ClientClassAgent,
-					AgentUsername: "agent1",
-					OwnerID:       "owner",
-					Confidential:  true,
-					CreatedAt:     time.Now().Add(-24 * time.Hour),
-				},
-			},
-			usersByUsername: map[string]storagemodels.User{
-				"agent1": {
-					Username:   "agent1",
-					IsAgent:    true,
-					AgentType:  "assistant",
-					AgentOwner: "@owner",
-				},
-			},
-		}
-		h, _, _ := round11NewHandler(t, cfg, state)
-
+	t.Run("client_credentials is unsupported after cutover", func(t *testing.T) {
+		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
 		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type=client_credentials&client_id=client-agent&client_secret=secret"))
-		resp := requireStatus(t, http.StatusOK)(h.HandleOAuthTokenLift(ctx))
-		var body apimodels.OAuthTokenResponse
-		require.NoError(t, json.Unmarshal(resp.Body, &body))
-		require.NotEmpty(t, body.AccessToken)
-		require.Empty(t, body.RefreshToken)
-		require.Equal(t, "read write", body.Scope)
-		require.Equal(t, int(auth.AgentAccessTokenTTL(cfg).Seconds()), body.ExpiresIn)
-
-		claims := round12DecodeJWTClaims(t, body.AccessToken)
-		require.Equal(t, "agent1", claims.Username)
-		require.Equal(t, "client-agent", claims.ClientID)
-		require.Equal(t, auth.ClientClassAgent, claims.ClientClass)
-		require.True(t, claims.IsAgent)
-		require.Equal(t, "assistant", claims.AgentType)
-		require.Equal(t, "@owner", claims.DelegatedBy)
-		require.NotEmpty(t, claims.SessionID)
-		require.Equal(t, claims.SessionID, claims.AgentSessionID)
-	})
-
-	t.Run("client_credentials resource sets jwt audience", func(t *testing.T) {
-		state := &round10QueryState{
-			oauthClientsByID: map[string]storagemodels.OAuthClient{
-				"client-agent": {
-					ClientID:      "client-agent",
-					ClientSecret:  "secret",
-					Name:          "Agent Connector",
-					RedirectURIs:  []string{"https://example.com/callback"},
-					GrantTypes:    []string{auth.GrantTypeClientCredentials},
-					Scopes:        []string{auth.ScopeRead, auth.ScopeWrite},
-					ClientClass:   auth.ClientClassAgent,
-					AgentUsername: "agent1",
-					OwnerID:       "owner",
-					Confidential:  true,
-					CreatedAt:     time.Now().Add(-24 * time.Hour),
-				},
-			},
-			usersByUsername: map[string]storagemodels.User{
-				"agent1": {
-					Username:   "agent1",
-					IsAgent:    true,
-					AgentType:  "assistant",
-					AgentOwner: "@owner",
-				},
-			},
-		}
-		h, _, _ := round11NewHandler(t, cfg, state)
-
-		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type=client_credentials&client_id=client-agent&client_secret=secret&resource=https%3A%2F%2Fmcp.example%2Fresource"))
-		resp := requireStatus(t, http.StatusOK)(h.HandleOAuthTokenLift(ctx))
-		var body apimodels.OAuthTokenResponse
-		require.NoError(t, json.Unmarshal(resp.Body, &body))
-
-		claims := round12DecodeJWTClaims(t, body.AccessToken)
-		require.Equal(t, []string{"https://mcp.example/resource"}, []string(claims.Audience))
-	})
-
-	t.Run("client_credentials accepts client_secret_basic and prefers it over body credentials", func(t *testing.T) {
-		state := &round10QueryState{
-			oauthClientsByID: map[string]storagemodels.OAuthClient{
-				"client-agent": {
-					ClientID:      "client-agent",
-					ClientSecret:  "secret",
-					Name:          "Agent Connector",
-					RedirectURIs:  []string{"https://example.com/callback"},
-					GrantTypes:    []string{auth.GrantTypeClientCredentials},
-					Scopes:        []string{auth.ScopeRead, auth.ScopeWrite},
-					ClientClass:   auth.ClientClassAgent,
-					AgentUsername: "agent1",
-					OwnerID:       "owner",
-					Confidential:  true,
-					CreatedAt:     time.Now().Add(-24 * time.Hour),
-				},
-			},
-			usersByUsername: map[string]storagemodels.User{
-				"agent1": {
-					Username:   "agent1",
-					IsAgent:    true,
-					AgentType:  "assistant",
-					AgentOwner: "@owner",
-				},
-			},
-		}
-		h, _, _ := round11NewHandler(t, cfg, state)
-
-		basic := base64.StdEncoding.EncodeToString([]byte("client-agent:secret"))
-		ctx := round10NewLiftContextWithBodyBytes(
-			http.MethodPost,
-			"/oauth/token",
-			map[string]string{"Authorization": "Basic " + basic},
-			nil,
-			[]byte("grant_type=client_credentials&client_id=client-wrong&client_secret=wrong"),
-		)
-		resp := requireStatus(t, http.StatusOK)(h.HandleOAuthTokenLift(ctx))
-		var body apimodels.OAuthTokenResponse
-		require.NoError(t, json.Unmarshal(resp.Body, &body))
-		require.NotEmpty(t, body.AccessToken)
-		require.Empty(t, body.RefreshToken)
-
-		claims := round12DecodeJWTClaims(t, body.AccessToken)
-		require.Equal(t, "client-agent", claims.ClientID)
-		require.Equal(t, "agent1", claims.Username)
-	})
-
-	t.Run("client_credentials accepts previous secret during grace window", func(t *testing.T) {
-		activeHash, err := auth.HashOAuthClientSecret("secret-new")
-		require.NoError(t, err)
-		previousHash, err := auth.HashOAuthClientSecret("secret-old")
-		require.NoError(t, err)
-
-		state := &round10QueryState{
-			oauthClientsByID: map[string]storagemodels.OAuthClient{
-				"client-agent": {
-					ClientID:                           "client-agent",
-					ClientSecret:                       activeHash,
-					PreviousClientSecret:               previousHash,
-					PreviousClientSecretGraceExpiresAt: time.Now().Add(30 * time.Minute),
-					Name:                               "Agent Connector",
-					RedirectURIs:                       []string{"https://example.com/callback"},
-					GrantTypes:                         []string{auth.GrantTypeClientCredentials},
-					Scopes:                             []string{auth.ScopeRead, auth.ScopeWrite},
-					ClientClass:                        auth.ClientClassAgent,
-					AgentUsername:                      "agent1",
-					OwnerID:                            "owner",
-					Confidential:                       true,
-					CreatedAt:                          time.Now().Add(-24 * time.Hour),
-				},
-			},
-			usersByUsername: map[string]storagemodels.User{
-				"agent1": {
-					Username:   "agent1",
-					IsAgent:    true,
-					AgentOwner: "@owner",
-				},
-			},
-		}
-
-		h, _, _ := round11NewHandler(t, cfg, state)
-		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type=client_credentials&client_id=client-agent&client_secret=secret-old"))
-		resp := requireStatus(t, http.StatusOK)(h.HandleOAuthTokenLift(ctx))
-		var body apimodels.OAuthTokenResponse
-		require.NoError(t, json.Unmarshal(resp.Body, &body))
-		require.NotEmpty(t, body.AccessToken)
-		require.Empty(t, body.RefreshToken)
-	})
-
-	t.Run("client_credentials rejects previous secret after grace window", func(t *testing.T) {
-		activeHash, err := auth.HashOAuthClientSecret("secret-new")
-		require.NoError(t, err)
-		previousHash, err := auth.HashOAuthClientSecret("secret-old")
-		require.NoError(t, err)
-
-		state := &round10QueryState{
-			oauthClientsByID: map[string]storagemodels.OAuthClient{
-				"client-agent": {
-					ClientID:                           "client-agent",
-					ClientSecret:                       activeHash,
-					PreviousClientSecret:               previousHash,
-					PreviousClientSecretGraceExpiresAt: time.Now().Add(-1 * time.Minute),
-					Name:                               "Agent Connector",
-					RedirectURIs:                       []string{"https://example.com/callback"},
-					GrantTypes:                         []string{auth.GrantTypeClientCredentials},
-					Scopes:                             []string{auth.ScopeRead, auth.ScopeWrite},
-					ClientClass:                        auth.ClientClassAgent,
-					AgentUsername:                      "agent1",
-					OwnerID:                            "owner",
-					Confidential:                       true,
-					CreatedAt:                          time.Now().Add(-24 * time.Hour),
-				},
-			},
-			usersByUsername: map[string]storagemodels.User{
-				"agent1": {
-					Username:   "agent1",
-					IsAgent:    true,
-					AgentOwner: "@owner",
-				},
-			},
-		}
-
-		h, _, _ := round11NewHandler(t, cfg, state)
-		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type=client_credentials&client_id=client-agent&client_secret=secret-old"))
 		resp := requireStatus(t, http.StatusBadRequest)(h.HandleOAuthTokenLift(ctx))
 		var body map[string]string
 		require.NoError(t, json.Unmarshal(resp.Body, &body))
-		require.Equal(t, "invalid_client", body["error"])
+		require.Equal(t, "unsupported_grant_type", body["error"])
+		require.Equal(t, "Only authorization_code and refresh_token grant types are supported", body["error_description"])
 	})
 
-	t.Run("client_credentials rejects non-agent clients", func(t *testing.T) {
-		state := &round10QueryState{
-			oauthClientsByID: map[string]storagemodels.OAuthClient{
-				"client-web": {
-					ClientID:     "client-web",
-					ClientSecret: "secret",
-					Name:         "Web App",
-					RedirectURIs: []string{"https://example.com/callback"},
-					GrantTypes:   []string{auth.GrantTypeAuthorizationCode, auth.GrantTypeRefreshToken},
-					Scopes:       []string{auth.ScopeRead, auth.ScopeWrite},
-					ClientClass:  auth.ClientClassWeb,
-					Confidential: true,
-					CreatedAt:    time.Now().Add(-24 * time.Hour),
-				},
-			},
-		}
-		h, _, _ := round11NewHandler(t, cfg, state)
-
-		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type=client_credentials&client_id=client-web&client_secret=secret"))
+	t.Run("client_credentials remains unsupported when device flow is enabled", func(t *testing.T) {
+		cfgDevice := round11TestConfig()
+		cfgDevice.AllowDeviceFlow = true
+		h, _, _ := round11NewHandler(t, cfgDevice, &round10QueryState{})
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type=client_credentials&client_id=client-agent&client_secret=secret"))
 		resp := requireStatus(t, http.StatusBadRequest)(h.HandleOAuthTokenLift(ctx))
 		var body map[string]string
 		require.NoError(t, json.Unmarshal(resp.Body, &body))
-		require.Equal(t, "unauthorized_client", body["error"])
-	})
-
-	t.Run("client_credentials rejects requested scopes outside the client scope set", func(t *testing.T) {
-		state := &round10QueryState{
-			oauthClientsByID: map[string]storagemodels.OAuthClient{
-				"client-agent": {
-					ClientID:      "client-agent",
-					ClientSecret:  "secret",
-					Name:          "Agent Connector",
-					RedirectURIs:  []string{"https://example.com/callback"},
-					GrantTypes:    []string{auth.GrantTypeClientCredentials},
-					Scopes:        []string{auth.ScopeRead},
-					ClientClass:   auth.ClientClassAgent,
-					AgentUsername: "agent1",
-					OwnerID:       "owner",
-					Confidential:  true,
-					CreatedAt:     time.Now().Add(-24 * time.Hour),
-				},
-			},
-			usersByUsername: map[string]storagemodels.User{
-				"agent1": {
-					Username:   "agent1",
-					IsAgent:    true,
-					AgentOwner: "@owner",
-				},
-			},
-		}
-		h, _, _ := round11NewHandler(t, cfg, state)
-
-		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type=client_credentials&client_id=client-agent&client_secret=secret&scope=write"))
-		resp := requireStatus(t, http.StatusBadRequest)(h.HandleOAuthTokenLift(ctx))
-		var body map[string]string
-		require.NoError(t, json.Unmarshal(resp.Body, &body))
-		require.Equal(t, "invalid_scope", body["error"])
+		require.Equal(t, "unsupported_grant_type", body["error"])
+		require.Equal(t, "Only authorization_code, refresh_token, and device_code grant types are supported", body["error_description"])
 	})
 
 	t.Run("device_code grant disabled returns access_denied", func(t *testing.T) {
@@ -1612,6 +1396,9 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		deviceHash := oauthDeviceCodeHash(deviceCode)
 
 		state := &round10QueryState{
+			oauthClientsByID: map[string]storagemodels.OAuthClient{
+				"client-1": newDeviceFlowCLIClient(),
+			},
 			notFoundPKs: map[string]bool{
 				"OAUTH_DEVICE#" + deviceHash: true,
 			},
@@ -1631,6 +1418,9 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		deviceHash := oauthDeviceCodeHash(deviceCode)
 
 		state := &round10QueryState{
+			oauthClientsByID: map[string]storagemodels.OAuthClient{
+				"client-1": newDeviceFlowCLIClient(),
+			},
 			oauthDeviceSessionsByHash: map[string]storagemodels.OAuthDeviceSession{
 				deviceHash: {
 					DeviceCodeHash:  deviceHash,
@@ -1660,6 +1450,9 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		deviceHash := oauthDeviceCodeHash(deviceCode)
 
 		state := &round10QueryState{
+			oauthClientsByID: map[string]storagemodels.OAuthClient{
+				"client-1": newDeviceFlowCLIClient(),
+			},
 			oauthDeviceSessionsByHash: map[string]storagemodels.OAuthDeviceSession{
 				deviceHash: {
 					DeviceCodeHash:  deviceHash,
@@ -1690,6 +1483,9 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		last := time.Now().UTC()
 
 		state := &round10QueryState{
+			oauthClientsByID: map[string]storagemodels.OAuthClient{
+				"client-1": newDeviceFlowCLIClient(),
+			},
 			oauthDeviceSessionsByHash: map[string]storagemodels.OAuthDeviceSession{
 				deviceHash: {
 					DeviceCodeHash:  deviceHash,
@@ -1721,6 +1517,9 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		deviceHash := oauthDeviceCodeHash(deviceCode)
 
 		state := &round10QueryState{
+			oauthClientsByID: map[string]storagemodels.OAuthClient{
+				"client-1": newDeviceFlowCLIClient(),
+			},
 			oauthDeviceSessionsByHash: map[string]storagemodels.OAuthDeviceSession{
 				deviceHash: {
 					DeviceCodeHash:  deviceHash,
@@ -1750,6 +1549,9 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		deviceHash := oauthDeviceCodeHash(deviceCode)
 
 		state := &round10QueryState{
+			oauthClientsByID: map[string]storagemodels.OAuthClient{
+				"client-1": newDeviceFlowCLIClient(),
+			},
 			oauthDeviceSessionsByHash: map[string]storagemodels.OAuthDeviceSession{
 				deviceHash: {
 					DeviceCodeHash:  deviceHash,
@@ -1780,13 +1582,7 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 
 		state := &round10QueryState{
 			oauthClientsByID: map[string]storagemodels.OAuthClient{
-				"client-1": {
-					ClientID:     "client-1",
-					Name:         "CLI App",
-					RedirectURIs: []string{"https://example.com/callback"},
-					ClientClass:  auth.ClientClassCLI,
-					CreatedAt:    time.Now().Add(-24 * time.Hour),
-				},
+				"client-1": newDeviceFlowCLIClient(),
 			},
 			oauthDeviceSessionsByHash: map[string]storagemodels.OAuthDeviceSession{
 				deviceHash: {
@@ -1844,10 +1640,9 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		require.Equal(t, claims1.SessionID, refreshClaims.SessionID)
 	})
 
-	t.Run("device_code approved agent client issues standard refresh session", func(t *testing.T) {
+	t.Run("device_code approved agent client is rejected after cutover", func(t *testing.T) {
 		cfgDevice := round11TestConfig()
 		cfgDevice.AllowDeviceFlow = true
-		cfgDevice.AgentAccessTokenDuration = 12 * time.Hour
 		deviceCode := "agent-approved"
 		deviceHash := oauthDeviceCodeHash(deviceCode)
 
@@ -1889,42 +1684,14 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 
 		h, _, _ := round11NewHandler(t, cfgDevice, state)
 		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type="+oauthDeviceCodeGrantType+"&device_code="+deviceCode+"&client_id=client-agent"))
-		resp := requireStatus(t, http.StatusOK)(h.HandleOAuthTokenLift(ctx))
-
-		var body apimodels.OAuthTokenResponse
+		resp := requireStatus(t, http.StatusBadRequest)(h.HandleOAuthTokenLift(ctx))
+		var body map[string]string
 		require.NoError(t, json.Unmarshal(resp.Body, &body))
-		require.NotEmpty(t, body.AccessToken)
-		require.NotEmpty(t, body.RefreshToken)
-		require.Equal(t, "read follow", body.Scope)
-		require.Equal(t, int((12 * time.Hour).Seconds()), body.ExpiresIn)
-
-		claims := round12DecodeJWTClaims(t, body.AccessToken)
-		require.Equal(t, "agent1", claims.Username)
-		require.True(t, claims.IsAgent)
-		require.Equal(t, auth.ClientClassAgent, claims.ClientClass)
-		require.Equal(t, "assistant", claims.AgentType)
-		require.Equal(t, "@owner", claims.DelegatedBy)
-		require.NotEmpty(t, claims.SessionID)
-		require.Equal(t, claims.SessionID, claims.AgentSessionID)
-
-		storedRefresh, ok := state.refreshTokensByToken[body.RefreshToken]
-		require.True(t, ok)
-		require.Equal(t, auth.ClientClassAgent, storedRefresh.ClientClass)
-		require.Equal(t, "agent1", storedRefresh.Username)
-		require.Equal(t, []string{auth.ScopeRead, auth.ScopeFollow}, storedRefresh.Scopes)
-		require.NotEmpty(t, storedRefresh.SessionID)
-		require.Equal(t, claims.SessionID, storedRefresh.SessionID)
-		require.Empty(t, storedRefresh.FamilyID)
-		require.False(t, storedRefresh.Current)
-		require.Zero(t, storedRefresh.Generation)
-		require.Empty(t, storedRefresh.DeviceLabel)
-		require.Zero(t, storedRefresh.AccessTTLSeconds)
-		require.True(t, storedRefresh.SessionCreatedAt.IsZero())
-		require.True(t, storedRefresh.IdleExpiresAt.IsZero())
-		require.True(t, storedRefresh.AbsoluteExpiresAt.IsZero())
+		require.Equal(t, "unauthorized_client", body["error"])
+		require.Equal(t, "device_code is not allowed for this client", body["error_description"])
 	})
 
-	t.Run("device_code approved agent client rejects non-owner approval", func(t *testing.T) {
+	t.Run("device_code agent client is rejected before ownership checks", func(t *testing.T) {
 		cfgDevice := round11TestConfig()
 		cfgDevice.AllowDeviceFlow = true
 		deviceCode := "agent-forbidden"
@@ -1971,7 +1738,8 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 
 		var body map[string]string
 		require.NoError(t, json.Unmarshal(resp.Body, &body))
-		require.Equal(t, "invalid_grant", body["error"])
+		require.Equal(t, "unauthorized_client", body["error"])
+		require.Equal(t, "device_code is not allowed for this client", body["error_description"])
 		require.Empty(t, state.refreshTokensByToken)
 	})
 }

--- a/cmd/api/handlers/oauth_round13_helper_coverage_test.go
+++ b/cmd/api/handlers/oauth_round13_helper_coverage_test.go
@@ -126,15 +126,11 @@ func TestOAuthDeviceApprovedTokenContext(t *testing.T) {
 	require.NotEmpty(t, sessionID)
 	require.Equal(t, auth.AccessTokenDuration, accessTTL)
 
-	username, clientClass, sessionID, accessTTL, err = handler.oauthDeviceApprovedTokenContext(context.Background(), &storage.OAuthClient{
+	_, _, _, _, err = handler.oauthDeviceApprovedTokenContext(context.Background(), &storage.OAuthClient{
 		ClientClass:   auth.ClientClassAgent,
 		AgentUsername: "agent-1",
 	}, "owner")
-	require.NoError(t, err)
-	require.Equal(t, "agent-1", username)
-	require.Equal(t, auth.ClientClassAgent, clientClass)
-	require.NotEmpty(t, sessionID)
-	require.Equal(t, auth.AgentAccessTokenTTL(cfg), accessTTL)
+	require.ErrorIs(t, err, auth.ErrInvalidGrant)
 
 	_, _, _, _, err = handler.oauthDeviceApprovedTokenContext(context.Background(), &storage.OAuthClient{
 		ClientClass:   auth.ClientClassAgent,

--- a/cmd/api/handlers/oauth_scope_policy_test.go
+++ b/cmd/api/handlers/oauth_scope_policy_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/equaltoai/lesser/pkg/auth"
-	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,28 +22,4 @@ func TestNormalizeAuthorizeScopes(t *testing.T) {
 
 	_, err = h.normalizeAuthorizeScopes("admin")
 	require.Error(t, err)
-}
-
-func TestResolveOAuthClientRequestedScopes(t *testing.T) {
-	t.Parallel()
-
-	t.Run("canonical follow allowed by broad write registration", func(t *testing.T) {
-		client := &storage.OAuthClient{Scopes: []string{auth.ScopeWrite}}
-		scopes, err := resolveOAuthClientRequestedScopes(client, auth.ScopeFollow)
-		require.NoError(t, err)
-		require.Equal(t, []string{auth.ScopeFollow}, scopes)
-	})
-
-	t.Run("legacy write_follows allowed by follow registration", func(t *testing.T) {
-		client := &storage.OAuthClient{Scopes: []string{auth.ScopeFollow}}
-		scopes, err := resolveOAuthClientRequestedScopes(client, "write:follows")
-		require.NoError(t, err)
-		require.Equal(t, []string{"write:follows"}, scopes)
-	})
-
-	t.Run("admin remains non requestable", func(t *testing.T) {
-		client := &storage.OAuthClient{Scopes: []string{auth.ScopeWrite}}
-		_, err := resolveOAuthClientRequestedScopes(client, auth.ScopeAdmin)
-		require.ErrorIs(t, err, auth.ErrInvalidScope)
-	})
 }

--- a/cmd/lesser/main.go
+++ b/cmd/lesser/main.go
@@ -44,6 +44,7 @@ var (
 	runMigrateAgentGovernanceStateFn             = runMigrateAgentGovernanceState
 	runMigrateDirectMessageStateFn               = runMigrateDirectMessageState
 	runMigrateNumericIDsFn                       = runMigrateNumericIDs
+	runMigrateMCPAuthCutoverFn                   = runMigrateMCPAuthCutover
 )
 
 func runCLI(args []string, stderr io.Writer) int {
@@ -114,6 +115,7 @@ func commandRunner(cmd string) (func([]string) error, bool) {
 		"migrate-agent-governance-state": func(argv []string) error { return runMigrateAgentGovernanceStateFn(argv) },
 		"migrate-direct-message-state":   func(argv []string) error { return runMigrateDirectMessageStateFn(argv) },
 		"migrate-numeric-ids":            func(argv []string) error { return runMigrateNumericIDsFn(argv) },
+		"migrate-mcp-auth-cutover":       func(argv []string) error { return runMigrateMCPAuthCutoverFn(argv) },
 	}
 
 	runner, ok := runners[cmd]
@@ -176,6 +178,7 @@ func printUsageTo(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  lesser migrate-agent-governance-state [--app <slug>] [--env dev|staging|live] [--aws-profile <profile>] [--table <name>] [--limit <n>] [--apply]")
 	_, _ = fmt.Fprintln(w, "  lesser migrate-direct-message-state [--app <slug>] [--env dev|staging|live] [--aws-profile <profile>] [--table <name>] [--limit <n>] [--apply]")
 	_, _ = fmt.Fprintln(w, "  lesser migrate-numeric-ids [--app <slug>] [--env dev|staging|live] [--aws-profile <profile>] [--table <name>] [--limit <n>] [--apply]")
+	_, _ = fmt.Fprintln(w, "  lesser migrate-mcp-auth-cutover [--app <slug>] [--env dev|staging|live] [--aws-profile <profile>] [--table <name>] [--limit <n>] [--apply]")
 }
 
 func exitCodeFromErr(err error, stderr io.Writer) int {

--- a/cmd/lesser/main_test.go
+++ b/cmd/lesser/main_test.go
@@ -140,7 +140,9 @@ func TestRunCLI_DispatchesAllCommands(t *testing.T) {
 	prevMigrateConversationMetadata := runMigrateConversationMetadataFn
 	prevMigrateConversationParticipantSnapshots := runMigrateConversationParticipantSnapshotsFn
 	prevMigrateAgentGovernanceState := runMigrateAgentGovernanceStateFn
+	prevMigrateDirectMessageState := runMigrateDirectMessageStateFn
 	prevMigrateNumericIDs := runMigrateNumericIDsFn
+	prevMigrateMCPAuthCutover := runMigrateMCPAuthCutoverFn
 	t.Cleanup(func() {
 		runUpFn = prevUp
 		runDownFn = prevDown
@@ -173,7 +175,9 @@ func TestRunCLI_DispatchesAllCommands(t *testing.T) {
 		runMigrateConversationMetadataFn = prevMigrateConversationMetadata
 		runMigrateConversationParticipantSnapshotsFn = prevMigrateConversationParticipantSnapshots
 		runMigrateAgentGovernanceStateFn = prevMigrateAgentGovernanceState
+		runMigrateDirectMessageStateFn = prevMigrateDirectMessageState
 		runMigrateNumericIDsFn = prevMigrateNumericIDs
+		runMigrateMCPAuthCutoverFn = prevMigrateMCPAuthCutover
 	})
 
 	type call struct {
@@ -220,6 +224,7 @@ func TestRunCLI_DispatchesAllCommands(t *testing.T) {
 	runMigrateAgentGovernanceStateFn = stub("migrate-agent-governance-state")
 	runMigrateDirectMessageStateFn = stub("migrate-direct-message-state")
 	runMigrateNumericIDsFn = stub("migrate-numeric-ids")
+	runMigrateMCPAuthCutoverFn = stub("migrate-mcp-auth-cutover")
 
 	var buf bytes.Buffer
 	require.Equal(t, 0, runCLI([]string{"lesser", helpFlagShort}, &buf))
@@ -330,6 +335,9 @@ func TestRunCLI_DispatchesAllCommands(t *testing.T) {
 
 	require.Equal(t, 0, runCLI([]string{"lesser", "migrate-numeric-ids", "--env", "dev"}, &buf))
 	require.Equal(t, []string{"--env", "dev"}, calls["migrate-numeric-ids"].argv)
+
+	require.Equal(t, 0, runCLI([]string{"lesser", "migrate-mcp-auth-cutover", "--env", "dev"}, &buf))
+	require.Equal(t, []string{"--env", "dev"}, calls["migrate-mcp-auth-cutover"].argv)
 }
 
 func TestExitCodeFromErr(t *testing.T) {

--- a/cmd/lesser/migrate_mcp_auth_cutover.go
+++ b/cmd/lesser/migrate_mcp_auth_cutover.go
@@ -1,0 +1,685 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+)
+
+const (
+	mcpAuthCutoverOAuthClientPKPrefix  = "OAUTH_CLIENT#"
+	mcpAuthCutoverOAuthClientSK        = "CLIENT"
+	mcpAuthCutoverRefreshTokenPKPrefix = "REFRESHTOKEN#"
+	mcpAuthCutoverRefreshTokenSK       = "TOKEN"
+	mcpAuthCutoverAuthorizationCodePK  = "AUTHCODE#"
+	mcpAuthCutoverAuthorizationCodeSK  = "CODE"
+	mcpAuthCutoverOAuthStatePKPrefix   = "OAUTH_STATE#"
+	mcpAuthCutoverOAuthStateSK         = "STATE"
+	mcpAuthCutoverOAuthDevicePKPrefix  = "OAUTH_DEVICE#"
+	mcpAuthCutoverOAuthDeviceSK        = "SESSION"
+	mcpAuthCutoverUserConsentPKPrefix  = "USER#"
+	mcpAuthCutoverUserConsentSKPrefix  = "CONSENT#"
+)
+
+type mcpAuthCutoverMigrationClient interface {
+	Scan(context.Context, *dynamodb.ScanInput, ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error)
+	DeleteItem(context.Context, *dynamodb.DeleteItemInput, ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error)
+}
+
+type mcpAuthCutoverMigrationSummary struct {
+	OAuthClientsScanned                int
+	ConnectorClientsMatched            int
+	ConnectorClientsDeleted            int
+	RefreshTokensScanned               int
+	ConnectorRefreshTokensMatched      int
+	ConnectorRefreshTokensDeleted      int
+	RuntimeRefreshTokensPreserved      int
+	AuthorizationCodesScanned          int
+	ConnectorAuthorizationCodesMatched int
+	ConnectorAuthorizationCodesDeleted int
+	OAuthStatesScanned                 int
+	ConnectorOAuthStatesMatched        int
+	ConnectorOAuthStatesDeleted        int
+	DeviceSessionsScanned              int
+	ConnectorDeviceSessionsMatched     int
+	ConnectorDeviceSessionsDeleted     int
+	UserAppConsentsScanned             int
+	ConnectorUserAppConsentsMatched    int
+	ConnectorUserAppConsentsDeleted    int
+	SampleConnectorClientIDs           []string
+	SampleConnectorRefreshSessions     []string
+	SampleRuntimeRefreshSessions       []string
+}
+
+type mcpAuthCutoverDeleteCandidate struct {
+	PK     string
+	SK     string
+	Sample string
+}
+
+type mcpAuthCutoverOAuthClientCandidate struct {
+	mcpAuthCutoverDeleteCandidate
+	ClientID string
+}
+
+var newMCPAuthCutoverMigrationClientFn = func(cfg aws.Config) mcpAuthCutoverMigrationClient {
+	return dynamodb.NewFromConfig(cfg)
+}
+
+func runMigrateMCPAuthCutover(argv []string) error {
+	return runCommonMigrationCLI(
+		argv,
+		"migrate-mcp-auth-cutover",
+		"maximum number of connector-era OAuth clients to process (0 = all)",
+		"revoke connector-bound MCP sessions and retire persisted connector client records",
+		func(ctx context.Context, awsCfg aws.Config, tableName string, apply bool, limit int) (mcpAuthCutoverMigrationSummary, error) {
+			return executeMCPAuthCutoverMigration(
+				ctx,
+				newMCPAuthCutoverMigrationClientFn(awsCfg),
+				tableName,
+				apply,
+				limit,
+			)
+		},
+		printMCPAuthCutoverMigrationSummary,
+	)
+}
+
+func printMCPAuthCutoverMigrationSummary(
+	summary mcpAuthCutoverMigrationSummary,
+	tableName string,
+	resolvedProfile string,
+	apply bool,
+) {
+	fmt.Printf("migrate-mcp-auth-cutover %s complete\n", selectedMigrationMode(apply))
+	fmt.Printf("table: %s\n", tableName)
+	if resolvedProfile != "" {
+		fmt.Printf("aws_profile: %s\n", resolvedProfile)
+	}
+	fmt.Printf("oauth_clients_scanned: %d\n", summary.OAuthClientsScanned)
+	fmt.Printf("connector_clients_matched: %d\n", summary.ConnectorClientsMatched)
+	fmt.Printf("connector_clients_deleted: %d\n", summary.ConnectorClientsDeleted)
+	fmt.Printf("refresh_tokens_scanned: %d\n", summary.RefreshTokensScanned)
+	fmt.Printf("connector_refresh_tokens_matched: %d\n", summary.ConnectorRefreshTokensMatched)
+	fmt.Printf("connector_refresh_tokens_deleted: %d\n", summary.ConnectorRefreshTokensDeleted)
+	fmt.Printf("runtime_refresh_tokens_preserved: %d\n", summary.RuntimeRefreshTokensPreserved)
+	fmt.Printf("authorization_codes_scanned: %d\n", summary.AuthorizationCodesScanned)
+	fmt.Printf("connector_authorization_codes_matched: %d\n", summary.ConnectorAuthorizationCodesMatched)
+	fmt.Printf("connector_authorization_codes_deleted: %d\n", summary.ConnectorAuthorizationCodesDeleted)
+	fmt.Printf("oauth_states_scanned: %d\n", summary.OAuthStatesScanned)
+	fmt.Printf("connector_oauth_states_matched: %d\n", summary.ConnectorOAuthStatesMatched)
+	fmt.Printf("connector_oauth_states_deleted: %d\n", summary.ConnectorOAuthStatesDeleted)
+	fmt.Printf("device_sessions_scanned: %d\n", summary.DeviceSessionsScanned)
+	fmt.Printf("connector_device_sessions_matched: %d\n", summary.ConnectorDeviceSessionsMatched)
+	fmt.Printf("connector_device_sessions_deleted: %d\n", summary.ConnectorDeviceSessionsDeleted)
+	fmt.Printf("user_app_consents_scanned: %d\n", summary.UserAppConsentsScanned)
+	fmt.Printf("connector_user_app_consents_matched: %d\n", summary.ConnectorUserAppConsentsMatched)
+	fmt.Printf("connector_user_app_consents_deleted: %d\n", summary.ConnectorUserAppConsentsDeleted)
+	printMigrationSamples("sample_connector_client_ids", summary.SampleConnectorClientIDs)
+	printMigrationSamples("sample_connector_refresh_sessions", summary.SampleConnectorRefreshSessions)
+	printMigrationSamples("sample_runtime_refresh_sessions", summary.SampleRuntimeRefreshSessions)
+
+	if !apply {
+		fmt.Println("no writes performed; re-run with --apply to revoke connector-bound refresh sessions and retire persisted connector client artifacts")
+	}
+}
+
+func executeMCPAuthCutoverMigration(
+	ctx context.Context,
+	client mcpAuthCutoverMigrationClient,
+	tableName string,
+	apply bool,
+	limit int,
+) (mcpAuthCutoverMigrationSummary, error) {
+	summary := mcpAuthCutoverMigrationSummary{}
+
+	if client == nil {
+		return summary, fmt.Errorf("migration client is required")
+	}
+	if strings.TrimSpace(tableName) == "" {
+		return summary, fmt.Errorf("table name is required")
+	}
+
+	oauthClientItems, err := scanMCPAuthCutoverItems(
+		ctx,
+		client,
+		tableName,
+		"begins_with(PK, :pk) AND SK = :sk",
+		map[string]types.AttributeValue{
+			":pk": &types.AttributeValueMemberS{Value: mcpAuthCutoverOAuthClientPKPrefix},
+			":sk": &types.AttributeValueMemberS{Value: mcpAuthCutoverOAuthClientSK},
+		},
+		nil,
+	)
+	if err != nil {
+		return summary, fmt.Errorf("scan oauth clients: %w", err)
+	}
+
+	connectorClients, connectorClientIDs, err := buildMCPAuthCutoverOAuthClientCandidates(oauthClientItems, limit, &summary)
+	if err != nil {
+		return summary, err
+	}
+
+	refreshTokenItems, err := scanMCPAuthCutoverItems(
+		ctx,
+		client,
+		tableName,
+		"begins_with(PK, :pk) AND SK = :sk",
+		map[string]types.AttributeValue{
+			":pk": &types.AttributeValueMemberS{Value: mcpAuthCutoverRefreshTokenPKPrefix},
+			":sk": &types.AttributeValueMemberS{Value: mcpAuthCutoverRefreshTokenSK},
+		},
+		nil,
+	)
+	if err != nil {
+		return summary, fmt.Errorf("scan refresh tokens: %w", err)
+	}
+	connectorRefreshTokens, runtimeRefreshTokens, err := buildMCPAuthCutoverRefreshCandidates(refreshTokenItems, connectorClientIDs, &summary)
+	if err != nil {
+		return summary, err
+	}
+
+	authorizationCodeItems, err := scanMCPAuthCutoverItems(
+		ctx,
+		client,
+		tableName,
+		"begins_with(PK, :pk) AND SK = :sk",
+		map[string]types.AttributeValue{
+			":pk": &types.AttributeValueMemberS{Value: mcpAuthCutoverAuthorizationCodePK},
+			":sk": &types.AttributeValueMemberS{Value: mcpAuthCutoverAuthorizationCodeSK},
+		},
+		nil,
+	)
+	if err != nil {
+		return summary, fmt.Errorf("scan authorization codes: %w", err)
+	}
+	connectorAuthorizationCodes, err := buildMCPAuthCutoverAuthorizationCodeCandidates(authorizationCodeItems, connectorClientIDs, &summary)
+	if err != nil {
+		return summary, err
+	}
+
+	oauthStateItems, err := scanMCPAuthCutoverItems(
+		ctx,
+		client,
+		tableName,
+		"begins_with(PK, :pk) AND SK = :sk",
+		map[string]types.AttributeValue{
+			":pk": &types.AttributeValueMemberS{Value: mcpAuthCutoverOAuthStatePKPrefix},
+			":sk": &types.AttributeValueMemberS{Value: mcpAuthCutoverOAuthStateSK},
+		},
+		nil,
+	)
+	if err != nil {
+		return summary, fmt.Errorf("scan oauth state: %w", err)
+	}
+	connectorStates, err := buildMCPAuthCutoverOAuthStateCandidates(oauthStateItems, connectorClientIDs, &summary)
+	if err != nil {
+		return summary, err
+	}
+
+	deviceSessionItems, err := scanMCPAuthCutoverItems(
+		ctx,
+		client,
+		tableName,
+		"begins_with(PK, :pk) AND SK = :sk",
+		map[string]types.AttributeValue{
+			":pk": &types.AttributeValueMemberS{Value: mcpAuthCutoverOAuthDevicePKPrefix},
+			":sk": &types.AttributeValueMemberS{Value: mcpAuthCutoverOAuthDeviceSK},
+		},
+		nil,
+	)
+	if err != nil {
+		return summary, fmt.Errorf("scan oauth device sessions: %w", err)
+	}
+	connectorDeviceSessions, err := buildMCPAuthCutoverDeviceSessionCandidates(deviceSessionItems, connectorClientIDs, &summary)
+	if err != nil {
+		return summary, err
+	}
+
+	consentItems, err := scanMCPAuthCutoverItems(
+		ctx,
+		client,
+		tableName,
+		"begins_with(PK, :pk) AND begins_with(SK, :sk)",
+		map[string]types.AttributeValue{
+			":pk": &types.AttributeValueMemberS{Value: mcpAuthCutoverUserConsentPKPrefix},
+			":sk": &types.AttributeValueMemberS{Value: mcpAuthCutoverUserConsentSKPrefix},
+		},
+		nil,
+	)
+	if err != nil {
+		return summary, fmt.Errorf("scan user app consents: %w", err)
+	}
+	connectorConsents, err := buildMCPAuthCutoverUserConsentCandidates(consentItems, connectorClientIDs, &summary)
+	if err != nil {
+		return summary, err
+	}
+
+	if err := deleteMCPAuthCutoverCandidates(ctx, client, tableName, apply, connectorAuthorizationCodes, &summary.ConnectorAuthorizationCodesDeleted); err != nil {
+		return summary, err
+	}
+	if err := deleteMCPAuthCutoverCandidates(ctx, client, tableName, apply, connectorStates, &summary.ConnectorOAuthStatesDeleted); err != nil {
+		return summary, err
+	}
+	if err := deleteMCPAuthCutoverCandidates(ctx, client, tableName, apply, connectorDeviceSessions, &summary.ConnectorDeviceSessionsDeleted); err != nil {
+		return summary, err
+	}
+	if err := deleteMCPAuthCutoverCandidates(ctx, client, tableName, apply, connectorConsents, &summary.ConnectorUserAppConsentsDeleted); err != nil {
+		return summary, err
+	}
+	if err := deleteMCPAuthCutoverCandidates(ctx, client, tableName, apply, connectorRefreshTokens, &summary.ConnectorRefreshTokensDeleted); err != nil {
+		return summary, err
+	}
+	if err := deleteMCPAuthCutoverOAuthClientCandidates(ctx, client, tableName, apply, connectorClients, &summary.ConnectorClientsDeleted); err != nil {
+		return summary, err
+	}
+
+	summary.SampleConnectorClientIDs = sampleStrings(summary.SampleConnectorClientIDs, 5)
+	summary.SampleConnectorRefreshSessions = sampleStrings(summary.SampleConnectorRefreshSessions, 5)
+	summary.SampleRuntimeRefreshSessions = sampleStrings(summary.SampleRuntimeRefreshSessions, 5)
+	_ = runtimeRefreshTokens
+
+	return summary, nil
+}
+
+func scanMCPAuthCutoverItems(
+	ctx context.Context,
+	client mcpAuthCutoverMigrationClient,
+	tableName string,
+	filterExpression string,
+	expressionAttributeValues map[string]types.AttributeValue,
+	expressionAttributeNames map[string]string,
+) ([]map[string]types.AttributeValue, error) {
+	scanInput := &dynamodb.ScanInput{
+		TableName:                 aws.String(tableName),
+		FilterExpression:          aws.String(filterExpression),
+		ExpressionAttributeValues: expressionAttributeValues,
+	}
+	if len(expressionAttributeNames) > 0 {
+		scanInput.ExpressionAttributeNames = expressionAttributeNames
+	}
+
+	var items []map[string]types.AttributeValue
+	for {
+		out, err := client.Scan(ctx, scanInput)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, out.Items...)
+		if len(out.LastEvaluatedKey) == 0 {
+			return items, nil
+		}
+		scanInput.ExclusiveStartKey = out.LastEvaluatedKey
+	}
+}
+
+func buildMCPAuthCutoverOAuthClientCandidates(
+	items []map[string]types.AttributeValue,
+	limit int,
+	summary *mcpAuthCutoverMigrationSummary,
+) ([]mcpAuthCutoverOAuthClientCandidate, map[string]struct{}, error) {
+	summary.OAuthClientsScanned = len(items)
+
+	candidates := make([]mcpAuthCutoverOAuthClientCandidate, 0, len(items))
+	for _, item := range items {
+		var client models.OAuthClient
+		if err := attributevalue.UnmarshalMap(item, &client); err != nil {
+			return nil, nil, fmt.Errorf("unmarshal oauth client: %w", err)
+		}
+		if !isConnectorOAuthClient(&client) {
+			continue
+		}
+
+		clientID := strings.TrimSpace(client.ClientID)
+		candidates = append(candidates, mcpAuthCutoverOAuthClientCandidate{
+			mcpAuthCutoverDeleteCandidate: mcpAuthCutoverDeleteCandidate{
+				PK:     strings.TrimSpace(client.PK),
+				SK:     strings.TrimSpace(client.SK),
+				Sample: clientID,
+			},
+			ClientID: clientID,
+		})
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].ClientID < candidates[j].ClientID
+	})
+	if limit > 0 && len(candidates) > limit {
+		candidates = candidates[:limit]
+	}
+
+	clientIDs := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		clientIDs[candidate.ClientID] = struct{}{}
+		summary.SampleConnectorClientIDs = append(summary.SampleConnectorClientIDs, candidate.Sample)
+	}
+	summary.ConnectorClientsMatched = len(candidates)
+
+	return candidates, clientIDs, nil
+}
+
+func buildMCPAuthCutoverRefreshCandidates(
+	items []map[string]types.AttributeValue,
+	connectorClientIDs map[string]struct{},
+	summary *mcpAuthCutoverMigrationSummary,
+) ([]mcpAuthCutoverDeleteCandidate, []mcpAuthCutoverDeleteCandidate, error) {
+	summary.RefreshTokensScanned = len(items)
+
+	connectorCandidates := make([]mcpAuthCutoverDeleteCandidate, 0, len(items))
+	runtimeCandidates := make([]mcpAuthCutoverDeleteCandidate, 0, len(items))
+	for _, item := range items {
+		var token models.RefreshToken
+		if err := attributevalue.UnmarshalMap(item, &token); err != nil {
+			return nil, nil, fmt.Errorf("unmarshal refresh token: %w", err)
+		}
+
+		candidate := mcpAuthCutoverDeleteCandidate{
+			PK:     strings.TrimSpace(token.PK),
+			SK:     strings.TrimSpace(token.SK),
+			Sample: summarizeMCPAuthCutoverRefreshToken(&token),
+		}
+
+		switch {
+		case isPreservedRuntimeRefreshToken(&token):
+			runtimeCandidates = append(runtimeCandidates, candidate)
+			summary.SampleRuntimeRefreshSessions = append(summary.SampleRuntimeRefreshSessions, candidate.Sample)
+		case isConnectorRefreshToken(&token, connectorClientIDs):
+			connectorCandidates = append(connectorCandidates, candidate)
+			summary.SampleConnectorRefreshSessions = append(summary.SampleConnectorRefreshSessions, candidate.Sample)
+		}
+	}
+
+	summary.ConnectorRefreshTokensMatched = len(connectorCandidates)
+	summary.RuntimeRefreshTokensPreserved = len(runtimeCandidates)
+	return connectorCandidates, runtimeCandidates, nil
+}
+
+func buildMCPAuthCutoverAuthorizationCodeCandidates(
+	items []map[string]types.AttributeValue,
+	connectorClientIDs map[string]struct{},
+	summary *mcpAuthCutoverMigrationSummary,
+) ([]mcpAuthCutoverDeleteCandidate, error) {
+	summary.AuthorizationCodesScanned = len(items)
+
+	candidates := make([]mcpAuthCutoverDeleteCandidate, 0, len(items))
+	for _, item := range items {
+		var code models.AuthorizationCode
+		if err := attributevalue.UnmarshalMap(item, &code); err != nil {
+			return nil, fmt.Errorf("unmarshal authorization code: %w", err)
+		}
+		if !isConnectorAuthorizationCode(&code, connectorClientIDs) {
+			continue
+		}
+		candidates = append(candidates, mcpAuthCutoverDeleteCandidate{
+			PK:     strings.TrimSpace(code.PK),
+			SK:     strings.TrimSpace(code.SK),
+			Sample: summarizeMCPAuthCutoverClientArtifact(code.ClientID, code.Username, code.Resource),
+		})
+	}
+
+	summary.ConnectorAuthorizationCodesMatched = len(candidates)
+	return candidates, nil
+}
+
+func buildMCPAuthCutoverOAuthStateCandidates(
+	items []map[string]types.AttributeValue,
+	connectorClientIDs map[string]struct{},
+	summary *mcpAuthCutoverMigrationSummary,
+) ([]mcpAuthCutoverDeleteCandidate, error) {
+	summary.OAuthStatesScanned = len(items)
+
+	candidates := make([]mcpAuthCutoverDeleteCandidate, 0, len(items))
+	for _, item := range items {
+		var state models.OAuthState
+		if err := attributevalue.UnmarshalMap(item, &state); err != nil {
+			return nil, fmt.Errorf("unmarshal oauth state: %w", err)
+		}
+		if !isConnectorOAuthState(&state, connectorClientIDs) {
+			continue
+		}
+		candidates = append(candidates, mcpAuthCutoverDeleteCandidate{
+			PK:     strings.TrimSpace(state.PK),
+			SK:     strings.TrimSpace(state.SK),
+			Sample: summarizeMCPAuthCutoverClientArtifact(state.ClientID, state.Username, state.Resource),
+		})
+	}
+
+	summary.ConnectorOAuthStatesMatched = len(candidates)
+	return candidates, nil
+}
+
+func buildMCPAuthCutoverDeviceSessionCandidates(
+	items []map[string]types.AttributeValue,
+	connectorClientIDs map[string]struct{},
+	summary *mcpAuthCutoverMigrationSummary,
+) ([]mcpAuthCutoverDeleteCandidate, error) {
+	summary.DeviceSessionsScanned = len(items)
+
+	candidates := make([]mcpAuthCutoverDeleteCandidate, 0, len(items))
+	for _, item := range items {
+		var session models.OAuthDeviceSession
+		if err := attributevalue.UnmarshalMap(item, &session); err != nil {
+			return nil, fmt.Errorf("unmarshal oauth device session: %w", err)
+		}
+		if !isConnectorDeviceSession(&session, connectorClientIDs) {
+			continue
+		}
+		candidates = append(candidates, mcpAuthCutoverDeleteCandidate{
+			PK:     strings.TrimSpace(session.PK),
+			SK:     strings.TrimSpace(session.SK),
+			Sample: summarizeMCPAuthCutoverClientArtifact(session.ClientID, session.ApprovedUsername, ""),
+		})
+	}
+
+	summary.ConnectorDeviceSessionsMatched = len(candidates)
+	return candidates, nil
+}
+
+func buildMCPAuthCutoverUserConsentCandidates(
+	items []map[string]types.AttributeValue,
+	connectorClientIDs map[string]struct{},
+	summary *mcpAuthCutoverMigrationSummary,
+) ([]mcpAuthCutoverDeleteCandidate, error) {
+	summary.UserAppConsentsScanned = len(items)
+
+	candidates := make([]mcpAuthCutoverDeleteCandidate, 0, len(items))
+	for _, item := range items {
+		var consent models.UserAppConsent
+		if err := attributevalue.UnmarshalMap(item, &consent); err != nil {
+			return nil, fmt.Errorf("unmarshal user app consent: %w", err)
+		}
+		if !isConnectorUserConsent(&consent, connectorClientIDs) {
+			continue
+		}
+		candidates = append(candidates, mcpAuthCutoverDeleteCandidate{
+			PK:     strings.TrimSpace(consent.PK),
+			SK:     strings.TrimSpace(consent.SK),
+			Sample: summarizeMCPAuthCutoverClientArtifact(consent.AppID, consent.UserID, consent.Resource),
+		})
+	}
+
+	summary.ConnectorUserAppConsentsMatched = len(candidates)
+	return candidates, nil
+}
+
+func deleteMCPAuthCutoverOAuthClientCandidates(
+	ctx context.Context,
+	client mcpAuthCutoverMigrationClient,
+	tableName string,
+	apply bool,
+	candidates []mcpAuthCutoverOAuthClientCandidate,
+	deleted *int,
+) error {
+	keys := make([]mcpAuthCutoverDeleteCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		keys = append(keys, candidate.mcpAuthCutoverDeleteCandidate)
+	}
+	return deleteMCPAuthCutoverCandidates(ctx, client, tableName, apply, keys, deleted)
+}
+
+func deleteMCPAuthCutoverCandidates(
+	ctx context.Context,
+	client mcpAuthCutoverMigrationClient,
+	tableName string,
+	apply bool,
+	candidates []mcpAuthCutoverDeleteCandidate,
+	deleted *int,
+) error {
+	if !apply {
+		return nil
+	}
+
+	for _, candidate := range candidates {
+		if _, err := client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+			TableName: aws.String(tableName),
+			Key: map[string]types.AttributeValue{
+				"PK": &types.AttributeValueMemberS{Value: candidate.PK},
+				"SK": &types.AttributeValueMemberS{Value: candidate.SK},
+			},
+		}); err != nil {
+			return fmt.Errorf("delete %s %s: %w", candidate.PK, candidate.SK, err)
+		}
+		if deleted != nil {
+			*deleted = *deleted + 1
+		}
+	}
+
+	return nil
+}
+
+func isConnectorOAuthClient(client *models.OAuthClient) bool {
+	if client == nil {
+		return false
+	}
+	clientID := strings.TrimSpace(client.ClientID)
+	if clientID == "" || auth.IsAgentRuntimeClientID(clientID) {
+		return false
+	}
+
+	return strings.EqualFold(strings.TrimSpace(client.ClientClass), auth.ClientClassAgent) ||
+		strings.TrimSpace(client.AgentUsername) != ""
+}
+
+func isPreservedRuntimeRefreshToken(token *models.RefreshToken) bool {
+	return token != nil && auth.IsAgentRuntimeClientID(strings.TrimSpace(token.ClientID))
+}
+
+func isConnectorRefreshToken(token *models.RefreshToken, connectorClientIDs map[string]struct{}) bool {
+	if token == nil {
+		return false
+	}
+	clientID := strings.TrimSpace(token.ClientID)
+	if clientID == "" || auth.IsAgentRuntimeClientID(clientID) {
+		return false
+	}
+	if _, ok := connectorClientIDs[clientID]; ok {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(token.ClientClass), auth.ClientClassAgent)
+}
+
+func isConnectorAuthorizationCode(code *models.AuthorizationCode, connectorClientIDs map[string]struct{}) bool {
+	if code == nil {
+		return false
+	}
+	_, ok := connectorClientIDs[strings.TrimSpace(code.ClientID)]
+	return ok
+}
+
+func isConnectorOAuthState(state *models.OAuthState, connectorClientIDs map[string]struct{}) bool {
+	if state == nil {
+		return false
+	}
+	if strings.TrimSpace(state.AgentUsername) != "" {
+		return true
+	}
+	_, ok := connectorClientIDs[strings.TrimSpace(state.ClientID)]
+	return ok
+}
+
+func isConnectorDeviceSession(session *models.OAuthDeviceSession, connectorClientIDs map[string]struct{}) bool {
+	if session == nil {
+		return false
+	}
+	_, ok := connectorClientIDs[strings.TrimSpace(session.ClientID)]
+	return ok
+}
+
+func isConnectorUserConsent(consent *models.UserAppConsent, connectorClientIDs map[string]struct{}) bool {
+	if consent == nil {
+		return false
+	}
+	_, ok := connectorClientIDs[strings.TrimSpace(consent.AppID)]
+	return ok
+}
+
+func summarizeMCPAuthCutoverRefreshToken(token *models.RefreshToken) string {
+	if token == nil {
+		return ""
+	}
+	resource := strings.TrimSpace(token.Resource)
+	if resource != "" {
+		return summarizeMCPAuthCutoverClientArtifact(token.ClientID, token.Username, resource)
+	}
+	sessionID := strings.TrimSpace(token.SessionID)
+	if sessionID != "" {
+		return fmt.Sprintf("%s user=%s session=%s", strings.TrimSpace(token.ClientID), strings.TrimSpace(token.Username), sessionID)
+	}
+	return summarizeMCPAuthCutoverClientArtifact(token.ClientID, token.Username, "")
+}
+
+func summarizeMCPAuthCutoverClientArtifact(clientID, username, resource string) string {
+	clientID = strings.TrimSpace(clientID)
+	username = strings.TrimSpace(username)
+	resource = strings.TrimSpace(resource)
+
+	parts := make([]string, 0, 3)
+	if clientID != "" {
+		parts = append(parts, clientID)
+	}
+	if username != "" {
+		parts = append(parts, "user="+username)
+	}
+	if resource != "" {
+		parts = append(parts, "resource="+resource)
+	}
+	return strings.Join(parts, " ")
+}
+
+func sampleStrings(values []string, limit int) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, minInt(limit, len(values)))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+	}
+	return out
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/cmd/lesser/migrate_mcp_auth_cutover_test.go
+++ b/cmd/lesser/migrate_mcp_auth_cutover_test.go
@@ -1,0 +1,556 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+type stagedMCPAuthCutoverMigrationClient struct {
+	scanOutputs []*dynamodb.ScanOutput
+	scanErr     error
+	failScanAt  int
+	scanCalls   int
+}
+
+func (s *stagedMCPAuthCutoverMigrationClient) Scan(_ context.Context, _ *dynamodb.ScanInput, _ ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error) {
+	s.scanCalls++
+	if s.failScanAt > 0 && s.scanCalls == s.failScanAt {
+		return nil, s.scanErr
+	}
+	if len(s.scanOutputs) == 0 {
+		return &dynamodb.ScanOutput{}, nil
+	}
+	out := s.scanOutputs[0]
+	s.scanOutputs = s.scanOutputs[1:]
+	return out, nil
+}
+
+func (s *stagedMCPAuthCutoverMigrationClient) DeleteItem(_ context.Context, _ *dynamodb.DeleteItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error) {
+	return &dynamodb.DeleteItemOutput{}, nil
+}
+
+func TestRunMigrateMCPAuthCutover_PrintsDryRunSummary(t *testing.T) {
+	previousLoadAWSConfig := loadAWSConfigForCLIFn
+	previousClientFactory := newMCPAuthCutoverMigrationClientFn
+	t.Cleanup(func() {
+		loadAWSConfigForCLIFn = previousLoadAWSConfig
+		newMCPAuthCutoverMigrationClientFn = previousClientFactory
+	})
+
+	client := &fakeUserKeyMigrationClient{
+		scanOutputs: mcpAuthCutoverScanOutputs(t),
+	}
+
+	var seenProfile string
+	loadAWSConfigForCLIFn = func(_ context.Context, awsProfile string) (aws.Config, string, error) {
+		seenProfile = awsProfile
+		return aws.Config{}, "Sim", nil
+	}
+	newMCPAuthCutoverMigrationClientFn = func(aws.Config) mcpAuthCutoverMigrationClient {
+		return client
+	}
+
+	output := captureStdout(t, func() {
+		require.NoError(t, runMigrateMCPAuthCutover([]string{
+			"--app", "simulacrum",
+			"--env", "dev",
+			"--aws-profile", "Sim",
+		}))
+	})
+
+	require.Equal(t, "Sim", seenProfile)
+	require.Contains(t, output, "migrate-mcp-auth-cutover dry-run complete")
+	require.Contains(t, output, "table: simulacrum-dev-main-table")
+	require.Contains(t, output, "aws_profile: Sim")
+	require.Contains(t, output, "oauth_clients_scanned: 2")
+	require.Contains(t, output, "connector_clients_matched: 1")
+	require.Contains(t, output, "connector_clients_deleted: 0")
+	require.Contains(t, output, "refresh_tokens_scanned: 2")
+	require.Contains(t, output, "connector_refresh_tokens_matched: 1")
+	require.Contains(t, output, "connector_refresh_tokens_deleted: 0")
+	require.Contains(t, output, "runtime_refresh_tokens_preserved: 1")
+	require.Contains(t, output, "authorization_codes_scanned: 1")
+	require.Contains(t, output, "connector_authorization_codes_matched: 1")
+	require.Contains(t, output, "oauth_states_scanned: 1")
+	require.Contains(t, output, "connector_oauth_states_matched: 1")
+	require.Contains(t, output, "device_sessions_scanned: 1")
+	require.Contains(t, output, "connector_device_sessions_matched: 1")
+	require.Contains(t, output, "user_app_consents_scanned: 1")
+	require.Contains(t, output, "connector_user_app_consents_matched: 1")
+	require.Contains(t, output, "sample_connector_client_ids:")
+	require.Contains(t, output, "client-agent")
+	require.Contains(t, output, "sample_connector_refresh_sessions:")
+	require.Contains(t, output, "resource=https://example.com/mcp/agent1")
+	require.Contains(t, output, "sample_runtime_refresh_sessions:")
+	require.Contains(t, output, auth.DelegatedAgentRuntimeClientID)
+	require.Contains(t, output, "no writes performed; re-run with --apply")
+	require.Empty(t, client.deleteInputs)
+}
+
+func TestExecuteMCPAuthCutoverMigration_ApplyDeletesConnectorArtifacts(t *testing.T) {
+	client := &fakeUserKeyMigrationClient{
+		scanOutputs: mcpAuthCutoverScanOutputs(t),
+	}
+
+	summary, err := executeMCPAuthCutoverMigration(context.Background(), client, "simulacrum-dev-main-table", true, 0)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, summary.ConnectorClientsDeleted)
+	require.Equal(t, 1, summary.ConnectorRefreshTokensDeleted)
+	require.Equal(t, 1, summary.ConnectorAuthorizationCodesDeleted)
+	require.Equal(t, 1, summary.ConnectorOAuthStatesDeleted)
+	require.Equal(t, 1, summary.ConnectorDeviceSessionsDeleted)
+	require.Equal(t, 1, summary.ConnectorUserAppConsentsDeleted)
+	require.Len(t, client.deleteInputs, 6)
+
+	deletedKeys := make([]string, 0, len(client.deleteInputs))
+	for _, input := range client.deleteInputs {
+		deletedKeys = append(deletedKeys, strAttr(t, input.Key["PK"])+"\x00"+strAttr(t, input.Key["SK"]))
+	}
+
+	require.Contains(t, deletedKeys, "AUTHCODE#code-agent\x00CODE")
+	require.Contains(t, deletedKeys, "OAUTH_STATE#state-agent\x00STATE")
+	require.Contains(t, deletedKeys, "OAUTH_DEVICE#hash-agent\x00SESSION")
+	require.Contains(t, deletedKeys, "USER#owner\x00CONSENT#client-agent#RESOURCE#https://example.com/mcp/agent1")
+	require.Contains(t, deletedKeys, "REFRESHTOKEN#rt-agent\x00TOKEN")
+	require.Contains(t, deletedKeys, "OAUTH_CLIENT#client-agent\x00CLIENT")
+}
+
+func TestExecuteMCPAuthCutoverMigration_ValidatesInputs(t *testing.T) {
+	_, err := executeMCPAuthCutoverMigration(context.Background(), nil, "simulacrum-dev-main-table", false, 0)
+	require.ErrorContains(t, err, "migration client is required")
+
+	client := &fakeUserKeyMigrationClient{}
+	_, err = executeMCPAuthCutoverMigration(context.Background(), client, "", false, 0)
+	require.ErrorContains(t, err, "table name is required")
+}
+
+func TestExecuteMCPAuthCutoverMigration_PropagatesStageErrors(t *testing.T) {
+	t.Run("oauth client scan failure", func(t *testing.T) {
+		client := &stagedMCPAuthCutoverMigrationClient{
+			failScanAt: 1,
+			scanErr:    context.DeadlineExceeded,
+		}
+		_, err := executeMCPAuthCutoverMigration(context.Background(), client, "simulacrum-dev-main-table", false, 0)
+		require.ErrorContains(t, err, "scan oauth clients")
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("refresh token scan failure", func(t *testing.T) {
+		client := &stagedMCPAuthCutoverMigrationClient{
+			scanOutputs: []*dynamodb.ScanOutput{{}},
+			failScanAt:  2,
+			scanErr:     context.DeadlineExceeded,
+		}
+		_, err := executeMCPAuthCutoverMigration(context.Background(), client, "simulacrum-dev-main-table", false, 0)
+		require.ErrorContains(t, err, "scan refresh tokens")
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("malformed oauth client row", func(t *testing.T) {
+		client := &stagedMCPAuthCutoverMigrationClient{
+			scanOutputs: []*dynamodb.ScanOutput{{
+				Items: []map[string]types.AttributeValue{{
+					"clientID": &types.AttributeValueMemberL{Value: []types.AttributeValue{&types.AttributeValueMemberS{Value: "bad"}}},
+				}},
+			}},
+		}
+		_, err := executeMCPAuthCutoverMigration(context.Background(), client, "simulacrum-dev-main-table", false, 0)
+		require.ErrorContains(t, err, "unmarshal oauth client")
+	})
+}
+
+func TestMCPAuthCutoverHelpers(t *testing.T) {
+	t.Run("connector client classification excludes runtime ids and blanks", func(t *testing.T) {
+		require.False(t, isConnectorOAuthClient(nil))
+		require.False(t, isConnectorOAuthClient(&models.OAuthClient{}))
+		require.False(t, isConnectorOAuthClient(&models.OAuthClient{ClientID: auth.DelegatedAgentRuntimeClientID, ClientClass: auth.ClientClassAgent}))
+		require.True(t, isConnectorOAuthClient(&models.OAuthClient{ClientID: "client-agent", ClientClass: auth.ClientClassAgent}))
+		require.True(t, isConnectorOAuthClient(&models.OAuthClient{ClientID: "client-legacy", AgentUsername: "agent1"}))
+	})
+
+	t.Run("refresh token classification preserves runtime and revokes connector state", func(t *testing.T) {
+		connectorClientIDs := map[string]struct{}{"client-agent": {}}
+
+		require.False(t, isPreservedRuntimeRefreshToken(nil))
+		require.True(t, isPreservedRuntimeRefreshToken(&models.RefreshToken{ClientID: auth.DelegatedAgentRuntimeClientID}))
+		require.False(t, isPreservedRuntimeRefreshToken(&models.RefreshToken{ClientID: "client-cli"}))
+
+		require.False(t, isConnectorRefreshToken(nil, connectorClientIDs))
+		require.False(t, isConnectorRefreshToken(&models.RefreshToken{}, connectorClientIDs))
+		require.False(t, isConnectorRefreshToken(&models.RefreshToken{ClientID: auth.DelegatedAgentRuntimeClientID, ClientClass: auth.ClientClassAgent}, connectorClientIDs))
+		require.True(t, isConnectorRefreshToken(&models.RefreshToken{ClientID: "client-agent"}, connectorClientIDs))
+		require.True(t, isConnectorRefreshToken(&models.RefreshToken{ClientID: "client-legacy", ClientClass: auth.ClientClassAgent}, connectorClientIDs))
+		require.False(t, isConnectorRefreshToken(&models.RefreshToken{ClientID: "client-cli", ClientClass: auth.ClientClassCLI}, connectorClientIDs))
+	})
+
+	t.Run("artifact classifiers key off connector client ids or legacy agent usernames", func(t *testing.T) {
+		connectorClientIDs := map[string]struct{}{"client-agent": {}}
+
+		require.False(t, isConnectorAuthorizationCode(nil, connectorClientIDs))
+		require.True(t, isConnectorAuthorizationCode(&models.AuthorizationCode{ClientID: "client-agent"}, connectorClientIDs))
+		require.False(t, isConnectorAuthorizationCode(&models.AuthorizationCode{ClientID: "client-cli"}, connectorClientIDs))
+
+		require.False(t, isConnectorOAuthState(nil, connectorClientIDs))
+		require.True(t, isConnectorOAuthState(&models.OAuthState{AgentUsername: "agent1"}, connectorClientIDs))
+		require.True(t, isConnectorOAuthState(&models.OAuthState{ClientID: "client-agent"}, connectorClientIDs))
+		require.False(t, isConnectorOAuthState(&models.OAuthState{ClientID: "client-cli"}, connectorClientIDs))
+
+		require.False(t, isConnectorDeviceSession(nil, connectorClientIDs))
+		require.True(t, isConnectorDeviceSession(&models.OAuthDeviceSession{ClientID: "client-agent"}, connectorClientIDs))
+		require.False(t, isConnectorDeviceSession(&models.OAuthDeviceSession{ClientID: "client-cli"}, connectorClientIDs))
+
+		require.False(t, isConnectorUserConsent(nil, connectorClientIDs))
+		require.True(t, isConnectorUserConsent(&models.UserAppConsent{AppID: "client-agent"}, connectorClientIDs))
+		require.False(t, isConnectorUserConsent(&models.UserAppConsent{AppID: "client-cli"}, connectorClientIDs))
+	})
+
+	t.Run("summaries prefer resource then session fallback", func(t *testing.T) {
+		require.Empty(t, summarizeMCPAuthCutoverRefreshToken(nil))
+		require.Equal(t,
+			"client-agent user=agent1 resource=https://example.com/mcp/agent1",
+			summarizeMCPAuthCutoverRefreshToken(&models.RefreshToken{
+				ClientID: "client-agent",
+				Username: "agent1",
+				Resource: "https://example.com/mcp/agent1",
+			}),
+		)
+		require.Equal(t,
+			"client-agent user=agent1 session=session-1",
+			summarizeMCPAuthCutoverRefreshToken(&models.RefreshToken{
+				ClientID:  "client-agent",
+				Username:  "agent1",
+				SessionID: "session-1",
+			}),
+		)
+		require.Equal(t,
+			"client-agent user=agent1",
+			summarizeMCPAuthCutoverRefreshToken(&models.RefreshToken{
+				ClientID: "client-agent",
+				Username: "agent1",
+			}),
+		)
+		require.Equal(t,
+			"client-agent user=agent1 resource=https://example.com/mcp/agent1",
+			summarizeMCPAuthCutoverClientArtifact(" client-agent ", " agent1 ", " https://example.com/mcp/agent1 "),
+		)
+	})
+
+	t.Run("sample helpers deduplicate and respect limits", func(t *testing.T) {
+		require.Nil(t, sampleStrings(nil, 5))
+		require.Equal(t, []string{"one", "two"}, sampleStrings([]string{"one", " ", "one", "two", "two"}, 0))
+		require.Equal(t, []string{"one"}, sampleStrings([]string{"one", "two"}, 1))
+		require.Equal(t, 1, minInt(1, 2))
+		require.Equal(t, 2, minInt(3, 2))
+	})
+}
+
+func TestScanMCPAuthCutoverItems_PaginatesAndHandlesErrors(t *testing.T) {
+	client := &fakeUserKeyMigrationClient{
+		scanOutputs: []*dynamodb.ScanOutput{
+			{
+				Items: []map[string]types.AttributeValue{
+					{"PK": sAttr("first"), "SK": sAttr("row")},
+				},
+				LastEvaluatedKey: map[string]types.AttributeValue{
+					"PK": sAttr("cursor-pk"),
+					"SK": sAttr("cursor-sk"),
+				},
+			},
+			{
+				Items: []map[string]types.AttributeValue{
+					{"PK": sAttr("second"), "SK": sAttr("row")},
+				},
+			},
+		},
+	}
+
+	items, err := scanMCPAuthCutoverItems(
+		context.Background(),
+		client,
+		"simulacrum-dev-main-table",
+		"begins_with(PK, :pk)",
+		map[string]types.AttributeValue{":pk": sAttr("OAUTH_CLIENT#")},
+		map[string]string{"#pk": "PK"},
+	)
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	require.Len(t, client.scanInputs, 2)
+	require.Equal(t, "PK", client.scanInputs[0].ExpressionAttributeNames["#pk"])
+	require.Equal(t, "cursor-pk", strAttr(t, client.scanInputs[1].ExclusiveStartKey["PK"]))
+
+	client.scanErr = context.DeadlineExceeded
+	client.scanOutputs = nil
+	_, err = scanMCPAuthCutoverItems(
+		context.Background(),
+		client,
+		"simulacrum-dev-main-table",
+		"begins_with(PK, :pk)",
+		map[string]types.AttributeValue{":pk": sAttr("OAUTH_CLIENT#")},
+		nil,
+	)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestMCPAuthCutoverBuilders_HandleLimitsAndMalformedItems(t *testing.T) {
+	baseTime := time.Date(2026, 3, 28, 12, 0, 0, 0, time.UTC)
+
+	connectorA := models.OAuthClient{
+		ClientID:      "client-a",
+		ClientClass:   auth.ClientClassAgent,
+		AgentUsername: "agent-a",
+		CreatedAt:     baseTime,
+		UpdatedAt:     baseTime,
+	}
+	require.NoError(t, connectorA.BeforeCreate())
+
+	connectorB := models.OAuthClient{
+		ClientID:      "client-b",
+		ClientClass:   auth.ClientClassAgent,
+		AgentUsername: "agent-b",
+		CreatedAt:     baseTime,
+		UpdatedAt:     baseTime,
+	}
+	require.NoError(t, connectorB.BeforeCreate())
+
+	publicClient := models.OAuthClient{
+		ClientID:    "client-cli",
+		ClientClass: auth.ClientClassCLI,
+		CreatedAt:   baseTime,
+		UpdatedAt:   baseTime,
+	}
+	require.NoError(t, publicClient.BeforeCreate())
+
+	summary := &mcpAuthCutoverMigrationSummary{}
+	candidates, clientIDs, err := buildMCPAuthCutoverOAuthClientCandidates([]map[string]types.AttributeValue{
+		mustMarshalMCPAuthCutoverModel(t, connectorB),
+		mustMarshalMCPAuthCutoverModel(t, publicClient),
+		mustMarshalMCPAuthCutoverModel(t, connectorA),
+	}, 1, summary)
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	require.Equal(t, "client-a", candidates[0].ClientID)
+	require.Equal(t, 1, summary.ConnectorClientsMatched)
+	_, ok := clientIDs["client-a"]
+	require.True(t, ok)
+
+	badItem := []map[string]types.AttributeValue{{
+		"clientID": &types.AttributeValueMemberL{Value: []types.AttributeValue{&types.AttributeValueMemberS{Value: "bad"}}},
+	}}
+	_, _, err = buildMCPAuthCutoverOAuthClientCandidates(badItem, 0, &mcpAuthCutoverMigrationSummary{})
+	require.ErrorContains(t, err, "unmarshal oauth client")
+	_, _, err = buildMCPAuthCutoverRefreshCandidates(badItem, map[string]struct{}{}, &mcpAuthCutoverMigrationSummary{})
+	require.ErrorContains(t, err, "unmarshal refresh token")
+	_, err = buildMCPAuthCutoverAuthorizationCodeCandidates(badItem, map[string]struct{}{}, &mcpAuthCutoverMigrationSummary{})
+	require.ErrorContains(t, err, "unmarshal authorization code")
+	_, err = buildMCPAuthCutoverOAuthStateCandidates(badItem, map[string]struct{}{}, &mcpAuthCutoverMigrationSummary{})
+	require.ErrorContains(t, err, "unmarshal oauth state")
+	_, err = buildMCPAuthCutoverDeviceSessionCandidates(badItem, map[string]struct{}{}, &mcpAuthCutoverMigrationSummary{})
+	require.ErrorContains(t, err, "unmarshal oauth device session")
+
+	badConsentItem := []map[string]types.AttributeValue{{
+		"appID": &types.AttributeValueMemberL{Value: []types.AttributeValue{&types.AttributeValueMemberS{Value: "bad"}}},
+	}}
+	_, err = buildMCPAuthCutoverUserConsentCandidates(badConsentItem, map[string]struct{}{}, &mcpAuthCutoverMigrationSummary{})
+	require.ErrorContains(t, err, "unmarshal user app consent")
+}
+
+func TestMCPAuthCutoverArtifactBuilders_SkipNonConnectorRows(t *testing.T) {
+	baseTime := time.Date(2026, 3, 28, 12, 0, 0, 0, time.UTC)
+	summary := &mcpAuthCutoverMigrationSummary{}
+	connectorClientIDs := map[string]struct{}{"client-agent": {}}
+
+	publicCode := models.AuthorizationCode{
+		Code:        "code-cli",
+		ClientID:    "client-cli",
+		RedirectURI: "https://example.com/callback",
+		Username:    "owner",
+		ExpiresAt:   baseTime.Add(10 * time.Minute),
+		CreatedAt:   baseTime,
+	}
+	require.NoError(t, publicCode.BeforeCreate())
+	candidates, err := buildMCPAuthCutoverAuthorizationCodeCandidates(
+		[]map[string]types.AttributeValue{mustMarshalMCPAuthCutoverModel(t, publicCode)},
+		connectorClientIDs,
+		summary,
+	)
+	require.NoError(t, err)
+	require.Empty(t, candidates)
+	require.Equal(t, 0, summary.ConnectorAuthorizationCodesMatched)
+}
+
+func TestDeleteMCPAuthCutoverCandidates_ReportsDeleteErrors(t *testing.T) {
+	client := &fakeUserKeyMigrationClient{deleteErr: errors.New("boom")}
+	deleted := 0
+
+	err := deleteMCPAuthCutoverCandidates(context.Background(), client, "simulacrum-dev-main-table", true, []mcpAuthCutoverDeleteCandidate{{
+		PK: "OAUTH_CLIENT#client-agent",
+		SK: "CLIENT",
+	}}, &deleted)
+	require.ErrorContains(t, err, "delete OAUTH_CLIENT#client-agent CLIENT")
+	require.ErrorContains(t, err, "boom")
+	require.Zero(t, deleted)
+}
+
+func TestDeleteMCPAuthCutoverCandidates_ApplyIncrementsDeleted(t *testing.T) {
+	client := &fakeUserKeyMigrationClient{}
+	deleted := 0
+
+	err := deleteMCPAuthCutoverCandidates(context.Background(), client, "simulacrum-dev-main-table", true, []mcpAuthCutoverDeleteCandidate{
+		{PK: "OAUTH_CLIENT#client-a", SK: "CLIENT"},
+		{PK: "REFRESHTOKEN#token-a", SK: "TOKEN"},
+	}, &deleted)
+	require.NoError(t, err)
+	require.Equal(t, 2, deleted)
+	require.Len(t, client.deleteInputs, 2)
+	require.Equal(t, "OAUTH_CLIENT#client-a", strAttr(t, client.deleteInputs[0].Key["PK"]))
+	require.Equal(t, "TOKEN", strAttr(t, client.deleteInputs[1].Key["SK"]))
+}
+
+func mcpAuthCutoverScanOutputs(t *testing.T) []*dynamodb.ScanOutput {
+	t.Helper()
+
+	baseTime := time.Date(2026, 3, 28, 12, 0, 0, 0, time.UTC)
+
+	connectorClient := models.OAuthClient{
+		ClientID:      "client-agent",
+		ClientClass:   auth.ClientClassAgent,
+		AgentUsername: "agent1",
+		GrantTypes:    []string{auth.GrantTypeAuthorizationCode, auth.GrantTypeRefreshToken},
+		Scopes:        []string{auth.ScopeRead, auth.ScopeWrite},
+		CreatedAt:     baseTime,
+		UpdatedAt:     baseTime,
+	}
+	require.NoError(t, connectorClient.BeforeCreate())
+
+	publicClient := models.OAuthClient{
+		ClientID:    "client-cli",
+		ClientClass: auth.ClientClassCLI,
+		GrantTypes:  []string{auth.GrantTypeAuthorizationCode, auth.GrantTypeRefreshToken, "urn:ietf:params:oauth:grant-type:device_code"},
+		Scopes:      []string{auth.ScopeRead},
+		CreatedAt:   baseTime,
+		UpdatedAt:   baseTime,
+	}
+	require.NoError(t, publicClient.BeforeCreate())
+
+	connectorRefresh := models.RefreshToken{
+		Token:       "rt-agent",
+		ClientID:    connectorClient.ClientID,
+		Username:    "agent1",
+		Resource:    "https://example.com/mcp/agent1",
+		ExpiresAt:   baseTime.Add(24 * time.Hour),
+		Scopes:      []string{auth.ScopeRead},
+		ClientClass: auth.ClientClassAgent,
+		CreatedAt:   baseTime,
+	}
+	require.NoError(t, connectorRefresh.BeforeCreate())
+
+	runtimeRefresh := models.RefreshToken{
+		Token:             "rt-runtime",
+		ClientID:          auth.DelegatedAgentRuntimeClientID,
+		Username:          "agent1",
+		ExpiresAt:         baseTime.Add(24 * time.Hour),
+		Scopes:            []string{auth.ScopeRead},
+		ClientClass:       auth.ClientClassAgent,
+		SessionID:         "session-runtime",
+		FamilyID:          "family-runtime",
+		Generation:        1,
+		Current:           true,
+		DeviceLabel:       "local-agent",
+		LastUsedAt:        baseTime,
+		IdleExpiresAt:     baseTime.Add(24 * time.Hour),
+		AbsoluteExpiresAt: baseTime.Add(30 * 24 * time.Hour),
+		SessionCreatedAt:  baseTime.Add(-1 * time.Hour),
+		AccessTTLSeconds:  3600,
+		CreatedAt:         baseTime,
+	}
+	require.NoError(t, runtimeRefresh.BeforeCreate())
+
+	authCode := models.AuthorizationCode{
+		Code:        "code-agent",
+		ClientID:    connectorClient.ClientID,
+		RedirectURI: "https://example.com/callback",
+		Resource:    "https://example.com/mcp/agent1",
+		Username:    "owner",
+		ExpiresAt:   baseTime.Add(10 * time.Minute),
+		Scopes:      []string{auth.ScopeRead},
+		CreatedAt:   baseTime,
+	}
+	require.NoError(t, authCode.BeforeCreate())
+
+	oauthState := models.OAuthState{
+		State:         "state-agent",
+		RedirectURI:   "https://example.com/callback",
+		Username:      "owner",
+		AgentUsername: "agent1",
+		ClientID:      connectorClient.ClientID,
+		Resource:      "https://example.com/mcp/agent1",
+		CreatedAt:     baseTime,
+		ExpiresAt:     baseTime.Add(10 * time.Minute),
+	}
+	require.NoError(t, oauthState.UpdateKeys())
+
+	deviceSession := models.OAuthDeviceSession{
+		DeviceCodeHash:   "hash-agent",
+		UserCode:         "ABCD-EFGH",
+		ClientID:         connectorClient.ClientID,
+		Status:           "approved",
+		ApprovedUsername: "owner",
+		CreatedAt:        baseTime,
+		UpdatedAt:        baseTime,
+		ExpiresAt:        baseTime.Add(10 * time.Minute),
+	}
+	require.NoError(t, deviceSession.UpdateKeys())
+
+	consent := models.UserAppConsent{
+		UserID:    "owner",
+		AppID:     connectorClient.ClientID,
+		Resource:  "https://example.com/mcp/agent1",
+		Scopes:    []string{auth.ScopeRead},
+		CreatedAt: baseTime,
+		UpdatedAt: baseTime,
+		Active:    true,
+	}
+	require.NoError(t, consent.UpdateKeys())
+
+	return []*dynamodb.ScanOutput{
+		{Items: []map[string]types.AttributeValue{
+			mustMarshalMCPAuthCutoverModel(t, connectorClient),
+			mustMarshalMCPAuthCutoverModel(t, publicClient),
+		}},
+		{Items: []map[string]types.AttributeValue{
+			mustMarshalMCPAuthCutoverModel(t, connectorRefresh),
+			mustMarshalMCPAuthCutoverModel(t, runtimeRefresh),
+		}},
+		{Items: []map[string]types.AttributeValue{
+			mustMarshalMCPAuthCutoverModel(t, authCode),
+		}},
+		{Items: []map[string]types.AttributeValue{
+			mustMarshalMCPAuthCutoverModel(t, oauthState),
+		}},
+		{Items: []map[string]types.AttributeValue{
+			mustMarshalMCPAuthCutoverModel(t, deviceSession),
+		}},
+		{Items: []map[string]types.AttributeValue{
+			mustMarshalMCPAuthCutoverModel(t, consent),
+		}},
+	}
+}
+
+func mustMarshalMCPAuthCutoverModel(t *testing.T, model any) map[string]types.AttributeValue {
+	t.Helper()
+
+	item, err := attributevalue.MarshalMap(model)
+	require.NoError(t, err)
+	return item
+}

--- a/docs/architecture/auth/oauth-client-secret-rotation.md
+++ b/docs/architecture/auth/oauth-client-secret-rotation.md
@@ -14,13 +14,12 @@ minting a replacement secret for them.
 Routine rotation is intentionally no-downtime:
 
 - existing bearer access tokens remain valid until their normal expiry
-- refresh-token exchanges remain anchored to `client_id` and continue to accept the previous secret only while the grace window is still active
-- `client_credentials` token acquisition also continues to accept the previous secret only while the grace window is still active
+- client-authenticated authorization-code and refresh-token exchanges remain anchored to `client_id` and continue to accept the previous secret only while the grace window is still active
 - once the grace window expires, new client-authenticated exchanges must use the replacement secret
 
 Forced invalidation is narrower than token revocation:
 
-- Lesser immediately rejects the previous secret for refresh-token and `client_credentials` requests
+- Lesser immediately rejects the previous secret for client-authenticated authorization-code and refresh-token requests
 - Lesser does not retroactively revoke already-issued bearer access tokens as part of secret rotation alone
 - operators should treat refresh-token or session revocation as a separate incident-response action when they need to cut off already-issued tokens
 

--- a/docs/device-code-agent-auth.md
+++ b/docs/device-code-agent-auth.md
@@ -1,12 +1,12 @@
 # Device Code For Agent Auth
 
-Lesser supports three OAuth grant families for agent-facing integrations. They solve different operational problems:
+Lesser supports two public OAuth grant families for agent-facing integrations. Dedicated internal runtime clients use a
+separate owned architecture outside this document.
 
 | Grant | User approval | Browser redirect on the agent host | Best fit |
 | --- | --- | --- | --- |
 | `authorization_code` | Yes | Yes | Interactive MCP clients with a browser on the same machine |
 | `urn:ietf:params:oauth:grant-type:device_code` | Yes | No | Headless agents that still need an operator to approve each session |
-| `client_credentials` | No | No | Fully autonomous, pre-approved machine-to-machine agents |
 
 ## When to use device code
 
@@ -16,7 +16,7 @@ Choose `device_code` when:
 - an operator still wants to review the requesting app and scopes before the session starts
 - a browser redirect back to the agent host is inconvenient or impossible
 
-Device flow is the middle ground between browser-based `authorization_code` and fully autonomous `client_credentials`.
+Device flow is the middle ground between browser-based `authorization_code` and a fully headless bootstrap path.
 
 ## Boundary with the public MCP contract
 
@@ -27,8 +27,8 @@ Current device-code flow is outside that canonical actor-URL contract for now. `
 accepts `client_id` and scopes only; it does not accept the actor-scoped `resource` value used by the canonical public
 MCP flow.
 
-Treat device code as a separate, non-canonical compatibility/bootstrap path until a later milestone rewires it around
-the actor-scoped resource contract.
+Treat device code as a separate, non-canonical bootstrap path until a later milestone rewires it around the actor-scoped
+resource contract.
 
 ## Lesser device-flow sequence
 
@@ -46,27 +46,21 @@ the actor-scoped resource contract.
 
 ## Token behavior by client class
 
-Device flow inherits the OAuth client's class rather than forcing one uniform token shape:
+After cutover, device flow is limited to CLI-style public clients rather than connector-era agent-bound clients:
 
 - `client_class=cli`
   - access tokens are minted as CLI tokens
   - CLI automation safety rails apply
   - refresh records keep CLI-style session metadata
 - `client_class=agent`
-  - internal or legacy compatibility runtime path; not provisioned by public registration and not part of the canonical actor-scoped public contract
-  - access tokens are minted for the bound agent identity, not the approving operator principal
-  - tokens carry `client_class`, `is_agent`, `agent_type`, and `delegated_by`
-  - ordinary public or legacy compatibility agent clients now store standard OAuth refresh records
-  - only the dedicated internal runtime client IDs keep runtime-family, device-label, and idle/absolute-expiry session semantics
-  - runtime-session diagnostics and revocation endpoints cover only those dedicated internal runtime client IDs
+  - no longer supported on the public device-flow surface
+  - connector-era agent device sessions are revoked by the cutover migration and must re-enter through the canonical actor-scoped authorization-code flow or a dedicated internal runtime path
 
-For agent clients, the approving operator must own the bound agent. Lesser rejects approvals that no longer satisfy that ownership relationship.
-
-## Choosing between the three grants
+## Choosing between the two grants
 
 - Prefer `authorization_code` when the MCP client can open a browser locally and complete a normal redirect.
 - Prefer `device_code` when the client is headless but you still want a human approval step.
-- Prefer `client_credentials` only for legacy compatibility clients or dedicated internal runtimes that are intentionally pre-approved to act without per-session operator consent.
+- Dedicated internal runtime automation belongs to a separate owned architecture, not to the public device-flow contract in this document.
 
 ## Current approval-page contract
 

--- a/docs/oauth-agent-clients.md
+++ b/docs/oauth-agent-clients.md
@@ -6,7 +6,7 @@ The MCP-facing auth error contract for refresh, re-auth, and scope failures live
 
 Public remote MCP clients should treat the actor-scoped contract in [docs/specs/mcp-actor-url-auth-contract.md](/home/aron/ai-workspace/codebases/equaltoai/lesser/docs/specs/mcp-actor-url-auth-contract.md) as canonical.
 Dedicated internal runtime clients such as `lesser-agent-delegation` and `lesser-agent-self-sovereign`, secret-rotation
-flows, and similar owned-client operations are compatibility/runtime surfaces, not the source of truth for public MCP
+flows, and similar owned-client operations are runtime/management surfaces, not the source of truth for public MCP
 access.
 
 ## Simple MCP access panel
@@ -52,17 +52,15 @@ Legacy `read:*`, `write:*`, and `write:follows` aliases remain accepted for comp
 ## Supported token flow
 
 - For public MCP authorization, send the actor-scoped MCP URL as the canonical `resource`.
-- For remote MCP authorization, `/oauth/authorize` derives the target actor from that actor-scoped `resource`. Legacy compatibility clients must send it explicitly; Lesser no longer selects the actor from `agent_username`.
+- For remote MCP authorization, send the actor-scoped MCP URL as `resource`; Lesser binds the target actor from that canonical value and does not select the actor from client metadata.
 - Treat `authorization_code` and `refresh_token` state as resource-bound to that MCP URL.
 - Consent redirects and stored OAuth state for that flow carry the canonical `resource` target instead of `agent_username`.
-- Do not treat `agent_username` as the canonical public token target; it is legacy compatibility state during the migration.
+- Do not treat `agent_username` as a supported public token target. Connector-era client rows and sessions that depended on it are retired by the cutover migration.
 - Public MCP refresh-token records use standard OAuth rotation state, not connector-family/device-label runtime metadata.
-- Runtime-session diagnostics and `/api/v1/agents/{username}/runtime-sessions` cover only the dedicated internal runtime client IDs; public or legacy compatibility agent clients do not appear there.
-- Compatibility/runtime only: `POST /oauth/token` supports `client_credentials` for confidential agent clients that already exist outside the public registration contract.
-- Compatibility/runtime only: `POST /oauth/token` also supports `urn:ietf:params:oauth:grant-type:device_code` for agent clients that request operator approval without a redirect-capable browser.
-- `client_credentials` responses are access-token-only.
-- Access tokens inherit Lesser's configured agent access-token TTL.
-- Device-code and client-credentials tokens for agent clients are minted for the bound agent identity and carry `client_class`, `is_agent`, `agent_type`, and `delegated_by` claims.
+- Runtime-session diagnostics and `/api/v1/agents/{username}/runtime-sessions` cover only the dedicated internal runtime client IDs.
+- `POST /oauth/token` supports `authorization_code` and `refresh_token` for the canonical public MCP flow.
+- If device flow is enabled, `POST /oauth/token` also supports `urn:ietf:params:oauth:grant-type:device_code` for `client_class=cli` as a separate, non-canonical bootstrap flow.
+- Lesser no longer supports public or connector-era agent `client_credentials` or agent `device_code` flows after cutover.
 
 ## Secret recovery
 
@@ -72,7 +70,7 @@ public remote MCP agent-page contract and should not be presented as the primary
 - Operators can rotate an owned confidential client secret in place with `POST /api/v1/apps/{id}/rotate_secret`.
 - Owned public clients do not have a rotatable secret-management path; if they need a different client secret posture, they must register a new client.
 - Existing bearer access tokens remain valid until their normal expiry.
-- Refresh-token and `client_credentials` exchanges continue to accept the previous secret only until the grace window expires.
+- Client-authenticated authorization-code and refresh-token exchanges continue to accept the previous secret only until the grace window expires.
 - Forced invalidation skips the grace window and cuts off new client-authenticated exchanges immediately.
 - Secret rotation does not retroactively revoke already-issued bearer tokens; token revocation remains a separate operator action.
 - The replacement secret is returned once in the rotation response and must be redistributed to the managed client deployment.
@@ -81,7 +79,7 @@ public remote MCP agent-page contract and should not be presented as the primary
 
 Lesser now exposes `POST /oauth/register` and advertises it through RFC 8414 metadata.
 
-The current compatibility story is:
+The current registration contract is:
 
 - native or CLI discovery clients can dynamically register a public client with `token_endpoint_auth_method=none`
 - browser-based public clients can dynamically register a confidential `web` client with `client_secret_post`

--- a/docs/specs/mcp-actor-url-auth-contract.md
+++ b/docs/specs/mcp-actor-url-auth-contract.md
@@ -10,7 +10,7 @@ It is the single written contract for M0 and covers:
 - the canonical public registration path
 - the resource-bound token model for public MCP access
 - the public MCP versus internal runtime auth boundary
-- the deprecated connector-era surfaces scheduled for removal
+- the connector-era surfaces retired by cutover
 
 ## Canonical remote MCP access form
 
@@ -89,8 +89,8 @@ That means:
 - `/oauth/authorize` must validate that `resource` against the actor-scoped `https://{domain}/mcp/{actor}` form before issuing consent or codes
 
 For public remote MCP access, `client_class`, `agent_username`, or any similar client metadata must not be treated as
-the canonical actor-binding source. If those fields continue to exist for compatibility during the migration, they are
-secondary legacy signals and must not override the actor-scoped resource URL.
+the canonical actor-binding source. Connector-era rows that still contain those fields are legacy data only and must
+not override the actor-scoped resource URL.
 
 ## Canonical public client registration path
 
@@ -123,9 +123,8 @@ That contract applies across the normal OAuth flow:
 
 The public MCP token model is therefore resource-bound, not connector-bound.
 
-`agent_username` is not part of the canonical public token model. If it remains present in stored state during the
-migration, it is legacy compatibility data only and must not replace `resource` as the target identifier for public MCP
-sessions.
+`agent_username` is not part of the canonical public token model. If it appears in stale pre-cutover rows, it is legacy
+data only and must not replace `resource` as the target identifier for public MCP sessions.
 Public MCP refresh-token records also must not depend on runtime-only fields such as connector session families, device
 labels, or idle/absolute runtime expiry policy.
 
@@ -145,20 +144,20 @@ The following are not part of the canonical public remote MCP contract:
 - agent runtime refresh-token families and runtime-session diagnostics
 - runtime-session listing or revocation endpoints that only manage those dedicated internal runtime clients
 - public MCP refresh-token records that depend on connector-era runtime session metadata
-- operator-only secret rotation and compatibility workflows for owned internal clients
+- operator-only secret rotation and owned runtime-management workflows
 - any browser-local connector inventory or connector-management UX
 
-Those compatibility/runtime mechanisms may continue to exist temporarily for operational reasons, but public MCP
-support must not depend on them. Public remote clients should be implementable from the actor-scoped resource contract
-alone.
+Those runtime-management mechanisms remain separate from the public MCP contract. Public remote clients should be
+implementable from the actor-scoped resource contract alone.
 
-## Deprecated connector-era MCP surfaces
+## Retired connector-era MCP surfaces
 
-The following public-facing MCP-era surfaces are deprecated for removal:
+The following public-facing MCP-era surfaces are outside the supported contract after cutover:
 
 - Simulacrum connector registration flows that create or manage public MCP connector records
 - browser-local connector inventory, pasted-secret flows, and similar connector-management UX
 - public registration semantics that depended on `client_class=agent` or `agent_username`
 
-They may continue to exist temporarily as compatibility aids, but new public MCP clients, examples, and docs must not
-use them as the canonical integration path.
+The cutover migration retires persisted connector client records, connector-bound refresh sessions, and other
+connector-era grant/session artifacts. New public MCP clients, examples, and docs must not use the retired surfaces as
+the integration path.

--- a/tools/audit_gates/baseline.yml
+++ b/tools/audit_gates/baseline.yml
@@ -29,6 +29,7 @@ goDynamoDBQueryScan:
   cmd/lesser/migrate_conversation_metadata.go: 1
   cmd/lesser/migrate_conversation_participant_snapshots.go: 1
   cmd/lesser/migrate_conversations.go: 1
+  cmd/lesser/migrate_mcp_auth_cutover.go: 1
   cmd/lesser/migrate_numeric_ids.go: 1
   cmd/lesser/migrate_user_keys.go: 1
   pkg/cost/dynamorm_tracker.go: 1


### PR DESCRIPTION
## Summary
- add a dedicated `lesser migrate-mcp-auth-cutover` command that inventories and removes connector-era MCP OAuth clients, refresh tokens, codes, state, device sessions, and consent rows while preserving supported internal runtime records
- finish the public-surface cutover by removing connector-era `client_credentials` and public agent device-code behavior from Lesser’s OAuth handlers, tests, and docs
- validate the migration against the Sim table and confirm Simulacrum no longer has live browser callsites for connector inventory helpers

## Verification
- `GOTOOLCHAIN=auto go test ./cmd/api/handlers -run 'TestOAuth|TestOAuthDevice|TestOAuthClientHelperCoverage|TestHandleOAuthAuthorizationServerMetadataLift' -count=1`
- `GOTOOLCHAIN=auto go test ./cmd/lesser -count=1`
- `PATH="$(GOTOOLCHAIN=auto go env GOROOT)/bin:$PATH" ./lesser verify ci`
- `AWS_PROFILE=Sim GOTOOLCHAIN=auto go run ./cmd/lesser migrate-mcp-auth-cutover --table simulacrum-dev-main-table`
- `AWS_PROFILE=Sim GOTOOLCHAIN=auto go run ./cmd/lesser migrate-mcp-auth-cutover --table simulacrum-dev-main-table --apply`
- `AWS_PROFILE=Sim GOTOOLCHAIN=auto go run ./cmd/lesser migrate-mcp-auth-cutover --table simulacrum-dev-main-table`

## Sim Cutover Results
- connector clients removed: 17
- connector refresh sessions revoked: 226
- runtime refresh sessions preserved: 2
- connector client/refresh matches after apply: 0 / 0

Closes #541
Closes #542
Closes #543
Closes #544
Closes #545
Closes #546
Closes #547
Closes #548