### PR TITLE
[codex] fix client ssr function url 403

### DIFF
--- a/infra/cdk/stacks/frontend_routing_test.go
+++ b/infra/cdk/stacks/frontend_routing_test.go
@@ -79,6 +79,36 @@ func TestClientFrontendLogicalIDsRemainStable(t *testing.T) {
 	requireResourceLogicalIDPrefixAbsent(t, resources, "FrontendAliasAAAARecord")
 }
 
+func TestClientSSRFunctionURLOriginPermissions(t *testing.T) {
+	resources := synthClientFrontendResources(t)
+
+	invokeURLPermission := findLambdaPermissionByAction(t, resources, "lambda:InvokeFunctionUrl")
+	invokeURLProps := extractLambdaPermissionProperties(t, invokeURLPermission)
+	if got, _ := invokeURLProps["Principal"].(string); got != "cloudfront.amazonaws.com" {
+		t.Fatalf("InvokeFunctionUrl permission principal = %q, want cloudfront.amazonaws.com", got)
+	}
+	requireContainsAll(t, mustJSON(t, invokeURLProps["SourceArn"]), []string{
+		"cloudfront",
+		"distribution",
+		"ClientFrontendDistribution015B354C",
+	})
+
+	invokePermission := findLambdaPermissionByAction(t, resources, "lambda:InvokeFunction")
+	invokeProps := extractLambdaPermissionProperties(t, invokePermission)
+	if got, _ := invokeProps["Principal"].(string); got != "cloudfront.amazonaws.com" {
+		t.Fatalf("InvokeFunction permission principal = %q, want cloudfront.amazonaws.com", got)
+	}
+	invokedViaURL, ok := invokeProps["InvokedViaFunctionUrl"].(bool)
+	if !ok || !invokedViaURL {
+		t.Fatalf("InvokeFunction permission must set InvokedViaFunctionUrl=true")
+	}
+	requireContainsAll(t, mustJSON(t, invokeProps["SourceArn"]), []string{
+		"cloudfront",
+		"distribution",
+		"ClientFrontendDistribution015B354C",
+	})
+}
+
 func synthClientFrontendResources(t *testing.T) map[string]any {
 	t.Helper()
 
@@ -138,6 +168,7 @@ func synthClientFrontendResources(t *testing.T) map[string]any {
 		},
 		PriceClass: awscloudfront.PriceClass_PRICE_CLASS_100,
 	})
+	grantCloudFrontFunctionURLInvokePermission(clientSSRFn, dist)
 	dist.AddBehavior(jsii.String("/auth/wallet/*"), apiOriginTarget, &awscloudfront.AddBehaviorOptions{
 		ViewerProtocolPolicy: awscloudfront.ViewerProtocolPolicy_REDIRECT_TO_HTTPS,
 		OriginRequestPolicy:  awscloudfront.OriginRequestPolicy_ALL_VIEWER_EXCEPT_HOST_HEADER(),
@@ -226,6 +257,48 @@ func requireResourceLogicalIDPrefixAbsent(t *testing.T, resources map[string]any
 			t.Fatalf("expected no logical IDs with prefix %q, found %q", prefix, logicalID)
 		}
 	}
+}
+
+func findLambdaPermissionByAction(t *testing.T, resources map[string]any, action string) map[string]any {
+	t.Helper()
+	var permission map[string]any
+	for _, raw := range resources {
+		typed, ok := raw.(map[string]any)
+		if !ok || typed["Type"] != "AWS::Lambda::Permission" {
+			continue
+		}
+		props := extractLambdaPermissionProperties(t, typed)
+		got, _ := props["Action"].(string)
+		if got != action {
+			continue
+		}
+		if permission != nil {
+			t.Fatalf("expected one Lambda permission for %q, found multiple", action)
+		}
+		permission = typed
+	}
+	if permission == nil {
+		t.Fatalf("expected Lambda permission for %q", action)
+	}
+	return permission
+}
+
+func extractLambdaPermissionProperties(t *testing.T, permission map[string]any) map[string]any {
+	t.Helper()
+	props, ok := permission["Properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("Lambda Permission Properties missing or wrong type")
+	}
+	return props
+}
+
+func mustJSON(t *testing.T, value any) string {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal value: %v", err)
+	}
+	return string(data)
 }
 
 func findCacheBehaviorByPathPattern(t *testing.T, behaviors []map[string]any, pathPattern string) map[string]any {

--- a/infra/cdk/stacks/lesser_api_stack.go
+++ b/infra/cdk/stacks/lesser_api_stack.go
@@ -326,6 +326,7 @@ func (s *LesserApiStack) createClientInfrastructure(domain string) {
 		Certificate: s.CDNCertificate,
 		PriceClass:  awscloudfront.PriceClass_PRICE_CLASS_100,
 	})
+	grantCloudFrontFunctionURLInvokePermission(clientSSRFn, dist)
 
 	authOrigin := awscloudfrontorigins.S3BucketOrigin_WithOriginAccessControl(authAssetsBucket, nil)
 	clientAssetOrigin := awscloudfrontorigins.S3BucketOrigin_WithOriginAccessControl(clientAssetsBucket, nil)
@@ -419,6 +420,21 @@ func relativeRecordName(domain string, zone awsroute53.IHostedZone) *string {
 	}
 
 	return jsii.String(domain)
+}
+
+func grantCloudFrontFunctionURLInvokePermission(fn awslambda.Function, dist awscloudfront.Distribution) {
+	if fn == nil || dist == nil {
+		return
+	}
+
+	// CloudFront OAC for an AWS_IAM Lambda Function URL needs lambda:InvokeFunction in addition to
+	// the lambda:InvokeFunctionUrl permission synthesized by the FunctionUrl origin helper.
+	fn.AddPermission(jsii.String("AllowCloudFrontInvokeViaFunctionUrl"), &awslambda.Permission{
+		Action:                jsii.String("lambda:InvokeFunction"),
+		Principal:             awsiam.NewServicePrincipal(jsii.String("cloudfront.amazonaws.com"), nil),
+		SourceArn:             dist.DistributionArn(),
+		InvokedViaFunctionUrl: jsii.Bool(true),
+	})
 }
 
 func clientSSRHostAssetPath() string {


### PR DESCRIPTION
## What changed
- add the missing `lambda:InvokeFunction` resource permission for the client SSR Lambda when CloudFront uses the Function URL origin with OAC
- keep that permission scoped to the CloudFront distribution ARN and gated by `InvokedViaFunctionUrl`
- add synth coverage that asserts the CloudFront `InvokeFunctionUrl` permission still exists and that the paired `InvokeFunction` permission is present for the SSR origin path

## Why
Issue #621 showed that `lesser client install` published the active FaceTheory install correctly, but `/l/*` still failed at the CloudFront -> Lambda Function URL hop with a 403 before the SSR host Lambda ever ran.

The stack was already synthesizing the `lambda:InvokeFunctionUrl` permission for the Function URL origin, but CloudFront OAC with an `AWS_IAM` Function URL also needs the paired `lambda:InvokeFunction` permission. Without that second statement, the SSR origin request is rejected before application code runs.

Closes #621.

## Validation
- `cd infra/cdk && GOTOOLCHAIN=auto go test ./stacks`
- `cd infra/cdk && GOTOOLCHAIN=auto go test ./stacks -run 'TestFrontendDistributionForwardsOAuthQueryStringsAndHandlesBasePaths|TestClientFrontendLogicalIDsRemainStable|TestClientSSRFunctionURLOriginPermissions' -count=1`