### PR TITLE
fix release synth template parsing

### DIFF
--- a/pkg/releaseassets/deploy_assembly.go
+++ b/pkg/releaseassets/deploy_assembly.go
@@ -493,8 +493,14 @@ func runCDKSynthJSON(repoRoot string, stackName string, contexts map[string]stri
 		return nil, cdkAssetsManifest{}, "", fmt.Errorf("cdk synth %s: %w\n%s", stackName, err, strings.TrimSpace(stderr.String()))
 	}
 
+	templateData, err := readSynthesizedTemplateFile(synthDir, stackName, stdout.Bytes())
+	if err != nil {
+		_ = os.RemoveAll(synthDir)
+		return nil, cdkAssetsManifest{}, "", err
+	}
+
 	var template map[string]any
-	if err := json.Unmarshal(stdout.Bytes(), &template); err != nil {
+	if err := json.Unmarshal(templateData, &template); err != nil {
 		_ = os.RemoveAll(synthDir)
 		return nil, cdkAssetsManifest{}, "", fmt.Errorf("parse synthesized template for %s: %w", stackName, err)
 	}
@@ -510,6 +516,20 @@ func runCDKSynthJSON(repoRoot string, stackName string, contexts map[string]stri
 
 	assets = absolutizeAssetPaths(synthDir, assets)
 	return template, assets, synthDir, nil
+}
+
+func readSynthesizedTemplateFile(synthDir string, stackName string, stdout []byte) ([]byte, error) {
+	templatePath := filepath.Join(synthDir, stackName+".template.json")
+	templateData, err := os.ReadFile(templatePath)
+	if err == nil {
+		return templateData, nil
+	}
+
+	if len(bytes.TrimSpace(stdout)) != 0 {
+		return stdout, nil
+	}
+
+	return nil, fmt.Errorf("read synthesized template %s: %w", templatePath, err)
 }
 
 func absolutizeAssetPaths(synthDir string, manifest cdkAssetsManifest) cdkAssetsManifest {

--- a/pkg/releaseassets/deploy_assembly_test.go
+++ b/pkg/releaseassets/deploy_assembly_test.go
@@ -416,6 +416,54 @@ func TestRunCDKSynthJSON_ErrorsOnInvalidTemplateJSON(t *testing.T) {
 	require.Contains(t, err.Error(), "parse synthesized template")
 }
 
+func TestRunCDKSynthJSON_PrefersSynthesizedTemplateFileOverNoisyStdout(t *testing.T) {
+	repoRoot := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, "infra", "cdk"), 0o755))
+
+	binDir := t.TempDir()
+	script := `#!/usr/bin/env bash
+set -euo pipefail
+stack="$2"
+shift 2
+output=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output)
+      output="$2"
+      shift 2
+      ;;
+    --context)
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+mkdir -p "$output"
+cat > "$output/$stack.template.json" <<'JSON'
+{
+  "Resources": {
+    "Example": {
+      "Type": "AWS::S3::Bucket"
+    }
+  }
+}
+JSON
+printf '7 feature flags are not configured.\n'
+`
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "cdk"), []byte(script), 0o755))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	template, _, synthDir, err := runCDKSynthJSON(repoRoot, "demo", map[string]string{"app": "demo"})
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(synthDir) }()
+
+	resources, ok := template["Resources"].(map[string]any)
+	require.True(t, ok)
+	require.Contains(t, resources, "Example")
+}
+
 func TestRunCDKSynthJSON_ErrorsOnInvalidAssetsManifest(t *testing.T) {
 	repoRoot := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, "infra", "cdk"), 0o755))


### PR DESCRIPTION
## Summary
- read synthesized CloudFormation templates from the CDK output files instead of trusting raw cdk synth --json stdout
- keep stdout only as a fallback so local test scaffolding still works
- add a regression test covering noisy synth stdout with a valid emitted template file

## Verification
- env GOTOOLCHAIN=auto go test ./pkg/releaseassets -run 'TestRunCDKSynthJSON|TestWriteDeployAssembly' -count=1
- env GOTOOLCHAIN=auto bash scripts/build_release_assets.sh v0.0.0-test /tmp/tmp.egRfZWY7S3
- env GOTOOLCHAIN=auto bash scripts/verify_artifact_deploy.sh /tmp/tmp.egRfZWY7S3
- env GOTOOLCHAIN=auto ./lesser verify ci