### PR TITLE
strip bootstrap rules from deploy assembly

### DIFF
--- a/pkg/releaseassets/deploy_assembly.go
+++ b/pkg/releaseassets/deploy_assembly.go
@@ -40,6 +40,7 @@ const (
 	deployAssemblyPayloadContractVersion  = 1
 	deployAssemblyInternalManifestKind    = "lesser.cloudformation_release_assembly_manifest"
 	deployAssemblyInternalManifestVersion = 1
+	cdkBootstrapValidationRule            = "CheckBootstrapVersion"
 	placeholderAppSlug                    = "appslugplaceholder"
 	placeholderBaseDomain                 = "base.example.com"
 	placeholderHostedZoneID               = "ZHOSTEDZONEPLACEHOLDER"
@@ -369,7 +370,7 @@ func synthesizeSharedTemplate(repoRoot string) ([]byte, error) {
 	}
 	defer func() { _ = os.RemoveAll(synthDir) }()
 
-	deleteTemplateParameter(template, "BootstrapVersion")
+	stripCDKBootstrapValidation(template)
 	addStringParameter(template, "AppSlug", "app slug / stack prefix for this installation", false, "")
 
 	replacements := orderedPlaceholderReplacements(map[string]string{
@@ -404,7 +405,7 @@ func synthesizeStageTemplate(repoRoot string, stage naming.Stage) ([]byte, []dep
 	}
 	defer func() { _ = os.RemoveAll(synthDir) }()
 
-	deleteTemplateParameter(template, "BootstrapVersion")
+	stripCDKBootstrapValidation(template)
 	deleteStageLookupParameters(template)
 	addStringParameter(template, "AppSlug", "app slug / stack prefix for this installation", false, "")
 	addStringParameter(template, "BaseDomain", "base domain for this installation", false, "")
@@ -682,6 +683,25 @@ func deleteTemplateParameter(template map[string]any, name string) {
 		return
 	}
 	delete(parameters, name)
+	if len(parameters) == 0 {
+		delete(template, "Parameters")
+	}
+}
+
+func deleteTemplateRule(template map[string]any, name string) {
+	rules, ok := template["Rules"].(map[string]any)
+	if !ok {
+		return
+	}
+	delete(rules, name)
+	if len(rules) == 0 {
+		delete(template, "Rules")
+	}
+}
+
+func stripCDKBootstrapValidation(template map[string]any) {
+	deleteTemplateParameter(template, "BootstrapVersion")
+	deleteTemplateRule(template, cdkBootstrapValidationRule)
 }
 
 func addStringParameter(template map[string]any, name string, description string, withDefault bool, defaultValue string) {

--- a/pkg/releaseassets/deploy_assembly_test.go
+++ b/pkg/releaseassets/deploy_assembly_test.go
@@ -179,9 +179,19 @@ func TestTemplateTransformHelpers(t *testing.T) {
 				},
 			},
 		},
+		"Rules": map[string]any{
+			cdkBootstrapValidationRule: map[string]any{
+				"Assertions": []any{
+					map[string]any{
+						"Assert":            map[string]any{"Fn::Contains": []any{[]any{"1", "2"}, map[string]any{"Ref": "BootstrapVersion"}}},
+						"AssertDescription": "CDK bootstrap version 6 required",
+					},
+				},
+			},
+		},
 	}
 
-	deleteTemplateParameter(template, "BootstrapVersion")
+	stripCDKBootstrapValidation(template)
 	deleteStageLookupParameters(template)
 	addStringParameter(template, "AppSlug", "app slug", false, "")
 	addStringParameter(template, "HostedZoneId", "zone", true, "ZDEFAULT")
@@ -198,6 +208,7 @@ func TestTemplateTransformHelpers(t *testing.T) {
 
 	parameters := transformed["Parameters"].(map[string]any)
 	require.NotContains(t, parameters, "BootstrapVersion")
+	require.NotContains(t, transformed, "Rules")
 	require.Equal(t, map[string]any{
 		"Description": "app slug",
 		"Type":        "String",
@@ -236,6 +247,7 @@ func TestDeleteTemplateParameter_NoParametersSection(t *testing.T) {
 	}
 
 	deleteTemplateParameter(template, "Missing")
+	deleteTemplateRule(template, cdkBootstrapValidationRule)
 	require.Equal(t, map[string]any{
 		"Resources": map[string]any{},
 	}, template)
@@ -385,6 +397,16 @@ func TestWriteDeployAssembly(t *testing.T) {
 	sharedTemplate := string(archiveEntries["templates/lesser-shared.template.json"])
 	require.Contains(t, sharedTemplate, `"AppSlug"`)
 	require.Contains(t, sharedTemplate, `${AWS::AccountId}`)
+	for _, templatePath := range []string{
+		"templates/lesser-shared.template.json",
+		stageTemplateFileNames[naming.StageDev],
+		stageTemplateFileNames[naming.StageStaging],
+		stageTemplateFileNames[naming.StageLive],
+	} {
+		templateJSON := string(archiveEntries[templatePath])
+		require.NotContains(t, templateJSON, `"BootstrapVersion"`)
+		require.NotContains(t, templateJSON, `"CheckBootstrapVersion"`)
+	}
 }
 
 func TestRunCDKSynthJSON_ErrorsWhenCommandFails(t *testing.T) {
@@ -607,11 +629,21 @@ JSON
 }
 
 case "$stack" in
-  %q)
+ %q)
     cat <<'JSON'
 {
   "Parameters": {
     "BootstrapVersion": { "Type": "String" }
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": { "Fn::Contains": [["6"], { "Ref": "BootstrapVersion" }] },
+          "AssertDescription": "CDK bootstrap version 6 required"
+        }
+      ]
+    }
   },
   "Resources": {
     "Example": {
@@ -644,6 +676,16 @@ JSON
     "JWTSecretArnParamLookupParameter": { "Type": "String", "Default": "appslugplaceholder" },
     "ActorKeyArnParamLookupParameter": { "Type": "String", "Default": "appslugplaceholder" },
     "LesserBodyMcpLambdaArnParamLookupParameter": { "Type": "String", "Default": "appslugplaceholder" }
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": { "Fn::Contains": [["6"], { "Ref": "BootstrapVersion" }] },
+          "AssertDescription": "CDK bootstrap version 6 required"
+        }
+      ]
+    }
   },
   "Resources": {
     "Example": {


### PR DESCRIPTION
## Summary
- strip CDK bootstrap validation from release assembly templates by removing both Parameters.BootstrapVersion and Rules.CheckBootstrapVersion
- apply that cleanup to shared and stage templates before they are packaged into lesser-deploy-assembly.tar.gz
- strengthen the deploy assembly tests so the fake synth output includes the CDK bootstrap rule and the packaged templates prove it is gone

Closes #671.

## Verification
- env GOTOOLCHAIN=auto go test ./pkg/releaseassets -run 'TestTemplateTransformHelpers|TestWriteDeployAssembly|TestRunCDKSynthJSON' -count=1
- env GOTOOLCHAIN=auto bash scripts/build_release_assets.sh v0.0.0-test /tmp/tmp.k2tMxquFbt
- env GOTOOLCHAIN=auto bash scripts/verify_artifact_deploy.sh /tmp/tmp.k2tMxquFbt
- env GOTOOLCHAIN=auto ./lesser verify ci
