### PR TITLE
normalize deploy assembly dependson values

### DIFF
--- a/pkg/releaseassets/deploy_assembly.go
+++ b/pkg/releaseassets/deploy_assembly.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -78,6 +79,8 @@ var stageLookupParameterNames = map[string]struct{}{
 	"ActorKeyArnParamLookupParameter":            {},
 	"LesserBodyMcpLambdaArnParamLookupParameter": {},
 }
+
+var cloudFormationLogicalIDPattern = regexp.MustCompile(`^[A-Za-z0-9]+$`)
 
 // DeployAssemblyDescriptor describes the published deploy assembly archive and
 // the outer executor contract.
@@ -383,6 +386,9 @@ func synthesizeSharedTemplate(repoRoot string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := normalizeTemplateDependsOn(transformed); err != nil {
+		return nil, err
+	}
 	return marshalTemplateJSON(transformed)
 }
 
@@ -445,6 +451,9 @@ func synthesizeStageTemplate(repoRoot string, stage naming.Stage) ([]byte, []dep
 	}
 
 	replaceStageLookupRefs(transformed, stage)
+	if err := normalizeTemplateDependsOn(transformed); err != nil {
+		return nil, nil, err
+	}
 
 	templateBytes, err := marshalTemplateJSON(transformed)
 	if err != nil {
@@ -805,6 +814,156 @@ func transformValue(value any, path []string, skip func(path []string) bool, rep
 	default:
 		return value, nil
 	}
+}
+
+func normalizeTemplateDependsOn(value any) error {
+	switch v := value.(type) {
+	case map[string]any:
+		if dependsOn, ok := v["DependsOn"]; ok {
+			normalized, keep, err := normalizeDependsOnValue(dependsOn)
+			if err != nil {
+				return err
+			}
+			if keep {
+				v["DependsOn"] = normalized
+			} else {
+				delete(v, "DependsOn")
+			}
+		}
+		for _, child := range v {
+			if err := normalizeTemplateDependsOn(child); err != nil {
+				return err
+			}
+		}
+	case []any:
+		for _, child := range v {
+			if err := normalizeTemplateDependsOn(child); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func normalizeDependsOnValue(value any) (any, bool, error) {
+	items, err := flattenDependsOnValues(value)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(items) == 0 {
+		return nil, false, nil
+	}
+	if len(items) == 1 {
+		return items[0], true, nil
+	}
+
+	normalized := make([]any, len(items))
+	for idx, item := range items {
+		normalized[idx] = item
+	}
+	return normalized, true, nil
+}
+
+func flattenDependsOnValues(value any) ([]string, error) {
+	switch v := value.(type) {
+	case string:
+		resolved, err := normalizeDependsOnString(v)
+		if err != nil {
+			return nil, err
+		}
+		return []string{resolved}, nil
+	case map[string]any:
+		resolved, err := normalizeDependsOnSub(v)
+		if err != nil {
+			return nil, err
+		}
+		return []string{resolved}, nil
+	case []any:
+		flattened := make([]string, 0, len(v))
+		for _, child := range v {
+			items, err := flattenDependsOnValues(child)
+			if err != nil {
+				return nil, err
+			}
+			flattened = append(flattened, items...)
+		}
+		return flattened, nil
+	case nil:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unsupported DependsOn value type %T", value)
+	}
+}
+
+func normalizeDependsOnSub(value map[string]any) (string, error) {
+	raw, ok := value["Fn::Sub"]
+	if !ok || len(value) != 1 {
+		return "", fmt.Errorf("DependsOn contains unsupported intrinsic %#v", value)
+	}
+
+	switch v := raw.(type) {
+	case string:
+		return normalizeDependsOnString(resolveDependsOnPlaceholders(v))
+	case []any:
+		if len(v) == 0 {
+			return "", fmt.Errorf("DependsOn Fn::Sub is empty")
+		}
+		template, ok := v[0].(string)
+		if !ok {
+			return "", fmt.Errorf("DependsOn Fn::Sub template has unsupported type %T", v[0])
+		}
+		resolved := resolveDependsOnPlaceholders(template)
+		if len(v) == 2 {
+			vars, ok := v[1].(map[string]any)
+			if !ok {
+				return "", fmt.Errorf("DependsOn Fn::Sub variables have unsupported type %T", v[1])
+			}
+			for key, rawValue := range vars {
+				strValue, ok := rawValue.(string)
+				if !ok {
+					return "", fmt.Errorf("DependsOn Fn::Sub variable %s has unsupported type %T", key, rawValue)
+				}
+				resolved = strings.ReplaceAll(resolved, "${"+key+"}", strValue)
+			}
+		}
+		return normalizeDependsOnString(resolved)
+	default:
+		return "", fmt.Errorf("DependsOn Fn::Sub has unsupported type %T", raw)
+	}
+}
+
+func resolveDependsOnPlaceholders(value string) string {
+	replacements := orderedPlaceholderReplacements(map[string]string{
+		"${AppSlug}":                   placeholderAppSlug,
+		"${AWS::AccountId}":            placeholderAccountID,
+		"${AWS::Region}":               placeholderRegion,
+		"${BaseDomain}":                placeholderBaseDomain,
+		"${HostedZoneId}":              placeholderHostedZoneID,
+		"${ReleaseAssetBucketName}":    assetBucketPlaceholder(),
+		"${LesserHostUrl}":             placeholderLesserHostURL,
+		"${LesserHostAttestationsUrl}": placeholderLesserHostAttestationsURL,
+		"${LesserHostInstanceKeyArn}":  placeholderLesserHostInstanceKeyARN,
+		"${TranslationEnabled}":        placeholderTranslationEnabled,
+		"${TipEnabled}":                placeholderTipEnabled,
+		"${TipChainId}":                placeholderTipChainID,
+		"${TipContractAddress}":        placeholderTipContractAddress,
+	})
+	resolved, _ := applyPlaceholderReplacements(value, replacements)
+	return resolved
+}
+
+func normalizeDependsOnString(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("DependsOn value is empty")
+	}
+	if strings.Contains(value, "${") {
+		return "", fmt.Errorf("DependsOn value %q has unresolved substitutions", value)
+	}
+	if !cloudFormationLogicalIDPattern.MatchString(value) {
+		return "", fmt.Errorf("DependsOn value %q is not a valid logical ID", value)
+	}
+	return value, nil
 }
 
 func applyPlaceholderReplacements(value string, replacements []placeholderReplacement) (string, bool) {

--- a/pkg/releaseassets/deploy_assembly_test.go
+++ b/pkg/releaseassets/deploy_assembly_test.go
@@ -228,6 +228,180 @@ func TestTemplateTransformHelpers(t *testing.T) {
 	}, props["Lookup"])
 }
 
+func TestNormalizeTemplateDependsOn(t *testing.T) {
+	template := map[string]any{
+		"Resources": map[string]any{
+			"ScalarSub": map[string]any{
+				"Type": "Custom::Example",
+				"DependsOn": map[string]any{
+					"Fn::Sub": "ImportedBasicRolePolicy${AppSlug}devImportedBasicRole2EE626BABA11CB8E",
+				},
+			},
+			"NestedList": map[string]any{
+				"Type": "Custom::Example",
+				"DependsOn": []any{
+					[]any{"ImportedEncryptionRolePolicyappslugplaceholderdevImportedEncryptionRole173ECB6CE41A2D5A"},
+					[]any{
+						map[string]any{
+							"Fn::Sub": "ImportedBasicRolePolicy${AppSlug}devImportedBasicRole2EE626BABA11CB8E",
+						},
+					},
+				},
+			},
+			"EmptyList": map[string]any{
+				"Type":      "Custom::Example",
+				"DependsOn": []any{},
+			},
+		},
+	}
+
+	require.NoError(t, normalizeTemplateDependsOn(template))
+
+	resources := template["Resources"].(map[string]any)
+	require.Equal(t,
+		"ImportedBasicRolePolicyappslugplaceholderdevImportedBasicRole2EE626BABA11CB8E",
+		resources["ScalarSub"].(map[string]any)["DependsOn"],
+	)
+	require.Equal(t, []any{
+		"ImportedEncryptionRolePolicyappslugplaceholderdevImportedEncryptionRole173ECB6CE41A2D5A",
+		"ImportedBasicRolePolicyappslugplaceholderdevImportedBasicRole2EE626BABA11CB8E",
+	}, resources["NestedList"].(map[string]any)["DependsOn"])
+	require.NotContains(t, resources["EmptyList"].(map[string]any), "DependsOn")
+}
+
+func TestNormalizeTemplateDependsOn_ErrorsOnUnsupportedValues(t *testing.T) {
+	template := map[string]any{
+		"Resources": map[string]any{
+			"Bad": map[string]any{
+				"Type":      "Custom::Example",
+				"DependsOn": map[string]any{"Fn::GetAtt": []any{"Other", "Arn"}},
+			},
+		},
+	}
+
+	err := normalizeTemplateDependsOn(template)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported intrinsic")
+}
+
+func TestNormalizeDependsOnSub_ArrayFormResolvesVariables(t *testing.T) {
+	resolved, err := normalizeDependsOnSub(map[string]any{
+		"Fn::Sub": []any{
+			"ImportedBasicRolePolicy${AppSlug}${StageDependency}",
+			map[string]any{
+				"StageDependency": "devImportedBasicRole2EE626BABA11CB8E",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t,
+		"ImportedBasicRolePolicyappslugplaceholderdevImportedBasicRole2EE626BABA11CB8E",
+		resolved,
+	)
+}
+
+func TestNormalizeDependsOnValue_FlattensNilAndNestedValues(t *testing.T) {
+	normalized, keep, err := normalizeDependsOnValue([]any{
+		nil,
+		[]any{
+			"ImportedEncryptionRolePolicyappslugplaceholderdevImportedEncryptionRole173ECB6CE41A2D5A",
+			map[string]any{
+				"Fn::Sub": "ImportedBasicRolePolicy${AppSlug}devImportedBasicRole2EE626BABA11CB8E",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, keep)
+	require.Equal(t, []any{
+		"ImportedEncryptionRolePolicyappslugplaceholderdevImportedEncryptionRole173ECB6CE41A2D5A",
+		"ImportedBasicRolePolicyappslugplaceholderdevImportedBasicRole2EE626BABA11CB8E",
+	}, normalized)
+}
+
+func TestNormalizeDependsOnHelpers_ErrorBranches(t *testing.T) {
+	_, err := normalizeDependsOnSub(map[string]any{
+		"Fn::Sub": []any{
+			"ImportedBasicRolePolicy${AppSlug}${StageDependency}",
+			map[string]any{
+				"StageDependency": 17,
+			},
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported type")
+
+	_, err = normalizeDependsOnString("ImportedBasicRolePolicy${AppSlug}")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unresolved substitutions")
+
+	_, err = normalizeDependsOnString("not-a-logical-id")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a valid logical ID")
+
+	_, _, err = normalizeDependsOnValue(17)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported DependsOn value type")
+}
+
+func TestNormalizeDependsOnSub_ErrorsOnInvalidShapes(t *testing.T) {
+	testCases := []struct {
+		name    string
+		value   map[string]any
+		wantErr string
+	}{
+		{
+			name: "unsupported intrinsic wrapper",
+			value: map[string]any{
+				"Fn::Sub": "ImportedBasicRolePolicy${AppSlug}",
+				"Ref":     "OtherResource",
+			},
+			wantErr: "unsupported intrinsic",
+		},
+		{
+			name: "empty sub array",
+			value: map[string]any{
+				"Fn::Sub": []any{},
+			},
+			wantErr: "is empty",
+		},
+		{
+			name: "non string template",
+			value: map[string]any{
+				"Fn::Sub": []any{17},
+			},
+			wantErr: "template has unsupported type",
+		},
+		{
+			name: "variables not map",
+			value: map[string]any{
+				"Fn::Sub": []any{"ImportedBasicRolePolicy${AppSlug}", "bad-vars"},
+			},
+			wantErr: "variables have unsupported type",
+		},
+		{
+			name: "raw type unsupported",
+			value: map[string]any{
+				"Fn::Sub": 17,
+			},
+			wantErr: "unsupported type",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := normalizeDependsOnSub(tc.value)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestNormalizeDependsOnString_ErrorsOnEmptyValue(t *testing.T) {
+	_, err := normalizeDependsOnString("   ")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "DependsOn value is empty")
+}
+
 func TestAddStringParameter_CreatesParametersMapAndPreservesExisting(t *testing.T) {
 	template := map[string]any{}
 	addStringParameter(template, "AppSlug", "app slug", true, "demo")
@@ -406,6 +580,29 @@ func TestWriteDeployAssembly(t *testing.T) {
 		templateJSON := string(archiveEntries[templatePath])
 		require.NotContains(t, templateJSON, `"BootstrapVersion"`)
 		require.NotContains(t, templateJSON, `"CheckBootstrapVersion"`)
+	}
+
+	var devTemplateJSON map[string]any
+	require.NoError(t, json.Unmarshal(archiveEntries[stageTemplateFileNames[naming.StageDev]], &devTemplateJSON))
+	for _, resource := range devTemplateJSON["Resources"].(map[string]any) {
+		resMap := resource.(map[string]any)
+		dependsOn, ok := resMap["DependsOn"]
+		if !ok {
+			continue
+		}
+		switch v := dependsOn.(type) {
+		case string:
+			require.NotContains(t, v, "${")
+		case []any:
+			require.NotEmpty(t, v)
+			for _, item := range v {
+				itemStr, ok := item.(string)
+				require.True(t, ok)
+				require.NotContains(t, itemStr, "${")
+			}
+		default:
+			t.Fatalf("unexpected DependsOn type %T", dependsOn)
+		}
 	}
 }
 
@@ -688,7 +885,16 @@ JSON
     }
   },
   "Resources": {
+    "ImportedBasicRolePolicyappslugplaceholderdevImportedBasicRole2EE626BABA11CB8E": {
+      "Type": "AWS::IAM::Policy"
+    },
+    "ImportedEncryptionRolePolicyappslugplaceholderdevImportedEncryptionRole173ECB6CE41A2D5A": {
+      "Type": "AWS::IAM::Policy"
+    },
     "Example": {
+      "DependsOn": [
+        "ImportedBasicRolePolicyappslugplaceholderdevImportedBasicRole2EE626BABA11CB8E"
+      ],
       "Properties": {
         "Domain": "$stage_domain",
         "WildcardDomain": "*.$stage_domain",
@@ -711,6 +917,18 @@ JSON
         "ActorKey": { "Ref": "ActorKeyArnParamLookupParameter" },
         "BodyLambda": { "Ref": "LesserBodyMcpLambdaArnParamLookupParameter" }
       }
+    },
+    "NestedDependsOnExample": {
+      "DependsOn": [
+        [
+          "ImportedEncryptionRolePolicyappslugplaceholderdevImportedEncryptionRole173ECB6CE41A2D5A"
+        ]
+      ],
+      "Type": "Custom::Example"
+    },
+    "EmptyDependsOnExample": {
+      "DependsOn": [],
+      "Type": "Custom::Example"
     }
   }
 }


### PR DESCRIPTION
Closes #673.

## Summary
- normalize release-assembly template `DependsOn` values after placeholder substitution so stage templates only ship literal CloudFormation logical IDs
- reject unsupported intrinsic/value shapes in `DependsOn` during release packaging instead of publishing invalid templates
- add regression coverage for helper normalization paths and end-to-end deploy assembly packaging

## Verification
- `env GOTOOLCHAIN=auto go test ./pkg/releaseassets -run 'TestNormalizeDependsOnSub|TestNormalizeDependsOnString|TestNormalizeTemplateDependsOn|TestWriteDeployAssembly|TestRunCDKSynthJSON' -count=1`\n- `env GOTOOLCHAIN=auto ./lesser verify ci`\n- `env GOTOOLCHAIN=auto bash scripts/build_release_assets.sh v0.0.0-test /tmp/tmp.SYqQTRwNGe`\n- `env GOTOOLCHAIN=auto bash scripts/verify_artifact_deploy.sh /tmp/tmp.SYqQTRwNGe`