### PR TITLE
[codex] fix /l asset behavior precedence

### DIFF
--- a/infra/cdk/stacks/frontend_routing_test.go
+++ b/infra/cdk/stacks/frontend_routing_test.go
@@ -53,6 +53,7 @@ func TestFrontendDistributionForwardsOAuthQueryStringsAndHandlesBasePaths(t *tes
 	findCacheBehaviorByPathPattern(t, cacheBehaviors, "/l")
 	findCacheBehaviorByPathPattern(t, cacheBehaviors, "/l/*")
 	findCacheBehaviorByPathPattern(t, cacheBehaviors, "/l/_assets/*")
+	requirePathPatternPrecedes(t, cacheBehaviors, "/l/_assets/*", "/l/*")
 
 	// Issue #54/#587: rewrite function must normalize /l and preserve directory-index semantics for auth-ui routes.
 	fn := findSingleCloudFrontFunction(t, resources)
@@ -193,17 +194,17 @@ func synthClientFrontendResources(t *testing.T) map[string]any {
 		ResponseHeadersPolicy: clientPolicy,
 		FunctionAssociations:  functionAssociations,
 	})
+	dist.AddBehavior(jsii.String("/l/_assets/*"), clientAssetOrigin, &awscloudfront.AddBehaviorOptions{
+		ViewerProtocolPolicy:  awscloudfront.ViewerProtocolPolicy_REDIRECT_TO_HTTPS,
+		CachePolicy:           awscloudfront.CachePolicy_CACHING_OPTIMIZED(),
+		ResponseHeadersPolicy: clientPolicy,
+		FunctionAssociations:  functionAssociations,
+	})
 	dist.AddBehavior(jsii.String("/l/*"), clientSSROrigin, &awscloudfront.AddBehaviorOptions{
 		ViewerProtocolPolicy:  awscloudfront.ViewerProtocolPolicy_REDIRECT_TO_HTTPS,
 		AllowedMethods:        awscloudfront.AllowedMethods_ALLOW_ALL(),
 		CachePolicy:           awscloudfront.CachePolicy_CACHING_DISABLED(),
 		OriginRequestPolicy:   awscloudfront.OriginRequestPolicy_ALL_VIEWER_EXCEPT_HOST_HEADER(),
-		ResponseHeadersPolicy: clientPolicy,
-		FunctionAssociations:  functionAssociations,
-	})
-	dist.AddBehavior(jsii.String("/l/_assets/*"), clientAssetOrigin, &awscloudfront.AddBehaviorOptions{
-		ViewerProtocolPolicy:  awscloudfront.ViewerProtocolPolicy_REDIRECT_TO_HTTPS,
-		CachePolicy:           awscloudfront.CachePolicy_CACHING_OPTIMIZED(),
 		ResponseHeadersPolicy: clientPolicy,
 		FunctionAssociations:  functionAssociations,
 	})
@@ -311,6 +312,32 @@ func findCacheBehaviorByPathPattern(t *testing.T, behaviors []map[string]any, pa
 	}
 	t.Fatalf("expected cache behavior for %q", pathPattern)
 	return nil
+}
+
+func requirePathPatternPrecedes(t *testing.T, behaviors []map[string]any, earlier string, later string) {
+	t.Helper()
+
+	earlierIndex := -1
+	laterIndex := -1
+	for i, behavior := range behaviors {
+		got, _ := behavior["PathPattern"].(string)
+		switch got {
+		case earlier:
+			earlierIndex = i
+		case later:
+			laterIndex = i
+		}
+	}
+
+	if earlierIndex == -1 {
+		t.Fatalf("expected cache behavior for %q", earlier)
+	}
+	if laterIndex == -1 {
+		t.Fatalf("expected cache behavior for %q", later)
+	}
+	if earlierIndex >= laterIndex {
+		t.Fatalf("expected cache behavior %q to precede %q, got indexes %d >= %d", earlier, later, earlierIndex, laterIndex)
+	}
 }
 
 func findSingleCloudFrontFunction(t *testing.T, resources map[string]any) map[string]any {

--- a/infra/cdk/stacks/lesser_api_stack.go
+++ b/infra/cdk/stacks/lesser_api_stack.go
@@ -364,17 +364,17 @@ func (s *LesserApiStack) createClientInfrastructure(domain string) {
 		ResponseHeadersPolicy: clientPolicy,
 		FunctionAssociations:  functionAssociations,
 	})
+	dist.AddBehavior(jsii.String("/l/_assets/*"), clientAssetOrigin, &awscloudfront.AddBehaviorOptions{
+		ViewerProtocolPolicy:  awscloudfront.ViewerProtocolPolicy_REDIRECT_TO_HTTPS,
+		CachePolicy:           awscloudfront.CachePolicy_CACHING_OPTIMIZED(),
+		ResponseHeadersPolicy: clientPolicy,
+		FunctionAssociations:  functionAssociations,
+	})
 	dist.AddBehavior(jsii.String("/l/*"), clientSSROrigin, &awscloudfront.AddBehaviorOptions{
 		ViewerProtocolPolicy:  awscloudfront.ViewerProtocolPolicy_REDIRECT_TO_HTTPS,
 		AllowedMethods:        awscloudfront.AllowedMethods_ALLOW_ALL(),
 		CachePolicy:           awscloudfront.CachePolicy_CACHING_DISABLED(),
 		OriginRequestPolicy:   awscloudfront.OriginRequestPolicy_ALL_VIEWER_EXCEPT_HOST_HEADER(),
-		ResponseHeadersPolicy: clientPolicy,
-		FunctionAssociations:  functionAssociations,
-	})
-	dist.AddBehavior(jsii.String("/l/_assets/*"), clientAssetOrigin, &awscloudfront.AddBehaviorOptions{
-		ViewerProtocolPolicy:  awscloudfront.ViewerProtocolPolicy_REDIRECT_TO_HTTPS,
-		CachePolicy:           awscloudfront.CachePolicy_CACHING_OPTIMIZED(),
 		ResponseHeadersPolicy: clientPolicy,
 		FunctionAssociations:  functionAssociations,
 	})


### PR DESCRIPTION
## What changed
This reorders the Lesser CloudFront client behaviors so `/l/_assets/*` is registered before `/l/*`.

It also adds a routing test that asserts the asset behavior stays ahead of the broader SSR behavior in the synthesized distribution config.

## Why
The live `dev.simulacrum.greater.website` distribution is currently serving FaceTheory SSR HTML for `/l/_assets/...` requests instead of the static client asset bucket.

The browser HTML is already pointing at the correct asset prefix (`/l/_assets/...`), and the CSS object exists in the client bucket with the expected `text/css` content type. The break is at CloudFront behavior matching: `/l/*` is currently listed ahead of `/l/_assets/*`, so asset requests are captured by the SSR origin before they can reach S3.

## Impact
After this Lesser change is deployed through the normal Lesser release cycle, Simulacrum's CSS and JS assets under `/l/_assets/*` should resolve from the static bucket again instead of returning SSR HTML.

## Validation
- `GOTOOLCHAIN=auto bash -lc 'cd infra/cdk && go test ./stacks -run "TestFrontendDistributionForwardsOAuthQueryStringsAndHandlesBasePaths|TestClientFrontendLogicalIDsRemainStable|TestClientSSRFunctionURLOriginPermissions"'`
- `GOTOOLCHAIN=auto bash -lc 'cd infra/cdk && go test ./stacks'`

## Root cause
CloudFront cache behaviors are priority-ordered. Because `/l/*` was registered before `/l/_assets/*`, the broader SSR behavior swallowed asset requests, which surfaced in the browser as module/CSS MIME errors and `text/html` responses for static assets.
