### PR TITLE
[codex] align MCP OAuth resource host

### DIFF
--- a/cmd/api/handlers/agents_helpers_round20_test.go
+++ b/cmd/api/handlers/agents_helpers_round20_test.go
@@ -157,13 +157,14 @@ func TestAgentHelpersRound20(t *testing.T) {
 			Verified:   true,
 			VerifiedAt: &verifiedAt,
 		}, "https://example.com/")
+		bundle := auth.BuildPublicMCPAccessBundle("https://example.com/", "agent1")
 		require.True(t, verified.Verified)
 		require.NotNil(t, verified.VerifiedAt)
 		require.Equal(t, verifiedAt.UTC(), *verified.VerifiedAt)
-		require.Equal(t, "https://example.com/mcp/agent1", verified.MCPAccess.MCPURL)
-		require.Equal(t, "https://example.com/.well-known/oauth-protected-resource/mcp/agent1", verified.MCPAccess.ProtectedResourceURL)
-		require.Equal(t, "https://example.com/.well-known/oauth-authorization-server", verified.MCPAccess.AuthorizationServerURL)
-		require.Equal(t, "https://example.com/oauth/register", verified.MCPAccess.RegistrationURL)
+		require.Equal(t, bundle.MCPURL, verified.MCPAccess.MCPURL)
+		require.Equal(t, bundle.ProtectedResourceURL, verified.MCPAccess.ProtectedResourceURL)
+		require.Equal(t, bundle.AuthorizationServerURL, verified.MCPAccess.AuthorizationServerURL)
+		require.Equal(t, bundle.RegistrationURL, verified.MCPAccess.RegistrationURL)
 		require.Len(t, verified.MCPAccess.Guidance, 5)
 	})
 

--- a/cmd/api/handlers/agents_management_round20_test.go
+++ b/cmd/api/handlers/agents_management_round20_test.go
@@ -88,11 +88,12 @@ func TestAgentManagementHandlersRound20(t *testing.T) {
 		resp := requireStatus(t, http.StatusOK)(h.HandleGetAgentLift(ctx))
 		var out apimodels.Agent
 		require.NoError(t, json.Unmarshal(resp.Body, &out))
+		bundle := auth.BuildPublicMCPAccessBundle(cfg.BaseURL(), "agent1")
 		require.Equal(t, "agent1", out.Username)
-		require.Equal(t, cfg.BaseURL()+"/mcp/agent1", out.MCPAccess.MCPURL)
-		require.Equal(t, cfg.BaseURL()+"/.well-known/oauth-protected-resource/mcp/agent1", out.MCPAccess.ProtectedResourceURL)
-		require.Equal(t, cfg.BaseURL()+"/.well-known/oauth-authorization-server", out.MCPAccess.AuthorizationServerURL)
-		require.Equal(t, cfg.BaseURL()+"/oauth/register", out.MCPAccess.RegistrationURL)
+		require.Equal(t, bundle.MCPURL, out.MCPAccess.MCPURL)
+		require.Equal(t, bundle.ProtectedResourceURL, out.MCPAccess.ProtectedResourceURL)
+		require.Equal(t, bundle.AuthorizationServerURL, out.MCPAccess.AuthorizationServerURL)
+		require.Equal(t, bundle.RegistrationURL, out.MCPAccess.RegistrationURL)
 		require.Len(t, out.MCPAccess.Guidance, 5)
 	})
 

--- a/cmd/api/handlers/oauth.go
+++ b/cmd/api/handlers/oauth.go
@@ -335,12 +335,7 @@ func (h *Handler) resolveAuthorizeTargetActorFromResource(ctx context.Context, r
 			description: "resource must be the actor-scoped MCP URL for this server",
 		}
 	}
-
-	baseURL, baseErr := url.Parse(h.cfg.BaseURL())
-	if baseErr != nil || baseURL == nil {
-		return "", "", errors.New("authorization server base URL is invalid")
-	}
-	if !strings.EqualFold(parsed.Hostname(), baseURL.Hostname()) {
+	if strings.TrimSpace(parsed.RawQuery) != "" || strings.TrimSpace(parsed.Fragment) != "" {
 		return "", "", &oauthAuthorizeTargetError{
 			code:        "invalid_target",
 			description: "resource must be the actor-scoped MCP URL for this server",
@@ -377,7 +372,20 @@ func (h *Handler) resolveAuthorizeTargetActorFromResource(ctx context.Context, r
 		}
 	}
 
-	canonicalResource := strings.TrimRight(baseURL.String(), "/") + "/mcp/" + actorUsername
+	canonicalResource := auth.BuildPublicMCPAccessBundle(h.cfg.BaseURL(), actorUsername).MCPURL
+	canonicalURL, canonicalErr := url.Parse(canonicalResource)
+	if canonicalErr != nil || canonicalURL == nil {
+		return "", "", errors.New("authorization server resource URL is invalid")
+	}
+	if !strings.EqualFold(parsed.Scheme, canonicalURL.Scheme) ||
+		!strings.EqualFold(parsed.Host, canonicalURL.Host) ||
+		parsed.EscapedPath() != canonicalURL.EscapedPath() {
+		return "", "", &oauthAuthorizeTargetError{
+			code:        "invalid_target",
+			description: "resource must be the actor-scoped MCP URL for this server",
+		}
+	}
+
 	return actorUsername, canonicalResource, nil
 }
 

--- a/cmd/api/handlers/oauth_round12_test.go
+++ b/cmd/api/handlers/oauth_round12_test.go
@@ -36,6 +36,8 @@ func round12DecodeJWTClaims(t *testing.T, tokenString string) auth.Claims {
 
 func TestOAuthAuthorizeFlowRound12(t *testing.T) {
 	cfg := round11TestConfig()
+	agent1Resource := auth.BuildPublicMCPAccessBundle(cfg.BaseURL(), "agent1").MCPURL
+	agent2Resource := auth.BuildPublicMCPAccessBundle(cfg.BaseURL(), "agent2").MCPURL
 
 	t.Run("unsupported response type without redirect_uri returns JSON error", func(t *testing.T) {
 		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
@@ -234,7 +236,7 @@ func TestOAuthAuthorizeFlowRound12(t *testing.T) {
 			"response_type": "code",
 			"client_id":     "client-1",
 			"redirect_uri":  "https://example.com/callback",
-			"resource":      "https://example.com/mcp/agent1",
+			"resource":      agent1Resource,
 			"scope":         "read write",
 			"state":         "state-6",
 		}, nil)
@@ -243,11 +245,11 @@ func TestOAuthAuthorizeFlowRound12(t *testing.T) {
 
 		resp := requireStatus(t, http.StatusFound)(h.HandleOAuthAuthorizeLift(ctx))
 		require.Contains(t, firstStringValue(resp.Headers, "location"), "/auth/consent?")
-		require.Contains(t, firstStringValue(resp.Headers, "location"), "resource=https%3A%2F%2Fexample.com%2Fmcp%2Fagent1")
+		require.Contains(t, firstStringValue(resp.Headers, "location"), url.QueryEscape(agent1Resource))
 		require.NotNil(t, storedState)
 		require.NotNil(t, consentQuery)
-		require.Equal(t, "https://example.com/mcp/agent1", consentQuery.Resource)
-		require.Equal(t, "https://example.com/mcp/agent1", storedState.Resource)
+		require.Equal(t, agent1Resource, consentQuery.Resource)
+		require.Equal(t, agent1Resource, storedState.Resource)
 		require.Equal(t, "agent1", storedState.Username)
 		require.Equal(t, "alice", storedState.PrincipalUsername)
 	})
@@ -342,7 +344,7 @@ func TestOAuthAuthorizeFlowRound12(t *testing.T) {
 		require.Contains(t, redirectURL, "resource+is+required+for+remote+MCP+authorization")
 	})
 
-	t.Run("resource-bound authorize denies principals that do not own the requested actor", func(t *testing.T) {
+	t.Run("resource-bound authorize rejects apex mcp resource when api host is canonical", func(t *testing.T) {
 		state := &round10QueryState{
 			usersByUsername: map[string]storagemodels.User{
 				"agent1": {Username: "agent1", IsAgent: true, AgentOwner: "@owner"},
@@ -355,6 +357,31 @@ func TestOAuthAuthorizeFlowRound12(t *testing.T) {
 			"client_id":     "client-1",
 			"redirect_uri":  "https://example.com/callback",
 			"resource":      "https://example.com/mcp/agent1",
+			"scope":         "read write",
+			"state":         "state-agent-apex-invalid",
+		}, nil)
+		require.NoError(t, err)
+		ctx.Set("username", "owner")
+
+		resp := requireStatus(t, http.StatusFound)(h.HandleOAuthAuthorizeLift(ctx))
+		redirectURL := firstStringValue(resp.Headers, "location")
+		require.Contains(t, redirectURL, "error=invalid_target")
+		require.Contains(t, redirectURL, "resource+must+be+the+actor-scoped+MCP+URL+for+this+server")
+	})
+
+	t.Run("resource-bound authorize denies principals that do not own the requested actor", func(t *testing.T) {
+		state := &round10QueryState{
+			usersByUsername: map[string]storagemodels.User{
+				"agent1": {Username: "agent1", IsAgent: true, AgentOwner: "@owner"},
+			},
+		}
+
+		h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{AccountsSvc: &AccountsServiceStub{}})
+		ctx, err := round10NewLiftContext(http.MethodGet, "/oauth/authorize", map[string]string{"Accept": "text/html"}, map[string]string{
+			"response_type": "code",
+			"client_id":     "client-1",
+			"redirect_uri":  "https://example.com/callback",
+			"resource":      agent1Resource,
 			"scope":         "read write",
 			"state":         "state-agent-forbidden",
 		}, nil)
@@ -410,7 +437,7 @@ func TestOAuthAuthorizeFlowRound12(t *testing.T) {
 			"response_type": "code",
 			"client_id":     "client-agent",
 			"redirect_uri":  "https://example.com/callback",
-			"resource":      "https://example.com/mcp/agent1",
+			"resource":      agent1Resource,
 			"scope":         "read write",
 			"state":         "state-agent-consent",
 		}, nil)
@@ -418,7 +445,7 @@ func TestOAuthAuthorizeFlowRound12(t *testing.T) {
 		ctx.Set("username", "owner")
 
 		resp := requireStatus(t, http.StatusFound)(h.HandleOAuthAuthorizeLift(ctx))
-		require.Contains(t, firstStringValue(resp.Headers, "location"), "resource=https%3A%2F%2Fexample.com%2Fmcp%2Fagent1")
+		require.Contains(t, firstStringValue(resp.Headers, "location"), url.QueryEscape(agent1Resource))
 		require.NotContains(t, firstStringValue(resp.Headers, "location"), "agent_username=")
 		require.NotContains(t, firstStringValue(resp.Headers, "location"), "principal_username=")
 		require.NotNil(t, storedState)
@@ -434,7 +461,7 @@ func TestOAuthAuthorizeFlowRound12(t *testing.T) {
 			GetUserAppConsentFunc: func(_ context.Context, query *accounts.GetUserAppConsentQuery) (*accounts.GetUserAppConsentResult, error) {
 				consentQuery = query
 				if query.Username == "alice" && query.ClientID == "client-1" &&
-					(query.Resource == "" || query.Resource == "https://example.com/mcp/agent1") {
+					(query.Resource == "" || query.Resource == agent1Resource) {
 					return &accounts.GetUserAppConsentResult{
 						Consent: &storage.UserAppConsent{Scopes: []string{"read", "write"}},
 					}, nil
@@ -465,7 +492,7 @@ func TestOAuthAuthorizeFlowRound12(t *testing.T) {
 			"response_type": "code",
 			"client_id":     "client-1",
 			"redirect_uri":  "https://example.com/callback",
-			"resource":      "https://example.com/mcp/agent2",
+			"resource":      agent2Resource,
 			"scope":         "read write",
 			"state":         "state-resource-bound-consent",
 		}, nil)
@@ -476,9 +503,9 @@ func TestOAuthAuthorizeFlowRound12(t *testing.T) {
 		redirectURL := firstStringValue(resp.Headers, "location")
 		require.Contains(t, redirectURL, "/auth/consent?")
 		require.NotNil(t, consentQuery)
-		require.Equal(t, "https://example.com/mcp/agent2", consentQuery.Resource)
+		require.Equal(t, agent2Resource, consentQuery.Resource)
 		require.NotNil(t, storedState)
-		require.Equal(t, "https://example.com/mcp/agent2", storedState.Resource)
+		require.Equal(t, agent2Resource, storedState.Resource)
 		require.Equal(t, "agent2", storedState.Username)
 	})
 
@@ -504,7 +531,7 @@ func TestOAuthAuthorizeFlowRound12(t *testing.T) {
 			"response_type": "code",
 			"client_id":     "client-1",
 			"redirect_uri":  "https://example.com/callback",
-			"resource":      "https://example.com/mcp/agent1",
+			"resource":      agent1Resource,
 			"state":         "state-7",
 		}, nil)
 		require.NoError(t, err)
@@ -519,10 +546,10 @@ func TestOAuthAuthorizeFlowRound12(t *testing.T) {
 		require.NotEmpty(t, parsed.Query().Get("code"))
 		require.Equal(t, "state-7", parsed.Query().Get("state"))
 		require.NotNil(t, consentQuery)
-		require.Equal(t, "https://example.com/mcp/agent1", consentQuery.Resource)
+		require.Equal(t, agent1Resource, consentQuery.Resource)
 		require.NotNil(t, issuedAuthCode)
 		require.NotEmpty(t, issuedAuthCode.Code)
-		require.Equal(t, "https://example.com/mcp/agent1", issuedAuthCode.Resource)
+		require.Equal(t, agent1Resource, issuedAuthCode.Resource)
 		require.Equal(t, "agent1", issuedAuthCode.Username)
 	})
 
@@ -662,6 +689,7 @@ func TestOAuthAuthorizeHelpersRound12(t *testing.T) {
 
 func TestOAuthTokenLiftRound12(t *testing.T) {
 	cfg := round11TestConfig()
+	agent1Resource := auth.BuildPublicMCPAccessBundle(cfg.BaseURL(), "agent1").MCPURL
 	newDeviceFlowCLIClient := func() storagemodels.OAuthClient {
 		return storagemodels.OAuthClient{
 			ClientID:     "client-1",
@@ -967,7 +995,7 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 					Code:              "agent-code",
 					ClientID:          "client-agent",
 					RedirectURI:       "https://example.com/callback",
-					Resource:          "https://example.com/mcp/agent1",
+					Resource:          agent1Resource,
 					Username:          "agent1",
 					PrincipalUsername: "owner",
 					ExpiresAt:         time.Now().Add(5 * time.Minute),
@@ -980,7 +1008,7 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		}
 		h, _, _ := round11NewHandler(t, cfg, state)
 
-		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type=authorization_code&code=agent-code&client_id=client-agent&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&resource=https%3A%2F%2Fexample.com%2Fmcp%2Fagent1"))
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type=authorization_code&code=agent-code&client_id=client-agent&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&resource="+url.QueryEscape(agent1Resource)))
 		resp := requireStatus(t, http.StatusOK)(h.HandleOAuthTokenLift(ctx))
 		var body apimodels.OAuthTokenResponse
 		require.NoError(t, json.Unmarshal(resp.Body, &body))
@@ -993,13 +1021,13 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		require.Equal(t, auth.ClientClassAgent, claims.ClientClass)
 		require.Equal(t, "@owner", claims.DelegatedBy)
 		require.NotEmpty(t, claims.SessionID)
-		require.Equal(t, []string{"https://example.com/mcp/agent1"}, []string(claims.Audience))
+		require.Equal(t, []string{agent1Resource}, []string(claims.Audience))
 
 		storedRefresh, ok := state.refreshTokensByToken[body.RefreshToken]
 		require.True(t, ok)
 		require.Equal(t, auth.ClientClassAgent, storedRefresh.ClientClass)
 		require.Equal(t, "agent1", storedRefresh.Username)
-		require.Equal(t, "https://example.com/mcp/agent1", storedRefresh.Resource)
+		require.Equal(t, agent1Resource, storedRefresh.Resource)
 		require.NotEmpty(t, storedRefresh.SessionID)
 		require.Equal(t, claims.SessionID, storedRefresh.SessionID)
 		require.Empty(t, storedRefresh.FamilyID)
@@ -1015,7 +1043,7 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 	t.Run("refresh_token public agent client rotates legacy runtime state into standard refresh state", func(t *testing.T) {
 		now := time.Now().UTC()
 		token := buildRuntimeRefreshToken(t, "rt-agent-connector", "agent1", "client-agent", "sid-agent-connector", "family-agent-connector", "Connector App", 1, true, false, now)
-		token.Resource = "https://example.com/mcp/agent1"
+		token.Resource = agent1Resource
 		state := &round10QueryState{
 			oauthClientsByID: map[string]storagemodels.OAuthClient{
 				"client-agent": {
@@ -1048,7 +1076,7 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		claims := round12DecodeJWTClaims(t, body.AccessToken)
 		require.Equal(t, auth.ClientClassAgent, claims.ClientClass)
 		require.Equal(t, token.SessionID, claims.SessionID)
-		require.Equal(t, []string{"https://example.com/mcp/agent1"}, []string(claims.Audience))
+		require.Equal(t, []string{agent1Resource}, []string(claims.Audience))
 
 		_, ok := state.refreshTokensByToken["rt-agent-connector"]
 		require.False(t, ok)
@@ -1057,7 +1085,7 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, auth.ClientClassAgent, newToken.ClientClass)
 		require.Equal(t, token.SessionID, newToken.SessionID)
-		require.Equal(t, "https://example.com/mcp/agent1", newToken.Resource)
+		require.Equal(t, agent1Resource, newToken.Resource)
 		require.Empty(t, newToken.FamilyID)
 		require.Zero(t, newToken.Generation)
 		require.False(t, newToken.Current)
@@ -1071,7 +1099,7 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 	t.Run("refresh_token public agent client ignores legacy runtime session bounds", func(t *testing.T) {
 		now := time.Now().UTC()
 		token := buildRuntimeRefreshToken(t, "rt-agent-aged", "agent1", "client-agent", "sid-agent-aged", "family-agent-aged", "Connector App", 1, true, false, now)
-		token.Resource = "https://example.com/mcp/agent1"
+		token.Resource = agent1Resource
 		token.SessionCreatedAt = now.Add(-72 * time.Hour)
 		token.LastUsedAt = now.Add(-2 * time.Hour)
 		token.IdleExpiresAt = now.Add(36 * time.Hour)
@@ -1111,7 +1139,7 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		claims := round12DecodeJWTClaims(t, body.AccessToken)
 		require.Equal(t, auth.ClientClassAgent, claims.ClientClass)
 		require.Equal(t, "sid-agent-aged", claims.SessionID)
-		require.Equal(t, []string{"https://example.com/mcp/agent1"}, []string(claims.Audience))
+		require.Equal(t, []string{agent1Resource}, []string(claims.Audience))
 		require.NotNil(t, claims.IssuedAt)
 		require.NotNil(t, claims.ExpiresAt)
 		require.InDelta(t, auth.AgentAccessTokenTTL(cfg).Seconds(), claims.ExpiresAt.Time.Sub(claims.IssuedAt.Time).Seconds(), 5)

--- a/cmd/lesser/verify_mcp_auth_cutover.go
+++ b/cmd/lesser/verify_mcp_auth_cutover.go
@@ -156,13 +156,14 @@ func executeVerifyMCPAuthCutover(ctx context.Context, client *http.Client, baseU
 
 	seenResources := map[string]string{}
 	for _, actor := range actors {
+		bundle := auth.BuildPublicMCPAccessBundle(summary.BaseURL, actor)
 		var protectedMeta verifyMCPAuthCutoverProtectedResourceMetadata
-		endpoint := summary.BaseURL + "/.well-known/oauth-protected-resource/mcp/" + url.PathEscape(actor)
+		endpoint := bundle.ProtectedResourceURL
 		if err := verifyMCPAuthCutoverGetJSON(ctx, client, endpoint, &protectedMeta); err != nil {
 			return summary, fmt.Errorf("load protected-resource metadata for %q: %w", actor, err)
 		}
 
-		expectedResource := summary.BaseURL + "/mcp/" + actor
+		expectedResource := bundle.MCPURL
 		resource := strings.TrimRight(strings.TrimSpace(protectedMeta.Resource), "/")
 		if resource != expectedResource {
 			return summary, fmt.Errorf("protected-resource metadata for %q returned %q (expected %q)", actor, resource, expectedResource)

--- a/graph/agent_model_helpers_test.go
+++ b/graph/agent_model_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/equaltoai/lesser/pkg/agents"
+	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/stretchr/testify/require"
@@ -48,10 +49,11 @@ func TestConvertStorageUserToAgent_HydratesMetadataAndCapabilities(t *testing.T)
 	require.Equal(t, 0, agent.AgentCapabilities.MaxPostsPerHour)
 	require.True(t, agent.AgentCapabilities.RequiresApproval)
 	require.NotNil(t, agent.McpAccess)
-	require.Equal(t, "https://example.com/mcp/lowkey", agent.McpAccess.McpURL)
-	require.Equal(t, "https://example.com/.well-known/oauth-protected-resource/mcp/lowkey", agent.McpAccess.ProtectedResourceURL)
-	require.Equal(t, "https://example.com/.well-known/oauth-authorization-server", agent.McpAccess.AuthorizationServerURL)
-	require.Equal(t, "https://example.com/oauth/register", agent.McpAccess.RegistrationURL)
+	bundle := auth.BuildPublicMCPAccessBundle("https://example.com", "lowkey")
+	require.Equal(t, bundle.MCPURL, agent.McpAccess.McpURL)
+	require.Equal(t, bundle.ProtectedResourceURL, agent.McpAccess.ProtectedResourceURL)
+	require.Equal(t, bundle.AuthorizationServerURL, agent.McpAccess.AuthorizationServerURL)
+	require.Equal(t, bundle.RegistrationURL, agent.McpAccess.RegistrationURL)
 	require.Len(t, agent.McpAccess.Guidance, 5)
 }
 

--- a/pkg/auth/mcp_access.go
+++ b/pkg/auth/mcp_access.go
@@ -1,6 +1,10 @@
 package auth
 
-import "strings"
+import (
+	"net"
+	"net/url"
+	"strings"
+)
 
 // PublicMCPAccessBundle describes the client-neutral actor-scoped MCP access
 // surface that can be shown by agent UIs without provisioning connector state.
@@ -33,10 +37,48 @@ func BuildPublicMCPAccessBundle(baseURL, actorUsername string) PublicMCPAccessBu
 		return bundle
 	}
 
-	bundle.MCPURL = baseURL + "/mcp/" + actorUsername
-	bundle.ProtectedResourceURL = baseURL + "/.well-known/oauth-protected-resource/mcp/" + actorUsername
+	resourceBaseURL := canonicalMCPResourceBaseURL(baseURL)
+	bundle.MCPURL = resourceBaseURL + "/mcp/" + actorUsername
+	bundle.ProtectedResourceURL = resourceBaseURL + "/.well-known/oauth-protected-resource/mcp/" + actorUsername
 	bundle.AuthorizationServerURL = baseURL + "/.well-known/oauth-authorization-server"
 	bundle.RegistrationURL = baseURL + "/oauth/register"
 
 	return bundle
+}
+
+func canonicalMCPResourceBaseURL(baseURL string) string {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(baseURL)
+	if err != nil || parsed == nil || parsed.Scheme == "" || parsed.Host == "" {
+		return baseURL
+	}
+
+	host := strings.TrimSpace(strings.ToLower(parsed.Hostname()))
+	if host == "" || isLocalMCPHostname(host) || strings.HasPrefix(host, "api.") {
+		return strings.TrimRight(parsed.String(), "/")
+	}
+
+	apiHost := "api." + parsed.Hostname()
+	if port := parsed.Port(); port != "" {
+		parsed.Host = net.JoinHostPort(apiHost, port)
+	} else {
+		parsed.Host = apiHost
+	}
+
+	return strings.TrimRight(parsed.String(), "/")
+}
+
+func isLocalMCPHostname(host string) bool {
+	host = strings.TrimSpace(strings.ToLower(host))
+	if host == "" {
+		return false
+	}
+	if host == "localhost" || host == "::1" || strings.HasSuffix(host, ".localhost") {
+		return true
+	}
+	return net.ParseIP(host) != nil
 }

--- a/pkg/auth/mcp_access_test.go
+++ b/pkg/auth/mcp_access_test.go
@@ -10,8 +10,8 @@ func TestBuildPublicMCPAccessBundle(t *testing.T) {
 	t.Run("returns actor scoped urls and canonical guidance", func(t *testing.T) {
 		bundle := BuildPublicMCPAccessBundle("https://example.com/", "agent-one")
 
-		require.Equal(t, "https://example.com/mcp/agent-one", bundle.MCPURL)
-		require.Equal(t, "https://example.com/.well-known/oauth-protected-resource/mcp/agent-one", bundle.ProtectedResourceURL)
+		require.Equal(t, "https://api.example.com/mcp/agent-one", bundle.MCPURL)
+		require.Equal(t, "https://api.example.com/.well-known/oauth-protected-resource/mcp/agent-one", bundle.ProtectedResourceURL)
 		require.Equal(t, "https://example.com/.well-known/oauth-authorization-server", bundle.AuthorizationServerURL)
 		require.Equal(t, "https://example.com/oauth/register", bundle.RegistrationURL)
 		require.Equal(t, []string{ScopeRead, ScopeWrite, ScopeFollow, ScopePush}, bundle.SupportedScopes)
@@ -29,5 +29,23 @@ func TestBuildPublicMCPAccessBundle(t *testing.T) {
 		require.Empty(t, bundle.RegistrationURL)
 		require.Equal(t, []string{ScopeRead, ScopeWrite, ScopeFollow, ScopePush}, bundle.SupportedScopes)
 		require.Len(t, bundle.Guidance, 5)
+	})
+
+	t.Run("keeps local hosts unchanged for development", func(t *testing.T) {
+		bundle := BuildPublicMCPAccessBundle("http://localhost:8788", "agent-one")
+
+		require.Equal(t, "http://localhost:8788/mcp/agent-one", bundle.MCPURL)
+		require.Equal(t, "http://localhost:8788/.well-known/oauth-protected-resource/mcp/agent-one", bundle.ProtectedResourceURL)
+		require.Equal(t, "http://localhost:8788/.well-known/oauth-authorization-server", bundle.AuthorizationServerURL)
+		require.Equal(t, "http://localhost:8788/oauth/register", bundle.RegistrationURL)
+	})
+
+	t.Run("preserves api hosts when already canonical", func(t *testing.T) {
+		bundle := BuildPublicMCPAccessBundle("https://api.dev.example.com", "agent-one")
+
+		require.Equal(t, "https://api.dev.example.com/mcp/agent-one", bundle.MCPURL)
+		require.Equal(t, "https://api.dev.example.com/.well-known/oauth-protected-resource/mcp/agent-one", bundle.ProtectedResourceURL)
+		require.Equal(t, "https://api.dev.example.com/.well-known/oauth-authorization-server", bundle.AuthorizationServerURL)
+		require.Equal(t, "https://api.dev.example.com/oauth/register", bundle.RegistrationURL)
 	})
 }


### PR DESCRIPTION
## What changed
- canonicalize the public MCP access bundle so the actor-scoped MCP URL and protected-resource metadata use the `api.<stage-domain>` host
- keep the authorization server and dynamic client registration URLs on the normal instance base URL
- make OAuth authorize validate the requested `resource` against the canonical actor-scoped MCP URL instead of the apex host
- update the MCP auth cutover verifier and affected tests to follow the same resource host

## Why
`lesser-body` and the live MCP runtime now expose the actor-scoped protected resource on `https://api.<stage-domain>/mcp/{actor}`, but OAuth authorize was still canonicalizing against the apex host. That meant valid remote-MCP logins were rejected with `invalid_target` even when the client sent the actual protected resource URL.

## Impact
- one canonical MCP resource URL is accepted and emitted end-to-end
- OAuth consents, authorization codes, refresh tokens, and access token audiences all align with the `api.<stage-domain>` resource host
- the cutover verifier checks the same protected-resource URLs that clients will use in production

## Validation
- `GOTOOLCHAIN=auto go test ./pkg/auth ./graph ./cmd/api/handlers ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`
- `bash scripts/verify_artifact_deploy.sh`
