### PR TITLE
[codex] accept code-bound MCP resources when token exchange omits resource

### DIFF
--- a/cmd/api/handlers/oauth.go
+++ b/cmd/api/handlers/oauth.go
@@ -1124,6 +1124,7 @@ func (h *Handler) exchangeAuthorizationCode(ctx context.Context, oauthSvc *auth.
 	clientID = strings.TrimSpace(clientID)
 	redirectURI = strings.TrimSpace(redirectURI)
 	clientSecret = strings.TrimSpace(clientSecret)
+	requestedResource = strings.TrimSpace(requestedResource)
 
 	client, err := h.validateAuthorizationCodeExchangeClient(ctx, oauthSvc, clientID, redirectURI, clientSecret, code)
 	if err != nil {
@@ -1134,7 +1135,14 @@ func (h *Handler) exchangeAuthorizationCode(ctx context.Context, oauthSvc *auth.
 	if err != nil {
 		return "", "", nil, err
 	}
-	if strings.TrimSpace(authCode.Resource) != strings.TrimSpace(requestedResource) {
+	storedResource := strings.TrimSpace(authCode.Resource)
+	if storedResource != "" && requestedResource == "" {
+		// Some public MCP clients bind the resource at authorization time but omit it
+		// during the token exchange. Preserve the original code-bound resource instead
+		// of rejecting an otherwise valid authorization-code flow.
+		requestedResource = storedResource
+	}
+	if storedResource != requestedResource {
 		return "", "", nil, errOAuthInvalidTarget
 	}
 

--- a/cmd/api/handlers/oauth_round12_test.go
+++ b/cmd/api/handlers/oauth_round12_test.go
@@ -796,6 +796,42 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		require.Equal(t, "invalid_target", body["error"])
 	})
 
+	t.Run("authorization_code accepts omitted resource when original authorization request was resource-bound", func(t *testing.T) {
+		state := &round10QueryState{
+			oauthClientsByID: map[string]storagemodels.OAuthClient{
+				"client-1": {
+					ClientID:           "client-1",
+					Name:               "Codex",
+					RedirectURIs:       []string{"https://example.com/callback"},
+					Scopes:             []string{auth.ScopeRead, auth.ScopeWrite, auth.ScopeFollow, auth.ScopePush},
+					Confidential:       false,
+					RegistrationSource: oauthRegistrationSourceDynamic,
+					CreatedAt:          time.Now().Add(-24 * time.Hour),
+				},
+			},
+			authorizationCodesByCode: map[string]storagemodels.AuthorizationCode{
+				"code-resource-omitted": {
+					Code:          "code-resource-omitted",
+					ClientID:      "client-1",
+					RedirectURI:   "https://example.com/callback",
+					Resource:      "https://mcp.example/resource",
+					Username:      "alice",
+					ExpiresAt:     time.Now().Add(10 * time.Minute),
+					Scopes:        []string{auth.ScopeRead, auth.ScopeWrite, auth.ScopeFollow, auth.ScopePush},
+					CodeChallenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+				},
+			},
+		}
+
+		h, _, _ := round11NewHandler(t, cfg, state)
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type=authorization_code&code=code-resource-omitted&client_id=client-1&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_verifier=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"))
+		resp := requireStatus(t, http.StatusOK)(h.HandleOAuthTokenLift(ctx))
+		var body apimodels.OAuthTokenResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.NotEmpty(t, body.AccessToken)
+		require.NotEmpty(t, body.RefreshToken)
+	})
+
 	t.Run("authorization_code confidential client requires client_secret", func(t *testing.T) {
 		state := &round10QueryState{
 			oauthClientsByID: map[string]storagemodels.OAuthClient{


### PR DESCRIPTION
## What changed
- allow the authorization-code token exchange to inherit the resource already bound to the stored authorization code when the token request omits `resource`
- keep returning `invalid_target` when a token request explicitly sends a different resource than the original authorization request
- add a regression test covering the Codex-shaped OAuth flow where `/oauth/authorize` includes `resource` but `/oauth/token` does not

## Why
Codex sends the MCP `resource` parameter on `/oauth/authorize`, but omits it on the follow-up `/oauth/token` request. Lesser was requiring the token request to repeat the resource exactly, so Codex failed with `invalid_target` even though the authorization code was already bound to the correct actor-scoped MCP resource.

Claude Code is not regressed by this change because explicit matching resources still succeed, and explicit mismatches still fail. The only relaxed case is when the code is already resource-bound and the token request leaves `resource` blank.

## Impact
- Codex OIDC login now succeeds for actor-scoped MCP resources without loosening audience binding
- existing Claude Code flows continue to work
- explicit resource mismatches continue to fail with `invalid_target`

## Validation
- `./lesser verify ci`
- direct local probe of `codex mcp login` confirmed Codex omits `resource` on the token POST while including it on the authorize request
