### PR TITLE
[codex] expose agent quarantine state

### DIFF
--- a/cmd/api/handlers/agent_feature_round12_coverage_test.go
+++ b/cmd/api/handlers/agent_feature_round12_coverage_test.go
@@ -12,6 +12,7 @@ import (
 	apimodels "github.com/equaltoai/lesser/cmd/api/models"
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/storage"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
@@ -281,6 +282,9 @@ func TestAgentFeaturesRound12_AdminPolicyAndVerification(t *testing.T) {
 		require.NoError(t, json.Unmarshal(verifyResp.Body, &verified))
 		require.True(t, verified.Verified)
 		require.NotNil(t, verified.VerifiedAt)
+		require.Equal(t, storage.AgentQuarantineStatusApproved, verified.QuarantineStatus)
+		require.False(t, verified.QuarantineActive)
+		require.NotNil(t, verified.QuarantineApprovedAt)
 
 		unverifyReq := apimodels.AdminVerifyAgentRequest{Reason: "nope"}
 		unverifyCtx, err := round10NewLiftContext(http.MethodPost, "/api/v1/admin/agents/agent1/unverify", headers, nil, unverifyReq)

--- a/cmd/api/handlers/agents.go
+++ b/cmd/api/handlers/agents.go
@@ -1011,6 +1011,7 @@ func agentFromStorageUserWithBaseURL(user *storage.User, governance *storage.Age
 		verifiedAt := governance.VerifiedAt.UTC()
 		out.VerifiedAt = &verifiedAt
 	}
+	applyAPIAgentQuarantineSummary(&out, governance)
 
 	out.DelegatedScopes = agentDelegatedScopes(governance)
 	out.AgentCapabilities = apiAgentCapabilitiesFromStorage(user.AgentCapabilities)
@@ -1025,6 +1026,19 @@ func agentFromStorageUserWithBaseURL(user *storage.User, governance *storage.Age
 	out.IdentitySemantics = apiAgentIdentitySemantics(agents.DeriveDroneIdentitySemantics(user.Username, workflowState, false, ""))
 
 	return out
+}
+
+func applyAPIAgentQuarantineSummary(out *apimodels.Agent, governance *storage.AgentGovernanceState) {
+	if out == nil {
+		return
+	}
+	summary := governance.QuarantineSummaryAt(time.Now().UTC())
+	out.QuarantineStatus = summary.Status
+	out.QuarantineStart = summary.Start
+	out.QuarantineEnd = summary.End
+	out.QuarantineApprovedBy = summary.ApprovedBy
+	out.QuarantineApprovedAt = summary.ApprovedAt
+	out.QuarantineActive = summary.Active
 }
 
 func collectAgentUsernames(users []*storage.User) []string {

--- a/cmd/api/handlers/agents_helpers_round20_test.go
+++ b/cmd/api/handlers/agents_helpers_round20_test.go
@@ -137,13 +137,24 @@ func TestAgentHelpersRound20(t *testing.T) {
 		}
 
 		unverified := agentFromStorageUser(user, &storage.AgentGovernanceState{
-			Username:        "agent1",
-			Verified:        false,
-			VerifiedAt:      &verifiedAt,
-			DelegatedScopes: []string{"read"},
+			Username:             "agent1",
+			Verified:             false,
+			VerifiedAt:           &verifiedAt,
+			DelegatedScopes:      []string{"read"},
+			QuarantineStatus:     storage.AgentQuarantineStatusQuarantined,
+			QuarantineStart:      ptrTime(createdAt),
+			QuarantineEnd:        ptrTime(createdAt.Add(24 * time.Hour)),
+			QuarantineApprovedBy: "admin",
+			QuarantineApprovedAt: ptrTime(createdAt.Add(time.Hour)),
 		})
 		require.False(t, unverified.Verified)
 		require.Nil(t, unverified.VerifiedAt)
+		require.Equal(t, storage.AgentQuarantineStatusQuarantined, unverified.QuarantineStatus)
+		require.NotNil(t, unverified.QuarantineStart)
+		require.NotNil(t, unverified.QuarantineEnd)
+		require.Equal(t, "admin", unverified.QuarantineApprovedBy)
+		require.NotNil(t, unverified.QuarantineApprovedAt)
+		require.True(t, unverified.QuarantineActive)
 		require.Equal(t, agentTypeCustom, unverified.AgentType)
 		require.Equal(t, agentVersionUnknown, unverified.AgentVersion)
 		require.Equal(t, []string{"read"}, unverified.DelegatedScopes)
@@ -166,6 +177,8 @@ func TestAgentHelpersRound20(t *testing.T) {
 		require.Equal(t, bundle.AuthorizationServerURL, verified.MCPAccess.AuthorizationServerURL)
 		require.Equal(t, bundle.RegistrationURL, verified.MCPAccess.RegistrationURL)
 		require.Len(t, verified.MCPAccess.Guidance, 5)
+		require.False(t, verified.QuarantineActive)
+		require.Empty(t, verified.QuarantineStatus)
 	})
 
 	t.Run("agent governance state helpers handle nil found and missing rows", func(t *testing.T) {

--- a/cmd/api/handlers/agents_management_round20_test.go
+++ b/cmd/api/handlers/agents_management_round20_test.go
@@ -8,6 +8,7 @@ import (
 
 	apimodels "github.com/equaltoai/lesser/cmd/api/models"
 	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/storage"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/require"
 )
@@ -95,6 +96,9 @@ func TestAgentManagementHandlersRound20(t *testing.T) {
 		require.Equal(t, bundle.AuthorizationServerURL, out.MCPAccess.AuthorizationServerURL)
 		require.Equal(t, bundle.RegistrationURL, out.MCPAccess.RegistrationURL)
 		require.Len(t, out.MCPAccess.Guidance, 5)
+		require.Equal(t, storage.AgentQuarantineStatusQuarantined, out.QuarantineStatus)
+		require.True(t, out.QuarantineActive)
+		require.NotNil(t, out.QuarantineEnd)
 	})
 
 	t.Run("update agent success", func(t *testing.T) {
@@ -113,6 +117,9 @@ func TestAgentManagementHandlersRound20(t *testing.T) {
 		var out apimodels.Agent
 		require.NoError(t, json.Unmarshal(resp.Body, &out))
 		require.Equal(t, "Updated Agent", out.DisplayName)
+		require.Equal(t, storage.AgentQuarantineStatusApproved, out.QuarantineStatus)
+		require.False(t, out.QuarantineActive)
+		require.NotNil(t, out.QuarantineApprovedAt)
 	})
 
 	t.Run("delete agent forbidden for wrong owner", func(t *testing.T) {

--- a/cmd/api/models/agents.go
+++ b/cmd/api/models/agents.go
@@ -45,19 +45,25 @@ type AgentIdentitySemantics struct {
 
 // Agent is the REST representation of a local agent account.
 type Agent struct {
-	Username          string                 `json:"username"`
-	DisplayName       string                 `json:"display_name"`
-	Bio               string                 `json:"bio,omitempty"`
-	CreatedAt         *time.Time             `json:"created_at,omitempty"`
-	Verified          bool                   `json:"verified"`
-	VerifiedAt        *time.Time             `json:"verified_at,omitempty"`
-	AgentType         string                 `json:"agent_type"`
-	AgentVersion      string                 `json:"agent_version"`
-	AgentOwner        string                 `json:"agent_owner,omitempty"`
-	DelegatedScopes   []string               `json:"delegated_scopes,omitempty"`
-	AgentCapabilities AgentCapabilities      `json:"agent_capabilities"`
-	MCPAccess         AgentMCPAccess         `json:"mcp_access"`
-	IdentitySemantics AgentIdentitySemantics `json:"identity_semantics"`
+	Username             string                 `json:"username"`
+	DisplayName          string                 `json:"display_name"`
+	Bio                  string                 `json:"bio,omitempty"`
+	CreatedAt            *time.Time             `json:"created_at,omitempty"`
+	Verified             bool                   `json:"verified"`
+	VerifiedAt           *time.Time             `json:"verified_at,omitempty"`
+	QuarantineStatus     string                 `json:"quarantine_status,omitempty"`
+	QuarantineStart      *time.Time             `json:"quarantine_start,omitempty"`
+	QuarantineEnd        *time.Time             `json:"quarantine_end,omitempty"`
+	QuarantineApprovedBy string                 `json:"quarantine_approved_by,omitempty"`
+	QuarantineApprovedAt *time.Time             `json:"quarantine_approved_at,omitempty"`
+	QuarantineActive     bool                   `json:"quarantine_active"`
+	AgentType            string                 `json:"agent_type"`
+	AgentVersion         string                 `json:"agent_version"`
+	AgentOwner           string                 `json:"agent_owner,omitempty"`
+	DelegatedScopes      []string               `json:"delegated_scopes,omitempty"`
+	AgentCapabilities    AgentCapabilities      `json:"agent_capabilities"`
+	MCPAccess            AgentMCPAccess         `json:"mcp_access"`
+	IdentitySemantics    AgentIdentitySemantics `json:"identity_semantics"`
 }
 
 // AgentDelegationRequest is the request payload for POST /api/v1/agents/delegate.

--- a/docs/contracts/graphql-schema.graphql
+++ b/docs/contracts/graphql-schema.graphql
@@ -4181,6 +4181,12 @@ type Agent {
   mcpAccess: AgentMCPAccess!
   verified: Boolean!
   verifiedAt: Time
+  quarantineStatus: String
+  quarantineStart: Time
+  quarantineEnd: Time
+  quarantineApprovedBy: String
+  quarantineApprovedAt: Time
+  quarantineActive: Boolean!
   ownerActor: Actor
 
   # Legacy/back-compat (to be removed once Simulacrum migrates)

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -893,6 +893,24 @@ components:
                     $ref: '#/components/schemas/AgentIdentitySemantics'
                 mcp_access:
                     $ref: '#/components/schemas/AgentMCPAccess'
+                quarantine_active:
+                    type: boolean
+                quarantine_approved_at:
+                    anyOf:
+                        - $ref: '#/components/schemas/RFC3339DateTime'
+                        - type: "null"
+                quarantine_approved_by:
+                    type: string
+                quarantine_end:
+                    anyOf:
+                        - $ref: '#/components/schemas/RFC3339DateTime'
+                        - type: "null"
+                quarantine_start:
+                    anyOf:
+                        - $ref: '#/components/schemas/RFC3339DateTime'
+                        - type: "null"
+                quarantine_status:
+                    type: string
                 username:
                     type: string
                 verified:
@@ -908,6 +926,7 @@ components:
                 - display_name
                 - identity_semantics
                 - mcp_access
+                - quarantine_active
                 - username
                 - verified
             type: object

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.9 // indirect
+require github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.9
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,6 @@ github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/aws/aws-lambda-go v1.54.0 h1:EGYpdyRGF88xszqlGcBewz811mJeRS+maNlLZXFheII=
 github.com/aws/aws-lambda-go v1.54.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
-github.com/aws/aws-sdk-go-v2 v1.41.4 h1:10f50G7WyU02T56ox1wWXq+zTX9I1zxG46HYuG1hH/k=
-github.com/aws/aws-sdk-go-v2 v1.41.4/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
 github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.7 h1:3kGOqnh1pPeddVa/E37XNTaWJ8W6vrbYV9lJEkCnhuY=
@@ -40,12 +38,8 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.20 h1:zOgq3uezl5nznfoK3ODuqb
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.20/go.mod h1:z/MVwUARehy6GAg/yQ1GO2IMl0k++cu1ohP9zo887wE=
 github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.10 h1:2KCL4TmeiNvpPedtC4Bey5jvjRLD74WUYqGeHJ//aco=
 github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.10/go.mod h1:KwaiUFVO7pG8Z9F5bMGvvrRibdSDaAu8HtlKGKkjZSA=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20 h1:CNXO7mvgThFGqOFgbNAP2nol2qAWBOGfqR/7tQlvLmc=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20/go.mod h1:oydPDJKcfMhgfcgBUZaG+toBbwy8yPWubJXBVERtI4o=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 h1:Rgg6wvjjtX8bNHcvi9OnXWwcE0a2vGpbwmtICOsvcf4=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21/go.mod h1:A/kJFst/nm//cyqonihbdpQZwiUhhzpqTsdbhDdRF9c=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20 h1:tN6W/hg+pkM+tf9XDkWUbDEjGLb+raoBMFsTodcoYKw=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20/go.mod h1:YJ898MhD067hSHA6xYCx5ts/jEd8BSOLtQDL3iZsvbc=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 h1:PEgGVtPoB6NTpPrBgqSE5hE/o47Ij9qk/SEZFbUOe9A=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21/go.mod h1:p+hz+PRAYlY3zcpJhPwXlLC4C+kqn70WIHwnzAfs6ps=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72MnLuFK9tJwmrbHw=

--- a/graph/agent_delegation_round32_test.go
+++ b/graph/agent_delegation_round32_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
 	apperrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/storage"
 	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
 	"github.com/equaltoai/lesser/pkg/storage/theorydb/marshalers"
@@ -626,6 +627,39 @@ func TestAdminUnverifyAgent_ClearsStaleVerificationFields(t *testing.T) {
 	require.Equal(t, "admin", updated.UnverifiedBy)
 	require.Equal(t, "revoked", updated.UnverifiedReason)
 	require.NotNil(t, updated.UnverifiedAt)
+}
+
+func TestAdminVerifyAgent_ReturnsUpdatedQuarantineState(t *testing.T) {
+	state := newDelegationGraphState("agent1", []string{"read"})
+	start := time.Now().UTC().Add(-time.Hour)
+	end := time.Now().UTC().Add(24 * time.Hour)
+	governance := state.governanceState("agent1")
+	governance.QuarantineStatus = storage.AgentQuarantineStatusQuarantined
+	governance.QuarantineStart = &start
+	governance.QuarantineEnd = &end
+
+	resolver := newDelegationResolver(t, state, true)
+	ctx := delegatedAgentAuthContext("admin", auth.ScopeAdmin)
+
+	exit := true
+	result, err := resolver.Mutation().AdminVerifyAgent(ctx, "agent1", &model.AdminVerifyAgentInput{
+		Reason:         ptrString("ok"),
+		ExitQuarantine: &exit,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.Verified)
+	require.NotNil(t, result.QuarantineStatus)
+	require.Equal(t, storage.AgentQuarantineStatusApproved, *result.QuarantineStatus)
+	require.False(t, result.QuarantineActive)
+	require.NotNil(t, result.QuarantineApprovedBy)
+	require.Equal(t, "admin", *result.QuarantineApprovedBy)
+	require.NotNil(t, result.QuarantineApprovedAt)
+
+	updated := state.governanceState("agent1")
+	require.Equal(t, storage.AgentQuarantineStatusApproved, updated.QuarantineStatus)
+	require.Equal(t, "admin", updated.QuarantineApprovedBy)
+	require.NotNil(t, updated.QuarantineApprovedAt)
 }
 
 func TestAdminUnverifyAgent_MissingGovernanceFailsClosed(t *testing.T) {

--- a/graph/agent_model_helpers.go
+++ b/graph/agent_model_helpers.go
@@ -65,27 +65,61 @@ func (r *Resolver) convertStorageUserToAgent(user *storage.User, governance *sto
 		createdAt = user.CreatedAt
 	}
 
+	quarantineStatus, quarantineStart, quarantineEnd, quarantineApprovedBy, quarantineApprovedAt, quarantineActive := graphAgentQuarantineFields(governance)
+
 	return &model.Agent{
-		ID:                id,
-		Username:          username,
-		DisplayName:       displayName,
-		Bio:               bio,
-		AgentType:         agentType,
-		AgentVersion:      agentVersion,
-		AgentCapabilities: capabilities,
-		AgentOwner:        agentOwner,
-		DelegatedScopes:   delegatedScopes,
-		McpAccess:         graphAgentMCPAccessModel(auth.BuildPublicMCPAccessBundle(baseURL, username)),
-		Verified:          verified,
-		VerifiedAt:        verifiedAt,
-		OwnerActor:        nil,
-		Type:              agentType,
-		Version:           agentVersion,
-		Capabilities:      capabilities,
-		Owner:             nil,
-		CreatedAt:         model.Time(createdAt),
-		ActivityCount:     0,
+		ID:                   id,
+		Username:             username,
+		DisplayName:          displayName,
+		Bio:                  bio,
+		AgentType:            agentType,
+		AgentVersion:         agentVersion,
+		AgentCapabilities:    capabilities,
+		AgentOwner:           agentOwner,
+		DelegatedScopes:      delegatedScopes,
+		McpAccess:            graphAgentMCPAccessModel(auth.BuildPublicMCPAccessBundle(baseURL, username)),
+		Verified:             verified,
+		VerifiedAt:           verifiedAt,
+		QuarantineStatus:     quarantineStatus,
+		QuarantineStart:      quarantineStart,
+		QuarantineEnd:        quarantineEnd,
+		QuarantineApprovedBy: quarantineApprovedBy,
+		QuarantineApprovedAt: quarantineApprovedAt,
+		QuarantineActive:     quarantineActive,
+		OwnerActor:           nil,
+		Type:                 agentType,
+		Version:              agentVersion,
+		Capabilities:         capabilities,
+		Owner:                nil,
+		CreatedAt:            model.Time(createdAt),
+		ActivityCount:        0,
 	}
+}
+
+func graphAgentQuarantineFields(governance *storage.AgentGovernanceState) (*string, *model.Time, *model.Time, *string, *model.Time, bool) {
+	summary := governance.QuarantineSummaryAt(time.Now().UTC())
+	return graphOptionalString(summary.Status),
+		graphOptionalModelTime(summary.Start),
+		graphOptionalModelTime(summary.End),
+		graphOptionalString(summary.ApprovedBy),
+		graphOptionalModelTime(summary.ApprovedAt),
+		summary.Active
+}
+
+func graphOptionalString(value string) *string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func graphOptionalModelTime(value *time.Time) *model.Time {
+	if value == nil || value.IsZero() {
+		return nil
+	}
+	timestamp := model.Time(value.UTC())
+	return &timestamp
 }
 
 func graphAgentMCPAccessModel(bundle auth.PublicMCPAccessBundle) *model.AgentMCPAccess {

--- a/graph/agent_model_helpers_test.go
+++ b/graph/agent_model_helpers_test.go
@@ -32,10 +32,15 @@ func TestConvertStorageUserToAgent_HydratesMetadataAndCapabilities(t *testing.T)
 		CreatedAt: createdAt,
 	}
 	governance := &storage.AgentGovernanceState{
-		Username:        "lowkey",
-		Verified:        true,
-		VerifiedAt:      ptrGraphTime(time.Date(2026, 2, 13, 13, 56, 1, 0, time.UTC)),
-		DelegatedScopes: []string{"read"},
+		Username:             "lowkey",
+		Verified:             true,
+		VerifiedAt:           ptrGraphTime(time.Date(2026, 2, 13, 13, 56, 1, 0, time.UTC)),
+		DelegatedScopes:      []string{"read"},
+		QuarantineStatus:     storage.AgentQuarantineStatusApproved,
+		QuarantineStart:      ptrGraphTime(time.Date(2026, 2, 13, 12, 42, 10, 0, time.UTC)),
+		QuarantineEnd:        ptrGraphTime(time.Date(2026, 2, 20, 12, 42, 10, 0, time.UTC)),
+		QuarantineApprovedBy: "owner",
+		QuarantineApprovedAt: ptrGraphTime(time.Date(2026, 2, 14, 8, 0, 0, 0, time.UTC)),
 	}
 
 	agent := resolver.convertStorageUserToAgent(user, governance)
@@ -48,6 +53,14 @@ func TestConvertStorageUserToAgent_HydratesMetadataAndCapabilities(t *testing.T)
 	require.True(t, agent.AgentCapabilities.CanDM)
 	require.Equal(t, 0, agent.AgentCapabilities.MaxPostsPerHour)
 	require.True(t, agent.AgentCapabilities.RequiresApproval)
+	require.NotNil(t, agent.QuarantineStatus)
+	require.Equal(t, storage.AgentQuarantineStatusApproved, *agent.QuarantineStatus)
+	require.NotNil(t, agent.QuarantineApprovedBy)
+	require.Equal(t, "owner", *agent.QuarantineApprovedBy)
+	require.NotNil(t, agent.QuarantineApprovedAt)
+	require.NotNil(t, agent.QuarantineStart)
+	require.NotNil(t, agent.QuarantineEnd)
+	require.False(t, agent.QuarantineActive)
 	require.NotNil(t, agent.McpAccess)
 	bundle := auth.BuildPublicMCPAccessBundle("https://example.com", "lowkey")
 	require.Equal(t, bundle.MCPURL, agent.McpAccess.McpURL)
@@ -73,6 +86,29 @@ func TestConvertStorageUserToAgent_HidesVerifiedAtWhenAgentIsNotVerified(t *test
 	require.NotNil(t, agent)
 	require.False(t, agent.Verified)
 	require.Nil(t, agent.VerifiedAt)
+}
+
+func TestConvertStorageUserToAgent_NormalizesExpiredQuarantine(t *testing.T) {
+	resolver := &Resolver{}
+	now := time.Now().UTC()
+	past := now.Add(-2 * time.Hour)
+	user := &storage.User{
+		Username: "lowkey",
+		IsAgent:  true,
+	}
+	governance := &storage.AgentGovernanceState{
+		Username:         "lowkey",
+		QuarantineStatus: storage.AgentQuarantineStatusQuarantined,
+		QuarantineEnd:    &past,
+	}
+
+	agent := resolver.convertStorageUserToAgent(user, governance)
+	require.NotNil(t, agent)
+	require.NotNil(t, agent.QuarantineStatus)
+	require.Equal(t, storage.AgentQuarantineStatusExpired, *agent.QuarantineStatus)
+	require.False(t, agent.QuarantineActive)
+	require.NotNil(t, agent.QuarantineEnd)
+	require.Equal(t, past.UTC(), time.Time(*agent.QuarantineEnd))
 }
 
 func ptrGraphTime(value time.Time) *time.Time {

--- a/graph/agents.graphql
+++ b/graph/agents.graphql
@@ -46,6 +46,12 @@ type Agent {
   mcpAccess: AgentMCPAccess!
   verified: Boolean!
   verifiedAt: Time
+  quarantineStatus: String
+  quarantineStart: Time
+  quarantineEnd: Time
+  quarantineApprovedBy: String
+  quarantineApprovedAt: Time
+  quarantineActive: Boolean!
   ownerActor: Actor
 
   # Legacy/back-compat (to be removed once Simulacrum migrates)

--- a/graph/generated.go
+++ b/graph/generated.go
@@ -535,27 +535,33 @@ type ComplexityRoot struct {
 	}
 
 	Agent struct {
-		ActivityCount     func(childComplexity int) int
-		AgentCapabilities func(childComplexity int) int
-		AgentOwner        func(childComplexity int) int
-		AgentType         func(childComplexity int) int
-		AgentVersion      func(childComplexity int) int
-		Bio               func(childComplexity int) int
-		Capabilities      func(childComplexity int) int
-		CreatedAt         func(childComplexity int) int
-		DelegatedScopes   func(childComplexity int) int
-		DisplayName       func(childComplexity int) int
-		ID                func(childComplexity int) int
-		IdentitySemantics func(childComplexity int) int
-		McpAccess         func(childComplexity int) int
-		Owner             func(childComplexity int) int
-		OwnerActor        func(childComplexity int) int
-		Type              func(childComplexity int) int
-		Username          func(childComplexity int) int
-		Verified          func(childComplexity int) int
-		VerifiedAt        func(childComplexity int) int
-		Version           func(childComplexity int) int
-		Workflow          func(childComplexity int) int
+		ActivityCount        func(childComplexity int) int
+		AgentCapabilities    func(childComplexity int) int
+		AgentOwner           func(childComplexity int) int
+		AgentType            func(childComplexity int) int
+		AgentVersion         func(childComplexity int) int
+		Bio                  func(childComplexity int) int
+		Capabilities         func(childComplexity int) int
+		CreatedAt            func(childComplexity int) int
+		DelegatedScopes      func(childComplexity int) int
+		DisplayName          func(childComplexity int) int
+		ID                   func(childComplexity int) int
+		IdentitySemantics    func(childComplexity int) int
+		McpAccess            func(childComplexity int) int
+		Owner                func(childComplexity int) int
+		OwnerActor           func(childComplexity int) int
+		QuarantineActive     func(childComplexity int) int
+		QuarantineApprovedAt func(childComplexity int) int
+		QuarantineApprovedBy func(childComplexity int) int
+		QuarantineEnd        func(childComplexity int) int
+		QuarantineStart      func(childComplexity int) int
+		QuarantineStatus     func(childComplexity int) int
+		Type                 func(childComplexity int) int
+		Username             func(childComplexity int) int
+		Verified             func(childComplexity int) int
+		VerifiedAt           func(childComplexity int) int
+		Version              func(childComplexity int) int
+		Workflow             func(childComplexity int) int
 	}
 
 	AgentAccessLease struct {
@@ -5889,6 +5895,48 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Agent.OwnerActor(childComplexity), true
+
+	case "Agent.quarantineActive":
+		if e.complexity.Agent.QuarantineActive == nil {
+			break
+		}
+
+		return e.complexity.Agent.QuarantineActive(childComplexity), true
+
+	case "Agent.quarantineApprovedAt":
+		if e.complexity.Agent.QuarantineApprovedAt == nil {
+			break
+		}
+
+		return e.complexity.Agent.QuarantineApprovedAt(childComplexity), true
+
+	case "Agent.quarantineApprovedBy":
+		if e.complexity.Agent.QuarantineApprovedBy == nil {
+			break
+		}
+
+		return e.complexity.Agent.QuarantineApprovedBy(childComplexity), true
+
+	case "Agent.quarantineEnd":
+		if e.complexity.Agent.QuarantineEnd == nil {
+			break
+		}
+
+		return e.complexity.Agent.QuarantineEnd(childComplexity), true
+
+	case "Agent.quarantineStart":
+		if e.complexity.Agent.QuarantineStart == nil {
+			break
+		}
+
+		return e.complexity.Agent.QuarantineStart(childComplexity), true
+
+	case "Agent.quarantineStatus":
+		if e.complexity.Agent.QuarantineStatus == nil {
+			break
+		}
+
+		return e.complexity.Agent.QuarantineStatus(childComplexity), true
 
 	case "Agent.type":
 		if e.complexity.Agent.Type == nil {
@@ -29311,6 +29359,18 @@ func (ec *executionContext) fieldContext_Actor_agentInfo(_ context.Context, fiel
 				return ec.fieldContext_Agent_verified(ctx, field)
 			case "verifiedAt":
 				return ec.fieldContext_Agent_verifiedAt(ctx, field)
+			case "quarantineStatus":
+				return ec.fieldContext_Agent_quarantineStatus(ctx, field)
+			case "quarantineStart":
+				return ec.fieldContext_Agent_quarantineStart(ctx, field)
+			case "quarantineEnd":
+				return ec.fieldContext_Agent_quarantineEnd(ctx, field)
+			case "quarantineApprovedBy":
+				return ec.fieldContext_Agent_quarantineApprovedBy(ctx, field)
+			case "quarantineApprovedAt":
+				return ec.fieldContext_Agent_quarantineApprovedAt(ctx, field)
+			case "quarantineActive":
+				return ec.fieldContext_Agent_quarantineActive(ctx, field)
 			case "ownerActor":
 				return ec.fieldContext_Agent_ownerActor(ctx, field)
 			case "type":
@@ -40239,6 +40299,255 @@ func (ec *executionContext) fieldContext_Agent_verifiedAt(_ context.Context, fie
 	return fc, nil
 }
 
+func (ec *executionContext) _Agent_quarantineStatus(ctx context.Context, field graphql.CollectedField, obj *model.Agent) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Agent_quarantineStatus(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.QuarantineStatus, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Agent_quarantineStatus(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Agent",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Agent_quarantineStart(ctx context.Context, field graphql.CollectedField, obj *model.Agent) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Agent_quarantineStart(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.QuarantineStart, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Agent_quarantineStart(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Agent",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Agent_quarantineEnd(ctx context.Context, field graphql.CollectedField, obj *model.Agent) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Agent_quarantineEnd(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.QuarantineEnd, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Agent_quarantineEnd(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Agent",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Agent_quarantineApprovedBy(ctx context.Context, field graphql.CollectedField, obj *model.Agent) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Agent_quarantineApprovedBy(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.QuarantineApprovedBy, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Agent_quarantineApprovedBy(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Agent",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Agent_quarantineApprovedAt(ctx context.Context, field graphql.CollectedField, obj *model.Agent) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Agent_quarantineApprovedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.QuarantineApprovedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Agent_quarantineApprovedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Agent",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Agent_quarantineActive(ctx context.Context, field graphql.CollectedField, obj *model.Agent) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Agent_quarantineActive(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.QuarantineActive, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Agent_quarantineActive(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Agent",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Agent_ownerActor(ctx context.Context, field graphql.CollectedField, obj *model.Agent) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Agent_ownerActor(ctx, field)
 	if err != nil {
@@ -43761,6 +44070,18 @@ func (ec *executionContext) fieldContext_AgentEdge_node(_ context.Context, field
 				return ec.fieldContext_Agent_verified(ctx, field)
 			case "verifiedAt":
 				return ec.fieldContext_Agent_verifiedAt(ctx, field)
+			case "quarantineStatus":
+				return ec.fieldContext_Agent_quarantineStatus(ctx, field)
+			case "quarantineStart":
+				return ec.fieldContext_Agent_quarantineStart(ctx, field)
+			case "quarantineEnd":
+				return ec.fieldContext_Agent_quarantineEnd(ctx, field)
+			case "quarantineApprovedBy":
+				return ec.fieldContext_Agent_quarantineApprovedBy(ctx, field)
+			case "quarantineApprovedAt":
+				return ec.fieldContext_Agent_quarantineApprovedAt(ctx, field)
+			case "quarantineActive":
+				return ec.fieldContext_Agent_quarantineActive(ctx, field)
 			case "ownerActor":
 				return ec.fieldContext_Agent_ownerActor(ctx, field)
 			case "type":
@@ -57996,6 +58317,18 @@ func (ec *executionContext) fieldContext_DelegationPayload_agent(_ context.Conte
 				return ec.fieldContext_Agent_verified(ctx, field)
 			case "verifiedAt":
 				return ec.fieldContext_Agent_verifiedAt(ctx, field)
+			case "quarantineStatus":
+				return ec.fieldContext_Agent_quarantineStatus(ctx, field)
+			case "quarantineStart":
+				return ec.fieldContext_Agent_quarantineStart(ctx, field)
+			case "quarantineEnd":
+				return ec.fieldContext_Agent_quarantineEnd(ctx, field)
+			case "quarantineApprovedBy":
+				return ec.fieldContext_Agent_quarantineApprovedBy(ctx, field)
+			case "quarantineApprovedAt":
+				return ec.fieldContext_Agent_quarantineApprovedAt(ctx, field)
+			case "quarantineActive":
+				return ec.fieldContext_Agent_quarantineActive(ctx, field)
 			case "ownerActor":
 				return ec.fieldContext_Agent_ownerActor(ctx, field)
 			case "type":
@@ -59742,6 +60075,18 @@ func (ec *executionContext) fieldContext_DroneWorkflowMutationPayload_agent(_ co
 				return ec.fieldContext_Agent_verified(ctx, field)
 			case "verifiedAt":
 				return ec.fieldContext_Agent_verifiedAt(ctx, field)
+			case "quarantineStatus":
+				return ec.fieldContext_Agent_quarantineStatus(ctx, field)
+			case "quarantineStart":
+				return ec.fieldContext_Agent_quarantineStart(ctx, field)
+			case "quarantineEnd":
+				return ec.fieldContext_Agent_quarantineEnd(ctx, field)
+			case "quarantineApprovedBy":
+				return ec.fieldContext_Agent_quarantineApprovedBy(ctx, field)
+			case "quarantineApprovedAt":
+				return ec.fieldContext_Agent_quarantineApprovedAt(ctx, field)
+			case "quarantineActive":
+				return ec.fieldContext_Agent_quarantineActive(ctx, field)
 			case "ownerActor":
 				return ec.fieldContext_Agent_ownerActor(ctx, field)
 			case "type":
@@ -95263,6 +95608,18 @@ func (ec *executionContext) fieldContext_Mutation_updateAgent(ctx context.Contex
 				return ec.fieldContext_Agent_verified(ctx, field)
 			case "verifiedAt":
 				return ec.fieldContext_Agent_verifiedAt(ctx, field)
+			case "quarantineStatus":
+				return ec.fieldContext_Agent_quarantineStatus(ctx, field)
+			case "quarantineStart":
+				return ec.fieldContext_Agent_quarantineStart(ctx, field)
+			case "quarantineEnd":
+				return ec.fieldContext_Agent_quarantineEnd(ctx, field)
+			case "quarantineApprovedBy":
+				return ec.fieldContext_Agent_quarantineApprovedBy(ctx, field)
+			case "quarantineApprovedAt":
+				return ec.fieldContext_Agent_quarantineApprovedAt(ctx, field)
+			case "quarantineActive":
+				return ec.fieldContext_Agent_quarantineActive(ctx, field)
 			case "ownerActor":
 				return ec.fieldContext_Agent_ownerActor(ctx, field)
 			case "type":
@@ -95362,6 +95719,18 @@ func (ec *executionContext) fieldContext_Mutation_deleteAgent(ctx context.Contex
 				return ec.fieldContext_Agent_verified(ctx, field)
 			case "verifiedAt":
 				return ec.fieldContext_Agent_verifiedAt(ctx, field)
+			case "quarantineStatus":
+				return ec.fieldContext_Agent_quarantineStatus(ctx, field)
+			case "quarantineStart":
+				return ec.fieldContext_Agent_quarantineStart(ctx, field)
+			case "quarantineEnd":
+				return ec.fieldContext_Agent_quarantineEnd(ctx, field)
+			case "quarantineApprovedBy":
+				return ec.fieldContext_Agent_quarantineApprovedBy(ctx, field)
+			case "quarantineApprovedAt":
+				return ec.fieldContext_Agent_quarantineApprovedAt(ctx, field)
+			case "quarantineActive":
+				return ec.fieldContext_Agent_quarantineActive(ctx, field)
 			case "ownerActor":
 				return ec.fieldContext_Agent_ownerActor(ctx, field)
 			case "type":
@@ -96505,6 +96874,18 @@ func (ec *executionContext) fieldContext_Mutation_adminVerifyAgent(ctx context.C
 				return ec.fieldContext_Agent_verified(ctx, field)
 			case "verifiedAt":
 				return ec.fieldContext_Agent_verifiedAt(ctx, field)
+			case "quarantineStatus":
+				return ec.fieldContext_Agent_quarantineStatus(ctx, field)
+			case "quarantineStart":
+				return ec.fieldContext_Agent_quarantineStart(ctx, field)
+			case "quarantineEnd":
+				return ec.fieldContext_Agent_quarantineEnd(ctx, field)
+			case "quarantineApprovedBy":
+				return ec.fieldContext_Agent_quarantineApprovedBy(ctx, field)
+			case "quarantineApprovedAt":
+				return ec.fieldContext_Agent_quarantineApprovedAt(ctx, field)
+			case "quarantineActive":
+				return ec.fieldContext_Agent_quarantineActive(ctx, field)
 			case "ownerActor":
 				return ec.fieldContext_Agent_ownerActor(ctx, field)
 			case "type":
@@ -96604,6 +96985,18 @@ func (ec *executionContext) fieldContext_Mutation_adminUnverifyAgent(ctx context
 				return ec.fieldContext_Agent_verified(ctx, field)
 			case "verifiedAt":
 				return ec.fieldContext_Agent_verifiedAt(ctx, field)
+			case "quarantineStatus":
+				return ec.fieldContext_Agent_quarantineStatus(ctx, field)
+			case "quarantineStart":
+				return ec.fieldContext_Agent_quarantineStart(ctx, field)
+			case "quarantineEnd":
+				return ec.fieldContext_Agent_quarantineEnd(ctx, field)
+			case "quarantineApprovedBy":
+				return ec.fieldContext_Agent_quarantineApprovedBy(ctx, field)
+			case "quarantineApprovedAt":
+				return ec.fieldContext_Agent_quarantineApprovedAt(ctx, field)
+			case "quarantineActive":
+				return ec.fieldContext_Agent_quarantineActive(ctx, field)
 			case "ownerActor":
 				return ec.fieldContext_Agent_ownerActor(ctx, field)
 			case "type":
@@ -96703,6 +97096,18 @@ func (ec *executionContext) fieldContext_Mutation_adminSuspendAgent(ctx context.
 				return ec.fieldContext_Agent_verified(ctx, field)
 			case "verifiedAt":
 				return ec.fieldContext_Agent_verifiedAt(ctx, field)
+			case "quarantineStatus":
+				return ec.fieldContext_Agent_quarantineStatus(ctx, field)
+			case "quarantineStart":
+				return ec.fieldContext_Agent_quarantineStart(ctx, field)
+			case "quarantineEnd":
+				return ec.fieldContext_Agent_quarantineEnd(ctx, field)
+			case "quarantineApprovedBy":
+				return ec.fieldContext_Agent_quarantineApprovedBy(ctx, field)
+			case "quarantineApprovedAt":
+				return ec.fieldContext_Agent_quarantineApprovedAt(ctx, field)
+			case "quarantineActive":
+				return ec.fieldContext_Agent_quarantineActive(ctx, field)
 			case "ownerActor":
 				return ec.fieldContext_Agent_ownerActor(ctx, field)
 			case "type":
@@ -115366,6 +115771,18 @@ func (ec *executionContext) fieldContext_Query_agent(ctx context.Context, field 
 				return ec.fieldContext_Agent_verified(ctx, field)
 			case "verifiedAt":
 				return ec.fieldContext_Agent_verifiedAt(ctx, field)
+			case "quarantineStatus":
+				return ec.fieldContext_Agent_quarantineStatus(ctx, field)
+			case "quarantineStart":
+				return ec.fieldContext_Agent_quarantineStart(ctx, field)
+			case "quarantineEnd":
+				return ec.fieldContext_Agent_quarantineEnd(ctx, field)
+			case "quarantineApprovedBy":
+				return ec.fieldContext_Agent_quarantineApprovedBy(ctx, field)
+			case "quarantineApprovedAt":
+				return ec.fieldContext_Agent_quarantineApprovedAt(ctx, field)
+			case "quarantineActive":
+				return ec.fieldContext_Agent_quarantineActive(ctx, field)
 			case "ownerActor":
 				return ec.fieldContext_Agent_ownerActor(ctx, field)
 			case "type":
@@ -115528,6 +115945,18 @@ func (ec *executionContext) fieldContext_Query_myAgents(_ context.Context, field
 				return ec.fieldContext_Agent_verified(ctx, field)
 			case "verifiedAt":
 				return ec.fieldContext_Agent_verifiedAt(ctx, field)
+			case "quarantineStatus":
+				return ec.fieldContext_Agent_quarantineStatus(ctx, field)
+			case "quarantineStart":
+				return ec.fieldContext_Agent_quarantineStart(ctx, field)
+			case "quarantineEnd":
+				return ec.fieldContext_Agent_quarantineEnd(ctx, field)
+			case "quarantineApprovedBy":
+				return ec.fieldContext_Agent_quarantineApprovedBy(ctx, field)
+			case "quarantineApprovedAt":
+				return ec.fieldContext_Agent_quarantineApprovedAt(ctx, field)
+			case "quarantineActive":
+				return ec.fieldContext_Agent_quarantineActive(ctx, field)
 			case "ownerActor":
 				return ec.fieldContext_Agent_ownerActor(ctx, field)
 			case "type":
@@ -118438,6 +118867,18 @@ func (ec *executionContext) fieldContext_RegisterAgentPayload_agent(_ context.Co
 				return ec.fieldContext_Agent_verified(ctx, field)
 			case "verifiedAt":
 				return ec.fieldContext_Agent_verifiedAt(ctx, field)
+			case "quarantineStatus":
+				return ec.fieldContext_Agent_quarantineStatus(ctx, field)
+			case "quarantineStart":
+				return ec.fieldContext_Agent_quarantineStart(ctx, field)
+			case "quarantineEnd":
+				return ec.fieldContext_Agent_quarantineEnd(ctx, field)
+			case "quarantineApprovedBy":
+				return ec.fieldContext_Agent_quarantineApprovedBy(ctx, field)
+			case "quarantineApprovedAt":
+				return ec.fieldContext_Agent_quarantineApprovedAt(ctx, field)
+			case "quarantineActive":
+				return ec.fieldContext_Agent_quarantineActive(ctx, field)
 			case "ownerActor":
 				return ec.fieldContext_Agent_ownerActor(ctx, field)
 			case "type":
@@ -150172,6 +150613,21 @@ func (ec *executionContext) _Agent(ctx context.Context, sel ast.SelectionSet, ob
 			}
 		case "verifiedAt":
 			out.Values[i] = ec._Agent_verifiedAt(ctx, field, obj)
+		case "quarantineStatus":
+			out.Values[i] = ec._Agent_quarantineStatus(ctx, field, obj)
+		case "quarantineStart":
+			out.Values[i] = ec._Agent_quarantineStart(ctx, field, obj)
+		case "quarantineEnd":
+			out.Values[i] = ec._Agent_quarantineEnd(ctx, field, obj)
+		case "quarantineApprovedBy":
+			out.Values[i] = ec._Agent_quarantineApprovedBy(ctx, field, obj)
+		case "quarantineApprovedAt":
+			out.Values[i] = ec._Agent_quarantineApprovedAt(ctx, field, obj)
+		case "quarantineActive":
+			out.Values[i] = ec._Agent_quarantineActive(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		case "ownerActor":
 			out.Values[i] = ec._Agent_ownerActor(ctx, field, obj)
 		case "type":

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -557,27 +557,33 @@ type AffectedRelationshipEdge struct {
 }
 
 type Agent struct {
-	ID                string                         `json:"id"`
-	Username          string                         `json:"username"`
-	DisplayName       string                         `json:"displayName"`
-	Bio               *string                        `json:"bio,omitempty"`
-	IdentitySemantics *AgentIdentitySemantics        `json:"identitySemantics"`
-	Workflow          *AgentWorkflowSurface          `json:"workflow,omitempty"`
-	AgentType         AgentType                      `json:"agentType"`
-	AgentVersion      string                         `json:"agentVersion"`
-	AgentCapabilities *activitypub.AgentCapabilities `json:"agentCapabilities"`
-	AgentOwner        *string                        `json:"agentOwner,omitempty"`
-	DelegatedScopes   []string                       `json:"delegatedScopes"`
-	McpAccess         *AgentMCPAccess                `json:"mcpAccess"`
-	Verified          bool                           `json:"verified"`
-	VerifiedAt        *Time                          `json:"verifiedAt,omitempty"`
-	OwnerActor        *activitypub.Actor             `json:"ownerActor,omitempty"`
-	Type              AgentType                      `json:"type"`
-	Version           string                         `json:"version"`
-	Capabilities      *activitypub.AgentCapabilities `json:"capabilities"`
-	Owner             *activitypub.Actor             `json:"owner,omitempty"`
-	CreatedAt         Time                           `json:"createdAt"`
-	ActivityCount     int                            `json:"activityCount"`
+	ID                   string                         `json:"id"`
+	Username             string                         `json:"username"`
+	DisplayName          string                         `json:"displayName"`
+	Bio                  *string                        `json:"bio,omitempty"`
+	IdentitySemantics    *AgentIdentitySemantics        `json:"identitySemantics"`
+	Workflow             *AgentWorkflowSurface          `json:"workflow,omitempty"`
+	AgentType            AgentType                      `json:"agentType"`
+	AgentVersion         string                         `json:"agentVersion"`
+	AgentCapabilities    *activitypub.AgentCapabilities `json:"agentCapabilities"`
+	AgentOwner           *string                        `json:"agentOwner,omitempty"`
+	DelegatedScopes      []string                       `json:"delegatedScopes"`
+	McpAccess            *AgentMCPAccess                `json:"mcpAccess"`
+	Verified             bool                           `json:"verified"`
+	VerifiedAt           *Time                          `json:"verifiedAt,omitempty"`
+	QuarantineStatus     *string                        `json:"quarantineStatus,omitempty"`
+	QuarantineStart      *Time                          `json:"quarantineStart,omitempty"`
+	QuarantineEnd        *Time                          `json:"quarantineEnd,omitempty"`
+	QuarantineApprovedBy *string                        `json:"quarantineApprovedBy,omitempty"`
+	QuarantineApprovedAt *Time                          `json:"quarantineApprovedAt,omitempty"`
+	QuarantineActive     bool                           `json:"quarantineActive"`
+	OwnerActor           *activitypub.Actor             `json:"ownerActor,omitempty"`
+	Type                 AgentType                      `json:"type"`
+	Version              string                         `json:"version"`
+	Capabilities         *activitypub.AgentCapabilities `json:"capabilities"`
+	Owner                *activitypub.Actor             `json:"owner,omitempty"`
+	CreatedAt            Time                           `json:"createdAt"`
+	ActivityCount        int                            `json:"activityCount"`
 }
 
 type AgentActivityConnection struct {

--- a/pkg/storage/agent_governance.go
+++ b/pkg/storage/agent_governance.go
@@ -10,7 +10,19 @@ const (
 	AgentQuarantineStatusQuarantined = "quarantined"
 	// AgentQuarantineStatusApproved marks an agent as approved to operate.
 	AgentQuarantineStatusApproved = "approved"
+	// AgentQuarantineStatusExpired marks a quarantine window that ended without an explicit early release.
+	AgentQuarantineStatusExpired = "expired"
 )
+
+// AgentQuarantineSummary is the normalized read-side quarantine contract for agent clients.
+type AgentQuarantineSummary struct {
+	Status     string
+	Start      *time.Time
+	End        *time.Time
+	ApprovedBy string
+	ApprovedAt *time.Time
+	Active     bool
+}
 
 // AgentGovernanceState stores typed governance state for an agent account.
 // It is intentionally separate from User.Metadata so core account hydration
@@ -97,6 +109,54 @@ func (s *AgentGovernanceState) QuarantineActiveAt(now time.Time) (bool, time.Tim
 		return true, end
 	}
 	return false, end
+}
+
+// QuarantineSummaryAt returns the normalized client-facing quarantine state.
+func (s *AgentGovernanceState) QuarantineSummaryAt(now time.Time) AgentQuarantineSummary {
+	if s == nil {
+		return AgentQuarantineSummary{}
+	}
+
+	active, _ := s.QuarantineActiveAt(now)
+
+	return AgentQuarantineSummary{
+		Status:     s.quarantineStatusAt(now, active),
+		Start:      cloneAgentGovernanceTime(s.QuarantineStart),
+		End:        cloneAgentGovernanceTime(s.QuarantineEnd),
+		ApprovedBy: strings.TrimSpace(s.QuarantineApprovedBy),
+		ApprovedAt: cloneAgentGovernanceTime(s.QuarantineApprovedAt),
+		Active:     active,
+	}
+}
+
+func (s *AgentGovernanceState) quarantineStatusAt(now time.Time, active bool) string {
+	if s == nil {
+		return ""
+	}
+
+	status := strings.ToLower(strings.TrimSpace(s.QuarantineStatus))
+	if active {
+		return AgentQuarantineStatusQuarantined
+	}
+	if status == AgentQuarantineStatusApproved || strings.TrimSpace(s.QuarantineApprovedBy) != "" || (s.QuarantineApprovedAt != nil && !s.QuarantineApprovedAt.IsZero()) {
+		return AgentQuarantineStatusApproved
+	}
+	if status == AgentQuarantineStatusQuarantined {
+		if s.QuarantineEnd == nil || s.QuarantineEnd.IsZero() {
+			return AgentQuarantineStatusQuarantined
+		}
+		return AgentQuarantineStatusExpired
+	}
+	if s.QuarantineEnd != nil && !s.QuarantineEnd.IsZero() {
+		if now.IsZero() {
+			now = time.Now().UTC()
+		}
+		if !now.UTC().Before(s.QuarantineEnd.UTC()) {
+			return AgentQuarantineStatusExpired
+		}
+		return AgentQuarantineStatusQuarantined
+	}
+	return status
 }
 
 func cloneAgentGovernanceTime(value *time.Time) *time.Time {

--- a/pkg/storage/agent_governance_test.go
+++ b/pkg/storage/agent_governance_test.go
@@ -112,3 +112,60 @@ func TestAgentGovernanceStateQuarantineActiveAt(t *testing.T) {
 	require.True(t, active)
 	require.Equal(t, autoFuture.UTC(), until)
 }
+
+func TestAgentGovernanceStateQuarantineSummaryAt(t *testing.T) {
+	now := time.Date(2026, 4, 4, 18, 0, 0, 0, time.UTC)
+	start := now.Add(-24 * time.Hour)
+	future := now.Add(24 * time.Hour)
+	past := now.Add(-time.Hour)
+	approvedAt := now.Add(-30 * time.Minute)
+
+	t.Run("nil state", func(t *testing.T) {
+		var nilState *AgentGovernanceState
+		summary := nilState.QuarantineSummaryAt(now)
+		require.False(t, summary.Active)
+		require.Empty(t, summary.Status)
+		require.Nil(t, summary.Start)
+		require.Nil(t, summary.End)
+		require.Nil(t, summary.ApprovedAt)
+		require.Empty(t, summary.ApprovedBy)
+	})
+
+	t.Run("active quarantine normalizes to quarantined", func(t *testing.T) {
+		summary := (&AgentGovernanceState{
+			QuarantineStatus: AgentQuarantineStatusQuarantined,
+			QuarantineStart:  &start,
+			QuarantineEnd:    &future,
+		}).QuarantineSummaryAt(now)
+		require.True(t, summary.Active)
+		require.Equal(t, AgentQuarantineStatusQuarantined, summary.Status)
+		require.Equal(t, start.UTC(), *summary.Start)
+		require.Equal(t, future.UTC(), *summary.End)
+	})
+
+	t.Run("approved quarantine exposes release details", func(t *testing.T) {
+		summary := (&AgentGovernanceState{
+			QuarantineStatus:     AgentQuarantineStatusApproved,
+			QuarantineStart:      &start,
+			QuarantineEnd:        &past,
+			QuarantineApprovedBy: "admin",
+			QuarantineApprovedAt: &approvedAt,
+		}).QuarantineSummaryAt(now)
+		require.False(t, summary.Active)
+		require.Equal(t, AgentQuarantineStatusApproved, summary.Status)
+		require.Equal(t, "admin", summary.ApprovedBy)
+		require.Equal(t, approvedAt.UTC(), *summary.ApprovedAt)
+		require.Equal(t, past.UTC(), *summary.End)
+	})
+
+	t.Run("elapsed quarantine normalizes to expired", func(t *testing.T) {
+		summary := (&AgentGovernanceState{
+			QuarantineStatus: AgentQuarantineStatusQuarantined,
+			QuarantineStart:  &start,
+			QuarantineEnd:    &past,
+		}).QuarantineSummaryAt(now)
+		require.False(t, summary.Active)
+		require.Equal(t, AgentQuarantineStatusExpired, summary.Status)
+		require.Equal(t, past.UTC(), *summary.End)
+	})
+}


### PR DESCRIPTION
## Summary
- expose normalized quarantine state on GraphQL `Agent` and REST/OpenAPI `Agent`
- derive that state from a shared governance summary helper so read contracts do not drift from stored governance semantics
- cover active, approved, and expired quarantine flows in storage, GraphQL, and REST tests

## Root Cause
Lesser already persisted quarantine governance state and already accepted `exitQuarantine` on the write path, but its read contracts did not expose that state. Simulacrum could trigger quarantine dismissal without any first-class way to render current quarantine status, end time, or early-release metadata.

## What Changed
- added shared `AgentGovernanceState.QuarantineSummaryAt(...)` normalization for `quarantined`, `approved`, and naturally `expired` quarantine windows
- added `quarantineStatus`, `quarantineStart`, `quarantineEnd`, `quarantineApprovedBy`, `quarantineApprovedAt`, and `quarantineActive` to GraphQL `Agent`
- added matching REST/OpenAPI fields to `cmd/api/models.Agent`
- updated GraphQL and REST agent mapping so `get`, `list`, `update`, and admin verify responses return the normalized quarantine state immediately
- regenerated `graph/generated.go`, `graph/model/models_gen.go`, `docs/contracts/graphql-schema.graphql`, and `docs/contracts/openapi.yaml`

## Validation
- `GOTOOLCHAIN=auto go test ./pkg/storage`
- `GOTOOLCHAIN=auto go test ./graph`
- `GOTOOLCHAIN=auto go test ./cmd/api/handlers`
- `GOTOOLCHAIN=auto go build -o lesser ./cmd/lesser`
- `GOTOOLCHAIN=auto ./lesser verify ci`

Closes #704