### PR TITLE
[codex] fix federation discovery surfaces

### DIFF
--- a/cmd/actor/main.go
+++ b/cmd/actor/main.go
@@ -25,12 +25,14 @@ import (
 
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/activitypubutil"
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/crawler"
 	"github.com/equaltoai/lesser/pkg/federation"
 	securityheaders "github.com/equaltoai/lesser/pkg/security/headers"
 	"github.com/equaltoai/lesser/pkg/security/htmlsafe"
+	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/core"
 	"github.com/equaltoai/lesser/pkg/storage/factory"
 	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
@@ -69,12 +71,17 @@ func init() {
 // Handler contains dependencies for the actor service
 type Handler struct {
 	actorRepo              actorGetter
+	accountRepo            accountGetter
 	authorizedFetchService authorizedFetchVerifier
 	instanceRepo           instanceStateGetter
 }
 
 type actorGetter interface {
 	GetActorByUsername(ctx context.Context, username string) (*activitypub.Actor, error)
+}
+
+type accountGetter interface {
+	GetAccount(ctx context.Context, username string) (*storage.Account, error)
 }
 
 type authorizedFetchVerifier interface {
@@ -102,6 +109,7 @@ func NewHandler() *Handler {
 
 	return &Handler{
 		actorRepo:              actorRepo,
+		accountRepo:            repos.Account(),
 		authorizedFetchService: authorizedFetchService,
 		instanceRepo:           repos.Instance(),
 	}
@@ -198,8 +206,9 @@ func (h *Handler) HandleActorProfile(ctx *apptheory.Context) (*apptheory.Respons
 		zap.String("request_id", requestID),
 	)
 
-	// Get actor from repository
-	actor, err := h.actorRepo.GetActorByUsername(ctx.Context(), username)
+	// Serve a hydrated local actor document so federation clients do not see
+	// sparse legacy rows with missing required ActivityPub identifiers.
+	actor, err := h.loadActorProfile(ctx.Context(), username)
 	if err != nil {
 		if common.IsNotFound(err) {
 			return actorJSONError(http.StatusNotFound, "actor not found"), nil
@@ -666,4 +675,62 @@ func actorActivityJSON(status int, value any) (*apptheory.Response, error) {
 		},
 		Body: body,
 	}, nil
+}
+
+func (h *Handler) loadActorProfile(ctx context.Context, username string) (*activitypub.Actor, error) {
+	var accountErr error
+	actorLogger := logger
+	if actorLogger == nil {
+		actorLogger = zap.NewNop()
+	}
+
+	if h.accountRepo != nil {
+		account, err := h.accountRepo.GetAccount(ctx, username)
+		if err == nil {
+			if actor := h.hydrateAccountActor(username, account); actor != nil {
+				return actor, nil
+			}
+			accountErr = errors.New("account actor data is missing")
+		} else {
+			accountErr = err
+			if !common.IsNotFound(err) {
+				actorLogger.Warn("failed to load account for actor hydration",
+					zap.String("username", username),
+					zap.Error(err),
+				)
+			}
+		}
+	}
+
+	if h.actorRepo != nil {
+		actor, err := h.actorRepo.GetActorByUsername(ctx, username)
+		if err == nil {
+			return activitypubutil.BuildLocalActor(username, h.actorBaseURL(), nil, actor), nil
+		}
+		if accountErr != nil && !common.IsNotFound(accountErr) && common.IsNotFound(err) {
+			return nil, accountErr
+		}
+		return nil, err
+	}
+
+	if accountErr != nil {
+		return nil, accountErr
+	}
+
+	return nil, common.ActorNotFoundError{Username: username}
+}
+
+func (h *Handler) hydrateAccountActor(username string, account *storage.Account) *activitypub.Actor {
+	if account == nil {
+		return nil
+	}
+
+	return activitypubutil.BuildLocalActor(username, h.actorBaseURL(), account.User, account.Actor)
+}
+
+func (h *Handler) actorBaseURL() string {
+	if cfg == nil {
+		return ""
+	}
+	return cfg.BaseURL()
 }

--- a/cmd/actor/round12_actor_test.go
+++ b/cmd/actor/round12_actor_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
+	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/factory"
 	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/require"
@@ -35,6 +36,20 @@ func (f *fakeActorRepo) GetActorByUsername(_ context.Context, username string) (
 		return nil, f.err
 	}
 	return f.actor, nil
+}
+
+type fakeAccountRepo struct {
+	account     *storage.Account
+	err         error
+	gotUsername string
+}
+
+func (f *fakeAccountRepo) GetAccount(_ context.Context, username string) (*storage.Account, error) {
+	f.gotUsername = username
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.account, nil
 }
 
 type fakeAuthorizedFetch struct {
@@ -243,6 +258,82 @@ func TestActorHandler_Round12(t *testing.T) {
 		require.NotNil(t, resp)
 		require.Equal(t, 200, resp.Status)
 		require.Equal(t, []string{"application/activity+json"}, resp.Headers["content-type"])
+		require.Equal(t, "alice", repo.gotUsername)
+	})
+
+	t.Run("json response hydrates sparse local actor from account record", func(t *testing.T) {
+		accountRepo := &fakeAccountRepo{
+			account: &storage.Account{
+				User: &storage.User{
+					Username:     "alice",
+					DisplayName:  "Alice",
+					Note:         "<p>Hello</p>",
+					Avatar:       "https://cdn.example/avatar.png",
+					Locked:       true,
+					Discoverable: true,
+				},
+				Actor: &activitypub.Actor{},
+			},
+		}
+		repo := &fakeActorRepo{actor: &activitypub.Actor{}}
+		h := &Handler{
+			instanceRepo:           &fakeInstanceRepo{state: &storageModels.InstanceState{Locked: false}},
+			accountRepo:            accountRepo,
+			actorRepo:              repo,
+			authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
+		}
+		resp, err := h.HandleActorProfile(&apptheory.Context{
+			Request: apptheory.Request{
+				Method:  http.MethodGet,
+				Path:    "/users/alice",
+				Headers: map[string][]string{"accept": {"application/activity+json"}},
+			},
+			Params: map[string]string{"username": "alice"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, 200, resp.Status)
+
+		var body activitypub.Actor
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, cfg.ActorURL("alice"), body.ID)
+		require.Equal(t, activitypub.PersonType, body.Type)
+		require.Equal(t, "alice", body.PreferredUsername)
+		require.Equal(t, "Alice", body.Name)
+		require.Equal(t, cfg.ActorURL("alice")+"/inbox", body.Inbox)
+		require.True(t, body.ManuallyApprovesFollowers)
+		require.True(t, body.Discoverable)
+		require.NotNil(t, body.Icon)
+		require.Equal(t, "https://cdn.example/avatar.png", body.Icon.URL)
+		require.Equal(t, "alice", accountRepo.gotUsername)
+		require.Empty(t, repo.gotUsername)
+	})
+
+	t.Run("json response falls back to normalized actor repo data when account hydration misses", func(t *testing.T) {
+		accountRepo := &fakeAccountRepo{err: common.ActorNotFoundError{Username: "alice"}}
+		repo := &fakeActorRepo{actor: &activitypub.Actor{}}
+		h := &Handler{
+			instanceRepo:           &fakeInstanceRepo{state: &storageModels.InstanceState{Locked: false}},
+			accountRepo:            accountRepo,
+			actorRepo:              repo,
+			authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
+		}
+		resp, err := h.HandleActorProfile(&apptheory.Context{
+			Request: apptheory.Request{
+				Method:  http.MethodGet,
+				Path:    "/users/alice",
+				Headers: map[string][]string{"accept": {"application/activity+json"}},
+			},
+			Params: map[string]string{"username": "alice"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, 200, resp.Status)
+
+		var body activitypub.Actor
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, cfg.ActorURL("alice"), body.ID)
+		require.Equal(t, activitypub.PersonType, body.Type)
 		require.Equal(t, "alice", repo.gotUsername)
 	})
 

--- a/cmd/actor/round25_actor_helpers_test.go
+++ b/cmd/actor/round25_actor_helpers_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/config"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestLoadActorProfile_Round25_HelperFallbacks(t *testing.T) {
+	origCfg := cfg
+	origLogger := logger
+	t.Cleanup(func() {
+		cfg = origCfg
+		logger = origLogger
+	})
+
+	t.Run("falls back to normalized actor repo when account load fails", func(t *testing.T) {
+		cfg = &config.Config{Domain: "example.com"}
+		logger = nil
+
+		h := &Handler{
+			accountRepo: &fakeAccountRepo{err: errors.New("account repo down")},
+			actorRepo:   &fakeActorRepo{actor: &activitypub.Actor{}},
+		}
+
+		actor, err := h.loadActorProfile(context.Background(), "alice")
+		require.NoError(t, err)
+		require.NotNil(t, actor)
+		require.Equal(t, cfg.ActorURL("alice"), actor.ID)
+		require.Equal(t, activitypub.PersonType, actor.Type)
+	})
+
+	t.Run("prefers account error when fallback only reports not found", func(t *testing.T) {
+		cfg = &config.Config{Domain: "example.com"}
+		logger = zap.NewNop()
+		wantErr := errors.New("account repo down")
+
+		h := &Handler{
+			accountRepo: &fakeAccountRepo{err: wantErr},
+			actorRepo:   &fakeActorRepo{err: common.ActorNotFoundError{Username: "alice"}},
+		}
+
+		actor, err := h.loadActorProfile(context.Background(), "alice")
+		require.Nil(t, actor)
+		require.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("returns actor not found when no repositories are available", func(t *testing.T) {
+		cfg = &config.Config{Domain: "example.com"}
+		logger = zap.NewNop()
+
+		actor, err := (&Handler{}).loadActorProfile(context.Background(), "alice")
+		require.Nil(t, actor)
+		require.Error(t, err)
+		require.True(t, common.IsNotFound(err))
+	})
+
+	t.Run("helper methods stay safe with nil inputs", func(t *testing.T) {
+		cfg = nil
+		logger = zap.NewNop()
+
+		h := &Handler{}
+		require.Nil(t, h.hydrateAccountActor("alice", nil))
+		require.Equal(t, "", h.actorBaseURL())
+	})
+}

--- a/cmd/webfinger/main.go
+++ b/cmd/webfinger/main.go
@@ -20,9 +20,12 @@ import (
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/crawler"
 	"github.com/equaltoai/lesser/pkg/storage/core"
+	"github.com/equaltoai/lesser/pkg/storage/factory"
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
 	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/equaltoai/lesser/pkg/storage/theorydb"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+	dynamormCore "github.com/theory-cloud/tabletheory/pkg/core"
 	"go.uber.org/zap"
 )
 
@@ -259,11 +262,15 @@ var (
 	logger    *zap.Logger
 	repos     core.RepositoryStorage
 
-	mustInitializeLambdaFn   = common.MustInitializeLambda
-	initializeWithDefaultsFn = (*common.LambdaContext).InitializeWithDefaults
-	lambdaStartFn            = lambda.Start
-	rsaGenerateKeyFn         = rsa.GenerateKey
-	timeNowFn                = time.Now
+	mustInitializeLambdaFn     = common.MustInitializeLambda
+	initializeWithDefaultsFn   = (*common.LambdaContext).InitializeWithDefaults
+	lambdaStartFn              = lambda.Start
+	rsaGenerateKeyFn           = rsa.GenerateKey
+	timeNowFn                  = time.Now
+	newLambdaOptimizedClientFn = theorydb.NewLambdaOptimizedClient
+	newRepositoryFactoryFn     = func(db dynamormCore.DB, tableName string, logger *zap.Logger) (core.RepositoryStorage, error) {
+		return factory.NewRepositoryFactory(db, tableName, logger)
+	}
 )
 
 func init() {
@@ -291,12 +298,49 @@ func initializeWebFinger() {
 	// Automatic dependency injection
 	cfg = lambdaCtx.Config
 	logger = lambdaCtx.Logger
-	repos = lambdaCtx.Repos.(core.RepositoryStorage)
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 
 	// Initialize with default options for API Lambda type
 	if err := initializeWithDefaultsFn(lambdaCtx); err != nil {
 		logger.Warn("failed to initialize with defaults, some features may be limited", zap.Error(err))
 	}
+
+	storage, ok := lambdaCtx.Repos.(core.RepositoryStorage)
+	if !ok || storage == nil {
+		logger.Warn("lambda context repository missing after initialization, attempting manual storage initialization")
+		initializeManualStorage()
+		storage, ok = lambdaCtx.Repos.(core.RepositoryStorage)
+	}
+	if !ok || storage == nil {
+		logger.Fatal("lambda context repository is not core.RepositoryStorage")
+	}
+	repos = storage
+}
+
+func initializeManualStorage() {
+	if lambdaCtx == nil {
+		logger.Fatal("manual storage initialization requires lambda context")
+	}
+
+	tableName := strings.TrimSpace(cfg.DynamoTableName)
+	if tableName == "" {
+		logger.Fatal("DYNAMODB_TABLE environment variable is required for webfinger lambda")
+	}
+
+	db, err := newLambdaOptimizedClientFn(context.Background(), cfg.Region)
+	if err != nil {
+		logger.Fatal("failed to initialize DynamORM", zap.Error(err))
+	}
+
+	storage, err := newRepositoryFactoryFn(db, tableName, logger)
+	if err != nil {
+		logger.Fatal("failed to initialize repository factory", zap.Error(err))
+	}
+
+	lambdaCtx.DynamoDB = db
+	lambdaCtx.Repos = storage
 }
 
 func main() {

--- a/cmd/webfinger/round12_init_test.go
+++ b/cmd/webfinger/round12_init_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/config"
+	storageCore "github.com/equaltoai/lesser/pkg/storage/core"
+	"github.com/equaltoai/lesser/pkg/storage/factory"
+	dynamormCore "github.com/theory-cloud/tabletheory/pkg/core"
+	"go.uber.org/zap"
+)
+
+type noopCoreDB struct{}
+
+func (noopCoreDB) Model(any) dynamormCore.Query { return nil }
+
+func (noopCoreDB) Transaction(fn func(tx *dynamormCore.Tx) error) error {
+	if fn == nil {
+		return nil
+	}
+	return fn(nil)
+}
+
+func (noopCoreDB) Migrate() error { return nil }
+
+func (noopCoreDB) AutoMigrate(...any) error { return nil }
+
+func (noopCoreDB) Close() error { return nil }
+
+func (noopCoreDB) WithContext(context.Context) dynamormCore.DB { return noopCoreDB{} }
+
+func TestInitializeWebFinger_ManualStorageInitialization_Round12(t *testing.T) {
+	origMustInitializeLambdaFn := mustInitializeLambdaFn
+	origInitializeWithDefaultsFn := initializeWithDefaultsFn
+	origNewLambdaOptimizedClientFn := newLambdaOptimizedClientFn
+	origNewRepositoryFactoryFn := newRepositoryFactoryFn
+
+	origLambdaCtx := lambdaCtx
+	origCfg := cfg
+	origLogger := logger
+	origRepos := repos
+
+	t.Cleanup(func() {
+		mustInitializeLambdaFn = origMustInitializeLambdaFn
+		initializeWithDefaultsFn = origInitializeWithDefaultsFn
+		newLambdaOptimizedClientFn = origNewLambdaOptimizedClientFn
+		newRepositoryFactoryFn = origNewRepositoryFactoryFn
+
+		lambdaCtx = origLambdaCtx
+		cfg = origCfg
+		logger = origLogger
+		repos = origRepos
+	})
+
+	mustInitializeLambdaFn = func(common.LambdaConfig) *common.LambdaContext {
+		return &common.LambdaContext{
+			Config:   &config.Config{Region: "us-east-1", DynamoTableName: "test-table"},
+			Logger:   zap.NewNop(),
+			Repos:    nil,
+			DynamoDB: nil,
+		}
+	}
+
+	initializeWithDefaultsFn = func(*common.LambdaContext) error {
+		return errors.New("defaults not available in unit test")
+	}
+
+	newLambdaOptimizedClientFn = func(context.Context, string) (dynamormCore.DB, error) {
+		return noopCoreDB{}, nil
+	}
+
+	newRepositoryFactoryFn = func(db dynamormCore.DB, tableName string, logger *zap.Logger) (storageCore.RepositoryStorage, error) {
+		return factory.NewRepositoryFactory(db, tableName, logger)
+	}
+
+	initializeWebFinger()
+
+	if lambdaCtx == nil {
+		t.Fatalf("expected lambdaCtx to be set")
+	}
+	if lambdaCtx.DynamoDB == nil {
+		t.Fatalf("expected lambdaCtx.DynamoDB to be set")
+	}
+	if lambdaCtx.Repos == nil {
+		t.Fatalf("expected lambdaCtx.Repos to be set")
+	}
+	if repos == nil {
+		t.Fatalf("expected repos to be set")
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes the two federation discovery failures tracked in #706:

- `/.well-known/webfinger` could fail before request handling on cold start because `cmd/webfinger` dereferenced `lambdaCtx.Repos` before default initialization had a chance to wire storage.
- `/users/:username` ActivityPub responses were served from the raw stored actor row, which allowed sparse legacy actor records to leak empty `id` / `type` and other missing local identifiers.

## What Changed

- updated `cmd/webfinger` to use the same resilient storage bootstrap pattern as the other public federation lambdas, including manual repository initialization when default wiring is unavailable
- updated `cmd/actor` to load a hydrated local actor view from the account record first and fall back to normalized actor-repo data when needed
- added regression coverage for both the webfinger cold-start path and the actor hydration / fallback helpers

## Why

Federation discovery was failing before outbound delivery:

- WebFinger failures surfaced as `503` because the lambda could die during initialization instead of reaching an application error path
- actor lookups could return malformed ActivityPub documents even when the endpoint itself was reachable

With these fixes in place, both discovery surfaces are robust against the failure modes described in the issue and return normalized local actor data.

## Validation

- `GOTOOLCHAIN=auto go test ./cmd/actor ./cmd/webfinger`
- `GOTOOLCHAIN=auto go build -o lesser ./cmd/lesser`
- `GOTOOLCHAIN=auto ./lesser verify ci`

Closes #706