### PR TITLE
[codex] federation cache/search followup

### DIFF
--- a/cmd/api/handlers/helpers_round18_more_coverage_test.go
+++ b/cmd/api/handlers/helpers_round18_more_coverage_test.go
@@ -25,6 +25,8 @@ func TestHelpersRound18_ResolveAccountID_CacheHits(t *testing.T) {
 		},
 		PreferredUsername: "alice",
 		Name:              "Alice",
+		Inbox:             "https://remote.example/users/alice/inbox",
+		Outbox:            "https://remote.example/users/alice/outbox",
 	}
 
 	cached := storagemodels.RemoteActor{

--- a/cmd/api/handlers/scheduled_search_round11_test.go
+++ b/cmd/api/handlers/scheduled_search_round11_test.go
@@ -177,6 +177,8 @@ func TestSearchHandlers_Round11(t *testing.T) {
 	require.NoError(t, err)
 	requireStatus(t, http.StatusOK)(handler.HandleStatusSearchLift(statusCtx))
 
+	require.True(t, isValidHandle("user@example.com"))
 	require.True(t, isValidHandle("@user@example.com"))
+	require.False(t, isValidHandle("@user"))
 	require.False(t, isValidHandle("plain"))
 }

--- a/cmd/api/handlers/search.go
+++ b/cmd/api/handlers/search.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/equaltoai/lesser/cmd/api/models"
@@ -519,20 +520,8 @@ func (h *Handler) finalizeStatusSearchResponse(ctx *apptheory.Context, resp *app
 		zap.Bool("local_only", params.localOnly))
 }
 
-// isValidHandle checks if a query looks like a federated handle (@user@domain.com)
+// isValidHandle checks if a query looks like a remote-resolvable handle.
 func isValidHandle(query string) bool {
-	// Simple check for @user@domain pattern
-	if len(query) < 5 {
-		return false
-	}
-
-	atCount := 0
-	for _, ch := range query {
-		if ch == '@' {
-			atCount++
-		}
-	}
-
-	// Should have exactly 2 @ symbols for federated handle
-	return atCount == 2 || (atCount == 1 && query[0] == '@')
+	query = strings.TrimPrefix(query, "@")
+	return strings.Count(query, "@") == 1
 }

--- a/cmd/api/handlers/search_round12_coverage_test.go
+++ b/cmd/api/handlers/search_round12_coverage_test.go
@@ -70,7 +70,7 @@ func TestSearch_Round12Coverage(t *testing.T) {
 				return nil
 			}
 			actors := []*activitypub.Actor{}
-			handler.addRemoteSearchResults(context.Background(), &actors, "@user@example.com", 10)
+			handler.addRemoteSearchResults(context.Background(), &actors, "user@example.com", 10)
 			require.Empty(t, actors)
 		})
 
@@ -79,7 +79,7 @@ func TestSearch_Round12Coverage(t *testing.T) {
 				return &round12RemoteSearchStub{err: errors.New("boom")}
 			}
 			actors := []*activitypub.Actor{}
-			handler.addRemoteSearchResults(context.Background(), &actors, "@user@example.com", 10)
+			handler.addRemoteSearchResults(context.Background(), &actors, "user@example.com", 10)
 			require.Empty(t, actors)
 		})
 
@@ -93,12 +93,13 @@ func TestSearch_Round12Coverage(t *testing.T) {
 				}
 			}
 			actors := []*activitypub.Actor{}
-			handler.addRemoteSearchResults(context.Background(), &actors, "@user@example.com", 10)
+			handler.addRemoteSearchResults(context.Background(), &actors, "user@example.com", 10)
 			require.Len(t, actors, 1)
 		})
 
+		require.True(t, isValidHandle("user@example.com"))
 		require.True(t, isValidHandle("@user@example.com"))
-		require.True(t, isValidHandle("@user"))
+		require.False(t, isValidHandle("@user"))
 		require.False(t, isValidHandle("nope"))
 	})
 

--- a/pkg/activitypub/validation.go
+++ b/pkg/activitypub/validation.go
@@ -98,6 +98,30 @@ func ValidateActor(actor *Actor) error {
 	return nil
 }
 
+// ValidateResolvedActor validates the minimum actor fields Lesser requires
+// after remote resolution or cache lookup.
+func ValidateResolvedActor(actor *Actor) error {
+	if actor == nil {
+		return common.ValidationError{Field: "actor", Message: "cannot be nil"}
+	}
+
+	if err := common.ValidateRequiredParam("id", actor.ID); err != nil {
+		return common.ValidationError{Field: "id", Message: "required field missing"}
+	}
+	if err := ValidateURL(actor.ID, "id"); err != nil {
+		return err
+	}
+
+	if err := common.ValidateRequiredParam("inbox", actor.Inbox); err != nil {
+		return common.ValidationError{Field: "inbox", Message: "required field missing"}
+	}
+	if err := ValidateURL(actor.Inbox, "inbox"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // ValidateActivity validates an Activity object
 func ValidateActivity(activity *Activity) error {
 	if activity == nil {

--- a/pkg/activitypub/validation_test.go
+++ b/pkg/activitypub/validation_test.go
@@ -257,6 +257,44 @@ func TestValidateActor_OptionalFields(t *testing.T) {
 	})
 }
 
+func TestValidateResolvedActor(t *testing.T) {
+	baseActor := &Actor{
+		BaseObject: BaseObject{
+			ID:   "https://example.com/users/alice",
+			Type: PersonType,
+		},
+		PreferredUsername: "alice",
+		Inbox:             "https://example.com/users/alice/inbox",
+	}
+
+	t.Run("valid minimal actor", func(t *testing.T) {
+		err := ValidateResolvedActor(baseActor)
+		assert.NoError(t, err)
+	})
+
+	t.Run("nil actor", func(t *testing.T) {
+		err := ValidateResolvedActor(nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be nil")
+	})
+
+	t.Run("missing id", func(t *testing.T) {
+		actor := *baseActor
+		actor.ID = ""
+		err := ValidateResolvedActor(&actor)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "id")
+	})
+
+	t.Run("invalid inbox", func(t *testing.T) {
+		actor := *baseActor
+		actor.Inbox = "not-a-url"
+		err := ValidateResolvedActor(&actor)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "inbox")
+	})
+}
+
 func TestValidateActivity(t *testing.T) {
 	baseActivity := &Activity{
 		BaseObject: BaseObject{

--- a/pkg/federation/dynamorm_storage.go
+++ b/pkg/federation/dynamorm_storage.go
@@ -104,6 +104,14 @@ func (s *DynamORMFederationStorage) GetCachedRemoteActor(ctx context.Context, ac
 		return nil, storage.ErrNotFound
 	}
 
+	if err := activitypub.ValidateResolvedActor(remoteActor.Actor); err != nil {
+		zap.L().Warn("ignoring invalid cached remote actor",
+			zap.String("handle", handle),
+			zap.String("actorID", actorID),
+			zap.Error(err))
+		return nil, storage.ErrNotFound
+	}
+
 	return remoteActor.Actor, nil
 }
 

--- a/pkg/federation/dynamorm_storage_test.go
+++ b/pkg/federation/dynamorm_storage_test.go
@@ -174,7 +174,10 @@ func TestDynamORMFederationStorage_GetCachedRemoteActor(t *testing.T) {
 	t.Run("expired_cache_returns_storage_not_found", func(t *testing.T) {
 		testDB := dynamormtesting.NewTestDB()
 		stored := &models.RemoteActor{
-			Actor:     &activitypub.Actor{BaseObject: activitypub.BaseObject{ID: "https://remote.example/users/bob"}},
+			Actor: &activitypub.Actor{
+				BaseObject: activitypub.BaseObject{ID: "https://remote.example/users/bob"},
+				Inbox:      "https://remote.example/users/bob/inbox",
+			},
 			Handle:    "bob@remote.example",
 			ExpiresAt: time.Now().Add(-time.Second),
 		}
@@ -193,9 +196,36 @@ func TestDynamORMFederationStorage_GetCachedRemoteActor(t *testing.T) {
 		testDB.AssertExpectations(t)
 	})
 
+	t.Run("invalid_cached_actor_returns_storage_not_found", func(t *testing.T) {
+		testDB := dynamormtesting.NewTestDB()
+		stored := &models.RemoteActor{
+			Actor: &activitypub.Actor{
+				BaseObject: activitypub.BaseObject{ID: "https://remote.example/users/bob"},
+			},
+			Handle:    "bob@remote.example",
+			ExpiresAt: time.Now().Add(5 * time.Minute),
+		}
+
+		testDB.ExpectWhere("PK", "=", "REMOTE_ACTOR#bob@remote.example").
+			ExpectWhere("SK", "=", "PROFILE")
+		testDB.MockQuery.On("First", mock.Anything).Run(func(args mock.Arguments) {
+			dest := args.Get(0).(*models.RemoteActor)
+			*dest = *stored
+		}).Return(nil).Once()
+
+		svc := &DynamORMFederationStorage{db: testDB.MockDB}
+		actor, err := svc.GetCachedRemoteActor(ctx, "https://remote.example/users/bob")
+		require.ErrorIs(t, err, storage.ErrNotFound)
+		assert.Nil(t, actor)
+		testDB.AssertExpectations(t)
+	})
+
 	t.Run("success_returns_cached_actor", func(t *testing.T) {
 		testDB := dynamormtesting.NewTestDB()
-		expected := &activitypub.Actor{BaseObject: activitypub.BaseObject{ID: "https://remote.example/users/bob"}}
+		expected := &activitypub.Actor{
+			BaseObject: activitypub.BaseObject{ID: "https://remote.example/users/bob"},
+			Inbox:      "https://remote.example/users/bob/inbox",
+		}
 		stored := &models.RemoteActor{
 			Actor:     expected,
 			Handle:    "bob@remote.example",

--- a/pkg/federation/remote_search.go
+++ b/pkg/federation/remote_search.go
@@ -530,7 +530,32 @@ func (s *RemoteSearchService) getCachedRemoteActor(ctx context.Context, handle s
 	if s.actorRepo == nil {
 		return nil, common.ActorNotFoundError{Username: handle}
 	}
-	return s.actorRepo.GetCachedRemoteActor(ctx, handle)
+
+	actor, err := s.actorRepo.GetCachedRemoteActor(ctx, handle)
+	if err != nil {
+		return nil, err
+	}
+	if actor == nil {
+		return nil, common.ActorNotFoundError{Username: cachedRemoteActorUsername(handle)}
+	}
+	if err := activitypub.ValidateResolvedActor(actor); err != nil {
+		s.logger.Warn("ignoring invalid cached remote actor",
+			zap.String("handle", handle),
+			zap.String("actor_id", strings.TrimSpace(actor.ID)),
+			zap.Error(err))
+		return nil, common.ActorNotFoundError{Username: cachedRemoteActorUsername(handle)}
+	}
+	if !cachedRemoteActorMatchesHandle(actor, handle) {
+		identity := DescribeActorIdentity(actor, "")
+		s.logger.Warn("ignoring cached remote actor identity mismatch",
+			zap.String("handle", handle),
+			zap.String("actor_id", strings.TrimSpace(actor.ID)),
+			zap.String("cached_username", identity.Username),
+			zap.String("cached_domain", identity.Domain))
+		return nil, common.ActorNotFoundError{Username: cachedRemoteActorUsername(handle)}
+	}
+
+	return actor, nil
 }
 
 func (s *RemoteSearchService) cacheRemoteActor(ctx context.Context, handle string, actor *activitypub.Actor, ttl time.Duration) error {
@@ -669,6 +694,24 @@ func normalizeActorDomain(value string) string {
 		value = value[:idx]
 	}
 	return strings.TrimSpace(value)
+}
+
+func cachedRemoteActorMatchesHandle(actor *activitypub.Actor, handle string) bool {
+	username, domain, err := parseHandle(handle)
+	if err != nil || domain == "" {
+		return false
+	}
+
+	identity := DescribeActorIdentity(actor, "")
+	return strings.EqualFold(exactHandle(identity.Username, identity.Domain), exactHandle(username, domain))
+}
+
+func cachedRemoteActorUsername(handle string) string {
+	username, _, err := parseLooseHandle(handle)
+	if err == nil && username != "" {
+		return username
+	}
+	return strings.TrimSpace(strings.TrimPrefix(handle, "@"))
 }
 
 // searchKnownInstances performs fuzzy search on known remote instances

--- a/pkg/federation/remote_search_test.go
+++ b/pkg/federation/remote_search_test.go
@@ -133,11 +133,20 @@ func TestRemoteSearchService_ResolveActor_LocalAndCached(t *testing.T) {
 		Inbox:             "https://local.example/users/alice/inbox",
 		Outbox:            "https://local.example/users/alice/outbox",
 	}
+	remoteActor := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://remote.example/users/bob",
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: "bob",
+		Inbox:             "https://remote.example/users/bob/inbox",
+		Outbox:            "https://remote.example/users/bob/outbox",
+	}
 
 	svc := &RemoteSearchService{
 		actorRepo: &fakeRemoteSearchActorRepo{
 			localByUsername: map[string]*activitypub.Actor{"alice": localActor},
-			cachedByHandle:  map[string]*activitypub.Actor{"bob@remote.example": localActor},
+			cachedByHandle:  map[string]*activitypub.Actor{"bob@remote.example": remoteActor},
 		},
 		userRepo:   &fakeRemoteSearchUserRepo{},
 		httpClient: &fakeHTTPMux{do: func(_ *http.Request) (*http.Response, error) { return nil, errors.New("unexpected") }},
@@ -234,7 +243,15 @@ func TestRemoteSearchService_ResolveActor_WebFingerErrors(t *testing.T) {
 func TestRemoteSearchService_ResolveActorURL_CacheAndFetch(t *testing.T) {
 	actorRepo := &fakeRemoteSearchActorRepo{
 		cachedByHandle: map[string]*activitypub.Actor{
-			"bob@remote.example": {BaseObject: activitypub.BaseObject{ID: "cached"}},
+			"bob@remote.example": {
+				BaseObject: activitypub.BaseObject{
+					ID:   "https://remote.example/users/bob",
+					Type: activitypub.PersonType,
+				},
+				PreferredUsername: "bob",
+				Inbox:             "https://remote.example/users/bob/inbox",
+				Outbox:            "https://remote.example/users/bob/outbox",
+			},
 		},
 	}
 	userRepo := &fakeRemoteSearchUserRepo{}
@@ -262,7 +279,7 @@ func TestRemoteSearchService_ResolveActorURL_CacheAndFetch(t *testing.T) {
 		res, err := svc.ResolveActorURL(context.Background(), "https://remote.example/users/bob")
 		require.NoError(t, err)
 		require.NotNil(t, res)
-		assert.Equal(t, "cached", res.Actor.ID)
+		assert.Equal(t, "https://remote.example/users/bob", res.Actor.ID)
 	})
 
 	t.Run("fetch_and_cache_by_actor_id_fallback", func(t *testing.T) {
@@ -276,6 +293,103 @@ func TestRemoteSearchService_ResolveActorURL_CacheAndFetch(t *testing.T) {
 		userRepo.mu.Unlock()
 		assert.True(t, cached)
 	})
+}
+
+func TestRemoteSearchService_ResolveActor_IgnoresInvalidCachedActor(t *testing.T) {
+	actorRepo := &fakeRemoteSearchActorRepo{
+		cachedByHandle: map[string]*activitypub.Actor{
+			"bob@remote.example": {
+				BaseObject: activitypub.BaseObject{
+					ID:   "https://remote.example/users/bob",
+					Type: activitypub.PersonType,
+				},
+				PreferredUsername: "bob",
+			},
+		},
+	}
+	userRepo := &fakeRemoteSearchUserRepo{}
+
+	const actorURL = "https://remote.example/users/bob"
+
+	httpClient := &fakeHTTPMux{do: func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case "/.well-known/webfinger":
+			return jsonResponse(http.StatusOK, activitypub.WebFingerResource{
+				Links: []activitypub.WebFingerLink{
+					{Rel: "self", Type: "application/activity+json", Href: actorURL},
+				},
+			}), nil
+		case "/users/bob":
+			return jsonResponse(http.StatusOK, &activitypub.Actor{
+				BaseObject: activitypub.BaseObject{
+					ID:   actorURL,
+					Type: activitypub.PersonType,
+				},
+				PreferredUsername: "bob",
+				Inbox:             actorURL + "/inbox",
+				Outbox:            actorURL + "/outbox",
+			}), nil
+		default:
+			return nil, errors.New("unexpected url: " + req.URL.String())
+		}
+	}}
+
+	svc := &RemoteSearchService{
+		actorRepo:  actorRepo,
+		userRepo:   userRepo,
+		httpClient: httpClient,
+		logger:     common.Logger(),
+	}
+
+	res, err := svc.ResolveActor(context.Background(), "bob@remote.example")
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, actorURL, res.Actor.ID)
+	assert.Equal(t, actorURL+"/inbox", res.Actor.Inbox)
+}
+
+func TestRemoteSearchService_ResolveActorURL_IgnoresCachedActorIdentityMismatch(t *testing.T) {
+	actorRepo := &fakeRemoteSearchActorRepo{
+		cachedByHandle: map[string]*activitypub.Actor{
+			"bob@remote.example": {
+				BaseObject: activitypub.BaseObject{
+					ID:   "https://remote.example/users/alice",
+					Type: activitypub.PersonType,
+				},
+				PreferredUsername: "alice",
+				Inbox:             "https://remote.example/users/alice/inbox",
+				Outbox:            "https://remote.example/users/alice/outbox",
+			},
+		},
+	}
+
+	const actorURL = "https://remote.example/users/bob"
+
+	svc := &RemoteSearchService{
+		actorRepo: actorRepo,
+		userRepo:  &fakeRemoteSearchUserRepo{},
+		httpClient: &fakeHTTPMux{do: func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path == "/users/bob" {
+				return jsonResponse(http.StatusOK, &activitypub.Actor{
+					BaseObject: activitypub.BaseObject{
+						ID:   actorURL,
+						Type: activitypub.PersonType,
+					},
+					PreferredUsername: "bob",
+					Inbox:             actorURL + "/inbox",
+					Outbox:            actorURL + "/outbox",
+				}), nil
+			}
+			return nil, errors.New("unexpected: " + req.URL.String())
+		}},
+		logger: common.Logger(),
+	}
+
+	res, err := svc.ResolveActorURL(context.Background(), actorURL)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, actorURL, res.Actor.ID)
+	assert.Equal(t, "bob", res.Actor.PreferredUsername)
 }
 
 func TestRemoteSearchService_ResolveExactActor_LocalAndRemote(t *testing.T) {

--- a/pkg/storage/repositories/actor_repository.go
+++ b/pkg/storage/repositories/actor_repository.go
@@ -1400,13 +1400,31 @@ func (r *ActorRepository) GetCachedRemoteActor(ctx context.Context, handle strin
 	if time.Now().After(remoteActor.ExpiresAt) {
 		log.Debug("cached remote actor expired",
 			zap.Time("expired_at", remoteActor.ExpiresAt))
-		// Extract username from handle for error (consistent with legacy)
-		username := strings.Split(handle, "@")[0]
-		return nil, common.ActorNotFoundError{Username: username}
+		return nil, common.ActorNotFoundError{Username: cachedRemoteActorLookupUsername(handle)}
+	}
+
+	if err := activitypub.ValidateResolvedActor(remoteActor.Actor); err != nil {
+		log.Warn("cached remote actor invalid",
+			zap.Error(err))
+		return nil, common.ActorNotFoundError{Username: cachedRemoteActorLookupUsername(handle)}
 	}
 
 	log.Debug("retrieved cached remote actor",
 		zap.String("actor_id", remoteActor.Actor.ID))
 
 	return remoteActor.Actor, nil
+}
+
+func cachedRemoteActorLookupUsername(handle string) string {
+	handle = strings.TrimSpace(strings.TrimPrefix(handle, "@"))
+	if handle == "" {
+		return ""
+	}
+
+	parts := strings.Split(handle, "@")
+	if len(parts) == 0 {
+		return handle
+	}
+
+	return strings.TrimSpace(parts[0])
 }

--- a/pkg/storage/repositories/actor_repository_additional_coverage_test.go
+++ b/pkg/storage/repositories/actor_repository_additional_coverage_test.go
@@ -311,14 +311,25 @@ func TestActorRepository_migration_and_remote_actor_cache(t *testing.T) {
 	_, err = repo.GetCachedRemoteActor(ctx, "alice@remote")
 	assert.Error(t, err)
 
-	// GetCachedRemoteActor not found and success
+	// GetCachedRemoteActor not found, invalid payload, and success
 	mockQuery.On("First", mock.Anything).Return(dynamormerrors.ErrItemNotFound).Once()
 	_, err = repo.GetCachedRemoteActor(ctx, "bob@remote")
 	assert.Error(t, err)
 
 	mockQuery.On("First", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		m := args.Get(0).(*models.RemoteActor)
-		m.Actor = &activitypub.Actor{BaseObject: activitypub.BaseObject{ID: "https://remote/users/carla"}}
+		m.Actor = nil
+		m.ExpiresAt = time.Now().Add(time.Minute)
+	}).Once()
+	_, err = repo.GetCachedRemoteActor(ctx, "bad@remote")
+	assert.Error(t, err)
+
+	mockQuery.On("First", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		m := args.Get(0).(*models.RemoteActor)
+		m.Actor = &activitypub.Actor{
+			BaseObject: activitypub.BaseObject{ID: "https://remote/users/carla"},
+			Inbox:      "https://remote/users/carla/inbox",
+		}
 		m.ExpiresAt = time.Now().Add(time.Minute)
 	}).Once()
 	actor, err := repo.GetCachedRemoteActor(ctx, "carla@remote")


### PR DESCRIPTION
## Summary
This PR lands the post-release federation follow-up for the two residual identity/search issues we found after the cross-instance federation release.

## What Changed
- validate cached remote actors before reusing them so malformed cache rows fall back to a cache miss instead of bypassing exact remote identity resolution
- reject cached remote actors whose derived identity no longer matches the requested `user@domain` handle
- harden both repository-backed and federation storage cache readers around the same minimal resolved-actor contract
- allow REST account search remote resolution for plain `user@domain` queries so it matches the newer exact-identity behavior already used in GraphQL and follow flows
- update regression coverage for malformed cached actors, handle mismatches, and REST remote-search parsing

## Why
We found two residual issues after release:
1. Existing malformed cached remote-actor rows could still be replayed on cache hit.
2. `/api/v1/accounts/search?q=user@domain&resolve=true` still skipped remote resolution because the REST handler only treated `@user@domain` as remote-resolvable.

## Impact
- stale or malformed cached remote actors now safely degrade to a miss and re-resolve instead of being trusted indefinitely
- REST and exact identity flows now agree on the accepted remote handle contract
- the follow-up is covered by targeted regression tests

## Root Cause
The earlier exact-identity seam tightened resolution for fresh remote lookups, but cache-hit paths were still returning stored actors without structural validation, and the REST handler kept an older local handle parser that had not been aligned with federation resolution rules.

## Validation
- `env GOTOOLCHAIN=auto go test ./pkg/activitypub ./pkg/federation ./pkg/storage/repositories ./cmd/api/handlers`
