### PR TITLE
[codex] complete local follow reconciliation on delivered accept and reject

### DIFF
--- a/cmd/inbox/internal/routing/follow_response_round13_reconciliation_test.go
+++ b/cmd/inbox/internal/routing/follow_response_round13_reconciliation_test.go
@@ -2,6 +2,7 @@ package routing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -10,6 +11,15 @@ import (
 	"github.com/equaltoai/lesser/pkg/testing/inmemory"
 	"github.com/stretchr/testify/require"
 )
+
+type rejectFollowErrorRepo struct {
+	*inmemory.RelationshipRepository
+	err error
+}
+
+func (r *rejectFollowErrorRepo) RejectFollowRequest(context.Context, string, string) error {
+	return r.err
+}
 
 func newFollowResponseReconciliationEnv(t *testing.T) *inboxTestEnv {
 	t.Helper()
@@ -158,4 +168,80 @@ func TestInboxHandler_ProcessFollowResponses_DoNotMutateOnMismatchedObjectID(t *
 			require.Equal(t, models.RelationshipPending, relationshipState(t, env))
 		})
 	}
+}
+
+func TestInboxHandler_RejectFollowRelationship_GuardsAndErrors(t *testing.T) {
+	env := newFollowResponseReconciliationEnv(t)
+
+	require.NoError(t, env.handler.rejectFollowRelationship(context.Background(), "", "bob@remote.social"))
+	require.NoError(t, env.handler.rejectFollowRelationship(context.Background(), "alice", ""))
+
+	rejectErr := errors.New("reject boom")
+	env.handler.relationshipRepository = &rejectFollowErrorRepo{
+		RelationshipRepository: inmemory.NewRelationshipRepository(),
+		err:                    rejectErr,
+	}
+	require.ErrorIs(t, env.handler.rejectFollowRelationship(context.Background(), "alice", "bob@remote.social"), rejectErr)
+}
+
+func TestInboxHandler_ReconcileFollowResponseFromRelationship_EarlyExitBranches(t *testing.T) {
+	env := newFollowResponseReconciliationEnv(t)
+	objectID := env.cfg.BaseURL() + "/activities/follow-fallback"
+
+	reconciled, err := env.handler.reconcileFollowResponseFromRelationship(context.Background(), activitypub.AcceptType, objectID, nil, "bob@remote.social")
+	require.NoError(t, err)
+	require.False(t, reconciled)
+
+	reconciled, err = env.handler.reconcileFollowResponseFromRelationship(context.Background(), activitypub.AcceptType, "https://remote.social/activities/follow-fallback", env.local, "bob@remote.social")
+	require.NoError(t, err)
+	require.False(t, reconciled)
+
+	anonymousLocal := &activitypub.Actor{}
+	reconciled, err = env.handler.reconcileFollowResponseFromRelationship(context.Background(), activitypub.AcceptType, objectID, anonymousLocal, "bob@remote.social")
+	require.NoError(t, err)
+	require.False(t, reconciled)
+}
+
+func TestInboxHandler_LocalActivityIDSuffix_InvalidShapes(t *testing.T) {
+	env := newFollowResponseReconciliationEnv(t)
+
+	suffix, ok := env.handler.localActivityIDSuffix("")
+	require.False(t, ok)
+	require.Empty(t, suffix)
+
+	suffix, ok = env.handler.localActivityIDSuffix("https://remote.social/activities/follow-1")
+	require.False(t, ok)
+	require.Empty(t, suffix)
+
+	suffix, ok = env.handler.localActivityIDSuffix(env.cfg.BaseURL() + "/activities/follow/nested")
+	require.False(t, ok)
+	require.Empty(t, suffix)
+}
+
+func TestInboxHandler_ProcessRejectFollow_PropagatesRelationshipError(t *testing.T) {
+	env := newFollowResponseReconciliationEnv(t)
+	rejectErr := errors.New("reject follow failed")
+	env.handler.relationshipRepository = &rejectFollowErrorRepo{
+		RelationshipRepository: inmemory.NewRelationshipRepository(),
+		err:                    rejectErr,
+	}
+
+	rejectActivity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Context: activitypub.Context,
+			Type:    activitypub.RejectType,
+			ID:      env.cfg.BaseURL() + "/activities/reject-error",
+		},
+		Actor: env.remoteActorID,
+	}
+	followActivity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Context: activitypub.Context,
+			Type:    activitypub.FollowType,
+			ID:      env.cfg.BaseURL() + "/activities/follow-error",
+		},
+		Actor: env.local.ID,
+	}
+
+	require.ErrorIs(t, env.handler.processRejectFollow(context.Background(), rejectActivity, env.local, followActivity), rejectErr)
 }

--- a/cmd/inbox/internal/routing/follow_response_round13_reconciliation_test.go
+++ b/cmd/inbox/internal/routing/follow_response_round13_reconciliation_test.go
@@ -1,0 +1,161 @@
+package routing
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/equaltoai/lesser/pkg/testing/inmemory"
+	"github.com/stretchr/testify/require"
+)
+
+func newFollowResponseReconciliationEnv(t *testing.T) *inboxTestEnv {
+	t.Helper()
+
+	env := newInboxTestEnv(t)
+	env.handler.activityRepository = inmemory.NewActivityRepository()
+	env.handler.relationshipRepository = inmemory.NewRelationshipRepository()
+
+	return env
+}
+
+func seedPendingLocalOutboundFollow(t *testing.T, env *inboxTestEnv, relationshipActivityID, storedActivityID string) {
+	t.Helper()
+
+	ctx := context.Background()
+	followerHandle := env.local.PreferredUsername
+	followeeHandle := env.handler.extractHandleFromActorID(env.remoteActorID)
+	require.NoError(t, env.handler.relationshipRepository.CreateRelationship(ctx, followerHandle, followeeHandle, relationshipActivityID))
+
+	if storedActivityID == "" {
+		return
+	}
+
+	require.NoError(t, env.handler.activityRepository.CreateActivity(ctx, &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Context: activitypub.Context,
+			Type:    activitypub.FollowType,
+			ID:      storedActivityID,
+		},
+		Actor:  env.local.ID,
+		Object: env.remoteActorID,
+	}))
+}
+
+func relationshipState(t *testing.T, env *inboxTestEnv) string {
+	t.Helper()
+
+	record, err := env.handler.relationshipRepository.GetRelationship(
+		context.Background(),
+		env.local.PreferredUsername,
+		env.handler.extractHandleFromActorID(env.remoteActorID),
+	)
+	require.NoError(t, err)
+	return record.State
+}
+
+func TestInboxHandler_ProcessAcceptActivity_ReconcilesStoredOriginalFollow(t *testing.T) {
+	env := newFollowResponseReconciliationEnv(t)
+	followID := env.cfg.BaseURL() + "/activities/follow-stored-accept"
+	seedPendingLocalOutboundFollow(t, env, followID, followID)
+
+	accept := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Context: activitypub.Context,
+			Type:    activitypub.AcceptType,
+			ID:      env.cfg.BaseURL() + "/activities/accept-stored",
+		},
+		Actor:  env.remoteActorID,
+		Object: followID,
+	}
+
+	require.NoError(t, env.handler.processAcceptActivity(context.Background(), accept, env.local))
+	require.Equal(t, models.RelationshipAccepted, relationshipState(t, env))
+}
+
+func TestInboxHandler_ProcessAcceptActivity_FallbackReconcilesLegacyBareActivityID(t *testing.T) {
+	env := newFollowResponseReconciliationEnv(t)
+	followSuffix := "follow-legacy-accept"
+	seedPendingLocalOutboundFollow(t, env, followSuffix, "")
+
+	accept := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Context: activitypub.Context,
+			Type:    activitypub.AcceptType,
+			ID:      env.cfg.BaseURL() + "/activities/accept-fallback",
+		},
+		Actor:  env.remoteActorID,
+		Object: env.cfg.BaseURL() + "/activities/" + followSuffix,
+	}
+
+	require.NoError(t, env.handler.processAcceptActivity(context.Background(), accept, env.local))
+	require.Equal(t, models.RelationshipAccepted, relationshipState(t, env))
+}
+
+func TestInboxHandler_ProcessRejectActivity_ReconcilesStoredOriginalFollow(t *testing.T) {
+	env := newFollowResponseReconciliationEnv(t)
+	followID := env.cfg.BaseURL() + "/activities/follow-stored-reject"
+	seedPendingLocalOutboundFollow(t, env, followID, followID)
+
+	reject := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Context: activitypub.Context,
+			Type:    activitypub.RejectType,
+			ID:      env.cfg.BaseURL() + "/activities/reject-stored",
+		},
+		Actor:  env.remoteActorID,
+		Object: followID,
+	}
+
+	require.NoError(t, env.handler.processRejectActivity(context.Background(), reject, env.local))
+	require.Equal(t, models.RelationshipRejected, relationshipState(t, env))
+}
+
+func TestInboxHandler_ProcessRejectActivity_FallbackReconcilesLegacyBareActivityID(t *testing.T) {
+	env := newFollowResponseReconciliationEnv(t)
+	followSuffix := "follow-legacy-reject"
+	seedPendingLocalOutboundFollow(t, env, followSuffix, "")
+
+	reject := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Context: activitypub.Context,
+			Type:    activitypub.RejectType,
+			ID:      env.cfg.BaseURL() + "/activities/reject-fallback",
+		},
+		Actor:  env.remoteActorID,
+		Object: env.cfg.BaseURL() + "/activities/" + followSuffix,
+	}
+
+	require.NoError(t, env.handler.processRejectActivity(context.Background(), reject, env.local))
+	require.Equal(t, models.RelationshipRejected, relationshipState(t, env))
+}
+
+func TestInboxHandler_ProcessFollowResponses_DoNotMutateOnMismatchedObjectID(t *testing.T) {
+	for _, responseType := range []string{activitypub.AcceptType, activitypub.RejectType} {
+		t.Run(responseType, func(t *testing.T) {
+			env := newFollowResponseReconciliationEnv(t)
+			expectedID := env.cfg.BaseURL() + "/activities/follow-match"
+			seedPendingLocalOutboundFollow(t, env, expectedID, "")
+
+			response := &activitypub.Activity{
+				BaseObject: activitypub.BaseObject{
+					Context: activitypub.Context,
+					Type:    responseType,
+					ID:      fmt.Sprintf("%s/activities/%s-response", env.cfg.BaseURL(), responseType),
+				},
+				Actor:  env.remoteActorID,
+				Object: env.cfg.BaseURL() + "/activities/follow-mismatch",
+			}
+
+			if responseType == activitypub.AcceptType {
+				require.NoError(t, env.handler.processAcceptActivity(context.Background(), response, env.local))
+			} else {
+				require.NoError(t, env.handler.processRejectActivity(context.Background(), response, env.local))
+			}
+
+			require.Equal(t, models.RelationshipPending, relationshipState(t, env))
+		})
+	}
+}

--- a/cmd/inbox/internal/routing/inbox.go
+++ b/cmd/inbox/internal/routing/inbox.go
@@ -1675,6 +1675,13 @@ func (ih *InboxHandler) processAcceptByActivityID(ctx context.Context, objectID 
 
 	if err != nil {
 		log.Warn("failed to find original activity", zap.String("id", objectID), zap.Error(err))
+		reconciled, fallbackErr := ih.reconcileFollowResponseFromRelationship(ctx, activitypub.AcceptType, objectID, targetActor, acceptorHandle)
+		if fallbackErr != nil {
+			return fallbackErr
+		}
+		if reconciled {
+			return nil
+		}
 		return nil
 	}
 
@@ -1731,6 +1738,111 @@ func (ih *InboxHandler) acceptFollowRelationship(ctx context.Context, followerHa
 	return nil
 }
 
+func (ih *InboxHandler) rejectFollowRelationship(ctx context.Context, followerHandle, rejectorHandle string) error {
+	if followerHandle == "" || rejectorHandle == "" {
+		return nil
+	}
+
+	if err := ih.relationshipRepository.RejectFollowRequest(ctx, followerHandle, rejectorHandle); err != nil {
+		common.WithContext(ctx).Error("failed to update follow rejection",
+			zap.String("follower", followerHandle),
+			zap.String("rejector", rejectorHandle),
+			zap.Error(err))
+		return err
+	}
+
+	return nil
+}
+
+func (ih *InboxHandler) reconcileFollowResponseFromRelationship(ctx context.Context, responseType, objectID string, targetActor *activitypub.Actor, remoteHandle string) (bool, error) {
+	log := common.WithContext(ctx)
+	if targetActor == nil || strings.TrimSpace(remoteHandle) == "" {
+		return false, nil
+	}
+	if _, ok := ih.localActivityIDSuffix(objectID); !ok {
+		return false, nil
+	}
+
+	followerHandle := strings.TrimSpace(targetActor.PreferredUsername)
+	if followerHandle == "" {
+		followerHandle = ih.extractHandleFromActorID(targetActor.ID)
+	}
+	if followerHandle == "" {
+		return false, nil
+	}
+
+	relationship, err := ih.relationshipRepository.GetRelationship(ctx, followerHandle, remoteHandle)
+	if err != nil {
+		log.Warn("failed to load pending relationship for follow response fallback",
+			zap.String("follower", followerHandle),
+			zap.String("remote", remoteHandle),
+			zap.Error(err))
+		return false, nil
+	}
+	if relationship == nil || relationship.State != models.RelationshipPending {
+		return false, nil
+	}
+	if !ih.followResponseActivityIDsMatch(objectID, relationship.ActivityID) {
+		log.Warn("follow response fallback activity id mismatch",
+			zap.String("object_id", objectID),
+			zap.String("stored_activity_id", relationship.ActivityID),
+			zap.String("follower", followerHandle),
+			zap.String("remote", remoteHandle))
+		return false, nil
+	}
+
+	switch responseType {
+	case activitypub.AcceptType:
+		return true, ih.acceptFollowRelationship(ctx, followerHandle, remoteHandle)
+	case activitypub.RejectType:
+		return true, ih.rejectFollowRelationship(ctx, followerHandle, remoteHandle)
+	default:
+		return false, nil
+	}
+}
+
+func (ih *InboxHandler) localActivityIDSuffix(activityID string) (string, bool) {
+	trimmed := strings.TrimSpace(activityID)
+	baseURL := strings.TrimSuffix(ih.getConfig().BaseURL(), "/")
+	if trimmed == "" || baseURL == "" {
+		return "", false
+	}
+
+	prefix := baseURL + "/activities/"
+	if !strings.HasPrefix(trimmed, prefix) {
+		return "", false
+	}
+
+	suffix := strings.TrimPrefix(trimmed, prefix)
+	if suffix == "" || strings.Contains(suffix, "/") {
+		return "", false
+	}
+
+	return suffix, true
+}
+
+func (ih *InboxHandler) followResponseActivityIDsMatch(objectID, storedActivityID string) bool {
+	objectID = strings.TrimSpace(objectID)
+	storedActivityID = strings.TrimSpace(storedActivityID)
+	if objectID == "" || storedActivityID == "" {
+		return false
+	}
+	if objectID == storedActivityID {
+		return true
+	}
+
+	objectSuffix, ok := ih.localActivityIDSuffix(objectID)
+	if !ok {
+		return false
+	}
+	if objectSuffix == storedActivityID {
+		return true
+	}
+
+	storedSuffix, storedIsLocal := ih.localActivityIDSuffix(storedActivityID)
+	return storedIsLocal && storedSuffix == objectSuffix
+}
+
 // processRejectActivity processes an incoming Reject activity
 func (ih *InboxHandler) processRejectActivity(ctx context.Context, activity *activitypub.Activity, targetActor *activitypub.Actor) error {
 	log := common.WithContext(ctx)
@@ -1766,6 +1878,13 @@ func (ih *InboxHandler) processRejectByActivityID(ctx context.Context, activity 
 		log.Warn("failed to find original activity for rejection",
 			zap.String("activity_id", objectID),
 			zap.Error(err))
+		reconciled, fallbackErr := ih.reconcileFollowResponseFromRelationship(ctx, activitypub.RejectType, objectID, targetActor, ih.extractHandleFromActorID(activity.Actor))
+		if fallbackErr != nil {
+			return fallbackErr
+		}
+		if reconciled {
+			return nil
+		}
 		return nil // Don't fail, just ignore unknown activities
 	}
 
@@ -1892,23 +2011,8 @@ func (ih *InboxHandler) processRejectFollow(ctx context.Context, rejectActivity 
 		zap.String("rejector", rejectorHandle),
 		zap.String("follow_id", followActivity.ID))
 
-	// Remove the pending follow relationship
-	if err := ih.relationshipRepository.DeleteRelationship(ctx, requesterHandle, rejectorHandle); err != nil {
-		log.Debug("no follow relationship to remove during rejection",
-			zap.String("requester", requesterHandle),
-			zap.String("rejector", rejectorHandle),
-			zap.Error(err))
-		// Don't fail - this is idempotent
-	}
-
-	// Optionally update the relationship state to explicitly rejected
-	// This allows tracking that the follow was explicitly rejected vs. just deleted
-	if err := ih.relationshipRepository.RejectFollowRequest(ctx, requesterHandle, rejectorHandle); err != nil {
-		log.Debug("could not mark follow as rejected",
-			zap.String("requester", requesterHandle),
-			zap.String("rejector", rejectorHandle),
-			zap.Error(err))
-		// This is not critical - the deletion above is the main action
+	if err := ih.rejectFollowRelationship(ctx, requesterHandle, rejectorHandle); err != nil {
+		return err
 	}
 
 	log.Info("successfully processed follow rejection",

--- a/docs/planning/federation-follow-reconciliation-validation.md
+++ b/docs/planning/federation-follow-reconciliation-validation.md
@@ -1,0 +1,36 @@
+# Federation Follow Reconciliation Validation
+
+This validation gate closes the local follow reconciliation milestone for delivered remote `Accept` and `Reject` responses.
+
+Delivery alone is not success. The round is only complete when Lesser's local follow state tells the truth after the remote response comes back.
+
+## Automated Coverage
+
+These tests cover the contract for new rows and legacy fallback rows:
+
+- `pkg/services/relationships/service_round21_follow_activity_persistence_test.go`
+- `pkg/services/relationships/service_round22_relationship_activity_id_contract_test.go`
+- `cmd/inbox/internal/routing/follow_response_round13_reconciliation_test.go`
+
+## Live Validation Order
+
+1. Start from a clean Sim state with no pre-existing pending row for the target remote account.
+2. Execute one fresh Sim -> Theory follow.
+3. Verify Sim creates a pending relationship row.
+4. Verify the Sim relationship row stores the canonical full local follow activity URL in `ActivityID`.
+5. Verify Sim persists the original outbound local `Follow` activity in `ActivityRepository`.
+6. Verify Theory persists the follower row and reaches accepted state.
+7. Verify Theory delivers `Accept` back to Sim.
+8. Verify Sim moves the same local relationship row from `pending` to `accepted`.
+9. Repeat the proof with a clean pending row that receives a delivered `Reject`.
+10. Verify Sim reconciles that row to `rejected` without mutating unrelated rows.
+11. Resume downstream federation-proof work only after both response paths pass.
+
+## Close Condition
+
+The milestone is closed only when all of the following are true:
+
+- new outbound local follows generate one canonical local activity URL used across queueing, relationship storage, and activity persistence
+- delivered remote `Accept` reconciles the local pending follow row
+- delivered remote `Reject` reconciles the local pending follow row
+- fallback reconciliation only applies to matching local activity URLs and does not mutate mismatched rows

--- a/pkg/services/relationships/service.go
+++ b/pkg/services/relationships/service.go
@@ -6,6 +6,7 @@ package relationships
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -771,6 +772,9 @@ func (s *Service) reconcileStoredFollowActivity(
 	if generatedActivityID == "" || storedActivityID == "" || generatedActivityID == storedActivityID {
 		return followActivity, nil, nil
 	}
+	if err := s.deleteSupersededFollowActivity(ctx, generatedActivityID, storedActivityID); err != nil {
+		return nil, nil, err
+	}
 
 	relationship, err := s.GetRelationship(ctx, followerID, followingID)
 	if err != nil {
@@ -802,6 +806,46 @@ func (s *Service) reconcileStoredFollowActivity(
 		zap.String("relationship_state", relationshipRecord.State))
 
 	return canonicalActivity, result, nil
+}
+
+func (s *Service) deleteSupersededFollowActivity(ctx context.Context, generatedActivityID, storedActivityID string) error {
+	if s.storage == nil {
+		return nil
+	}
+
+	generatedActivityID = strings.TrimSpace(generatedActivityID)
+	storedActivityID = strings.TrimSpace(storedActivityID)
+	if generatedActivityID == "" || generatedActivityID == storedActivityID {
+		return nil
+	}
+
+	activityRepo := s.storage.Activity()
+	if activityRepo == nil {
+		return nil
+	}
+
+	deleteRepo, ok := activityRepo.(interface {
+		DeleteActivity(ctx context.Context, activityID string) error
+	})
+	if !ok {
+		s.logger.Debug("activity repository does not support deleting superseded follow activities",
+			zap.String("activity_id", generatedActivityID),
+			zap.String("stored_activity_id", storedActivityID))
+		return nil
+	}
+
+	if err := deleteRepo.DeleteActivity(ctx, generatedActivityID); err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil
+		}
+		s.logger.Error("failed to delete superseded follow activity",
+			zap.String("activity_id", generatedActivityID),
+			zap.String("stored_activity_id", storedActivityID),
+			zap.Error(err))
+		return err
+	}
+
+	return nil
 }
 
 func (s *Service) loadStoredFollowActivity(ctx context.Context, activityID string) *activitypub.Activity {

--- a/pkg/services/relationships/service.go
+++ b/pkg/services/relationships/service.go
@@ -324,13 +324,13 @@ func (s *Service) Follow(ctx context.Context, cmd *FollowCommand) (*FollowResult
 		s.logger.Info("follow request short-circuited by prerequisites",
 			zap.Bool("existing_relationship", existingResult != nil))
 		if existingResult != nil {
-			existingResult.Activity = s.buildFollowActivity(ctx, follower, following, cmd.FollowerID, cmd.FollowingID, existingResult.Relationship)
+			existingResult.Activity = s.buildFollowActivity(ctx, follower, following, cmd.FollowerID, cmd.FollowingID, existingResult.RequestID, existingResult.Relationship)
 		}
 		return existingResult, nil
 	}
 
 	// Create and process the follow
-	activityID := uuid.New().String()
+	activityID := s.newCanonicalLocalActivityID()
 	s.logger.Info("invoking createRelationship",
 		zap.String("follower_id", cmd.FollowerID),
 		zap.String("following_id", cmd.FollowingID),
@@ -342,7 +342,8 @@ func (s *Service) Follow(ctx context.Context, cmd *FollowCommand) (*FollowResult
 	// Handle approval workflow
 	s.logger.Info("processing follow approval",
 		zap.Bool("requires_manual_approval", following != nil && following.Actor != nil && following.Actor.ManuallyApprovesFollowers))
-	result, err := s.processFollowApproval(ctx, follower, following, activityID, cmd.FollowerID, cmd.FollowingID)
+	followActivity := s.buildFollowActivity(ctx, follower, following, cmd.FollowerID, cmd.FollowingID, activityID, nil)
+	result, err := s.processFollowApproval(ctx, follower, following, followActivity, cmd.FollowerID, cmd.FollowingID)
 	if err != nil {
 		return nil, err
 	}
@@ -467,7 +468,7 @@ func (s *Service) checkFollowPrerequisites(ctx context.Context, followerID, foll
 			IsFollowing:  true,
 			Events:       []*streaming.Event{},
 		}
-		result.Activity = s.buildFollowActivity(ctx, nil, nil, followerID, followingID, relationship)
+		result.Activity = s.buildFollowActivity(ctx, nil, nil, followerID, followingID, "", relationship)
 		return result, true, nil
 	}
 
@@ -487,7 +488,7 @@ func (s *Service) checkFollowPrerequisites(ctx context.Context, followerID, foll
 			IsFollowing:  false,
 			Events:       []*streaming.Event{},
 		}
-		result.Activity = s.buildFollowActivity(ctx, nil, nil, followerID, followingID, relationship)
+		result.Activity = s.buildFollowActivity(ctx, nil, nil, followerID, followingID, requestID, relationship)
 		return result, true, nil
 	}
 
@@ -531,7 +532,7 @@ func (s *Service) pendingFollowState(ctx context.Context, followerID, followingI
 }
 
 // createRelationship creates the relationship record
-func (s *Service) buildFollowActivity(ctx context.Context, follower, following *storage.Account, followerID, followingID string, relationship *RelationshipData) *activitypub.Activity {
+func (s *Service) buildFollowActivity(ctx context.Context, follower, following *storage.Account, followerID, followingID, activityID string, relationship *RelationshipData) *activitypub.Activity {
 	followerID = s.normalizeActorIdentifier(followerID)
 	followingID = s.normalizeActorIdentifier(followingID)
 
@@ -555,6 +556,9 @@ func (s *Service) buildFollowActivity(ctx context.Context, follower, following *
 	if actorID == "" {
 		return nil
 	}
+	if !strings.Contains(actorID, "://") && s.baseURL() != "" {
+		actorID = fmt.Sprintf("%s/users/%s", s.baseURL(), url.PathEscape(actorID))
+	}
 
 	objectSlug := followingID
 	if following != nil {
@@ -577,13 +581,22 @@ func (s *Service) buildFollowActivity(ctx context.Context, follower, following *
 			objectIdentifier = following.Actor.URL
 		}
 	}
+	if objectIdentifier == "" {
+		objectIdentifier = objectSlug
+	}
+	if !strings.Contains(objectIdentifier, "://") && s.baseURL() != "" && !strings.Contains(objectIdentifier, "@") {
+		objectIdentifier = fmt.Sprintf("%s/users/%s", s.baseURL(), url.PathEscape(objectIdentifier))
+	}
 
 	baseActor := strings.TrimSuffix(actorID, "/")
 	if baseActor == "" {
 		baseActor = actorID
 	}
 
-	activityID := fmt.Sprintf("%s/follows/%s", baseActor, url.PathEscape(objectSlug))
+	canonicalActivityID := s.canonicalizeLocalActivityID(activityID)
+	if canonicalActivityID == "" {
+		canonicalActivityID = fmt.Sprintf("%s/follows/%s", baseActor, url.PathEscape(objectSlug))
+	}
 
 	published := time.Now().UTC()
 	if relationship != nil && !relationship.CreatedAt.IsZero() {
@@ -592,25 +605,45 @@ func (s *Service) buildFollowActivity(ctx context.Context, follower, following *
 
 	activity := &activitypub.Activity{
 		BaseObject: activitypub.BaseObject{
-			ID:        activityID,
+			Context:   activitypub.Context,
+			ID:        canonicalActivityID,
 			Type:      activitypub.FollowType,
 			Published: &published,
 		},
-		Actor: actorID,
+		Actor:  actorID,
+		Object: objectIdentifier,
 	}
-
-	fallbackObjectID := objectIdentifier
-	if fallbackObjectID == "" {
-		fallbackObjectID = objectSlug
-	}
-
-	if actorPayload := s.sanitizeActivityActor(ctx, following, objectSlug); actorPayload != nil {
-		activity.Object = actorPayload
-	} else {
-		activity.Object = fallbackObjectID
+	if objectIdentifier != "" {
+		activity.To = []string{objectIdentifier}
 	}
 
 	return activity
+}
+
+func (s *Service) newCanonicalLocalActivityID() string {
+	baseURL := s.baseURL()
+	if baseURL == "" {
+		baseURL = "https://example.invalid"
+	}
+
+	return fmt.Sprintf("%s/activities/%s", baseURL, uuid.New().String())
+}
+
+func (s *Service) canonicalizeLocalActivityID(activityID string) string {
+	trimmed := strings.TrimSpace(activityID)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.HasPrefix(trimmed, "http://") || strings.HasPrefix(trimmed, "https://") {
+		return trimmed
+	}
+
+	baseURL := s.baseURL()
+	if baseURL == "" {
+		baseURL = "https://example.invalid"
+	}
+
+	return fmt.Sprintf("%s/activities/%s", baseURL, trimmed)
 }
 
 func (s *Service) ensureAccountForActivity(ctx context.Context, account *storage.Account, identifier string) *storage.Account {
@@ -730,25 +763,29 @@ func (s *Service) createRelationship(ctx context.Context, followerID, followingI
 }
 
 // processFollowApproval handles the approval workflow and emits events
-func (s *Service) processFollowApproval(ctx context.Context, follower, following *storage.Account, activityID, followerID, followingID string) (*FollowResult, error) {
+func (s *Service) processFollowApproval(ctx context.Context, follower, following *storage.Account, followActivity *activitypub.Activity, followerID, followingID string) (*FollowResult, error) {
 	requiresApproval := following.Actor != nil && following.Actor.ManuallyApprovesFollowers
 	requiresRemoteAcceptance := s.followRequiresRemoteAcceptance(following)
 
 	var events []*streaming.Event
 	var requestID string
 	isFollowingNow := false
+	activityID := ""
+	if followActivity != nil {
+		activityID = strings.TrimSpace(followActivity.ID)
+	}
 
 	if requiresApproval || requiresRemoteAcceptance {
 		requestID = activityID
 		events = s.emitFollowRequestedEvents(ctx, follower, following, activityID)
-		s.queueFederationFollowRequest(ctx, follower, following, activityID)
+		s.queueFederationFollowRequest(ctx, followActivity, follower, following)
 	} else {
 		if err := s.acceptFollowRequest(ctx, followerID, followingID); err != nil {
 			return nil, err
 		}
 		isFollowingNow = true
 		events = s.emitFollowAcceptedEvents(ctx, follower, following, activityID)
-		s.queueFederationFollowDirectly(ctx, follower, following, activityID)
+		s.queueFederationFollowDirectly(ctx, followActivity, follower, following)
 	}
 
 	relationship, err := s.GetRelationship(ctx, followerID, followingID)
@@ -761,7 +798,7 @@ func (s *Service) processFollowApproval(ctx context.Context, follower, following
 		RequestID:    requestID,
 		IsFollowing:  isFollowingNow,
 		Events:       events,
-		Activity:     s.buildFollowActivity(ctx, follower, following, followerID, followingID, relationship),
+		Activity:     followActivity,
 	}, nil
 }
 
@@ -2831,7 +2868,7 @@ func (s *Service) emitUnmuteEvents(ctx context.Context, muter, muted *storage.Ac
 // Federation queueing methods
 
 // queueFederationFollow queues a follow activity for federation
-func (s *Service) queueFederationFollow(ctx context.Context, follower, following *storage.Account, activityID string, actionType string) {
+func (s *Service) queueFederationFollow(ctx context.Context, activity *activitypub.Activity, follower, following *storage.Account, actionType string) {
 	if isNilFederationService(s.federation) {
 		s.logger.Debug(fmt.Sprintf("federation service not available, skipping %s", actionType))
 		return
@@ -2846,18 +2883,8 @@ func (s *Service) queueFederationFollow(ctx context.Context, follower, following
 	if following.Actor == nil || isLocalActor(following.Actor, s.domainName) {
 		return
 	}
-
-	now := time.Now()
-	activity := &activitypub.Activity{
-		BaseObject: activitypub.BaseObject{
-			Context:   activitypub.Context,
-			Type:      "Follow",
-			ID:        fmt.Sprintf("https://%s/activities/%s", s.domainName, activityID),
-			Published: &now,
-			To:        []string{following.Actor.ID},
-		},
-		Actor:  follower.Actor.ID,
-		Object: following.Actor.ID,
+	if activity == nil {
+		return
 	}
 
 	defer func() {
@@ -2877,12 +2904,12 @@ func (s *Service) queueFederationFollow(ctx context.Context, follower, following
 	}
 }
 
-func (s *Service) queueFederationFollowRequest(ctx context.Context, follower, following *storage.Account, activityID string) {
-	s.queueFederationFollow(ctx, follower, following, activityID, "follow request")
+func (s *Service) queueFederationFollowRequest(ctx context.Context, activity *activitypub.Activity, follower, following *storage.Account) {
+	s.queueFederationFollow(ctx, activity, follower, following, "follow request")
 }
 
-func (s *Service) queueFederationFollowDirectly(ctx context.Context, follower, following *storage.Account, activityID string) {
-	s.queueFederationFollow(ctx, follower, following, activityID, "follow")
+func (s *Service) queueFederationFollowDirectly(ctx context.Context, activity *activitypub.Activity, follower, following *storage.Account) {
+	s.queueFederationFollow(ctx, activity, follower, following, "follow")
 }
 
 func (s *Service) queueFederationAccept(ctx context.Context, follower, following *storage.Account, originalActivityID string) {

--- a/pkg/services/relationships/service.go
+++ b/pkg/services/relationships/service.go
@@ -343,6 +343,9 @@ func (s *Service) Follow(ctx context.Context, cmd *FollowCommand) (*FollowResult
 	s.logger.Info("processing follow approval",
 		zap.Bool("requires_manual_approval", following != nil && following.Actor != nil && following.Actor.ManuallyApprovesFollowers))
 	followActivity := s.buildFollowActivity(ctx, follower, following, cmd.FollowerID, cmd.FollowingID, activityID, nil)
+	if err := s.persistOutboundFollowActivity(ctx, followActivity); err != nil {
+		return nil, err
+	}
 	result, err := s.processFollowApproval(ctx, follower, following, followActivity, cmd.FollowerID, cmd.FollowingID)
 	if err != nil {
 		return nil, err
@@ -800,6 +803,19 @@ func (s *Service) processFollowApproval(ctx context.Context, follower, following
 		Events:       events,
 		Activity:     followActivity,
 	}, nil
+}
+
+func (s *Service) persistOutboundFollowActivity(ctx context.Context, followActivity *activitypub.Activity) error {
+	if followActivity == nil || s.storage == nil {
+		return nil
+	}
+
+	activityRepo := s.storage.Activity()
+	if activityRepo == nil {
+		return RepositoryNotAvailable("activity")
+	}
+
+	return activityRepo.CreateActivity(ctx, followActivity)
 }
 
 func (s *Service) followRequiresRemoteAcceptance(following *storage.Account) bool {

--- a/pkg/services/relationships/service.go
+++ b/pkg/services/relationships/service.go
@@ -344,6 +344,13 @@ func (s *Service) Follow(ctx context.Context, cmd *FollowCommand) (*FollowResult
 	if err := s.createRelationship(ctx, cmd.FollowerID, cmd.FollowingID, activityID); err != nil {
 		return nil, err
 	}
+	followActivity, existingResult, err = s.reconcileStoredFollowActivity(ctx, follower, following, cmd.FollowerID, cmd.FollowingID, followActivity)
+	if err != nil {
+		return nil, err
+	}
+	if existingResult != nil {
+		return existingResult, nil
+	}
 
 	// Handle approval workflow
 	s.logger.Info("processing follow approval",
@@ -737,6 +744,85 @@ func (s *Service) createRelationship(ctx context.Context, followerID, followingI
 		return s.relationshipRepo.CreateFollowRequest(ctx, followerID, followingID)
 	}
 	return NoRepositoryOrStorage()
+}
+
+func (s *Service) reconcileStoredFollowActivity(
+	ctx context.Context,
+	follower, following *storage.Account,
+	followerID, followingID string,
+	followActivity *activitypub.Activity,
+) (*activitypub.Activity, *FollowResult, error) {
+	if followActivity == nil || s.storage == nil {
+		return followActivity, nil, nil
+	}
+
+	relationshipRepo := s.storage.Relationship()
+	if relationshipRepo == nil {
+		return followActivity, nil, RepositoryNotAvailable("relationship")
+	}
+
+	relationshipRecord, err := relationshipRepo.GetRelationship(ctx, followerID, followingID)
+	if err != nil || relationshipRecord == nil {
+		return followActivity, nil, err
+	}
+
+	generatedActivityID := strings.TrimSpace(followActivity.ID)
+	storedActivityID := strings.TrimSpace(relationshipRecord.ActivityID)
+	if generatedActivityID == "" || storedActivityID == "" || generatedActivityID == storedActivityID {
+		return followActivity, nil, nil
+	}
+
+	relationship, err := s.GetRelationship(ctx, followerID, followingID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	canonicalActivity := s.loadStoredFollowActivity(ctx, storedActivityID)
+	if canonicalActivity == nil {
+		canonicalActivity = s.buildFollowActivity(ctx, follower, following, followerID, followingID, storedActivityID, relationship)
+	}
+
+	result := &FollowResult{
+		Relationship: relationship,
+		Events:       []*streaming.Event{},
+		Activity:     canonicalActivity,
+	}
+	switch relationshipRecord.State {
+	case models.RelationshipAccepted:
+		result.IsFollowing = true
+	case models.RelationshipPending:
+		result.RequestID = storedActivityID
+	}
+
+	s.logger.Info("follow request adopted existing canonical activity id",
+		zap.String("follower_id", followerID),
+		zap.String("following_id", followingID),
+		zap.String("generated_activity_id", generatedActivityID),
+		zap.String("stored_activity_id", storedActivityID),
+		zap.String("relationship_state", relationshipRecord.State))
+
+	return canonicalActivity, result, nil
+}
+
+func (s *Service) loadStoredFollowActivity(ctx context.Context, activityID string) *activitypub.Activity {
+	if s.storage == nil {
+		return nil
+	}
+
+	activityRepo := s.storage.Activity()
+	if activityRepo == nil {
+		return nil
+	}
+
+	activity, err := activityRepo.GetActivity(ctx, activityID)
+	if err != nil {
+		s.logger.Debug("failed to load stored follow activity, rebuilding from relationship state",
+			zap.String("activity_id", activityID),
+			zap.Error(err))
+		return nil
+	}
+
+	return activity
 }
 
 // processFollowApproval handles the approval workflow and emits events

--- a/pkg/services/relationships/service.go
+++ b/pkg/services/relationships/service.go
@@ -329,8 +329,14 @@ func (s *Service) Follow(ctx context.Context, cmd *FollowCommand) (*FollowResult
 		return existingResult, nil
 	}
 
-	// Create and process the follow
+	// Persist the outbound Follow before recording pending state so a transient
+	// activity write failure cannot wedge retries behind a stale relationship row.
 	activityID := s.newCanonicalLocalActivityID()
+	followActivity := s.buildFollowActivity(ctx, follower, following, cmd.FollowerID, cmd.FollowingID, activityID, nil)
+	if err := s.persistOutboundFollowActivity(ctx, followActivity); err != nil {
+		return nil, err
+	}
+
 	s.logger.Info("invoking createRelationship",
 		zap.String("follower_id", cmd.FollowerID),
 		zap.String("following_id", cmd.FollowingID),
@@ -342,10 +348,6 @@ func (s *Service) Follow(ctx context.Context, cmd *FollowCommand) (*FollowResult
 	// Handle approval workflow
 	s.logger.Info("processing follow approval",
 		zap.Bool("requires_manual_approval", following != nil && following.Actor != nil && following.Actor.ManuallyApprovesFollowers))
-	followActivity := s.buildFollowActivity(ctx, follower, following, cmd.FollowerID, cmd.FollowingID, activityID, nil)
-	if err := s.persistOutboundFollowActivity(ctx, followActivity); err != nil {
-		return nil, err
-	}
 	result, err := s.processFollowApproval(ctx, follower, following, followActivity, cmd.FollowerID, cmd.FollowingID)
 	if err != nil {
 		return nil, err
@@ -691,34 +693,6 @@ func (s *Service) ensureAccountForActivity(ctx context.Context, account *storage
 	}
 
 	return account
-}
-
-func (s *Service) sanitizeActivityActor(ctx context.Context, account *storage.Account, fallback string) *activitypub.Actor {
-	if account == nil {
-		return nil
-	}
-
-	baseURL := s.baseURL()
-	username := strings.TrimSpace(fallback)
-	if account.User != nil {
-		userName := strings.TrimSpace(account.User.Username)
-		if userName != "" {
-			username = userName
-		}
-	}
-	if account.Actor != nil {
-		username = activitypubutil.DerivePreferredUsername(account.Actor, username)
-	}
-
-	if account.Actor == nil {
-		return activitypubutil.BuildLocalActor(username, baseURL, account.User, nil)
-	}
-
-	if enriched := s.buildAccountFromActor(ctx, account.Actor, username); enriched != nil && enriched.Actor != nil {
-		return enriched.Actor
-	}
-
-	return activitypubutil.BuildLocalActor(username, baseURL, account.User, account.Actor)
 }
 
 func (s *Service) createRelationship(ctx context.Context, followerID, followingID, activityID string) error {

--- a/pkg/services/relationships/service_round16_mainline_test.go
+++ b/pkg/services/relationships/service_round16_mainline_test.go
@@ -683,7 +683,16 @@ func TestFederationQueueHelpers_HandleNilAndPanics(t *testing.T) {
 	// Typed nil should also be treated as nil.
 	var typedNil *MockFederationService
 	service.federation = typedNil
-	service.queueFederationFollowDirectly(ctx, local, remote, "activity")
+	service.queueFederationFollowDirectly(ctx, &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Context: activitypub.Context,
+			Type:    activitypub.FollowType,
+			ID:      "https://example.com/activities/test-follow",
+			To:      []string{remote.Actor.ID},
+		},
+		Actor:  local.Actor.ID,
+		Object: remote.Actor.ID,
+	}, local, remote)
 
 	// Panic in queue should be suppressed.
 	service.federation = panicFederationService{}
@@ -1171,7 +1180,7 @@ func TestService_BuildFollowActivity_CornerCases(t *testing.T) {
 	service := NewService(nil, nil, streaming.NewMockPublisher(), nil, zap.NewNop(), "example.com")
 
 	// Empty actor ID returns nil.
-	assert.Nil(t, service.buildFollowActivity(ctx, nil, nil, "", "bob", nil))
+	assert.Nil(t, service.buildFollowActivity(ctx, nil, nil, "", "bob", "", nil))
 
 	createdAt := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
 	relationship := &RelationshipData{CreatedAt: createdAt}
@@ -1182,12 +1191,13 @@ func TestService_BuildFollowActivity_CornerCases(t *testing.T) {
 		nil,
 		"alice",
 		"",
+		"",
 		relationship,
 	)
 	require.NotNil(t, activity)
 	require.NotNil(t, activity.Published)
 	assert.Equal(t, createdAt, *activity.Published)
-	assert.Equal(t, "alice", activity.Actor)
+	assert.Equal(t, "https://example.com/users/alice", activity.Actor)
 	assert.IsType(t, "", activity.Object)
 
 	// Actor.ID trimming fallback when baseActor becomes empty.
@@ -1196,6 +1206,7 @@ func TestService_BuildFollowActivity_CornerCases(t *testing.T) {
 		&storage.Account{User: &storage.User{Username: "bob"}, Actor: &activitypub.Actor{URL: "https://remote.social/users/bob"}},
 		"alice",
 		"bob",
+		"",
 		nil,
 	)
 	require.NotNil(t, activity)
@@ -1510,10 +1521,20 @@ func TestService_QueueFederationFollow_Branches(t *testing.T) {
 		Maybe()
 
 	service := NewService(nil, nil, publisher, fed, zap.NewNop(), "example.com")
+	followActivity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Context: activitypub.Context,
+			Type:    activitypub.FollowType,
+			ID:      "https://example.com/activities/follow-act",
+			To:      []string{followingRemote.Actor.ID},
+		},
+		Actor:  follower.Actor.ID,
+		Object: followingRemote.Actor.ID,
+	}
 
 	// Missing domain name.
 	service.domainName = ""
-	service.queueFederationFollow(ctx, follower, followingRemote, "act", "follow")
+	service.queueFederationFollow(ctx, followActivity, follower, followingRemote, "follow")
 
 	// Local actor is skipped.
 	service.domainName = "example.com"
@@ -1521,13 +1542,13 @@ func TestService_QueueFederationFollow_Branches(t *testing.T) {
 		User:  &storage.User{Username: "bob"},
 		Actor: &activitypub.Actor{BaseObject: activitypub.BaseObject{ID: "https://example.com/users/bob"}},
 	}
-	service.queueFederationFollow(ctx, follower, followingLocal, "act", "follow")
+	service.queueFederationFollow(ctx, followActivity, follower, followingLocal, "follow")
 
 	// Nil actor is skipped.
-	service.queueFederationFollow(ctx, follower, &storage.Account{User: &storage.User{Username: "bob"}}, "act", "follow")
+	service.queueFederationFollow(ctx, followActivity, follower, &storage.Account{User: &storage.User{Username: "bob"}}, "follow")
 
 	// Remote actor queues and handles QueueActivity errors.
-	service.queueFederationFollow(ctx, follower, followingRemote, "act", "follow")
+	service.queueFederationFollow(ctx, followActivity, follower, followingRemote, "follow")
 	require.Len(t, queued, 1)
 	require.Equal(t, followingRemote.Actor.ID, queued[0].Object)
 	require.Equal(t, []string{followingRemote.Actor.ID}, queued[0].To)

--- a/pkg/services/relationships/service_round16_mainline_test.go
+++ b/pkg/services/relationships/service_round16_mainline_test.go
@@ -1215,19 +1215,6 @@ func TestService_BuildFollowActivity_CornerCases(t *testing.T) {
 	require.NotNil(t, activity)
 }
 
-func TestService_SanitizeActivityActor_NilAndUserOnly(t *testing.T) {
-	ctx := context.Background()
-	service := NewService(nil, nil, streaming.NewMockPublisher(), nil, zap.NewNop(), "example.com")
-
-	assert.Nil(t, service.sanitizeActivityActor(ctx, nil, "bob"))
-
-	actor := service.sanitizeActivityActor(ctx, &storage.Account{User: &storage.User{Username: "alice"}}, "bob")
-	require.NotNil(t, actor)
-
-	actor = service.sanitizeActivityActor(ctx, &storage.Account{}, "bob")
-	require.NotNil(t, actor)
-}
-
 func TestService_Block_UnfollowWarningBranches(t *testing.T) {
 	ctx := context.Background()
 	service, _ := newServiceWithStorageHarness(t)

--- a/pkg/services/relationships/service_round16_mainline_test.go
+++ b/pkg/services/relationships/service_round16_mainline_test.go
@@ -250,6 +250,7 @@ type testRepositoryStorage struct {
 	logger    *zap.Logger
 
 	actorRepo        interfaces.ActorRepository
+	activityRepo     interfaces.ActivityRepository
 	domainBlockRepo  *repositories.DomainBlockRepository
 	relationshipRepo interfaces.ConcreteRelationshipRepository
 	socialRepo       *repositories.SocialRepository
@@ -274,7 +275,7 @@ func (s *testRepositoryStorage) User() interfaces.UserRepository        { return
 func (s *testRepositoryStorage) Account() *repositories.AccountRepository             { return nil }
 func (s *testRepositoryStorage) Bookmark() *repositories.BookmarkRepository           { return nil }
 func (s *testRepositoryStorage) Object() interfaces.ObjectRepository                  { return nil }
-func (s *testRepositoryStorage) Activity() interfaces.ActivityRepository              { return nil }
+func (s *testRepositoryStorage) Activity() interfaces.ActivityRepository              { return s.activityRepo }
 func (s *testRepositoryStorage) Timeline() interfaces.TimelineRepository              { return nil }
 func (s *testRepositoryStorage) Notification() interfaces.NotificationRepository      { return nil }
 func (s *testRepositoryStorage) Like() *repositories.LikeRepository                   { return nil }
@@ -384,6 +385,7 @@ func newServiceWithStorageHarness(t *testing.T) (*Service, *testRepositoryStorag
 		tableName:        tableName,
 		logger:           logger,
 		actorRepo:        repositories.NewActorRepository(db, tableName, logger),
+		activityRepo:     inmemory.NewActivityRepository(),
 		domainBlockRepo:  repositories.NewDomainBlockRepository(db, tableName, logger),
 		relationshipRepo: repositories.NewRelationshipRepository(db, tableName, logger),
 		socialRepo:       repositories.NewSocialRepository(db, tableName, logger, nil),
@@ -420,6 +422,7 @@ func newServiceWithStorageHarnessConfigured(
 		tableName:        tableName,
 		logger:           logger,
 		actorRepo:        repositories.NewActorRepository(db, tableName, logger),
+		activityRepo:     inmemory.NewActivityRepository(),
 		domainBlockRepo:  repositories.NewDomainBlockRepository(db, tableName, logger),
 		relationshipRepo: repositories.NewRelationshipRepository(db, tableName, logger),
 		socialRepo:       repositories.NewSocialRepository(db, tableName, logger, nil),

--- a/pkg/services/relationships/service_round17_remote_follow_test.go
+++ b/pkg/services/relationships/service_round17_remote_follow_test.go
@@ -2,7 +2,6 @@ package relationships
 
 import (
 	"context"
-	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -53,7 +52,8 @@ func TestService_Follow_AllowsRemoteFolloweeByHandle(t *testing.T) {
 	require.False(t, result.Relationship.Following)
 	require.True(t, result.Relationship.Requested)
 	require.NotNil(t, result.Activity)
-	require.True(t, strings.Contains(result.Activity.ID, url.PathEscape("bob@remote.social")))
+	require.True(t, strings.HasPrefix(result.Activity.ID, "https://example.com/activities/"))
+	require.Equal(t, result.Activity.ID, result.RequestID)
 
 	record, err := relationshipRepo.GetRelationship(ctx, "alice", "bob@remote.social")
 	require.NoError(t, err)
@@ -108,6 +108,8 @@ func TestService_Follow_AllowsRemoteFolloweeByActorURL(t *testing.T) {
 	require.NotNil(t, result.Relationship)
 	require.True(t, result.Relationship.Requested)
 	require.NotNil(t, result.Activity)
+	require.True(t, strings.HasPrefix(result.Activity.ID, "https://example.com/activities/"))
+	require.Equal(t, result.Activity.ID, result.RequestID)
 
 	record, err := relationshipRepo.GetRelationship(ctx, "alice", "bob@remote.social")
 	require.NoError(t, err)
@@ -161,6 +163,7 @@ func TestService_Follow_RemotePendingRequestIsIdempotent(t *testing.T) {
 	require.False(t, first.IsFollowing)
 	require.True(t, first.Relationship.Requested)
 	require.NotEmpty(t, first.RequestID)
+	require.True(t, strings.HasPrefix(first.RequestID, "https://example.com/activities/"))
 
 	second, err := service.Follow(ctx, &FollowCommand{
 		FollowerID:  "alice",
@@ -171,6 +174,7 @@ func TestService_Follow_RemotePendingRequestIsIdempotent(t *testing.T) {
 	require.False(t, second.IsFollowing)
 	require.True(t, second.Relationship.Requested)
 	require.Equal(t, first.RequestID, second.RequestID)
+	require.Equal(t, second.RequestID, second.Activity.ID)
 }
 
 func TestService_BuildAccountFromActor_PreservesRemoteIdentity(t *testing.T) {

--- a/pkg/services/relationships/service_round21_follow_activity_persistence_test.go
+++ b/pkg/services/relationships/service_round21_follow_activity_persistence_test.go
@@ -1,0 +1,112 @@
+package relationships
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/storage/interfaces"
+	"github.com/equaltoai/lesser/pkg/testing/inmemory"
+	testmocks "github.com/equaltoai/lesser/pkg/testing/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func buildRemoteFollowPersistenceService(
+	t *testing.T,
+	activityRepo interfaces.ActivityRepository,
+) (*Service, *inmemory.RelationshipRepository, *activitypub.Actor, *activitypub.Actor, *MockFederationService) {
+	t.Helper()
+
+	ctx := context.Background()
+	service, storageHarness := newServiceWithStorageHarness(t)
+	actorRepo := inmemory.NewActorRepository()
+	relationshipRepo := inmemory.NewRelationshipRepository()
+	storageHarness.actorRepo = actorRepo
+	storageHarness.activityRepo = activityRepo
+	storageHarness.relationshipRepo = relationshipRepo
+
+	localActor := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://example.com/users/alice",
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: "alice",
+		Inbox:             "https://example.com/users/alice/inbox",
+		Outbox:            "https://example.com/users/alice/outbox",
+	}
+	require.NoError(t, actorRepo.CreateActor(ctx, localActor, ""))
+
+	remoteActor := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://remote.social/users/bob",
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: "bob",
+		Inbox:             "https://remote.social/users/bob/inbox",
+		Outbox:            "https://remote.social/users/bob/outbox",
+	}
+	actorRepo.SetCachedRemoteActor("bob@remote.social", remoteActor, time.Hour)
+
+	fed := &MockFederationService{}
+	fed.On("QueueActivity", mock.Anything, mock.Anything).Return(nil).Maybe()
+	service.federation = fed
+
+	return service, relationshipRepo, localActor, remoteActor, fed
+}
+
+func TestService_Follow_PersistsOutboundLocalActivityBeforeQueueing(t *testing.T) {
+	ctx := context.Background()
+	activityRepo := inmemory.NewActivityRepository()
+	service, relationshipRepo, localActor, remoteActor, fed := buildRemoteFollowPersistenceService(t, activityRepo)
+
+	result, err := service.Follow(ctx, &FollowCommand{
+		FollowerID:  "alice",
+		FollowingID: "bob@remote.social",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Activity)
+
+	record, err := relationshipRepo.GetRelationship(ctx, "alice", "bob@remote.social")
+	require.NoError(t, err)
+	require.Equal(t, result.Activity.ID, record.ActivityID)
+
+	persisted, err := activityRepo.GetActivity(ctx, result.Activity.ID)
+	require.NoError(t, err)
+	require.Equal(t, activitypub.FollowType, persisted.Type)
+	require.Equal(t, result.Activity.ID, persisted.ID)
+	require.Equal(t, localActor.ID, persisted.Actor)
+	require.Equal(t, remoteActor.ID, persisted.Object)
+
+	require.Len(t, fed.Calls, 1)
+	queued, ok := fed.Calls[0].Arguments.Get(1).(*activitypub.Activity)
+	require.True(t, ok)
+	require.Equal(t, persisted.ID, queued.ID)
+}
+
+func TestService_Follow_PersistenceErrorStopsBeforeFederationQueueing(t *testing.T) {
+	ctx := context.Background()
+	activityRepo := testmocks.NewMockActivityRepository()
+	service, _, _, _, fed := buildRemoteFollowPersistenceService(t, activityRepo)
+
+	activityRepo.
+		On("CreateActivity", ctx, mock.MatchedBy(func(activity *activitypub.Activity) bool {
+			return activity != nil &&
+				activity.Type == activitypub.FollowType &&
+				strings.HasPrefix(activity.ID, "https://example.com/activities/")
+		})).
+		Return(errors.New("persist boom")).
+		Once()
+
+	result, err := service.Follow(ctx, &FollowCommand{
+		FollowerID:  "alice",
+		FollowingID: "bob@remote.social",
+	})
+	require.Nil(t, result)
+	require.ErrorContains(t, err, "persist boom")
+	require.Empty(t, fed.Calls)
+}

--- a/pkg/services/relationships/service_round21_follow_activity_persistence_test.go
+++ b/pkg/services/relationships/service_round21_follow_activity_persistence_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
 	"github.com/equaltoai/lesser/pkg/testing/inmemory"
 	testmocks "github.com/equaltoai/lesser/pkg/testing/mocks"
@@ -91,7 +92,7 @@ func TestService_Follow_PersistsOutboundLocalActivityBeforeQueueing(t *testing.T
 func TestService_Follow_PersistenceErrorStopsBeforeFederationQueueing(t *testing.T) {
 	ctx := context.Background()
 	activityRepo := testmocks.NewMockActivityRepository()
-	service, _, _, _, fed := buildRemoteFollowPersistenceService(t, activityRepo)
+	service, relationshipRepo, _, _, fed := buildRemoteFollowPersistenceService(t, activityRepo)
 
 	activityRepo.
 		On("CreateActivity", ctx, mock.MatchedBy(func(activity *activitypub.Activity) bool {
@@ -109,4 +110,7 @@ func TestService_Follow_PersistenceErrorStopsBeforeFederationQueueing(t *testing
 	require.Nil(t, result)
 	require.ErrorContains(t, err, "persist boom")
 	require.Empty(t, fed.Calls)
+
+	_, lookupErr := relationshipRepo.GetRelationship(ctx, "alice", "bob@remote.social")
+	require.ErrorIs(t, lookupErr, storage.ErrNotFound)
 }

--- a/pkg/services/relationships/service_round22_relationship_activity_id_contract_test.go
+++ b/pkg/services/relationships/service_round22_relationship_activity_id_contract_test.go
@@ -4,9 +4,13 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/storage/interfaces"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/testing/inmemory"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -81,4 +85,102 @@ func TestService_Follow_ReopensRejectedRelationshipWithFreshActivityID(t *testin
 	require.NoError(t, err)
 	require.Equal(t, models.RelationshipPending, record.State)
 	require.Equal(t, second.RequestID, record.ActivityID)
+}
+
+type raceWinningRelationshipRepository struct {
+	*inmemory.RelationshipRepository
+	winnerActivityID   string
+	observedActivityID string
+}
+
+func (r *raceWinningRelationshipRepository) CreateRelationship(ctx context.Context, followerUsername, followingUsername, activityID string) error {
+	r.observedActivityID = activityID
+
+	if _, err := r.RelationshipRepository.GetRelationship(ctx, followerUsername, followingUsername); err == nil {
+		return nil
+	}
+
+	return r.RelationshipRepository.CreateRelationship(ctx, followerUsername, followingUsername, r.winnerActivityID)
+}
+
+func buildRemoteFollowPersistenceServiceWithRelationshipRepo(
+	t *testing.T,
+	activityRepo interfaces.ActivityRepository,
+	relationshipRepo interfaces.ConcreteRelationshipRepository,
+) (*Service, *activitypub.Actor, *activitypub.Actor, *MockFederationService) {
+	t.Helper()
+
+	ctx := context.Background()
+	service, storageHarness := newServiceWithStorageHarness(t)
+	actorRepo := inmemory.NewActorRepository()
+	storageHarness.actorRepo = actorRepo
+	storageHarness.activityRepo = activityRepo
+	storageHarness.relationshipRepo = relationshipRepo
+
+	localActor := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://example.com/users/alice",
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: "alice",
+		Inbox:             "https://example.com/users/alice/inbox",
+		Outbox:            "https://example.com/users/alice/outbox",
+	}
+	require.NoError(t, actorRepo.CreateActor(ctx, localActor, ""))
+
+	remoteActor := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://remote.social/users/bob",
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: "bob",
+		Inbox:             "https://remote.social/users/bob/inbox",
+		Outbox:            "https://remote.social/users/bob/outbox",
+	}
+	actorRepo.SetCachedRemoteActor("bob@remote.social", remoteActor, time.Hour)
+
+	fed := &MockFederationService{}
+	fed.On("QueueActivity", mock.Anything, mock.Anything).Return(nil).Maybe()
+	service.federation = fed
+
+	return service, localActor, remoteActor, fed
+}
+
+func TestService_Follow_AdoptsStoredCanonicalActivityIDWhenCreateWinsRace(t *testing.T) {
+	ctx := context.Background()
+	activityRepo := inmemory.NewActivityRepository()
+	winnerRepo := &raceWinningRelationshipRepository{
+		RelationshipRepository: inmemory.NewRelationshipRepository(),
+		winnerActivityID:       "https://example.com/activities/winner",
+	}
+	service, localActor, remoteActor, fed := buildRemoteFollowPersistenceServiceWithRelationshipRepo(t, activityRepo, winnerRepo)
+
+	winnerActivity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Context: activitypub.Context,
+			ID:      winnerRepo.winnerActivityID,
+			Type:    activitypub.FollowType,
+			To:      []string{remoteActor.ID},
+		},
+		Actor:  localActor.ID,
+		Object: remoteActor.ID,
+	}
+	require.NoError(t, activityRepo.CreateActivity(ctx, winnerActivity))
+
+	result, err := service.Follow(ctx, &FollowCommand{
+		FollowerID:  "alice",
+		FollowingID: "bob@remote.social",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Activity)
+	require.Equal(t, winnerRepo.winnerActivityID, result.Activity.ID)
+	require.Equal(t, winnerRepo.winnerActivityID, result.RequestID)
+	require.True(t, result.Relationship.Requested)
+	require.NotEqual(t, winnerRepo.winnerActivityID, winnerRepo.observedActivityID)
+	require.Empty(t, fed.Calls)
+
+	record, err := winnerRepo.GetRelationship(ctx, "alice", "bob@remote.social")
+	require.NoError(t, err)
+	require.Equal(t, winnerRepo.winnerActivityID, record.ActivityID)
 }

--- a/pkg/services/relationships/service_round22_relationship_activity_id_contract_test.go
+++ b/pkg/services/relationships/service_round22_relationship_activity_id_contract_test.go
@@ -1,0 +1,52 @@
+package relationships
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/testing/inmemory"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_Follow_StoresCanonicalActivityIDOnPendingRelationshipRow(t *testing.T) {
+	ctx := context.Background()
+	service, relationshipRepo, _, _, _ := buildRemoteFollowPersistenceService(t, inmemory.NewActivityRepository())
+
+	result, err := service.Follow(ctx, &FollowCommand{
+		FollowerID:  "alice",
+		FollowingID: "bob@remote.social",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotEmpty(t, result.RequestID)
+	require.True(t, strings.HasPrefix(result.RequestID, "https://example.com/activities/"))
+
+	record, err := relationshipRepo.GetRelationship(ctx, "alice", "bob@remote.social")
+	require.NoError(t, err)
+	require.Equal(t, result.RequestID, record.ActivityID)
+}
+
+func TestService_Follow_ReusesCanonicalRelationshipActivityIDOnIdempotentRetry(t *testing.T) {
+	ctx := context.Background()
+	service, relationshipRepo, _, _, _ := buildRemoteFollowPersistenceService(t, inmemory.NewActivityRepository())
+
+	first, err := service.Follow(ctx, &FollowCommand{
+		FollowerID:  "alice",
+		FollowingID: "bob@remote.social",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, first)
+
+	second, err := service.Follow(ctx, &FollowCommand{
+		FollowerID:  "alice",
+		FollowingID: "bob@remote.social",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, second)
+
+	record, err := relationshipRepo.GetRelationship(ctx, "alice", "bob@remote.social")
+	require.NoError(t, err)
+	require.Equal(t, first.RequestID, record.ActivityID)
+	require.Equal(t, second.RequestID, record.ActivityID)
+}

--- a/pkg/services/relationships/service_round22_relationship_activity_id_contract_test.go
+++ b/pkg/services/relationships/service_round22_relationship_activity_id_contract_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/testing/inmemory"
 	"github.com/stretchr/testify/require"
 )
@@ -48,5 +49,36 @@ func TestService_Follow_ReusesCanonicalRelationshipActivityIDOnIdempotentRetry(t
 	record, err := relationshipRepo.GetRelationship(ctx, "alice", "bob@remote.social")
 	require.NoError(t, err)
 	require.Equal(t, first.RequestID, record.ActivityID)
+	require.Equal(t, second.RequestID, record.ActivityID)
+}
+
+func TestService_Follow_ReopensRejectedRelationshipWithFreshActivityID(t *testing.T) {
+	ctx := context.Background()
+	service, relationshipRepo, _, _, _ := buildRemoteFollowPersistenceService(t, inmemory.NewActivityRepository())
+
+	first, err := service.Follow(ctx, &FollowCommand{
+		FollowerID:  "alice",
+		FollowingID: "bob@remote.social",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, first)
+
+	require.NoError(t, relationshipRepo.RejectFollowRequest(ctx, "alice", "bob@remote.social"))
+
+	second, err := service.Follow(ctx, &FollowCommand{
+		FollowerID:  "alice",
+		FollowingID: "bob@remote.social",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	require.NotEmpty(t, second.RequestID)
+	require.NotEqual(t, first.RequestID, second.RequestID)
+	require.NotNil(t, second.Relationship)
+	require.True(t, second.Relationship.Requested)
+	require.False(t, second.Relationship.Following)
+
+	record, err := relationshipRepo.GetRelationship(ctx, "alice", "bob@remote.social")
+	require.NoError(t, err)
+	require.Equal(t, models.RelationshipPending, record.State)
 	require.Equal(t, second.RequestID, record.ActivityID)
 }

--- a/pkg/services/relationships/service_round22_relationship_activity_id_contract_test.go
+++ b/pkg/services/relationships/service_round22_relationship_activity_id_contract_test.go
@@ -361,3 +361,81 @@ func TestService_ReconcileStoredFollowActivity_RelationshipRepoFallbackBranches(
 	require.Same(t, followActivity, reconciledActivity)
 	require.Nil(t, result)
 }
+
+func TestService_LocalActivityIDHelpers_FallbackBaseURL(t *testing.T) {
+	service := NewService(nil, nil, nil, nil, nil, "")
+
+	generatedID := service.newCanonicalLocalActivityID()
+	require.True(t, strings.HasPrefix(generatedID, "https://example.invalid/activities/"))
+	require.NotEmpty(t, strings.TrimPrefix(generatedID, "https://example.invalid/activities/"))
+
+	require.Equal(t, "", service.canonicalizeLocalActivityID("   "))
+	require.Equal(t, "https://remote.social/activities/follow-1", service.canonicalizeLocalActivityID("https://remote.social/activities/follow-1"))
+	require.Equal(t, "https://example.invalid/activities/follow-1", service.canonicalizeLocalActivityID(" follow-1 "))
+}
+
+func TestService_PersistOutboundFollowActivity_RepositoryBranches(t *testing.T) {
+	ctx := context.Background()
+	followActivity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Context: activitypub.Context,
+			ID:      "https://example.com/activities/follow-persist",
+			Type:    activitypub.FollowType,
+		},
+		Actor:  "https://example.com/users/alice",
+		Object: "https://remote.social/users/bob",
+	}
+
+	service, storageHarness := newServiceWithStorageHarness(t)
+	storageHarness.activityRepo = nil
+	require.Error(t, service.persistOutboundFollowActivity(ctx, followActivity))
+
+	storageHarness.activityRepo = inmemory.NewActivityRepository()
+	require.NoError(t, service.persistOutboundFollowActivity(ctx, followActivity))
+}
+
+func TestService_CreateRelationship_StorageErrorBranch(t *testing.T) {
+	ctx := context.Background()
+	storageRepo := testmocks.NewMockRelationshipRepository()
+	storageRepo.On("CreateRelationship", ctx, "alice", "bob", "activity").Return(errors.New("create boom")).Once()
+
+	service, storageHarness := newServiceWithStorageHarness(t)
+	storageHarness.relationshipRepo = storageRepo
+
+	err := service.createRelationship(ctx, "alice", "bob", "activity")
+	require.ErrorContains(t, err, "create boom")
+}
+
+func TestService_GetRelationship_StorageFallbackBranches(t *testing.T) {
+	ctx := context.Background()
+
+	service, storageHarness := newServiceWithStorageHarness(t)
+	storageHarness.relationshipRepo = nil
+
+	relationship, err := service.GetRelationship(ctx, "alice", "bob")
+	require.NoError(t, err)
+	require.NotNil(t, relationship)
+	require.Equal(t, "bob", relationship.ID)
+	require.False(t, relationship.Following)
+	require.False(t, relationship.Requested)
+
+	erroringRepo := testmocks.NewMockRelationshipRepository()
+	erroringRepo.On("IsFollowing", ctx, "alice", "bob").Return(false, errors.New("following boom")).Once()
+	erroringRepo.On("IsFollowing", ctx, "bob", "alice").Return(false, errors.New("followed_by boom")).Once()
+	erroringRepo.On("IsBlocked", ctx, "alice", "bob").Return(false, errors.New("blocking boom")).Once()
+	erroringRepo.On("IsBlocked", ctx, "bob", "alice").Return(false, errors.New("blocked_by boom")).Once()
+	erroringRepo.On("HasPendingFollowRequest", ctx, "alice", "bob").Return(false, errors.New("requested boom")).Once()
+	erroringRepo.On("HasPendingFollowRequest", ctx, "bob", "alice").Return(false, errors.New("requested_by boom")).Once()
+
+	storageHarness.relationshipRepo = erroringRepo
+
+	relationship, err = service.GetRelationship(ctx, "alice", "bob")
+	require.NoError(t, err)
+	require.NotNil(t, relationship)
+	require.False(t, relationship.Following)
+	require.False(t, relationship.FollowedBy)
+	require.False(t, relationship.Blocking)
+	require.False(t, relationship.BlockedBy)
+	require.False(t, relationship.Requested)
+	require.False(t, relationship.RequestedBy)
+}

--- a/pkg/services/relationships/service_round22_relationship_activity_id_contract_test.go
+++ b/pkg/services/relationships/service_round22_relationship_activity_id_contract_test.go
@@ -2,14 +2,17 @@ package relationships
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/testing/inmemory"
+	testmocks "github.com/equaltoai/lesser/pkg/testing/mocks"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -103,6 +106,15 @@ func (r *raceWinningRelationshipRepository) CreateRelationship(ctx context.Conte
 	return r.RelationshipRepository.CreateRelationship(ctx, followerUsername, followingUsername, r.winnerActivityID)
 }
 
+type relationshipLookupErrorRepo struct {
+	*inmemory.RelationshipRepository
+	err error
+}
+
+func (r *relationshipLookupErrorRepo) GetRelationship(context.Context, string, string) (*models.RelationshipRecord, error) {
+	return nil, r.err
+}
+
 func buildRemoteFollowPersistenceServiceWithRelationshipRepo(
 	t *testing.T,
 	activityRepo interfaces.ActivityRepository,
@@ -179,8 +191,173 @@ func TestService_Follow_AdoptsStoredCanonicalActivityIDWhenCreateWinsRace(t *tes
 	require.True(t, result.Relationship.Requested)
 	require.NotEqual(t, winnerRepo.winnerActivityID, winnerRepo.observedActivityID)
 	require.Empty(t, fed.Calls)
+	_, err = activityRepo.GetActivity(ctx, winnerRepo.observedActivityID)
+	require.ErrorIs(t, err, storage.ErrNotFound)
+
+	outboxActivities, nextCursor, err := activityRepo.GetOutboxActivities(ctx, "alice", 10, "")
+	require.NoError(t, err)
+	require.Empty(t, nextCursor)
+	require.Len(t, outboxActivities, 1)
+	require.Equal(t, winnerRepo.winnerActivityID, outboxActivities[0].ID)
 
 	record, err := winnerRepo.GetRelationship(ctx, "alice", "bob@remote.social")
 	require.NoError(t, err)
 	require.Equal(t, winnerRepo.winnerActivityID, record.ActivityID)
+}
+
+func TestService_ReconcileStoredFollowActivity_RebuildsWinnerWhenActivityMissing(t *testing.T) {
+	ctx := context.Background()
+	activityRepo := inmemory.NewActivityRepository()
+	service, relationshipRepo, localActor, remoteActor, _ := buildRemoteFollowPersistenceService(t, activityRepo)
+
+	storedWinnerID := "https://example.com/activities/winner-missing"
+	require.NoError(t, relationshipRepo.CreateRelationship(ctx, "alice", "bob@remote.social", storedWinnerID))
+
+	loserActivity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Context: activitypub.Context,
+			ID:      "https://example.com/activities/loser-missing",
+			Type:    activitypub.FollowType,
+			To:      []string{remoteActor.ID},
+		},
+		Actor:  localActor.ID,
+		Object: remoteActor.ID,
+	}
+	require.NoError(t, activityRepo.CreateActivity(ctx, loserActivity))
+
+	follower := &storage.Account{User: &storage.User{Username: "alice"}, Actor: localActor}
+	following := &storage.Account{User: &storage.User{Username: "bob@remote.social"}, Actor: remoteActor}
+
+	reconciledActivity, result, err := service.reconcileStoredFollowActivity(ctx, follower, following, "alice", "bob@remote.social", loserActivity)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, reconciledActivity)
+	require.Equal(t, storedWinnerID, reconciledActivity.ID)
+	require.Equal(t, storedWinnerID, result.RequestID)
+	require.True(t, result.Relationship.Requested)
+	_, err = activityRepo.GetActivity(ctx, loserActivity.ID)
+	require.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestService_ReconcileStoredFollowActivity_AdoptsAcceptedWinnerState(t *testing.T) {
+	ctx := context.Background()
+	activityRepo := inmemory.NewActivityRepository()
+	service, relationshipRepo, localActor, remoteActor, _ := buildRemoteFollowPersistenceService(t, activityRepo)
+
+	storedWinnerID := "https://example.com/activities/winner-accepted"
+	require.NoError(t, relationshipRepo.CreateRelationship(ctx, "alice", "bob@remote.social", storedWinnerID))
+	require.NoError(t, relationshipRepo.AcceptFollowRequest(ctx, "alice", "bob@remote.social"))
+
+	loserActivity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Context: activitypub.Context,
+			ID:      "https://example.com/activities/loser-accepted",
+			Type:    activitypub.FollowType,
+			To:      []string{remoteActor.ID},
+		},
+		Actor:  localActor.ID,
+		Object: remoteActor.ID,
+	}
+	require.NoError(t, activityRepo.CreateActivity(ctx, loserActivity))
+
+	follower := &storage.Account{User: &storage.User{Username: "alice"}, Actor: localActor}
+	following := &storage.Account{User: &storage.User{Username: "bob@remote.social"}, Actor: remoteActor}
+
+	reconciledActivity, result, err := service.reconcileStoredFollowActivity(ctx, follower, following, "alice", "bob@remote.social", loserActivity)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, reconciledActivity)
+	require.True(t, result.IsFollowing)
+	require.Empty(t, result.RequestID)
+	require.Equal(t, storedWinnerID, reconciledActivity.ID)
+}
+
+func TestService_DeleteSupersededFollowActivity_NoopBranches(t *testing.T) {
+	ctx := context.Background()
+
+	service := NewService(nil, nil, nil, nil, nil, "example.com")
+	require.NoError(t, service.deleteSupersededFollowActivity(ctx, "loser", "winner"))
+
+	serviceWithStorage, storageHarness := newServiceWithStorageHarness(t)
+	require.NoError(t, serviceWithStorage.deleteSupersededFollowActivity(ctx, "", "winner"))
+	require.NoError(t, serviceWithStorage.deleteSupersededFollowActivity(ctx, "same", "same"))
+	storageHarness.activityRepo = nil
+	require.NoError(t, serviceWithStorage.deleteSupersededFollowActivity(ctx, "loser", "winner"))
+
+	unsupportedRepo := testmocks.NewMockActivityRepository()
+	storageHarness.activityRepo = unsupportedRepo
+	require.NoError(t, serviceWithStorage.deleteSupersededFollowActivity(ctx, "loser", "winner"))
+
+	notFoundRepo := &deleteNotFoundActivityRepo{ActivityRepository: inmemory.NewActivityRepository()}
+	storageHarness.activityRepo = notFoundRepo
+	require.NoError(t, serviceWithStorage.deleteSupersededFollowActivity(ctx, "loser", "winner"))
+}
+
+type deleteNotFoundActivityRepo struct {
+	interfaces.ActivityRepository
+}
+
+func (r *deleteNotFoundActivityRepo) DeleteActivity(context.Context, string) error {
+	return storage.ErrNotFound
+}
+
+type deleteErrorActivityRepo struct {
+	interfaces.ActivityRepository
+}
+
+func (r *deleteErrorActivityRepo) DeleteActivity(context.Context, string) error {
+	return errors.New("delete boom")
+}
+
+func TestService_DeleteSupersededFollowActivity_DeleteErrorReturnsError(t *testing.T) {
+	ctx := context.Background()
+	service, storageHarness := newServiceWithStorageHarness(t)
+	storageHarness.activityRepo = &deleteErrorActivityRepo{ActivityRepository: inmemory.NewActivityRepository()}
+
+	err := service.deleteSupersededFollowActivity(ctx, "loser", "winner")
+	require.ErrorContains(t, err, "delete boom")
+}
+
+func TestService_LoadStoredFollowActivity_FallbackBranches(t *testing.T) {
+	ctx := context.Background()
+
+	service := NewService(nil, nil, nil, nil, nil, "example.com")
+	require.Nil(t, service.loadStoredFollowActivity(ctx, "winner"))
+
+	serviceWithStorage, storageHarness := newServiceWithStorageHarness(t)
+	storageHarness.activityRepo = nil
+	require.Nil(t, serviceWithStorage.loadStoredFollowActivity(ctx, "winner"))
+
+	lookupFailingRepo := testmocks.NewMockActivityRepository()
+	lookupFailingRepo.On("GetActivity", ctx, "winner").Return(nil, errors.New("lookup boom")).Once()
+	storageHarness.activityRepo = lookupFailingRepo
+	require.Nil(t, serviceWithStorage.loadStoredFollowActivity(ctx, "winner"))
+}
+
+func TestService_ReconcileStoredFollowActivity_RelationshipRepoFallbackBranches(t *testing.T) {
+	ctx := context.Background()
+	followActivity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://example.com/activities/loser",
+			Type: activitypub.FollowType,
+		},
+	}
+
+	serviceWithMissingRepo, missingRepoHarness := newServiceWithStorageHarness(t)
+	missingRepoHarness.relationshipRepo = nil
+	reconciledActivity, result, err := serviceWithMissingRepo.reconcileStoredFollowActivity(ctx, nil, nil, "alice", "bob@remote.social", followActivity)
+	require.Error(t, err)
+	require.Same(t, followActivity, reconciledActivity)
+	require.Nil(t, result)
+
+	lookupErr := errors.New("relationship lookup boom")
+	serviceWithLookupErr, lookupErrHarness := newServiceWithStorageHarness(t)
+	lookupErrHarness.relationshipRepo = &relationshipLookupErrorRepo{
+		RelationshipRepository: inmemory.NewRelationshipRepository(),
+		err:                    lookupErr,
+	}
+	reconciledActivity, result, err = serviceWithLookupErr.reconcileStoredFollowActivity(ctx, nil, nil, "alice", "bob@remote.social", followActivity)
+	require.ErrorIs(t, err, lookupErr)
+	require.Same(t, followActivity, reconciledActivity)
+	require.Nil(t, result)
 }

--- a/pkg/storage/repositories/activity_repository.go
+++ b/pkg/storage/repositories/activity_repository.go
@@ -112,6 +112,39 @@ func (r *ActivityRepository) GetActivity(ctx context.Context, id string) (*activ
 	return activities[0].Activity, nil
 }
 
+// DeleteActivity removes an activity by ID.
+func (r *ActivityRepository) DeleteActivity(ctx context.Context, id string) error {
+	var activities []*models.Activity
+
+	err := r.db.WithContext(ctx).Model(&models.Activity{}).
+		Index("gsi2").
+		Where("gsi2PK", "=", "ACTIVITYID#"+id).
+		Limit(1).
+		All(&activities)
+	if err != nil {
+		r.logger.Error("failed to find activity for delete",
+			zap.String("activity_id", id),
+			zap.Error(err))
+		return ErrorHandler.HandleDeleteError(err, EntityActivity, id)
+	}
+
+	if len(activities) == 0 || activities[0] == nil {
+		return nil
+	}
+
+	if err := r.Delete(ctx, activities[0].PK, activities[0].SK); err != nil {
+		r.logger.Error("failed to delete activity",
+			zap.String("activity_id", id),
+			zap.String("pk", activities[0].PK),
+			zap.String("sk", activities[0].SK),
+			zap.Error(err))
+		return ErrorHandler.HandleDeleteError(err, EntityActivity, id)
+	}
+
+	r.logger.Info("activity deleted successfully", zap.String("activity_id", id))
+	return nil
+}
+
 // GetInboxActivities retrieves inbox activities for a user - matches legacy implementation
 const (
 	activityDefaultLimit = 20

--- a/pkg/storage/repositories/activity_repository_round09_coverage_test.go
+++ b/pkg/storage/repositories/activity_repository_round09_coverage_test.go
@@ -107,6 +107,69 @@ func TestActivityRepository_Round09_Coverage(t *testing.T) {
 		require.Nil(t, missing)
 	})
 
+	t.Run("DeleteActivity deletes by activity ID and noops when missing", func(t *testing.T) {
+		mockDB := new(mocks.MockDB)
+		mockQuery := new(mocks.MockQuery)
+		mockQuery.
+			On("All", mock.Anything).
+			Run(func(args mock.Arguments) {
+				out := args.Get(0).(*[]*models.Activity)
+				*out = append(*out, &models.Activity{
+					PK: "ACTOR#alice",
+					SK: "ACTIVITY#2025-01-01T00:00:00Z#act-1",
+				})
+			}).
+			Return(nil).
+			Once()
+		mockQuery.On("Delete").Return(nil).Once()
+		setupPermissiveRound08Mocks(mockDB, mockQuery, nil, baseTime)
+
+		repo := NewActivityRepository(mockDB, "test-table", zap.NewNop(), nil)
+		require.NoError(t, repo.DeleteActivity(ctx, "act-1"))
+
+		mockDBMissing := new(mocks.MockDB)
+		mockQueryMissing := new(mocks.MockQuery)
+		mockQueryMissing.
+			On("All", mock.Anything).
+			Run(func(args mock.Arguments) {
+				out := args.Get(0).(*[]*models.Activity)
+				*out = nil
+			}).
+			Return(nil).
+			Once()
+		setupPermissiveRound08Mocks(mockDBMissing, mockQueryMissing, nil, baseTime)
+
+		repoMissing := NewActivityRepository(mockDBMissing, "test-table", zap.NewNop(), nil)
+		require.NoError(t, repoMissing.DeleteActivity(ctx, "missing"))
+
+		mockDBLookupErr := new(mocks.MockDB)
+		mockQueryLookupErr := new(mocks.MockQuery)
+		mockQueryLookupErr.On("All", mock.Anything).Return(ErrTestMockError).Once()
+		setupPermissiveRound08Mocks(mockDBLookupErr, mockQueryLookupErr, nil, baseTime)
+
+		repoLookupErr := NewActivityRepository(mockDBLookupErr, "test-table", zap.NewNop(), nil)
+		require.Error(t, repoLookupErr.DeleteActivity(ctx, "lookup-boom"))
+
+		mockDBDeleteErr := new(mocks.MockDB)
+		mockQueryDeleteErr := new(mocks.MockQuery)
+		mockQueryDeleteErr.
+			On("All", mock.Anything).
+			Run(func(args mock.Arguments) {
+				out := args.Get(0).(*[]*models.Activity)
+				*out = append(*out, &models.Activity{
+					PK: "ACTOR#alice",
+					SK: "ACTIVITY#2025-01-01T00:00:00Z#act-delete-boom",
+				})
+			}).
+			Return(nil).
+			Once()
+		mockQueryDeleteErr.On("Delete").Return(ErrTestMockError).Once()
+		setupPermissiveRound08Mocks(mockDBDeleteErr, mockQueryDeleteErr, nil, baseTime)
+
+		repoDeleteErr := NewActivityRepository(mockDBDeleteErr, "test-table", zap.NewNop(), nil)
+		require.Error(t, repoDeleteErr.DeleteActivity(ctx, "act-delete-boom"))
+	})
+
 	t.Run("Inbox/outbox pagination and GetCollection branches", func(t *testing.T) {
 		mockDB := new(mocks.MockDB)
 		mockQuery := new(mocks.MockQuery)

--- a/pkg/storage/repositories/relationship_repository.go
+++ b/pkg/storage/repositories/relationship_repository.go
@@ -123,12 +123,7 @@ func (r *RelationshipRepository) CreateRelationship(ctx context.Context, followe
 	if err := r.ValidateAndCreate(ctx, relationship); err != nil {
 		// Check if it's a duplicate key error
 		if errors.IsConditionFailed(err) {
-			r.logger.Debug("follow relationship already exists",
-				zap.String("follower", followerUsername),
-				zap.String("following", followingUsername),
-				zap.Bool("validation_enabled", r.HasValidation()),
-				zap.Bool("events_enabled", r.HasEvents()))
-			return nil
+			return r.handleDuplicateRelationshipCreate(ctx, followerUsername, followingUsername, activityID)
 		}
 		r.logger.Error("failed to validate or create follow relationship",
 			zap.String("follower", followerUsername),
@@ -146,6 +141,50 @@ func (r *RelationshipRepository) CreateRelationship(ctx context.Context, followe
 		zap.Bool("validation_enabled", r.HasValidation()),
 		zap.Bool("events_enabled", r.HasEvents()),
 		zap.Bool("caching_enabled", r.HasCaching()))
+
+	return nil
+}
+
+func (r *RelationshipRepository) handleDuplicateRelationshipCreate(ctx context.Context, followerUsername, followingUsername, activityID string) error {
+	existing, err := r.getRelationshipRecord(ctx, followerUsername, followingUsername)
+	if err != nil {
+		r.logger.Error("failed to load existing follow relationship after duplicate create",
+			zap.String("follower", followerUsername),
+			zap.String("following", followingUsername),
+			zap.String("activity_id", activityID),
+			zap.Error(err))
+		return ErrorHandler.HandleQueryError(err, EntityFollow, "duplicate check")
+	}
+
+	if existing.State != models.RelationshipRejected {
+		r.logger.Debug("follow relationship already exists",
+			zap.String("follower", followerUsername),
+			zap.String("following", followingUsername),
+			zap.String("state", existing.State),
+			zap.Bool("validation_enabled", r.HasValidation()),
+			zap.Bool("events_enabled", r.HasEvents()))
+		return nil
+	}
+
+	existing.State = models.RelationshipPending
+	if trimmedActivityID := strings.TrimSpace(activityID); trimmedActivityID != "" {
+		existing.ActivityID = trimmedActivityID
+	}
+	existing.UpdatedAt = time.Now()
+
+	if err := r.Update(ctx, existing); err != nil {
+		r.logger.Error("failed to reopen rejected follow relationship",
+			zap.String("follower", followerUsername),
+			zap.String("following", followingUsername),
+			zap.String("activity_id", activityID),
+			zap.Error(err))
+		return ErrorHandler.HandleUpdateError(err, EntityFollow, "reopen")
+	}
+
+	r.logger.Info("reopened rejected follow relationship",
+		zap.String("follower", followerUsername),
+		zap.String("following", followingUsername),
+		zap.String("activity_id", existing.ActivityID))
 
 	return nil
 }

--- a/pkg/storage/repositories/relationship_repository_additional_coverage_test.go
+++ b/pkg/storage/repositories/relationship_repository_additional_coverage_test.go
@@ -72,7 +72,19 @@ func TestRelationshipRepository_additional_zero_percent_methods(t *testing.T) {
 	mockQuery4 := new(mocks.MockQuery)
 	mockDB4.On("WithContext", mock.Anything).Return(mockDB4)
 	mockDB4.On("Model", mock.Anything).Return(mockQuery4)
+	mockQuery4.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery4).Maybe()
 	mockQuery4.On("Create").Return(dynamormerrors.ErrConditionFailed).Once()
+	mockQuery4.On("First", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		m := args.Get(0).(*models.RelationshipRecord)
+		m.PK = "FOLLOW#alice"
+		m.SK = "FOLLOWING#bob"
+		m.GSI1PK = "FOLLOW#bob"
+		m.GSI1SK = "FOLLOWER#alice"
+		m.ActivityID = "act-existing"
+		m.State = models.RelationshipPending
+		m.CreatedAt = time.Now()
+		m.UpdatedAt = time.Now()
+	}).Once()
 	repo4 := NewRelationshipRepository(mockDB4, "test-table", logger)
 	repo4.EnhancedBaseRepository.SetValidationService(nil)
 	repo4.EnhancedBaseRepository.SetPermissionService(nil)
@@ -152,4 +164,43 @@ func TestRelationshipRepository_additional_zero_percent_methods(t *testing.T) {
 	repo9 := NewRelationshipRepository(mockDB9, "test-table", logger)
 	assert.Error(t, repo9.BlockUser(ctx, "", "bob"))
 	assert.NoError(t, repo9.BlockUser(ctx, "alice", "bob"))
+}
+
+func TestRelationshipRepository_CreateRelationship_ReopensRejectedDuplicate(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+	var lastModel *models.RelationshipRecord
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB).Maybe()
+	mockDB.On("Model", mock.Anything).Return(mockQuery).Run(func(args mock.Arguments) {
+		if model, ok := args.Get(0).(*models.RelationshipRecord); ok {
+			lastModel = model
+		}
+	}).Maybe()
+	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery).Maybe()
+	mockQuery.On("Create").Return(dynamormerrors.ErrConditionFailed).Once()
+	mockQuery.On("First", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		model := args.Get(0).(*models.RelationshipRecord)
+		*model = *models.NewRelationshipRecord("alice", "bob", "act-old")
+		model.State = models.RelationshipRejected
+	}).Once()
+	mockQuery.On("Update", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		model := lastModel
+		if assert.NotNil(t, model) {
+			assert.Equal(t, "FOLLOW#alice", model.PK)
+			assert.Equal(t, "FOLLOWING#bob", model.SK)
+			assert.Equal(t, models.RelationshipPending, model.State)
+			assert.Equal(t, "act-new", model.ActivityID)
+		}
+	}).Once()
+
+	repo := NewRelationshipRepository(mockDB, "test-table", logger)
+	repo.EnhancedBaseRepository.SetValidationService(nil)
+	repo.EnhancedBaseRepository.SetPermissionService(nil)
+	repo.EnhancedBaseRepository.SetCachingService(nil)
+	repo.EnhancedBaseRepository.SetEventService(nil)
+
+	assert.NoError(t, repo.CreateRelationship(ctx, "alice", "bob", "act-new"))
 }

--- a/pkg/testing/inmemory/activity_repository.go
+++ b/pkg/testing/inmemory/activity_repository.go
@@ -122,6 +122,27 @@ func (r *ActivityRepository) GetActivity(_ context.Context, id string) (*activit
 	return entry.activity, nil
 }
 
+// DeleteActivity removes an activity and updates the inbox/outbox indexes.
+func (r *ActivityRepository) DeleteActivity(_ context.Context, id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	entry, exists := r.activities[id]
+	if !exists {
+		return storage.ErrNotFound
+	}
+
+	delete(r.activities, id)
+
+	if entry.isInbox {
+		r.inboxByUser[entry.username] = removeActivityID(r.inboxByUser[entry.username], id)
+	} else {
+		r.outboxByUser[entry.username] = removeActivityID(r.outboxByUser[entry.username], id)
+	}
+
+	return nil
+}
+
 // ===== Inbox/Outbox Operations =====
 
 // GetInboxActivities retrieves inbox activities for a user with pagination
@@ -174,6 +195,18 @@ func (r *ActivityRepository) getActivitiesFromIDs(activityIDs []string, limit in
 	}
 
 	return results, nextCursor, nil
+}
+
+func removeActivityID(activityIDs []string, id string) []string {
+	for i, existingID := range activityIDs {
+		if existingID != id {
+			continue
+		}
+
+		return append(activityIDs[:i], activityIDs[i+1:]...)
+	}
+
+	return activityIDs
 }
 
 // ===== Collection Operations =====

--- a/pkg/testing/inmemory/relationship_repository.go
+++ b/pkg/testing/inmemory/relationship_repository.go
@@ -83,7 +83,14 @@ func (r *RelationshipRepository) CreateRelationship(_ context.Context, followerU
 	}
 
 	// Check if relationship already exists
-	if _, exists := r.relationships[followerUsername][followingUsername]; exists {
+	if existing, exists := r.relationships[followerUsername][followingUsername]; exists {
+		if existing.State == models.RelationshipRejected {
+			existing.State = models.RelationshipPending
+			if activityID != "" {
+				existing.ActivityID = activityID
+			}
+			existing.UpdatedAt = time.Now()
+		}
 		return nil // Already exists, no error
 	}
 


### PR DESCRIPTION
## Summary
- generate one canonical local Follow activity URL and reuse it across follow creation, relationship storage, activity persistence, and outbound federation queueing
- persist outbound local Follow activities before federation queueing and lock the relationship/activity contract down with focused regression coverage
- add narrow inbox fallback reconciliation for delivered `Accept` and `Reject` when activity lookup misses, plus explicit live validation gates for the milestone proof

## Root Cause
Sim was still carrying a split local follow contract. The outbound follow row and wire response path could disagree on activity identity shape, and the original outbound `Follow` was not guaranteed to exist in `ActivityRepository`. When Theory delivered `Accept.object` or `Reject.object` as the full local activity URL, Sim could miss the lookup and leave the local relationship row stuck in `pending`.

## Impact
- new outbound local follows now use one canonical local activity URL everywhere
- delivered remote `Accept` reconciles matching pending local follow rows to `accepted`
- delivered remote `Reject` reconciles matching pending local follow rows to `rejected`
- fallback reconciliation only mutates rows when the local activity URL actually matches the pending relationship state

## Checks
- `go test ./pkg/services/relationships -run 'TestService_(Follow_AllowsRemoteFolloweeByHandle|Follow_AllowsRemoteFolloweeByActorURL|Follow_RemotePendingRequestIsIdempotent|BuildFollowActivity_CornerCases|QueueFederationFollow_Branches)|TestFederationQueueHelpers_HandleNilAndPanics'`
- `go test ./pkg/services/relationships -run 'TestService_(Follow_PersistsOutboundLocalActivityBeforeQueueing|Follow_PersistenceErrorStopsBeforeFederationQueueing|Follow_AllowsRemoteFolloweeByHandle|Follow_AllowsRemoteFolloweeByActorURL|Follow_RemotePendingRequestIsIdempotent)'`
- `go test ./pkg/services/relationships -run 'TestService_(Follow_StoresCanonicalActivityIDOnPendingRelationshipRow|Follow_ReusesCanonicalRelationshipActivityIDOnIdempotentRetry|Follow_PersistsOutboundLocalActivityBeforeQueueing|Follow_RemotePendingRequestIsIdempotent)'`
- `go test ./cmd/inbox/internal/routing -run 'TestInboxHandler_(Round11_ProcessAcceptActivity_EmbeddedFollowAcceptsCanonicalRelationship|Round11_ProcessAcceptActivity_FallsBackToPendingRelationshipWhenOriginalMissing|ProcessAcceptActivity_ReconcilesStoredOriginalFollow|ProcessAcceptActivity_FallbackReconcilesLegacyBareActivityID|ProcessRejectActivity_ReconcilesStoredOriginalFollow|ProcessRejectActivity_FallbackReconcilesLegacyBareActivityID|ProcessFollowResponses_DoNotMutateOnMismatchedObjectID)'`
- `go test ./cmd/inbox/internal/routing`
- `go test ./pkg/services/relationships ./cmd/inbox/internal/routing`

Closes #758
Closes #759
Closes #760
Closes #761
Closes #762
Closes #763
