### PR TITLE
[codex] validate framework hydration fix

### DIFF
--- a/cmd/inbox/internal/routing/inbox.go
+++ b/cmd/inbox/internal/routing/inbox.go
@@ -1665,12 +1665,17 @@ func (ih *InboxHandler) processAcceptByActivityID(ctx context.Context, objectID 
 	log := common.WithContext(ctx)
 
 	originalActivity, err := ih.activityRepository.GetActivity(ctx, objectID)
-	if err == nil && originalActivity != nil && originalActivity.Type == activitypub.FollowType {
-		followerHandle := ih.extractHandleFromActorID(originalActivity.Actor)
-		if followerHandle == "" {
-			followerHandle = targetActor.PreferredUsername
+	if err == nil {
+		if validationErr := ih.ensureStoredActivityHydrated(ctx, objectID, originalActivity); validationErr != nil {
+			return validationErr
 		}
-		return ih.acceptFollowRelationship(ctx, followerHandle, acceptorHandle)
+		if originalActivity.Type == activitypub.FollowType {
+			followerHandle := ih.extractHandleFromActorID(originalActivity.Actor)
+			if followerHandle == "" {
+				followerHandle = targetActor.PreferredUsername
+			}
+			return ih.acceptFollowRelationship(ctx, followerHandle, acceptorHandle)
+		}
 	}
 
 	if err != nil {
@@ -1843,6 +1848,35 @@ func (ih *InboxHandler) followResponseActivityIDsMatch(objectID, storedActivityI
 	return storedIsLocal && storedSuffix == objectSuffix
 }
 
+func (ih *InboxHandler) ensureStoredActivityHydrated(ctx context.Context, objectID string, activity *activitypub.Activity) error {
+	log := common.WithContext(ctx)
+
+	missingFields := make([]string, 0, 3)
+	if activity == nil {
+		missingFields = append(missingFields, "activity")
+	} else {
+		if strings.TrimSpace(activity.ID) == "" {
+			missingFields = append(missingFields, "id")
+		}
+		if strings.TrimSpace(activity.Type) == "" {
+			missingFields = append(missingFields, "type")
+		}
+	}
+
+	if len(missingFields) == 0 {
+		return nil
+	}
+
+	log.Error("stored activity missing required routing fields",
+		zap.String("id", objectID),
+		zap.Strings("missing_fields", missingFields))
+
+	return fmt.Errorf("%w: stored activity %q missing required routing fields: %s",
+		storage.ErrInvalidInput,
+		objectID,
+		strings.Join(missingFields, ", "))
+}
+
 // processRejectActivity processes an incoming Reject activity
 func (ih *InboxHandler) processRejectActivity(ctx context.Context, activity *activitypub.Activity, targetActor *activitypub.Actor) error {
 	log := common.WithContext(ctx)
@@ -1886,6 +1920,10 @@ func (ih *InboxHandler) processRejectByActivityID(ctx context.Context, activity 
 			return nil
 		}
 		return nil // Don't fail, just ignore unknown activities
+	}
+
+	if validationErr := ih.ensureStoredActivityHydrated(ctx, objectID, originalActivity); validationErr != nil {
+		return validationErr
 	}
 
 	log.Info("processing reject for original activity",
@@ -2815,6 +2853,9 @@ func (ih *InboxHandler) processUndoActivity(ctx context.Context, activity *activ
 		if err != nil {
 			log.Warn("failed to find activity to undo", zap.String("id", obj))
 			return nil
+		}
+		if validationErr := ih.ensureStoredActivityHydrated(ctx, obj, originalActivity); validationErr != nil {
+			return validationErr
 		}
 	case map[string]any:
 		// Convert to activity

--- a/cmd/inbox/internal/routing/stored_activity_visibility_round14_test.go
+++ b/cmd/inbox/internal/routing/stored_activity_visibility_round14_test.go
@@ -1,0 +1,107 @@
+package routing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	testmocks "github.com/equaltoai/lesser/pkg/testing/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInboxHandler_ProcessAcceptActivity_ReturnsErrorForMalformedStoredActivity(t *testing.T) {
+	env := newFollowResponseReconciliationEnv(t)
+	followID := env.cfg.BaseURL() + "/activities/follow-broken-accept"
+	seedPendingLocalOutboundFollow(t, env, followID, "")
+
+	mockActivityRepo := testmocks.NewMockActivityRepository()
+	mockActivityRepo.
+		On("GetActivity", mock.Anything, followID).
+		Return(&activitypub.Activity{
+			Actor:  env.local.ID,
+			Object: env.remoteActorID,
+		}, nil).
+		Once()
+	env.handler.activityRepository = mockActivityRepo
+
+	accept := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Context: activitypub.Context,
+			Type:    activitypub.AcceptType,
+			ID:      env.cfg.BaseURL() + "/activities/accept-broken",
+		},
+		Actor:  env.remoteActorID,
+		Object: followID,
+	}
+
+	err := env.handler.processAcceptActivity(context.Background(), accept, env.local)
+	require.ErrorIs(t, err, storage.ErrInvalidInput)
+	require.ErrorContains(t, err, "missing required routing fields")
+	require.Equal(t, models.RelationshipPending, relationshipState(t, env))
+	mockActivityRepo.AssertExpectations(t)
+}
+
+func TestInboxHandler_ProcessRejectActivity_ReturnsErrorForMalformedStoredActivity(t *testing.T) {
+	env := newFollowResponseReconciliationEnv(t)
+	followID := env.cfg.BaseURL() + "/activities/follow-broken-reject"
+	seedPendingLocalOutboundFollow(t, env, followID, "")
+
+	mockActivityRepo := testmocks.NewMockActivityRepository()
+	mockActivityRepo.
+		On("GetActivity", mock.Anything, followID).
+		Return(&activitypub.Activity{
+			Actor:  env.local.ID,
+			Object: env.remoteActorID,
+		}, nil).
+		Once()
+	env.handler.activityRepository = mockActivityRepo
+
+	reject := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Context: activitypub.Context,
+			Type:    activitypub.RejectType,
+			ID:      env.cfg.BaseURL() + "/activities/reject-broken",
+		},
+		Actor:  env.remoteActorID,
+		Object: followID,
+	}
+
+	err := env.handler.processRejectActivity(context.Background(), reject, env.local)
+	require.ErrorIs(t, err, storage.ErrInvalidInput)
+	require.ErrorContains(t, err, "missing required routing fields")
+	require.Equal(t, models.RelationshipPending, relationshipState(t, env))
+	mockActivityRepo.AssertExpectations(t)
+}
+
+func TestInboxHandler_ProcessUndoActivity_ReturnsErrorForMalformedStoredActivity(t *testing.T) {
+	env := newInboxTestEnv(t)
+	activityID := env.cfg.BaseURL() + "/activities/undo-broken"
+
+	mockActivityRepo := testmocks.NewMockActivityRepository()
+	mockActivityRepo.
+		On("GetActivity", mock.Anything, activityID).
+		Return(&activitypub.Activity{
+			Actor:  env.local.ID,
+			Object: env.remoteActorID,
+		}, nil).
+		Once()
+	env.handler.activityRepository = mockActivityRepo
+
+	undo := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Context: activitypub.Context,
+			Type:    activitypub.UndoType,
+			ID:      env.cfg.BaseURL() + "/activities/undo-request",
+		},
+		Actor:  env.remoteActorID,
+		Object: activityID,
+	}
+
+	err := env.handler.processUndoActivity(context.Background(), undo, env.local)
+	require.ErrorIs(t, err, storage.ErrInvalidInput)
+	require.ErrorContains(t, err, "missing required routing fields")
+	mockActivityRepo.AssertExpectations(t)
+}

--- a/go.mod
+++ b/go.mod
@@ -48,8 +48,8 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/spruceid/siwe-go v0.2.1
 	github.com/stretchr/testify v1.11.1
-	github.com/theory-cloud/apptheory v0.24.6
-	github.com/theory-cloud/tabletheory v1.5.5
+	github.com/theory-cloud/apptheory v0.25.0
+	github.com/theory-cloud/tabletheory v1.6.0
 	github.com/tyler-smith/go-bip32 v1.0.0
 	github.com/tyler-smith/go-bip39 v1.1.0
 	github.com/vektah/gqlparser/v2 v2.5.32

--- a/go.sum
+++ b/go.sum
@@ -255,10 +255,10 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/supranational/blst v0.3.16 h1:bTDadT+3fK497EvLdWRQEjiGnUtzJ7jjIUMF0jqwYhE=
 github.com/supranational/blst v0.3.16/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
-github.com/theory-cloud/apptheory v0.24.6 h1:sHt3WMO3oKprToxOgxLuA5G6tH0YrHguqa1KOMgEhUY=
-github.com/theory-cloud/apptheory v0.24.6/go.mod h1:QdE7QGTgnv8XNY8RnkGfD+a21Lv4w3LtVUhy16gQ4Fo=
-github.com/theory-cloud/tabletheory v1.5.5 h1:XW4TTHqMLUGN7NXvKlSFMUodnL7UIp0Begk3pXnyITg=
-github.com/theory-cloud/tabletheory v1.5.5/go.mod h1:ZbXJkyBD2iTw/Ht3fec3BTECZaOD72D2ufAuTz6ZYrU=
+github.com/theory-cloud/apptheory v0.25.0 h1:wJ/dWimuC6UWTkxIsdzTyQJGSWX+YDMfNxuHCbCVi30=
+github.com/theory-cloud/apptheory v0.25.0/go.mod h1:QdE7QGTgnv8XNY8RnkGfD+a21Lv4w3LtVUhy16gQ4Fo=
+github.com/theory-cloud/tabletheory v1.6.0 h1:n/LqQIb0IftotMnd5d5x1rDawkmmH2XkYo+NmtxN/dg=
+github.com/theory-cloud/tabletheory v1.6.0/go.mod h1:ZbXJkyBD2iTw/Ht3fec3BTECZaOD72D2ufAuTz6ZYrU=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=

--- a/infra/cdk/go.mod
+++ b/infra/cdk/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/constructs-go/constructs/v10 v10.6.0
 	github.com/aws/jsii-runtime-go v1.127.0
 	github.com/equaltoai/lesser v1.1.17
-	github.com/theory-cloud/apptheory v0.24.6
+	github.com/theory-cloud/apptheory v0.25.0
 )
 
 require (

--- a/infra/cdk/go.sum
+++ b/infra/cdk/go.sum
@@ -26,8 +26,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/theory-cloud/apptheory v0.24.6 h1:sHt3WMO3oKprToxOgxLuA5G6tH0YrHguqa1KOMgEhUY=
-github.com/theory-cloud/apptheory v0.24.6/go.mod h1:QdE7QGTgnv8XNY8RnkGfD+a21Lv4w3LtVUhy16gQ4Fo=
+github.com/theory-cloud/apptheory v0.25.0 h1:wJ/dWimuC6UWTkxIsdzTyQJGSWX+YDMfNxuHCbCVi30=
+github.com/theory-cloud/apptheory v0.25.0/go.mod h1:QdE7QGTgnv8XNY8RnkGfD+a21Lv4w3LtVUhy16gQ4Fo=
 github.com/yuin/goldmark v1.7.16 h1:n+CJdUxaFMiDUNnWC3dMWCIQJSkxH4uz3ZwQBkAlVNE=
 github.com/yuin/goldmark v1.7.16/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/pkg/storage/repositories/activity_repository_hydration_contract_test.go
+++ b/pkg/storage/repositories/activity_repository_hydration_contract_test.go
@@ -1,0 +1,40 @@
+package repositories
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+	ttquery "github.com/theory-cloud/tabletheory/pkg/query"
+)
+
+func TestActivityHydrationContract_TableTheoryEmbeddedBaseObject(t *testing.T) {
+	const (
+		activityID = "https://example.com/activities/follow-contract"
+		actorID    = "https://example.com/users/alice"
+		objectID   = "https://remote.social/users/bob"
+	)
+
+	item := map[string]types.AttributeValue{
+		"PK":     &types.AttributeValueMemberS{Value: "ACTOR#alice"},
+		"SK":     &types.AttributeValueMemberS{Value: "ACTIVITY#2026-04-18T00:00:00Z#" + activityID},
+		"gsi2PK": &types.AttributeValueMemberS{Value: "ACTIVITYID#" + activityID},
+		"gsi2SK": &types.AttributeValueMemberS{Value: "ACTIVITY#2026-04-18T00:00:00Z#" + activityID},
+		"activity": &types.AttributeValueMemberM{Value: map[string]types.AttributeValue{
+			"id":     &types.AttributeValueMemberS{Value: activityID},
+			"type":   &types.AttributeValueMemberS{Value: activitypub.FollowType},
+			"actor":  &types.AttributeValueMemberS{Value: actorID},
+			"object": &types.AttributeValueMemberS{Value: objectID},
+		}},
+	}
+
+	var out models.Activity
+	require.NoError(t, ttquery.UnmarshalItem(item, &out))
+	require.NotNil(t, out.Activity)
+	require.Equal(t, activityID, out.Activity.ID)
+	require.Equal(t, activitypub.FollowType, out.Activity.Type)
+	require.Equal(t, actorID, out.Activity.Actor)
+	require.Equal(t, objectID, out.Activity.Object)
+}


### PR DESCRIPTION
## Summary
- bump Theory Cloud dependencies to `github.com/theory-cloud/apptheory v0.25.0` and `github.com/theory-cloud/tabletheory v1.6.0`
- add direct regression coverage for `models.Activity` hydration so nested `activitypub.Activity.BaseObject` fields (`id`, `type`) must survive TableTheory unmarshal
- make inbox `Accept`, `Reject`, and `Undo` paths fail visibly when a stored activity loads without required routing fields instead of silently no-oping

## Root Cause
Issue #769 traced follow-response reconciliation failures to malformed hydrated stored activities. `ActivityRepository.GetActivity(...)` could return a non-nil `activitypub.Activity` with embedded `BaseObject` fields empty, which left inbox routing without the `id`/`type` fields it needs.

The application should not silently reconcile around that corruption. TableTheory owns the decode fix; lesser should validate the contract and make failures visible if it regresses.

## Impact
- lesser now validates the upstream TableTheory fix with always-on regression coverage
- inbox routing surfaces malformed stored activities as explicit errors in the ID-based `Accept` / `Reject` / `Undo` paths
- the nested `infra/cdk` Go module stays aligned with the AppTheory bump used by the root module

## Validation
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `AWS_EC2_METADATA_DISABLED=true ./lesser verify ci`
