### PR TITLE
[codex] align REST auth gate with OAuth validation

### DIFF
--- a/cmd/api/agent_safety_middleware.go
+++ b/cmd/api/agent_safety_middleware.go
@@ -49,15 +49,6 @@ const (
 
 var errAgentConcurrencyExceeded = errors.New("agent concurrency exceeded")
 
-func createOptionalOAuthAuthMiddleware(cfg *config.Config, repos core.RepositoryStorage, _ *zap.Logger) apptheory.Middleware {
-	if cfg == nil || strings.TrimSpace(cfg.JWTSecret) == "" || repos == nil {
-		return func(next apptheory.Handler) apptheory.Handler { return next }
-	}
-
-	oauthSvc := auth.NewOAuthService(cfg.JWTSecret, cfg, repos, nil)
-	return auth.CreatePrincipalContextBridgeFromOAuthService(oauthSvc, nil, "api")
-}
-
 func createAgentSafetyRailsMiddleware(cfg *config.Config, repos core.RepositoryStorage, logger *zap.Logger) apptheory.Middleware {
 	if cfg == nil || repos == nil {
 		return func(next apptheory.Handler) apptheory.Handler { return next }

--- a/cmd/api/agent_safety_middleware_round13_test.go
+++ b/cmd/api/agent_safety_middleware_round13_test.go
@@ -11,9 +11,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/config"
 	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
-	"github.com/equaltoai/lesser/pkg/storage/repositories"
 	storageRepos "github.com/equaltoai/lesser/pkg/storage/repositories"
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
@@ -100,93 +98,6 @@ func newRateLimitRepoForCLISafety(t *testing.T) (*storageRepos.RateLimitReposito
 	q.On("Delete").Return(nil).Maybe()
 
 	return storageRepos.NewRateLimitRepository(db, "test-table", zap.NewNop(), nil), update
-}
-
-func TestCreateOptionalOAuthAuthMiddleware_Round13(t *testing.T) {
-	t.Run("no-op when config or repos missing", func(t *testing.T) {
-		mw := createOptionalOAuthAuthMiddleware(nil, nil, nil)
-		called := false
-		next := func(*apptheory.Context) (*apptheory.Response, error) {
-			called = true
-			return apptheory.Text(http.StatusOK, "ok"), nil
-		}
-		_, err := mw(next)(&apptheory.Context{})
-		require.NoError(t, err)
-		require.True(t, called)
-	})
-
-	t.Run("sets claims when bearer token validates", func(t *testing.T) {
-		cfg := &config.Config{JWTSecret: "secret"}
-		repos := &apiHandlers.MockRepositoryStorage{}
-		repos.On("Account").Return((*repositories.AccountRepository)(nil)).Maybe()
-		mw := createOptionalOAuthAuthMiddleware(cfg, repos, zap.NewNop())
-
-		now := time.Now()
-		claims := auth.Claims{
-			RegisteredClaims: jwt.RegisteredClaims{
-				Subject:   "agent",
-				IssuedAt:  jwt.NewNumericDate(now.Add(-time.Minute)),
-				NotBefore: jwt.NewNumericDate(now.Add(-time.Minute)),
-				ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
-			},
-			Username:  "agent",
-			Scopes:    []string{auth.ScopeRead},
-			SessionID: "sess-1",
-			IsAgent:   true,
-		}
-		token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(cfg.JWTSecret))
-		require.NoError(t, err)
-
-		ctx := &apptheory.Context{
-			Request: apptheory.Request{
-				Method: http.MethodGet,
-				Path:   "/",
-				Headers: map[string][]string{
-					"authorization": {"Bearer " + token},
-				},
-			},
-		}
-
-		resp, err := mw(func(c *apptheory.Context) (*apptheory.Response, error) {
-			stored, ok := c.Get("claims").(*auth.Claims)
-			require.True(t, ok)
-			require.Equal(t, "agent", stored.Username)
-			require.NotNil(t, c.AuthPrincipal)
-			require.Equal(t, "agent", c.AuthIdentity)
-			require.Equal(t, "agent", c.Get("username"))
-			require.Equal(t, true, c.Get("is_authenticated"))
-			return apptheory.Text(http.StatusOK, "ok"), nil
-		})(ctx)
-		require.NoError(t, err)
-		require.Equal(t, http.StatusOK, resp.Status)
-	})
-
-	t.Run("does not override existing auth context", func(t *testing.T) {
-		cfg := &config.Config{JWTSecret: "secret"}
-		repos := &apiHandlers.MockRepositoryStorage{}
-		repos.On("Account").Return((*repositories.AccountRepository)(nil)).Maybe()
-		mw := createOptionalOAuthAuthMiddleware(cfg, repos, zap.NewNop())
-
-		ctx := &apptheory.Context{
-			Request: apptheory.Request{
-				Method: http.MethodGet,
-				Path:   "/",
-			},
-		}
-		ctx.Set("claims", &auth.Claims{Username: "existing"})
-		ctx.Set("username", "existing")
-
-		resp, err := mw(func(c *apptheory.Context) (*apptheory.Response, error) {
-			stored := c.Get("claims").(*auth.Claims)
-			require.Equal(t, "existing", stored.Username)
-			require.NotNil(t, c.AuthPrincipal)
-			require.Equal(t, "existing", c.AuthIdentity)
-			require.Equal(t, "existing", c.Get("username"))
-			return apptheory.Text(http.StatusOK, "ok"), nil
-		})(ctx)
-		require.NoError(t, err)
-		require.Equal(t, http.StatusOK, resp.Status)
-	})
 }
 
 func TestAcquireAgentConcurrencyLease_Round13(t *testing.T) {

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -77,8 +77,8 @@ var (
 	newAuthService = auth.NewAuthService
 	newStreamQueue = streaming.NewDynamoStreamQueue
 
-	createAPIAuthMiddlewareFromAuthService = auth.CreateAPIAuthMiddlewareFromAuthService
-	newAPIHandler                          = apiHandlers.NewHandler
+	createAPIAuthMiddlewareFromOAuthService = auth.CreateAPIAuthMiddlewareFromOAuthService
+	newAPIHandler                           = apiHandlers.NewHandler
 
 	createInstanceLockMiddlewareFn = createInstanceLockMiddleware
 	configureRoutesFn              = configureRoutes
@@ -345,7 +345,21 @@ func main() {
 	lambdaStart(lambdaHandler)
 }
 
+func newAPIOAuthService(serviceLogger *zap.Logger) *auth.OAuthService {
+	if cfg == nil || cfg.JWTSecret == "" {
+		if serviceLogger != nil {
+			serviceLogger.Warn("JWT secret is not configured; API auth principal hook disabled")
+		}
+		return nil
+	}
+
+	auditLogger := auth.NewAuditLogger(repos, serviceLogger, auth.DefaultAuditConfig())
+	return auth.NewOAuthService(cfg.JWTSecret, cfg, repos, auditLogger)
+}
+
 func buildApp(lambdaLogger *zap.Logger) *apptheory.App {
+	oauthService := newAPIOAuthService(lambdaLogger)
+
 	options := []apptheory.Option{
 		apptheory.WithCORS(apptheory.CORSConfig{
 			AllowedOrigins:   []string{"*"},
@@ -366,9 +380,9 @@ func buildApp(lambdaLogger *zap.Logger) *apptheory.App {
 			MaxResponseBytes: 0,
 		}),
 	}
-	if authService != nil {
+	if authService != nil && oauthService != nil {
 		options = append(options, apptheory.WithAuthPrincipalHook(
-			auth.NewAppTheoryPrincipalHookFromAuthService(authService, lambdaLogger, "api"),
+			auth.NewAppTheoryPrincipalHookFromOAuthService(oauthService, lambdaLogger, "api"),
 		))
 	}
 	app := apptheory.New(options...)
@@ -385,8 +399,8 @@ func buildApp(lambdaLogger *zap.Logger) *apptheory.App {
 	app.Use(createInstanceLockMiddlewareFn(repos, lambdaLogger))
 
 	// Optional auth (enables user context for public endpoints).
-	if authService != nil {
-		app.Use(createAPIAuthMiddlewareFromAuthService(authService, lambdaLogger))
+	if authService != nil && oauthService != nil {
+		app.Use(createAPIAuthMiddlewareFromOAuthService(oauthService, lambdaLogger))
 	}
 	// Optional OAuth auth fallback (enables user context for OAuth/agent tokens too).
 	// This allows downstream middleware (rate limits, logging) to key by username for agents.

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -77,8 +77,8 @@ var (
 	newAuthService = auth.NewAuthService
 	newStreamQueue = streaming.NewDynamoStreamQueue
 
-	createAPIAuthMiddlewareFromOAuthService = auth.CreateAPIAuthMiddlewareFromOAuthService
-	newAPIHandler                           = apiHandlers.NewHandler
+	createAPIAuthMiddlewareFromAuthAndOAuthServices = auth.CreateAPIAuthMiddlewareFromAuthAndOAuthServices
+	newAPIHandler                                   = apiHandlers.NewHandler
 
 	createInstanceLockMiddlewareFn = createInstanceLockMiddleware
 	configureRoutesFn              = configureRoutes
@@ -382,7 +382,7 @@ func buildApp(lambdaLogger *zap.Logger) *apptheory.App {
 	}
 	if authService != nil && oauthService != nil {
 		options = append(options, apptheory.WithAuthPrincipalHook(
-			auth.NewAppTheoryPrincipalHookFromOAuthService(oauthService, lambdaLogger, "api"),
+			auth.NewAppTheoryPrincipalHookFromAuthAndOAuthServices(authService, oauthService, lambdaLogger, "api"),
 		))
 	}
 	app := apptheory.New(options...)
@@ -400,11 +400,8 @@ func buildApp(lambdaLogger *zap.Logger) *apptheory.App {
 
 	// Optional auth (enables user context for public endpoints).
 	if authService != nil && oauthService != nil {
-		app.Use(createAPIAuthMiddlewareFromOAuthService(oauthService, lambdaLogger))
+		app.Use(createAPIAuthMiddlewareFromAuthAndOAuthServices(authService, oauthService, lambdaLogger))
 	}
-	// Optional OAuth auth fallback (enables user context for OAuth/agent tokens too).
-	// This allows downstream middleware (rate limits, logging) to key by username for agents.
-	app.Use(createOptionalOAuthAuthMiddleware(cfg, repos, lambdaLogger))
 
 	// Enforce default-deny public surface policy.
 	app.Use(createPublicSurfaceMiddleware())

--- a/cmd/api/main_round12_test.go
+++ b/cmd/api/main_round12_test.go
@@ -20,13 +20,16 @@ import (
 	"github.com/equaltoai/lesser/pkg/cost"
 	"github.com/equaltoai/lesser/pkg/observability"
 	storagecore "github.com/equaltoai/lesser/pkg/storage/core"
+	storageinterfaces "github.com/equaltoai/lesser/pkg/storage/interfaces"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
 	"github.com/equaltoai/lesser/pkg/streaming"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	dynamormCore "github.com/theory-cloud/tabletheory/pkg/core"
+	dynamormErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 	"github.com/theory-cloud/tabletheory/pkg/mocks"
 	"go.uber.org/zap"
 )
@@ -395,12 +398,140 @@ func TestCreateCentralizedCostTrackingMiddlewareRound12(t *testing.T) {
 	}
 }
 
-func TestBuildApp_PublicOAuthBearerAuthenticatesProtectedAndOptionalRoutes(t *testing.T) {
+type apiRouteAuthTestConfig struct {
+	session            *storagemodels.Session
+	revokedAccessToken *storagemodels.RevokedAccessToken
+}
+
+func newAPIRouteAuthRepos(t *testing.T, cfg apiRouteAuthTestConfig) *mainTestRepos {
+	t.Helper()
+
+	mockDB := new(mocks.MockDB)
+	sessionQuery := new(mocks.MockQuery)
+	revokedQuery := new(mocks.MockQuery)
+	metricQuery := new(mocks.MockQuery)
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB).Maybe()
+	mockDB.On("Model", mock.MatchedBy(func(model any) bool {
+		_, ok := model.(*storagemodels.Session)
+		return ok
+	})).Return(sessionQuery).Maybe()
+	mockDB.On("Model", mock.MatchedBy(func(model any) bool {
+		_, ok := model.(*storagemodels.RevokedAccessToken)
+		return ok
+	})).Return(revokedQuery).Maybe()
+	mockDB.On("Model", mock.MatchedBy(func(model any) bool {
+		_, ok := model.(*storagemodels.MetricRecord)
+		return ok
+	})).Return(metricQuery).Maybe()
+
+	sessionQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(sessionQuery).Maybe()
+	if cfg.session != nil {
+		sessionQuery.On("First", mock.MatchedBy(func(dest any) bool {
+			_, ok := dest.(*storagemodels.Session)
+			return ok
+		})).Return(nil).Run(func(args mock.Arguments) {
+			*args.Get(0).(*storagemodels.Session) = *cfg.session
+		}).Maybe()
+	} else {
+		sessionQuery.On("First", mock.MatchedBy(func(dest any) bool {
+			_, ok := dest.(*storagemodels.Session)
+			return ok
+		})).Return(dynamormErrors.ErrItemNotFound).Maybe()
+	}
+
+	revokedQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(revokedQuery).Maybe()
+	revokedQuery.On("ConsistentRead").Return(revokedQuery).Maybe()
+	if cfg.revokedAccessToken != nil {
+		revokedQuery.On("First", mock.MatchedBy(func(dest any) bool {
+			_, ok := dest.(*storagemodels.RevokedAccessToken)
+			return ok
+		})).Return(nil).Run(func(args mock.Arguments) {
+			*args.Get(0).(*storagemodels.RevokedAccessToken) = *cfg.revokedAccessToken
+		}).Maybe()
+	} else {
+		revokedQuery.On("First", mock.MatchedBy(func(dest any) bool {
+			_, ok := dest.(*storagemodels.RevokedAccessToken)
+			return ok
+		})).Return(dynamormErrors.ErrItemNotFound).Maybe()
+	}
+
+	metricQuery.On("Create").Return(nil).Maybe()
+
+	logger := zap.NewNop()
+	account := repositories.NewAccountRepository(mockDB, "test-table", "example.com", logger)
+	metric := repositories.NewMetricRecordRepository(mockDB, "test-table", logger, nil)
+
+	mockRepos := &apiHandlers.MockRepositoryStorage{}
+	mockRepos.On("Activity").Return((storageinterfaces.ActivityRepository)(nil)).Maybe()
+	mockRepos.On("Notification").Return((storageinterfaces.NotificationRepository)(nil)).Maybe()
+	mockRepos.On("Recovery").Return((*repositories.RecoveryRepository)(nil)).Maybe()
+	mockRepos.On("Audit").Return((*repositories.AuditRepository)(nil)).Maybe()
+	mockRepos.On("PushSubscription").Return((*repositories.PushSubscriptionRepository)(nil)).Maybe()
+
+	return &mainTestRepos{
+		MockRepositoryStorage: mockRepos,
+		account:               account,
+		metricRecord:          metric,
+	}
+}
+
+func signNativeSessionAccessToken(t *testing.T, jwtSecret, username, sessionID string, scopes []string) string {
+	t.Helper()
+
+	now := time.Now().UTC()
+	claims := auth.Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   username,
+			IssuedAt:  jwt.NewNumericDate(now.Add(-time.Minute)),
+			NotBefore: jwt.NewNumericDate(now.Add(-time.Minute)),
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+		},
+		Username:  username,
+		ClientID:  "web",
+		Scopes:    scopes,
+		SessionID: sessionID,
+	}
+
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(jwtSecret))
+	require.NoError(t, err)
+	return token
+}
+
+func parseAccessTokenClaims(t *testing.T, jwtSecret, token string) *auth.Claims {
+	t.Helper()
+
+	parsed, err := jwt.ParseWithClaims(token, &auth.Claims{}, func(token *jwt.Token) (any, error) {
+		return []byte(jwtSecret), nil
+	})
+	require.NoError(t, err)
+
+	claims, ok := parsed.Claims.(*auth.Claims)
+	require.True(t, ok)
+	require.True(t, parsed.Valid)
+	return claims
+}
+
+func TestBuildApp_APIAuthRouteMatrix(t *testing.T) {
 	origRoutes := configureRoutesFn
 	origLock := createInstanceLockMiddlewareFn
+	origCfg := cfg
+	origLogger := logger
+	origRepos := repos
+	origAuthService := authService
+	origEMF := emfMetrics
+	origTracing := tracingManager
+	origCost := costTrackingService
 	t.Cleanup(func() {
 		configureRoutesFn = origRoutes
 		createInstanceLockMiddlewareFn = origLock
+		cfg = origCfg
+		logger = origLogger
+		repos = origRepos
+		authService = origAuthService
+		emfMetrics = origEMF
+		tracingManager = origTracing
+		costTrackingService = origCost
 	})
 
 	cfg = &config.Config{
@@ -412,10 +543,10 @@ func TestBuildApp_PublicOAuthBearerAuthenticatesProtectedAndOptionalRoutes(t *te
 		JWTSecret:       "a-very-strong-jwt-key-without-weak-patterns-9876543210",
 	}
 	logger = zap.NewNop()
-	repos = nil
-	authService = &auth.AuthService{}
+	emfMetrics = nil
+	tracingManager = nil
+	costTrackingService = nil
 
-	// Exercise OAuth-only API auth behavior without a backing session row.
 	createInstanceLockMiddlewareFn = func(_ storagecore.RepositoryStorage, _ *zap.Logger) apptheory.Middleware {
 		return func(next apptheory.Handler) apptheory.Handler { return next }
 	}
@@ -432,41 +563,137 @@ func TestBuildApp_PublicOAuthBearerAuthenticatesProtectedAndOptionalRoutes(t *te
 		}, apptheory.OptionalAuth())
 	}
 
-	oauthService := auth.NewOAuthService(cfg.JWTSecret, cfg, nil, nil)
-	token, _, err := oauthService.GenerateTokensWithAccessTokenTTLAndClientContext(
-		context.Background(),
-		"alice",
-		"client-agent",
-		"",
-		[]string{auth.ScopeRead},
-		time.Hour,
-		auth.ClientClassAgent,
-		"sid-public-oauth",
-	)
-	require.NoError(t, err)
+	now := time.Now().UTC()
+	validNativeSession := &storagemodels.Session{
+		PK:          "session#sid-native",
+		SK:          "session#sid-native",
+		SessionID:   "sid-native",
+		UserID:      "USER#alice",
+		AccessToken: "native-access",
+		CreatedAt:   now.Add(-time.Hour),
+		LastUsedAt:  now.Add(-time.Minute),
+		ExpiresAt:   now.Add(time.Hour).Unix(),
+		Version:     1,
+	}
 
-	app := buildApp(logger)
-	headers := map[string][]string{"Authorization": {"Bearer " + token}}
+	testCases := []struct {
+		name                  string
+		build                 func(t *testing.T) (string, *mainTestRepos)
+		wantProtectedStatus   int
+		wantProtectedUsername string
+		checkOptional         bool
+		wantOptionalUsername  string
+	}{
+		{
+			name: "public OAuth bearer without session row authenticates protected and optional routes",
+			build: func(t *testing.T) (string, *mainTestRepos) {
+				t.Helper()
+				oauthService := auth.NewOAuthService(cfg.JWTSecret, cfg, nil, nil)
+				token, _, err := oauthService.GenerateTokensWithAccessTokenTTLAndClientContext(
+					context.Background(),
+					"alice",
+					"client-agent",
+					"",
+					[]string{auth.ScopeRead},
+					time.Hour,
+					auth.ClientClassAgent,
+					"sid-public-oauth",
+				)
+				require.NoError(t, err)
+				return token, newAPIRouteAuthRepos(t, apiRouteAuthTestConfig{})
+			},
+			wantProtectedStatus:   http.StatusOK,
+			wantProtectedUsername: "alice",
+			checkOptional:         true,
+			wantOptionalUsername:  "alice",
+		},
+		{
+			name: "native session bearer with valid session row authenticates protected and optional routes",
+			build: func(t *testing.T) (string, *mainTestRepos) {
+				t.Helper()
+				token := signNativeSessionAccessToken(t, cfg.JWTSecret, "alice", "sid-native", []string{auth.ScopeRead})
+				return token, newAPIRouteAuthRepos(t, apiRouteAuthTestConfig{session: validNativeSession})
+			},
+			wantProtectedStatus:   http.StatusOK,
+			wantProtectedUsername: "alice",
+			checkOptional:         true,
+			wantOptionalUsername:  "alice",
+		},
+		{
+			name: "native session bearer without session row is rejected at protected route gate",
+			build: func(t *testing.T) (string, *mainTestRepos) {
+				t.Helper()
+				token := signNativeSessionAccessToken(t, cfg.JWTSecret, "alice", "sid-missing", []string{auth.ScopeRead})
+				return token, newAPIRouteAuthRepos(t, apiRouteAuthTestConfig{})
+			},
+			wantProtectedStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "revoked OAuth access token is rejected at protected route gate",
+			build: func(t *testing.T) (string, *mainTestRepos) {
+				t.Helper()
+				oauthService := auth.NewOAuthService(cfg.JWTSecret, cfg, nil, nil)
+				token, _, err := oauthService.GenerateTokensWithAccessTokenTTLAndClientContext(
+					context.Background(),
+					"alice",
+					"client-agent",
+					"",
+					[]string{auth.ScopeRead},
+					time.Hour,
+					auth.ClientClassAgent,
+					"sid-revoked-oauth",
+				)
+				require.NoError(t, err)
+				claims := parseAccessTokenClaims(t, cfg.JWTSecret, token)
+				revoked := &storagemodels.RevokedAccessToken{
+					JTI:       claims.ID,
+					ExpiresAt: now.Add(time.Hour),
+					RevokedAt: now,
+				}
+				require.NoError(t, revoked.BeforeCreate())
+				return token, newAPIRouteAuthRepos(t, apiRouteAuthTestConfig{revokedAccessToken: revoked})
+			},
+			wantProtectedStatus: http.StatusUnauthorized,
+		},
+	}
 
-	protectedResp := app.Serve(context.Background(), apptheory.Request{
-		Method:  http.MethodGet,
-		Path:    "/protected",
-		Headers: headers,
-	})
-	require.Equal(t, http.StatusOK, protectedResp.Status)
-	var protectedBody map[string]string
-	require.NoError(t, json.Unmarshal(protectedResp.Body, &protectedBody))
-	require.Equal(t, "alice", protectedBody["username"])
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			token, routeRepos := tc.build(t)
+			repos = routeRepos
 
-	optionalResp := app.Serve(context.Background(), apptheory.Request{
-		Method:  http.MethodGet,
-		Path:    "/optional",
-		Headers: headers,
-	})
-	require.Equal(t, http.StatusOK, optionalResp.Status)
-	var optionalBody map[string]string
-	require.NoError(t, json.Unmarshal(optionalResp.Body, &optionalBody))
-	require.Equal(t, "alice", optionalBody["username"])
+			var err error
+			authService, err = auth.NewAuthService(cfg, repos)
+			require.NoError(t, err)
+
+			app := buildApp(logger)
+			headers := map[string][]string{"Authorization": {"Bearer " + token}}
+
+			protectedResp := app.Serve(context.Background(), apptheory.Request{
+				Method:  http.MethodGet,
+				Path:    "/protected",
+				Headers: headers,
+			})
+			require.Equal(t, tc.wantProtectedStatus, protectedResp.Status)
+			if tc.wantProtectedUsername != "" {
+				var protectedBody map[string]string
+				require.NoError(t, json.Unmarshal(protectedResp.Body, &protectedBody))
+				require.Equal(t, tc.wantProtectedUsername, protectedBody["username"])
+			}
+
+			if tc.checkOptional {
+				optionalResp := app.Serve(context.Background(), apptheory.Request{
+					Method:  http.MethodGet,
+					Path:    "/optional",
+					Headers: headers,
+				})
+				require.Equal(t, http.StatusOK, optionalResp.Status)
+				var optionalBody map[string]string
+				require.NoError(t, json.Unmarshal(optionalResp.Body, &optionalBody))
+				require.Equal(t, tc.wantOptionalUsername, optionalBody["username"])
+			}
+		})
+	}
 }
 
 func TestMainRound12(t *testing.T) {

--- a/cmd/api/main_round12_test.go
+++ b/cmd/api/main_round12_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"os"
 	"testing"
 	"time"
@@ -392,6 +393,80 @@ func TestCreateCentralizedCostTrackingMiddlewareRound12(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatalf("timed out waiting for cost tracking")
 	}
+}
+
+func TestBuildApp_PublicOAuthBearerAuthenticatesProtectedAndOptionalRoutes(t *testing.T) {
+	origRoutes := configureRoutesFn
+	origLock := createInstanceLockMiddlewareFn
+	t.Cleanup(func() {
+		configureRoutesFn = origRoutes
+		createInstanceLockMiddlewareFn = origLock
+	})
+
+	cfg = &config.Config{
+		Domain:          "example.com",
+		Region:          "us-east-1",
+		Stage:           "development",
+		Version:         "test",
+		DynamoTableName: "test-table",
+		JWTSecret:       "a-very-strong-jwt-key-without-weak-patterns-9876543210",
+	}
+	logger = zap.NewNop()
+	repos = nil
+	authService = &auth.AuthService{}
+
+	// Exercise OAuth-only API auth behavior without a backing session row.
+	createInstanceLockMiddlewareFn = func(_ storagecore.RepositoryStorage, _ *zap.Logger) apptheory.Middleware {
+		return func(next apptheory.Handler) apptheory.Handler { return next }
+	}
+	configureRoutesFn = func(app *apptheory.App) {
+		app.Get("/protected", func(ctx *apptheory.Context) (*apptheory.Response, error) {
+			return apptheory.JSON(http.StatusOK, map[string]string{
+				"username": auth.UsernameFromAppTheoryContext(ctx),
+			})
+		}, apptheory.RequireScope(auth.ScopeRead))
+		app.Get("/optional", func(ctx *apptheory.Context) (*apptheory.Response, error) {
+			return apptheory.JSON(http.StatusOK, map[string]string{
+				"username": auth.UsernameFromAppTheoryContext(ctx),
+			})
+		}, apptheory.OptionalAuth())
+	}
+
+	oauthService := auth.NewOAuthService(cfg.JWTSecret, cfg, nil, nil)
+	token, _, err := oauthService.GenerateTokensWithAccessTokenTTLAndClientContext(
+		context.Background(),
+		"alice",
+		"client-agent",
+		"",
+		[]string{auth.ScopeRead},
+		time.Hour,
+		auth.ClientClassAgent,
+		"sid-public-oauth",
+	)
+	require.NoError(t, err)
+
+	app := buildApp(logger)
+	headers := map[string][]string{"Authorization": {"Bearer " + token}}
+
+	protectedResp := app.Serve(context.Background(), apptheory.Request{
+		Method:  http.MethodGet,
+		Path:    "/protected",
+		Headers: headers,
+	})
+	require.Equal(t, http.StatusOK, protectedResp.Status)
+	var protectedBody map[string]string
+	require.NoError(t, json.Unmarshal(protectedResp.Body, &protectedBody))
+	require.Equal(t, "alice", protectedBody["username"])
+
+	optionalResp := app.Serve(context.Background(), apptheory.Request{
+		Method:  http.MethodGet,
+		Path:    "/optional",
+		Headers: headers,
+	})
+	require.Equal(t, http.StatusOK, optionalResp.Status)
+	var optionalBody map[string]string
+	require.NoError(t, json.Unmarshal(optionalResp.Body, &optionalBody))
+	require.Equal(t, "alice", optionalBody["username"])
 }
 
 func TestMainRound12(t *testing.T) {

--- a/pkg/auth/apptheory_principal.go
+++ b/pkg/auth/apptheory_principal.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/golang-jwt/jwt/v5"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	"go.uber.org/zap"
 )
@@ -14,6 +15,14 @@ const (
 )
 
 type principalClaimsValidator func(string) (*Claims, error)
+
+type principalTokenFamily string
+
+const (
+	principalTokenFamilyUnknown principalTokenFamily = "unknown"
+	principalTokenFamilySession principalTokenFamily = "session"
+	principalTokenFamilyOAuth   principalTokenFamily = "oauth"
+)
 
 type appTheoryPrincipalResolver struct {
 	validate    principalClaimsValidator
@@ -52,6 +61,17 @@ func NewAppTheoryPrincipalHookFromOAuthService(oauthService *OAuthService, logge
 	return resolver.Resolve
 }
 
+// NewAppTheoryPrincipalHookFromAuthAndOAuthServices builds an AppTheory principal hook that preserves
+// native session validation while also accepting OAuth-issued access tokens on the same API surface.
+func NewAppTheoryPrincipalHookFromAuthAndOAuthServices(authService *AuthService, oauthService *OAuthService, logger *zap.Logger, serviceName string) apptheory.PrincipalAuthHook {
+	resolver := newCompositeAppTheoryPrincipalResolver(authService, oauthService, logger, serviceName)
+	if resolver == nil {
+		return nil
+	}
+
+	return resolver.Resolve
+}
+
 // CreatePrincipalContextBridgeFromAuthService mirrors AuthService-backed principal data into the legacy request context.
 func CreatePrincipalContextBridgeFromAuthService(authService *AuthService, logger *zap.Logger, serviceName string) apptheory.Middleware {
 	if authService == nil {
@@ -73,6 +93,72 @@ func CreatePrincipalContextBridgeFromOAuthService(oauthService *OAuthService, lo
 
 	resolver := newAppTheoryPrincipalResolver(oauthService.ValidateAccessToken, logger, serviceName)
 	return createPrincipalContextBridge(resolver)
+}
+
+// CreatePrincipalContextBridgeFromAuthAndOAuthServices mirrors principal data for both native
+// session-backed tokens and OAuth-issued tokens into the legacy request context.
+func CreatePrincipalContextBridgeFromAuthAndOAuthServices(authService *AuthService, oauthService *OAuthService, logger *zap.Logger, serviceName string) apptheory.Middleware {
+	resolver := newCompositeAppTheoryPrincipalResolver(authService, oauthService, logger, serviceName)
+	if resolver == nil {
+		return func(next apptheory.Handler) apptheory.Handler { return next }
+	}
+
+	return createPrincipalContextBridge(resolver)
+}
+
+func newCompositeAppTheoryPrincipalResolver(authService *AuthService, oauthService *OAuthService, logger *zap.Logger, serviceName string) *appTheoryPrincipalResolver {
+	validate := newCompositePrincipalClaimsValidator(authService, oauthService)
+	if validate == nil {
+		return nil
+	}
+
+	return newAppTheoryPrincipalResolver(validate, logger, serviceName)
+}
+
+func newCompositePrincipalClaimsValidator(authService *AuthService, oauthService *OAuthService) principalClaimsValidator {
+	if authService == nil && oauthService == nil {
+		return nil
+	}
+
+	return func(token string) (*Claims, error) {
+		switch inferPrincipalTokenFamily(token) {
+		case principalTokenFamilyOAuth:
+			if oauthService == nil {
+				return nil, ErrInvalidToken
+			}
+			return oauthService.ValidateAccessToken(token)
+		case principalTokenFamilySession:
+			if authService == nil {
+				return nil, ErrInvalidToken
+			}
+			return authService.ValidateAccessToken(token)
+		default:
+			return nil, ErrInvalidToken
+		}
+	}
+}
+
+func inferPrincipalTokenFamily(token string) principalTokenFamily {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return principalTokenFamilyUnknown
+	}
+
+	claims := &Claims{}
+	parser := jwt.NewParser()
+	if _, _, err := parser.ParseUnverified(token, claims); err != nil {
+		return principalTokenFamilyUnknown
+	}
+
+	// API route auth deliberately distinguishes Lesser's two current bearer families:
+	// OAuthService-issued access tokens always carry a JWT ID (`jti`) because revocation is keyed by JTI,
+	// while AuthService's short-lived native session tokens intentionally omit `jti` and remain anchored
+	// to backing session rows. If either family changes, revisit this classifier and the route-matrix tests.
+	if strings.TrimSpace(claims.ID) != "" {
+		return principalTokenFamilyOAuth
+	}
+
+	return principalTokenFamilySession
 }
 
 func createPrincipalContextBridge(resolver *appTheoryPrincipalResolver) apptheory.Middleware {
@@ -115,13 +201,13 @@ func (r *appTheoryPrincipalResolver) Resolve(ctx *apptheory.Context) (*apptheory
 
 	token, err := ExtractBearerToken(authHeader)
 	if err != nil || strings.TrimSpace(token) == "" {
-		r.logDebug(ctx, "optional auth: invalid bearer token format", zap.Error(err))
+		r.logDebug(ctx, "principal authentication skipped - invalid bearer token format", zap.Error(err))
 		return nil, nil
 	}
 
 	claims, err := r.validate(token)
 	if err != nil || claims == nil {
-		r.logWarn(ctx, "optional authentication failed - header present but validation failed", zap.Error(err))
+		r.logWarn(ctx, "principal authentication failed - header present but validation failed", zap.Error(err))
 		return nil, nil
 	}
 

--- a/pkg/auth/apptheory_principal_round13_edgecases_test.go
+++ b/pkg/auth/apptheory_principal_round13_edgecases_test.go
@@ -1,0 +1,294 @@
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func newSessionAuthServiceForPrincipalTests(sessionID string) *AuthService {
+	return &AuthService{
+		jwtSecret: []byte("test-secret"),
+		accountRepo: compositeAuthAccountRepo{
+			session: &storage.Session{
+				SessionID: sessionID,
+				ExpiresAt: time.Now().Add(time.Hour),
+			},
+		},
+	}
+}
+
+func newSessionAccessTokenForPrincipalTests(t *testing.T, sessionID string) string {
+	t.Helper()
+
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, &Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   "alice",
+			IssuedAt:  jwt.NewNumericDate(time.Now().Add(-time.Minute)),
+			NotBefore: jwt.NewNumericDate(time.Now().Add(-time.Minute)),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+		Username:  "alice",
+		Scopes:    []string{"read"},
+		SessionID: sessionID,
+	}).SignedString([]byte("test-secret"))
+	require.NoError(t, err)
+
+	return token
+}
+
+func TestAppTheoryPrincipalResolver_EdgeCases(t *testing.T) {
+	t.Run("nil resolver marks attempted and returns nil", func(t *testing.T) {
+		ctx := newTestContext("GET", "/api/v1/statuses")
+
+		var resolver *appTheoryPrincipalResolver
+		principal, err := resolver.Resolve(ctx)
+		require.NoError(t, err)
+		assert.Nil(t, principal)
+		assert.True(t, principalResolutionAttempted(ctx))
+	})
+
+	t.Run("nil context returns nil without panic", func(t *testing.T) {
+		resolver := newAppTheoryPrincipalResolver(func(string) (*Claims, error) {
+			t.Fatal("validator should not run for nil context")
+			return nil, nil
+		}, zap.NewNop(), "api")
+
+		principal, err := resolver.Resolve(nil)
+		require.NoError(t, err)
+		assert.Nil(t, principal)
+	})
+
+	t.Run("nil validator returns nil principal", func(t *testing.T) {
+		ctx := newTestContext("GET", "/api/v1/statuses", withHeaders(map[string]string{
+			"Authorization": "Bearer token",
+		}))
+
+		resolver := &appTheoryPrincipalResolver{}
+		principal, err := resolver.Resolve(ctx)
+		require.NoError(t, err)
+		assert.Nil(t, principal)
+		assert.True(t, principalResolutionAttempted(ctx))
+	})
+
+	t.Run("nil claims still logs validation failure", func(t *testing.T) {
+		core, observed := observer.New(zap.WarnLevel)
+		resolver := newAppTheoryPrincipalResolver(func(token string) (*Claims, error) {
+			assert.Equal(t, "token", token)
+			return nil, nil
+		}, zap.New(core), "api")
+
+		ctx := newTestContext("GET", "/api/v1/statuses", withHeaders(map[string]string{
+			"Authorization": "Bearer token",
+		}))
+
+		principal, err := resolver.Resolve(ctx)
+		require.NoError(t, err)
+		assert.Nil(t, principal)
+
+		entries := observed.FilterMessage("principal authentication failed - header present but validation failed").AllUntimed()
+		require.Len(t, entries, 1)
+		assert.Equal(t, "api", entries[0].ContextMap()["service"])
+	})
+}
+
+func TestAppTheoryPrincipalContextBridge_FallbacksAndSkips(t *testing.T) {
+	t.Run("nil context passes through unchanged", func(t *testing.T) {
+		nextCalled := false
+		resp, err := createPrincipalContextBridge(nil)(func(ctx *apptheory.Context) (*apptheory.Response, error) {
+			nextCalled = true
+			assert.Nil(t, ctx)
+			return &apptheory.Response{Status: 204}, nil
+		})(nil)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.True(t, nextCalled)
+	})
+
+	t.Run("attempted context does not re-resolve", func(t *testing.T) {
+		ctx := newTestContext("GET", "/api/v1/public", withHeaders(map[string]string{
+			"Authorization": "Bearer token",
+		}))
+		markPrincipalResolutionAttempted(ctx)
+
+		nextCalled := false
+		middleware := createPrincipalContextBridge(newAppTheoryPrincipalResolver(func(string) (*Claims, error) {
+			t.Fatal("resolver should not run when principal resolution was already attempted")
+			return nil, nil
+		}, zap.NewNop(), "api"))
+
+		resp, err := middleware(func(ctx *apptheory.Context) (*apptheory.Response, error) {
+			nextCalled = true
+			assert.False(t, IsAppTheoryContextAuthenticated(ctx))
+			assert.Equal(t, false, ctx.Get("is_authenticated"))
+			return &apptheory.Response{Status: 204}, nil
+		})(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.True(t, nextCalled)
+	})
+
+	t.Run("principal identity seeds legacy auth context when username claims are absent", func(t *testing.T) {
+		ctx := newTestContext("GET", "/api/v1/public")
+		ctx.AuthPrincipal = &apptheory.AuthPrincipal{
+			Identity: "  principal-user  ",
+			Claims:   map[string]any{},
+		}
+
+		nextCalled := false
+		resp, err := createPrincipalContextBridge(nil)(func(ctx *apptheory.Context) (*apptheory.Response, error) {
+			nextCalled = true
+			assert.Equal(t, "principal-user", ctx.AuthIdentity)
+			assert.Equal(t, "principal-user", ctx.Get("username"))
+			assert.Equal(t, true, ctx.Get("is_authenticated"))
+			return &apptheory.Response{Status: 204}, nil
+		})(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.True(t, nextCalled)
+	})
+}
+
+func TestAppTheoryPrincipalHelperFallbackBranches(t *testing.T) {
+	assert.Nil(t, PrincipalFromClaims(nil))
+	assert.False(t, principalResolutionAttempted(nil))
+	assert.Equal(t, principalTokenFamilyUnknown, inferPrincipalTokenFamily("   "))
+
+	t.Run("username falls back to legacy username field when no claims exist", func(t *testing.T) {
+		ctx := newTestContext("GET", "/api/v1/accounts")
+		ctx.Set("username", "  legacy-user  ")
+		assert.Nil(t, ClaimsFromAppTheoryContext(ctx))
+		assert.Equal(t, "legacy-user", UsernameFromAppTheoryContext(ctx))
+	})
+
+	t.Run("claims are synthesized from principal username claim when raw claims are absent", func(t *testing.T) {
+		ctx := newTestContext("GET", "/api/v1/accounts")
+		ctx.AuthPrincipal = &apptheory.AuthPrincipal{
+			Identity: "fallback-id",
+			Scopes:   []string{"read"},
+			Claims: map[string]any{
+				"username": "  principal-user  ",
+				"subject":  "subject-2",
+			},
+		}
+
+		claims := ClaimsFromAppTheoryContext(ctx)
+		require.NotNil(t, claims)
+		assert.Equal(t, "principal-user", claims.GetUsername())
+		assert.Equal(t, "subject-2", claims.Subject)
+		assert.Equal(t, "principal-user", UsernameFromAppTheoryContext(ctx))
+	})
+}
+
+func TestCompositePrincipalClaimsValidator_ServiceAvailabilityBranches(t *testing.T) {
+	authService := newSessionAuthServiceForPrincipalTests("session-1")
+	oauthService := &OAuthService{jwtSecret: []byte("test-secret")}
+
+	require.Nil(t, newCompositePrincipalClaimsValidator(nil, nil))
+
+	sessionToken := newSessionAccessTokenForPrincipalTests(t, "session-1")
+	oauthToken, err := oauthService.generateAccessTokenWithMetadata("alice", "client-agent", []string{"read"}, accessTokenMetadata{
+		SessionID: "session-oauth",
+	})
+	require.NoError(t, err)
+
+	oauthOnly := newCompositePrincipalClaimsValidator(nil, oauthService)
+	require.NotNil(t, oauthOnly)
+	_, err = oauthOnly(sessionToken)
+	require.ErrorIs(t, err, ErrInvalidToken)
+	oauthClaims, err := oauthOnly(oauthToken)
+	require.NoError(t, err)
+	require.NotNil(t, oauthClaims)
+
+	authOnly := newCompositePrincipalClaimsValidator(authService, nil)
+	require.NotNil(t, authOnly)
+	sessionClaims, err := authOnly(sessionToken)
+	require.NoError(t, err)
+	require.NotNil(t, sessionClaims)
+	_, err = authOnly(oauthToken)
+	require.ErrorIs(t, err, ErrInvalidToken)
+	_, err = authOnly("not-a-jwt")
+	require.ErrorIs(t, err, ErrInvalidToken)
+}
+
+func TestAppTheoryPrincipalHooksAndBridges_WithRealServices(t *testing.T) {
+	authService := newSessionAuthServiceForPrincipalTests("session-1")
+	oauthService := &OAuthService{jwtSecret: []byte("test-secret")}
+
+	sessionToken := newSessionAccessTokenForPrincipalTests(t, "session-1")
+	oauthToken, err := oauthService.generateAccessTokenWithMetadata("alice", "client-agent", []string{"read"}, accessTokenMetadata{
+		SessionID: "session-oauth",
+	})
+	require.NoError(t, err)
+
+	t.Run("auth service hook validates native session token", func(t *testing.T) {
+		hook := NewAppTheoryPrincipalHookFromAuthService(authService, zap.NewNop(), "api")
+		require.NotNil(t, hook)
+
+		principal, err := hook(newTestContext("GET", "/api/v1/me", withHeaders(map[string]string{
+			"Authorization": "Bearer " + sessionToken,
+		})))
+		require.NoError(t, err)
+		require.NotNil(t, principal)
+		assert.Equal(t, "alice", principal.Identity)
+	})
+
+	t.Run("auth service bridge hydrates legacy context", func(t *testing.T) {
+		nextCalled := false
+		middleware := CreatePrincipalContextBridgeFromAuthService(authService, zap.NewNop(), "api")
+
+		resp, err := middleware(func(ctx *apptheory.Context) (*apptheory.Response, error) {
+			nextCalled = true
+			assert.Equal(t, "alice", UsernameFromAppTheoryContext(ctx))
+			assert.Equal(t, true, ctx.Get("is_authenticated"))
+			return &apptheory.Response{Status: 204}, nil
+		})(newTestContext("GET", "/api/v1/me", withHeaders(map[string]string{
+			"Authorization": "Bearer " + sessionToken,
+		})))
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.True(t, nextCalled)
+	})
+
+	t.Run("composite hook accepts oauth token without session row", func(t *testing.T) {
+		hook := NewAppTheoryPrincipalHookFromAuthAndOAuthServices(&AuthService{
+			jwtSecret:   []byte("test-secret"),
+			accountRepo: compositeAuthAccountRepo{},
+		}, oauthService, zap.NewNop(), "api")
+		require.NotNil(t, hook)
+
+		principal, err := hook(newTestContext("GET", "/api/v1/me", withHeaders(map[string]string{
+			"Authorization": "Bearer " + oauthToken,
+		})))
+		require.NoError(t, err)
+		require.NotNil(t, principal)
+		assert.Equal(t, "alice", principal.Identity)
+	})
+
+	t.Run("composite bridge accepts oauth token without session row", func(t *testing.T) {
+		nextCalled := false
+		middleware := CreatePrincipalContextBridgeFromAuthAndOAuthServices(&AuthService{
+			jwtSecret:   []byte("test-secret"),
+			accountRepo: compositeAuthAccountRepo{},
+		}, oauthService, zap.NewNop(), "api")
+
+		resp, err := middleware(func(ctx *apptheory.Context) (*apptheory.Response, error) {
+			nextCalled = true
+			assert.Equal(t, "alice", UsernameFromAppTheoryContext(ctx))
+			assert.Equal(t, true, ctx.Get("is_authenticated"))
+			return &apptheory.Response{Status: 204}, nil
+		})(newTestContext("GET", "/api/v1/me", withHeaders(map[string]string{
+			"Authorization": "Bearer " + oauthToken,
+		})))
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.True(t, nextCalled)
+	})
+}

--- a/pkg/auth/apptheory_principal_test.go
+++ b/pkg/auth/apptheory_principal_test.go
@@ -1,10 +1,14 @@
 package auth
 
 import (
+	"context"
 	"errors"
 	"testing"
+	"time"
 
+	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,6 +16,53 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
+
+type compositeAuthAccountRepo struct {
+	session *storage.Session
+}
+
+func (r compositeAuthAccountRepo) GetUser(_ context.Context, _ string) (*storage.User, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (r compositeAuthAccountRepo) UpdateUser(_ context.Context, _ string, _ map[string]any) error {
+	return errors.New("not implemented")
+}
+
+func (r compositeAuthAccountRepo) GetActor(_ context.Context, _ string) (*activitypub.Actor, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (r compositeAuthAccountRepo) GetDevice(_ context.Context, _ string) (*storage.Device, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (r compositeAuthAccountRepo) GetSession(_ context.Context, _ string) (*storage.Session, error) {
+	if r.session == nil {
+		return nil, errors.New("missing session")
+	}
+	return r.session, nil
+}
+
+func (r compositeAuthAccountRepo) GetUserWalletCredentials(_ context.Context, _ string) ([]*storage.WalletCredential, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (r compositeAuthAccountRepo) MarkWalletChallengeSpent(_ context.Context, _ string) error {
+	return errors.New("not implemented")
+}
+
+func (r compositeAuthAccountRepo) ResetWalletChallengeSpent(_ context.Context, _ string) error {
+	return errors.New("not implemented")
+}
+
+func (r compositeAuthAccountRepo) GetWalletChallenge(_ context.Context, _ string) (*storage.WalletChallenge, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (r compositeAuthAccountRepo) StoreRecoveryToken(_ context.Context, _ string, _ map[string]any) error {
+	return errors.New("not implemented")
+}
 
 func testAppTheoryClaims() *Claims {
 	return &Claims{
@@ -60,7 +111,7 @@ func TestAppTheoryPrincipalResolverResolve(t *testing.T) {
 		assert.Nil(t, principal)
 		assert.True(t, principalResolutionAttempted(ctx))
 
-		entries := observed.FilterMessage("optional auth: invalid bearer token format").AllUntimed()
+		entries := observed.FilterMessage("principal authentication skipped - invalid bearer token format").AllUntimed()
 		require.Len(t, entries, 1)
 		assert.Equal(t, "api", entries[0].ContextMap()["service"])
 		assert.Equal(t, "/api/v1/statuses", entries[0].ContextMap()["path"])
@@ -83,7 +134,7 @@ func TestAppTheoryPrincipalResolverResolve(t *testing.T) {
 		assert.Nil(t, principal)
 		assert.True(t, principalResolutionAttempted(ctx))
 
-		entries := observed.FilterMessage("optional authentication failed - header present but validation failed").AllUntimed()
+		entries := observed.FilterMessage("principal authentication failed - header present but validation failed").AllUntimed()
 		require.Len(t, entries, 1)
 		assert.Equal(t, "graphql", entries[0].ContextMap()["service"])
 		assert.Equal(t, "/graphql", entries[0].ContextMap()["path"])
@@ -301,6 +352,7 @@ func TestAppTheoryPrincipalContextHelpers(t *testing.T) {
 
 func TestAppTheoryPrincipalUtilityFunctions(t *testing.T) {
 	assert.Nil(t, NewAppTheoryPrincipalHookFromAuthService(nil, zap.NewNop(), "api"))
+	assert.Nil(t, NewAppTheoryPrincipalHookFromAuthAndOAuthServices(nil, nil, zap.NewNop(), "api"))
 
 	noOpAuthBridge := CreatePrincipalContextBridgeFromAuthService(nil, zap.NewNop(), "api")
 	nextCalled := false
@@ -312,6 +364,14 @@ func TestAppTheoryPrincipalUtilityFunctions(t *testing.T) {
 	assert.True(t, nextCalled)
 
 	assert.Nil(t, NewAppTheoryPrincipalHookFromOAuthService(nil, zap.NewNop(), "api"))
+	noOpCompositeBridge := CreatePrincipalContextBridgeFromAuthAndOAuthServices(nil, nil, zap.NewNop(), "api")
+	nextCalled = false
+	_, err = noOpCompositeBridge(func(ctx *apptheory.Context) (*apptheory.Response, error) {
+		nextCalled = true
+		return &apptheory.Response{Status: 204}, nil
+	})(newTestContext("GET", "/api/v1/public"))
+	require.NoError(t, err)
+	assert.True(t, nextCalled)
 
 	noOpOAuthBridge := CreatePrincipalContextBridgeFromOAuthService(nil, zap.NewNop(), "api")
 	nextCalled = false
@@ -365,4 +425,71 @@ func TestAppTheoryPrincipalUtilityFunctions(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, principal)
 	assert.Equal(t, "alice", principal.Identity)
+
+	sessionToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, &Claims{
+		RegisteredClaims: jwt.RegisteredClaims{Subject: "alice"},
+		Username:         "alice",
+		Scopes:           []string{"read"},
+		SessionID:        "session-1",
+	}).SignedString([]byte("test-secret"))
+	require.NoError(t, err)
+	assert.Equal(t, principalTokenFamilySession, inferPrincipalTokenFamily(sessionToken))
+	assert.Equal(t, principalTokenFamilyUnknown, inferPrincipalTokenFamily("not-a-jwt"))
+
+	oauthToken, err := oauthService.generateAccessTokenWithMetadata("Alice", "web", []string{"read"}, accessTokenMetadata{
+		SessionID: "session-1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, principalTokenFamilyOAuth, inferPrincipalTokenFamily(oauthToken))
+}
+
+func TestCompositePrincipalClaimsValidatorRoutesByTokenFamily(t *testing.T) {
+	authService := &AuthService{
+		jwtSecret: []byte("test-secret"),
+		accountRepo: compositeAuthAccountRepo{
+			session: &storage.Session{
+				SessionID: "session-1",
+				ExpiresAt: time.Now().Add(time.Hour),
+			},
+		},
+	}
+	oauthService := &OAuthService{jwtSecret: []byte("test-secret")}
+
+	validator := newCompositePrincipalClaimsValidator(authService, oauthService)
+	require.NotNil(t, validator)
+
+	sessionToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, &Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   "alice",
+			IssuedAt:  jwt.NewNumericDate(time.Now().Add(-time.Minute)),
+			NotBefore: jwt.NewNumericDate(time.Now().Add(-time.Minute)),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+		Username:  "alice",
+		Scopes:    []string{"read"},
+		SessionID: "session-1",
+	}).SignedString([]byte("test-secret"))
+	require.NoError(t, err)
+
+	sessionClaims, err := validator(sessionToken)
+	require.NoError(t, err)
+	require.NotNil(t, sessionClaims)
+	assert.Equal(t, "alice", sessionClaims.GetUsername())
+	assert.Equal(t, "session-1", sessionClaims.SessionID)
+
+	oauthToken, err := oauthService.generateAccessTokenWithMetadata("alice", "client-agent", []string{"read"}, accessTokenMetadata{
+		SessionID: "session-oauth",
+	})
+	require.NoError(t, err)
+
+	oauthClaims, err := validator(oauthToken)
+	require.NoError(t, err)
+	require.NotNil(t, oauthClaims)
+	assert.Equal(t, "alice", oauthClaims.GetUsername())
+	assert.Equal(t, "session-oauth", oauthClaims.SessionID)
+	assert.NotEmpty(t, oauthClaims.ID)
+
+	authService.accountRepo = compositeAuthAccountRepo{}
+	_, err = validator(sessionToken)
+	require.ErrorIs(t, err, ErrInvalidToken)
 }

--- a/pkg/auth/auth_round13_buffer_test.go
+++ b/pkg/auth/auth_round13_buffer_test.go
@@ -1,0 +1,144 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+)
+
+type rateLimitSelectiveErrRepo struct {
+	*rateLimitRepoStub
+	countErrByID map[string]error
+	limitErrByID map[string]error
+}
+
+func (r *rateLimitSelectiveErrRepo) IsRateLimited(_ context.Context, identifier string) (bool, time.Time, error) {
+	if err := r.limitErrByID[identifier]; err != nil {
+		return false, time.Time{}, err
+	}
+	if r.rateLimitRepoStub == nil {
+		return false, time.Time{}, nil
+	}
+	return r.rateLimitRepoStub.IsRateLimited(context.Background(), identifier)
+}
+
+func (r *rateLimitSelectiveErrRepo) GetLoginAttemptCount(_ context.Context, identifier string, _ time.Time) (int, error) {
+	if err := r.countErrByID[identifier]; err != nil {
+		return 0, err
+	}
+	if r.rateLimitRepoStub == nil {
+		return 0, nil
+	}
+	return r.rateLimitRepoStub.GetLoginAttemptCount(context.Background(), identifier, time.Time{})
+}
+
+func TestScopePolicy_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	scopes := CanonicalOAuthScopes()
+	scopes[0] = "mutated"
+	require.Equal(t, []string{ScopeRead, ScopeWrite, ScopeFollow, ScopePush}, CanonicalOAuthScopes())
+
+	require.NoError(t, ValidatePublicOAuthScopes(nil))
+	require.NoError(t, ValidatePublicOAuthScopes([]string{" READ "}))
+	require.False(t, ScopeGrantAllows("", ScopeRead))
+	require.False(t, ScopeGrantAllows(ScopeRead, ""))
+	require.True(t, ScopeGrantAllows(ScopeAdmin, "admin:write"))
+	require.True(t, ScopeSetAllows([]string{ScopeRead}, []string{"", "read:notifications"}))
+
+	require.True(t, isRecognizedOAuthScope(" PUSH "))
+	require.True(t, isRecognizedOAuthScope("admin:write"))
+	require.False(t, isRecognizedOAuthScope(""))
+	require.False(t, isRecognizedOAuthScope("custom:scope"))
+}
+
+func TestMCPAccessHelper_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	bundle := BuildPublicMCPAccessBundle(" https://example.com/ ", "   ")
+	require.Empty(t, bundle.MCPURL)
+	require.Empty(t, bundle.ProtectedResourceURL)
+	require.Len(t, bundle.Guidance, 5)
+
+	require.Equal(t, "https://api.example.com:8443", canonicalMCPResourceBaseURL("https://example.com:8443/"))
+	require.Equal(t, "not a url", canonicalMCPResourceBaseURL("not a url"))
+	require.True(t, isLocalMCPHostname("127.0.0.1"))
+	require.True(t, isLocalMCPHostname("service.localhost"))
+	require.True(t, isLocalMCPHostname("::1"))
+	require.False(t, isLocalMCPHostname(""))
+}
+
+func TestOAuthService_HelperEarlyReturns(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, getOAuthAccountRepo(nil))
+	require.Nil(t, getOAuthAccountRepo(reposStub{}))
+
+	var nilService *OAuthService
+	require.NoError(t, nilService.validateAccessTokenNotRevoked(&Claims{
+		RegisteredClaims: jwt.RegisteredClaims{ID: "jti"},
+	}))
+
+	svc := &OAuthService{}
+	require.NoError(t, svc.validateAccessTokenNotRevoked(nil))
+	require.NoError(t, svc.validateAccessTokenNotRevoked(&Claims{}))
+
+	svc = &OAuthService{repos: reposStub{}}
+	require.NoError(t, svc.validateAccessTokenNotRevoked(&Claims{
+		RegisteredClaims: jwt.RegisteredClaims{ID: "jti"},
+	}))
+}
+
+func TestRateLimiter_ErrorBranches(t *testing.T) {
+	t.Parallel()
+
+	rl := NewRateLimiter(reposStub{})
+	require.Nil(t, rl.accountRepo)
+
+	ctx := context.Background()
+	baseStub := &rateLimitRepoStub{
+		limited: map[string]bool{},
+		until:   map[string]time.Time{},
+		counts:  map[string]int{},
+	}
+	stub := &rateLimitSelectiveErrRepo{
+		rateLimitRepoStub: baseStub,
+		countErrByID:      map[string]error{},
+		limitErrByID:      map[string]error{},
+	}
+	rl = &RateLimiter{accountRepo: stub}
+
+	stub.limitErrByID[RateLimitTypeIP+":192.0.2.1"] = errors.New("limit failed")
+	err := rl.CheckRateLimit(ctx, "", "192.0.2.1")
+	require.ErrorIs(t, err, ErrIPRateLimitCheck)
+
+	delete(stub.limitErrByID, RateLimitTypeIP+":192.0.2.1")
+	stub.limitErrByID[RateLimitTypeAccount+":alice"] = errors.New("account limit failed")
+	err = rl.CheckRateLimit(ctx, "alice", "192.0.2.1")
+	require.ErrorIs(t, err, ErrAccountRateLimitCheck)
+	delete(stub.limitErrByID, RateLimitTypeAccount+":alice")
+
+	stub.countErrByID[RateLimitTypeIP+":192.0.2.1"] = errors.New("ip count failed")
+	err = rl.RecordAttempt(ctx, "", "192.0.2.1", false)
+	require.ErrorIs(t, err, ErrGetIPAttemptCount)
+	delete(stub.countErrByID, RateLimitTypeIP+":192.0.2.1")
+
+	baseStub.counts[RateLimitTypeIP+":192.0.2.1"] = 0
+	baseStub.counts[RateLimitTypeAccount+":alice"] = 0
+	stub.countErrByID[RateLimitTypeAccount+":alice"] = errors.New("account count failed")
+	err = rl.RecordAttempt(ctx, "alice", "192.0.2.1", false)
+	require.ErrorIs(t, err, ErrGetAccountAttemptCount)
+	delete(stub.countErrByID, RateLimitTypeAccount+":alice")
+
+	baseStub.clearErr = errors.New("clear failed")
+	require.Error(t, rl.ClearAccountLockout(ctx, "alice"))
+
+	baseStub.clearErr = nil
+	stub.limitErrByID[RateLimitTypeAccount+":alice"] = errors.New("status failed")
+	_, err = rl.GetAccountStatus(ctx, "alice")
+	require.Error(t, err)
+}

--- a/pkg/auth/middleware_more_test.go
+++ b/pkg/auth/middleware_more_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -51,4 +52,12 @@ func TestMiddleware_RequireAuth_LowercaseHeader_AndInvalidTokenPaths(t *testing.
 		},
 	})
 	require.ErrorIs(t, err, ErrInvalidToken)
+}
+
+func TestMiddleware_ValidateToken_PropagatesServiceValidationErrors(t *testing.T) {
+	m := &Middleware{oauthService: &OAuthService{jwtSecret: []byte("test-secret")}}
+
+	claims, err := m.ValidateToken("Bearer not-a-jwt")
+	require.ErrorIs(t, err, ErrInvalidToken)
+	assert.Nil(t, claims)
 }

--- a/pkg/auth/middleware_unified_round13_wrapper_test.go
+++ b/pkg/auth/middleware_unified_round13_wrapper_test.go
@@ -1,0 +1,44 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestUnifiedAuthMiddleware_OptionalWrapperConstructors(t *testing.T) {
+	wrappers := map[string]func(common.OAuthServiceInterface, *zap.Logger) apptheory.Middleware{
+		"api":        CreateAPIAuthMiddleware,
+		"graphql":    CreateGraphQLAuthMiddleware,
+		"federation": CreateFederationAuthMiddleware,
+	}
+
+	for serviceName, build := range wrappers {
+		t.Run(serviceName+" logs wrapper service name on invalid header", func(t *testing.T) {
+			core, observed := observer.New(zap.WarnLevel)
+			logger := zap.New(core)
+			ctx := newTestContext("GET", "/"+serviceName, withHeaders(map[string]string{
+				"Authorization": "Bearer invalid-token",
+			}))
+
+			nextCalled := false
+			resp, err := build(oauthServiceStub{err: ErrInvalidToken}, logger)(func(ctx *apptheory.Context) (*apptheory.Response, error) {
+				nextCalled = true
+				assert.False(t, IsAuthenticated(ctx))
+				return &apptheory.Response{Status: 204}, nil
+			})(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			assert.True(t, nextCalled)
+
+			entries := observed.FilterMessage("optional authentication failed - header present but validation failed").AllUntimed()
+			require.Len(t, entries, 1)
+			assert.Equal(t, serviceName, entries[0].ContextMap()["service"])
+		})
+	}
+}

--- a/pkg/auth/oauth_adapter.go
+++ b/pkg/auth/oauth_adapter.go
@@ -34,9 +34,10 @@ func CreateAPIAuthMiddlewareFromAuthService(authService *AuthService, logger *za
 	return CreatePrincipalContextBridgeFromAuthService(authService, logger, "api")
 }
 
-// CreateAPIAuthMiddlewareFromOAuthService creates API auth middleware from OAuthService.
-func CreateAPIAuthMiddlewareFromOAuthService(oauthService *OAuthService, logger *zap.Logger) apptheory.Middleware {
-	return CreatePrincipalContextBridgeFromOAuthService(oauthService, logger, "api")
+// CreateAPIAuthMiddlewareFromAuthAndOAuthServices creates API auth middleware that preserves
+// native session validation while also accepting OAuth-issued tokens.
+func CreateAPIAuthMiddlewareFromAuthAndOAuthServices(authService *AuthService, oauthService *OAuthService, logger *zap.Logger) apptheory.Middleware {
+	return CreatePrincipalContextBridgeFromAuthAndOAuthServices(authService, oauthService, logger, "api")
 }
 
 // CreateGraphQLAuthMiddlewareFromAuthService creates GraphQL auth middleware from AuthService.

--- a/pkg/auth/oauth_adapter.go
+++ b/pkg/auth/oauth_adapter.go
@@ -29,17 +29,22 @@ func (a *OAuthServiceAdapter) ValidateAccessToken(token string) (common.Claims, 
 	return enhancedClaims, nil
 }
 
-// CreateAPIAuthMiddlewareFromAuthService creates API auth middleware from AuthService
+// CreateAPIAuthMiddlewareFromAuthService creates API auth middleware from AuthService.
 func CreateAPIAuthMiddlewareFromAuthService(authService *AuthService, logger *zap.Logger) apptheory.Middleware {
 	return CreatePrincipalContextBridgeFromAuthService(authService, logger, "api")
 }
 
-// CreateGraphQLAuthMiddlewareFromAuthService creates GraphQL auth middleware from AuthService
+// CreateAPIAuthMiddlewareFromOAuthService creates API auth middleware from OAuthService.
+func CreateAPIAuthMiddlewareFromOAuthService(oauthService *OAuthService, logger *zap.Logger) apptheory.Middleware {
+	return CreatePrincipalContextBridgeFromOAuthService(oauthService, logger, "api")
+}
+
+// CreateGraphQLAuthMiddlewareFromAuthService creates GraphQL auth middleware from AuthService.
 func CreateGraphQLAuthMiddlewareFromAuthService(authService *AuthService, logger *zap.Logger) apptheory.Middleware {
 	return CreatePrincipalContextBridgeFromAuthService(authService, logger, "graphql")
 }
 
-// CreateFederationAuthMiddlewareFromAuthService creates federation auth middleware from AuthService
+// CreateFederationAuthMiddlewareFromAuthService creates federation auth middleware from AuthService.
 func CreateFederationAuthMiddlewareFromAuthService(authService *AuthService, logger *zap.Logger) apptheory.Middleware {
 	return CreatePrincipalContextBridgeFromAuthService(authService, logger, "federation")
 }

--- a/pkg/auth/oauth_adapter_round13_test.go
+++ b/pkg/auth/oauth_adapter_round13_test.go
@@ -1,0 +1,90 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"go.uber.org/zap"
+)
+
+func TestOAuthServiceAdapter_ValidateAccessToken_WithSessionBackedClaims(t *testing.T) {
+	authService := newSessionAuthServiceForPrincipalTests("session-1")
+	adapter := NewOAuthServiceAdapter(authService)
+	require.NotNil(t, adapter)
+
+	claims, err := adapter.ValidateAccessToken(newSessionAccessTokenForPrincipalTests(t, "session-1"))
+	require.NoError(t, err)
+	require.NotNil(t, claims)
+	assert.Equal(t, "alice", claims.GetUsername())
+}
+
+func TestOAuthAdapterMiddlewareWrappers(t *testing.T) {
+	authService := newSessionAuthServiceForPrincipalTests("session-1")
+	oauthService := &OAuthService{jwtSecret: []byte("test-secret")}
+	sessionToken := newSessionAccessTokenForPrincipalTests(t, "session-1")
+	oauthToken, err := oauthService.generateAccessTokenWithMetadata("alice", "client-agent", []string{"read"}, accessTokenMetadata{
+		SessionID: "session-oauth",
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name   string
+		token  string
+		build  func() apptheory.Middleware
+		expect string
+	}{
+		{
+			name:  "api auth service wrapper",
+			token: sessionToken,
+			build: func() apptheory.Middleware {
+				return CreateAPIAuthMiddlewareFromAuthService(authService, zap.NewNop())
+			},
+			expect: "alice",
+		},
+		{
+			name:  "graphql auth service wrapper",
+			token: sessionToken,
+			build: func() apptheory.Middleware {
+				return CreateGraphQLAuthMiddlewareFromAuthService(authService, zap.NewNop())
+			},
+			expect: "alice",
+		},
+		{
+			name:  "federation auth service wrapper",
+			token: sessionToken,
+			build: func() apptheory.Middleware {
+				return CreateFederationAuthMiddlewareFromAuthService(authService, zap.NewNop())
+			},
+			expect: "alice",
+		},
+		{
+			name:  "api composite auth wrapper",
+			token: oauthToken,
+			build: func() apptheory.Middleware {
+				return CreateAPIAuthMiddlewareFromAuthAndOAuthServices(&AuthService{
+					jwtSecret:   []byte("test-secret"),
+					accountRepo: compositeAuthAccountRepo{},
+				}, oauthService, zap.NewNop())
+			},
+			expect: "alice",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nextCalled := false
+			resp, err := tt.build()(func(ctx *apptheory.Context) (*apptheory.Response, error) {
+				nextCalled = true
+				assert.Equal(t, tt.expect, UsernameFromAppTheoryContext(ctx))
+				return &apptheory.Response{Status: 204}, nil
+			})(newTestContext("GET", "/auth", withHeaders(map[string]string{
+				"Authorization": "Bearer " + tt.token,
+			})))
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			assert.True(t, nextCalled)
+		})
+	}
+}

--- a/pkg/auth/password_round13_more_test.go
+++ b/pkg/auth/password_round13_more_test.go
@@ -1,0 +1,38 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHashPasswordAndStrengthHelperEdges(t *testing.T) {
+	t.Parallel()
+
+	_, err := HashPassword("short")
+	require.ErrorIs(t, err, ErrPasswordTooShort)
+
+	_, err = HashPassword(strings.Repeat("a", 73))
+	require.ErrorIs(t, err, ErrPasswordTooLong)
+
+	hash, err := HashPassword("ValidPass123!")
+	require.NoError(t, err)
+	require.NoError(t, VerifyPassword("ValidPass123!", hash))
+
+	cfg := PasswordStrengthConfig{
+		MinLength:               0,
+		LongLength:              0,
+		SequentialPatternMinRun: 0,
+		LongBonus:               2,
+	}
+	require.Equal(t, 0, PasswordStrengthWithConfig("short", cfg))
+	require.True(t, hasSequentialRun("abcd", 1))
+	require.False(t, hasSequentialRun("abx", 4))
+
+	require.Equal(t, "Very Weak", PasswordStrengthLabel(-1))
+	require.Equal(t, "Very Strong", PasswordStrengthLabel(99))
+
+	hints := GeneratePasswordHint("ALLUPPER123!!!")
+	require.Contains(t, hints, "Add lowercase letters")
+}


### PR DESCRIPTION
## Milestone
public OAuth REST auth regression — restore protected REST access for OAuth bearers without session rows

## Classification
bug-fix / contract-stability / operational-reliability / test-coverage

## Surfaces affected
- Mastodon REST `/api/v1/*` route auth in `cmd/api`
- API optional-auth hydration
- `pkg/auth` API auth adapter helpers

## Specialist walks referenced
- Investigation: root cause isolated to lesser API auth boundary, not lesser-body
- Contract / API: backward-compatible restoration; no response shape changes
- Schema: none
- Framework: local idiomatic AppTheory usage; no framework patching

## Consumer impact
- Restores public OAuth bearer access for `lesser-body` social tools
- Restores protected REST access for public OAuth clients whose tokens mint/refresh successfully but do not have `session#{sid}` rows
- Keeps GraphQL/handler fallback behavior aligned with REST

## What changed
- Added an app-level regression test that exercises API route auth through `buildApp`, not handler-direct tests
- Switched API AppTheory protected-route auth to `OAuthService`
- Switched API optional-auth hydration to the OAuth-backed bridge helper

## Root cause
API AppTheory route auth was validating access tokens through `AuthService`, which requires a session row for `claims.SessionID`. Public OAuth flows mint and refresh tokens through `OAuthService` and persist refresh-token state with `SessionID`, but they do not create ordinary session rows. That made valid OAuth bearers fail protected REST routes like `GET /api/v1/accounts/verify_credentials` before handlers ran.

## Tasks
- [x] Add route-gate regression coverage for public OAuth bearers on REST
- [x] Align API route auth and optional-auth hydration with OAuth validation

## Validation
- `GOTOOLCHAIN=auto go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
none
