### PR TITLE
fix(federation): resolve remote delivery targets

### DIFF
--- a/pkg/federation/delivery.go
+++ b/pkg/federation/delivery.go
@@ -866,15 +866,6 @@ func (d *DeliveryService) DeliverDirectMessage(ctx context.Context, activity *ac
 	return nil
 }
 
-// isLocalRecipient checks if a recipient is local to this instance
-func (d *DeliveryService) isLocalRecipient(recipientID, signingActorID string) bool {
-	// Extract domain from both IDs to compare
-	recipientDomain := extractDomainFromURL(recipientID)
-	signingActorDomain := extractDomainFromURL(signingActorID)
-
-	return recipientDomain == signingActorDomain
-}
-
 // calculateDeliveryPriority calculates delivery priority based on activity type and target health
 func (d *DeliveryService) calculateDeliveryPriority(ctx context.Context, activity *activitypub.Activity, targetInbox string) int {
 	priority := 5 // Default priority

--- a/pkg/federation/delivery.go
+++ b/pkg/federation/delivery.go
@@ -253,6 +253,103 @@ func (d *DeliveryService) DeliverActivity(ctx context.Context, activity *activit
 	return ErrDeliveryHTTPStatusFailed
 }
 
+type resolvedDeliveryTarget struct {
+	actor   *activitypub.Actor
+	isLocal bool
+}
+
+func (d *DeliveryService) resolveDeliverableTarget(ctx context.Context, identifier string) (*resolvedDeliveryTarget, error) {
+	identifier = strings.TrimSpace(identifier)
+	if err := common.ValidateRequiredParam("identifier", identifier); err != nil {
+		return nil, err
+	}
+
+	localDomain := ""
+	if d.cfg != nil {
+		localDomain = normalizeActorDomain(d.cfg.Domain)
+	}
+
+	if isActorURL(identifier) {
+		parsed, err := url.Parse(identifier)
+		if err != nil {
+			return nil, err
+		}
+
+		host := normalizeActorDomain(parsed.Hostname())
+		if localDomain != "" && host == localDomain {
+			username := usernameFromActorPath(parsed.Path)
+			if username == "" {
+				return nil, common.ActorNotFoundError{Username: identifier}
+			}
+
+			actor, err := d.store.GetActor(ctx, username)
+			if err != nil {
+				return nil, err
+			}
+			return &resolvedDeliveryTarget{actor: actor, isLocal: true}, nil
+		}
+
+		actor, err := d.fetchRemoteActor(ctx, identifier)
+		if err != nil {
+			return nil, err
+		}
+		return &resolvedDeliveryTarget{actor: actor}, nil
+	}
+
+	username, domain, err := parseHandle(identifier)
+	if err != nil {
+		return nil, err
+	}
+
+	if domain == "" || (localDomain != "" && domain == localDomain) {
+		actor, err := d.store.GetActor(ctx, username)
+		if err != nil {
+			return nil, err
+		}
+		return &resolvedDeliveryTarget{actor: actor, isLocal: true}, nil
+	}
+
+	handle := exactHandle(username, domain)
+	actor, err := d.resolveRemoteHandleTarget(ctx, handle)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resolvedDeliveryTarget{actor: actor}, nil
+}
+
+func (d *DeliveryService) resolveRemoteHandleTarget(ctx context.Context, handle string) (*activitypub.Actor, error) {
+	if cached, err := d.store.GetCachedRemoteActor(ctx, handle); err == nil && cached != nil {
+		if err := activitypub.ValidateResolvedActor(cached); err == nil && cachedRemoteActorMatchesHandle(cached, handle) {
+			return cached, nil
+		}
+	}
+
+	username, domain, err := parseHandle(handle)
+	if err != nil {
+		return nil, err
+	}
+
+	actorURL, err := webFingerLookupWithClient(ctx, d.httpClient, d.logger, username, domain)
+	if err != nil {
+		return nil, errors.Join(ErrWebFingerLookupFailed, err)
+	}
+
+	actor, err := d.fetchRemoteActor(ctx, actorURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := d.store.CacheRemoteActor(ctx, handle, actor, 24*time.Hour); err != nil {
+		d.logger.Warn("failed to cache remote actor resolved by handle",
+			zap.String("handle", handle),
+			zap.String("actor_id", strings.TrimSpace(actor.ID)),
+			zap.Error(err))
+	}
+
+	return actor, nil
+}
+
 // DeliverToFollowers delivers an activity to all followers of an actor
 func (d *DeliveryService) DeliverToFollowers(ctx context.Context, activity *activitypub.Activity, actor *activitypub.Actor) error {
 	log := common.WithContext(ctx).With(
@@ -275,17 +372,17 @@ func (d *DeliveryService) DeliverToFollowers(ctx context.Context, activity *acti
 	inboxMap := make(map[string][]string) // inbox URL -> follower IDs
 
 	for _, followerUsername := range followerUsernames {
-		// Get follower actor details
-		follower, err := d.store.GetActor(ctx, followerUsername)
+		target, err := d.resolveDeliverableTarget(ctx, followerUsername)
 		if err != nil {
 			log.Warn("failed to get follower actor",
 				zap.String("username", followerUsername),
 				zap.Error(err))
 			continue
 		}
+		follower := target.actor
 
 		// Skip local followers (they already have the activity via fan-out)
-		if isLocalActor(follower.ID, actor.ID) {
+		if target.isLocal || isLocalActor(follower.ID, actor.ID) {
 			continue
 		}
 
@@ -721,19 +818,17 @@ func (d *DeliveryService) DeliverDirectMessage(ctx context.Context, activity *ac
 	inboxMap := make(map[string][]string) // inbox URL -> recipient IDs
 
 	for recipientID := range targets.DirectRecipients {
-		// Skip local recipients
-		if d.isLocalRecipient(recipientID, signingActor.ID) {
-			continue
-		}
-
-		// Get recipient actor to find their inbox
-		recipient, err := d.store.GetActor(ctx, recipientID)
+		target, err := d.resolveDeliverableTarget(ctx, recipientID)
 		if err != nil {
 			log.Warn("failed to get recipient actor",
 				zap.String("recipient_id", recipientID),
 				zap.Error(err))
 			continue
 		}
+		if target.isLocal {
+			continue
+		}
+		recipient := target.actor
 
 		// Determine inbox URL (prefer shared inbox for efficiency)
 		inboxURL := recipient.Inbox

--- a/pkg/federation/delivery_round12_coverage_test.go
+++ b/pkg/federation/delivery_round12_coverage_test.go
@@ -37,9 +37,6 @@ func TestDeliveryHelpers_RecipientsAndDomains(t *testing.T) {
 	assert.Equal(t, "example.com", extractDomainFromURL("https://example.com/inbox"))
 	assert.Equal(t, "unknown", extractDomainFromURL("://bad"))
 
-	assert.True(t, d.isLocalRecipient("https://example.com/users/bob", "https://example.com/users/alice"))
-	assert.False(t, d.isLocalRecipient("https://remote.example/users/bob", "https://example.com/users/alice"))
-
 	assert.Equal(t, 2, maxInt(1, 2))
 	assert.Equal(t, 2, maxInt(2, 1))
 }

--- a/pkg/federation/delivery_round21_coverage_test.go
+++ b/pkg/federation/delivery_round21_coverage_test.go
@@ -433,6 +433,119 @@ func TestDeliveryService_FetchRemoteActor_CacheAndFailures(t *testing.T) {
 func TestDeliveryService_RecipientsAndQueueing(t *testing.T) {
 	privateKey := mustTestRSAPrivateKeyPEM(t)
 
+	t.Run("deliver_to_followers_resolves_remote_handle_targets", func(t *testing.T) {
+		signingActor := testSigningActor()
+
+		bob := activitypub.Actor{
+			BaseObject:        activitypub.BaseObject{ID: "https://remote.example/users/bob", Type: "Person"},
+			PreferredUsername: "bob",
+			Inbox:             "https://remote.example/users/bob/inbox",
+			Outbox:            "https://remote.example/users/bob/outbox",
+			Endpoints:         &activitypub.Endpoints{SharedInbox: "https://remote.example/inbox"},
+		}
+		carol := activitypub.Actor{
+			BaseObject:        activitypub.BaseObject{ID: "https://remote.example/users/carol", Type: "Person"},
+			PreferredUsername: "carol",
+			Inbox:             "https://remote.example/users/carol/inbox",
+			Outbox:            "https://remote.example/users/carol/outbox",
+			Endpoints:         &activitypub.Endpoints{SharedInbox: "https://remote.example/inbox"},
+		}
+		carolJSON, err := jsonMarshalStable(&carol)
+		require.NoError(t, err)
+
+		store := &federationStoreStub{
+			getActorPrivateKeyFn: func(_ context.Context, _ string) (string, error) { return privateKey, nil },
+			getFollowersFn: func(_ context.Context, _ string, _ int, _ string) ([]string, string, error) {
+				return []string{"local", "bob@remote.example", "carol@remote.example", "missing@remote.example"}, "", nil
+			},
+			getActorFn: func(_ context.Context, username string) (*activitypub.Actor, error) {
+				if username != "local" {
+					return nil, errors.New("not found")
+				}
+				return &activitypub.Actor{
+					BaseObject: activitypub.BaseObject{ID: "https://example.com/users/local", Type: "Person"},
+					Inbox:      "https://example.com/users/local/inbox",
+					Outbox:     "https://example.com/users/local/outbox",
+				}, nil
+			},
+			getCachedActorFn: func(_ context.Context, identifier string) (*activitypub.Actor, error) {
+				switch identifier {
+				case "bob@remote.example":
+					return &bob, nil
+				default:
+					return nil, errors.New("cache miss")
+				}
+			},
+		}
+
+		httpDoer := &httpDoerStub{
+			doFn: func(req *http.Request) (*http.Response, error) {
+				switch req.Method {
+				case http.MethodGet:
+					switch req.URL.String() {
+					case "https://remote.example/.well-known/webfinger?resource=acct%3Acarol%40remote.example":
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Body: io.NopCloser(strings.NewReader(`{
+								"subject":"acct:carol@remote.example",
+								"links":[{"rel":"self","type":"application/activity+json","href":"https://remote.example/users/carol"}]
+							}`)),
+							Header: make(http.Header),
+						}, nil
+					case "https://remote.example/.well-known/webfinger?resource=acct%3Amissing%40remote.example":
+						return &http.Response{
+							StatusCode: http.StatusNotFound,
+							Body:       io.NopCloser(strings.NewReader("missing")),
+							Header:     make(http.Header),
+						}, nil
+					case carol.ID:
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       io.NopCloser(bytes.NewReader(carolJSON)),
+							Header:     make(http.Header),
+						}, nil
+					default:
+						t.Fatalf("unexpected GET %s", req.URL.String())
+						return nil, nil
+					}
+				case http.MethodPost:
+					require.Equal(t, "https://remote.example/inbox", req.URL.String())
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader("ok")),
+						Header:     make(http.Header),
+					}, nil
+				default:
+					t.Fatalf("unexpected method %s", req.Method)
+					return nil, nil
+				}
+			},
+		}
+
+		d := &DeliveryService{store: store, httpClient: httpDoer, logger: zap.NewNop(), cfg: &appConfig.Config{Domain: "example.com"}}
+		err = d.DeliverToFollowers(context.Background(), &activitypub.Activity{
+			BaseObject: activitypub.BaseObject{ID: "act-remote-followers", Type: "Create"},
+		}, signingActor)
+		require.NoError(t, err)
+
+		httpDoer.mu.Lock()
+		requests := append([]*http.Request(nil), httpDoer.requests...)
+		httpDoer.mu.Unlock()
+
+		var getTargets []string
+		for _, req := range requests {
+			switch req.Method {
+			case http.MethodGet:
+				getTargets = append(getTargets, req.URL.String())
+			}
+		}
+
+		require.Contains(t, getTargets, "https://remote.example/.well-known/webfinger?resource=acct%3Acarol%40remote.example")
+		require.Contains(t, getTargets, "https://remote.example/.well-known/webfinger?resource=acct%3Amissing%40remote.example")
+		require.Contains(t, getTargets, "https://remote.example/users/carol")
+		require.NotContains(t, getTargets, bob.ID)
+	})
+
 	t.Run("deliver_to_followers_groups_by_shared_inbox_and_skips_locals", func(t *testing.T) {
 		signingActor := testSigningActor()
 
@@ -660,19 +773,34 @@ func TestDeliveryService_DirectMessage_AndSharedInboxHelpers(t *testing.T) {
 	t.Run("deliver_direct_message_success", func(t *testing.T) {
 		store := &federationStoreStub{
 			getActorPrivateKeyFn: func(_ context.Context, _ string) (string, error) { return privateKey, nil },
-			getActorFn: func(_ context.Context, recipientID string) (*activitypub.Actor, error) {
-				return &activitypub.Actor{
-					BaseObject: activitypub.BaseObject{ID: recipientID, Type: "Person"},
-					Inbox:      "https://remote.example/users/bob/inbox",
-					Outbox:     "https://remote.example/users/bob/outbox",
-					Endpoints:  &activitypub.Endpoints{SharedInbox: "https://remote.example/inbox"},
-				}, nil
+			getActorFn: func(_ context.Context, _ string) (*activitypub.Actor, error) {
+				return nil, errors.New("unexpected local actor lookup")
 			},
+			getCachedActorFn: func(_ context.Context, _ string) (*activitypub.Actor, error) { return nil, errors.New("cache miss") },
 		}
 
+		recipient := activitypub.Actor{
+			BaseObject:        activitypub.BaseObject{ID: "https://remote.example/users/bob", Type: "Person"},
+			PreferredUsername: "bob",
+			Inbox:             "https://remote.example/users/bob/inbox",
+			Outbox:            "https://remote.example/users/bob/outbox",
+			Endpoints:         &activitypub.Endpoints{SharedInbox: "https://remote.example/inbox"},
+		}
+		recipientJSON, err := jsonMarshalStable(&recipient)
+		require.NoError(t, err)
+
 		httpDoer := &httpDoerStub{doFn: func(req *http.Request) (*http.Response, error) {
-			require.Equal(t, http.MethodPost, req.Method)
-			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("ok")), Header: make(http.Header)}, nil
+			switch req.Method {
+			case http.MethodGet:
+				require.Equal(t, recipient.ID, req.URL.String())
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(recipientJSON)), Header: make(http.Header)}, nil
+			case http.MethodPost:
+				require.Equal(t, "https://remote.example/inbox", req.URL.String())
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("ok")), Header: make(http.Header)}, nil
+			default:
+				t.Fatalf("unexpected method %s", req.Method)
+				return nil, nil
+			}
 		}}
 
 		d := &DeliveryService{store: store, httpClient: httpDoer, logger: zap.NewNop(), cfg: &appConfig.Config{Domain: "example.com"}}
@@ -687,27 +815,54 @@ func TestDeliveryService_DirectMessage_AndSharedInboxHelpers(t *testing.T) {
 			Object: &activitypub.Note{BaseObject: activitypub.BaseObject{ID: "note-1", Type: "Note"}},
 		}
 		require.NoError(t, d.DeliverDirectMessage(context.Background(), activity, signingActor))
+
+		httpDoer.mu.Lock()
+		requests := append([]*http.Request(nil), httpDoer.requests...)
+		httpDoer.mu.Unlock()
+		require.Len(t, requests, 2)
+		require.Equal(t, http.MethodGet, requests[0].Method)
+		require.Equal(t, recipient.ID, requests[0].URL.String())
+		require.Equal(t, http.MethodPost, requests[1].Method)
+		require.Equal(t, "https://remote.example/inbox", requests[1].URL.String())
 	})
 
 	t.Run("deliver_direct_message_failure_aggregates_errors", func(t *testing.T) {
 		store := &federationStoreStub{
 			getActorPrivateKeyFn: func(_ context.Context, _ string) (string, error) { return privateKey, nil },
-			getActorFn: func(_ context.Context, recipientID string) (*activitypub.Actor, error) {
-				if strings.Contains(recipientID, "missing") {
-					return nil, errors.New("missing actor")
-				}
-				return &activitypub.Actor{
-					BaseObject: activitypub.BaseObject{ID: recipientID, Type: "Person"},
-					Inbox:      "https://remote.example/users/bob/inbox",
-					Outbox:     "https://remote.example/users/bob/outbox",
-					Endpoints:  &activitypub.Endpoints{SharedInbox: "https://remote.example/inbox"},
-				}, nil
+			getActorFn: func(_ context.Context, _ string) (*activitypub.Actor, error) {
+				return nil, errors.New("unexpected local actor lookup")
 			},
+			getCachedActorFn: func(_ context.Context, _ string) (*activitypub.Actor, error) { return nil, errors.New("cache miss") },
 		}
 
+		recipient := activitypub.Actor{
+			BaseObject:        activitypub.BaseObject{ID: "https://remote.example/users/bob", Type: "Person"},
+			PreferredUsername: "bob",
+			Inbox:             "https://remote.example/users/bob/inbox",
+			Outbox:            "https://remote.example/users/bob/outbox",
+			Endpoints:         &activitypub.Endpoints{SharedInbox: "https://remote.example/inbox"},
+		}
+		recipientJSON, err := jsonMarshalStable(&recipient)
+		require.NoError(t, err)
+
 		httpDoer := &httpDoerStub{doFn: func(req *http.Request) (*http.Response, error) {
-			require.Equal(t, http.MethodPost, req.Method)
-			return &http.Response{StatusCode: http.StatusInternalServerError, Body: io.NopCloser(strings.NewReader("fail")), Header: make(http.Header)}, nil
+			switch req.Method {
+			case http.MethodGet:
+				switch req.URL.String() {
+				case recipient.ID:
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(recipientJSON)), Header: make(http.Header)}, nil
+				case "https://remote.example/users/missing":
+					return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader("missing")), Header: make(http.Header)}, nil
+				default:
+					t.Fatalf("unexpected GET %s", req.URL.String())
+					return nil, nil
+				}
+			case http.MethodPost:
+				return &http.Response{StatusCode: http.StatusInternalServerError, Body: io.NopCloser(strings.NewReader("fail")), Header: make(http.Header)}, nil
+			default:
+				t.Fatalf("unexpected method %s", req.Method)
+				return nil, nil
+			}
 		}}
 
 		d := &DeliveryService{store: store, httpClient: httpDoer, logger: zap.NewNop(), cfg: &appConfig.Config{Domain: "example.com"}}
@@ -723,7 +878,7 @@ func TestDeliveryService_DirectMessage_AndSharedInboxHelpers(t *testing.T) {
 			Object: &activitypub.Note{BaseObject: activitypub.BaseObject{ID: "note-1", Type: "Note"}},
 		}
 
-		err := d.DeliverDirectMessage(context.Background(), activity, signingActor)
+		err = d.DeliverDirectMessage(context.Background(), activity, signingActor)
 		require.ErrorIs(t, err, ErrDeliveryDirectMessageToInboxesFailed)
 	})
 }
@@ -830,11 +985,15 @@ func TestDeliveryService_FollowersAndQueueDelivery_MoreBranches(t *testing.T) {
 		store := &federationStoreStub{
 			getActorPrivateKeyFn: func(_ context.Context, _ string) (string, error) { return privateKey, nil },
 			getFollowersFn: func(_ context.Context, _ string, _ int, _ string) ([]string, string, error) {
-				return []string{"remote1", "remote2"}, "", nil
+				return []string{"remote1@remote.example", "remote2@remote.example"}, "", nil
 			},
-			getActorFn: func(_ context.Context, username string) (*activitypub.Actor, error) {
+			getActorFn: func(_ context.Context, _ string) (*activitypub.Actor, error) {
+				return nil, errors.New("unexpected local actor lookup")
+			},
+			getCachedActorFn: func(_ context.Context, identifier string) (*activitypub.Actor, error) {
+				username := strings.TrimSuffix(identifier, "@remote.example")
 				return &activitypub.Actor{
-					BaseObject:        activitypub.BaseObject{ID: "https://remote.example/users/" + username},
+					BaseObject:        activitypub.BaseObject{ID: "https://remote.example/users/" + username, Type: "Person"},
 					PreferredUsername: username,
 					Inbox:             "https://remote.example/users/" + username + "/inbox",
 					Outbox:            "https://remote.example/users/" + username + "/outbox",

--- a/pkg/federation/remote_search.go
+++ b/pkg/federation/remote_search.go
@@ -307,12 +307,16 @@ func exactHandle(username, domain string) string {
 
 // webFingerLookup performs a WebFinger query to find an actor's ActivityPub URL
 func (s *RemoteSearchService) webFingerLookup(ctx context.Context, username, domain string) (string, error) {
+	return webFingerLookupWithClient(ctx, s.httpClient, s.logger, username, domain)
+}
+
+func webFingerLookupWithClient(ctx context.Context, client httpDoer, logger *zap.Logger, username, domain string) (string, error) {
 	// Build WebFinger URL
 	resource := fmt.Sprintf("acct:%s@%s", username, domain)
 	webfingerURL := fmt.Sprintf("https://%s/.well-known/webfinger?resource=%s",
 		domain, url.QueryEscape(resource))
 
-	s.logger.Debug("performing webfinger lookup",
+	logger.Debug("performing webfinger lookup",
 		zap.String("url", webfingerURL))
 
 	req, err := http.NewRequestWithContext(ctx, "GET", webfingerURL, nil)
@@ -322,9 +326,9 @@ func (s *RemoteSearchService) webFingerLookup(ctx context.Context, username, dom
 
 	req.Header.Set("Accept", "application/jrd+json")
 
-	resp, err := s.httpClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
-		s.logger.Error("webfinger request failed",
+		logger.Error("webfinger request failed",
 			zap.String("url", webfingerURL),
 			zap.Error(err))
 		return "", errors.Join(ErrWebFingerRequestFailed, err)
@@ -332,7 +336,7 @@ func (s *RemoteSearchService) webFingerLookup(ctx context.Context, username, dom
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		s.logger.Error("webfinger returned non-2xx status",
+		logger.Error("webfinger returned non-2xx status",
 			zap.String("url", webfingerURL),
 			zap.Int("status_code", resp.StatusCode))
 		return "", ErrWebFingerNon2xxStatus
@@ -341,7 +345,7 @@ func (s *RemoteSearchService) webFingerLookup(ctx context.Context, username, dom
 	// Parse WebFinger response
 	var webfingerResp activitypub.WebFingerResource
 	if err := common.ParseHTTPResponse(resp.Body, &webfingerResp); err != nil {
-		s.logger.Error("failed to parse webfinger response",
+		logger.Error("failed to parse webfinger response",
 			zap.String("url", webfingerURL),
 			zap.Error(err))
 		return "", errors.Join(ErrWebFingerResponseParseFailed, err)
@@ -354,7 +358,7 @@ func (s *RemoteSearchService) webFingerLookup(ctx context.Context, username, dom
 		}
 	}
 
-	s.logger.Error("no ActivityPub link found in webfinger response",
+	logger.Error("no ActivityPub link found in webfinger response",
 		zap.String("url", webfingerURL))
 	return "", ErrNoActivityPubLinkFound
 }


### PR DESCRIPTION
## Milestone
M1.4I.1 — characterize outbound delivery families and introduce a shared federation delivery-target resolver

## Classification
federation-trust / bug-fix / test-coverage / operational-reliability

## Surfaces affected
- `pkg/federation/delivery.go`
- `pkg/federation/remote_search.go`
- `pkg/federation/delivery_round21_coverage_test.go`

## Specialist walks referenced
- Federation trust: completed in-session for complete outbound federation delivery resolution
- Contract / API: no public API shape change
- Schema: no schema change
- Framework: idiomatic; no framework patching

## Consumer impact
Operators and remote ActivityPub peers. This PR repairs the first shared seam behind incomplete outbound delivery truth for canonical remote follower handles and shared helper resolution.

## Tasks
- [x] #781 Characterize outbound delivery families and introduce a shared federation delivery-target resolver
- [ ] #782 Add followers-collection delivery policy and route all outbound families through the shared resolver
- [ ] #783 Harden proof coverage for complete outbound federation delivery resolution

## What changed
- added regression coverage proving remote follower handles no longer depend on local actor lookup semantics in `DeliverToFollowers(...)`
- added regression coverage for `DeliverDirectMessage(...)` resolving remote actor URLs through the same delivery-target seam
- introduced shared federation-layer delivery target resolution for local usernames, local/remote handles, and actor URLs
- routed `DeliverToFollowers(...)` and `DeliverDirectMessage(...)` through that resolver
- extracted a shared WebFinger helper so remote search and delivery use the same lookup contract

## Validation
- `go test ./pkg/federation -run 'TestDeliveryService_DirectMessage_AndSharedInboxHelpers|TestDeliveryService_FollowersAndQueueDelivery_MoreBranches|TestDeliveryService_RecipientsAndQueueing' -count=1`
- `go test ./pkg/federation -run 'TestRemoteSearchService_ResolveActor|TestRemoteSearchService_webFingerLookup|TestRemoteSearchService_fetchRemoteActor' -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `gofmt -l .` (empty)
- `go build -o lesser ./cmd/lesser`
- `./lesser verify --smoke` **environment-blocked here** (`SMOKE_BASE_URL` / `--base-url` unset)

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None
