### PR TITLE
fix(federation): implement truthful shared inbox support

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -7,3 +7,6 @@ model_instructions_file = "steward.md"
 
 [mcp_servers.lesser_lab.tools.memory_append]
 approval_mode = "approve"
+
+[mcp_servers.lesser_lab.tools.email_mark_read]
+approval_mode = "approve"

--- a/cmd/api/handlers/debug.go
+++ b/cmd/api/handlers/debug.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/federation/surface"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	"go.uber.org/zap"
 )
@@ -331,7 +332,7 @@ func (h *Handler) HandleDebugFederationDomainLift(ctx *apptheory.Context) (*appt
 	response.LastContact = time.Now().Add(-1 * time.Hour)
 
 	// Add shared inbox if known
-	response.SharedInbox = fmt.Sprintf("https://%s/inbox", domain)
+	response.SharedInbox = surface.SharedInboxURL(fmt.Sprintf("https://%s", domain))
 
 	return okJSON(response)
 }

--- a/cmd/inbox/internal/routing/inbox.go
+++ b/cmd/inbox/internal/routing/inbox.go
@@ -423,8 +423,17 @@ func NewInboxHandler(lambdaCtx *common.LambdaContext) (*InboxHandler, error) {
 // RegisterRoutes registers all inbox routes
 func (ih *InboxHandler) RegisterRoutes(app *apptheory.App) {
 	// ActivityPub inbox endpoints
-	app.Get(surface.SharedInbox().Path, ih.handleGetSharedInbox)
-	app.Post(surface.SharedInbox().Path, ih.handlePostSharedInbox)
+	sharedInbox := surface.SharedInbox()
+	for _, method := range sharedInbox.ServedMethods() {
+		switch method {
+		case http.MethodGet:
+			app.Get(sharedInbox.Path, ih.handleGetSharedInbox)
+		case http.MethodPost:
+			app.Post(sharedInbox.Path, ih.handlePostSharedInbox)
+		default:
+			panic(fmt.Sprintf("unsupported shared inbox method in federation surface manifest: %s", method))
+		}
+	}
 	app.Get("/users/:username/inbox", ih.handleGetInbox)
 	app.Post("/users/:username/inbox", ih.handlePostInbox)
 }

--- a/cmd/inbox/internal/routing/inbox.go
+++ b/cmd/inbox/internal/routing/inbox.go
@@ -24,6 +24,7 @@ import (
 	costpkg "github.com/equaltoai/lesser/pkg/cost"
 	"github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/federation"
+	"github.com/equaltoai/lesser/pkg/federation/surface"
 	"github.com/equaltoai/lesser/pkg/monitoring"
 	notifpush "github.com/equaltoai/lesser/pkg/notifications"
 	"github.com/equaltoai/lesser/pkg/observability"
@@ -422,6 +423,8 @@ func NewInboxHandler(lambdaCtx *common.LambdaContext) (*InboxHandler, error) {
 // RegisterRoutes registers all inbox routes
 func (ih *InboxHandler) RegisterRoutes(app *apptheory.App) {
 	// ActivityPub inbox endpoints
+	app.Get(surface.SharedInbox().Path, ih.handleGetSharedInbox)
+	app.Post(surface.SharedInbox().Path, ih.handlePostSharedInbox)
 	app.Get("/users/:username/inbox", ih.handleGetInbox)
 	app.Post("/users/:username/inbox", ih.handlePostInbox)
 }
@@ -632,46 +635,37 @@ func (ih *InboxHandler) buildCollectionPage(actor *activitypub.Actor, activities
 
 // InboxRequest represents an incoming ActivityPub request
 type InboxRequest struct {
-	Username    string
-	Activity    *activitypub.Activity
-	Actor       *activitypub.Actor
-	Body        []byte
-	ActorDomain string
-	StartTime   time.Time
-	CostParams  *federation.CostCalculationParams
+	Username     string
+	Activity     *activitypub.Activity
+	Actor        *activitypub.Actor
+	TargetActors []*activitypub.Actor
+	Body         []byte
+	ActorDomain  string
+	StartTime    time.Time
+	CostParams   *federation.CostCalculationParams
 }
 
 // handlePostInbox handles POST requests to receive activities
 func (ih *InboxHandler) handlePostInbox(ctx *apptheory.Context) (*apptheory.Response, error) {
-	// Initialize and validate request
-	req, err := ih.initializeInboxRequest(ctx)
+	req, err := ih.initializeActorInboxRequest(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// Perform security checks (rate limiting, domain blocks)
 	if err := ih.performSecurityChecks(ctx, req); err != nil {
 		return nil, err
 	}
-
-	// Verify authentication (signature verification)
 	if err := ih.verifyAuthentication(ctx, req); err != nil {
 		return nil, err
 	}
-
-	// Validate addressing fields and privacy compliance
-	if err := ih.validateAddressingAndPrivacy(ctx, req); err != nil {
+	if err := ih.validateActorInboxAddressingAndPrivacy(req); err != nil {
 		return nil, err
 	}
-
-	// Store and process the activity
 	if err := ih.storeAndProcessActivity(ctx, req); err != nil {
 		return nil, err
 	}
 
-	// Record success and complete
 	ih.recordSuccessAndComplete(ctx, req)
-
 	return apptheory.Text(http.StatusAccepted, ""), nil
 }
 
@@ -1212,13 +1206,26 @@ func (ih *InboxHandler) storeAndProcessActivity(ctx *apptheory.Context, req *Inb
 
 	req.CostParams.DynamoDBWriteCount = 1 // Activity storage
 
-	// Process by activity type
+	targetActors := req.TargetActors
+	if len(targetActors) == 0 && req.Actor != nil {
+		targetActors = []*activitypub.Actor{req.Actor}
+	}
+	if len(targetActors) == 0 {
+		ih.recordFailureCost(req, "No local target actors resolved", 1)
+		return errors.NotFound("resource")
+	}
+
 	processingStart := time.Now()
-	if err := ih.processActivityByType(ctx.Context(), req); err != nil {
-		processingDuration := time.Since(processingStart)
-		req.CostParams.ProcessingTimeMs += processingDuration.Milliseconds()
-		ih.recordFailureCost(req, fmt.Sprintf("Failed to process %s activity: %v", req.Activity.Type, err), 0)
-		return errors.InternalWithCause(err, fmt.Sprintf("failed to process %s activity", req.Activity.Type))
+	for _, targetActor := range targetActors {
+		if targetActor == nil {
+			continue
+		}
+		if err := ih.processActivityByTypeForTarget(ctx.Context(), req.Activity, targetActor, req.CostParams); err != nil {
+			processingDuration := time.Since(processingStart)
+			req.CostParams.ProcessingTimeMs += processingDuration.Milliseconds()
+			ih.recordFailureCost(req, fmt.Sprintf("Failed to process %s activity: %v", req.Activity.Type, err), 0)
+			return errors.InternalWithCause(err, fmt.Sprintf("failed to process %s activity", req.Activity.Type))
+		}
 	}
 
 	processingDuration := time.Since(processingStart)
@@ -1226,128 +1233,135 @@ func (ih *InboxHandler) storeAndProcessActivity(ctx *apptheory.Context, req *Inb
 	return nil
 }
 
-// processActivityByType processes the activity based on its type
+// processActivityByType processes the activity based on its type.
 func (ih *InboxHandler) processActivityByType(ctx context.Context, req *InboxRequest) error {
-	switch req.Activity.Type {
+	targetActor := req.Actor
+	if targetActor == nil && len(req.TargetActors) > 0 {
+		targetActor = req.TargetActors[0]
+	}
+	return ih.processActivityByTypeForTarget(ctx, req.Activity, targetActor, req.CostParams)
+}
+
+func (ih *InboxHandler) processActivityByTypeForTarget(ctx context.Context, activity *activitypub.Activity, targetActor *activitypub.Actor, costParams *federation.CostCalculationParams) error {
+	switch activity.Type {
 	case activitypub.FollowType:
-		if err := ih.processFollowActivity(ctx, req.Activity, req.Actor); err != nil {
+		if err := ih.processFollowActivity(ctx, activity, targetActor); err != nil {
 			ih.logger.Error("failed to process follow activity", zap.Error(err))
 			return err
 		}
-		req.CostParams.DynamoDBWriteCount++ // Relationship creation
-		req.CostParams.DynamoDBReadCount++  // Follow approval check
+		costParams.DynamoDBWriteCount++ // Relationship creation
+		costParams.DynamoDBReadCount++  // Follow approval check
 
 	case activitypub.AcceptType:
-		if err := ih.processAcceptActivity(ctx, req.Activity, req.Actor); err != nil {
+		if err := ih.processAcceptActivity(ctx, activity, targetActor); err != nil {
 			ih.logger.Error("failed to process accept activity", zap.Error(err))
 			return err
 		}
-		req.CostParams.DynamoDBWriteCount++ // Relationship update
-		req.CostParams.DynamoDBReadCount++  // Original activity lookup
+		costParams.DynamoDBWriteCount++ // Relationship update
+		costParams.DynamoDBReadCount++  // Original activity lookup
 
 	case activitypub.RejectType:
-		if err := ih.processRejectActivity(ctx, req.Activity, req.Actor); err != nil {
+		if err := ih.processRejectActivity(ctx, activity, targetActor); err != nil {
 			ih.logger.Error("failed to process reject activity", zap.Error(err))
 			return err
 		}
-		req.CostParams.DynamoDBWriteCount++ // Relationship deletion
-		req.CostParams.DynamoDBReadCount++  // Original activity lookup
+		costParams.DynamoDBWriteCount++ // Relationship deletion
+		costParams.DynamoDBReadCount++  // Original activity lookup
 
 	case activitypub.CreateType:
-		if err := ih.processRemoteCreateActivity(ctx, req.Activity, req.Actor); err != nil {
+		if err := ih.processRemoteCreateActivity(ctx, activity, targetActor); err != nil {
 			ih.logger.Error("failed to process create activity", zap.Error(err))
 			return err
 		}
-		req.CostParams.DynamoDBWriteCount += 2 // Object creation + timeline entry
-		req.CostParams.DynamoDBReadCount++     // Content validation
+		costParams.DynamoDBWriteCount += 2 // Object creation + timeline entry
+		costParams.DynamoDBReadCount++     // Content validation
 
 	case activitypub.UpdateType:
-		if err := ih.processRemoteUpdateActivity(ctx, req.Activity, req.Actor); err != nil {
+		if err := ih.processRemoteUpdateActivity(ctx, activity, targetActor); err != nil {
 			ih.logger.Error("failed to process update activity", zap.Error(err))
 			return err
 		}
-		req.CostParams.DynamoDBWriteCount++ // Object update
-		req.CostParams.DynamoDBReadCount++  // Object lookup
+		costParams.DynamoDBWriteCount++ // Object update
+		costParams.DynamoDBReadCount++  // Object lookup
 
 	case activitypub.DeleteType:
-		if err := ih.processRemoteDeleteActivity(ctx, req.Activity, req.Actor); err != nil {
+		if err := ih.processRemoteDeleteActivity(ctx, activity, targetActor); err != nil {
 			ih.logger.Error("failed to process delete activity", zap.Error(err))
 			return err
 		}
-		req.CostParams.DynamoDBWriteCount++ // Object deletion
-		req.CostParams.DynamoDBReadCount++  // Object lookup
+		costParams.DynamoDBWriteCount++ // Object deletion
+		costParams.DynamoDBReadCount++  // Object lookup
 
 	case activitypub.LikeType:
-		if err := ih.processLikeActivity(ctx, req.Activity, req.Actor); err != nil {
+		if err := ih.processLikeActivity(ctx, activity, targetActor); err != nil {
 			ih.logger.Error("failed to process like activity", zap.Error(err))
 			return err
 		}
-		req.CostParams.DynamoDBWriteCount += 2 // Like creation + notification
-		req.CostParams.DynamoDBReadCount++     // Object verification
+		costParams.DynamoDBWriteCount += 2 // Like creation + notification
+		costParams.DynamoDBReadCount++     // Object verification
 
 	case activitypub.AnnounceType:
-		if err := ih.processAnnounceActivity(ctx, req.Activity, req.Actor); err != nil {
+		if err := ih.processAnnounceActivity(ctx, activity, targetActor); err != nil {
 			ih.logger.Error("failed to process announce activity", zap.Error(err))
 			return err
 		}
-		req.CostParams.DynamoDBWriteCount += 2 // Announce creation + notification
-		req.CostParams.DynamoDBReadCount++     // Object verification
+		costParams.DynamoDBWriteCount += 2 // Announce creation + notification
+		costParams.DynamoDBReadCount++     // Object verification
 
 	case activitypub.UndoType:
-		if err := ih.processUndoActivity(ctx, req.Activity, req.Actor); err != nil {
+		if err := ih.processUndoActivity(ctx, activity, targetActor); err != nil {
 			ih.logger.Error("failed to process undo activity", zap.Error(err))
 			return err
 		}
-		req.CostParams.DynamoDBWriteCount++   // Undo operation
-		req.CostParams.DynamoDBReadCount += 2 // Original activity + target lookup
+		costParams.DynamoDBWriteCount++   // Undo operation
+		costParams.DynamoDBReadCount += 2 // Original activity + target lookup
 
 	case activitypub.BlockType:
-		if err := ih.processBlockActivity(ctx, req.Activity, req.Actor); err != nil {
+		if err := ih.processBlockActivity(ctx, activity, targetActor); err != nil {
 			ih.logger.Error("failed to process block activity", zap.Error(err))
 			return err
 		}
-		req.CostParams.DynamoDBWriteCount += 2 // Block creation + remove follow relationships
-		req.CostParams.DynamoDBReadCount++     // Relationship check
+		costParams.DynamoDBWriteCount += 2 // Block creation + remove follow relationships
+		costParams.DynamoDBReadCount++     // Relationship check
 
 	case activitypub.AddType:
-		if err := ih.processAddActivity(ctx, req.Activity, req.Actor); err != nil {
+		if err := ih.processAddActivity(ctx, activity, targetActor); err != nil {
 			ih.logger.Error("failed to process add activity", zap.Error(err))
 			return err
 		}
-		req.CostParams.DynamoDBWriteCount++   // Collection item creation
-		req.CostParams.DynamoDBReadCount += 2 // Target collection + authorization check
+		costParams.DynamoDBWriteCount++   // Collection item creation
+		costParams.DynamoDBReadCount += 2 // Target collection + authorization check
 
 	case activitypub.RemoveType:
-		if err := ih.processRemoveActivity(ctx, req.Activity, req.Actor); err != nil {
+		if err := ih.processRemoveActivity(ctx, activity, targetActor); err != nil {
 			ih.logger.Error("failed to process remove activity", zap.Error(err))
 			return err
 		}
-		req.CostParams.DynamoDBWriteCount++   // Collection item removal
-		req.CostParams.DynamoDBReadCount += 2 // Target collection + authorization check
+		costParams.DynamoDBWriteCount++   // Collection item removal
+		costParams.DynamoDBReadCount += 2 // Target collection + authorization check
 
 	case activitypub.FlagType:
-		if err := ih.processFlagActivity(ctx, req.Activity, req.Actor); err != nil {
+		if err := ih.processFlagActivity(ctx, activity, targetActor); err != nil {
 			ih.logger.Error("failed to process flag activity", zap.Error(err))
 			return err
 		}
-		req.CostParams.DynamoDBWriteCount += 2 // Report creation + moderation queue
-		req.CostParams.DynamoDBReadCount++     // Authorization check
+		costParams.DynamoDBWriteCount += 2 // Report creation + moderation queue
+		costParams.DynamoDBReadCount++     // Authorization check
 
 	case activitypub.MoveType:
-		if err := ih.processMoveActivity(ctx, req.Activity, req.Actor); err != nil {
+		if err := ih.processMoveActivity(ctx, activity, targetActor); err != nil {
 			ih.logger.Error("failed to process move activity", zap.Error(err))
 			return err
 		}
-		req.CostParams.DynamoDBWriteCount++   // Migration record
-		req.CostParams.DynamoDBReadCount += 2 // Actor validation + authorization check
+		costParams.DynamoDBWriteCount++   // Migration record
+		costParams.DynamoDBReadCount += 2 // Actor validation + authorization check
 
 	default:
 		ih.logger.Info("ignoring unsupported activity type in inbox",
-			zap.String("type", req.Activity.Type),
-			zap.String("actor", req.Activity.Actor),
-			zap.String("id", req.Activity.ID),
+			zap.String("type", activity.Type),
+			zap.String("actor", activity.Actor),
+			zap.String("id", activity.ID),
 		)
-		// Not an error - just unsupported activity type
 	}
 
 	return nil

--- a/cmd/inbox/internal/routing/inbox.go
+++ b/cmd/inbox/internal/routing/inbox.go
@@ -505,7 +505,7 @@ func (ih *InboxHandler) authenticateInboxRequest(ctx *apptheory.Context, usernam
 	// Get and validate actor
 	actor, err := ih.actorRepository.GetActorByUsername(ctx.Context(), username)
 	if err != nil {
-		if err.Error() == "actor not found" {
+		if err.Error() == actorNotFoundError {
 			return nil, errors.NotFound("actor")
 		}
 		ih.logger.Error("failed to get actor", zap.Error(err))
@@ -678,94 +678,6 @@ func (ih *InboxHandler) handlePostInbox(ctx *apptheory.Context) (*apptheory.Resp
 	return apptheory.Text(http.StatusAccepted, ""), nil
 }
 
-// initializeInboxRequest creates and validates the basic request structure
-func (ih *InboxHandler) initializeInboxRequest(ctx *apptheory.Context) (*InboxRequest, error) {
-	username := ctx.Param("username")
-	if err := common.ValidateRequiredParam("username", username); err != nil {
-		return nil, errors.ValidationFailed("username", "missing username parameter")
-	}
-
-	// Prevent federation to the bootstrap actor until activation completes.
-	if ih.instanceRepository != nil {
-		state, err := ih.instanceRepository.GetInstanceState(ctx.Context())
-		bootstrapUsername := models.DefaultBootstrapUsername
-		if err == nil && strings.TrimSpace(state.BootstrapUsername) != "" {
-			bootstrapUsername = strings.TrimSpace(state.BootstrapUsername)
-		}
-
-		if (err != nil && strings.EqualFold(username, bootstrapUsername)) ||
-			(err == nil && state.Locked && strings.EqualFold(username, bootstrapUsername)) {
-			return nil, errors.Forbidden("bootstrap actor does not accept federation while instance is locked")
-		}
-	}
-
-	ih.logger.Info("received inbox POST request",
-		zap.String("username", username),
-		zap.String("content_type", headerValue(ctx, "Content-Type")),
-		zap.String("user_agent", headerValue(ctx, "User-Agent")),
-		zap.String("request_id", ctx.RequestID))
-
-	// Validate Content-Type using centralized validation
-	contentType := headerValue(ctx, "Content-Type")
-	if err := common.ValidateActivityPubContentType(contentType); err != nil {
-		ih.logger.Warn("invalid content type", zap.String("content_type", contentType), zap.Error(err))
-		return nil, errors.ValidationFailed("Content-Type", fmt.Sprintf("invalid Content-Type: %v", err))
-	}
-
-	// Verify the actor exists
-	actor, err := ih.actorRepository.GetActorByUsername(ctx.Context(), username)
-	if err != nil {
-		if err.Error() == "actor not found" {
-			return nil, errors.NotFound("actor")
-		}
-		ih.logger.Error("failed to get actor", zap.Error(err))
-		return nil, errors.InternalWithCause(err, "internal server error")
-	}
-
-	// Validate and parse request body
-	body := ctx.Request.Body
-	if err := ih.validateRequestBody(body); err != nil {
-		return nil, err
-	}
-
-	activity, err := ih.parseActivity(body)
-	if err != nil {
-		return nil, err
-	}
-
-	// Validate activity and addressing
-	if err := ih.validateActivity(activity, actor); err != nil {
-		return nil, err
-	}
-
-	// Initialize request structure
-	startTime := time.Now()
-	actorDomain := ih.extractDomainFromURL(activity.Actor)
-
-	req := &InboxRequest{
-		Username:    username,
-		Activity:    activity,
-		Actor:       actor,
-		Body:        body,
-		ActorDomain: actorDomain,
-		StartTime:   startTime,
-		CostParams: &federation.CostCalculationParams{
-			ActivityID:         activity.ID,
-			Domain:             actorDomain,
-			ActivityType:       activity.Type,
-			Direction:          "inbound",
-			OperationType:      "inbox_processing",
-			Timestamp:          startTime,
-			PayloadSize:        int64(len(body)),
-			LambdaMemoryMB:     512,
-			DynamoDBReadCount:  1, // Actor verification
-			DynamoDBWriteCount: 0,
-		},
-	}
-
-	return req, nil
-}
-
 // validateRequestBody validates the request body size and content
 func (ih *InboxHandler) validateRequestBody(body []byte) error {
 	return inboxvalidation.ValidateRequestBody(ih.logger, body)
@@ -774,51 +686,6 @@ func (ih *InboxHandler) validateRequestBody(body []byte) error {
 // parseActivity parses and sanitizes the ActivityPub activity
 func (ih *InboxHandler) parseActivity(body []byte) (*activitypub.Activity, error) {
 	return inboxvalidation.ParseActivity(ih.logger, body)
-}
-
-// validateActivity validates required activity fields and addressing
-func (ih *InboxHandler) validateActivity(activity *activitypub.Activity, actor *activitypub.Actor) error {
-	// Validate basic activity structure
-	if err := ih.validateBasicActivity(activity); err != nil {
-		return err
-	}
-
-	// Validate actor structure
-	if err := ih.validateBasicActor(actor); err != nil {
-		return err
-	}
-
-	// Validate addressing fields
-	if err := ih.validateActivityAddressing(activity); err != nil {
-		return err
-	}
-
-	// Validate actor username
-	if err := ih.validateActorUsername(activity.Actor); err != nil {
-		return err
-	}
-
-	// Validate actor public key if present
-	if err := ih.validateActorPublicKey(actor); err != nil {
-		return err
-	}
-
-	// Validate Create activity objects if applicable
-	if err := ih.validateCreateActivityObject(activity); err != nil {
-		return err
-	}
-
-	// Validate comprehensive addressing
-	if err := ih.validateComprehensiveAddressing(activity); err != nil {
-		return err
-	}
-
-	// Check if activity is addressed to this actor
-	if err := ih.validateActivityTargeting(activity, actor); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func stringSliceToInterfaceSlice(values []string) []interface{} {
@@ -1051,66 +918,6 @@ func (ih *InboxHandler) verifyAuthentication(ctx *apptheory.Context, req *InboxR
 	return nil
 }
 
-// validateAddressingAndPrivacy validates addressing fields and privacy compliance
-func (ih *InboxHandler) validateAddressingAndPrivacy(_ *apptheory.Context, req *InboxRequest) error {
-	start := time.Now()
-	addressingValidator := activitypub.NewAddressingValidator()
-
-	// Validate addressing fields are properly formatted
-	if err := addressingValidator.ValidateAddressing(req.Activity); err != nil {
-		ih.logger.Warn("activity has invalid addressing fields",
-			zap.String("actor", req.Activity.Actor),
-			zap.String("activity_id", req.Activity.ID),
-			zap.Error(err))
-		req.CostParams.ProcessingTimeMs = time.Since(start).Milliseconds()
-		ih.recordFailureCost(req, fmt.Sprintf("Invalid addressing: %v", err), 1)
-		return errors.ValidationFailed("addressing", "invalid addressing fields").WithInternalError(err)
-	}
-
-	// Validate privacy compliance (e.g., direct messages don't have public addressing)
-	if err := addressingValidator.ValidatePrivacyCompliance(req.Activity); err != nil {
-		ih.logger.Warn("activity violates privacy compliance",
-			zap.String("actor", req.Activity.Actor),
-			zap.String("activity_id", req.Activity.ID),
-			zap.Error(err))
-		req.CostParams.ProcessingTimeMs = time.Since(start).Milliseconds()
-		ih.recordFailureCost(req, fmt.Sprintf("Privacy violation: %v", err), 1)
-		return errors.ValidationFailed("privacy", "privacy compliance violation").WithInternalError(err)
-	}
-
-	// Check if the activity is actually addressed to this actor
-	if !ih.isAddressedTo(req.Activity, req.Actor) {
-		ih.logger.Warn("activity not addressed to this actor",
-			zap.String("actor", req.Activity.Actor),
-			zap.String("target_actor", req.Actor.ID),
-			zap.String("activity_id", req.Activity.ID))
-		req.CostParams.ProcessingTimeMs = time.Since(start).Milliseconds()
-		ih.recordFailureCost(req, "Activity not addressed to target actor", 1)
-		// Return 404 instead of 403 to maintain privacy (don't leak that actor exists)
-		return errors.NotFound("resource")
-	}
-
-	// For direct messages, perform additional validation
-	if addressingValidator.IsDirectMessage(req.Activity) {
-		if err := ih.validateDirectMessage(req.Activity, req.Actor); err != nil {
-			ih.logger.Warn("direct message validation failed",
-				zap.String("actor", req.Activity.Actor),
-				zap.String("activity_id", req.Activity.ID),
-				zap.Error(err))
-			req.CostParams.ProcessingTimeMs = time.Since(start).Milliseconds()
-			ih.recordFailureCost(req, fmt.Sprintf("Direct message validation failed: %v", err), 1)
-			return errors.ValidationFailed("direct_message", "direct message validation failed").WithInternalError(err)
-		}
-	}
-
-	req.CostParams.ProcessingTimeMs += time.Since(start).Milliseconds()
-	ih.logger.Debug("addressing and privacy validation successful",
-		zap.String("actor", req.Activity.Actor),
-		zap.String("visibility", addressingValidator.GetVisibilityLevel(req.Activity)))
-
-	return nil
-}
-
 // validateDirectMessage performs additional validation for direct messages
 func (ih *InboxHandler) validateDirectMessage(activity *activitypub.Activity, _ *activitypub.Actor) error {
 	// Validate all addressing fields using ActivityPub validators
@@ -1240,15 +1047,6 @@ func (ih *InboxHandler) storeAndProcessActivity(ctx *apptheory.Context, req *Inb
 	processingDuration := time.Since(processingStart)
 	req.CostParams.ProcessingTimeMs += processingDuration.Milliseconds()
 	return nil
-}
-
-// processActivityByType processes the activity based on its type.
-func (ih *InboxHandler) processActivityByType(ctx context.Context, req *InboxRequest) error {
-	targetActor := req.Actor
-	if targetActor == nil && len(req.TargetActors) > 0 {
-		targetActor = req.TargetActors[0]
-	}
-	return ih.processActivityByTypeForTarget(ctx, req.Activity, targetActor, req.CostParams)
 }
 
 func (ih *InboxHandler) processActivityByTypeForTarget(ctx context.Context, activity *activitypub.Activity, targetActor *activitypub.Actor, costParams *federation.CostCalculationParams) error {

--- a/cmd/inbox/internal/routing/legacy_test_helpers_test.go
+++ b/cmd/inbox/internal/routing/legacy_test_helpers_test.go
@@ -1,0 +1,50 @@
+package routing
+
+import (
+	"context"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+)
+
+// validateActivity preserves the legacy test seam while production code uses
+// the actor/shared-inbox specific validation paths directly.
+func (ih *InboxHandler) validateActivity(activity *activitypub.Activity, actor *activitypub.Actor) error {
+	if err := ih.validateBasicActivity(activity); err != nil {
+		return err
+	}
+	if err := ih.validateBasicActor(actor); err != nil {
+		return err
+	}
+	if err := ih.validateActivityAddressing(activity); err != nil {
+		return err
+	}
+	if err := ih.validateActorUsername(activity.Actor); err != nil {
+		return err
+	}
+	if err := ih.validateActorPublicKey(actor); err != nil {
+		return err
+	}
+	if err := ih.validateCreateActivityObject(activity); err != nil {
+		return err
+	}
+	if err := ih.validateComprehensiveAddressing(activity); err != nil {
+		return err
+	}
+	return ih.validateActivityTargeting(activity, actor)
+}
+
+// validateAddressingAndPrivacy preserves the legacy test seam while production
+// code uses validateActorInboxAddressingAndPrivacy / validateSharedInboxAddressingAndPrivacy.
+func (ih *InboxHandler) validateAddressingAndPrivacy(_ any, req *InboxRequest) error {
+	return ih.validateActorInboxAddressingAndPrivacy(req)
+}
+
+// processActivityByType preserves the legacy test seam while production code
+// routes directly to processActivityByTypeForTarget.
+func (ih *InboxHandler) processActivityByType(ctx context.Context, req *InboxRequest) error {
+	targetActor := req.Actor
+	if targetActor == nil && len(req.TargetActors) > 0 {
+		targetActor = req.TargetActors[0]
+	}
+	return ih.processActivityByTypeForTarget(ctx, req.Activity, targetActor, req.CostParams)
+}

--- a/cmd/inbox/internal/routing/shared_inbox_ingress.go
+++ b/cmd/inbox/internal/routing/shared_inbox_ingress.go
@@ -16,6 +16,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const actorNotFoundError = "actor not found"
+
 func (ih *InboxHandler) handleGetSharedInbox(*apptheory.Context) (*apptheory.Response, error) {
 	return apptheory.Text(http.StatusMethodNotAllowed, ""), nil
 }
@@ -66,7 +68,7 @@ func (ih *InboxHandler) initializeActorInboxRequest(ctx *apptheory.Context) (*In
 
 	actor, err := ih.actorRepository.GetActorByUsername(ctx.Context(), username)
 	if err != nil {
-		if err.Error() == "actor not found" {
+		if err.Error() == actorNotFoundError {
 			return nil, errors.NotFound("actor")
 		}
 		ih.logger.Error("failed to get actor", zap.Error(err))

--- a/cmd/inbox/internal/routing/shared_inbox_ingress.go
+++ b/cmd/inbox/internal/routing/shared_inbox_ingress.go
@@ -1,0 +1,357 @@
+package routing
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/federation"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"go.uber.org/zap"
+)
+
+func (ih *InboxHandler) handleGetSharedInbox(*apptheory.Context) (*apptheory.Response, error) {
+	return apptheory.Text(http.StatusMethodNotAllowed, ""), nil
+}
+
+func (ih *InboxHandler) handlePostSharedInbox(ctx *apptheory.Context) (*apptheory.Response, error) {
+	req, err := ih.initializeSharedInboxRequest(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ih.performSecurityChecks(ctx, req); err != nil {
+		return nil, err
+	}
+	if err := ih.verifyAuthentication(ctx, req); err != nil {
+		return nil, err
+	}
+	if err := ih.validateSharedInboxAddressingAndPrivacy(req); err != nil {
+		return nil, err
+	}
+	if err := ih.storeAndProcessActivity(ctx, req); err != nil {
+		return nil, err
+	}
+
+	ih.recordSuccessAndComplete(ctx, req)
+	return apptheory.Text(http.StatusAccepted, ""), nil
+}
+
+func (ih *InboxHandler) initializeActorInboxRequest(ctx *apptheory.Context) (*InboxRequest, error) {
+	username := ctx.Param("username")
+	if err := common.ValidateRequiredParam("username", username); err != nil {
+		return nil, errors.ValidationFailed("username", "missing username parameter")
+	}
+
+	if err := ih.rejectLockedBootstrapActor(ctx.Context(), username); err != nil {
+		return nil, err
+	}
+
+	ih.logger.Info("received inbox POST request",
+		zap.String("username", username),
+		zap.String("content_type", headerValue(ctx, "Content-Type")),
+		zap.String("user_agent", headerValue(ctx, "User-Agent")),
+		zap.String("request_id", ctx.RequestID))
+
+	activity, body, err := ih.parseAndValidateInboundActivity(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	actor, err := ih.actorRepository.GetActorByUsername(ctx.Context(), username)
+	if err != nil {
+		if err.Error() == "actor not found" {
+			return nil, errors.NotFound("actor")
+		}
+		ih.logger.Error("failed to get actor", zap.Error(err))
+		return nil, errors.InternalWithCause(err, "internal server error")
+	}
+
+	if err := ih.validateResolvedTargetActors(activity, []*activitypub.Actor{actor}, true); err != nil {
+		return nil, err
+	}
+
+	return ih.buildInboxRequest(username, activity, []*activitypub.Actor{actor}, body), nil
+}
+
+func (ih *InboxHandler) initializeSharedInboxRequest(ctx *apptheory.Context) (*InboxRequest, error) {
+	ih.logger.Info("received shared inbox POST request",
+		zap.String("content_type", headerValue(ctx, "Content-Type")),
+		zap.String("user_agent", headerValue(ctx, "User-Agent")),
+		zap.String("request_id", ctx.RequestID))
+
+	activity, body, err := ih.parseAndValidateInboundActivity(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	resolver := sharedInboxTargetResolver{
+		actorRepository:        ih.actorRepository,
+		relationshipRepository: ih.relationshipRepository,
+		activityRepository:     ih.activityRepository,
+		objectRepository:       ih.objectRepository,
+		localDomain:            ih.getConfig().Domain,
+	}
+	targetActors, err := resolver.Resolve(ctx.Context(), activity)
+	if err != nil {
+		return nil, errors.InternalWithCause(err, "failed to resolve shared inbox targets")
+	}
+
+	targetActors, err = ih.filterBootstrapTargets(ctx.Context(), targetActors)
+	if err != nil {
+		return nil, err
+	}
+	if len(targetActors) == 0 {
+		return nil, errors.NotFound("resource")
+	}
+
+	if err := ih.validateResolvedTargetActors(activity, targetActors, false); err != nil {
+		return nil, err
+	}
+
+	return ih.buildInboxRequest(targetActors[0].PreferredUsername, activity, targetActors, body), nil
+}
+
+func (ih *InboxHandler) parseAndValidateInboundActivity(ctx *apptheory.Context) (*activitypub.Activity, []byte, error) {
+	contentType := headerValue(ctx, "Content-Type")
+	if err := common.ValidateActivityPubContentType(contentType); err != nil {
+		ih.logger.Warn("invalid content type", zap.String("content_type", contentType), zap.Error(err))
+		return nil, nil, errors.ValidationFailed("Content-Type", fmt.Sprintf("invalid Content-Type: %v", err))
+	}
+
+	body := ctx.Request.Body
+	if err := ih.validateRequestBody(body); err != nil {
+		return nil, nil, err
+	}
+
+	activity, err := ih.parseActivity(body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := ih.validateActivityStructure(activity); err != nil {
+		return nil, nil, err
+	}
+
+	return activity, body, nil
+}
+
+func (ih *InboxHandler) validateActivityStructure(activity *activitypub.Activity) error {
+	if err := ih.validateBasicActivity(activity); err != nil {
+		return err
+	}
+	if err := ih.validateActivityAddressing(activity); err != nil {
+		return err
+	}
+	if err := ih.validateActorUsername(activity.Actor); err != nil {
+		return err
+	}
+	if err := ih.validateCreateActivityObject(activity); err != nil {
+		return err
+	}
+	if err := ih.validateComprehensiveAddressing(activity); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (ih *InboxHandler) validateResolvedTargetActors(activity *activitypub.Activity, actors []*activitypub.Actor, requireTargeting bool) error {
+	for _, actor := range actors {
+		if actor == nil {
+			continue
+		}
+		if err := ih.validateBasicActor(actor); err != nil {
+			return err
+		}
+		if err := ih.validateActorPublicKey(actor); err != nil {
+			return err
+		}
+		if requireTargeting {
+			if err := ih.validateActivityTargeting(activity, actor); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (ih *InboxHandler) buildInboxRequest(username string, activity *activitypub.Activity, targetActors []*activitypub.Actor, body []byte) *InboxRequest {
+	startTime := time.Now()
+	actorDomain := ih.extractDomainFromURL(activity.Actor)
+	var primaryActor *activitypub.Actor
+	if len(targetActors) > 0 {
+		primaryActor = targetActors[0]
+	}
+	readCount := int64(len(targetActors))
+	if readCount == 0 {
+		readCount = 1
+	}
+	return &InboxRequest{
+		Username:     username,
+		Activity:     activity,
+		Actor:        primaryActor,
+		TargetActors: targetActors,
+		Body:         body,
+		ActorDomain:  actorDomain,
+		StartTime:    startTime,
+		CostParams: &federation.CostCalculationParams{
+			ActivityID:         activity.ID,
+			Domain:             actorDomain,
+			ActivityType:       activity.Type,
+			Direction:          "inbound",
+			OperationType:      "inbox_processing",
+			Timestamp:          startTime,
+			PayloadSize:        int64(len(body)),
+			LambdaMemoryMB:     512,
+			DynamoDBReadCount:  readCount,
+			DynamoDBWriteCount: 0,
+		},
+	}
+}
+
+func (ih *InboxHandler) validateActorInboxAddressingAndPrivacy(req *InboxRequest) error {
+	start := time.Now()
+	addressingValidator := activitypub.NewAddressingValidator()
+	if err := ih.validateAddressingFields(req, addressingValidator, start); err != nil {
+		return err
+	}
+
+	if !ih.isAddressedTo(req.Activity, req.Actor) {
+		ih.logger.Warn("activity not addressed to this actor",
+			zap.String("actor", req.Activity.Actor),
+			zap.String("target_actor", req.Actor.ID),
+			zap.String("activity_id", req.Activity.ID))
+		req.CostParams.ProcessingTimeMs = time.Since(start).Milliseconds()
+		ih.recordFailureCost(req, "Activity not addressed to target actor", 1)
+		return errors.NotFound("resource")
+	}
+
+	if addressingValidator.IsDirectMessage(req.Activity) {
+		if err := ih.validateDirectMessage(req.Activity, req.Actor); err != nil {
+			ih.logger.Warn("direct message validation failed",
+				zap.String("actor", req.Activity.Actor),
+				zap.String("activity_id", req.Activity.ID),
+				zap.Error(err))
+			req.CostParams.ProcessingTimeMs = time.Since(start).Milliseconds()
+			ih.recordFailureCost(req, fmt.Sprintf("Direct message validation failed: %v", err), 1)
+			return errors.ValidationFailed("direct_message", "direct message validation failed").WithInternalError(err)
+		}
+	}
+
+	req.CostParams.ProcessingTimeMs += time.Since(start).Milliseconds()
+	ih.logger.Debug("addressing and privacy validation successful",
+		zap.String("actor", req.Activity.Actor),
+		zap.String("visibility", addressingValidator.GetVisibilityLevel(req.Activity)))
+	return nil
+}
+
+func (ih *InboxHandler) validateSharedInboxAddressingAndPrivacy(req *InboxRequest) error {
+	start := time.Now()
+	addressingValidator := activitypub.NewAddressingValidator()
+	if err := ih.validateAddressingFields(req, addressingValidator, start); err != nil {
+		return err
+	}
+
+	if len(req.TargetActors) == 0 {
+		req.CostParams.ProcessingTimeMs = time.Since(start).Milliseconds()
+		ih.recordFailureCost(req, "Shared inbox activity did not resolve to a local target", 1)
+		return errors.NotFound("resource")
+	}
+
+	if addressingValidator.IsDirectMessage(req.Activity) {
+		if err := ih.validateDirectMessage(req.Activity, req.Actor); err != nil {
+			ih.logger.Warn("shared inbox direct message validation failed",
+				zap.String("actor", req.Activity.Actor),
+				zap.String("activity_id", req.Activity.ID),
+				zap.Error(err))
+			req.CostParams.ProcessingTimeMs = time.Since(start).Milliseconds()
+			ih.recordFailureCost(req, fmt.Sprintf("Direct message validation failed: %v", err), 1)
+			return errors.ValidationFailed("direct_message", "direct message validation failed").WithInternalError(err)
+		}
+	}
+
+	req.CostParams.ProcessingTimeMs += time.Since(start).Milliseconds()
+	ih.logger.Debug("shared inbox addressing and privacy validation successful",
+		zap.String("actor", req.Activity.Actor),
+		zap.Int("target_count", len(req.TargetActors)),
+		zap.String("visibility", addressingValidator.GetVisibilityLevel(req.Activity)))
+	return nil
+}
+
+func (ih *InboxHandler) validateAddressingFields(req *InboxRequest, addressingValidator *activitypub.AddressingValidator, start time.Time) error {
+	if err := addressingValidator.ValidateAddressing(req.Activity); err != nil {
+		ih.logger.Warn("activity has invalid addressing fields",
+			zap.String("actor", req.Activity.Actor),
+			zap.String("activity_id", req.Activity.ID),
+			zap.Error(err))
+		req.CostParams.ProcessingTimeMs = time.Since(start).Milliseconds()
+		ih.recordFailureCost(req, fmt.Sprintf("Invalid addressing: %v", err), 1)
+		return errors.ValidationFailed("addressing", "invalid addressing fields").WithInternalError(err)
+	}
+
+	if err := addressingValidator.ValidatePrivacyCompliance(req.Activity); err != nil {
+		ih.logger.Warn("activity violates privacy compliance",
+			zap.String("actor", req.Activity.Actor),
+			zap.String("activity_id", req.Activity.ID),
+			zap.Error(err))
+		req.CostParams.ProcessingTimeMs = time.Since(start).Milliseconds()
+		ih.recordFailureCost(req, fmt.Sprintf("Privacy violation: %v", err), 1)
+		return errors.ValidationFailed("privacy", "privacy compliance violation").WithInternalError(err)
+	}
+
+	return nil
+}
+
+func (ih *InboxHandler) rejectLockedBootstrapActor(ctx context.Context, username string) error {
+	if ih.instanceRepository == nil {
+		return nil
+	}
+
+	state, err := ih.instanceRepository.GetInstanceState(ctx)
+	bootstrapUsername := models.DefaultBootstrapUsername
+	if err == nil && strings.TrimSpace(state.BootstrapUsername) != "" {
+		bootstrapUsername = strings.TrimSpace(state.BootstrapUsername)
+	}
+
+	if (err != nil && strings.EqualFold(username, bootstrapUsername)) ||
+		(err == nil && state.Locked && strings.EqualFold(username, bootstrapUsername)) {
+		return errors.Forbidden("bootstrap actor does not accept federation while instance is locked")
+	}
+
+	return nil
+}
+
+func (ih *InboxHandler) filterBootstrapTargets(ctx context.Context, actors []*activitypub.Actor) ([]*activitypub.Actor, error) {
+	if ih.instanceRepository == nil || len(actors) == 0 {
+		return actors, nil
+	}
+
+	state, err := ih.instanceRepository.GetInstanceState(ctx)
+	bootstrapUsername := models.DefaultBootstrapUsername
+	locked := false
+	if err == nil {
+		locked = state.Locked
+		if strings.TrimSpace(state.BootstrapUsername) != "" {
+			bootstrapUsername = strings.TrimSpace(state.BootstrapUsername)
+		}
+	}
+
+	filtered := make([]*activitypub.Actor, 0, len(actors))
+	for _, actor := range actors {
+		if actor == nil {
+			continue
+		}
+		if strings.EqualFold(actor.PreferredUsername, bootstrapUsername) && (locked || err != nil) {
+			continue
+		}
+		filtered = append(filtered, actor)
+	}
+
+	return filtered, nil
+}

--- a/cmd/inbox/internal/routing/shared_inbox_ingress_test.go
+++ b/cmd/inbox/internal/routing/shared_inbox_ingress_test.go
@@ -1,0 +1,145 @@
+package routing
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/testing/inmemory"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInboxHandler_SharedInboxGetReturnsMethodNotAllowed(t *testing.T) {
+	env := newInboxTestEnv(t)
+
+	resp, err := env.handler.handleGetSharedInbox(newAppTheoryContext(http.MethodGet, "/inbox", map[string]string{"Host": "localhost"}, nil, nil))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusMethodNotAllowed, resp.Status)
+}
+
+func TestInboxHandler_SharedInboxPublicCreateResolvesFollowerTargets(t *testing.T) {
+	env := newInboxTestEnv(t)
+	setRunAsyncSynchronous(t)
+
+	relationshipRepo := inmemory.NewRelationshipRepository()
+	require.NoError(t, relationshipRepo.CreateRelationship(context.Background(), "alice", "bob@remote.example", env.cfg.BaseURL()+"/activities/follow-remote"))
+	require.NoError(t, relationshipRepo.AcceptFollowRequest(context.Background(), "alice", "bob@remote.example"))
+	env.handler.relationshipRepository = relationshipRepo
+	env.handler.activityRepository = inmemory.NewActivityRepository()
+
+	activity := map[string]any{
+		"@context": activitypub.Context,
+		"type":     activitypub.CreateType,
+		"id":       env.cfg.BaseURL() + "/activities/shared-create-public",
+		"actor":    env.remoteActorID,
+		"to":       []string{activitypub.PublicAddress},
+		"cc":       []string{env.remoteActorID + "/followers"},
+		"object": map[string]any{
+			"@context":     activitypub.Context,
+			"id":           env.cfg.BaseURL() + "/objects/shared-note-public",
+			"type":         activitypub.NoteType,
+			"attributedTo": env.remoteActorID,
+			"content":      "hello shared inbox",
+			"to":           []string{activitypub.PublicAddress},
+			"cc":           []string{env.remoteActorID + "/followers"},
+		},
+	}
+	body, err := json.Marshal(activity)
+	require.NoError(t, err)
+
+	ctx := newAppTheoryContext(http.MethodPost, "/inbox", map[string]string{
+		"Host":         "localhost",
+		"Content-Type": "application/activity+json",
+		"User-Agent":   "Mastodon/4.0.0",
+	}, nil, body)
+	signAppTheoryRequest(t, env, ctx, body)
+
+	resp, err := env.handler.handlePostSharedInbox(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusAccepted, resp.Status)
+
+	stored, err := env.handler.activityRepository.GetActivity(context.Background(), env.cfg.BaseURL()+"/activities/shared-create-public")
+	require.NoError(t, err)
+	require.Equal(t, env.remoteActorID, stored.Actor)
+}
+
+func TestInboxHandler_SharedInboxFollowersOnlyCreateResolvesFollowerTargets(t *testing.T) {
+	env := newInboxTestEnv(t)
+	setRunAsyncSynchronous(t)
+
+	relationshipRepo := inmemory.NewRelationshipRepository()
+	require.NoError(t, relationshipRepo.CreateRelationship(context.Background(), "alice", "bob@remote.example", env.cfg.BaseURL()+"/activities/follow-private"))
+	require.NoError(t, relationshipRepo.AcceptFollowRequest(context.Background(), "alice", "bob@remote.example"))
+	env.handler.relationshipRepository = relationshipRepo
+	env.handler.activityRepository = inmemory.NewActivityRepository()
+
+	activity := map[string]any{
+		"@context": activitypub.Context,
+		"type":     activitypub.CreateType,
+		"id":       env.cfg.BaseURL() + "/activities/shared-create-private",
+		"actor":    env.remoteActorID,
+		"to":       []string{env.remoteActorID + "/followers"},
+		"object": map[string]any{
+			"@context":     activitypub.Context,
+			"id":           env.cfg.BaseURL() + "/objects/shared-note-private",
+			"type":         activitypub.NoteType,
+			"attributedTo": env.remoteActorID,
+			"content":      "hello followers only",
+			"to":           []string{env.remoteActorID + "/followers"},
+		},
+	}
+	body, err := json.Marshal(activity)
+	require.NoError(t, err)
+
+	ctx := newAppTheoryContext(http.MethodPost, "/inbox", map[string]string{
+		"Host":         "localhost",
+		"Content-Type": "application/activity+json",
+		"User-Agent":   "Mastodon/4.0.0",
+	}, nil, body)
+	signAppTheoryRequest(t, env, ctx, body)
+
+	resp, err := env.handler.handlePostSharedInbox(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusAccepted, resp.Status)
+}
+
+func TestInboxHandler_SharedInboxFollowResolvesTargetActorAndReusesProcessing(t *testing.T) {
+	env := newInboxTestEnv(t)
+	setRunAsyncSynchronous(t)
+
+	relationshipRepo := inmemory.NewRelationshipRepository()
+	env.handler.relationshipRepository = relationshipRepo
+	env.handler.activityRepository = inmemory.NewActivityRepository()
+
+	activity := map[string]any{
+		"@context": activitypub.Context,
+		"type":     activitypub.FollowType,
+		"id":       env.cfg.BaseURL() + "/activities/shared-follow",
+		"actor":    env.remoteActorID,
+		"object":   env.local.ID,
+		"to":       []string{env.local.ID},
+	}
+	body, err := json.Marshal(activity)
+	require.NoError(t, err)
+
+	ctx := newAppTheoryContext(http.MethodPost, "/inbox", map[string]string{
+		"Host":         "localhost",
+		"Content-Type": "application/activity+json",
+		"User-Agent":   "Mastodon/4.0.0",
+	}, nil, body)
+	signAppTheoryRequest(t, env, ctx, body)
+
+	resp, err := env.handler.handlePostSharedInbox(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusAccepted, resp.Status)
+
+	relationship, err := relationshipRepo.GetRelationship(context.Background(), "bob@remote.example", "alice")
+	require.NoError(t, err)
+	require.Equal(t, "accepted", relationship.State)
+}

--- a/cmd/inbox/internal/routing/shared_inbox_ingress_test.go
+++ b/cmd/inbox/internal/routing/shared_inbox_ingress_test.go
@@ -3,12 +3,21 @@ package routing
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"net/http"
 	"testing"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	apperrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/federation"
+	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/equaltoai/lesser/pkg/storage/repositories"
 	"github.com/equaltoai/lesser/pkg/testing/inmemory"
+	testingmocks "github.com/equaltoai/lesser/pkg/testing/mocks"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	dynamormmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
+	"go.uber.org/zap"
 )
 
 func TestInboxHandler_SharedInboxGetReturnsMethodNotAllowed(t *testing.T) {
@@ -142,4 +151,326 @@ func TestInboxHandler_SharedInboxFollowResolvesTargetActorAndReusesProcessing(t 
 	relationship, err := relationshipRepo.GetRelationship(context.Background(), "bob@remote.example", "alice")
 	require.NoError(t, err)
 	require.Equal(t, "accepted", relationship.State)
+}
+
+func TestInboxHandler_SharedInboxPostReturnsNotFoundWhenNoLocalTargetsResolve(t *testing.T) {
+	env := newInboxTestEnv(t)
+	setRunAsyncSynchronous(t)
+
+	env.handler.relationshipRepository = inmemory.NewRelationshipRepository()
+	env.handler.activityRepository = inmemory.NewActivityRepository()
+
+	activity := map[string]any{
+		"@context": activitypub.Context,
+		"type":     activitypub.CreateType,
+		"id":       env.remoteActorID + "/activities/shared-create-miss",
+		"actor":    env.remoteActorID,
+		"to":       []string{activitypub.PublicAddress},
+		"cc":       []string{env.remoteActorID + "/followers"},
+		"object": map[string]any{
+			"@context":     activitypub.Context,
+			"id":           env.remoteActorID + "/objects/shared-note-miss",
+			"type":         activitypub.NoteType,
+			"attributedTo": env.remoteActorID,
+			"content":      "nobody local should receive this",
+			"to":           []string{activitypub.PublicAddress},
+			"cc":           []string{env.remoteActorID + "/followers"},
+		},
+	}
+	body, err := json.Marshal(activity)
+	require.NoError(t, err)
+
+	ctx := newAppTheoryContext(http.MethodPost, "/inbox", map[string]string{
+		"Host":         "localhost",
+		"Content-Type": "application/activity+json",
+		"User-Agent":   "Mastodon/4.0.0",
+	}, nil, body)
+	signAppTheoryRequest(t, env, ctx, body)
+
+	resp, err := env.handler.handlePostSharedInbox(ctx)
+	require.Nil(t, resp)
+	require.Error(t, err)
+	require.Equal(t, http.StatusNotFound, apperrors.GetHTTPStatus(err))
+}
+
+func TestInboxHandler_SharedInboxPostReturnsValidationErrorForInvalidAddressing(t *testing.T) {
+	env := newInboxTestEnv(t)
+	setRunAsyncSynchronous(t)
+
+	activity := map[string]any{
+		"@context": activitypub.Context,
+		"type":     activitypub.CreateType,
+		"id":       env.remoteActorID + "/activities/shared-invalid-addressing",
+		"actor":    env.remoteActorID,
+		"to":       []string{env.local.ID},
+		"cc":       []string{"not-a-url"},
+		"object": map[string]any{
+			"@context":     activitypub.Context,
+			"id":           env.remoteActorID + "/objects/shared-invalid-addressing",
+			"type":         activitypub.NoteType,
+			"attributedTo": env.remoteActorID,
+			"content":      "invalid shared inbox addressing",
+			"to":           []string{env.local.ID},
+		},
+	}
+	body, err := json.Marshal(activity)
+	require.NoError(t, err)
+
+	ctx := newAppTheoryContext(http.MethodPost, "/inbox", map[string]string{
+		"Host":         "localhost",
+		"Content-Type": "application/activity+json",
+		"User-Agent":   "Mastodon/4.0.0",
+	}, nil, body)
+	signAppTheoryRequest(t, env, ctx, body)
+
+	resp, err := env.handler.handlePostSharedInbox(ctx)
+	require.Nil(t, resp)
+	require.Error(t, err)
+	require.Equal(t, http.StatusBadRequest, apperrors.GetHTTPStatus(err))
+}
+
+func TestInboxHandler_ValidateSharedInboxAddressingAndPrivacy_Branches(t *testing.T) {
+	env := newInboxTestEnv(t)
+
+	t.Run("requires resolved targets", func(t *testing.T) {
+		req := &InboxRequest{
+			Activity: &activitypub.Activity{
+				BaseObject: activitypub.BaseObject{
+					Type: activitypub.CreateType,
+					To:   []string{activitypub.PublicAddress},
+				},
+				Actor: env.remoteActorID,
+				Object: &activitypub.Note{
+					BaseObject: activitypub.BaseObject{
+						ID:   env.cfg.BaseURL() + "/objects/no-targets",
+						Type: activitypub.NoteType,
+						To:   []string{activitypub.PublicAddress},
+					},
+					Content:      "no local targets",
+					AttributedTo: env.remoteActorID,
+				},
+			},
+			Actor:      env.local,
+			CostParams: &federation.CostCalculationParams{},
+		}
+
+		err := env.handler.validateSharedInboxAddressingAndPrivacy(req)
+		require.Error(t, err)
+		require.Equal(t, http.StatusNotFound, apperrors.GetHTTPStatus(err))
+	})
+
+	t.Run("runs direct message validation", func(t *testing.T) {
+		req := &InboxRequest{
+			Activity: &activitypub.Activity{
+				BaseObject: activitypub.BaseObject{
+					Type: activitypub.CreateType,
+					To:   []string{"https://example.com/users/alice/following"},
+				},
+				Actor: env.remoteActorID,
+				Object: &activitypub.Note{
+					BaseObject: activitypub.BaseObject{
+						ID:   env.cfg.BaseURL() + "/objects/dm-validation",
+						Type: activitypub.NoteType,
+						To:   []string{"https://example.com/users/alice/following"},
+					},
+					Content:      "not a direct recipient",
+					AttributedTo: env.remoteActorID,
+				},
+			},
+			Actor:        env.local,
+			TargetActors: []*activitypub.Actor{env.local},
+			CostParams:   &federation.CostCalculationParams{},
+		}
+
+		err := env.handler.validateSharedInboxAddressingAndPrivacy(req)
+		require.Error(t, err)
+		require.Equal(t, http.StatusBadRequest, apperrors.GetHTTPStatus(err))
+	})
+}
+
+func TestInboxHandler_InitializeActorInboxRequest_RequiresUsername(t *testing.T) {
+	env := newInboxTestEnv(t)
+
+	ctx := newAppTheoryContext(http.MethodPost, "/users//inbox", map[string]string{
+		"Host":         "localhost",
+		"Content-Type": "application/activity+json",
+	}, nil, nil)
+
+	req, err := env.handler.initializeActorInboxRequest(ctx)
+	require.Nil(t, req)
+	require.Error(t, err)
+	require.Equal(t, http.StatusBadRequest, apperrors.GetHTTPStatus(err))
+}
+
+func TestInboxHandler_ValidateResolvedTargetActors_RejectsInvalidActor(t *testing.T) {
+	env := newInboxTestEnv(t)
+
+	err := env.handler.validateResolvedTargetActors(&activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Type: activitypub.FollowType,
+			To:   []string{env.local.ID},
+		},
+		Actor: env.remoteActorID,
+	}, []*activitypub.Actor{{PreferredUsername: "alice"}}, false)
+	require.Error(t, err)
+	require.Equal(t, http.StatusBadRequest, apperrors.GetHTTPStatus(err))
+}
+
+func TestInboxHandler_InitializeActorInboxRequest_ReturnsNotFoundForMissingActor(t *testing.T) {
+	env := newInboxTestEnv(t)
+
+	actorRepo := testingmocks.NewMockActorRepository()
+	env.handler.actorRepository = actorRepo
+	actorRepo.On("GetActorByUsername", mock.Anything, "missing").Return(nil, stderrors.New(actorNotFoundError)).Once()
+
+	activity := map[string]any{
+		"@context": activitypub.Context,
+		"type":     activitypub.FollowType,
+		"id":       env.remoteActorID + "/activities/follow-missing-actor",
+		"actor":    env.remoteActorID,
+		"object":   env.cfg.ActorURL("missing"),
+		"to":       []string{env.cfg.ActorURL("missing")},
+	}
+	body, err := json.Marshal(activity)
+	require.NoError(t, err)
+
+	ctx := newAppTheoryContext(http.MethodPost, "/users/missing/inbox", map[string]string{
+		"Host":         "localhost",
+		"Content-Type": "application/activity+json",
+		"User-Agent":   "Mastodon/4.0.0",
+	}, nil, body)
+	ctx.Params["username"] = "missing"
+	signAppTheoryRequest(t, env, ctx, body)
+
+	req, err := env.handler.initializeActorInboxRequest(ctx)
+	require.Nil(t, req)
+	require.Error(t, err)
+	require.Equal(t, http.StatusNotFound, apperrors.GetHTTPStatus(err))
+	actorRepo.AssertExpectations(t)
+}
+
+func TestInboxHandler_InitializeActorInboxRequest_RejectsLockedBootstrapActor(t *testing.T) {
+	env := newInboxTestEnv(t)
+	env.handler.instanceRepository = newInstanceRepositoryWithState(&storagemodels.InstanceState{
+		Locked:            true,
+		BootstrapUsername: "steward",
+	}, nil)
+
+	ctx := newAppTheoryContext(http.MethodPost, "/users/steward/inbox", map[string]string{
+		"Host":         "localhost",
+		"Content-Type": "application/activity+json",
+	}, nil, nil)
+	ctx.Params["username"] = "steward"
+
+	req, err := env.handler.initializeActorInboxRequest(ctx)
+	require.Nil(t, req)
+	require.Error(t, err)
+	require.Equal(t, http.StatusForbidden, apperrors.GetHTTPStatus(err))
+}
+
+func TestInboxHandler_InitializeSharedInboxRequest_RejectsInvalidResolvedTargetActor(t *testing.T) {
+	env := newInboxTestEnv(t)
+
+	relationshipRepo := inmemory.NewRelationshipRepository()
+	require.NoError(t, relationshipRepo.CreateRelationship(context.Background(), "alice", "bob@remote.example", env.cfg.BaseURL()+"/activities/follow-shared-invalid"))
+	require.NoError(t, relationshipRepo.AcceptFollowRequest(context.Background(), "alice", "bob@remote.example"))
+	env.handler.relationshipRepository = relationshipRepo
+
+	actorRepo := testingmocks.NewMockActorRepository()
+	env.handler.actorRepository = actorRepo
+	actorRepo.On("GetActorByUsername", mock.Anything, "alice").Return(&activitypub.Actor{PreferredUsername: "alice"}, nil).Once()
+
+	activity := map[string]any{
+		"@context": activitypub.Context,
+		"type":     activitypub.CreateType,
+		"id":       env.remoteActorID + "/activities/shared-invalid-target",
+		"actor":    env.remoteActorID,
+		"to":       []string{activitypub.PublicAddress},
+		"cc":       []string{env.remoteActorID + "/followers"},
+		"object": map[string]any{
+			"@context":     activitypub.Context,
+			"id":           env.remoteActorID + "/objects/shared-invalid-target",
+			"type":         activitypub.NoteType,
+			"attributedTo": env.remoteActorID,
+			"content":      "shared inbox invalid target actor",
+			"to":           []string{activitypub.PublicAddress},
+			"cc":           []string{env.remoteActorID + "/followers"},
+		},
+	}
+	body, err := json.Marshal(activity)
+	require.NoError(t, err)
+
+	ctx := newAppTheoryContext(http.MethodPost, "/inbox", map[string]string{
+		"Host":         "localhost",
+		"Content-Type": "application/activity+json",
+		"User-Agent":   "Mastodon/4.0.0",
+	}, nil, body)
+	signAppTheoryRequest(t, env, ctx, body)
+
+	req, err := env.handler.initializeSharedInboxRequest(ctx)
+	require.Nil(t, req)
+	require.Error(t, err)
+	require.Equal(t, http.StatusBadRequest, apperrors.GetHTTPStatus(err))
+	actorRepo.AssertExpectations(t)
+}
+
+func TestInboxHandler_RejectLockedBootstrapActor_Branches(t *testing.T) {
+	env := newInboxTestEnv(t)
+
+	t.Run("locked bootstrap is forbidden", func(t *testing.T) {
+		env.handler.instanceRepository = newInstanceRepositoryWithState(&storagemodels.InstanceState{
+			Locked:            true,
+			BootstrapUsername: "steward",
+		}, nil)
+
+		err := env.handler.rejectLockedBootstrapActor(context.Background(), "steward")
+		require.Error(t, err)
+		require.Equal(t, http.StatusForbidden, apperrors.GetHTTPStatus(err))
+	})
+
+	t.Run("repository error still protects default bootstrap actor", func(t *testing.T) {
+		env.handler.instanceRepository = newInstanceRepositoryWithState(nil, stderrors.New("boom"))
+
+		err := env.handler.rejectLockedBootstrapActor(context.Background(), storagemodels.DefaultBootstrapUsername)
+		require.Error(t, err)
+		require.Equal(t, http.StatusForbidden, apperrors.GetHTTPStatus(err))
+	})
+}
+
+func TestInboxHandler_FilterBootstrapTargets_FiltersLockedBootstrap(t *testing.T) {
+	env := newInboxTestEnv(t)
+	env.handler.instanceRepository = newInstanceRepositoryWithState(&storagemodels.InstanceState{
+		Locked:            true,
+		BootstrapUsername: "steward",
+	}, nil)
+
+	filtered, err := env.handler.filterBootstrapTargets(context.Background(), []*activitypub.Actor{
+		{PreferredUsername: "steward"},
+		{PreferredUsername: "alice"},
+		nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, filtered, 1)
+	require.Equal(t, "alice", filtered[0].PreferredUsername)
+}
+
+func newInstanceRepositoryWithState(state *storagemodels.InstanceState, err error) *repositories.InstanceRepository {
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.Anything).Return(q).Maybe()
+	q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q).Maybe()
+
+	first := q.On("First", mock.AnythingOfType("*models.InstanceState"))
+	if err != nil {
+		first.Return(err).Maybe()
+	} else {
+		first.Run(func(args mock.Arguments) {
+			current := args.Get(0).(*storagemodels.InstanceState)
+			*current = *state
+		}).Return(nil).Maybe()
+	}
+
+	return repositories.NewInstanceRepository(db, "test-table", zap.NewNop())
 }

--- a/cmd/inbox/internal/routing/shared_inbox_targets.go
+++ b/cmd/inbox/internal/routing/shared_inbox_targets.go
@@ -144,14 +144,21 @@ func (r sharedInboxTargetResolver) expandFollowerHandles(ctx context.Context, us
 	}
 
 	for handle := range followerHandles {
-		followers, _, err := r.relationshipRepository.GetFollowers(ctx, handle, sharedInboxFollowersLookupLimit, "")
-		if err != nil {
-			return err
-		}
-		for _, follower := range followers {
-			if username := r.localUsername(follower); username != "" {
-				usernames[username] = struct{}{}
+		cursor := ""
+		for {
+			followers, nextCursor, err := r.relationshipRepository.GetFollowers(ctx, handle, sharedInboxFollowersLookupLimit, cursor)
+			if err != nil {
+				return err
 			}
+			for _, follower := range followers {
+				if username := r.localUsername(follower); username != "" {
+					usernames[username] = struct{}{}
+				}
+			}
+			if nextCursor == "" {
+				break
+			}
+			cursor = nextCursor
 		}
 	}
 

--- a/cmd/inbox/internal/routing/shared_inbox_targets.go
+++ b/cmd/inbox/internal/routing/shared_inbox_targets.go
@@ -45,7 +45,7 @@ func (r sharedInboxTargetResolver) Resolve(ctx context.Context, activity *activi
 
 	switch activity.Type {
 	case activitypub.FollowType:
-		r.addObjectTargets(ctx, usernames, followerHandles, activity.Object)
+		r.addObjectTargets(usernames, followerHandles, activity.Object)
 	case activitypub.AcceptType, activitypub.RejectType:
 		if err := r.addStoredActivityTargets(ctx, usernames, activity.Object); err != nil {
 			return nil, err
@@ -55,7 +55,7 @@ func (r sharedInboxTargetResolver) Resolve(ctx context.Context, activity *activi
 			return nil, err
 		}
 	case activitypub.CreateType, activitypub.UpdateType, activitypub.DeleteType:
-		r.addObjectTargets(ctx, usernames, followerHandles, activity.Object)
+		r.addObjectTargets(usernames, followerHandles, activity.Object)
 	case activitypub.LikeType, activitypub.AnnounceType:
 		if err := r.addObjectOwnerTargets(ctx, usernames, activity.Object); err != nil {
 			return nil, err
@@ -105,7 +105,7 @@ func (r sharedInboxTargetResolver) addStoredActivityTargets(ctx context.Context,
 	return nil
 }
 
-func (r sharedInboxTargetResolver) addObjectTargets(ctx context.Context, usernames map[string]struct{}, followerHandles map[string]struct{}, object any) {
+func (r sharedInboxTargetResolver) addObjectTargets(usernames map[string]struct{}, followerHandles map[string]struct{}, object any) {
 	if username := r.localUsername(extractObjectID(object)); username != "" {
 		usernames[username] = struct{}{}
 	}

--- a/cmd/inbox/internal/routing/shared_inbox_targets.go
+++ b/cmd/inbox/internal/routing/shared_inbox_targets.go
@@ -1,0 +1,255 @@
+package routing
+
+import (
+	"context"
+	"strings"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+)
+
+const sharedInboxFollowersLookupLimit = 1000
+
+type sharedInboxActorRepository interface {
+	GetActorByUsername(ctx context.Context, username string) (*activitypub.Actor, error)
+}
+
+type sharedInboxRelationshipRepository interface {
+	GetFollowers(ctx context.Context, username string, limit int, cursor string) ([]string, string, error)
+}
+
+type sharedInboxActivityRepository interface {
+	GetActivity(ctx context.Context, id string) (*activitypub.Activity, error)
+}
+
+type sharedInboxObjectRepository interface {
+	GetObject(ctx context.Context, id string) (any, error)
+}
+
+type sharedInboxTargetResolver struct {
+	actorRepository        sharedInboxActorRepository
+	relationshipRepository sharedInboxRelationshipRepository
+	activityRepository     sharedInboxActivityRepository
+	objectRepository       sharedInboxObjectRepository
+	localDomain            string
+}
+
+func (r sharedInboxTargetResolver) Resolve(ctx context.Context, activity *activitypub.Activity) ([]*activitypub.Actor, error) {
+	usernames := make(map[string]struct{})
+	followerHandles := make(map[string]struct{})
+
+	r.addAddressTargets(usernames, followerHandles, activity.To...)
+	r.addAddressTargets(usernames, followerHandles, activity.CC...)
+	r.addAddressTargets(usernames, followerHandles, activity.BTo...)
+	r.addAddressTargets(usernames, followerHandles, activity.BCC...)
+
+	switch activity.Type {
+	case activitypub.FollowType:
+		r.addObjectTargets(ctx, usernames, followerHandles, activity.Object)
+	case activitypub.AcceptType, activitypub.RejectType:
+		if err := r.addStoredActivityTargets(ctx, usernames, activity.Object); err != nil {
+			return nil, err
+		}
+	case activitypub.UndoType:
+		if err := r.addUndoTargets(ctx, usernames, activity.Object); err != nil {
+			return nil, err
+		}
+	case activitypub.CreateType, activitypub.UpdateType, activitypub.DeleteType:
+		r.addObjectTargets(ctx, usernames, followerHandles, activity.Object)
+	case activitypub.LikeType, activitypub.AnnounceType:
+		if err := r.addObjectOwnerTargets(ctx, usernames, activity.Object); err != nil {
+			return nil, err
+		}
+	case activitypub.AddType, activitypub.RemoveType:
+		r.addAddressTargets(usernames, followerHandles, activity.Target)
+		if err := r.addObjectOwnerTargets(ctx, usernames, activity.Object); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := r.expandFollowerHandles(ctx, usernames, followerHandles); err != nil {
+		return nil, err
+	}
+
+	return r.loadActors(ctx, usernames)
+}
+
+func (r sharedInboxTargetResolver) addUndoTargets(ctx context.Context, usernames map[string]struct{}, object any) error {
+	if err := r.addStoredActivityTargets(ctx, usernames, object); err != nil {
+		return err
+	}
+	return r.addObjectOwnerTargets(ctx, usernames, object)
+}
+
+func (r sharedInboxTargetResolver) addStoredActivityTargets(ctx context.Context, usernames map[string]struct{}, object any) error {
+	activityID := extractObjectID(object)
+	if activityID == "" || r.activityRepository == nil {
+		return nil
+	}
+
+	activity, err := r.activityRepository.GetActivity(ctx, activityID)
+	if err != nil || activity == nil {
+		return nil
+	}
+
+	if username := r.localUsername(activity.Actor); username != "" {
+		usernames[username] = struct{}{}
+	}
+	if username := r.localUsername(activity.Target); username != "" {
+		usernames[username] = struct{}{}
+	}
+	for _, recipient := range explicitLocalRecipients(activity, r.localDomain) {
+		usernames[recipient] = struct{}{}
+	}
+
+	return nil
+}
+
+func (r sharedInboxTargetResolver) addObjectTargets(ctx context.Context, usernames map[string]struct{}, followerHandles map[string]struct{}, object any) {
+	if username := r.localUsername(extractObjectID(object)); username != "" {
+		usernames[username] = struct{}{}
+	}
+
+	switch typed := object.(type) {
+	case map[string]any:
+		if actorID, _ := typed["actor"].(string); actorID != "" {
+			r.addAddressTargets(usernames, followerHandles, actorID)
+		}
+		if attributedTo, _ := typed["attributedTo"].(string); attributedTo != "" {
+			r.addAddressTargets(usernames, followerHandles, attributedTo)
+		}
+	}
+}
+
+func (r sharedInboxTargetResolver) addObjectOwnerTargets(ctx context.Context, usernames map[string]struct{}, object any) error {
+	objectID := extractObjectID(object)
+	if objectID == "" || r.objectRepository == nil {
+		return nil
+	}
+
+	storedObject, err := r.objectRepository.GetObject(ctx, objectID)
+	if err != nil || storedObject == nil {
+		return nil
+	}
+
+	if username := r.localUsername(extractAttributedTo(storedObject)); username != "" {
+		usernames[username] = struct{}{}
+	}
+	return nil
+}
+
+func (r sharedInboxTargetResolver) expandFollowerHandles(ctx context.Context, usernames map[string]struct{}, followerHandles map[string]struct{}) error {
+	if r.relationshipRepository == nil {
+		return nil
+	}
+
+	for handle := range followerHandles {
+		followers, _, err := r.relationshipRepository.GetFollowers(ctx, handle, sharedInboxFollowersLookupLimit, "")
+		if err != nil {
+			return err
+		}
+		for _, follower := range followers {
+			if username := r.localUsername(follower); username != "" {
+				usernames[username] = struct{}{}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r sharedInboxTargetResolver) loadActors(ctx context.Context, usernames map[string]struct{}) ([]*activitypub.Actor, error) {
+	if len(usernames) == 0 || r.actorRepository == nil {
+		return nil, nil
+	}
+
+	actors := make([]*activitypub.Actor, 0, len(usernames))
+	for username := range usernames {
+		actor, err := r.actorRepository.GetActorByUsername(ctx, username)
+		if err != nil || actor == nil {
+			continue
+		}
+		actors = append(actors, actor)
+	}
+
+	return actors, nil
+}
+
+func (r sharedInboxTargetResolver) addAddressTargets(usernames map[string]struct{}, followerHandles map[string]struct{}, addresses ...string) {
+	for _, address := range addresses {
+		address = strings.TrimSpace(address)
+		if address == "" || address == activitypub.PublicAddress {
+			continue
+		}
+
+		normalized := models.NormalizeRelationshipIdentity(address, r.localDomain)
+		if normalized == "" {
+			continue
+		}
+
+		if strings.Contains(address, "/followers") {
+			if strings.Contains(normalized, "@") {
+				followerHandles[normalized] = struct{}{}
+				continue
+			}
+		}
+
+		if !strings.Contains(normalized, "@") {
+			usernames[normalized] = struct{}{}
+		}
+	}
+}
+
+func (r sharedInboxTargetResolver) localUsername(address string) string {
+	normalized := models.NormalizeRelationshipIdentity(address, r.localDomain)
+	if normalized == "" || strings.Contains(normalized, "@") {
+		return ""
+	}
+	return normalized
+}
+
+func explicitLocalRecipients(activity *activitypub.Activity, localDomain string) []string {
+	results := make([]string, 0)
+	seen := make(map[string]struct{})
+	for _, address := range append(append(append(activity.To, activity.CC...), activity.BTo...), activity.BCC...) {
+		normalized := models.NormalizeRelationshipIdentity(address, localDomain)
+		if normalized == "" || strings.Contains(normalized, "@") {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		results = append(results, normalized)
+	}
+	return results
+}
+
+func extractObjectID(object any) string {
+	switch typed := object.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case map[string]any:
+		if id, ok := typed["id"].(string); ok {
+			return strings.TrimSpace(id)
+		}
+	}
+	return ""
+}
+
+func extractAttributedTo(object any) string {
+	switch typed := object.(type) {
+	case *activitypub.Note:
+		if typed == nil {
+			return ""
+		}
+		return strings.TrimSpace(typed.AttributedTo)
+	case activitypub.Note:
+		return strings.TrimSpace(typed.AttributedTo)
+	case map[string]any:
+		if value, ok := typed["attributedTo"].(string); ok {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/cmd/inbox/internal/routing/shared_inbox_targets_test.go
+++ b/cmd/inbox/internal/routing/shared_inbox_targets_test.go
@@ -198,3 +198,115 @@ func TestSharedInboxTargetResolver_LikeUsesLocalObjectOwner(t *testing.T) {
 	require.Len(t, actors, 1)
 	require.Equal(t, "alice", actors[0].PreferredUsername)
 }
+
+func TestSharedInboxTargetResolver_UndoUsesStoredActivityTargetsAndObjectOwner(t *testing.T) {
+	t.Parallel()
+
+	resolver := sharedInboxTargetResolver{
+		actorRepository: &sharedInboxActorRepoStub{actors: map[string]*activitypub.Actor{
+			"alice": {BaseObject: activitypub.BaseObject{ID: "https://example.com/users/alice"}, PreferredUsername: "alice"},
+			"bob":   {BaseObject: activitypub.BaseObject{ID: "https://example.com/users/bob"}, PreferredUsername: "bob"},
+			"carol": {BaseObject: activitypub.BaseObject{ID: "https://example.com/users/carol"}, PreferredUsername: "carol"},
+		}},
+		activityRepository: &sharedInboxActivityRepoStub{activities: map[string]*activitypub.Activity{
+			"https://remote.example/activities/like-1": {
+				BaseObject: activitypub.BaseObject{
+					Type: activitypub.LikeType,
+					To:   []string{"https://example.com/users/carol", "https://remote.example/users/zane"},
+				},
+				Actor:  "https://example.com/users/alice",
+				Target: "https://example.com/users/bob",
+			},
+		}},
+		objectRepository: &sharedInboxObjectRepoStub{objects: map[string]any{
+			"https://remote.example/activities/like-1": &activitypub.Note{AttributedTo: "https://example.com/users/carol"},
+		}},
+		localDomain: "example.com",
+	}
+
+	activity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{Type: activitypub.UndoType},
+		Object:     "https://remote.example/activities/like-1",
+	}
+
+	actors, err := resolver.Resolve(context.Background(), activity)
+	require.NoError(t, err)
+	require.Len(t, actors, 3)
+	require.ElementsMatch(t, []string{"alice", "bob", "carol"}, []string{actors[0].PreferredUsername, actors[1].PreferredUsername, actors[2].PreferredUsername})
+}
+
+func TestSharedInboxTargetResolver_AddUsesTargetAndObjectOwner(t *testing.T) {
+	t.Parallel()
+
+	resolver := sharedInboxTargetResolver{
+		actorRepository: &sharedInboxActorRepoStub{actors: map[string]*activitypub.Actor{
+			"alice": {BaseObject: activitypub.BaseObject{ID: "https://example.com/users/alice"}, PreferredUsername: "alice"},
+			"bob":   {BaseObject: activitypub.BaseObject{ID: "https://example.com/users/bob"}, PreferredUsername: "bob"},
+		}},
+		objectRepository: &sharedInboxObjectRepoStub{objects: map[string]any{
+			"https://remote.example/collections/entry-1": map[string]any{"attributedTo": "https://example.com/users/bob"},
+		}},
+		localDomain: "example.com",
+	}
+
+	activity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{Type: activitypub.AddType},
+		Target:     "https://example.com/users/alice",
+		Object:     "https://remote.example/collections/entry-1",
+	}
+
+	actors, err := resolver.Resolve(context.Background(), activity)
+	require.NoError(t, err)
+	require.Len(t, actors, 2)
+	require.ElementsMatch(t, []string{"alice", "bob"}, []string{actors[0].PreferredUsername, actors[1].PreferredUsername})
+}
+
+func TestSharedInboxTargetResolver_CreateUsesEmbeddedObjectActorAndAttributedTo(t *testing.T) {
+	t.Parallel()
+
+	resolver := sharedInboxTargetResolver{
+		actorRepository: &sharedInboxActorRepoStub{actors: map[string]*activitypub.Actor{
+			"alice": {BaseObject: activitypub.BaseObject{ID: "https://example.com/users/alice"}, PreferredUsername: "alice"},
+			"bob":   {BaseObject: activitypub.BaseObject{ID: "https://example.com/users/bob"}, PreferredUsername: "bob"},
+		}},
+		localDomain: "example.com",
+	}
+
+	activity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{Type: activitypub.CreateType},
+		Object: map[string]any{
+			"id":           "https://remote.example/notes/3",
+			"actor":        "https://example.com/users/alice",
+			"attributedTo": "https://example.com/users/bob",
+		},
+	}
+
+	actors, err := resolver.Resolve(context.Background(), activity)
+	require.NoError(t, err)
+	require.Len(t, actors, 2)
+	require.ElementsMatch(t, []string{"alice", "bob"}, []string{actors[0].PreferredUsername, actors[1].PreferredUsername})
+}
+
+func TestSharedInboxTargetResolver_HelperFunctions(t *testing.T) {
+	t.Parallel()
+
+	activity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			To:  []string{"https://example.com/users/alice", "https://remote.example/users/zane"},
+			CC:  []string{"https://example.com/users/alice", "https://example.com/users/bob"},
+			BTo: []string{"https://example.com/users/carol"},
+			BCC: []string{"https://example.com/users/bob"},
+		},
+	}
+
+	require.ElementsMatch(t, []string{"alice", "bob", "carol"}, explicitLocalRecipients(activity, "example.com"))
+	require.Equal(t, "https://remote.example/notes/4", extractObjectID(" https://remote.example/notes/4 "))
+	require.Equal(t, "https://remote.example/notes/5", extractObjectID(map[string]any{"id": " https://remote.example/notes/5 "}))
+	require.Empty(t, extractObjectID(42))
+	require.Equal(t, "https://example.com/users/alice", extractAttributedTo(&activitypub.Note{AttributedTo: " https://example.com/users/alice "}))
+	require.Equal(t, "https://example.com/users/bob", extractAttributedTo(activitypub.Note{AttributedTo: " https://example.com/users/bob "}))
+	require.Equal(t, "https://example.com/users/carol", extractAttributedTo(map[string]any{"attributedTo": " https://example.com/users/carol "}))
+	var nilNote *activitypub.Note
+	require.Empty(t, extractAttributedTo(nilNote))
+	require.Empty(t, extractAttributedTo(struct{}{}))
+}

--- a/cmd/inbox/internal/routing/shared_inbox_targets_test.go
+++ b/cmd/inbox/internal/routing/shared_inbox_targets_test.go
@@ -16,11 +16,26 @@ func (s *sharedInboxActorRepoStub) GetActorByUsername(_ context.Context, usernam
 	return s.actors[username], nil
 }
 
-type sharedInboxRelationshipRepoStub struct {
-	followers map[string][]string
+type sharedInboxFollowerPage struct {
+	followers  []string
+	nextCursor string
 }
 
-func (s *sharedInboxRelationshipRepoStub) GetFollowers(_ context.Context, username string, _ int, _ string) ([]string, string, error) {
+type sharedInboxRelationshipRepoStub struct {
+	followers map[string][]string
+	pages     map[string]map[string]sharedInboxFollowerPage
+}
+
+func (s *sharedInboxRelationshipRepoStub) GetFollowers(_ context.Context, username string, _ int, cursor string) ([]string, string, error) {
+	if s.pages != nil {
+		if handlePages, ok := s.pages[username]; ok {
+			page, ok := handlePages[cursor]
+			if !ok {
+				return nil, "", nil
+			}
+			return append([]string(nil), page.followers...), page.nextCursor, nil
+		}
+	}
 	return append([]string(nil), s.followers[username]...), "", nil
 }
 
@@ -93,6 +108,44 @@ func TestSharedInboxTargetResolver_PublicCreateResolvesFollowerSetWithoutTreatin
 	require.NoError(t, err)
 	require.Len(t, actors, 2)
 	require.ElementsMatch(t, []string{"alice", "carol"}, []string{actors[0].PreferredUsername, actors[1].PreferredUsername})
+}
+
+func TestSharedInboxTargetResolver_PublicCreateResolvesFollowerPages(t *testing.T) {
+	t.Parallel()
+
+	resolver := sharedInboxTargetResolver{
+		actorRepository: &sharedInboxActorRepoStub{actors: map[string]*activitypub.Actor{
+			"alice": {BaseObject: activitypub.BaseObject{ID: "https://example.com/users/alice"}, PreferredUsername: "alice"},
+			"carol": {BaseObject: activitypub.BaseObject{ID: "https://example.com/users/carol"}, PreferredUsername: "carol"},
+			"dave":  {BaseObject: activitypub.BaseObject{ID: "https://example.com/users/dave"}, PreferredUsername: "dave"},
+		}},
+		relationshipRepository: &sharedInboxRelationshipRepoStub{pages: map[string]map[string]sharedInboxFollowerPage{
+			"bob@remote.example": {
+				"":       {followers: []string{"alice", "carol"}, nextCursor: "page-2"},
+				"page-2": {followers: []string{"dave"}},
+			},
+		}},
+		localDomain: "example.com",
+	}
+
+	activity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Type: activitypub.CreateType,
+			To:   []string{activitypub.PublicAddress},
+			CC:   []string{"https://remote.example/users/bob/followers"},
+		},
+		Actor: "https://remote.example/users/bob",
+		Object: map[string]any{
+			"id":           "https://remote.example/notes/2",
+			"type":         activitypub.NoteType,
+			"attributedTo": "https://remote.example/users/bob",
+		},
+	}
+
+	actors, err := resolver.Resolve(context.Background(), activity)
+	require.NoError(t, err)
+	require.Len(t, actors, 3)
+	require.ElementsMatch(t, []string{"alice", "carol", "dave"}, []string{actors[0].PreferredUsername, actors[1].PreferredUsername, actors[2].PreferredUsername})
 }
 
 func TestSharedInboxTargetResolver_AcceptUsesStoredFollowActor(t *testing.T) {

--- a/cmd/inbox/internal/routing/shared_inbox_targets_test.go
+++ b/cmd/inbox/internal/routing/shared_inbox_targets_test.go
@@ -1,0 +1,147 @@
+package routing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/stretchr/testify/require"
+)
+
+type sharedInboxActorRepoStub struct {
+	actors map[string]*activitypub.Actor
+}
+
+func (s *sharedInboxActorRepoStub) GetActorByUsername(_ context.Context, username string) (*activitypub.Actor, error) {
+	return s.actors[username], nil
+}
+
+type sharedInboxRelationshipRepoStub struct {
+	followers map[string][]string
+}
+
+func (s *sharedInboxRelationshipRepoStub) GetFollowers(_ context.Context, username string, _ int, _ string) ([]string, string, error) {
+	return append([]string(nil), s.followers[username]...), "", nil
+}
+
+type sharedInboxActivityRepoStub struct {
+	activities map[string]*activitypub.Activity
+}
+
+func (s *sharedInboxActivityRepoStub) GetActivity(_ context.Context, id string) (*activitypub.Activity, error) {
+	return s.activities[id], nil
+}
+
+type sharedInboxObjectRepoStub struct {
+	objects map[string]any
+}
+
+func (s *sharedInboxObjectRepoStub) GetObject(_ context.Context, id string) (any, error) {
+	return s.objects[id], nil
+}
+
+func TestSharedInboxTargetResolver_ResolveFollowToLocalActor(t *testing.T) {
+	t.Parallel()
+
+	resolver := sharedInboxTargetResolver{
+		actorRepository: &sharedInboxActorRepoStub{actors: map[string]*activitypub.Actor{
+			"alice": {BaseObject: activitypub.BaseObject{ID: "https://example.com/users/alice"}, PreferredUsername: "alice"},
+		}},
+		localDomain: "example.com",
+	}
+
+	activity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{Type: activitypub.FollowType},
+		Object:     "https://example.com/users/alice",
+	}
+
+	actors, err := resolver.Resolve(context.Background(), activity)
+	require.NoError(t, err)
+	require.Len(t, actors, 1)
+	require.Equal(t, "alice", actors[0].PreferredUsername)
+}
+
+func TestSharedInboxTargetResolver_PublicCreateResolvesFollowerSetWithoutTreatingPublicAsTarget(t *testing.T) {
+	t.Parallel()
+
+	resolver := sharedInboxTargetResolver{
+		actorRepository: &sharedInboxActorRepoStub{actors: map[string]*activitypub.Actor{
+			"alice": {BaseObject: activitypub.BaseObject{ID: "https://example.com/users/alice"}, PreferredUsername: "alice"},
+			"carol": {BaseObject: activitypub.BaseObject{ID: "https://example.com/users/carol"}, PreferredUsername: "carol"},
+		}},
+		relationshipRepository: &sharedInboxRelationshipRepoStub{followers: map[string][]string{
+			"bob@remote.example": {"alice", "carol"},
+		}},
+		localDomain: "example.com",
+	}
+
+	activity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Type: activitypub.CreateType,
+			To:   []string{activitypub.PublicAddress},
+			CC:   []string{"https://remote.example/users/bob/followers"},
+		},
+		Actor: "https://remote.example/users/bob",
+		Object: map[string]any{
+			"id":           "https://remote.example/notes/1",
+			"type":         activitypub.NoteType,
+			"attributedTo": "https://remote.example/users/bob",
+		},
+	}
+
+	actors, err := resolver.Resolve(context.Background(), activity)
+	require.NoError(t, err)
+	require.Len(t, actors, 2)
+	require.ElementsMatch(t, []string{"alice", "carol"}, []string{actors[0].PreferredUsername, actors[1].PreferredUsername})
+}
+
+func TestSharedInboxTargetResolver_AcceptUsesStoredFollowActor(t *testing.T) {
+	t.Parallel()
+
+	resolver := sharedInboxTargetResolver{
+		actorRepository: &sharedInboxActorRepoStub{actors: map[string]*activitypub.Actor{
+			"alice": {BaseObject: activitypub.BaseObject{ID: "https://example.com/users/alice"}, PreferredUsername: "alice"},
+		}},
+		activityRepository: &sharedInboxActivityRepoStub{activities: map[string]*activitypub.Activity{
+			"https://example.com/activities/follow-1": {
+				BaseObject: activitypub.BaseObject{Type: activitypub.FollowType},
+				Actor:      "https://example.com/users/alice",
+			},
+		}},
+		localDomain: "example.com",
+	}
+
+	activity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{Type: activitypub.AcceptType},
+		Object:     "https://example.com/activities/follow-1",
+	}
+
+	actors, err := resolver.Resolve(context.Background(), activity)
+	require.NoError(t, err)
+	require.Len(t, actors, 1)
+	require.Equal(t, "alice", actors[0].PreferredUsername)
+}
+
+func TestSharedInboxTargetResolver_LikeUsesLocalObjectOwner(t *testing.T) {
+	t.Parallel()
+
+	resolver := sharedInboxTargetResolver{
+		actorRepository: &sharedInboxActorRepoStub{actors: map[string]*activitypub.Actor{
+			"alice": {BaseObject: activitypub.BaseObject{ID: "https://example.com/users/alice"}, PreferredUsername: "alice"},
+		}},
+		objectRepository: &sharedInboxObjectRepoStub{objects: map[string]any{
+			"https://example.com/notes/1": &activitypub.Note{AttributedTo: "https://example.com/users/alice"},
+		}},
+		localDomain: "example.com",
+	}
+
+	activity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{Type: activitypub.LikeType},
+		Object:     "https://example.com/notes/1",
+	}
+
+	actors, err := resolver.Resolve(context.Background(), activity)
+	require.NoError(t, err)
+	require.Len(t, actors, 1)
+	require.Equal(t, "alice", actors[0].PreferredUsername)
+}

--- a/cmd/lesser/init_admin.go
+++ b/cmd/lesser/init_admin.go
@@ -19,6 +19,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/deploy/naming"
+	"github.com/equaltoai/lesser/pkg/federation/surface"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/ethereum/go-ethereum/accounts"
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -621,13 +622,7 @@ func buildActorModel(username, domain, publicKeyPEM, encryptedPrivateKeyB64 stri
 		Owner:        actorID,
 		PublicKeyPem: publicKeyPEM,
 	}
-	actor.Endpoints = &activitypub.Endpoints{
-		SharedInbox: fmt.Sprintf("https://%s/inbox", domain),
-	}
-	actor.Inbox = fmt.Sprintf("%s/inbox", actorID)
-	actor.Outbox = fmt.Sprintf("%s/outbox", actorID)
-	actor.Followers = fmt.Sprintf("%s/followers", actorID)
-	actor.Following = fmt.Sprintf("%s/following", actorID)
+	surface.ApplyLocalActorIdentifiers(actor, fmt.Sprintf("https://%s", domain), username)
 
 	model := &storagemodels.Actor{
 		Actor:          actor,

--- a/cmd/lesser/init_admin.go
+++ b/cmd/lesser/init_admin.go
@@ -17,9 +17,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/activitypubutil"
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/deploy/naming"
-	"github.com/equaltoai/lesser/pkg/federation/surface"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/ethereum/go-ethereum/accounts"
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -622,7 +622,7 @@ func buildActorModel(username, domain, publicKeyPEM, encryptedPrivateKeyB64 stri
 		Owner:        actorID,
 		PublicKeyPem: publicKeyPEM,
 	}
-	surface.ApplyLocalActorIdentifiers(actor, fmt.Sprintf("https://%s", domain), username)
+	activitypubutil.ApplyLocalActorIdentifiers(actor, fmt.Sprintf("https://%s", domain), username)
 
 	model := &storagemodels.Actor{
 		Actor:          actor,

--- a/cmd/owner-bootstrap/main.go
+++ b/cmd/owner-bootstrap/main.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/federation/surface"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 )
 
@@ -602,13 +603,7 @@ func buildActorModel(username, domain, publicKeyPEM, encryptedPrivateKeyB64 stri
 		Owner:        actorID,
 		PublicKeyPem: publicKeyPEM,
 	}
-	actor.Endpoints = &activitypub.Endpoints{
-		SharedInbox: fmt.Sprintf("https://%s/inbox", domain),
-	}
-	actor.Inbox = fmt.Sprintf("%s/inbox", actorID)
-	actor.Outbox = fmt.Sprintf("%s/outbox", actorID)
-	actor.Followers = fmt.Sprintf("%s/followers", actorID)
-	actor.Following = fmt.Sprintf("%s/following", actorID)
+	surface.ApplyLocalActorIdentifiers(actor, fmt.Sprintf("https://%s", domain), username)
 
 	model := &storagemodels.Actor{
 		Actor:          actor,

--- a/cmd/owner-bootstrap/main.go
+++ b/cmd/owner-bootstrap/main.go
@@ -31,8 +31,8 @@ import (
 	"github.com/theory-cloud/tabletheory/pkg/session"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/activitypubutil"
 	"github.com/equaltoai/lesser/pkg/common"
-	"github.com/equaltoai/lesser/pkg/federation/surface"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 )
 
@@ -603,7 +603,7 @@ func buildActorModel(username, domain, publicKeyPEM, encryptedPrivateKeyB64 stri
 		Owner:        actorID,
 		PublicKeyPem: publicKeyPEM,
 	}
-	surface.ApplyLocalActorIdentifiers(actor, fmt.Sprintf("https://%s", domain), username)
+	activitypubutil.ApplyLocalActorIdentifiers(actor, fmt.Sprintf("https://%s", domain), username)
 
 	model := &storagemodels.Actor{
 		Actor:          actor,

--- a/cmd/owner-bootstrap/round12_owner_bootstrap_test.go
+++ b/cmd/owner-bootstrap/round12_owner_bootstrap_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -249,6 +251,84 @@ func TestSecretExists_CreateAndDeleteSecret(t *testing.T) {
 	require.NoError(t, deleteSecretImmediate(context.Background(), sm, "name"))
 	require.Len(t, sm.deleteInputs, 1)
 	require.True(t, aws.ToBool(sm.deleteInputs[0].ForceDeleteWithoutRecovery))
+}
+
+func TestBuildActorModel_UsesManifestSharedInbox(t *testing.T) {
+	now := time.Now().UTC()
+
+	model, err := buildActorModel("alice", "example.com", "PUBLIC", "ENCRYPTED", now)
+	require.NoError(t, err)
+	require.NotNil(t, model.Actor)
+	require.Equal(t, "https://example.com/inbox", model.Actor.Endpoints.SharedInbox)
+	require.Equal(t, "https://example.com/users/alice/inbox", model.Actor.Inbox)
+	require.Equal(t, "https://example.com/users/alice/outbox", model.Actor.Outbox)
+	require.True(t, strings.HasPrefix(model.PK, "ACTOR#"))
+	require.Equal(t, storagemodels.SKProfile, model.SK)
+	require.Equal(t, "DOMAIN#example.com", model.GSI3PK)
+	require.Equal(t, "alice", model.GSI3SK)
+}
+
+func TestBuildUserModel_SetsAdminDefaults(t *testing.T) {
+	now := time.Now().UTC()
+
+	model, err := buildUserModel("alice", now)
+	require.NoError(t, err)
+	require.Equal(t, "alice", model.Username)
+	require.True(t, model.Approved)
+	require.Equal(t, "admin", model.Role)
+	require.False(t, model.Locked)
+	require.False(t, model.Discoverable)
+	require.False(t, model.AllowNSFW)
+	require.True(t, model.RequireNSFWWarning)
+	require.Equal(t, []string{"wallet"}, model.RecoveryMethods)
+	require.Equal(t, storagemodels.SKMetadata, model.SK)
+}
+
+func TestGenerateOAuthClientCredentials_ProduceURLSafeRandomValues(t *testing.T) {
+	clientID, err := generateOAuthClientID()
+	require.NoError(t, err)
+	require.NotEmpty(t, clientID)
+	decodedID, err := base64.URLEncoding.DecodeString(clientID)
+	require.NoError(t, err)
+	require.Len(t, decodedID, 16)
+
+	clientSecret, err := generateOAuthClientSecret()
+	require.NoError(t, err)
+	require.NotEmpty(t, clientSecret)
+	decodedSecret, err := base64.URLEncoding.DecodeString(clientSecret)
+	require.NoError(t, err)
+	require.Len(t, decodedSecret, 32)
+}
+
+func TestBuildWalletCredentialModel_SetsKeysAndDefaults(t *testing.T) {
+	now := time.Now().UTC()
+
+	model, err := buildWalletCredentialModel("alice", "0xabc", 1, now)
+	require.NoError(t, err)
+	require.Equal(t, "alice", model.Username)
+	require.Equal(t, "0xabc", model.Address)
+	require.Equal(t, 1, model.ChainID)
+	require.Equal(t, "ethereum", model.Type)
+	require.Equal(t, now, model.LinkedAt)
+	require.Equal(t, now, model.LastUsed)
+	require.NotEmpty(t, model.PK)
+	require.NotEmpty(t, model.SK)
+}
+
+func TestBuildOAuthClientModel_HashesSecretAndSetsDefaults(t *testing.T) {
+	now := time.Now().UTC()
+
+	model, err := buildOAuthClientModel("owner-1", "client-1", "super-secret", []string{"https://example.com/callback"}, now)
+	require.NoError(t, err)
+	require.Equal(t, "client-1", model.ClientID)
+	require.NotEqual(t, "super-secret", model.ClientSecret)
+	require.Equal(t, []string{"https://example.com/callback"}, model.RedirectURIs)
+	require.Equal(t, []string{"authorization_code", "refresh_token"}, model.GrantTypes)
+	require.Equal(t, []string{"read", "write", "admin"}, model.Scopes)
+	require.Equal(t, "owner-1", model.OwnerID)
+	require.True(t, model.Confidential)
+	require.NotEmpty(t, model.PK)
+	require.NotEmpty(t, model.SK)
 }
 
 func TestEncryptWithKMS(t *testing.T) {

--- a/cmd/webfinger/main.go
+++ b/cmd/webfinger/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/crawler"
+	"github.com/equaltoai/lesser/pkg/federation/surface"
 	"github.com/equaltoai/lesser/pkg/storage/core"
 	"github.com/equaltoai/lesser/pkg/storage/factory"
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
@@ -226,13 +227,7 @@ func (wh *WebFingerHandler) ensureBootstrapActor(ctx context.Context, username s
 		Owner:        actorID,
 		PublicKeyPem: string(publicKeyPEM),
 	}
-	actor.Endpoints = &activitypub.Endpoints{
-		SharedInbox: fmt.Sprintf("https://%s/inbox", cfg.Domain),
-	}
-	actor.Inbox = fmt.Sprintf("%s/inbox", actorID)
-	actor.Outbox = fmt.Sprintf("%s/outbox", actorID)
-	actor.Followers = fmt.Sprintf("%s/followers", actorID)
-	actor.Following = fmt.Sprintf("%s/following", actorID)
+	surface.ApplyLocalActorIdentifiers(actor, fmt.Sprintf("https://%s", cfg.Domain), username)
 
 	if err := wh.actorRepo.CreateActor(ctx, actor, string(privateKeyPEM)); err != nil {
 		if _, ok := err.(common.ConflictError); ok {

--- a/cmd/webfinger/main.go
+++ b/cmd/webfinger/main.go
@@ -16,10 +16,10 @@ import (
 
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/activitypubutil"
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/crawler"
-	"github.com/equaltoai/lesser/pkg/federation/surface"
 	"github.com/equaltoai/lesser/pkg/storage/core"
 	"github.com/equaltoai/lesser/pkg/storage/factory"
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
@@ -227,7 +227,7 @@ func (wh *WebFingerHandler) ensureBootstrapActor(ctx context.Context, username s
 		Owner:        actorID,
 		PublicKeyPem: string(publicKeyPEM),
 	}
-	surface.ApplyLocalActorIdentifiers(actor, fmt.Sprintf("https://%s", cfg.Domain), username)
+	activitypubutil.ApplyLocalActorIdentifiers(actor, fmt.Sprintf("https://%s", cfg.Domain), username)
 
 	if err := wh.actorRepo.CreateActor(ctx, actor, string(privateKeyPEM)); err != nil {
 		if _, ok := err.(common.ConflictError); ok {

--- a/cmd/webfinger/round12_webfinger_test.go
+++ b/cmd/webfinger/round12_webfinger_test.go
@@ -213,6 +213,41 @@ func TestWebFingerHandler_ensureBootstrapActor_Branches(t *testing.T) {
 	require.Error(t, handler.ensureBootstrapActor(context.Background(), "bootstrap4"))
 }
 
+func TestWebFingerHandler_EnsureBootstrapActor_CreatesManifestDrivenActor(t *testing.T) {
+	origGenerate := rsaGenerateKeyFn
+	origNow := timeNowFn
+	origCfg := cfg
+	t.Cleanup(func() {
+		rsaGenerateKeyFn = origGenerate
+		timeNowFn = origNow
+		cfg = origCfg
+	})
+
+	cfg = &config.Config{Domain: "example.com"}
+	timeNowFn = func() time.Time { return time.Unix(2, 0) }
+	rsaGenerateKeyFn = func(_ io.Reader, _ int) (*rsa.PrivateKey, error) {
+		return rsa.GenerateKey(rand.Reader, 2048)
+	}
+
+	actorRepo := testingmocks.NewMockActorRepository()
+	handler := &WebFingerHandler{
+		actorRepo: actorRepo,
+		logger:    zap.NewNop(),
+	}
+
+	var created *activitypub.Actor
+	actorRepo.On("GetActor", mock.Anything, "bootstrap").Return(nil, common.ActorNotFoundError{Username: "bootstrap"}).Once()
+	actorRepo.On("CreateActor", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		created = args.Get(1).(*activitypub.Actor)
+	}).Return(nil).Once()
+
+	require.NoError(t, handler.ensureBootstrapActor(context.Background(), "bootstrap"))
+	require.NotNil(t, created)
+	require.Equal(t, "https://example.com/inbox", created.Endpoints.SharedInbox)
+	require.Equal(t, "https://example.com/users/bootstrap/inbox", created.Inbox)
+	require.Equal(t, "https://example.com/users/bootstrap/outbox", created.Outbox)
+}
+
 func TestBuildApp_WebFingerRoute(t *testing.T) {
 	origCfg := cfg
 	origLogger := logger

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -18673,6 +18673,43 @@ paths:
             x-lesser-lambda: api
             x-lesser-routeSources:
                 - cmd/api/main.go
+    /inbox:
+        get:
+            operationId: get_inbox
+            tags:
+                - activitypub
+            responses:
+                "200":
+                    description: OK
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "405":
+                    description: Method Not Allowed
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+            x-lesser-lambda: inbox
+            x-lesser-routeSources:
+                - infra/cdk/inventory/lambdas.go:inbox
+        post:
+            operationId: post_inbox
+            tags:
+                - activitypub
+            responses:
+                "200":
+                    description: OK
+                "202":
+                    description: Accepted
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "404":
+                    $ref: '#/components/responses/NotFound'
+                "422":
+                    $ref: '#/components/responses/UnprocessableEntity'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+            x-lesser-lambda: inbox
+            x-lesser-routeSources:
+                - infra/cdk/inventory/lambdas.go:inbox
     /nodeinfo/2.0:
         get:
             operationId: get_nodeinfo_2_0
@@ -19406,35 +19443,6 @@ paths:
             x-lesser-lambda: collections
             x-lesser-routeSources:
                 - infra/cdk/inventory/lambdas.go:collections
-    /inbox:
-        get:
-            operationId: get_inbox
-            tags:
-                - activitypub
-            responses:
-                "405":
-                    description: Method Not Allowed
-            x-lesser-lambda: inbox
-            x-lesser-routeSources:
-                - infra/cdk/inventory/lambdas.go:inbox
-        post:
-            operationId: post_inbox
-            tags:
-                - activitypub
-            responses:
-                "202":
-                    description: Accepted
-                "400":
-                    $ref: '#/components/responses/BadRequest'
-                "404":
-                    $ref: '#/components/responses/NotFound'
-                "422":
-                    $ref: '#/components/responses/UnprocessableEntity'
-                "500":
-                    $ref: '#/components/responses/InternalServerError'
-            x-lesser-lambda: inbox
-            x-lesser-routeSources:
-                - infra/cdk/inventory/lambdas.go:inbox
     /users/{username}/inbox:
         get:
             operationId: get_users_by_username_inbox

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -19406,6 +19406,35 @@ paths:
             x-lesser-lambda: collections
             x-lesser-routeSources:
                 - infra/cdk/inventory/lambdas.go:collections
+    /inbox:
+        get:
+            operationId: get_inbox
+            tags:
+                - activitypub
+            responses:
+                "405":
+                    description: Method Not Allowed
+            x-lesser-lambda: inbox
+            x-lesser-routeSources:
+                - infra/cdk/inventory/lambdas.go:inbox
+        post:
+            operationId: post_inbox
+            tags:
+                - activitypub
+            responses:
+                "202":
+                    description: Accepted
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "404":
+                    $ref: '#/components/responses/NotFound'
+                "422":
+                    $ref: '#/components/responses/UnprocessableEntity'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+            x-lesser-lambda: inbox
+            x-lesser-routeSources:
+                - infra/cdk/inventory/lambdas.go:inbox
     /users/{username}/inbox:
         get:
             operationId: get_users_by_username_inbox

--- a/docs/development/shared-inbox-validation.md
+++ b/docs/development/shared-inbox-validation.md
@@ -1,0 +1,33 @@
+# Shared inbox validation
+
+Use this after deploying a build that advertises shared inbox support.
+
+## Dev proof sequence
+
+1. **Public Create**
+   - Sender delivers to `POST /inbox`
+   - Receiver materializes the remote note
+2. **Followers-only/private Create**
+   - Sender delivers to `POST /inbox`
+   - Receiver accepts the activity once and materializes the note
+3. **Control activity**
+   - Exercise either `Follow` or `Accept` through `POST /inbox`
+   - Confirm the relationship state changes as expected
+4. **Actor inbox regression**
+   - Replay a known-good request to `/users/{username}/inbox`
+   - Confirm the existing actor-scoped flow still succeeds
+
+## Endpoint truth checks
+
+```bash
+curl -i -X GET "https://dev.<domain>/inbox"
+curl -i -X POST "https://dev.<domain>/inbox" \
+  -H 'Content-Type: application/activity+json' \
+  --data @activity.json
+```
+
+Expected:
+
+- `GET /inbox` returns `405`
+- `POST /inbox` returns `202` for accepted ActivityPub deliveries
+- actor metadata advertises the same shared inbox URL that the route serves

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -23,6 +23,19 @@ curl -s -H "Accept: application/activity+json" "https://example.com/users/alice"
 curl -s -H "Accept: application/activity+json" "https://example.com/objects/<id>" | jq .
 ```
 
+### Inbox surface truth
+
+```bash
+curl -i -X GET "https://example.com/inbox"
+curl -i -X OPTIONS "https://example.com/inbox"
+```
+
+Expected after the shared inbox repair:
+
+- `GET /inbox` returns `405 Method Not Allowed`
+- `POST /inbox` is the real shared-inbox federation ingress
+- `/users/{username}/inbox` continues to serve actor-scoped inbox flows
+
 ## Locked deployments (expected behavior)
 
 New deployments come up **locked but reachable**.
@@ -42,6 +55,7 @@ curl -s "https://example.com/setup/status" | jq .
 ## Where federation lives in this repo
 
 - Protocol HTTP Lambdas: `cmd/actor`, `cmd/inbox`, `cmd/outbox`, `cmd/objects`, `cmd/collections`, `cmd/webfinger`
+- Labs validation checklist: `docs/development/shared-inbox-validation.md`
 - Core logic: `pkg/activitypub/`, `pkg/services/federation/`
 
 ## Troubleshooting

--- a/docs/specs/01-lambda-inventory-matrix.md
+++ b/docs/specs/01-lambda-inventory-matrix.md
@@ -55,7 +55,7 @@ The inventory set is enforced by:
 | graphql | api-http | HTTP: GET /api/graphql<br>HTTP: POST /api/graphql | — | encryption | memory=512MB; timeout=30s; logs=7d |
 | graphql-ws | api-ws | — | — | encryption | memory=512MB; timeout=30s; logs=7d |
 | import-processor | processor-sqs | SQS: queue=import-processor-queue; partialFailure=true | — | basic | memory=512MB; timeout=30s; logs=7d |
-| inbox | api-http | HTTP: GET /inbox<br>HTTP: POST /inbox<br>HTTP: GET /users/{username}/inbox<br>HTTP: POST /users/{username}/inbox | — | encryption | memory=512MB; timeout=30s; logs=7d |
+| inbox | api-http | HTTP: POST /inbox<br>HTTP: GET /inbox<br>HTTP: GET /users/{username}/inbox<br>HTTP: POST /users/{username}/inbox | — | encryption | memory=512MB; timeout=30s; logs=7d |
 | media-processor | processor-sqs | SQS: queue=media-processor-queue; partialFailure=true | — | basic | memory=512MB; timeout=30s; logs=7d |
 | metrics-aggregator | processor-stream | Stream: table=main-table; start=LATEST; batch=25; window=5s; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
 | metrics-processor | processor-stream | Stream: table=main-table; start=LATEST; batch=25; window=5s; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |

--- a/docs/specs/01-lambda-inventory-matrix.md
+++ b/docs/specs/01-lambda-inventory-matrix.md
@@ -55,7 +55,7 @@ The inventory set is enforced by:
 | graphql | api-http | HTTP: GET /api/graphql<br>HTTP: POST /api/graphql | — | encryption | memory=512MB; timeout=30s; logs=7d |
 | graphql-ws | api-ws | — | — | encryption | memory=512MB; timeout=30s; logs=7d |
 | import-processor | processor-sqs | SQS: queue=import-processor-queue; partialFailure=true | — | basic | memory=512MB; timeout=30s; logs=7d |
-| inbox | api-http | HTTP: GET /users/{username}/inbox<br>HTTP: POST /users/{username}/inbox | — | encryption | memory=512MB; timeout=30s; logs=7d |
+| inbox | api-http | HTTP: GET /inbox<br>HTTP: POST /inbox<br>HTTP: GET /users/{username}/inbox<br>HTTP: POST /users/{username}/inbox | — | encryption | memory=512MB; timeout=30s; logs=7d |
 | media-processor | processor-sqs | SQS: queue=media-processor-queue; partialFailure=true | — | basic | memory=512MB; timeout=30s; logs=7d |
 | metrics-aggregator | processor-stream | Stream: table=main-table; start=LATEST; batch=25; window=5s; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
 | metrics-processor | processor-stream | Stream: table=main-table; start=LATEST; batch=25; window=5s; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |

--- a/go.mod
+++ b/go.mod
@@ -55,10 +55,10 @@ require (
 	github.com/vektah/gqlparser/v2 v2.5.32
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.49.0
-	golang.org/x/image v0.38.0
+	golang.org/x/image v0.39.0
 	golang.org/x/net v0.52.0
 	golang.org/x/sync v0.20.0
-	golang.org/x/text v0.35.0
+	golang.org/x/text v0.36.0
 	golang.org/x/tools v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -305,8 +305,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
 golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
 golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
-golang.org/x/image v0.38.0 h1:5l+q+Y9JDC7mBOMjo4/aPhMDcxEptsX+Tt3GgRQRPuE=
-golang.org/x/image v0.38.0/go.mod h1:/3f6vaXC+6CEanU4KJxbcUZyEePbyKbaLoDOe4ehFYY=
+golang.org/x/image v0.39.0 h1:skVYidAEVKgn8lZ602XO75asgXBgLj9G/FE3RbuPFww=
+golang.org/x/image v0.39.0/go.mod h1:sIbmppfU+xFLPIG0FoVUTvyBMmgng1/XAMhQ2ft0hpA=
 golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=
 golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -320,8 +320,8 @@ golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
-golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
+golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
+golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
 golang.org/x/tools v0.43.0 h1:12BdW9CeB3Z+J/I/wj34VMl8X+fEXBxVR90JeMX5E7s=
 golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0=
 gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=

--- a/infra/cdk/cmd/generate-inventory/main.go
+++ b/infra/cdk/cmd/generate-inventory/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -28,10 +29,25 @@ type row struct {
 	operations  string
 }
 
+type httpRouteOutput struct {
+	Lambda string `json:"lambda"`
+	Method string `json:"method"`
+	Path   string `json:"path"`
+}
+
 func main() {
 	outPath := flag.String("out", targetRelPath, "target path for generated inventory doc")
 	checkOnly := flag.Bool("check", false, "fail if the generated content would differ without writing")
+	printHTTPRoutes := flag.Bool("print-http-routes", false, "print inventory HTTP routes as JSON and exit")
 	flag.Parse()
+
+	if *printHTTPRoutes {
+		if err := emitHTTPRoutes(os.Stdout, inventory.LambdaInventory); err != nil {
+			fmt.Fprintf(os.Stderr, "generate-inventory: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
 
 	targetPath := filepath.Clean(*outPath)
 	if err := writeInventoryTable(targetPath, *checkOnly); err != nil {
@@ -67,6 +83,27 @@ func writeInventoryTable(targetPath string, checkOnly bool) error {
 		return fmt.Errorf("write target file %s: %w", targetPath, err)
 	}
 	return nil
+}
+
+func emitHTTPRoutes(out *os.File, inv inventory.Inventory) error {
+	routes := collectHTTPRoutes(inv)
+	encoder := json.NewEncoder(out)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(routes)
+}
+
+func collectHTTPRoutes(inv inventory.Inventory) []httpRouteOutput {
+	routes := make([]httpRouteOutput, 0)
+	for _, spec := range inv.Lambdas {
+		for _, route := range spec.HTTPRoutes {
+			routes = append(routes, httpRouteOutput{
+				Lambda: spec.Name,
+				Method: route.Method,
+				Path:   route.Path,
+			})
+		}
+	}
+	return routes
 }
 
 func splice(existing, replacement string) (string, error) {

--- a/infra/cdk/inventory/lambdas.go
+++ b/infra/cdk/inventory/lambdas.go
@@ -2,6 +2,19 @@ package inventory
 
 import "github.com/equaltoai/lesser/pkg/federation/surface"
 
+func inboxHTTPRoutes() []HTTPRoute {
+	sharedInbox := surface.SharedInbox()
+	routes := make([]HTTPRoute, 0, len(sharedInbox.ServedMethods())+2)
+	for _, method := range sharedInbox.ServedMethods() {
+		routes = append(routes, HTTPRoute{Method: method, Path: sharedInbox.Path})
+	}
+	routes = append(routes,
+		HTTPRoute{Method: "GET", Path: "/users/{username}/inbox"},
+		HTTPRoute{Method: "POST", Path: "/users/{username}/inbox"},
+	)
+	return routes
+}
+
 // LambdaInventory is the canonical machine-readable source for all product Lambdas.
 // It must stay in lockstep with Makefile LAMBDAS and Spec 01.
 var LambdaInventory = Inventory{
@@ -216,15 +229,10 @@ var LambdaInventory = Inventory{
 			},
 		},
 		{
-			Name: "inbox",
-			Type: LambdaTypeAPIHTTP,
-			Role: RoleClassEncryption,
-			HTTPRoutes: []HTTPRoute{
-				{Method: "GET", Path: surface.SharedInbox().Path},
-				{Method: "POST", Path: surface.SharedInbox().Path},
-				{Method: "GET", Path: "/users/{username}/inbox"},
-				{Method: "POST", Path: "/users/{username}/inbox"},
-			},
+			Name:       "inbox",
+			Type:       LambdaTypeAPIHTTP,
+			Role:       RoleClassEncryption,
+			HTTPRoutes: inboxHTTPRoutes(),
 		},
 		{
 			Name: "media-processor",

--- a/infra/cdk/inventory/lambdas.go
+++ b/infra/cdk/inventory/lambdas.go
@@ -1,5 +1,7 @@
 package inventory
 
+import "github.com/equaltoai/lesser/pkg/federation/surface"
+
 // LambdaInventory is the canonical machine-readable source for all product Lambdas.
 // It must stay in lockstep with Makefile LAMBDAS and Spec 01.
 var LambdaInventory = Inventory{
@@ -218,6 +220,8 @@ var LambdaInventory = Inventory{
 			Type: LambdaTypeAPIHTTP,
 			Role: RoleClassEncryption,
 			HTTPRoutes: []HTTPRoute{
+				{Method: "GET", Path: surface.SharedInbox().Path},
+				{Method: "POST", Path: surface.SharedInbox().Path},
 				{Method: "GET", Path: "/users/{username}/inbox"},
 				{Method: "POST", Path: "/users/{username}/inbox"},
 			},

--- a/pkg/activitypubutil/actor_helpers.go
+++ b/pkg/activitypubutil/actor_helpers.go
@@ -2,6 +2,7 @@
 package activitypubutil
 
 import (
+	"fmt"
 	"net/url"
 	"strings"
 	"time"
@@ -412,8 +413,42 @@ func normalizeOperatedBy(value string) string {
 	return "@" + trimmed
 }
 
+// ApplyLocalActorIdentifiers sets canonical local ActivityPub identifiers
+// derived from the federation surface manifest.
+func ApplyLocalActorIdentifiers(actor *activitypub.Actor, base, username string) {
+	if actor == nil {
+		return
+	}
+
+	normalizedBase := strings.TrimSuffix(strings.TrimSpace(base), "/")
+	canonicalUsername := strings.TrimSpace(username)
+	if normalizedBase == "" || canonicalUsername == "" {
+		return
+	}
+
+	actor.ID = fmt.Sprintf("%s/users/%s", normalizedBase, canonicalUsername)
+	actor.URL = fmt.Sprintf("%s/@%s", normalizedBase, canonicalUsername)
+	actor.Inbox = fmt.Sprintf("%s/users/%s/inbox", normalizedBase, canonicalUsername)
+	actor.Outbox = fmt.Sprintf("%s/users/%s/outbox", normalizedBase, canonicalUsername)
+	actor.Followers = fmt.Sprintf("%s/users/%s/followers", normalizedBase, canonicalUsername)
+	actor.Following = fmt.Sprintf("%s/users/%s/following", normalizedBase, canonicalUsername)
+	actor.Liked = fmt.Sprintf("%s/users/%s/liked", normalizedBase, canonicalUsername)
+
+	if actor.Endpoints == nil {
+		actor.Endpoints = &activitypub.Endpoints{}
+	}
+	actor.Endpoints.SharedInbox = surface.SharedInboxURL(normalizedBase)
+
+	actor.PreferredUsername = canonicalUsername
+
+	if actor.PublicKey != nil {
+		actor.PublicKey.Owner = actor.ID
+		actor.PublicKey.ID = actor.ID + "#main-key"
+	}
+}
+
 func applyActorIdentifiers(actor *activitypub.Actor, base, username string) {
-	surface.ApplyLocalActorIdentifiers(actor, base, username)
+	ApplyLocalActorIdentifiers(actor, base, username)
 }
 
 func mergeUserProfile(actor *activitypub.Actor, user *storage.User, username string) {

--- a/pkg/activitypubutil/actor_helpers.go
+++ b/pkg/activitypubutil/actor_helpers.go
@@ -2,12 +2,12 @@
 package activitypubutil
 
 import (
-	"fmt"
 	"net/url"
 	"strings"
 	"time"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/federation/surface"
 	"github.com/equaltoai/lesser/pkg/storage"
 )
 
@@ -413,29 +413,7 @@ func normalizeOperatedBy(value string) string {
 }
 
 func applyActorIdentifiers(actor *activitypub.Actor, base, username string) {
-	if base == "" || username == "" {
-		return
-	}
-
-	actor.ID = fmt.Sprintf("%s/users/%s", base, username)
-	actor.URL = fmt.Sprintf("%s/@%s", base, username)
-	actor.Inbox = fmt.Sprintf("%s/users/%s/inbox", base, username)
-	actor.Outbox = fmt.Sprintf("%s/users/%s/outbox", base, username)
-	actor.Followers = fmt.Sprintf("%s/users/%s/followers", base, username)
-	actor.Following = fmt.Sprintf("%s/users/%s/following", base, username)
-	actor.Liked = fmt.Sprintf("%s/users/%s/liked", base, username)
-
-	if actor.Endpoints == nil {
-		actor.Endpoints = &activitypub.Endpoints{}
-	}
-	actor.Endpoints.SharedInbox = fmt.Sprintf("%s/inbox", base)
-
-	actor.PreferredUsername = username
-
-	if actor.PublicKey != nil {
-		actor.PublicKey.Owner = actor.ID
-		actor.PublicKey.ID = actor.ID + "#main-key"
-	}
+	surface.ApplyLocalActorIdentifiers(actor, base, username)
 }
 
 func mergeUserProfile(actor *activitypub.Actor, user *storage.User, username string) {

--- a/pkg/activitypubutil/actor_helpers_test.go
+++ b/pkg/activitypubutil/actor_helpers_test.go
@@ -141,6 +141,25 @@ func TestBuildLocalActorPreservesExistingFields(t *testing.T) {
 	require.Equal(t, pub.UTC(), actor.Published.UTC())
 }
 
+func TestApplyLocalActorIdentifiers_UsesManifestSharedInbox(t *testing.T) {
+	t.Parallel()
+
+	actor := &activitypub.Actor{PublicKey: &activitypub.PublicKey{PublicKeyPem: "pem"}}
+	ApplyLocalActorIdentifiers(actor, "https://example.com/", "alice")
+
+	require.Equal(t, "https://example.com/users/alice", actor.ID)
+	require.Equal(t, "https://example.com/@alice", actor.URL)
+	require.Equal(t, "https://example.com/users/alice/inbox", actor.Inbox)
+	require.Equal(t, "https://example.com/users/alice/outbox", actor.Outbox)
+	require.Equal(t, "https://example.com/users/alice/followers", actor.Followers)
+	require.Equal(t, "https://example.com/users/alice/following", actor.Following)
+	require.Equal(t, "https://example.com/users/alice/liked", actor.Liked)
+	require.NotNil(t, actor.Endpoints)
+	require.Equal(t, "https://example.com/inbox", actor.Endpoints.SharedInbox)
+	require.Equal(t, "https://example.com/users/alice", actor.PublicKey.Owner)
+	require.Equal(t, "https://example.com/users/alice#main-key", actor.PublicKey.ID)
+}
+
 func TestMergeActorMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/federation/surface/manifest.go
+++ b/pkg/federation/surface/manifest.go
@@ -2,11 +2,8 @@
 package surface
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
-
-	"github.com/equaltoai/lesser/pkg/activitypub"
 )
 
 // MethodPolicy describes how a served federation endpoint handles an HTTP method.
@@ -108,37 +105,4 @@ func SharedInboxURL(baseURL string) string {
 		return ""
 	}
 	return base + endpoint.Path
-}
-
-// ApplyLocalActorIdentifiers sets canonical local identifiers derived from the manifest.
-func ApplyLocalActorIdentifiers(actor *activitypub.Actor, baseURL, username string) {
-	if actor == nil {
-		return
-	}
-
-	base := strings.TrimSuffix(strings.TrimSpace(baseURL), "/")
-	canonicalUsername := strings.TrimSpace(username)
-	if base == "" || canonicalUsername == "" {
-		return
-	}
-
-	actor.ID = fmt.Sprintf("%s/users/%s", base, canonicalUsername)
-	actor.URL = fmt.Sprintf("%s/@%s", base, canonicalUsername)
-	actor.Inbox = fmt.Sprintf("%s/users/%s/inbox", base, canonicalUsername)
-	actor.Outbox = fmt.Sprintf("%s/users/%s/outbox", base, canonicalUsername)
-	actor.Followers = fmt.Sprintf("%s/users/%s/followers", base, canonicalUsername)
-	actor.Following = fmt.Sprintf("%s/users/%s/following", base, canonicalUsername)
-	actor.Liked = fmt.Sprintf("%s/users/%s/liked", base, canonicalUsername)
-
-	if actor.Endpoints == nil {
-		actor.Endpoints = &activitypub.Endpoints{}
-	}
-	actor.Endpoints.SharedInbox = SharedInboxURL(base)
-
-	actor.PreferredUsername = canonicalUsername
-
-	if actor.PublicKey != nil {
-		actor.PublicKey.Owner = actor.ID
-		actor.PublicKey.ID = actor.ID + "#main-key"
-	}
 }

--- a/pkg/federation/surface/manifest.go
+++ b/pkg/federation/surface/manifest.go
@@ -48,6 +48,23 @@ func SharedInbox() EndpointManifest {
 	return Current().SharedInbox
 }
 
+// ServedMethods returns the ordered list of explicitly served methods for the endpoint.
+func (e EndpointManifest) ServedMethods() []string {
+	methods := make([]string, 0, len(e.Policies))
+	seen := make(map[string]struct{}, len(e.Policies))
+	for _, policy := range e.Policies {
+		if !policy.Served {
+			continue
+		}
+		if _, ok := seen[policy.Method]; ok {
+			continue
+		}
+		seen[policy.Method] = struct{}{}
+		methods = append(methods, policy.Method)
+	}
+	return methods
+}
+
 // ServesMethod reports whether the endpoint is explicitly served for the given method.
 func (e EndpointManifest) ServesMethod(method string) bool {
 	_, ok := e.policy(method)

--- a/pkg/federation/surface/manifest.go
+++ b/pkg/federation/surface/manifest.go
@@ -1,3 +1,4 @@
+// Package surface defines the deploy-time ActivityPub federation surface contract.
 package surface
 
 import (

--- a/pkg/federation/surface/manifest.go
+++ b/pkg/federation/surface/manifest.go
@@ -1,0 +1,126 @@
+package surface
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+)
+
+// MethodPolicy describes how a served federation endpoint handles an HTTP method.
+type MethodPolicy struct {
+	Method     string
+	Served     bool
+	StatusCode int
+}
+
+// EndpointManifest describes the deploy-time contract for one federation endpoint.
+type EndpointManifest struct {
+	Path       string
+	Advertised bool
+	Policies   []MethodPolicy
+}
+
+// FederationManifest is the source of truth for deploy-time federation surface support.
+type FederationManifest struct {
+	SharedInbox EndpointManifest
+}
+
+var manifest = FederationManifest{
+	SharedInbox: EndpointManifest{
+		Path:       "/inbox",
+		Advertised: true,
+		Policies: []MethodPolicy{
+			{Method: http.MethodPost, Served: true},
+			{Method: http.MethodGet, Served: true, StatusCode: http.StatusMethodNotAllowed},
+		},
+	},
+}
+
+// Current returns the active deploy-time federation surface manifest.
+func Current() FederationManifest {
+	return manifest
+}
+
+// SharedInbox returns the shared inbox endpoint contract.
+func SharedInbox() EndpointManifest {
+	return Current().SharedInbox
+}
+
+// ServesMethod reports whether the endpoint is explicitly served for the given method.
+func (e EndpointManifest) ServesMethod(method string) bool {
+	_, ok := e.policy(method)
+	return ok
+}
+
+// AllowsMethod reports whether the method is served as an allowed success path.
+func (e EndpointManifest) AllowsMethod(method string) bool {
+	policy, ok := e.policy(method)
+	return ok && policy.StatusCode == 0
+}
+
+// MethodStatus returns the explicit served status for a method when one is defined.
+func (e EndpointManifest) MethodStatus(method string) (int, bool) {
+	policy, ok := e.policy(method)
+	if !ok || policy.StatusCode == 0 {
+		return 0, false
+	}
+	return policy.StatusCode, true
+}
+
+func (e EndpointManifest) policy(method string) (MethodPolicy, bool) {
+	normalized := strings.ToUpper(strings.TrimSpace(method))
+	for _, policy := range e.Policies {
+		if policy.Served && policy.Method == normalized {
+			return policy, true
+		}
+	}
+	return MethodPolicy{}, false
+}
+
+// SharedInboxURL returns the canonical shared inbox URL when the surface advertises it.
+func SharedInboxURL(baseURL string) string {
+	endpoint := SharedInbox()
+	if !endpoint.Advertised {
+		return ""
+	}
+	base := strings.TrimSuffix(strings.TrimSpace(baseURL), "/")
+	if base == "" {
+		return ""
+	}
+	return base + endpoint.Path
+}
+
+// ApplyLocalActorIdentifiers sets canonical local identifiers derived from the manifest.
+func ApplyLocalActorIdentifiers(actor *activitypub.Actor, baseURL, username string) {
+	if actor == nil {
+		return
+	}
+
+	base := strings.TrimSuffix(strings.TrimSpace(baseURL), "/")
+	canonicalUsername := strings.TrimSpace(username)
+	if base == "" || canonicalUsername == "" {
+		return
+	}
+
+	actor.ID = fmt.Sprintf("%s/users/%s", base, canonicalUsername)
+	actor.URL = fmt.Sprintf("%s/@%s", base, canonicalUsername)
+	actor.Inbox = fmt.Sprintf("%s/users/%s/inbox", base, canonicalUsername)
+	actor.Outbox = fmt.Sprintf("%s/users/%s/outbox", base, canonicalUsername)
+	actor.Followers = fmt.Sprintf("%s/users/%s/followers", base, canonicalUsername)
+	actor.Following = fmt.Sprintf("%s/users/%s/following", base, canonicalUsername)
+	actor.Liked = fmt.Sprintf("%s/users/%s/liked", base, canonicalUsername)
+
+	if actor.Endpoints == nil {
+		actor.Endpoints = &activitypub.Endpoints{}
+	}
+	actor.Endpoints.SharedInbox = SharedInboxURL(base)
+
+	actor.PreferredUsername = canonicalUsername
+
+	if actor.PublicKey != nil {
+		actor.PublicKey.Owner = actor.ID
+		actor.PublicKey.ID = actor.ID + "#main-key"
+	}
+}

--- a/pkg/federation/surface/manifest_test.go
+++ b/pkg/federation/surface/manifest_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,23 +22,4 @@ func TestSharedInboxManifest_DefaultContract(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, http.StatusMethodNotAllowed, status)
 	require.Equal(t, "https://example.com/inbox", SharedInboxURL("https://example.com/"))
-}
-
-func TestApplyLocalActorIdentifiers_UsesManifestSharedInbox(t *testing.T) {
-	t.Parallel()
-
-	actor := &activitypub.Actor{PublicKey: &activitypub.PublicKey{PublicKeyPem: "pem"}}
-	ApplyLocalActorIdentifiers(actor, "https://example.com/", "alice")
-
-	require.Equal(t, "https://example.com/users/alice", actor.ID)
-	require.Equal(t, "https://example.com/@alice", actor.URL)
-	require.Equal(t, "https://example.com/users/alice/inbox", actor.Inbox)
-	require.Equal(t, "https://example.com/users/alice/outbox", actor.Outbox)
-	require.Equal(t, "https://example.com/users/alice/followers", actor.Followers)
-	require.Equal(t, "https://example.com/users/alice/following", actor.Following)
-	require.Equal(t, "https://example.com/users/alice/liked", actor.Liked)
-	require.NotNil(t, actor.Endpoints)
-	require.Equal(t, "https://example.com/inbox", actor.Endpoints.SharedInbox)
-	require.Equal(t, "https://example.com/users/alice", actor.PublicKey.Owner)
-	require.Equal(t, "https://example.com/users/alice#main-key", actor.PublicKey.ID)
 }

--- a/pkg/federation/surface/manifest_test.go
+++ b/pkg/federation/surface/manifest_test.go
@@ -1,0 +1,44 @@
+package surface
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSharedInboxManifest_DefaultContract(t *testing.T) {
+	t.Parallel()
+
+	manifest := Current()
+	require.Equal(t, "/inbox", manifest.SharedInbox.Path)
+	require.True(t, manifest.SharedInbox.Advertised)
+	require.True(t, manifest.SharedInbox.ServesMethod(http.MethodPost))
+	require.True(t, manifest.SharedInbox.AllowsMethod(http.MethodPost))
+	require.True(t, manifest.SharedInbox.ServesMethod(http.MethodGet))
+	require.False(t, manifest.SharedInbox.AllowsMethod(http.MethodGet))
+	status, ok := manifest.SharedInbox.MethodStatus(http.MethodGet)
+	require.True(t, ok)
+	require.Equal(t, http.StatusMethodNotAllowed, status)
+	require.Equal(t, "https://example.com/inbox", SharedInboxURL("https://example.com/"))
+}
+
+func TestApplyLocalActorIdentifiers_UsesManifestSharedInbox(t *testing.T) {
+	t.Parallel()
+
+	actor := &activitypub.Actor{PublicKey: &activitypub.PublicKey{PublicKeyPem: "pem"}}
+	ApplyLocalActorIdentifiers(actor, "https://example.com/", "alice")
+
+	require.Equal(t, "https://example.com/users/alice", actor.ID)
+	require.Equal(t, "https://example.com/@alice", actor.URL)
+	require.Equal(t, "https://example.com/users/alice/inbox", actor.Inbox)
+	require.Equal(t, "https://example.com/users/alice/outbox", actor.Outbox)
+	require.Equal(t, "https://example.com/users/alice/followers", actor.Followers)
+	require.Equal(t, "https://example.com/users/alice/following", actor.Following)
+	require.Equal(t, "https://example.com/users/alice/liked", actor.Liked)
+	require.NotNil(t, actor.Endpoints)
+	require.Equal(t, "https://example.com/inbox", actor.Endpoints.SharedInbox)
+	require.Equal(t, "https://example.com/users/alice", actor.PublicKey.Owner)
+	require.Equal(t, "https://example.com/users/alice#main-key", actor.PublicKey.ID)
+}

--- a/pkg/federation/surface/manifest_test.go
+++ b/pkg/federation/surface/manifest_test.go
@@ -14,6 +14,7 @@ func TestSharedInboxManifest_DefaultContract(t *testing.T) {
 	manifest := Current()
 	require.Equal(t, "/inbox", manifest.SharedInbox.Path)
 	require.True(t, manifest.SharedInbox.Advertised)
+	require.Equal(t, []string{http.MethodPost, http.MethodGet}, manifest.SharedInbox.ServedMethods())
 	require.True(t, manifest.SharedInbox.ServesMethod(http.MethodPost))
 	require.True(t, manifest.SharedInbox.AllowsMethod(http.MethodPost))
 	require.True(t, manifest.SharedInbox.ServesMethod(http.MethodGet))

--- a/pkg/services/accounts/service.go
+++ b/pkg/services/accounts/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/activitypubutil"
 	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/federation/surface"
 	"github.com/equaltoai/lesser/pkg/security/htmlsafe"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/core"
@@ -1871,14 +1872,8 @@ func (s *Service) RegisterAccount(ctx context.Context, cmd *RegisterAccountComma
 		PublicKeyPem: string(publicKeyPEM),
 	}
 
-	// Set default endpoints
-	actor.Endpoints = &activitypub.Endpoints{
-		SharedInbox: fmt.Sprintf("https://%s/inbox", s.domainName),
-	}
-	actor.Inbox = fmt.Sprintf("%s/inbox", actorID)
-	actor.Outbox = fmt.Sprintf("%s/outbox", actorID)
-	actor.Followers = fmt.Sprintf("%s/followers", actorID)
-	actor.Following = fmt.Sprintf("%s/following", actorID)
+	// Set manifest-driven local actor identifiers.
+	surface.ApplyLocalActorIdentifiers(actor, fmt.Sprintf("https://%s", s.domainName), cmd.Username)
 
 	// Create account with actor
 	account := &storage.Account{

--- a/pkg/services/accounts/service.go
+++ b/pkg/services/accounts/service.go
@@ -15,7 +15,6 @@ import (
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/activitypubutil"
 	"github.com/equaltoai/lesser/pkg/common"
-	"github.com/equaltoai/lesser/pkg/federation/surface"
 	"github.com/equaltoai/lesser/pkg/security/htmlsafe"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/core"
@@ -1873,7 +1872,7 @@ func (s *Service) RegisterAccount(ctx context.Context, cmd *RegisterAccountComma
 	}
 
 	// Set manifest-driven local actor identifiers.
-	surface.ApplyLocalActorIdentifiers(actor, fmt.Sprintf("https://%s", s.domainName), cmd.Username)
+	activitypubutil.ApplyLocalActorIdentifiers(actor, fmt.Sprintf("https://%s", s.domainName), cmd.Username)
 
 	// Create account with actor
 	account := &storage.Account{

--- a/pkg/storage/repositories/actor_repository.go
+++ b/pkg/storage/repositories/actor_repository.go
@@ -14,6 +14,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	lesserconfig "github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/cost"
+	"github.com/equaltoai/lesser/pkg/federation/surface"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
 	"github.com/equaltoai/lesser/pkg/storage/models"
@@ -381,6 +382,10 @@ func canonicalLocalActorRepairNeeded(actor *activitypub.Actor) bool {
 		strings.TrimSpace(actor.Following) == "" ||
 		strings.TrimSpace(actor.Liked) == "" {
 		return true
+	}
+
+	if !surface.SharedInbox().Advertised {
+		return false
 	}
 
 	return actor.Endpoints == nil || strings.TrimSpace(actor.Endpoints.SharedInbox) == ""

--- a/pkg/storage/repositories/numeric_id_mapping_helpers.go
+++ b/pkg/storage/repositories/numeric_id_mapping_helpers.go
@@ -6,7 +6,6 @@ import (
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/activitypubutil"
 	"github.com/equaltoai/lesser/pkg/common"
-	"github.com/equaltoai/lesser/pkg/federation/surface"
 )
 
 func canonicalNumericMappingUsername(username string) string {
@@ -81,7 +80,7 @@ func normalizeLocalActorIdentityForStorage(username, baseURL string, actor *acti
 		return normalized
 	}
 
-	surface.ApplyLocalActorIdentifiers(normalized, normalizedBaseURL, canonical)
+	activitypubutil.ApplyLocalActorIdentifiers(normalized, normalizedBaseURL, canonical)
 
 	return normalized
 }

--- a/pkg/storage/repositories/numeric_id_mapping_helpers.go
+++ b/pkg/storage/repositories/numeric_id_mapping_helpers.go
@@ -1,12 +1,12 @@
 package repositories
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/activitypubutil"
 	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/federation/surface"
 )
 
 func canonicalNumericMappingUsername(username string) string {
@@ -81,17 +81,7 @@ func normalizeLocalActorIdentityForStorage(username, baseURL string, actor *acti
 		return normalized
 	}
 
-	normalized.ID = fmt.Sprintf("%s/users/%s", normalizedBaseURL, canonical)
-	normalized.URL = fmt.Sprintf("%s/@%s", normalizedBaseURL, canonical)
-	normalized.Inbox = fmt.Sprintf("%s/users/%s/inbox", normalizedBaseURL, canonical)
-	normalized.Outbox = fmt.Sprintf("%s/users/%s/outbox", normalizedBaseURL, canonical)
-	normalized.Followers = fmt.Sprintf("%s/users/%s/followers", normalizedBaseURL, canonical)
-	normalized.Following = fmt.Sprintf("%s/users/%s/following", normalizedBaseURL, canonical)
-	normalized.Liked = fmt.Sprintf("%s/users/%s/liked", normalizedBaseURL, canonical)
-	if normalized.Endpoints == nil {
-		normalized.Endpoints = &activitypub.Endpoints{}
-	}
-	normalized.Endpoints.SharedInbox = fmt.Sprintf("%s/inbox", normalizedBaseURL)
+	surface.ApplyLocalActorIdentifiers(normalized, normalizedBaseURL, canonical)
 
 	return normalized
 }

--- a/tools/openapi/main.go
+++ b/tools/openapi/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -1394,72 +1396,39 @@ func ensureResponseRef(responses map[string]response, statusCode string, compone
 }
 
 func extractInventoryHTTPRoutes(repoRoot string) ([]routeDef, error) {
-	path := filepath.Join(repoRoot, "infra", "cdk", "inventory", "lambdas.go")
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, path, nil, 0)
+	cdkDir := filepath.Join(repoRoot, "infra", "cdk")
+	cmd := exec.Command("go", "run", "./cmd/generate-inventory", "-print-http-routes")
+	cmd.Dir = cdkDir
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("parse %s: %w", path, err)
+		return nil, fmt.Errorf("extract inventory routes: %w: %s", err, strings.TrimSpace(string(output)))
 	}
 
-	inventoryLit, err := findInventoryComposite(file)
-	if err != nil {
-		return nil, fmt.Errorf("extract inventory routes: %w", err)
+	var inventoryRoutes []struct {
+		Lambda string `json:"lambda"`
+		Method string `json:"method"`
+		Path   string `json:"path"`
 	}
-
-	lambdasLit, err := findCompositeField(inventoryLit, "Lambdas")
-	if err != nil {
-		return nil, fmt.Errorf("extract inventory routes: %w", err)
+	if err := json.Unmarshal(output, &inventoryRoutes); err != nil {
+		return nil, fmt.Errorf("extract inventory routes: decode generator output: %w", err)
 	}
 
 	var routes []routeDef
-	for _, elt := range lambdasLit.Elts {
-		lambdaLit, ok := elt.(*ast.CompositeLit)
-		if !ok {
+	for _, route := range inventoryRoutes {
+		method := strings.ToUpper(strings.TrimSpace(route.Method))
+		routePath := normalizePath(route.Path)
+		if method == "ANY" {
+			continue
+		}
+		if strings.Contains(routePath, "{proxy+}") {
 			continue
 		}
 
-		name, ok := findStringField(lambdaLit, "Name")
-		if !ok {
-			return nil, fmt.Errorf("extract inventory routes: lambda spec missing Name in %s", path)
-		}
-
-		httpRoutesLit, err := findCompositeFieldOptional(lambdaLit, "HTTPRoutes")
-		if err != nil {
-			return nil, fmt.Errorf("extract inventory routes: %w", err)
-		}
-		if httpRoutesLit == nil {
-			continue
-		}
-
-		for _, routeElt := range httpRoutesLit.Elts {
-			routeLit, ok := routeElt.(*ast.CompositeLit)
-			if !ok {
-				continue
-			}
-			method, ok := findStringField(routeLit, "Method")
-			if !ok {
-				return nil, fmt.Errorf("extract inventory routes: HTTPRoute missing Method for lambda %q", name)
-			}
-			routePath, ok := findStringField(routeLit, "Path")
-			if !ok {
-				return nil, fmt.Errorf("extract inventory routes: HTTPRoute missing Path for lambda %q", name)
-			}
-
-			method = strings.ToUpper(strings.TrimSpace(method))
-			routePath = normalizePath(routePath)
-			if method == "ANY" {
-				continue
-			}
-			if strings.Contains(routePath, "{proxy+}") {
-				continue
-			}
-
-			routes = append(routes, routeDef{
-				Method: method,
-				Path:   routePath,
-				Lambda: name,
-			})
-		}
+		routes = append(routes, routeDef{
+			Method: method,
+			Path:   routePath,
+			Lambda: route.Lambda,
+		})
 	}
 
 	sortRoutes(routes)
@@ -2117,111 +2086,4 @@ func applyAuthOverrides(method, path, handler, lambda string, current authMode) 
 	_ = method
 	_ = handler
 	return current
-}
-
-func findInventoryComposite(file *ast.File) (*ast.CompositeLit, error) {
-	if file == nil {
-		return nil, errors.New("inventory file is nil")
-	}
-
-	for _, decl := range file.Decls {
-		gen, ok := decl.(*ast.GenDecl)
-		if !ok || gen.Tok != token.VAR {
-			continue
-		}
-		for _, spec := range gen.Specs {
-			valSpec, ok := spec.(*ast.ValueSpec)
-			if !ok {
-				continue
-			}
-			for i, name := range valSpec.Names {
-				if name == nil || name.Name != "LambdaInventory" {
-					continue
-				}
-				if i >= len(valSpec.Values) {
-					continue
-				}
-				if lit := unwrapComposite(valSpec.Values[i]); lit != nil {
-					return lit, nil
-				}
-			}
-		}
-	}
-	return nil, errors.New("LambdaInventory variable not found")
-}
-
-func unwrapComposite(expr ast.Expr) *ast.CompositeLit {
-	switch v := expr.(type) {
-	case *ast.CompositeLit:
-		return v
-	case *ast.UnaryExpr:
-		if v.Op == token.AND {
-			if lit, ok := v.X.(*ast.CompositeLit); ok {
-				return lit
-			}
-		}
-	}
-	return nil
-}
-
-func findCompositeField(lit *ast.CompositeLit, field string) (*ast.CompositeLit, error) {
-	value, ok := findKeyValueExpr(lit, field)
-	if !ok {
-		return nil, fmt.Errorf("missing %s field", field)
-	}
-	comp := unwrapComposite(value)
-	if comp == nil {
-		return nil, fmt.Errorf("%s field is not a composite literal", field)
-	}
-	return comp, nil
-}
-
-func findCompositeFieldOptional(lit *ast.CompositeLit, field string) (*ast.CompositeLit, error) {
-	value, ok := findKeyValueExpr(lit, field)
-	if !ok {
-		return nil, nil
-	}
-	comp := unwrapComposite(value)
-	if comp == nil {
-		return nil, fmt.Errorf("%s field is not a composite literal", field)
-	}
-	return comp, nil
-}
-
-func findKeyValueExpr(lit *ast.CompositeLit, field string) (ast.Expr, bool) {
-	if lit == nil {
-		return nil, false
-	}
-	for _, elt := range lit.Elts {
-		kv, ok := elt.(*ast.KeyValueExpr)
-		if !ok {
-			continue
-		}
-		keyIdent, ok := kv.Key.(*ast.Ident)
-		if !ok || keyIdent.Name != field {
-			continue
-		}
-		return kv.Value, true
-	}
-	return nil, false
-}
-
-func findStringField(lit *ast.CompositeLit, field string) (string, bool) {
-	value, ok := findKeyValueExpr(lit, field)
-	if !ok {
-		return "", false
-	}
-
-	switch v := value.(type) {
-	case *ast.BasicLit:
-		if v.Kind != token.STRING {
-			return "", false
-		}
-		parsed, err := strconv.Unquote(v.Value)
-		if err != nil {
-			return "", false
-		}
-		return parsed, true
-	}
-	return "", false
 }


### PR DESCRIPTION
## Summary
- add a deploy-time federation surface manifest and route local actor construction/repair through it
- implement real shared inbox ingress with shared target resolution, `POST /inbox`, and explicit `GET /inbox = 405`
- align inventory/docs/contract coverage and include the requested `.codex/config.toml` approval change

## Validation
- `go test ./... -count=1`
- `go vet ./...`
- `test -z "$(gofmt -l .)"`
- `go build -o lesser ./cmd/lesser`
