### PR TITLE
[codex] repair graphql remote-status actor hydration and public-read parity

### DIFF
--- a/cmd/lesser/migrate_helpers_round34_test.go
+++ b/cmd/lesser/migrate_helpers_round34_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppendConversationMigrationSample_LimitsAndDeduplicates(t *testing.T) {
+	appendConversationMigrationSample(nil, "conv-ignored")
+
+	samples := []string{}
+	appendConversationMigrationSample(&samples, "   ")
+	require.Empty(t, samples)
+
+	appendConversationMigrationSample(&samples, "conv-1")
+	appendConversationMigrationSample(&samples, "conv-1")
+	appendConversationMigrationSample(&samples, "conv-2")
+	appendConversationMigrationSample(&samples, "conv-3")
+	appendConversationMigrationSample(&samples, "conv-4")
+	appendConversationMigrationSample(&samples, "conv-5")
+	appendConversationMigrationSample(&samples, "conv-6")
+
+	require.Equal(t, []string{"conv-1", "conv-2", "conv-3", "conv-4", "conv-5"}, samples)
+}
+
+func TestSetMigrationStringAttribute_UpdatesAndAuditsGSIFields(t *testing.T) {
+	item := map[string]types.AttributeValue{}
+	audited := map[string]struct{}{}
+
+	require.True(t, setMigrationStringAttribute(item, "GSI1PK", "USER#arch", audited))
+	require.Equal(t, "USER#arch", strAttr(t, item["GSI1PK"]))
+	require.Contains(t, audited, "GSI1PK")
+
+	require.False(t, setMigrationStringAttribute(item, "GSI1PK", "USER#arch", audited))
+
+	require.True(t, setMigrationStringAttribute(item, "statusID", "status-2", audited))
+	require.Equal(t, "status-2", strAttr(t, item["statusID"]))
+	require.NotContains(t, audited, "statusID")
+}
+
+func TestMigrationUsernameKeyHelpers(t *testing.T) {
+	username, suffix, ok := splitActorKeyUsername("ACTOR#alice#followers")
+	require.True(t, ok)
+	require.Equal(t, "alice", username)
+	require.Equal(t, "#followers", suffix)
+
+	username, suffix, ok = splitActorKeyUsername("ACTOR#alice")
+	require.True(t, ok)
+	require.Equal(t, "alice", username)
+	require.Empty(t, suffix)
+
+	_, _, ok = splitActorKeyUsername("ACTOR#")
+	require.False(t, ok)
+	_, _, ok = splitActorKeyUsername("USER#alice")
+	require.False(t, ok)
+
+	value, ok := prefixedUsernameValue("following#alice", "following#")
+	require.True(t, ok)
+	require.Equal(t, "alice", value)
+
+	_, ok = prefixedUsernameValue("followers#alice", "following#")
+	require.False(t, ok)
+}

--- a/graph/actor_resolution_helpers.go
+++ b/graph/actor_resolution_helpers.go
@@ -79,6 +79,44 @@ func (r *Resolver) resolveExactActorLookup(ctx context.Context, actorID string) 
 	}, nil
 }
 
+func (r *Resolver) resolveStoredActorLookup(ctx context.Context, actorID string) (*federation.ExactActorResolution, error) {
+	actorID = strings.TrimSpace(actorID)
+	if actorID == "" {
+		return nil, common.ActorNotFoundError{Username: actorID}
+	}
+
+	store := r.getStorageForResolution()
+	if store == nil || store.Actor() == nil {
+		return nil, common.ActorNotFoundError{Username: actorID}
+	}
+
+	if username := r.localUsernameForLookup(actorID); username != "" {
+		actor, err := store.Actor().GetActorByUsername(ctx, username)
+		if err == nil && actor != nil {
+			return &federation.ExactActorResolution{
+				Actor:         actor,
+				ActorIdentity: federation.DescribeActorIdentity(actor, r.localActorDomain()),
+			}, nil
+		}
+		if err != nil && !graphActorLookupNotFound(err) {
+			return nil, err
+		}
+	}
+
+	actor, err := store.Actor().GetCachedRemoteActor(ctx, actorID)
+	if err == nil && actor != nil {
+		return &federation.ExactActorResolution{
+			Actor:         actor,
+			ActorIdentity: federation.DescribeActorIdentity(actor, r.localActorDomain()),
+		}, nil
+	}
+	if err != nil && !graphActorLookupNotFound(err) {
+		return nil, err
+	}
+
+	return nil, common.ActorNotFoundError{Username: actorID}
+}
+
 func graphActorLookupNotFound(err error) bool {
 	if err == nil {
 		return false

--- a/graph/constants.go
+++ b/graph/constants.go
@@ -106,6 +106,8 @@ const (
 	QueryTypeActor    = "actor"
 	QueryTypeAll      = "all"
 	QueryTypeAccounts = "accounts"
+	QueryTypeStatuses = "statuses"
+	QueryTypeHashtags = "hashtags"
 )
 
 // Pattern type constants

--- a/graph/query_resolvers_notes.go
+++ b/graph/query_resolvers_notes.go
@@ -241,12 +241,12 @@ func canonicalGraphQLSearchType(searchType string) string {
 	switch strings.ToLower(strings.TrimSpace(searchType)) {
 	case "", QueryTypeAll:
 		return QueryTypeAll
-	case "account", QueryTypeAccounts:
+	case AccountType, QueryTypeAccounts:
 		return QueryTypeAccounts
-	case "status", "statuses":
-		return "statuses"
-	case "hashtag", "hashtags":
-		return "hashtags"
+	case trendTypeStatus, QueryTypeStatuses:
+		return QueryTypeStatuses
+	case trendTypeHashtag, QueryTypeHashtags:
+		return QueryTypeHashtags
 	default:
 		return strings.ToLower(strings.TrimSpace(searchType))
 	}

--- a/graph/query_resolvers_notes.go
+++ b/graph/query_resolvers_notes.go
@@ -196,16 +196,13 @@ func (r *queryResolver) Timeline(ctx context.Context, timelineType model.Timelin
 // Search is the resolver for the search field.
 func (r *queryResolver) Search(ctx context.Context, query string, searchType *string, first *int, after *model.Cursor) (*model.SearchResult, error) {
 	viewerUsername := r.optionalAuth(ctx)
+	normalizedSearchType := normalizeGraphQLSearchType(searchType)
 
 	searchQuery := &search.Query{
 		Query:     query,
 		AccountID: viewerUsername,
-		Type:      "all",
+		Type:      normalizedSearchType,
 		Limit:     20,
-	}
-
-	if searchType != nil {
-		searchQuery.Type = *searchType
 	}
 
 	if first != nil && *first > 0 && *first <= 100 {
@@ -217,7 +214,7 @@ func (r *queryResolver) Search(ctx context.Context, query string, searchType *st
 		searchQuery.Offset = 20
 	}
 
-	if exact, handled, err := r.searchExactActorQuery(ctx, query, searchQuery.Type); handled {
+	if exact, handled, err := r.searchExactActorQuery(ctx, query, normalizedSearchType); handled {
 		return exact, err
 	}
 
@@ -230,6 +227,29 @@ func (r *queryResolver) Search(ctx context.Context, query string, searchType *st
 	}
 
 	return r.searchResultToGraphQL(ctx, result, viewerUsername), nil
+}
+
+func normalizeGraphQLSearchType(searchType *string) string {
+	if searchType == nil {
+		return QueryTypeAll
+	}
+
+	return canonicalGraphQLSearchType(*searchType)
+}
+
+func canonicalGraphQLSearchType(searchType string) string {
+	switch strings.ToLower(strings.TrimSpace(searchType)) {
+	case "", QueryTypeAll:
+		return QueryTypeAll
+	case "account", QueryTypeAccounts:
+		return QueryTypeAccounts
+	case "status", "statuses":
+		return "statuses"
+	case "hashtag", "hashtags":
+		return "hashtags"
+	default:
+		return strings.ToLower(strings.TrimSpace(searchType))
+	}
 }
 
 func (r *queryResolver) searchExactActorQuery(ctx context.Context, query string, searchType string) (*model.SearchResult, bool, error) {

--- a/graph/query_resolvers_remote_public_read_round34_test.go
+++ b/graph/query_resolvers_remote_public_read_round34_test.go
@@ -1,0 +1,129 @@
+package graph
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/graph/model"
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/equaltoai/lesser/pkg/testing/inmemory"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRound34QueryResolvers_RemotePublicReadHydratesRemoteActors(t *testing.T) {
+	resolver, storage := newRound12GraphResolver(t)
+	actorRepo, ok := storage.Actor().(*inmemory.ActorRepository)
+	require.True(t, ok)
+
+	remoteActor := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://remote.example/users/alice",
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: "alice",
+		Name:              "Remote Alice",
+		Inbox:             "https://remote.example/users/alice/inbox",
+		Outbox:            "https://remote.example/users/alice/outbox",
+	}
+	actorRepo.SetCachedRemoteActor("alice@remote.example", remoteActor, time.Hour)
+
+	now := time.Now().UTC()
+	root := &storageModels.Status{
+		StatusID:       "status-remote-root",
+		AuthorID:       remoteActor.ID,
+		AuthorUsername: "alice@remote.example",
+		Content:        "remote root",
+		CreatedAt:      now.Add(-2 * time.Minute),
+		UpdatedAt:      now.Add(-2 * time.Minute),
+		PublishedAt:    now.Add(-2 * time.Minute),
+		Visibility:     storageModels.VisibilityPublic,
+		Note: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:        "https://remote.example/notes/root",
+				Type:      activitypub.NoteType,
+				Published: pointTime(now.Add(-2 * time.Minute)),
+			},
+			AttributedTo: remoteActor.ID,
+			Content:      "remote root",
+		},
+	}
+	reply := &storageModels.Status{
+		StatusID:       "status-remote-reply",
+		AuthorID:       remoteActor.ID,
+		AuthorUsername: "alice@remote.example",
+		Content:        "remote reply",
+		InReplyToID:    root.StatusID,
+		CreatedAt:      now.Add(-time.Minute),
+		UpdatedAt:      now.Add(-time.Minute),
+		PublishedAt:    now.Add(-time.Minute),
+		Visibility:     storageModels.VisibilityPublic,
+		Note: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:        "https://remote.example/notes/reply",
+				Type:      activitypub.NoteType,
+				Published: pointTime(now.Add(-time.Minute)),
+				InReplyTo: root.Note.ID,
+			},
+			AttributedTo: remoteActor.ID,
+			Content:      "remote reply",
+		},
+	}
+
+	ctx := context.Background()
+	require.NoError(t, storage.Status().CreateStatus(ctx, root))
+	require.NoError(t, storage.Status().CreateStatus(ctx, reply))
+
+	q := resolver.Query()
+
+	obj, err := q.Object(ctx, root.StatusID)
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+	require.NotNil(t, obj.Actor)
+	require.Equal(t, remoteActor.ID, obj.Actor.ID)
+
+	first := 10
+	publicTimeline, err := q.Timeline(ctx, model.TimelineTypePublic, nil, nil, nil, &first, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, publicTimeline)
+	require.Equal(t, remoteActor.ID, findTimelineNodeByID(t, publicTimeline, root.StatusID).Actor.ID)
+
+	actorID := remoteActor.ID
+	actorTimeline, err := q.Timeline(ctx, model.TimelineTypeActor, nil, nil, &actorID, &first, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, actorTimeline)
+	require.Equal(t, remoteActor.ID, findTimelineNodeByID(t, actorTimeline, root.StatusID).Actor.ID)
+	require.Equal(t, remoteActor.ID, findTimelineNodeByID(t, actorTimeline, reply.StatusID).Actor.ID)
+
+	thread, err := q.ThreadContext(ctx, root.StatusID)
+	require.NoError(t, err)
+	require.NotNil(t, thread)
+	require.NotNil(t, thread.RootNote)
+	require.NotNil(t, thread.RootNote.Actor)
+	require.Equal(t, remoteActor.ID, thread.RootNote.Actor.ID)
+	require.Len(t, thread.Descendants, 1)
+	require.NotNil(t, thread.Descendants[0].Actor)
+	require.Equal(t, remoteActor.ID, thread.Descendants[0].Actor.ID)
+}
+
+func findTimelineNodeByID(t *testing.T, conn *model.ObjectConnection, statusID string) *model.Object {
+	t.Helper()
+
+	require.NotNil(t, conn)
+	for _, edge := range conn.Edges {
+		if edge == nil || edge.Node == nil {
+			continue
+		}
+		if edge.Node.ID == statusID {
+			return edge.Node
+		}
+	}
+
+	t.Fatalf("timeline missing status %s", statusID)
+	return nil
+}
+
+func pointTime(value time.Time) *time.Time {
+	return &value
+}

--- a/graph/query_resolvers_remote_public_read_round34_test.go
+++ b/graph/query_resolvers_remote_public_read_round34_test.go
@@ -107,6 +107,58 @@ func TestRound34QueryResolvers_RemotePublicReadHydratesRemoteActors(t *testing.T
 	require.Equal(t, remoteActor.ID, thread.Descendants[0].Actor.ID)
 }
 
+func TestRound34QueryResolvers_RemotePublicReadUsesPlaceholderWhenCacheMisses(t *testing.T) {
+	resolver, storage := newRound12GraphResolver(t)
+
+	now := time.Now().UTC()
+	remoteActorID := "https://127.0.0.1:1/users/alice"
+	root := &storageModels.Status{
+		StatusID:    "status-remote-root-uncached",
+		AuthorID:    remoteActorID,
+		Content:     "remote root uncached",
+		CreatedAt:   now.Add(-2 * time.Minute),
+		UpdatedAt:   now.Add(-2 * time.Minute),
+		PublishedAt: now.Add(-2 * time.Minute),
+		Visibility:  storageModels.VisibilityPublic,
+		Note: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:        "https://127.0.0.1:1/notes/root",
+				Type:      activitypub.NoteType,
+				Published: pointTime(now.Add(-2 * time.Minute)),
+			},
+			AttributedTo: remoteActorID,
+			Content:      "remote root uncached",
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+
+	require.NoError(t, storage.Status().CreateStatus(ctx, root))
+
+	q := resolver.Query()
+
+	obj, err := q.Object(ctx, root.StatusID)
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+	require.NotNil(t, obj.Actor)
+	require.Equal(t, remoteActorID, obj.Actor.ID)
+	require.Equal(t, "alice", obj.Actor.PreferredUsername)
+
+	first := 10
+	publicTimeline, err := q.Timeline(ctx, model.TimelineTypePublic, nil, nil, nil, &first, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, publicTimeline)
+	require.Equal(t, remoteActorID, findTimelineNodeByID(t, publicTimeline, root.StatusID).Actor.ID)
+
+	thread, err := q.ThreadContext(ctx, root.StatusID)
+	require.NoError(t, err)
+	require.NotNil(t, thread)
+	require.NotNil(t, thread.RootNote)
+	require.NotNil(t, thread.RootNote.Actor)
+	require.Equal(t, remoteActorID, thread.RootNote.Actor.ID)
+}
+
 func findTimelineNodeByID(t *testing.T, conn *model.ObjectConnection, statusID string) *model.Object {
 	t.Helper()
 

--- a/graph/query_resolvers_search_round31_regression_test.go
+++ b/graph/query_resolvers_search_round31_regression_test.go
@@ -113,6 +113,34 @@ func TestRound31QueryResolvers_Search_ExactRemoteHandleUsesRemoteAwareResolution
 	require.Equal(t, remoteActor.PreferredUsername, result.Accounts[0].PreferredUsername)
 }
 
+func TestRound31QueryResolvers_Search_NormalizesAccountTypeAliasForExactRemoteHandle(t *testing.T) {
+	resolver, storage := newRound12GraphResolver(t)
+	actorRepo, ok := storage.Actor().(*inmemory.ActorRepository)
+	require.True(t, ok)
+
+	remoteActor := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://remote.example/users/alice",
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: "alice",
+		Name:              "Remote Alice",
+		Inbox:             "https://remote.example/users/alice/inbox",
+		Outbox:            "https://remote.example/users/alice/outbox",
+	}
+	actorRepo.SetCachedRemoteActor("alice@remote.example", remoteActor, time.Hour)
+
+	searchType := "ACCOUNT"
+	result, err := resolver.Query().Search(context.Background(), "alice@remote.example", &searchType, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Accounts, 1)
+	require.Equal(t, remoteActor.ID, result.Accounts[0].ID)
+	require.Equal(t, remoteActor.PreferredUsername, result.Accounts[0].PreferredUsername)
+	require.Empty(t, result.Statuses)
+	require.Empty(t, result.Hashtags)
+}
+
 func TestRound31QueryResolvers_SearchResultToGraphQL_PreservesRemoteActorIdentity(t *testing.T) {
 	resolver, _ := newRound12GraphResolver(t)
 	remoteActor := &activitypub.Actor{

--- a/graph/status_object_helpers.go
+++ b/graph/status_object_helpers.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"context"
+	neturl "net/url"
 	"strings"
 	"time"
 
@@ -128,6 +129,7 @@ func (r *Resolver) resolveActorForStatus(ctx context.Context, status *models.Sta
 
 	username := resolveStatusAuthorUsername(status)
 	lookupCandidates := statusActorLookupCandidates(status)
+	authorIsRemote := statusAuthorIsRemote(status, r.localActorDomain())
 	if len(lookupCandidates) == 0 {
 		if convertLogger != nil {
 			convertLogger.Warn("status missing author username",
@@ -137,15 +139,17 @@ func (r *Resolver) resolveActorForStatus(ctx context.Context, status *models.Sta
 		return nil
 	}
 
-	if prefetched := prefetchedConversationAccount(ctx, username); prefetched != nil {
-		return r.convertAccountToActor(prefetched)
+	if !authorIsRemote {
+		if prefetched := prefetchedConversationAccount(ctx, username); prefetched != nil {
+			return r.convertAccountToActor(prefetched)
+		}
 	}
 
 	for _, candidate := range lookupCandidates {
 		lookupStart := time.Now()
-		resolution, err := r.resolveExactActorLookup(ctx, candidate)
+		resolution, err := r.resolveStoredActorLookup(ctx, candidate)
 		if convertLogger != nil {
-			convertLogger.Info("convertStatusToObject exact actor lookup",
+			convertLogger.Info("convertStatusToObject stored actor lookup",
 				zap.String("status_id", status.StatusID),
 				zap.String("actor_lookup", candidate),
 				zap.Duration("duration", time.Since(lookupStart)),
@@ -159,6 +163,22 @@ func (r *Resolver) resolveActorForStatus(ctx context.Context, status *models.Sta
 		if actor := r.materializeActorResolution(ctx, resolution); actor != nil {
 			return actor
 		}
+	}
+
+	if authorIsRemote {
+		placeholderID := statusActorPlaceholderIdentifier(status)
+		if placeholderID == "" {
+			return nil
+		}
+
+		placeholder := r.buildPlaceholderActor(placeholderID, "")
+		if convertLogger != nil {
+			convertLogger.Info("convertStatusToObject remote placeholder actor",
+				zap.String("status_id", status.StatusID),
+				zap.String("actor_lookup", placeholderID),
+				zap.Bool("found", placeholder != nil))
+		}
+		return placeholder
 	}
 
 	if r.Registry == nil || r.Registry.Accounts() == nil || username == "" {
@@ -279,13 +299,12 @@ func statusActorLookupCandidates(status *models.Status) []string {
 		return nil
 	}
 
-	candidates := make([]string, 0, 4)
+	candidates := make([]string, 0, 3)
 	appendStatusActorLookupCandidate(&candidates, status.AuthorID)
 	if status.Note != nil {
 		appendStatusActorLookupCandidate(&candidates, status.Note.AttributedTo)
 	}
 	appendStatusActorLookupCandidate(&candidates, status.AuthorUsername)
-	appendStatusActorLookupCandidate(&candidates, resolveStatusAuthorUsername(status))
 
 	return candidates
 }
@@ -303,4 +322,67 @@ func appendStatusActorLookupCandidate(dst *[]string, candidate string) {
 	}
 
 	*dst = append(*dst, trimmed)
+}
+
+func statusActorPlaceholderIdentifier(status *models.Status) string {
+	for _, candidate := range statusActorLookupCandidates(status) {
+		if strings.TrimSpace(candidate) != "" {
+			return strings.TrimSpace(candidate)
+		}
+	}
+
+	return resolveStatusAuthorUsername(status)
+}
+
+func statusAuthorIsRemote(status *models.Status, localDomain string) bool {
+	for _, candidate := range statusActorLookupCandidates(status) {
+		if actorIdentifierLooksRemote(candidate, localDomain) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func actorIdentifierLooksRemote(identifier, localDomain string) bool {
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return false
+	}
+
+	localDomain = strings.TrimSpace(strings.ToLower(localDomain))
+	lowerIdentifier := strings.ToLower(identifier)
+	if strings.HasPrefix(lowerIdentifier, "http://") || strings.HasPrefix(lowerIdentifier, "https://") {
+		parsed, err := neturl.Parse(identifier)
+		if err != nil {
+			return false
+		}
+		host := strings.TrimSpace(strings.ToLower(parsed.Hostname()))
+		if host == "" {
+			return false
+		}
+		if localDomain == "" {
+			return true
+		}
+		return host != localDomain
+	}
+
+	handle := strings.TrimPrefix(identifier, "@")
+	if strings.Count(handle, "@") != 1 {
+		return false
+	}
+
+	parts := strings.Split(handle, "@")
+	if len(parts) != 2 {
+		return false
+	}
+
+	domain := strings.TrimSpace(strings.ToLower(parts[1]))
+	if domain == "" {
+		return false
+	}
+	if localDomain == "" {
+		return true
+	}
+	return domain != localDomain
 }

--- a/graph/status_object_helpers.go
+++ b/graph/status_object_helpers.go
@@ -8,7 +8,6 @@ import (
 	"github.com/equaltoai/lesser/graph/model"
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/services/notes"
-	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"go.uber.org/zap"
 )
@@ -123,12 +122,13 @@ func (r *Resolver) viewerBoostState(ctx context.Context, status *models.Status, 
 }
 
 func (r *Resolver) resolveActorForStatus(ctx context.Context, status *models.Status, convertLogger *zap.Logger) *activitypub.Actor {
-	if status == nil || r.Registry == nil {
+	if status == nil {
 		return nil
 	}
 
 	username := resolveStatusAuthorUsername(status)
-	if username == "" {
+	lookupCandidates := statusActorLookupCandidates(status)
+	if len(lookupCandidates) == 0 {
 		if convertLogger != nil {
 			convertLogger.Warn("status missing author username",
 				zap.String("status_id", status.StatusID),
@@ -137,27 +137,38 @@ func (r *Resolver) resolveActorForStatus(ctx context.Context, status *models.Sta
 		return nil
 	}
 
-	if r.Registry.Accounts() == nil {
-		if convertLogger != nil {
-			convertLogger.Warn("account service unavailable while resolving actor",
-				zap.String("status_id", status.StatusID),
-				zap.String("username", username))
-		}
-		return nil
-	}
-
 	if prefetched := prefetchedConversationAccount(ctx, username); prefetched != nil {
 		return r.convertAccountToActor(prefetched)
 	}
 
+	for _, candidate := range lookupCandidates {
+		lookupStart := time.Now()
+		resolution, err := r.resolveExactActorLookup(ctx, candidate)
+		if convertLogger != nil {
+			convertLogger.Info("convertStatusToObject exact actor lookup",
+				zap.String("status_id", status.StatusID),
+				zap.String("actor_lookup", candidate),
+				zap.Duration("duration", time.Since(lookupStart)),
+				zap.Bool("found", err == nil && resolution != nil && resolution.Actor != nil),
+				zap.Error(err))
+		}
+		if err != nil || resolution == nil {
+			continue
+		}
+
+		if actor := r.materializeActorResolution(ctx, resolution); actor != nil {
+			return actor
+		}
+	}
+
+	if r.Registry == nil || r.Registry.Accounts() == nil || username == "" {
+		return nil
+	}
+
 	accountStart := time.Now()
-	var (
-		result *storage.Account
-		err    error
-	)
-	result, err = r.Registry.Accounts().GetAccount(ctx, username)
+	result, err := r.Registry.Accounts().GetAccount(ctx, username)
 	if convertLogger != nil {
-		convertLogger.Info("convertStatusToObject account lookup",
+		convertLogger.Info("convertStatusToObject account lookup fallback",
 			zap.String("status_id", status.StatusID),
 			zap.String("author_username", username),
 			zap.Duration("duration", time.Since(accountStart)),
@@ -261,4 +272,35 @@ func resolveStatusAuthorUsername(status *models.Status) string {
 	}
 
 	return extractUsernameFromActorIdentifier(status.AuthorID)
+}
+
+func statusActorLookupCandidates(status *models.Status) []string {
+	if status == nil {
+		return nil
+	}
+
+	candidates := make([]string, 0, 4)
+	appendStatusActorLookupCandidate(&candidates, status.AuthorID)
+	if status.Note != nil {
+		appendStatusActorLookupCandidate(&candidates, status.Note.AttributedTo)
+	}
+	appendStatusActorLookupCandidate(&candidates, status.AuthorUsername)
+	appendStatusActorLookupCandidate(&candidates, resolveStatusAuthorUsername(status))
+
+	return candidates
+}
+
+func appendStatusActorLookupCandidate(dst *[]string, candidate string) {
+	trimmed := strings.TrimSpace(candidate)
+	if trimmed == "" {
+		return
+	}
+
+	for _, existing := range *dst {
+		if strings.EqualFold(existing, trimmed) {
+			return
+		}
+	}
+
+	*dst = append(*dst, trimmed)
 }

--- a/graph/status_object_remote_actor_round34_test.go
+++ b/graph/status_object_remote_actor_round34_test.go
@@ -66,3 +66,36 @@ func TestRound34ConvertStatusToGraphQLObject_HydratesRemoteActorThroughExactReso
 	require.Equal(t, remoteActor.PreferredUsername, obj.Actor.PreferredUsername)
 	require.Equal(t, remoteActor.Inbox, obj.Actor.Inbox)
 }
+
+func TestRound34ConvertStatusToGraphQLObject_DegradesToRemotePlaceholderWithoutCache(t *testing.T) {
+	resolver, _ := newRound12GraphResolver(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+
+	now := time.Now().UTC()
+	status := &storageModels.Status{
+		StatusID:   "status-remote-uncached",
+		AuthorID:   "https://127.0.0.1:1/users/alice",
+		Content:    "hello from uncached remote alice",
+		CreatedAt:  now.Add(-time.Minute),
+		UpdatedAt:  now,
+		Visibility: storageModels.VisibilityPublic,
+		Note: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:        "https://127.0.0.1:1/notes/1",
+				Type:      activitypub.NoteType,
+				Published: &now,
+			},
+			AttributedTo: "https://127.0.0.1:1/users/alice",
+			Content:      "hello from uncached remote alice",
+		},
+	}
+
+	obj := resolver.ConvertStatusToGraphQLObject(ctx, status)
+	require.NotNil(t, obj)
+	require.NotNil(t, obj.Actor)
+	require.Equal(t, status.AuthorID, obj.Actor.ID)
+	require.Equal(t, "alice", obj.Actor.PreferredUsername)
+	require.NotEqual(t, config.Get().ActorURL("alice"), obj.Actor.ID)
+}

--- a/graph/status_object_remote_actor_round34_test.go
+++ b/graph/status_object_remote_actor_round34_test.go
@@ -1,0 +1,68 @@
+package graph
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/config"
+	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
+	pkgtesting "github.com/equaltoai/lesser/pkg/testing"
+	"github.com/equaltoai/lesser/pkg/testing/inmemory"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestRound34ConvertStatusToGraphQLObject_HydratesRemoteActorThroughExactResolution(t *testing.T) {
+	storage := pkgtesting.NewMockRepositoryStorage()
+	actorRepo, ok := storage.Actor().(*inmemory.ActorRepository)
+	require.True(t, ok)
+
+	remoteActor := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://remote.example/users/alice",
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: "alice",
+		Name:              "Remote Alice",
+		Inbox:             "https://remote.example/users/alice/inbox",
+		Outbox:            "https://remote.example/users/alice/outbox",
+	}
+	actorRepo.SetCachedRemoteActor("alice@remote.example", remoteActor, time.Hour)
+
+	resolver := &Resolver{
+		Storage: storage,
+		Config: &config.Config{
+			Domain: "localhost",
+		},
+		Logger: zap.NewNop(),
+	}
+
+	now := time.Now().UTC()
+	status := &storageModels.Status{
+		StatusID:       "status-remote-1",
+		AuthorID:       remoteActor.ID,
+		AuthorUsername: "alice@remote.example",
+		Content:        "hello from remote alice",
+		CreatedAt:      now.Add(-time.Minute),
+		UpdatedAt:      now,
+		Visibility:     storageModels.VisibilityPublic,
+		Note: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:        "https://remote.example/notes/1",
+				Type:      activitypub.NoteType,
+				Published: &now,
+			},
+			AttributedTo: remoteActor.ID,
+			Content:      "hello from remote alice",
+		},
+	}
+
+	obj := resolver.ConvertStatusToGraphQLObject(context.Background(), status)
+	require.NotNil(t, obj)
+	require.NotNil(t, obj.Actor)
+	require.Equal(t, remoteActor.ID, obj.Actor.ID)
+	require.Equal(t, remoteActor.PreferredUsername, obj.Actor.PreferredUsername)
+	require.Equal(t, remoteActor.Inbox, obj.Actor.Inbox)
+}


### PR DESCRIPTION
## Milestone
M1.4J — Repair GraphQL remote-status actor hydration and public-read parity (#788)

## Classification
contract-stability, bug-fix, test-coverage

## Surfaces affected
- `graph/status_object_helpers.go`
- `graph/actor_resolution_helpers.go`
- `graph/query_resolvers_notes.go`
- `graph/constants.go`
- `graph/query_resolvers_search_round31_regression_test.go`
- `graph/status_object_remote_actor_round34_test.go`
- `graph/query_resolvers_remote_public_read_round34_test.go`

## Specialist walks referenced
- Federation trust: not required for this read-layer repair
- Contract / API: completed via preserve-mastodon-api-compat
- Schema: not touched
- Framework: idiomatic Lesser/AppTheory/TableTheory usage; no framework escalation needed

## Consumer impact
- Fixes GraphQL public-read failures for remote-authored notes
- Preserves `Object.actor` non-null without weakening the schema
- Keeps timeline/thread/object hydration cache/storage-only on read paths
- Degrades uncached remote actors to a deterministic placeholder instead of performing live federation discovery
- Normalizes GraphQL `search(type: String)` aliases/case for account-oriented reads
- No Mastodon REST, ActivityPub wire, or schema-contract shape changes

## Root cause
Remote-authored statuses were still hydrating `Object.actor` through local account lookup instead of a remote-aware identity seam, leaving GraphQL timeline/thread/object reads with a null-actor path even though exact actor lookup already worked. Separately, `search(type: String)` forwarded raw values like `ACCOUNT`, skipping the exact-actor search seam and falling through to misleading mixed-type search behavior.

## Follow-up review fix
Addressed Tier 1 review feedback by splitting the lookup modes:
- exact actor query keeps the network-enabled exact resolution path
- status/object hydration now uses a storage/cache-only actor lookup path
- uncached remote status authors degrade to a local placeholder built from stored identity instead of triggering WebFinger or actor fetches during public reads

## Tasks
- [x] #789 Repair shared GraphQL actor hydration for remote-authored statuses
- [x] #790 Normalize the GraphQL search type contract for public-read parity
- [x] #791 Harden proof coverage for remote GraphQL public-read correctness

## Validation
- [x] `go build -o lesser ./cmd/lesser`
- [x] `./lesser build lambdas`
- [x] `./lesser verify ci`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (empty)
- [x] `go test ./graph -count=1`
- [x] Targeted: `go test ./graph -run 'TestRound34ConvertStatusToGraphQLObject_|TestRound34QueryResolvers_RemotePublicRead|TestRound31QueryResolvers_Search_NormalizesAccountTypeAliasForExactRemoteHandle' -count=1`
- [x] `./lesser verify smoke` waived by user as not practical at this stage

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
none

## Advisor-brief authorization (if applicable)
Derived from Arch's advisor brief (`arch@lessersoul.ai`) about Project 20's remaining GraphQL read-layer blocker; Aron authorized the investigation and implementation in-session.
