### PR TITLE
fix(federation): repair remote note reply integrity

### DIFF
--- a/cmd/api/handlers/helpers.go
+++ b/cmd/api/handlers/helpers.go
@@ -383,12 +383,25 @@ func (h *Handler) convertStorageStatusToAPI(storageStatus *storageModels.Status,
 	return h.convertStorageStatusToAPIWithContext(h.statusConversionContext(), storageStatus, currentUsername)
 }
 
+type statusAuthorAccountLoader func(context.Context, *storageModels.Status) *storage.Account
+
 func (h *Handler) convertStorageStatusToAPIWithContext(ctx context.Context, storageStatus *storageModels.Status, currentUsername string) (*models.Status, error) {
+	return h.convertStorageStatusToAPIWithAuthorLoader(ctx, storageStatus, currentUsername, h.loadStatusAuthorAccount)
+}
+
+func (h *Handler) convertStorageStatusToAPIWithStoredAuthorContext(ctx context.Context, storageStatus *storageModels.Status, currentUsername string) (*models.Status, error) {
+	return h.convertStorageStatusToAPIWithAuthorLoader(ctx, storageStatus, currentUsername, h.loadStoredStatusAuthorAccount)
+}
+
+func (h *Handler) convertStorageStatusToAPIWithAuthorLoader(ctx context.Context, storageStatus *storageModels.Status, currentUsername string, loadAuthor statusAuthorAccountLoader) (*models.Status, error) {
 	if ctx == nil {
 		ctx = h.statusConversionContext()
 	}
+	if loadAuthor == nil {
+		loadAuthor = h.loadStatusAuthorAccount
+	}
 	inReplyToID, inReplyToAccountID := h.statusReplyReferences(ctx, storageStatus)
-	authorAccount := h.loadStatusAuthorAccount(ctx, storageStatus)
+	authorAccount := loadAuthor(ctx, storageStatus)
 	counts := h.statusEngagementCounts(ctx, storageStatus)
 	interactions := h.statusInteractionState(ctx, storageStatus, currentUsername)
 	reblogStatus := h.loadReblogStatus(ctx, storageStatus, currentUsername)
@@ -514,6 +527,41 @@ func (h *Handler) loadStatusAuthorAccount(ctx context.Context, storageStatus *st
 	return authorAccount
 }
 
+func (h *Handler) loadStoredStatusAuthorAccount(ctx context.Context, storageStatus *storageModels.Status) *storage.Account {
+	if storageStatus == nil {
+		return &storage.Account{User: &storage.User{}}
+	}
+
+	if prefetched := prefetchedConversationAccount(ctx, storageStatus.AuthorUsername); prefetched != nil {
+		return prefetched
+	}
+
+	if !h.statusAppearsRemote(storageStatus) {
+		return h.loadStatusAuthorAccount(ctx, storageStatus)
+	}
+
+	if actor := h.loadStoredStatusAuthorActor(ctx, storageStatus); actor != nil {
+		account := storageAccountFromActor(actor, h.cfg.Domain)
+		if account != nil {
+			if account.User == nil {
+				account.User = &storage.User{}
+			}
+			if strings.TrimSpace(account.User.DisplayName) == "" {
+				account.User.DisplayName = strings.TrimSpace(storageStatus.AuthorUsername)
+			}
+			return account
+		}
+	}
+
+	displayName := strings.TrimSpace(storageStatus.AuthorUsername)
+	return &storage.Account{
+		User: &storage.User{
+			Username:    strings.TrimSpace(storageStatus.AuthorUsername),
+			DisplayName: displayName,
+		},
+	}
+}
+
 func (h *Handler) resolveStatusAuthorAccount(ctx context.Context, storageStatus *storageModels.Status) *storage.Account {
 	actor := h.resolveStatusAuthorActor(ctx, storageStatus)
 	if actor == nil {
@@ -532,6 +580,82 @@ func (h *Handler) resolveStatusAuthorAccount(ctx context.Context, storageStatus 
 	}
 
 	return account
+}
+
+func (h *Handler) loadStoredStatusAuthorActor(ctx context.Context, storageStatus *storageModels.Status) *activitypub.Actor {
+	if storageStatus == nil {
+		return nil
+	}
+
+	candidates := []string{
+		strings.TrimSpace(storageStatus.AuthorID),
+		strings.TrimSpace(storageStatus.AuthorUsername),
+	}
+	if storageStatus.Note != nil {
+		candidates = append(candidates, strings.TrimSpace(storageStatus.Note.AttributedTo))
+	}
+
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		candidate = normalizeResolvedAccountID(candidate)
+		if candidate == "" {
+			continue
+		}
+		if _, exists := seen[candidate]; exists {
+			continue
+		}
+		seen[candidate] = struct{}{}
+
+		if localUsername := h.localUsernameForStoredActorCandidate(candidate); localUsername != "" {
+			actor, err := h.repos.Actor().GetActor(ctx, localUsername)
+			if err == nil && actor != nil {
+				return actor
+			}
+		}
+
+		actor, err := h.repos.Actor().GetCachedRemoteActor(ctx, candidate)
+		if err == nil && actor != nil {
+			return actor
+		}
+	}
+
+	return nil
+}
+
+func (h *Handler) localUsernameForStoredActorCandidate(candidate string) string {
+	candidate = normalizeResolvedAccountID(candidate)
+	if candidate == "" || h == nil || h.cfg == nil {
+		return ""
+	}
+
+	if strings.HasPrefix(candidate, "http://") || strings.HasPrefix(candidate, "https://") {
+		parsed, err := url.Parse(candidate)
+		if err != nil || parsed == nil || !strings.EqualFold(parsed.Hostname(), h.cfg.Domain) {
+			return ""
+		}
+
+		path := strings.Trim(parsed.Path, "/")
+		parts := strings.Split(path, "/")
+		if len(parts) >= 2 && parts[0] == "users" && strings.TrimSpace(parts[1]) != "" {
+			return strings.TrimSpace(parts[1])
+		}
+		return ""
+	}
+
+	if strings.Contains(candidate, "@") {
+		trimmed := strings.TrimSpace(strings.TrimPrefix(candidate, "@"))
+		parts := strings.Split(trimmed, "@")
+		if len(parts) == 2 && strings.EqualFold(strings.TrimSpace(parts[1]), h.cfg.Domain) {
+			return strings.TrimSpace(parts[0])
+		}
+		return ""
+	}
+
+	if strings.Contains(candidate, "/") {
+		return ""
+	}
+
+	return strings.TrimSpace(candidate)
 }
 
 func (h *Handler) resolveStatusAuthorActor(ctx context.Context, storageStatus *storageModels.Status) *activitypub.Actor {

--- a/cmd/api/handlers/helpers.go
+++ b/cmd/api/handlers/helpers.go
@@ -636,7 +636,7 @@ func (h *Handler) localUsernameForStoredActorCandidate(candidate string) string 
 
 		path := strings.Trim(parsed.Path, "/")
 		parts := strings.Split(path, "/")
-		if len(parts) >= 2 && parts[0] == "users" && strings.TrimSpace(parts[1]) != "" {
+		if len(parts) >= 2 && parts[0] == actorUsersPathSegment && strings.TrimSpace(parts[1]) != "" {
 			return strings.TrimSpace(parts[1])
 		}
 		return ""

--- a/cmd/api/handlers/helpers_round18_more_coverage_test.go
+++ b/cmd/api/handlers/helpers_round18_more_coverage_test.go
@@ -362,6 +362,69 @@ func TestHelpersRound18_StatusHelpersHandleNilInputs(t *testing.T) {
 	require.Nil(t, h.loadReblogStatus(context.Background(), nil, "alice"))
 }
 
+func TestHelpersRound34_LoadStoredStatusAuthorAccount_RemotePaths(t *testing.T) {
+	cfg := round11TestConfig()
+	now := time.Now()
+	remoteActor := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://remote.example/users/alice",
+			Type: "Person",
+		},
+		PreferredUsername: "alice",
+		Name:              "Alice Remote",
+		URL:               "https://remote.example/@alice",
+		Inbox:             "https://remote.example/users/alice/inbox",
+		Outbox:            "https://remote.example/users/alice/outbox",
+	}
+
+	cached := storagemodels.RemoteActor{
+		Handle:    "alice@remote.example",
+		Actor:     remoteActor,
+		ExpiresAt: now.Add(1 * time.Hour),
+		CachedAt:  now.Add(-1 * time.Minute),
+		UpdatedAt: now.Add(-1 * time.Minute),
+	}
+	cached.UpdateKeys()
+
+	t.Run("uses cached remote actor without local account projection", func(t *testing.T) {
+		state := &round10QueryState{
+			remoteActorsByPK: map[string]storagemodels.RemoteActor{
+				cached.PK: cached,
+			},
+		}
+		h, _, _ := round11NewHandler(t, cfg, state)
+
+		account := h.loadStoredStatusAuthorAccount(context.Background(), &storagemodels.Status{
+			StatusID:       "status-1",
+			AuthorID:       remoteActor.ID,
+			AuthorUsername: "alice@remote.example",
+			Note:           &activitypub.Note{AttributedTo: remoteActor.ID},
+		})
+
+		require.NotNil(t, account)
+		require.NotNil(t, account.Actor)
+		require.Equal(t, remoteActor.ID, account.Actor.ID)
+		require.Equal(t, "alice@remote.example", account.User.Username)
+	})
+
+	t.Run("degrades from stored identity when remote actor cache is absent", func(t *testing.T) {
+		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
+
+		account := h.loadStoredStatusAuthorAccount(context.Background(), &storagemodels.Status{
+			StatusID:       "status-2",
+			AuthorID:       "https://remote.example/users/bob",
+			AuthorUsername: "bob@remote.example",
+			Note:           &activitypub.Note{AttributedTo: "https://remote.example/users/bob"},
+		})
+
+		require.NotNil(t, account)
+		require.NotNil(t, account.User)
+		require.Equal(t, "bob@remote.example", account.User.Username)
+		require.Equal(t, "bob@remote.example", account.User.DisplayName)
+		require.Nil(t, account.Actor)
+	})
+}
+
 func TestHelpersRound18_ResponseDefaults(t *testing.T) {
 	h := &Handler{logger: round10TestLogger(t)}
 

--- a/cmd/api/handlers/helpers_round18_more_coverage_test.go
+++ b/cmd/api/handlers/helpers_round18_more_coverage_test.go
@@ -425,6 +425,20 @@ func TestHelpersRound34_LoadStoredStatusAuthorAccount_RemotePaths(t *testing.T) 
 	})
 }
 
+func TestHelpersRound34_LocalUsernameForStoredActorCandidate(t *testing.T) {
+	cfg := round11TestConfig()
+	h, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
+
+	require.Equal(t, "alice", h.localUsernameForStoredActorCandidate(cfg.ActorURL("alice")))
+	require.Equal(t, "alice", h.localUsernameForStoredActorCandidate("alice@"+cfg.Domain))
+	require.Equal(t, "alice", h.localUsernameForStoredActorCandidate("alice"))
+	require.Empty(t, h.localUsernameForStoredActorCandidate("https://remote.example/users/alice"))
+	require.Empty(t, h.localUsernameForStoredActorCandidate("alice@remote.example"))
+	require.Empty(t, h.localUsernameForStoredActorCandidate("nested/path"))
+	require.Empty(t, h.localUsernameForStoredActorCandidate("https://"+cfg.Domain+"/actors/alice"))
+	require.Empty(t, (&Handler{}).localUsernameForStoredActorCandidate("alice"))
+}
+
 func TestHelpersRound18_ResponseDefaults(t *testing.T) {
 	h := &Handler{logger: round10TestLogger(t)}
 

--- a/cmd/api/handlers/statuses.go
+++ b/cmd/api/handlers/statuses.go
@@ -1013,9 +1013,11 @@ func (h *Handler) getStatusAncestors(ctx context.Context, root *storageMods.Stat
 
 	ancestors := make([]models.Status, 0, len(parents))
 	for i := len(parents) - 1; i >= 0; i-- {
-		actor := h.getActorForObject(ctx, parents[i])
-		status := transformations.ObjectToStatusAny(parents[i], actor, h.cfg.BaseURL())
-		ancestors = append(ancestors, status)
+		apiStatus, err := h.convertStorageStatusToAPIWithStoredAuthorContext(ctx, parents[i], viewerUsername)
+		if err != nil || apiStatus == nil {
+			continue
+		}
+		ancestors = append(ancestors, *apiStatus)
 	}
 
 	return ancestors
@@ -1107,6 +1109,11 @@ func (h *Handler) loadStatusWithActor(ctx context.Context, objectID string) *mod
 		return nil
 	}
 
+	apiStatus, convErr := h.convertStorageStatusToAPIWithStoredAuthorContext(ctx, obj, "")
+	if convErr == nil {
+		return apiStatus
+	}
+
 	actor := h.getActorForObject(ctx, obj)
 	status := transformations.ObjectToStatusAny(obj, actor, h.cfg.BaseURL())
 	return &status
@@ -1159,9 +1166,11 @@ func (h *Handler) getStatusDescendants(ctx context.Context, root *storageMods.St
 			continue
 		}
 
-		actor := h.getActorForObject(ctx, status)
-		apiStatus := transformations.ObjectToStatusAny(status, actor, h.cfg.BaseURL())
-		descendants = append(descendants, apiStatus)
+		apiStatus, convErr := h.convertStorageStatusToAPIWithStoredAuthorContext(ctx, status, viewerUsername)
+		if convErr != nil || apiStatus == nil {
+			continue
+		}
+		descendants = append(descendants, *apiStatus)
 	}
 
 	h.logger.Debug("fetched descendants for context",
@@ -1175,6 +1184,13 @@ func (h *Handler) getStatusDescendants(ctx context.Context, root *storageMods.St
 //
 //nolint:unused // Retained for future thread/context refactors.
 func (h *Handler) convertReplyToStatus(ctx context.Context, reply interface{}) *models.Status {
+	if status, ok := reply.(*storageMods.Status); ok {
+		apiStatus, err := h.convertStorageStatusToAPIWithStoredAuthorContext(ctx, status, "")
+		if err == nil {
+			return apiStatus
+		}
+	}
+
 	actor := h.getActorForObject(ctx, reply)
 	status := transformations.ObjectToStatusAny(reply, actor, h.cfg.BaseURL())
 	return &status

--- a/cmd/api/handlers/statuses.go
+++ b/cmd/api/handlers/statuses.go
@@ -1120,6 +1120,8 @@ func (h *Handler) loadStatusWithActor(ctx context.Context, objectID string) *mod
 }
 
 // getActorForObject retrieves the actor associated with an object
+//
+//nolint:unused // Retained for non-storage object fallbacks in thread/context helpers.
 func (h *Handler) getActorForObject(ctx context.Context, obj interface{}) *activitypub.Actor {
 	attributedTo := h.extractAttributedTo(obj)
 	if err := common.ValidateRequiredParam("attributed_to", attributedTo); err != nil {

--- a/cmd/api/handlers/statuses_round12_context_ancestors_test.go
+++ b/cmd/api/handlers/statuses_round12_context_ancestors_test.go
@@ -2,10 +2,13 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
+	apimodels "github.com/equaltoai/lesser/cmd/api/models"
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/services/notes"
@@ -76,4 +79,118 @@ func TestStatusesContextAncestors_Round12(t *testing.T) {
 	ctx.Params["id"] = "child"
 
 	requireStatus(t, http.StatusOK)(handler.HandleGetStatusContextLift(ctx))
+}
+
+func TestStatusesContextAncestors_Round34_HydratesRemoteAncestorFromCachedActor(t *testing.T) {
+	cfg := round11TestConfig()
+	now := time.Now().UTC()
+
+	remoteActor := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://remote.example/users/steward",
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: "steward",
+		Name:              "Steward Remote",
+		URL:               "https://remote.example/@steward",
+		Inbox:             "https://remote.example/users/steward/inbox",
+		Outbox:            "https://remote.example/users/steward/outbox",
+	}
+	cachedRemote := storagemodels.RemoteActor{
+		Handle:    "steward@remote.example",
+		Actor:     remoteActor,
+		CachedAt:  now,
+		UpdatedAt: now,
+		ExpiresAt: now.Add(time.Hour),
+	}
+	cachedRemote.UpdateKeys()
+
+	notesByID := map[string]*storagemodels.Status{
+		"child": {
+			StatusID:       "child",
+			AuthorUsername: "alice",
+			AuthorID:       cfg.ActorURL("alice"),
+			Content:        "child",
+			Visibility:     storagemodels.VisibilityPublic,
+			InReplyToID:    "remote-parent",
+			PublishedAt:    now,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+			Note: &activitypub.Note{
+				BaseObject: activitypub.BaseObject{
+					ID:        cfg.BaseURL() + "/users/alice/statuses/child",
+					Type:      activitypub.NoteType,
+					Published: &now,
+				},
+				AttributedTo: cfg.ActorURL("alice"),
+				Content:      "child",
+			},
+		},
+		"remote-parent": {
+			StatusID:       "remote-parent",
+			AuthorUsername: "steward@remote.example",
+			AuthorID:       remoteActor.ID,
+			Content:        "remote parent",
+			Visibility:     storagemodels.VisibilityPublic,
+			PublishedAt:    now,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+			URLs:           []string{"https://remote.example/users/steward/statuses/remote-parent"},
+			Note: &activitypub.Note{
+				BaseObject: activitypub.BaseObject{
+					ID:        "https://remote.example/users/steward/statuses/remote-parent",
+					Type:      activitypub.NoteType,
+					Published: &now,
+				},
+				AttributedTo: remoteActor.ID,
+				Content:      "remote parent",
+			},
+		},
+	}
+
+	notesSvc := &NotesServiceStub{
+		GetNoteFunc: func(_ context.Context, statusID string) (*storagemodels.Status, error) {
+			if note, ok := notesByID[statusID]; ok {
+				return note, nil
+			}
+			return nil, errors.New("not found")
+		},
+		GetNoteWithViewerFunc: func(_ context.Context, query *notes.GetNoteQuery) (*storagemodels.Status, error) {
+			if query == nil {
+				return nil, errors.New("missing query")
+			}
+			if note, ok := notesByID[query.StatusID]; ok {
+				return note, nil
+			}
+			return nil, errors.New("not found")
+		},
+		ListNotesFunc: func(context.Context, *notes.ListNotesQuery) (*notes.Result, error) {
+			return &notes.Result{}, nil
+		},
+	}
+
+	state := &round10QueryState{
+		remoteActorsByPK: map[string]storagemodels.RemoteActor{
+			cachedRemote.PK: cachedRemote,
+		},
+	}
+
+	handler, _, _ := round11NewHandler(t, cfg, state, makeRegistry(notesSvc, nil))
+
+	token := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{auth.ScopeRead})
+	headers := map[string]string{"Authorization": "Bearer " + token}
+	ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/child/context", headers, nil, nil)
+	require.NoError(t, err)
+	ctx.Params["id"] = "child"
+
+	resp := requireStatus(t, http.StatusOK)(handler.HandleGetStatusContextLift(ctx))
+
+	var body apimodels.StatusContext
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Len(t, body.Ancestors, 1)
+	require.Equal(t, remoteActor.ID, body.Ancestors[0].Account.ID)
+	require.Equal(t, "steward", body.Ancestors[0].Account.Username)
+	require.Equal(t, "steward@remote.example", body.Ancestors[0].Account.Acct)
+	require.Equal(t, "https://remote.example/users/steward/statuses/remote-parent", body.Ancestors[0].URI)
+	require.NotEmpty(t, body.Ancestors[0].Content)
 }

--- a/cmd/api/handlers/statuses_round19_unused_helpers_test.go
+++ b/cmd/api/handlers/statuses_round19_unused_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/storage"
@@ -95,6 +96,75 @@ func TestStatusesRound19_UnusedHelpers(t *testing.T) {
 			Content:      "hello",
 		})
 		require.NotNil(t, replyStatus)
+	})
+
+	t.Run("loadStatusWithActor and convertReplyToStatus use stored remote author seam", func(t *testing.T) {
+		now := time.Now().UTC()
+		remoteActor := &activitypub.Actor{
+			BaseObject: activitypub.BaseObject{
+				ID:   "https://remote.example/users/steward",
+				Type: activitypub.PersonType,
+			},
+			PreferredUsername: "steward",
+			Name:              "Steward Remote",
+			URL:               "https://remote.example/@steward",
+			Inbox:             "https://remote.example/users/steward/inbox",
+			Outbox:            "https://remote.example/users/steward/outbox",
+		}
+		cachedRemote := storagemodels.RemoteActor{
+			Handle:    "steward@remote.example",
+			Actor:     remoteActor,
+			CachedAt:  now,
+			UpdatedAt: now,
+			ExpiresAt: now.Add(time.Hour),
+		}
+		cachedRemote.UpdateKeys()
+
+		remoteStatus := &storagemodels.Status{
+			StatusID:       "remote-status",
+			AuthorUsername: "steward@remote.example",
+			AuthorID:       remoteActor.ID,
+			Content:        "remote content",
+			Visibility:     storagemodels.VisibilityPublic,
+			PublishedAt:    now,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+			Note: &activitypub.Note{
+				BaseObject: activitypub.BaseObject{
+					ID:        "https://remote.example/users/steward/statuses/remote-status",
+					Type:      activitypub.NoteType,
+					Published: &now,
+				},
+				AttributedTo: remoteActor.ID,
+				Content:      "remote content",
+			},
+		}
+
+		notesStub := &NotesServiceStub{
+			GetNoteFunc: func(_ context.Context, statusID string) (*storagemodels.Status, error) {
+				if statusID == remoteStatus.StatusID {
+					return remoteStatus, nil
+				}
+				return nil, errors.New("not found")
+			},
+		}
+
+		state := &round10QueryState{
+			remoteActorsByPK: map[string]storagemodels.RemoteActor{
+				cachedRemote.PK: cachedRemote,
+			},
+		}
+		h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{NotesSvc: notesStub})
+
+		loaded := h.loadStatusWithActor(context.Background(), remoteStatus.StatusID)
+		require.NotNil(t, loaded)
+		require.Equal(t, remoteActor.ID, loaded.Account.ID)
+		require.Equal(t, "steward@remote.example", loaded.Account.Acct)
+
+		replyStatus := h.convertReplyToStatus(context.Background(), remoteStatus)
+		require.NotNil(t, replyStatus)
+		require.Equal(t, remoteActor.ID, replyStatus.Account.ID)
+		require.Equal(t, "steward@remote.example", replyStatus.Account.Acct)
 	})
 
 	t.Run("extractInReplyTo and extractFromGenericMap cover common branches", func(t *testing.T) {

--- a/pkg/services/notes/service.go
+++ b/pkg/services/notes/service.go
@@ -321,6 +321,11 @@ func (s *Service) CreateNote(ctx context.Context, cmd *CreateNoteCommand) (*Note
 		return nil, err
 	}
 
+	replyParent, err := s.resolveCreateReplyParent(ctx, cmd)
+	if err != nil {
+		return nil, err
+	}
+
 	// Enforce "HTML-by-contract" invariants at write time. (Mastodon-compatible clients render `content` as HTML.)
 	sanitizedCmd := *cmd
 	sanitizedCmd.Content = strings.TrimSpace(htmlsafe.SanitizeHTMLByContract(cmd.Content))
@@ -337,8 +342,12 @@ func (s *Service) CreateNote(ctx context.Context, cmd *CreateNoteCommand) (*Note
 	// Generate unique status ID
 	statusID := uuid.New().String()
 
+	if replyParent != nil && strings.TrimSpace(sanitizedCmd.ConversationID) == "" {
+		sanitizedCmd.ConversationID = replyConversationID(&sanitizedCmd, replyParent)
+	}
+
 	// Create ActivityPub Note
-	note := s.buildActivityPubNote(&sanitizedCmd, statusID, author)
+	note := s.buildActivityPubNote(&sanitizedCmd, statusID, author, replyParent)
 
 	publishedAt := time.Now()
 	note.Published = &publishedAt
@@ -354,6 +363,7 @@ func (s *Service) CreateNote(ctx context.Context, cmd *CreateNoteCommand) (*Note
 		note.Tag = append(note.Tag, mentionTags...)
 		s.addMentionAudience(note, mentionTags)
 	}
+	s.addReplyAudience(note, replyParent)
 
 	// Attach media if provided
 	attachments, mediaIDsToMark, err := s.prepareMediaAttachments(ctx, author, sanitizedCmd.MediaIDs)
@@ -365,7 +375,12 @@ func (s *Service) CreateNote(ctx context.Context, cmd *CreateNoteCommand) (*Note
 	}
 
 	status := s.composeStatus(&sanitizedCmd, author, statusID, note, normalizedHashtags, attachments, publishedAt)
-	status.ConversationID = resolveConversationID(ctx, status, s.lookupParentStatus)
+	status.ConversationID = resolveConversationID(ctx, status, func(context.Context, string) (*models.Status, error) {
+		if replyParent == nil {
+			return nil, fmt.Errorf("reply parent unavailable")
+		}
+		return replyParent, nil
+	})
 
 	// Store the status
 	if err := s.noteRepo.CreateStatus(ctx, status); err != nil {
@@ -389,7 +404,7 @@ func (s *Service) CreateNote(ctx context.Context, cmd *CreateNoteCommand) (*Note
 
 	// Ensure AuthorUsername is populated before emitting events
 	s.ensureAuthorUsername(ctx, status)
-	s.notifyReply(ctx, status)
+	s.notifyReply(ctx, status, replyParent)
 	s.notifyMentions(ctx, status, mentionedUsers)
 
 	// Emit events and queue federation
@@ -480,6 +495,37 @@ func (s *Service) lookupParentStatus(ctx context.Context, statusID string) (*mod
 		return nil, fmt.Errorf("note repository unavailable")
 	}
 	return s.noteRepo.GetStatus(ctx, statusID)
+}
+
+func (s *Service) resolveCreateReplyParent(ctx context.Context, cmd *CreateNoteCommand) (*models.Status, error) {
+	if cmd == nil || strings.TrimSpace(cmd.InReplyToID) == "" {
+		return nil, nil
+	}
+
+	parent, err := s.lookupParentStatus(ctx, cmd.InReplyToID)
+	if err != nil || parent == nil {
+		return nil, ErrInvalidInReplyToID
+	}
+
+	return parent, nil
+}
+
+func replyConversationID(cmd *CreateNoteCommand, parent *models.Status) string {
+	if cmd == nil {
+		return ""
+	}
+
+	if conversationID := strings.TrimSpace(cmd.ConversationID); conversationID != "" {
+		return conversationID
+	}
+
+	if parent != nil {
+		if conversationID := strings.TrimSpace(parent.ConversationID); conversationID != "" {
+			return conversationID
+		}
+	}
+
+	return strings.TrimSpace(cmd.InReplyToID)
 }
 
 func (s *Service) markMediaAsUsed(ctx context.Context, statusID string, mediaIDs []string) {
@@ -1230,14 +1276,6 @@ func (s *Service) validateCreateCommand(ctx context.Context, cmd *CreateNoteComm
 		}
 	}
 
-	// Validate in_reply_to_id if provided
-	if cmd.InReplyToID != "" {
-		_, err := s.noteRepo.GetStatus(ctx, cmd.InReplyToID)
-		if err != nil {
-			return ErrInvalidInReplyToID
-		}
-	}
-
 	return nil
 }
 
@@ -1301,7 +1339,7 @@ func (s *Service) normalizeCreateAudience(cmd *CreateNoteCommand, author *storag
 	cmd.BccRecipients = bccRecipients
 }
 
-func (s *Service) buildActivityPubNote(cmd *CreateNoteCommand, statusID string, author *storage.Account) *activitypub.Note {
+func (s *Service) buildActivityPubNote(cmd *CreateNoteCommand, statusID string, author *storage.Account, replyParent *models.Status) *activitypub.Note {
 	now := time.Now()
 
 	note := &activitypub.Note{
@@ -1330,7 +1368,11 @@ func (s *Service) buildActivityPubNote(cmd *CreateNoteCommand, statusID string, 
 
 	// Set in reply to
 	if cmd.InReplyToID != "" {
-		note.InReplyTo = fmt.Sprintf("https://%s/users/%s/statuses/%s", s.domainName, author.User.Username, cmd.InReplyToID)
+		if parentObjectID := s.replyParentObjectID(replyParent); parentObjectID != "" {
+			note.InReplyTo = parentObjectID
+		} else {
+			note.InReplyTo = fmt.Sprintf("https://%s/users/%s/statuses/%s", s.domainName, author.User.Username, cmd.InReplyToID)
+		}
 	}
 
 	return note
@@ -1639,6 +1681,67 @@ func formatMentionTagName(username, domain, localDomain string) string {
 	return "@" + username + "@" + domain
 }
 
+func (s *Service) replyParentObjectID(parent *models.Status) string {
+	if parent == nil {
+		return ""
+	}
+
+	if parent.Note != nil {
+		if noteID := strings.TrimSpace(parent.Note.ID); noteID != "" {
+			return noteID
+		}
+	}
+
+	for _, value := range parent.URLs {
+		value = strings.TrimSpace(value)
+		if strings.HasPrefix(strings.ToLower(value), "http://") || strings.HasPrefix(strings.ToLower(value), "https://") {
+			return value
+		}
+	}
+
+	if statusID := strings.TrimSpace(parent.StatusID); strings.HasPrefix(strings.ToLower(statusID), "http://") || strings.HasPrefix(strings.ToLower(statusID), "https://") {
+		return statusID
+	}
+
+	if s.replyParentIsLocal(parent) {
+		return s.buildStatusURL(parent)
+	}
+
+	return ""
+}
+
+func (s *Service) replyParentActorID(parent *models.Status) string {
+	if parent == nil {
+		return ""
+	}
+
+	if actorID := strings.TrimSpace(parent.AuthorID); actorID != "" {
+		return actorID
+	}
+
+	if parent.Note != nil {
+		return strings.TrimSpace(parent.Note.AttributedTo)
+	}
+
+	return ""
+}
+
+func (s *Service) replyParentIsLocal(parent *models.Status) bool {
+	actorID := s.replyParentActorID(parent)
+	if actorID == "" {
+		return false
+	}
+
+	parsed, err := url.Parse(actorID)
+	if err != nil || parsed == nil {
+		return false
+	}
+
+	host := strings.TrimSpace(strings.ToLower(parsed.Hostname()))
+	localDomain := strings.TrimSpace(strings.ToLower(s.domainName))
+	return host != "" && localDomain != "" && host == localDomain
+}
+
 func (s *Service) addMentionAudience(note *activitypub.Note, mentionTags []activitypub.Tag) {
 	if note == nil || len(mentionTags) == 0 {
 		return
@@ -1654,6 +1757,24 @@ func (s *Service) addMentionAudience(note *activitypub.Note, mentionTags []activ
 		note.CC = appendUniqueAudience(note.CC, recipients...)
 	case models.VisibilityDirect:
 		note.To = appendUniqueAudience(note.To, recipients...)
+	}
+}
+
+func (s *Service) addReplyAudience(note *activitypub.Note, parent *models.Status) {
+	if note == nil || parent == nil || s.replyParentIsLocal(parent) {
+		return
+	}
+
+	recipient := s.replyParentActorID(parent)
+	if recipient == "" || recipient == strings.TrimSpace(note.AttributedTo) {
+		return
+	}
+
+	switch note.Visibility {
+	case models.VisibilityPublic, models.VisibilityUnlisted:
+		note.CC = appendUniqueAudience(note.CC, recipient)
+	case models.VisibilityPrivate:
+		note.BTo = appendUniqueAudience(note.BTo, recipient)
 	}
 }
 
@@ -3398,7 +3519,7 @@ func (s *Service) notifyBoost(ctx context.Context, status *models.Status, booste
 	}
 }
 
-func (s *Service) notifyReply(ctx context.Context, status *models.Status) {
+func (s *Service) notifyReply(ctx context.Context, status *models.Status, parent *models.Status) {
 	if s.notifications == nil || status == nil {
 		return
 	}
@@ -3408,8 +3529,10 @@ func (s *Service) notifyReply(ctx context.Context, status *models.Status) {
 		return
 	}
 
-	parent, err := s.lookupParentStatus(ctx, parentID)
-	if err != nil || parent == nil {
+	if parent == nil {
+		return
+	}
+	if !s.replyParentIsLocal(parent) {
 		return
 	}
 

--- a/pkg/services/notes/service_round12_coverage_test.go
+++ b/pkg/services/notes/service_round12_coverage_test.go
@@ -374,7 +374,7 @@ func TestService_buildActivityPubNote(t *testing.T) {
 		ToRecipients: []string{"https://www.w3.org/ns/activitystreams#Public"},
 	}
 
-	note := service.buildActivityPubNote(cmd, "status-1", author)
+	note := service.buildActivityPubNote(cmd, "status-1", author, nil)
 	if assert.NotNil(t, note) {
 		assert.Equal(t, "Note", note.Type)
 		assert.Equal(t, "https://example.com/users/alice/statuses/status-1", note.ID)

--- a/pkg/services/notes/service_round15_mainline_test.go
+++ b/pkg/services/notes/service_round15_mainline_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/common"
 	pkgerrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/services/notifications"
 	"github.com/equaltoai/lesser/pkg/storage"
@@ -351,6 +352,18 @@ func (r *fixedAccountRepo) GetAccount(context.Context, string) (*storage.Account
 		username = "fallback"
 	}
 	return &storage.Account{User: &storage.User{Username: username}}, nil
+}
+
+type delegatingStatusRepo struct {
+	interfaces.StatusRepository
+	getStatus func(context.Context, string) (*models.Status, error)
+}
+
+func (r *delegatingStatusRepo) GetStatus(ctx context.Context, statusID string) (*models.Status, error) {
+	if r != nil && r.getStatus != nil {
+		return r.getStatus(ctx, statusID)
+	}
+	return r.StatusRepository.GetStatus(ctx, statusID)
 }
 
 type stubAnalytics struct {
@@ -859,6 +872,203 @@ func TestService_round15_create_note_reply_creates_notification_for_parent_autho
 	assert.Equal(t, "alice", replyNotification.UserID)
 	assert.Equal(t, "bob", replyNotification.ActorID)
 	assert.Equal(t, created.Note.StatusID, replyNotification.TargetID)
+}
+
+func TestService_round15_create_note_reply_to_remote_parent_preserves_canonical_remote_identity(t *testing.T) {
+	t.Run("public reply derives remote parent recipient in cc", func(t *testing.T) {
+		service, _, federation, _, _ := newNotesServiceHarness(t)
+		originalRepo := service.noteRepo
+
+		remoteParent := &models.Status{
+			StatusID:       "remote-parent-public",
+			AuthorID:       "https://remote.example/users/steward",
+			AuthorUsername: "steward@remote.example",
+			ConversationID: "remote-conversation-public",
+			Visibility:     models.VisibilityPublic,
+			ToRecipients:   []string{activitypub.PublicAddress},
+			CcRecipients:   []string{"https://remote.example/users/steward/followers"},
+			PublishedAt:    time.Now().UTC(),
+			CreatedAt:      time.Now().UTC(),
+			UpdatedAt:      time.Now().UTC(),
+			ModifiedAt:     time.Now().UTC(),
+			Note: &activitypub.Note{
+				BaseObject: activitypub.BaseObject{
+					ID:   "https://remote.example/users/steward/statuses/remote-parent-public",
+					To:   []string{activitypub.PublicAddress},
+					CC:   []string{"https://remote.example/users/steward/followers"},
+					Type: activitypub.NoteType,
+				},
+				AttributedTo: "https://remote.example/users/steward",
+				Content:      "seed",
+				Visibility:   models.VisibilityPublic,
+			},
+		}
+
+		service.noteRepo = &delegatingStatusRepo{
+			StatusRepository: originalRepo,
+			getStatus: func(_ context.Context, statusID string) (*models.Status, error) {
+				if statusID == remoteParent.StatusID {
+					return remoteParent, nil
+				}
+				return originalRepo.GetStatus(context.Background(), statusID)
+			},
+		}
+
+		created, err := service.CreateNote(context.Background(), &CreateNoteCommand{
+			AuthorID:    "alice",
+			Content:     "reply without mention",
+			Visibility:  VisibilityPublic,
+			InReplyToID: remoteParent.StatusID,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, created)
+		require.NotNil(t, created.Note)
+		require.NotNil(t, created.Note.Note)
+		require.Len(t, federation.activities, 1)
+
+		expectedCC := []string{
+			"https://example.com/users/alice/followers",
+			remoteParent.AuthorID,
+		}
+
+		assert.Equal(t, remoteParent.Note.ID, created.Note.Note.InReplyTo)
+		assert.Equal(t, remoteParent.ConversationID, created.Note.ConversationID)
+		assert.Equal(t, remoteParent.ConversationID, created.Note.Note.ConversationID)
+		assert.Equal(t, []string{activitypub.PublicAddress}, created.Note.ToRecipients)
+		assert.Equal(t, expectedCC, created.Note.CcRecipients)
+		assert.Empty(t, created.Note.BtoRecipients)
+
+		assert.Equal(t, []string{activitypub.PublicAddress}, federation.activities[0].To)
+		assert.Equal(t, expectedCC, federation.activities[0].CC)
+		assert.Empty(t, federation.activities[0].BTo)
+
+		federatedNote, ok := federation.activities[0].Object.(*activitypub.Note)
+		require.True(t, ok)
+		assert.Equal(t, remoteParent.Note.ID, federatedNote.InReplyTo)
+		assert.Equal(t, remoteParent.ConversationID, federatedNote.ConversationID)
+		assert.Equal(t, expectedCC, federatedNote.CC)
+	})
+
+	t.Run("private reply derives remote parent recipient in bto", func(t *testing.T) {
+		service, _, federation, _, _ := newNotesServiceHarness(t)
+		originalRepo := service.noteRepo
+
+		remoteParent := &models.Status{
+			StatusID:       "remote-parent-private",
+			AuthorID:       "https://remote.example/users/steward",
+			AuthorUsername: "steward@remote.example",
+			ConversationID: "remote-conversation-private",
+			Visibility:     models.VisibilityPublic,
+			ToRecipients:   []string{activitypub.PublicAddress},
+			CcRecipients:   []string{"https://remote.example/users/steward/followers"},
+			PublishedAt:    time.Now().UTC(),
+			CreatedAt:      time.Now().UTC(),
+			UpdatedAt:      time.Now().UTC(),
+			ModifiedAt:     time.Now().UTC(),
+			Note: &activitypub.Note{
+				BaseObject: activitypub.BaseObject{
+					ID:   "https://remote.example/users/steward/statuses/remote-parent-private",
+					To:   []string{activitypub.PublicAddress},
+					CC:   []string{"https://remote.example/users/steward/followers"},
+					Type: activitypub.NoteType,
+				},
+				AttributedTo: "https://remote.example/users/steward",
+				Content:      "seed",
+				Visibility:   models.VisibilityPublic,
+			},
+		}
+
+		service.noteRepo = &delegatingStatusRepo{
+			StatusRepository: originalRepo,
+			getStatus: func(_ context.Context, statusID string) (*models.Status, error) {
+				if statusID == remoteParent.StatusID {
+					return remoteParent, nil
+				}
+				return originalRepo.GetStatus(context.Background(), statusID)
+			},
+		}
+
+		created, err := service.CreateNote(context.Background(), &CreateNoteCommand{
+			AuthorID:    "alice",
+			Content:     "private reply without mention",
+			Visibility:  models.VisibilityPrivate,
+			InReplyToID: remoteParent.StatusID,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, created)
+		require.NotNil(t, created.Note)
+		require.NotNil(t, created.Note.Note)
+		require.Len(t, federation.activities, 1)
+
+		expectedTo := []string{"https://example.com/users/alice/followers"}
+		expectedBTo := []string{remoteParent.AuthorID}
+
+		assert.Equal(t, remoteParent.Note.ID, created.Note.Note.InReplyTo)
+		assert.Equal(t, remoteParent.ConversationID, created.Note.ConversationID)
+		assert.Equal(t, remoteParent.ConversationID, created.Note.Note.ConversationID)
+		assert.Equal(t, expectedTo, created.Note.ToRecipients)
+		assert.Empty(t, created.Note.CcRecipients)
+		assert.Equal(t, expectedBTo, created.Note.BtoRecipients)
+
+		assert.Equal(t, expectedTo, federation.activities[0].To)
+		assert.Empty(t, federation.activities[0].CC)
+		assert.Equal(t, expectedBTo, federation.activities[0].BTo)
+
+		federatedNote, ok := federation.activities[0].Object.(*activitypub.Note)
+		require.True(t, ok)
+		assert.Equal(t, remoteParent.Note.ID, federatedNote.InReplyTo)
+		assert.Equal(t, remoteParent.ConversationID, federatedNote.ConversationID)
+		assert.Equal(t, expectedBTo, federatedNote.BTo)
+	})
+}
+
+func TestService_round15_create_note_reply_to_remote_parent_skips_local_notification(t *testing.T) {
+	service, _, _, notifier, _ := newNotesServiceHarness(t)
+	originalRepo := service.noteRepo
+
+	remoteParent := &models.Status{
+		StatusID:       "remote-parent-notify",
+		AuthorID:       "https://remote.example/users/steward",
+		AuthorUsername: "steward@remote.example",
+		ConversationID: "remote-conversation-notify",
+		Visibility:     models.VisibilityPublic,
+		PublishedAt:    time.Now().UTC(),
+		CreatedAt:      time.Now().UTC(),
+		UpdatedAt:      time.Now().UTC(),
+		ModifiedAt:     time.Now().UTC(),
+		Note: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:   "https://remote.example/users/steward/statuses/remote-parent-notify",
+				Type: activitypub.NoteType,
+			},
+			AttributedTo: "https://remote.example/users/steward",
+			Content:      "seed",
+			Visibility:   models.VisibilityPublic,
+		},
+	}
+
+	service.noteRepo = &delegatingStatusRepo{
+		StatusRepository: originalRepo,
+		getStatus: func(_ context.Context, statusID string) (*models.Status, error) {
+			if statusID == remoteParent.StatusID {
+				return remoteParent, nil
+			}
+			return originalRepo.GetStatus(context.Background(), statusID)
+		},
+	}
+
+	created, err := service.CreateNote(context.Background(), &CreateNoteCommand{
+		AuthorID:    "alice",
+		Content:     "reply without mention",
+		Visibility:  VisibilityPublic,
+		InReplyToID: remoteParent.StatusID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, created)
+
+	for _, cmd := range notifier.cmds {
+		require.NotEqual(t, common.NotificationTypeReply, cmd.Type)
+	}
 }
 
 func TestService_round15_create_note_derives_canonical_audience_defaults(t *testing.T) {


### PR DESCRIPTION
## Milestone
Project 20 remote reply integrity — repair remote note replies in `pkg/services/notes` and restore truthful remote ancestors in REST status context without turning hot reads into live federation lookups.

## Classification
federation-trust, contract-stability, operational-reliability, bug-fix, test-coverage

## Surfaces affected
- `pkg/services/notes/service.go`
- `cmd/api/handlers/helpers.go`
- `cmd/api/handlers/statuses.go`
- targeted notes-service regression tests
- targeted REST/status-context regression tests

## Specialist walks referenced
- Federation trust: completed via the remote reply write/delivery audit
- Contract / API: completed via `preserve-mastodon-api-compat`
- Schema: none
- Framework: idiomatic; no framework escalation needed

## Consumer impact
- operators validating cross-instance thread integrity
- remote ActivityPub peers receiving replies to remote parents
- Mastodon-compatible REST clients calling `/api/v1/statuses/:id/context`
- downstream `sim` public thread surfaces

## Tasks
- [x] repair remote reply write semantics so remote parents get canonical `inReplyTo` and recipient targeting without explicit mentions
- [x] keep REST status-context remote ancestor hydration storage/cache-only on hot reads
- [x] stop local reply notifications from targeting remote parent authors
- [x] restore cmd coverage margin after the new handlers seam landed

## Validation
- `go test ./...`
- `go vet ./...`
- `gofmt -l .` (empty)
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`
- Targeted:
  - `go test ./pkg/services/notes -count=1`
  - `go test ./cmd/api/handlers -count=1`
- `./lesser verify --smoke` blocked in local context: no `SMOKE_BASE_URL` / `SMOKE_USERNAME` / `SMOKE_OBJECT_ID` target was available in repo state

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
none

## Advisor-brief authorization (if applicable)
Arch brief from `arch@lessersoul.ai` received April 22, 2026 at 10:21 AM EDT, provenance verified, and explicitly authorized in-session by Aron/user before implementation.
