### PR TITLE
fix(federation): materialize unresolved remote reply parents

### DIFF
--- a/cmd/api/handlers/statuses.go
+++ b/cmd/api/handlers/statuses.go
@@ -77,6 +77,9 @@ func (h *Handler) HandleCreateStatusLift(ctx *apptheory.Context) (*apptheory.Res
 	result, err := h.registry.Notes().CreateNote(ctx.Context(), createCmd)
 	if err != nil {
 		h.logger.Error("failed to create note", zap.Error(err))
+		if appErr, ok := commonerrors.AsAppError(err); ok {
+			return common.RespondWithAppError(ctx, appErr)
+		}
 		return common.RespondInternalServerError(ctx, "failed to create status")
 	}
 
@@ -95,7 +98,7 @@ func (h *Handler) HandleCreateStatusLift(ctx *apptheory.Context) (*apptheory.Res
 		zap.String("id", result.Note.StatusID),
 		zap.String("content", req.Status))
 
-	h.recordAgentAuditEvent(ctx, claims, "agent.status.create", result.Note.StatusID, map[string]any{
+	auditMetadata := map[string]any{
 		"visibility":       req.Visibility,
 		"in_reply_to_id":   req.InReplyToID,
 		"has_media":        len(req.MediaIDs) > 0,
@@ -106,7 +109,9 @@ func (h *Handler) HandleCreateStatusLift(ctx *apptheory.Context) (*apptheory.Res
 		"sensitive":        req.Sensitive,
 		"scheduled":        req.ScheduledAt != nil,
 		"requested_scopes": strings.Join(claims.Scopes, " "),
-	})
+	}
+	appendReplyParentAuditMetadata(auditMetadata, result)
+	h.recordAgentAuditEvent(ctx, claims, "agent.status.create", result.Note.StatusID, auditMetadata)
 
 	return createdJSON(apiStatus)
 }
@@ -212,6 +217,21 @@ func buildStatusValidationParams(req *models.CreateStatusRequest) map[string]any
 	}
 
 	return statusParams
+}
+
+func appendReplyParentAuditMetadata(metadata map[string]any, result *notes.NoteResult) {
+	if metadata == nil || result == nil || result.ReplyParentAcquisition == nil {
+		return
+	}
+
+	parent := result.ReplyParentAcquisition
+	metadata["reply_parent"] = map[string]any{
+		"canonical_status_id":  parent.CanonicalStatusID,
+		"canonical_object_url": parent.CanonicalObjectURL,
+		"visibility":           parent.Visibility,
+		"fetched":              parent.Fetched,
+		"remote":               parent.Remote,
+	}
 }
 
 func (h *Handler) authenticateCreateStatus(ctx *apptheory.Context) (*auth.Claims, *apptheory.Response, error) {

--- a/cmd/api/handlers/statuses_round35_remote_reply_parent_test.go
+++ b/cmd/api/handlers/statuses_round35_remote_reply_parent_test.go
@@ -1,0 +1,156 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	apimodels "github.com/equaltoai/lesser/cmd/api/models"
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/auth"
+	commonerrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/services/notes"
+	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatusesRound35_HandleCreateStatusLift_AcceptsCanonicalRemoteReplyParentURL(t *testing.T) {
+	cfg := round10TestConfig()
+	now := time.Now().UTC()
+	replyParentURL := "https://remote.example/users/steward/statuses/seed-1"
+
+	var gotCmd *notes.CreateNoteCommand
+	h, _, _ := round11NewHandler(t, cfg, &round10QueryState{}, &RegistryStub{
+		NotesSvc: &NotesServiceStub{
+			CreateNoteFunc: func(_ context.Context, cmd *notes.CreateNoteCommand) (*notes.NoteResult, error) {
+				gotCmd = cmd
+				return &notes.NoteResult{
+					Note: &storagemodels.Status{
+						StatusID:       "status-1",
+						AuthorUsername: cmd.AuthorID,
+						AuthorID:       cfg.BaseURL() + "/users/" + cmd.AuthorID,
+						Visibility:     cmd.Visibility,
+						Sensitive:      cmd.Sensitive,
+						Language:       cmd.Language,
+						InReplyToID:    cmd.InReplyToID,
+						PublishedAt:    now,
+						CreatedAt:      now,
+						UpdatedAt:      now,
+						ModifiedAt:     now,
+						Version:        1,
+						Note: &activitypub.Note{
+							BaseObject: activitypub.BaseObject{
+								ID: cfg.BaseURL() + "/objects/status-1",
+							},
+							Content:      cmd.Content,
+							AttributedTo: cfg.BaseURL() + "/users/" + cmd.AuthorID,
+						},
+					},
+				}, nil
+			},
+		},
+	})
+
+	token := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{auth.ScopeRead, auth.ScopeWrite})
+	headers := map[string]string{"Authorization": "Bearer " + token}
+
+	ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses", headers, nil, apimodels.CreateStatusRequest{
+		Status:      "reply",
+		Visibility:  VisibilityPublic,
+		InReplyToID: replyParentURL,
+	})
+	require.NoError(t, err)
+
+	requireStatus(t, http.StatusCreated)(h.HandleCreateStatusLift(ctx))
+	require.NotNil(t, gotCmd)
+	require.Equal(t, replyParentURL, gotCmd.InReplyToID)
+}
+
+func TestStatusesRound35_HandleCreateStatusLift_RejectsInvalidRemoteReplyParentURL(t *testing.T) {
+	cfg := round10TestConfig()
+	called := false
+	h, _, _ := round11NewHandler(t, cfg, &round10QueryState{}, &RegistryStub{
+		NotesSvc: &NotesServiceStub{
+			CreateNoteFunc: func(context.Context, *notes.CreateNoteCommand) (*notes.NoteResult, error) {
+				called = true
+				return nil, nil
+			},
+		},
+	})
+
+	token := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{auth.ScopeRead, auth.ScopeWrite})
+	headers := map[string]string{"Authorization": "Bearer " + token}
+
+	ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses", headers, nil, apimodels.CreateStatusRequest{
+		Status:      "reply",
+		Visibility:  VisibilityPublic,
+		InReplyToID: "ftp://remote.example/statuses/seed-1",
+	})
+	require.NoError(t, err)
+
+	resp := requireStatus(t, http.StatusBadRequest)(h.HandleCreateStatusLift(ctx))
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Equal(t, "BAD_REQUEST", body["error_code"])
+	require.False(t, called)
+}
+
+func TestStatusesRound35_HandleCreateStatusLift_MapsReplyParentAppErrors(t *testing.T) {
+	cfg := round10TestConfig()
+	replyParentURL := "https://remote.example/users/steward/statuses/seed-1"
+
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "timeout surfaces 408",
+			err:        commonerrors.NewAppError(commonerrors.CodeTimeout, commonerrors.CategoryExternal, "Remote reply parent fetch timed out"),
+			wantStatus: http.StatusRequestTimeout,
+			wantCode:   string(commonerrors.CodeTimeout),
+		},
+		{
+			name:       "service unavailable surfaces 503",
+			err:        commonerrors.NewAppError(commonerrors.CodeExternalServiceUnavailable, commonerrors.CategoryExternal, "Remote reply parent is temporarily unavailable"),
+			wantStatus: http.StatusServiceUnavailable,
+			wantCode:   string(commonerrors.CodeExternalServiceUnavailable),
+		},
+		{
+			name:       "unprocessable parent surfaces 422",
+			err:        commonerrors.NewAppError(commonerrors.CodeUnprocessableEntity, commonerrors.CategoryValidation, "Remote reply parent is not usable"),
+			wantStatus: http.StatusUnprocessableEntity,
+			wantCode:   string(commonerrors.CodeUnprocessableEntity),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, _, _ := round11NewHandler(t, cfg, &round10QueryState{}, &RegistryStub{
+				NotesSvc: &NotesServiceStub{
+					CreateNoteFunc: func(context.Context, *notes.CreateNoteCommand) (*notes.NoteResult, error) {
+						return nil, tt.err
+					},
+				},
+			})
+
+			token := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{auth.ScopeRead, auth.ScopeWrite})
+			headers := map[string]string{"Authorization": "Bearer " + token}
+
+			ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses", headers, nil, apimodels.CreateStatusRequest{
+				Status:      "reply",
+				Visibility:  VisibilityPublic,
+				InReplyToID: replyParentURL,
+			})
+			require.NoError(t, err)
+
+			resp := requireStatus(t, tt.wantStatus)(h.HandleCreateStatusLift(ctx))
+			var body map[string]any
+			require.NoError(t, json.Unmarshal(resp.Body, &body))
+			require.Equal(t, tt.wantCode, body["error_code"])
+		})
+	}
+}

--- a/cmd/inbox/internal/routing/inbox.go
+++ b/cmd/inbox/internal/routing/inbox.go
@@ -2138,23 +2138,8 @@ func (ih *InboxHandler) buildCanonicalRemoteStatus(note *activitypub.Note) *mode
 }
 
 func (ih *InboxHandler) materializeRemoteNoteStatus(ctx context.Context, note *activitypub.Note) error {
-	if ih.statusRepository == nil {
-		return fmt.Errorf("status repository not configured")
-	}
-
-	status := ih.buildCanonicalRemoteStatus(note)
-	if status == nil {
-		return fmt.Errorf("canonical remote status payload is invalid")
-	}
-
-	if err := ih.statusRepository.CreateStatus(ctx, status); err != nil {
-		if dynamormerrors.IsConditionFailed(err) {
-			return nil
-		}
-		return err
-	}
-
-	return nil
+	_, err := federation.MaterializeRemoteNote(ctx, ih.objectRepository, ih.statusRepository, note, ih.baseURL)
+	return err
 }
 
 func (ih *InboxHandler) upsertRemoteNoteStatus(ctx context.Context, note *activitypub.Note) error {

--- a/cmd/lesser/verify_status_contract.go
+++ b/cmd/lesser/verify_status_contract.go
@@ -117,7 +117,7 @@ var (
 		return statusContractVerifierDeps{
 			accountWriter:           accountRepo,
 			userPreferenceWriter:    userRepo,
-			noteCreator:             notessvc.NewService(statusRepo, accountRepo, nil, nil, nil, nil, nil, conversationRepo, nil, nil, nil, userRepo, nil, noops, nil, nil, nil, logger, domain),
+			noteCreator:             notessvc.NewService(statusRepo, accountRepo, nil, nil, nil, nil, nil, conversationRepo, nil, nil, nil, userRepo, nil, noops, nil, nil, nil, nil, logger, domain),
 			conversationSender:      conversationsvc.NewService(conversationRepo, statusRepo, nil, accountRepo, nil, userRepo, nil, nil, noops, nil, logger, domain),
 			statusReader:            statusRepo,
 			conversationStateReader: conversationRepo,

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,6 +73,7 @@ internal/CI-only (except for building the `lesser` CLI itself).
 - CLI auth (device flow): `docs/cli/auth.md`
 - Configure: `docs/configuration.md`
 - Operate: `docs/monitoring.md`, `docs/security.md`, `docs/backup-recovery.md`, `docs/operations/runbook.md`
+- Release notes: `docs/operations/release-notes.md`
 - Release checklist: `docs/release-checklist.md`
 - Troubleshoot: `docs/troubleshooting.md`
 - Federation checks: `docs/federation.md`

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -206,6 +206,33 @@ curl -s \
   "https://<stage-domain>/api/v1/accounts/verify_credentials" | jq .
 ```
 
+### Pattern: reply to a remote status by canonical URL
+
+`POST /api/v1/statuses` accepts either a local status ID or a canonical remote status URL in `in_reply_to_id`.
+
+For canonical remote URLs, Lesser:
+
+- resolves locally first
+- performs request-scoped remote parent acquisition only if the parent is still unresolved
+- uses the resolved parent for reply threading, audience derivation, and delivery targeting
+
+This acquisition behavior is write-path only. It does **not** introduce live remote fetches on read paths such as
+timelines, thread context, or GraphQL public reads.
+
+Direct / DM replies remain conversations-owned and are out of scope for this Notes-service path.
+
+```bash
+curl -s -X POST "https://<stage-domain>/api/v1/statuses" \
+  -H "Authorization: Bearer <access_token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "status": "replying across instances",
+    "visibility": "public",
+    "sensitive": false,
+    "in_reply_to_id": "https://remote.example/users/steward/statuses/seed-1"
+  }' | jq .
+```
+
 ### Pattern: paginate list endpoints (Link header)
 
 Mastodon-compatible list endpoints return RFC 8288 `Link` headers.
@@ -233,6 +260,13 @@ Common responses:
 - `403 Forbidden`: locked instance or insufficient privilege
 - `422 Unprocessable Entity`: validation error (common on write endpoints)
 - `429 Too Many Requests`: rate limiting (see `X-RateLimit-*` headers)
+
+Create-status reply-parent acquisition can also return:
+
+- `400 Bad Request`: invalid `in_reply_to_id` shape or unsupported identifier form
+- `408 Request Timeout`: remote parent acquisition timed out
+- `422 Unprocessable Entity`: the remote parent resolved but cannot be used as a reply parent
+- `503 Service Unavailable`: remote parent acquisition could not reach a usable upstream
 
 ## GraphQL
 

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -2279,6 +2279,7 @@ components:
                         - $ref: '#/components/schemas/AgentPostAttribution'
                         - type: "null"
                 in_reply_to_id:
+                    description: Reply parent reference. Accepts a local status ID or a canonical remote status URL. Canonical remote URLs are resolved locally first and materialized on the create path when needed. Direct replies remain conversations-owned.
                     type: string
                 language:
                     type: string
@@ -2305,6 +2306,12 @@ components:
                 status:
                     type: string
                 visibility:
+                    description: Status visibility. `direct` messages must mention exactly one recipient using an @mention in the status content.
+                    enum:
+                        - public
+                        - unlisted
+                        - private
+                        - direct
                     type: string
             required:
                 - sensitive
@@ -8076,6 +8083,12 @@ components:
                         $ref: '#/components/schemas/Error'
         NotFound:
             description: Not Found
+            content:
+                application/json:
+                    schema:
+                        $ref: '#/components/schemas/Error'
+        RequestTimeout:
+            description: Request Timeout
             content:
                 application/json:
                     schema:
@@ -15289,6 +15302,7 @@ paths:
     /api/v1/statuses:
         post:
             operationId: post_api_v1_statuses
+            description: Create a status. `in_reply_to_id` accepts local status IDs and canonical remote status URLs. When a canonical remote URL is not yet materialized locally, Lesser performs request-scoped remote parent acquisition on the write path only. Direct replies continue through the conversations service.
             tags:
                 - statuses
             security:
@@ -15327,12 +15341,16 @@ paths:
                     $ref: '#/components/responses/Unauthorized'
                 "403":
                     $ref: '#/components/responses/Forbidden'
+                "408":
+                    $ref: '#/components/responses/RequestTimeout'
                 "422":
                     $ref: '#/components/responses/UnprocessableEntity'
                 "429":
                     $ref: '#/components/responses/TooManyRequests'
                 "500":
                     $ref: '#/components/responses/InternalServerError'
+                "503":
+                    $ref: '#/components/responses/ServiceUnavailable'
             x-lesser-handler: HandleCreateStatusLift
             x-lesser-lambda: api
             x-lesser-routeSources:

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -8,6 +8,7 @@ This directory contains the operator runbooks and workflows for deployed environ
 
 - Runbook: `docs/operations/runbook.md`
 - CloudWatch workflow: `docs/operations/cloudwatch-debugging.md`
+- Release notes: `docs/operations/release-notes.md`
 
 ## Common ops commands (CLI-first)
 

--- a/docs/operations/release-notes.md
+++ b/docs/operations/release-notes.md
@@ -1,0 +1,37 @@
+# Release Notes
+
+## Remote reply-parent acquisition on create-status
+
+`POST /api/v1/statuses` now accepts canonical remote status URLs in `in_reply_to_id` in addition to local status IDs.
+
+When a canonical remote reply parent is not yet materialized locally, Lesser now performs request-scoped remote parent
+acquisition on the create path. The resolved parent is reused for:
+
+- canonical `inReplyTo`
+- conversation inheritance
+- reply audience derivation
+- remote parent delivery targeting
+
+### Operator impact
+
+- Create-status requests that reply to unresolved remote parents can now incur synchronous upstream latency.
+- Followers-only/private remote parent acquisition uses authorized fetch in the local replying-actor context.
+- Read paths do **not** pick up new live remote fetch behavior from this change.
+
+### New create-status failure classes
+
+- `400 Bad Request` — invalid `in_reply_to_id` shape or unsupported identifier form
+- `408 Request Timeout` — remote parent acquisition timed out
+- `422 Unprocessable Entity` — the parent resolved but is not usable as a reply parent
+- `503 Service Unavailable` — remote parent acquisition could not reach a usable upstream
+
+### Monitoring focus
+
+- create-status latency for replies against unresolved remote parents
+- distribution of `400` / `408` / `422` / `503` responses on `POST /api/v1/statuses`
+- remote reply delivery success after parent acquisition
+- structured `remote reply parent acquisition` logs on the `api` Lambda
+
+### Explicit boundary
+
+Direct / DM reply integrity remains conversations-owned and is not changed by this Notes-service remediation.

--- a/pkg/common/validation_mastodon.go
+++ b/pkg/common/validation_mastodon.go
@@ -134,7 +134,7 @@ func validateStatusBasicFields(params map[string]interface{}) error {
 	// Validate in_reply_to_id
 	if replyToID, exists := params["in_reply_to_id"]; exists {
 		if replyStr, ok := replyToID.(string); ok && replyStr != "" {
-			if err := ValidateMastodonStatusID(replyStr); err != nil {
+			if err := ValidateMastodonStatusReference(replyStr); err != nil {
 				return err
 			}
 		}
@@ -566,6 +566,32 @@ func ValidateMastodonStatusID(statusID string) error {
 
 	if !MastodonStatusIDPattern.MatchString(statusID) {
 		return ValidationError{Field: "status_id", Message: "invalid format"}
+	}
+
+	return nil
+}
+
+// ValidateMastodonStatusReference validates create-status reply parent references.
+// It accepts traditional Mastodon status IDs plus canonical remote status URLs.
+func ValidateMastodonStatusReference(reference string) error {
+	reference = strings.TrimSpace(reference)
+	if reference == "" {
+		return ValidationError{Field: "in_reply_to_id", Message: "cannot be empty"}
+	}
+
+	if strings.HasPrefix(strings.ToLower(reference), "http://") || strings.HasPrefix(strings.ToLower(reference), "https://") {
+		if err := ValidateURL(reference, "in_reply_to_id"); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	if err := ValidateMastodonStatusID(reference); err != nil {
+		if validationErr, ok := err.(ValidationError); ok {
+			validationErr.Field = "in_reply_to_id"
+			return validationErr
+		}
+		return err
 	}
 
 	return nil

--- a/pkg/common/validation_mastodon_test.go
+++ b/pkg/common/validation_mastodon_test.go
@@ -67,6 +67,14 @@ func TestValidateStatusParams(t *testing.T) {
 			expectErr: false,
 		},
 		{
+			name: "valid status with canonical remote reply parent url",
+			params: map[string]interface{}{
+				"status":         "Great post!",
+				"in_reply_to_id": "https://remote.example/users/steward/statuses/seed-1",
+			},
+			expectErr: false,
+		},
+		{
 			name:      "missing content and media",
 			params:    map[string]interface{}{},
 			expectErr: true,
@@ -120,6 +128,15 @@ func TestValidateStatusParams(t *testing.T) {
 			},
 			expectErr: true,
 			errField:  "visibility",
+		},
+		{
+			name: "invalid reply parent url scheme",
+			params: map[string]interface{}{
+				"status":         "Hello",
+				"in_reply_to_id": "ftp://remote.example/statuses/seed-1",
+			},
+			expectErr: true,
+			errField:  "in_reply_to_id",
 		},
 		{
 			name: "valid private visibility",

--- a/pkg/federation/authorized_fetch.go
+++ b/pkg/federation/authorized_fetch.go
@@ -5,12 +5,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"net"
 	"net/http"
 	"time"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
+	pkgerrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/httpclient"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/core"
@@ -99,7 +102,7 @@ func (f *AuthorizedFetchService) FetchObject(ctx context.Context, objectURL stri
 	resp, err := f.httpClient.Do(req)
 	if err != nil {
 		f.logger.Error("failed to send request", zap.String("url", objectURL), zap.Error(err))
-		return nil, errors.Join(ErrHTTPRequestFailed, err)
+		return nil, errors.Join(classifyFetchRequestError(objectURL, err), ErrHTTPRequestFailed)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -108,7 +111,7 @@ func (f *AuthorizedFetchService) FetchObject(ctx context.Context, objectURL stri
 		f.logger.Error("object fetch failed with non-2xx status",
 			zap.String("url", objectURL),
 			zap.Int("status_code", resp.StatusCode))
-		return nil, ErrFetchObjectHTTPFailed
+		return nil, errors.Join(classifyFetchHTTPStatus(objectURL, resp.StatusCode), ErrFetchObjectHTTPFailed)
 	}
 
 	// Decode the response
@@ -125,6 +128,55 @@ func (f *AuthorizedFetchService) FetchObject(ctx context.Context, objectURL stri
 	}
 
 	return result, nil
+}
+
+func classifyFetchRequestError(objectURL string, err error) error {
+	if err == nil {
+		return pkgerrors.RemoteFetchFailed(objectURL, errors.New("remote fetch failed"))
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return pkgerrors.RemoteFetchTimeout(objectURL).WithInternalError(err)
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return pkgerrors.RemoteFetchTimeout(objectURL).WithInternalError(err)
+	}
+
+	return pkgerrors.NewAppError(pkgerrors.CodeExternalServiceUnavailable, pkgerrors.CategoryExternal, "Remote resource temporarily unavailable").
+		WithInternalError(err).
+		WithMetadata("url", objectURL).
+		AsRetryable()
+}
+
+func classifyFetchHTTPStatus(objectURL string, statusCode int) error {
+	switch statusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return pkgerrors.RemoteFetchUnauthorized(objectURL).WithMetadata("status_code", statusCode)
+	case http.StatusNotFound:
+		return pkgerrors.RemoteFetchNotFound(objectURL).WithMetadata("status_code", statusCode)
+	case http.StatusGone:
+		return pkgerrors.NewAppError(pkgerrors.CodeGone, pkgerrors.CategoryFederation, "Remote resource no longer available").
+			WithMetadata("url", objectURL).
+			WithMetadata("status_code", statusCode)
+	case http.StatusRequestTimeout, http.StatusGatewayTimeout:
+		return pkgerrors.RemoteFetchTimeout(objectURL).WithMetadata("status_code", statusCode)
+	case http.StatusTooManyRequests, http.StatusBadGateway, http.StatusServiceUnavailable:
+		return pkgerrors.NewAppError(pkgerrors.CodeExternalServiceUnavailable, pkgerrors.CategoryExternal, "Remote resource temporarily unavailable").
+			WithMetadata("url", objectURL).
+			WithMetadata("status_code", statusCode).
+			AsRetryable()
+	default:
+		if statusCode >= http.StatusInternalServerError {
+			return pkgerrors.NewAppError(pkgerrors.CodeExternalServiceUnavailable, pkgerrors.CategoryExternal, "Remote resource temporarily unavailable").
+				WithMetadata("url", objectURL).
+				WithMetadata("status_code", statusCode).
+				AsRetryable()
+		}
+		return pkgerrors.RemoteFetchFailed(objectURL, fmt.Errorf("unexpected http status %d", statusCode)).
+			WithMetadata("status_code", statusCode)
+	}
 }
 
 // FetchActor fetches an ActivityPub actor with authorization

--- a/pkg/federation/authorized_fetch_error_classification_test.go
+++ b/pkg/federation/authorized_fetch_error_classification_test.go
@@ -1,0 +1,75 @@
+package federation
+
+import (
+	"context"
+	stdErrors "errors"
+	"net/http"
+	"testing"
+
+	pkgerrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type timeoutNetError struct{}
+
+func (timeoutNetError) Error() string   { return "i/o timeout" }
+func (timeoutNetError) Timeout() bool   { return true }
+func (timeoutNetError) Temporary() bool { return true }
+
+func TestClassifyFetchRequestError(t *testing.T) {
+	t.Run("nil error becomes remote fetch failed", func(t *testing.T) {
+		appErr, ok := pkgerrors.AsAppError(classifyFetchRequestError("https://remote.example/objects/1", nil))
+		require.True(t, ok)
+		assert.Equal(t, pkgerrors.CodeRemoteFetchFailed, appErr.Code)
+	})
+
+	t.Run("context deadline becomes timeout", func(t *testing.T) {
+		appErr, ok := pkgerrors.AsAppError(classifyFetchRequestError("https://remote.example/objects/1", context.DeadlineExceeded))
+		require.True(t, ok)
+		assert.Equal(t, pkgerrors.CodeTimeout, appErr.Code)
+	})
+
+	t.Run("net timeout becomes timeout", func(t *testing.T) {
+		appErr, ok := pkgerrors.AsAppError(classifyFetchRequestError("https://remote.example/objects/1", timeoutNetError{}))
+		require.True(t, ok)
+		assert.Equal(t, pkgerrors.CodeTimeout, appErr.Code)
+	})
+
+	t.Run("generic network failure becomes external service unavailable", func(t *testing.T) {
+		appErr, ok := pkgerrors.AsAppError(classifyFetchRequestError("https://remote.example/objects/1", stdErrors.New("dial tcp failure")))
+		require.True(t, ok)
+		assert.Equal(t, pkgerrors.CodeExternalServiceUnavailable, appErr.Code)
+		assert.True(t, appErr.Retryable)
+	})
+}
+
+func TestClassifyFetchHTTPStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantCode   pkgerrors.ErrorCode
+		wantRetry  bool
+	}{
+		{name: "unauthorized", statusCode: http.StatusUnauthorized, wantCode: pkgerrors.CodeUnauthorized},
+		{name: "forbidden", statusCode: http.StatusForbidden, wantCode: pkgerrors.CodeUnauthorized},
+		{name: "not found", statusCode: http.StatusNotFound, wantCode: pkgerrors.CodeNotFound},
+		{name: "gone", statusCode: http.StatusGone, wantCode: pkgerrors.CodeGone},
+		{name: "request timeout", statusCode: http.StatusRequestTimeout, wantCode: pkgerrors.CodeTimeout, wantRetry: true},
+		{name: "gateway timeout", statusCode: http.StatusGatewayTimeout, wantCode: pkgerrors.CodeTimeout, wantRetry: true},
+		{name: "rate limited", statusCode: http.StatusTooManyRequests, wantCode: pkgerrors.CodeExternalServiceUnavailable, wantRetry: true},
+		{name: "bad gateway", statusCode: http.StatusBadGateway, wantCode: pkgerrors.CodeExternalServiceUnavailable, wantRetry: true},
+		{name: "service unavailable", statusCode: http.StatusServiceUnavailable, wantCode: pkgerrors.CodeExternalServiceUnavailable, wantRetry: true},
+		{name: "server error fallback", statusCode: http.StatusInternalServerError, wantCode: pkgerrors.CodeExternalServiceUnavailable, wantRetry: true},
+		{name: "unexpected status", statusCode: http.StatusTeapot, wantCode: pkgerrors.CodeRemoteFetchFailed, wantRetry: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			appErr, ok := pkgerrors.AsAppError(classifyFetchHTTPStatus("https://remote.example/objects/1", tt.statusCode))
+			require.True(t, ok)
+			assert.Equal(t, tt.wantCode, appErr.Code)
+			assert.Equal(t, tt.wantRetry, appErr.Retryable)
+		})
+	}
+}

--- a/pkg/federation/remote_note_materialization.go
+++ b/pkg/federation/remote_note_materialization.go
@@ -1,0 +1,65 @@
+package federation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	dynamormerrors "github.com/theory-cloud/tabletheory/pkg/errors"
+)
+
+type remoteNoteObjectRepository interface {
+	CreateObject(ctx context.Context, object any) error
+}
+
+type remoteNoteStatusRepository interface {
+	CreateStatus(ctx context.Context, status *models.Status) error
+	GetStatus(ctx context.Context, statusID string) (*models.Status, error)
+}
+
+// MaterializeRemoteNote stores a remote Note object and projects it into the
+// canonical Status row used by product-facing read and reply paths.
+func MaterializeRemoteNote(
+	ctx context.Context,
+	objectRepo remoteNoteObjectRepository,
+	statusRepo remoteNoteStatusRepository,
+	note *activitypub.Note,
+	localDomain string,
+) (*models.Status, error) {
+	if statusRepo == nil {
+		return nil, fmt.Errorf("status repository not configured")
+	}
+
+	if note == nil {
+		return nil, fmt.Errorf("remote note is required")
+	}
+
+	if objectRepo != nil {
+		if err := objectRepo.CreateObject(ctx, note); err != nil && !dynamormerrors.IsConditionFailed(err) {
+			return nil, err
+		}
+	}
+
+	status := BuildCanonicalRemoteStatus(note, localDomain)
+	if status == nil {
+		return nil, fmt.Errorf("canonical remote status payload is invalid")
+	}
+	if err := status.UpdateKeys(); err != nil {
+		return nil, err
+	}
+
+	if err := statusRepo.CreateStatus(ctx, status); err != nil {
+		if !dynamormerrors.IsConditionFailed(err) {
+			return nil, err
+		}
+
+		existing, getErr := statusRepo.GetStatus(ctx, status.StatusID)
+		if getErr != nil {
+			return nil, getErr
+		}
+		return existing, nil
+	}
+
+	return status, nil
+}

--- a/pkg/federation/remote_note_materialization_test.go
+++ b/pkg/federation/remote_note_materialization_test.go
@@ -1,0 +1,145 @@
+package federation
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	dynamormerrors "github.com/theory-cloud/tabletheory/pkg/errors"
+)
+
+type stubRemoteNoteObjectRepo struct {
+	created   []any
+	createErr error
+}
+
+func (s *stubRemoteNoteObjectRepo) CreateObject(_ context.Context, object any) error {
+	if s.createErr != nil {
+		return s.createErr
+	}
+	s.created = append(s.created, object)
+	return nil
+}
+
+type stubRemoteNoteStatusRepo struct {
+	created   []*models.Status
+	createErr error
+	existing  *models.Status
+	getErr    error
+}
+
+func (s *stubRemoteNoteStatusRepo) CreateStatus(_ context.Context, status *models.Status) error {
+	if s.createErr != nil {
+		return s.createErr
+	}
+	s.created = append(s.created, status)
+	return nil
+}
+
+func (s *stubRemoteNoteStatusRepo) GetStatus(_ context.Context, statusID string) (*models.Status, error) {
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	if s.existing != nil && s.existing.StatusID == statusID {
+		return s.existing, nil
+	}
+	return nil, storage.ErrNotFound
+}
+
+func TestMaterializeRemoteNote(t *testing.T) {
+	ctx := context.Background()
+	note := &activitypub.Note{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://remote.example/users/steward/statuses/seed-1",
+			Type: activitypub.NoteType,
+			To:   []string{activitypub.PublicAddress},
+			CC:   []string{"https://remote.example/users/steward/followers"},
+		},
+		AttributedTo: "https://remote.example/users/steward",
+		Content:      "seed",
+		Visibility:   models.VisibilityPublic,
+	}
+
+	t.Run("requires status repository", func(t *testing.T) {
+		status, err := MaterializeRemoteNote(ctx, nil, nil, note, "example.com")
+		require.Error(t, err)
+		assert.Nil(t, status)
+		assert.ErrorContains(t, err, "status repository not configured")
+	})
+
+	t.Run("requires note", func(t *testing.T) {
+		status, err := MaterializeRemoteNote(ctx, nil, &stubRemoteNoteStatusRepo{}, nil, "example.com")
+		require.Error(t, err)
+		assert.Nil(t, status)
+		assert.ErrorContains(t, err, "remote note is required")
+	})
+
+	t.Run("ignores object condition-failed when projecting remote note", func(t *testing.T) {
+		objectRepo := &stubRemoteNoteObjectRepo{createErr: dynamormerrors.ErrConditionFailed}
+		statusRepo := &stubRemoteNoteStatusRepo{}
+
+		status, err := MaterializeRemoteNote(ctx, objectRepo, statusRepo, note, "example.com")
+		require.NoError(t, err)
+		require.NotNil(t, status)
+		require.Len(t, statusRepo.created, 1)
+		assert.Equal(t, models.CanonicalStatusIDForDomain(note.ID, "example.com"), status.StatusID)
+		assert.Equal(t, note.ID, status.Note.ID)
+		assert.Equal(t, models.VisibilityPublic, status.Visibility)
+		assert.Equal(t, "steward@remote.example", status.AuthorUsername)
+	})
+
+	t.Run("returns object storage errors that are not condition-failed", func(t *testing.T) {
+		status, err := MaterializeRemoteNote(ctx, &stubRemoteNoteObjectRepo{createErr: errors.New("object write failed")}, &stubRemoteNoteStatusRepo{}, note, "example.com")
+		require.Error(t, err)
+		assert.Nil(t, status)
+		assert.ErrorContains(t, err, "object write failed")
+	})
+
+	t.Run("returns existing status when create is condition-failed", func(t *testing.T) {
+		existing := BuildCanonicalRemoteStatus(note, "example.com")
+		require.NotNil(t, existing)
+		require.NoError(t, existing.UpdateKeys())
+
+		statusRepo := &stubRemoteNoteStatusRepo{
+			createErr: dynamormerrors.ErrConditionFailed,
+			existing:  existing,
+		}
+
+		status, err := MaterializeRemoteNote(ctx, nil, statusRepo, note, "example.com")
+		require.NoError(t, err)
+		assert.Same(t, existing, status)
+	})
+
+	t.Run("returns lookup error when existing status cannot be loaded", func(t *testing.T) {
+		statusRepo := &stubRemoteNoteStatusRepo{
+			createErr: dynamormerrors.ErrConditionFailed,
+			getErr:    errors.New("load failed"),
+		}
+
+		status, err := MaterializeRemoteNote(ctx, nil, statusRepo, note, "example.com")
+		require.Error(t, err)
+		assert.Nil(t, status)
+		assert.ErrorContains(t, err, "load failed")
+	})
+
+	t.Run("returns status create errors that are not condition-failed", func(t *testing.T) {
+		status, err := MaterializeRemoteNote(ctx, nil, &stubRemoteNoteStatusRepo{createErr: errors.New("status write failed")}, note, "example.com")
+		require.Error(t, err)
+		assert.Nil(t, status)
+		assert.ErrorContains(t, err, "status write failed")
+	})
+
+	t.Run("rejects remote notes that cannot project to a canonical status", func(t *testing.T) {
+		status, err := MaterializeRemoteNote(ctx, nil, &stubRemoteNoteStatusRepo{}, &activitypub.Note{
+			BaseObject: activitypub.BaseObject{Type: activitypub.NoteType},
+		}, "example.com")
+		require.Error(t, err)
+		assert.Nil(t, status)
+		assert.ErrorContains(t, err, "canonical remote status payload is invalid")
+	})
+}

--- a/pkg/federation/remotenotes/reply_parent_resolver.go
+++ b/pkg/federation/remotenotes/reply_parent_resolver.go
@@ -1,0 +1,506 @@
+// Package remotenotes resolves and materializes remote note parents for
+// request-scoped write-path flows such as create-status reply creation.
+package remotenotes
+
+import (
+	"context"
+	"encoding/json"
+	stdErrors "errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/common"
+	commonerrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/federation"
+	"github.com/equaltoai/lesser/pkg/services/notes"
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"go.uber.org/zap"
+)
+
+// AuthorizedFetcher fetches a remote ActivityPub object in the local
+// replying-actor context when protected parent acquisition is required.
+type AuthorizedFetcher interface {
+	FetchObject(ctx context.Context, objectURL string, signingActor *activitypub.Actor) (any, error)
+}
+
+type statusRepository interface {
+	GetStatus(ctx context.Context, statusID string) (*models.Status, error)
+	GetStatusByURL(ctx context.Context, url string) (*models.Status, error)
+	CreateStatus(ctx context.Context, status *models.Status) error
+}
+
+type objectRepository interface {
+	CreateObject(ctx context.Context, object any) error
+}
+
+type domainBlockRepository interface {
+	IsDomainBlocked(ctx context.Context, domain string) (bool, *storage.InstanceDomainBlock, error)
+}
+
+// Resolver resolves reply parents locally first and materializes unresolved
+// canonical remote URLs on the create-status write path.
+type Resolver struct {
+	statusRepo      statusRepository
+	objectRepo      objectRepository
+	domainBlockRepo domainBlockRepository
+	fetcher         AuthorizedFetcher
+	localDomain     string
+	logger          *zap.Logger
+}
+
+var _ notes.ReplyParentResolver = (*Resolver)(nil)
+
+// NewReplyParentResolver constructs a create-status reply-parent resolver over
+// storage-first lookup plus optional authorized remote acquisition.
+func NewReplyParentResolver(
+	statusRepo statusRepository,
+	objectRepo objectRepository,
+	domainBlockRepo domainBlockRepository,
+	fetcher AuthorizedFetcher,
+	localDomain string,
+	logger *zap.Logger,
+) *Resolver {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	return &Resolver{
+		statusRepo:      statusRepo,
+		objectRepo:      objectRepo,
+		domainBlockRepo: domainBlockRepo,
+		fetcher:         fetcher,
+		localDomain:     strings.TrimSpace(localDomain),
+		logger:          logger,
+	}
+}
+
+// ResolveReplyParent resolves a reply parent for a single create-note request,
+// materializing a canonical remote parent when it is not yet stored locally.
+func (r *Resolver) ResolveReplyParent(
+	ctx context.Context,
+	author *storage.Account,
+	rawInReplyTo string,
+	requestedVisibility string,
+) (*notes.ResolvedReplyParent, error) {
+	rawInReplyTo = strings.TrimSpace(rawInReplyTo)
+	if rawInReplyTo == "" {
+		return nil, nil
+	}
+
+	if status, err := r.resolveStoredParent(ctx, rawInReplyTo); err == nil && status != nil {
+		if err := validateReplyParentVisibility(status, requestedVisibility); err != nil {
+			r.logOutcome("visibility_rejected", rawInReplyTo, status, false, err)
+			return nil, err
+		}
+		r.logOutcome("stored", rawInReplyTo, status, false, nil)
+		return replyParentResultFromStatus(status, false, r.localDomain), nil
+	} else if err != nil && !statusLookupNotFound(err) {
+		return nil, err
+	}
+
+	if !isReplyParentURL(rawInReplyTo) {
+		return nil, unusableReplyParent(rawInReplyTo, "reply parent is not materialized locally")
+	}
+
+	parentURL, err := normalizeReplyParentURL(rawInReplyTo)
+	if err != nil {
+		return nil, invalidReplyParentReference(rawInReplyTo, err)
+	}
+
+	if requestedVisibility == models.VisibilityDirect {
+		return nil, unusableReplyParent(parentURL, "direct replies are handled by conversations")
+	}
+
+	if err := r.ensureFetchAllowed(ctx, parentURL); err != nil {
+		return nil, err
+	}
+
+	signingActor, err := replyParentSigningActor(author, r.localDomain)
+	if err != nil {
+		return nil, err
+	}
+
+	obj, err := r.fetcher.FetchObject(ctx, parentURL, signingActor)
+	if err != nil {
+		mappedErr := mapReplyParentFetchError(parentURL, err)
+		r.logOutcome("fetch_failed", rawInReplyTo, nil, true, mappedErr)
+		return nil, mappedErr
+	}
+
+	note, err := fetchedReplyParentNote(obj)
+	if err != nil {
+		unusableErr := unusableReplyParent(parentURL, err.Error())
+		r.logOutcome("unusable", rawInReplyTo, nil, true, unusableErr)
+		return nil, unusableErr
+	}
+
+	status, err := federation.MaterializeRemoteNote(ctx, r.objectRepo, r.statusRepo, note, r.localDomain)
+	if err != nil {
+		mappedErr := materializeReplyParentFailure(parentURL, err)
+		r.logOutcome("materialize_failed", rawInReplyTo, nil, true, mappedErr)
+		return nil, mappedErr
+	}
+
+	if err := validateReplyParentVisibility(status, requestedVisibility); err != nil {
+		r.logOutcome("visibility_rejected", rawInReplyTo, status, true, err)
+		return nil, err
+	}
+
+	r.logOutcome("materialized", rawInReplyTo, status, true, nil)
+	return replyParentResultFromStatus(status, true, r.localDomain), nil
+}
+
+func (r *Resolver) resolveStoredParent(ctx context.Context, raw string) (*models.Status, error) {
+	if r.statusRepo == nil {
+		return nil, notes.ErrStatusRepositoryUnavailable
+	}
+
+	if isReplyParentURL(raw) {
+		status, err := r.statusRepo.GetStatusByURL(ctx, raw)
+		if err == nil && status != nil {
+			return status, nil
+		}
+		if err != nil && !statusLookupNotFound(err) {
+			return nil, err
+		}
+	}
+
+	var lastErr error
+	for _, candidate := range models.StatusLookupCandidatesForDomain(raw, r.localDomain) {
+		status, err := r.statusRepo.GetStatus(ctx, candidate)
+		if err == nil && status != nil {
+			return status, nil
+		}
+		if err != nil && !statusLookupNotFound(err) {
+			return nil, err
+		}
+		if err != nil {
+			lastErr = err
+		}
+	}
+
+	if lastErr == nil {
+		lastErr = storage.ErrNotFound
+	}
+	return nil, lastErr
+}
+
+func (r *Resolver) ensureFetchAllowed(ctx context.Context, parentURL string) error {
+	if r.fetcher == nil {
+		return serviceUnavailableReplyParent(parentURL, stdErrors.New("remote reply parent fetch unavailable"))
+	}
+
+	domain := replyParentDomain(parentURL)
+	if domain == "" || r.domainBlockRepo == nil {
+		return nil
+	}
+
+	blocked, _, err := r.domainBlockRepo.IsDomainBlocked(ctx, domain)
+	if err != nil {
+		return serviceUnavailableReplyParent(parentURL, err)
+	}
+	if blocked {
+		return unusableReplyParent(parentURL, fmt.Sprintf("reply parent domain %s is blocked", domain))
+	}
+
+	return nil
+}
+
+func replyParentSigningActor(author *storage.Account, localDomain string) (*activitypub.Actor, error) {
+	if author == nil || author.User == nil || strings.TrimSpace(author.User.Username) == "" {
+		return nil, serviceUnavailableReplyParent("", stdErrors.New("reply author identity unavailable"))
+	}
+
+	if author.Actor != nil && strings.TrimSpace(author.Actor.ID) != "" {
+		if author.Actor.PublicKey == nil {
+			authorCopy := *author.Actor
+			authorCopy.PublicKey = &activitypub.PublicKey{
+				ID:    strings.TrimRight(authorCopy.ID, "/") + "#main-key",
+				Owner: authorCopy.ID,
+			}
+			return &authorCopy, nil
+		}
+		return author.Actor, nil
+	}
+
+	if localDomain == "" {
+		return nil, serviceUnavailableReplyParent("", stdErrors.New("reply author actor unavailable"))
+	}
+
+	actorID := fmt.Sprintf("https://%s/users/%s", localDomain, author.User.Username)
+	return &activitypub.Actor{
+		BaseObject:        activitypub.BaseObject{ID: actorID},
+		PreferredUsername: author.User.Username,
+		PublicKey: &activitypub.PublicKey{
+			ID:    actorID + "#main-key",
+			Owner: actorID,
+		},
+	}, nil
+}
+
+func normalizeReplyParentURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", stdErrors.New("reply parent reference is empty")
+	}
+	if !isReplyParentURL(raw) {
+		return "", stdErrors.New("reply parent reference must be a canonical remote status URL")
+	}
+
+	if err := common.ValidateURL(raw, "in_reply_to_id"); err != nil {
+		return "", err
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed == nil || parsed.Host == "" {
+		return "", stdErrors.New("reply parent URL is invalid")
+	}
+	parsed.Fragment = ""
+	return parsed.String(), nil
+}
+
+func fetchedReplyParentNote(obj any) (*activitypub.Note, error) {
+	objMap, ok := obj.(map[string]any)
+	if !ok {
+		return nil, stdErrors.New("fetched parent object is not a valid ActivityPub object")
+	}
+
+	common.SanitizeActivityPubObjectDefault(objMap)
+
+	if noteType, _ := objMap["type"].(string); strings.TrimSpace(noteType) != activitypub.NoteType {
+		return nil, stdErrors.New("fetched parent object is not a Note")
+	}
+
+	if err := common.ValidateActivityPubNote(objMap); err != nil {
+		return nil, err
+	}
+
+	raw, err := json.Marshal(objMap)
+	if err != nil {
+		return nil, err
+	}
+
+	var note activitypub.Note
+	if err := common.ParseActivityPubObject(raw, &note); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(note.ID) == "" {
+		return nil, stdErrors.New("fetched parent note is empty")
+	}
+
+	return &note, nil
+}
+
+func validateReplyParentVisibility(status *models.Status, requestedVisibility string) error {
+	if status == nil {
+		return unusableReplyParent("", "reply parent is unavailable")
+	}
+
+	parentRank, parentOK := replyVisibilityRank(status.Visibility)
+	requestedRank, requestedOK := replyVisibilityRank(requestedVisibility)
+	if !parentOK || !requestedOK {
+		return unusableReplyParent(status.StatusID, "reply visibility is unsupported")
+	}
+
+	if requestedRank < parentRank {
+		return unusableReplyParent(status.StatusID, "reply visibility cannot broaden beyond the parent")
+	}
+
+	return nil
+}
+
+func replyVisibilityRank(visibility string) (int, bool) {
+	switch strings.TrimSpace(visibility) {
+	case models.VisibilityPublic:
+		return 0, true
+	case models.VisibilityUnlisted:
+		return 1, true
+	case models.VisibilityPrivate:
+		return 2, true
+	case models.VisibilityDirect:
+		return 3, true
+	default:
+		return 0, false
+	}
+}
+
+func replyParentResultFromStatus(status *models.Status, fetched bool, localDomain string) *notes.ResolvedReplyParent {
+	if status == nil {
+		return nil
+	}
+
+	objectURL := strings.TrimSpace(replyParentObjectURL(status, localDomain))
+	return &notes.ResolvedReplyParent{
+		Status:             status,
+		CanonicalObjectURL: objectURL,
+		CanonicalStatusID:  strings.TrimSpace(status.StatusID),
+		Fetched:            fetched,
+		Remote:             replyParentLooksRemote(status, objectURL, localDomain),
+		Visibility:         strings.TrimSpace(status.Visibility),
+	}
+}
+
+func replyParentObjectURL(status *models.Status, localDomain string) string {
+	if status == nil {
+		return ""
+	}
+	if status.Note != nil && strings.TrimSpace(status.Note.ID) != "" {
+		return strings.TrimSpace(status.Note.ID)
+	}
+	for _, raw := range status.URLs {
+		if isReplyParentURL(raw) {
+			return strings.TrimSpace(raw)
+		}
+	}
+	if isReplyParentURL(status.StatusID) {
+		return strings.TrimSpace(status.StatusID)
+	}
+	if strings.TrimSpace(localDomain) == "" || strings.TrimSpace(status.AuthorUsername) == "" || strings.TrimSpace(status.StatusID) == "" {
+		return ""
+	}
+	return fmt.Sprintf("https://%s/users/%s/statuses/%s", localDomain, status.AuthorUsername, status.StatusID)
+}
+
+func replyParentLooksRemote(status *models.Status, objectURL, localDomain string) bool {
+	if status == nil {
+		return false
+	}
+	if models.IsCanonicalRemoteStatusID(status.StatusID) {
+		return true
+	}
+	if actorID := strings.TrimSpace(status.AuthorID); actorID != "" {
+		if parsed, err := url.Parse(actorID); err == nil && parsed != nil {
+			host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+			return host != "" && !strings.EqualFold(host, localDomain)
+		}
+	}
+	if parsed, err := url.Parse(objectURL); err == nil && parsed != nil {
+		host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+		return host != "" && !strings.EqualFold(host, localDomain)
+	}
+	return false
+}
+
+func isReplyParentURL(raw string) bool {
+	raw = strings.ToLower(strings.TrimSpace(raw))
+	return strings.HasPrefix(raw, "http://") || strings.HasPrefix(raw, "https://")
+}
+
+func replyParentDomain(raw string) string {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed == nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+}
+
+func mapReplyParentFetchError(parentURL string, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if stdErrors.Is(err, context.DeadlineExceeded) {
+		return timeoutReplyParent(parentURL, err)
+	}
+
+	var netErr net.Error
+	if stdErrors.As(err, &netErr) && netErr.Timeout() {
+		return timeoutReplyParent(parentURL, err)
+	}
+
+	if appErr, ok := commonerrors.AsAppError(err); ok {
+		switch appErr.Code {
+		case commonerrors.CodeTimeout, commonerrors.CodeExternalServiceTimeout:
+			return timeoutReplyParent(parentURL, err)
+		case commonerrors.CodeExternalServiceUnavailable, commonerrors.CodeRateLimited:
+			return serviceUnavailableReplyParent(parentURL, err)
+		case commonerrors.CodeUnauthorized, commonerrors.CodeNotFound, commonerrors.CodeGone,
+			commonerrors.CodeUnprocessableEntity, commonerrors.CodeValidationFailed,
+			commonerrors.CodeInvalidInput, commonerrors.CodeInvalidFormat,
+			commonerrors.CodeActivityParsingFailed, commonerrors.CodeRemoteFetchFailed:
+			return unusableReplyParent(parentURL, appErr.Message)
+		}
+	}
+
+	return serviceUnavailableReplyParent(parentURL, err)
+}
+
+func materializeReplyParentFailure(parentURL string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return serviceUnavailableReplyParent(parentURL, err)
+}
+
+func invalidReplyParentReference(parentURL string, err error) error {
+	appErr := commonerrors.NewAppError(commonerrors.CodeBadRequest, commonerrors.CategoryValidation, "Invalid in_reply_to_id")
+	appErr = appErr.WithInternalError(err).WithMetadata("reply_parent", parentURL)
+	return appErr
+}
+
+func timeoutReplyParent(parentURL string, err error) error {
+	appErr := commonerrors.NewAppError(commonerrors.CodeTimeout, commonerrors.CategoryExternal, "Remote reply parent fetch timed out")
+	appErr = appErr.WithInternalError(err).WithMetadata("reply_parent", parentURL).AsRetryable()
+	return appErr
+}
+
+func serviceUnavailableReplyParent(parentURL string, err error) error {
+	appErr := commonerrors.NewAppError(commonerrors.CodeExternalServiceUnavailable, commonerrors.CategoryExternal, "Remote reply parent is temporarily unavailable")
+	appErr = appErr.WithInternalError(err).WithMetadata("reply_parent", parentURL).AsRetryable()
+	return appErr
+}
+
+func unusableReplyParent(parentURL string, reason string) error {
+	appErr := commonerrors.NewAppError(commonerrors.CodeUnprocessableEntity, commonerrors.CategoryValidation, "Remote reply parent is not usable")
+	appErr = appErr.WithMetadata("reply_parent", parentURL)
+	if reason != "" {
+		appErr = appErr.WithMetadata("reason", reason)
+	}
+	return appErr
+}
+
+func (r *Resolver) logOutcome(outcome, requested string, status *models.Status, fetched bool, err error) {
+	if r == nil || r.logger == nil {
+		return
+	}
+
+	fields := []zap.Field{
+		zap.String("outcome", outcome),
+		zap.String("requested_parent", requested),
+		zap.Bool("fetched", fetched),
+	}
+
+	if status != nil {
+		fields = append(fields,
+			zap.String("resolved_status_id", status.StatusID),
+			zap.String("resolved_parent_url", replyParentObjectURL(status, r.localDomain)),
+			zap.String("parent_visibility", status.Visibility),
+			zap.Bool("remote_parent", replyParentLooksRemote(status, replyParentObjectURL(status, r.localDomain), r.localDomain)),
+		)
+	}
+
+	if err != nil {
+		fields = append(fields, zap.Error(err))
+		r.logger.Warn("remote reply parent acquisition", fields...)
+		return
+	}
+
+	r.logger.Info("remote reply parent acquisition", fields...)
+}
+
+func statusLookupNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	if common.IsNotFound(err) {
+		return true
+	}
+	if appErr, ok := commonerrors.AsAppError(err); ok {
+		return appErr.Code == commonerrors.CodeNotFound
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "not found")
+}

--- a/pkg/federation/remotenotes/reply_parent_resolver_helpers_test.go
+++ b/pkg/federation/remotenotes/reply_parent_resolver_helpers_test.go
@@ -1,0 +1,330 @@
+package remotenotes
+
+import (
+	"context"
+	stdErrors "errors"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	commonerrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplyParentSigningActor(t *testing.T) {
+	t.Run("requires author identity", func(t *testing.T) {
+		actor, err := replyParentSigningActor(nil, "example.com")
+		require.Error(t, err)
+		assert.Nil(t, actor)
+		appErr, ok := commonerrors.AsAppError(err)
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeExternalServiceUnavailable, appErr.Code)
+	})
+
+	t.Run("fills missing public key from actor id", func(t *testing.T) {
+		actor, err := replyParentSigningActor(&storage.Account{
+			User: &storage.User{Username: "alice"},
+			Actor: &activitypub.Actor{
+				BaseObject:        activitypub.BaseObject{ID: "https://example.com/users/alice"},
+				PreferredUsername: "alice",
+			},
+		}, "example.com")
+		require.NoError(t, err)
+		require.NotNil(t, actor)
+		require.NotNil(t, actor.PublicKey)
+		assert.Equal(t, "https://example.com/users/alice#main-key", actor.PublicKey.ID)
+		assert.Equal(t, "https://example.com/users/alice", actor.PublicKey.Owner)
+	})
+
+	t.Run("synthesizes actor from local domain when actor is absent", func(t *testing.T) {
+		actor, err := replyParentSigningActor(&storage.Account{
+			User: &storage.User{Username: "alice"},
+		}, "example.com")
+		require.NoError(t, err)
+		require.NotNil(t, actor)
+		assert.Equal(t, "alice", actor.PreferredUsername)
+		assert.Equal(t, "https://example.com/users/alice", actor.ID)
+	})
+
+	t.Run("rejects missing local domain when actor is absent", func(t *testing.T) {
+		actor, err := replyParentSigningActor(&storage.Account{
+			User: &storage.User{Username: "alice"},
+		}, "")
+		require.Error(t, err)
+		assert.Nil(t, actor)
+		appErr, ok := commonerrors.AsAppError(err)
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeExternalServiceUnavailable, appErr.Code)
+	})
+}
+
+func TestNormalizeReplyParentURLAndFetchedReplyParentNote(t *testing.T) {
+	t.Run("normalizes canonical remote url and strips fragment", func(t *testing.T) {
+		normalized, err := normalizeReplyParentURL("https://remote.example/users/steward/statuses/seed-1#context")
+		require.NoError(t, err)
+		assert.Equal(t, "https://remote.example/users/steward/statuses/seed-1", normalized)
+	})
+
+	t.Run("rejects empty or non-url references", func(t *testing.T) {
+		_, err := normalizeReplyParentURL("   ")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "empty")
+
+		_, err = normalizeReplyParentURL("seed-1")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "canonical remote status URL")
+	})
+
+	t.Run("rejects invalid fetched note shapes", func(t *testing.T) {
+		_, err := fetchedReplyParentNote("not-a-map")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "valid ActivityPub object")
+
+		_, err = fetchedReplyParentNote(map[string]any{
+			"@context":     []any{"https://www.w3.org/ns/activitystreams"},
+			"id":           "https://remote.example/objects/seed",
+			"type":         "Article",
+			"content":      "seed",
+			"attributedTo": "https://remote.example/users/steward",
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "not a Note")
+	})
+
+	t.Run("parses a valid fetched note", func(t *testing.T) {
+		note, err := fetchedReplyParentNote(map[string]any{
+			"@context":     []any{"https://www.w3.org/ns/activitystreams"},
+			"id":           "https://remote.example/users/steward/statuses/seed-1",
+			"type":         activitypub.NoteType,
+			"content":      "seed",
+			"attributedTo": "https://remote.example/users/steward",
+			"to":           []any{activitypub.PublicAddress},
+			"cc":           []any{"https://remote.example/users/steward/followers"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, note)
+		assert.Equal(t, "https://remote.example/users/steward/statuses/seed-1", note.ID)
+		assert.Equal(t, "https://remote.example/users/steward", note.AttributedTo)
+	})
+
+	t.Run("rejects fetched notes without an id", func(t *testing.T) {
+		_, err := fetchedReplyParentNote(map[string]any{
+			"@context":     []any{"https://www.w3.org/ns/activitystreams"},
+			"type":         activitypub.NoteType,
+			"content":      "seed",
+			"attributedTo": "https://remote.example/users/steward",
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "empty")
+	})
+}
+
+func TestReplyParentErrorMappingAndHelpers(t *testing.T) {
+	t.Run("maps deadline to timeout", func(t *testing.T) {
+		appErr, ok := commonerrors.AsAppError(mapReplyParentFetchError("https://remote.example/statuses/seed-1", context.DeadlineExceeded))
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeTimeout, appErr.Code)
+	})
+
+	t.Run("maps known app errors to service unavailable or unprocessable", func(t *testing.T) {
+		serviceUnavailable, ok := commonerrors.AsAppError(mapReplyParentFetchError(
+			"https://remote.example/statuses/seed-1",
+			commonerrors.NewAppError(commonerrors.CodeExternalServiceUnavailable, commonerrors.CategoryExternal, "down"),
+		))
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeExternalServiceUnavailable, serviceUnavailable.Code)
+
+		unusable, ok := commonerrors.AsAppError(mapReplyParentFetchError(
+			"https://remote.example/statuses/seed-1",
+			commonerrors.RemoteFetchNotFound("https://remote.example/statuses/seed-1"),
+		))
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeUnprocessableEntity, unusable.Code)
+	})
+
+	t.Run("falls back to service unavailable for unknown fetch failures", func(t *testing.T) {
+		appErr, ok := commonerrors.AsAppError(mapReplyParentFetchError("https://remote.example/statuses/seed-1", stdErrors.New("dial tcp failure")))
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeExternalServiceUnavailable, appErr.Code)
+	})
+
+	t.Run("builds stable app errors for helper constructors", func(t *testing.T) {
+		badRequest, ok := commonerrors.AsAppError(invalidReplyParentReference("bad", stdErrors.New("boom")))
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeBadRequest, badRequest.Code)
+
+		timeout, ok := commonerrors.AsAppError(timeoutReplyParent("https://remote.example/statuses/seed-1", context.DeadlineExceeded))
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeTimeout, timeout.Code)
+
+		unavailable, ok := commonerrors.AsAppError(serviceUnavailableReplyParent("https://remote.example/statuses/seed-1", stdErrors.New("down")))
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeExternalServiceUnavailable, unavailable.Code)
+
+		unusable, ok := commonerrors.AsAppError(unusableReplyParent("https://remote.example/statuses/seed-1", "not a note"))
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeUnprocessableEntity, unusable.Code)
+	})
+
+	t.Run("tracks not-found classification and parent result projection", func(t *testing.T) {
+		assert.True(t, statusLookupNotFound(storage.ErrNotFound))
+		assert.True(t, statusLookupNotFound(commonerrors.NotFound("status")))
+		assert.False(t, statusLookupNotFound(stdErrors.New("boom")))
+
+		parent := remoteStatus("https://remote.example/users/steward/statuses/seed-1", models.VisibilityPublic)
+		result := replyParentResultFromStatus(parent, true, "example.com")
+		require.NotNil(t, result)
+		assert.True(t, result.Remote)
+		assert.True(t, result.Fetched)
+		assert.Equal(t, parent.Note.ID, result.CanonicalObjectURL)
+		assert.Equal(t, parent.StatusID, result.CanonicalStatusID)
+	})
+
+	t.Run("builds local fallback object urls and local parent classification", func(t *testing.T) {
+		parent := &models.Status{
+			StatusID:       "status-1",
+			AuthorID:       "https://example.com/users/alice",
+			AuthorUsername: "alice",
+			Visibility:     models.VisibilityPublic,
+		}
+
+		result := replyParentResultFromStatus(parent, false, "example.com")
+		require.NotNil(t, result)
+		assert.False(t, result.Remote)
+		assert.Equal(t, "https://example.com/users/alice/statuses/status-1", result.CanonicalObjectURL)
+	})
+
+	t.Run("covers object url and remote detection edge cases", func(t *testing.T) {
+		assert.Empty(t, replyParentObjectURL(nil, "example.com"))
+		assert.False(t, replyParentLooksRemote(nil, "", "example.com"))
+
+		urlBacked := &models.Status{
+			StatusID:   "status-1",
+			AuthorID:   "",
+			Visibility: models.VisibilityPublic,
+			URLs: []string{
+				"mailto:not-used@example.com",
+				"https://remote.example/users/steward/statuses/seed-2",
+			},
+		}
+		objectURL := replyParentObjectURL(urlBacked, "example.com")
+		assert.Equal(t, "https://remote.example/users/steward/statuses/seed-2", objectURL)
+		assert.True(t, replyParentLooksRemote(urlBacked, objectURL, "example.com"))
+
+		statusIDBacked := &models.Status{
+			StatusID:   "https://remote.example/users/steward/statuses/seed-3",
+			AuthorID:   "",
+			Visibility: models.VisibilityPublic,
+		}
+		assert.Equal(t, statusIDBacked.StatusID, replyParentObjectURL(statusIDBacked, "example.com"))
+		assert.True(t, replyParentLooksRemote(statusIDBacked, statusIDBacked.StatusID, "example.com"))
+
+		incompleteLocal := &models.Status{
+			StatusID:   "status-4",
+			AuthorID:   "https://example.com/users/alice",
+			Visibility: models.VisibilityPublic,
+		}
+		assert.Empty(t, replyParentObjectURL(incompleteLocal, "example.com"))
+		assert.False(t, replyParentLooksRemote(incompleteLocal, "not-a-url", "example.com"))
+	})
+}
+
+func TestResolveStoredParentAndFetchGuards(t *testing.T) {
+	t.Run("resolves stored parent from candidate ids", func(t *testing.T) {
+		parentURL := "https://remote.example/users/steward/statuses/seed-1"
+		stored := remoteStatus(parentURL, models.VisibilityPublic)
+		resolver := &Resolver{
+			statusRepo:  &stubStatusRepo{byID: map[string]*models.Status{stored.StatusID: stored}},
+			localDomain: "example.com",
+		}
+
+		parent, err := resolver.resolveStoredParent(context.Background(), parentURL)
+		require.NoError(t, err)
+		assert.Same(t, stored, parent)
+	})
+
+	t.Run("guards fetch availability and domain block repository errors", func(t *testing.T) {
+		resolver := &Resolver{}
+		appErr, ok := commonerrors.AsAppError(resolver.ensureFetchAllowed(context.Background(), "https://remote.example/statuses/seed-1"))
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeExternalServiceUnavailable, appErr.Code)
+
+		resolver = &Resolver{
+			fetcher:         &stubFetcher{},
+			domainBlockRepo: &stubDomainBlockRepo{err: stdErrors.New("lookup failed")},
+		}
+		appErr, ok = commonerrors.AsAppError(resolver.ensureFetchAllowed(context.Background(), "https://remote.example/statuses/seed-1"))
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeExternalServiceUnavailable, appErr.Code)
+	})
+
+	t.Run("returns not found when no stored parent candidates resolve", func(t *testing.T) {
+		resolver := &Resolver{
+			statusRepo:  &stubStatusRepo{},
+			localDomain: "example.com",
+		}
+
+		parent, err := resolver.resolveStoredParent(context.Background(), "status-1")
+		require.Error(t, err)
+		assert.Nil(t, parent)
+		assert.True(t, statusLookupNotFound(err))
+	})
+
+	t.Run("returns nil for empty reply parent and rejects unresolved local-only ids", func(t *testing.T) {
+		resolver := NewReplyParentResolver(
+			&stubStatusRepo{},
+			&stubObjectRepo{},
+			&stubDomainBlockRepo{},
+			&stubFetcher{},
+			"example.com",
+			nil,
+		)
+
+		parent, err := resolver.ResolveReplyParent(context.Background(), localAuthorAccount("alice"), "   ", models.VisibilityPublic)
+		require.NoError(t, err)
+		assert.Nil(t, parent)
+
+		parent, err = resolver.ResolveReplyParent(context.Background(), localAuthorAccount("alice"), "status-1", models.VisibilityPublic)
+		require.Error(t, err)
+		assert.Nil(t, parent)
+		appErr, ok := commonerrors.AsAppError(err)
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeUnprocessableEntity, appErr.Code)
+		assert.Equal(t, 422, appErr.HTTPStatusCode)
+	})
+}
+
+func TestReplyParentVisibilityAndFailureHelpers(t *testing.T) {
+	t.Run("maps supported visibility levels and rejects unknown values", func(t *testing.T) {
+		rank, ok := replyVisibilityRank(models.VisibilityPublic)
+		require.True(t, ok)
+		assert.Equal(t, 0, rank)
+
+		rank, ok = replyVisibilityRank(models.VisibilityUnlisted)
+		require.True(t, ok)
+		assert.Equal(t, 1, rank)
+
+		rank, ok = replyVisibilityRank(models.VisibilityPrivate)
+		require.True(t, ok)
+		assert.Equal(t, 2, rank)
+
+		rank, ok = replyVisibilityRank(models.VisibilityDirect)
+		require.True(t, ok)
+		assert.Equal(t, 3, rank)
+
+		_, ok = replyVisibilityRank("followers")
+		assert.False(t, ok)
+	})
+
+	t.Run("normalizes parent domains and materialize failure mapping", func(t *testing.T) {
+		assert.Equal(t, "remote.example", replyParentDomain("https://remote.example/users/steward/statuses/seed-1"))
+		assert.Empty(t, replyParentDomain("not-a-url"))
+		assert.Nil(t, materializeReplyParentFailure("https://remote.example/statuses/seed-1", nil))
+
+		appErr, ok := commonerrors.AsAppError(materializeReplyParentFailure("https://remote.example/statuses/seed-1", stdErrors.New("write failed")))
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeExternalServiceUnavailable, appErr.Code)
+	})
+}

--- a/pkg/federation/remotenotes/reply_parent_resolver_test.go
+++ b/pkg/federation/remotenotes/reply_parent_resolver_test.go
@@ -1,0 +1,368 @@
+package remotenotes
+
+import (
+	"context"
+	stdErrors "errors"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	commonerrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type stubStatusRepo struct {
+	byID      map[string]*models.Status
+	byURL     map[string]*models.Status
+	createErr error
+}
+
+func (s *stubStatusRepo) GetStatus(_ context.Context, statusID string) (*models.Status, error) {
+	if s.byID != nil {
+		if status := s.byID[statusID]; status != nil {
+			return status, nil
+		}
+	}
+	return nil, storage.ErrNotFound
+}
+
+func (s *stubStatusRepo) GetStatusByURL(_ context.Context, raw string) (*models.Status, error) {
+	if s.byURL != nil {
+		if status := s.byURL[raw]; status != nil {
+			return status, nil
+		}
+	}
+	return nil, storage.ErrNotFound
+}
+
+func (s *stubStatusRepo) CreateStatus(_ context.Context, status *models.Status) error {
+	if s.createErr != nil {
+		return s.createErr
+	}
+	if s.byID == nil {
+		s.byID = map[string]*models.Status{}
+	}
+	if s.byURL == nil {
+		s.byURL = map[string]*models.Status{}
+	}
+	s.byID[status.StatusID] = status
+	if status.Note != nil && status.Note.ID != "" {
+		s.byURL[status.Note.ID] = status
+	}
+	return nil
+}
+
+type stubObjectRepo struct {
+	created   []any
+	createErr error
+}
+
+func (s *stubObjectRepo) CreateObject(_ context.Context, object any) error {
+	if s.createErr != nil {
+		return s.createErr
+	}
+	s.created = append(s.created, object)
+	return nil
+}
+
+type stubDomainBlockRepo struct {
+	blocked map[string]bool
+	err     error
+}
+
+func (s *stubDomainBlockRepo) IsDomainBlocked(_ context.Context, domain string) (bool, *storage.InstanceDomainBlock, error) {
+	if s.err != nil {
+		return false, nil, s.err
+	}
+	blocked := s.blocked != nil && s.blocked[domain]
+	return blocked, nil, nil
+}
+
+type stubFetcher struct {
+	obj      any
+	err      error
+	gotURL   string
+	gotActor *activitypub.Actor
+}
+
+func (s *stubFetcher) FetchObject(_ context.Context, objectURL string, signingActor *activitypub.Actor) (any, error) {
+	s.gotURL = objectURL
+	s.gotActor = signingActor
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.obj, nil
+}
+
+func TestReplyParentResolver_ResolveReplyParent(t *testing.T) {
+	t.Run("returns stored parent without remote fetch", func(t *testing.T) {
+		parentURL := "https://remote.example/users/steward/statuses/seed"
+		stored := remoteStatus(parentURL, models.VisibilityPublic)
+		fetcher := &stubFetcher{}
+		resolver := NewReplyParentResolver(
+			&stubStatusRepo{
+				byID:  map[string]*models.Status{stored.StatusID: stored},
+				byURL: map[string]*models.Status{parentURL: stored},
+			},
+			&stubObjectRepo{},
+			&stubDomainBlockRepo{},
+			fetcher,
+			"example.com",
+			zap.NewNop(),
+		)
+
+		result, err := resolver.ResolveReplyParent(context.Background(), localAuthorAccount("alice"), parentURL, models.VisibilityPublic)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.False(t, result.Fetched)
+		assert.True(t, result.Remote)
+		assert.Equal(t, stored.StatusID, result.CanonicalStatusID)
+		assert.Empty(t, fetcher.gotURL)
+	})
+
+	t.Run("stored private parent cannot be broadened to public", func(t *testing.T) {
+		parentURL := "https://remote.example/users/steward/statuses/private-stored"
+		stored := remoteStatus(parentURL, models.VisibilityPrivate)
+		fetcher := &stubFetcher{}
+		resolver := NewReplyParentResolver(
+			&stubStatusRepo{
+				byID:  map[string]*models.Status{stored.StatusID: stored},
+				byURL: map[string]*models.Status{parentURL: stored},
+			},
+			&stubObjectRepo{},
+			&stubDomainBlockRepo{},
+			fetcher,
+			"example.com",
+			zap.NewNop(),
+		)
+
+		_, err := resolver.ResolveReplyParent(context.Background(), localAuthorAccount("alice"), parentURL, models.VisibilityPublic)
+		appErr, ok := commonerrors.AsAppError(err)
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeUnprocessableEntity, appErr.Code)
+		assert.Empty(t, fetcher.gotURL)
+	})
+
+	t.Run("materializes unresolved remote parent url through authorized fetch", func(t *testing.T) {
+		parentURL := "https://remote.example/users/steward/statuses/fresh"
+		statusRepo := &stubStatusRepo{}
+		objectRepo := &stubObjectRepo{}
+		fetcher := &stubFetcher{obj: remoteNoteObject(parentURL, models.VisibilityPublic)}
+		resolver := NewReplyParentResolver(
+			statusRepo,
+			objectRepo,
+			&stubDomainBlockRepo{},
+			fetcher,
+			"example.com",
+			zap.NewNop(),
+		)
+
+		result, err := resolver.ResolveReplyParent(context.Background(), localAuthorAccount("alice"), parentURL, models.VisibilityPublic)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.NotNil(t, result.Status)
+		require.Len(t, objectRepo.created, 1)
+		assert.True(t, result.Fetched)
+		assert.True(t, result.Remote)
+		assert.Equal(t, parentURL, result.CanonicalObjectURL)
+		assert.Equal(t, models.CanonicalStatusIDForDomain(parentURL, "example.com"), result.CanonicalStatusID)
+		assert.Equal(t, parentURL, fetcher.gotURL)
+		require.NotNil(t, fetcher.gotActor)
+		assert.Equal(t, "alice", fetcher.gotActor.PreferredUsername)
+		assert.Equal(t, "https://example.com/users/alice", fetcher.gotActor.ID)
+	})
+
+	t.Run("timeout maps to 408", func(t *testing.T) {
+		parentURL := "https://remote.example/users/steward/statuses/slow"
+		resolver := NewReplyParentResolver(
+			&stubStatusRepo{},
+			&stubObjectRepo{},
+			&stubDomainBlockRepo{},
+			&stubFetcher{err: context.DeadlineExceeded},
+			"example.com",
+			zap.NewNop(),
+		)
+
+		_, err := resolver.ResolveReplyParent(context.Background(), localAuthorAccount("alice"), parentURL, models.VisibilityPublic)
+		appErr, ok := commonerrors.AsAppError(err)
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeTimeout, appErr.Code)
+		assert.Equal(t, 408, appErr.HTTPStatusCode)
+	})
+
+	t.Run("unreachable remote parent maps to 503", func(t *testing.T) {
+		parentURL := "https://remote.example/users/steward/statuses/down"
+		resolver := NewReplyParentResolver(
+			&stubStatusRepo{},
+			&stubObjectRepo{},
+			&stubDomainBlockRepo{},
+			&stubFetcher{err: stdErrors.New("dial tcp: no route to host")},
+			"example.com",
+			zap.NewNop(),
+		)
+
+		_, err := resolver.ResolveReplyParent(context.Background(), localAuthorAccount("alice"), parentURL, models.VisibilityPublic)
+		appErr, ok := commonerrors.AsAppError(err)
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeExternalServiceUnavailable, appErr.Code)
+		assert.Equal(t, 503, appErr.HTTPStatusCode)
+	})
+
+	t.Run("fetched but unusable parent maps to 422", func(t *testing.T) {
+		parentURL := "https://remote.example/users/steward/statuses/missing"
+		resolver := NewReplyParentResolver(
+			&stubStatusRepo{},
+			&stubObjectRepo{},
+			&stubDomainBlockRepo{},
+			&stubFetcher{err: commonerrors.RemoteFetchNotFound(parentURL)},
+			"example.com",
+			zap.NewNop(),
+		)
+
+		_, err := resolver.ResolveReplyParent(context.Background(), localAuthorAccount("alice"), parentURL, models.VisibilityPublic)
+		appErr, ok := commonerrors.AsAppError(err)
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeUnprocessableEntity, appErr.Code)
+		assert.Equal(t, 422, appErr.HTTPStatusCode)
+	})
+
+	t.Run("private parent cannot be broadened to public", func(t *testing.T) {
+		parentURL := "https://remote.example/users/steward/statuses/private"
+		resolver := NewReplyParentResolver(
+			&stubStatusRepo{},
+			&stubObjectRepo{},
+			&stubDomainBlockRepo{},
+			&stubFetcher{obj: remoteNoteObject(parentURL, models.VisibilityPrivate)},
+			"example.com",
+			zap.NewNop(),
+		)
+
+		_, err := resolver.ResolveReplyParent(context.Background(), localAuthorAccount("alice"), parentURL, models.VisibilityPublic)
+		appErr, ok := commonerrors.AsAppError(err)
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeUnprocessableEntity, appErr.Code)
+	})
+
+	t.Run("direct replies stay out of scope for notes create path", func(t *testing.T) {
+		parentURL := "https://remote.example/users/steward/statuses/direct"
+		fetcher := &stubFetcher{obj: remoteNoteObject(parentURL, models.VisibilityPrivate)}
+		resolver := NewReplyParentResolver(
+			&stubStatusRepo{},
+			&stubObjectRepo{},
+			&stubDomainBlockRepo{},
+			fetcher,
+			"example.com",
+			zap.NewNop(),
+		)
+
+		_, err := resolver.ResolveReplyParent(context.Background(), localAuthorAccount("alice"), parentURL, models.VisibilityDirect)
+		appErr, ok := commonerrors.AsAppError(err)
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeUnprocessableEntity, appErr.Code)
+		assert.Empty(t, fetcher.gotURL)
+	})
+
+	t.Run("blocked parent domain is rejected before fetch", func(t *testing.T) {
+		parentURL := "https://blocked.example/users/steward/statuses/private"
+		fetcher := &stubFetcher{obj: remoteNoteObject(parentURL, models.VisibilityPrivate)}
+		resolver := NewReplyParentResolver(
+			&stubStatusRepo{},
+			&stubObjectRepo{},
+			&stubDomainBlockRepo{blocked: map[string]bool{"blocked.example": true}},
+			fetcher,
+			"example.com",
+			zap.NewNop(),
+		)
+
+		_, err := resolver.ResolveReplyParent(context.Background(), localAuthorAccount("alice"), parentURL, models.VisibilityPrivate)
+		appErr, ok := commonerrors.AsAppError(err)
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeUnprocessableEntity, appErr.Code)
+		assert.Empty(t, fetcher.gotURL)
+	})
+}
+
+func localAuthorAccount(username string) *storage.Account {
+	actorID := "https://example.com/users/" + username
+	return &storage.Account{
+		User: &storage.User{Username: username},
+		Actor: &activitypub.Actor{
+			BaseObject:        activitypub.BaseObject{ID: actorID},
+			PreferredUsername: username,
+			PublicKey: &activitypub.PublicKey{
+				ID:    actorID + "#main-key",
+				Owner: actorID,
+			},
+		},
+	}
+}
+
+func remoteStatus(parentURL string, visibility string) *models.Status {
+	at := time.Now().UTC()
+	return &models.Status{
+		StatusID:       models.CanonicalStatusIDForDomain(parentURL, "example.com"),
+		AuthorID:       "https://remote.example/users/steward",
+		AuthorUsername: "steward@remote.example",
+		ConversationID: "conv-1",
+		Visibility:     visibility,
+		PublishedAt:    at,
+		CreatedAt:      at,
+		UpdatedAt:      at,
+		ModifiedAt:     at,
+		Note: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:   parentURL,
+				To:   replyAudienceForVisibility(visibility),
+				CC:   replyCCForVisibility(visibility),
+				Type: activitypub.NoteType,
+			},
+			AttributedTo: "https://remote.example/users/steward",
+			Content:      "seed",
+			Visibility:   visibility,
+		},
+	}
+}
+
+func remoteNoteObject(parentURL string, visibility string) map[string]any {
+	return map[string]any{
+		"@context":     []any{"https://www.w3.org/ns/activitystreams"},
+		"id":           parentURL,
+		"type":         activitypub.NoteType,
+		"content":      "seed",
+		"attributedTo": "https://remote.example/users/steward",
+		"to":           stringSliceToAny(replyAudienceForVisibility(visibility)),
+		"cc":           stringSliceToAny(replyCCForVisibility(visibility)),
+		"visibility":   visibility,
+	}
+}
+
+func stringSliceToAny(values []string) []any {
+	if len(values) == 0 {
+		return nil
+	}
+
+	out := make([]any, 0, len(values))
+	for _, value := range values {
+		out = append(out, value)
+	}
+
+	return out
+}
+
+func replyAudienceForVisibility(visibility string) []string {
+	if visibility == models.VisibilityPrivate {
+		return []string{"https://remote.example/users/steward/followers"}
+	}
+	return []string{activitypub.PublicAddress}
+}
+
+func replyCCForVisibility(visibility string) []string {
+	if visibility == models.VisibilityPrivate {
+		return nil
+	}
+	return []string{"https://remote.example/users/steward/followers"}
+}

--- a/pkg/services/conversations/service_status_note_contract_test.go
+++ b/pkg/services/conversations/service_status_note_contract_test.go
@@ -136,7 +136,7 @@ func TestStatusNoteContractAcrossEntryPoints(t *testing.T) {
 		DirectMessagesFrom: "ANYONE",
 	}))
 
-	notesService := notessvc.NewService(statusRepo, accountRepo, nil, nil, nil, nil, nil, conversationRepo, nil, nil, nil, userRepo, nil, publisher, nil, nil, nil, logger, domain)
+	notesService := notessvc.NewService(statusRepo, accountRepo, nil, nil, nil, nil, nil, conversationRepo, nil, nil, nil, userRepo, nil, publisher, nil, nil, nil, nil, logger, domain)
 	conversationService := conversationsvc.NewService(conversationRepo, statusRepo, nil, accountRepo, nil, userRepo, nil, nil, publisher, nil, logger, domain)
 
 	publicResult, err := notesService.CreateNote(ctx, &notessvc.CreateNoteCommand{

--- a/pkg/services/notes/service.go
+++ b/pkg/services/notes/service.go
@@ -58,6 +58,7 @@ type Service struct {
 	logger            *zap.Logger
 	domainName        string
 	federation        FederationService // Interface to be defined
+	replyParents      ReplyParentResolver
 	notifications     notificationsService
 
 	// Business logic services
@@ -118,6 +119,21 @@ type FederationService interface {
 	QueueActivity(ctx context.Context, activity *activitypub.Activity) error
 }
 
+// ReplyParentResolver resolves and materializes reply parents for note creation.
+type ReplyParentResolver interface {
+	ResolveReplyParent(ctx context.Context, author *storage.Account, rawInReplyTo string, requestedVisibility string) (*ResolvedReplyParent, error)
+}
+
+// ResolvedReplyParent describes a reply parent resolved for a single create-note request.
+type ResolvedReplyParent struct {
+	Status             *models.Status `json:"status,omitempty"`
+	CanonicalObjectURL string         `json:"canonical_object_url,omitempty"`
+	CanonicalStatusID  string         `json:"canonical_status_id,omitempty"`
+	Visibility         string         `json:"visibility,omitempty"`
+	Fetched            bool           `json:"fetched"`
+	Remote             bool           `json:"remote"`
+}
+
 // AnalyticsService defines the interface for analytics operations needed by the notes service
 type AnalyticsService interface {
 	RecordStatusCreation(ctx context.Context, actorID string, timestamp time.Time) error
@@ -173,6 +189,7 @@ func NewService(
 	publisher streaming.Publisher,
 	analytics AnalyticsService,
 	federation FederationService,
+	replyParents ReplyParentResolver,
 	notifier notificationsService,
 	logger *zap.Logger,
 	domainName string,
@@ -213,6 +230,7 @@ func NewService(
 		publisher:         publisher,
 		analytics:         analytics,
 		federation:        federation,
+		replyParents:      replyParents,
 		notifications:     notifier,
 		logger:            logger,
 		domainName:        domainName,
@@ -296,8 +314,9 @@ type ListNotesQuery struct {
 
 // NoteResult contains a note and associated events that were emitted
 type NoteResult struct {
-	Note   *models.Status     `json:"note"`
-	Events []*streaming.Event `json:"events"`
+	Note                   *models.Status       `json:"note"`
+	Events                 []*streaming.Event   `json:"events"`
+	ReplyParentAcquisition *ResolvedReplyParent `json:"reply_parent_acquisition,omitempty"`
 }
 
 // Result contains multiple notes and pagination information
@@ -321,7 +340,14 @@ func (s *Service) CreateNote(ctx context.Context, cmd *CreateNoteCommand) (*Note
 		return nil, err
 	}
 
-	replyParent, err := s.resolveCreateReplyParent(ctx, cmd)
+	// Get author account before reply-parent resolution so protected remote parents
+	// can be fetched in the local replying-actor context when needed.
+	author, err := s.accountRepo.GetAccount(ctx, cmd.AuthorID)
+	if err != nil {
+		return nil, ErrGetAuthorAccount
+	}
+
+	replyParent, err := s.resolveCreateReplyParent(ctx, author, cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -330,11 +356,8 @@ func (s *Service) CreateNote(ctx context.Context, cmd *CreateNoteCommand) (*Note
 	sanitizedCmd := *cmd
 	sanitizedCmd.Content = strings.TrimSpace(htmlsafe.SanitizeHTMLByContract(cmd.Content))
 	sanitizedCmd.SpoilerText = strings.TrimSpace(htmlsafe.SanitizeHTMLByContract(cmd.SpoilerText))
-
-	// Get author account
-	author, err := s.accountRepo.GetAccount(ctx, cmd.AuthorID)
-	if err != nil {
-		return nil, ErrGetAuthorAccount
+	if replyParent != nil && strings.TrimSpace(replyParent.CanonicalStatusID) != "" {
+		sanitizedCmd.InReplyToID = strings.TrimSpace(replyParent.CanonicalStatusID)
 	}
 
 	s.normalizeCreateAudience(&sanitizedCmd, author)
@@ -343,11 +366,11 @@ func (s *Service) CreateNote(ctx context.Context, cmd *CreateNoteCommand) (*Note
 	statusID := uuid.New().String()
 
 	if replyParent != nil && strings.TrimSpace(sanitizedCmd.ConversationID) == "" {
-		sanitizedCmd.ConversationID = replyConversationID(&sanitizedCmd, replyParent)
+		sanitizedCmd.ConversationID = replyConversationID(&sanitizedCmd, replyParent.Status)
 	}
 
 	// Create ActivityPub Note
-	note := s.buildActivityPubNote(&sanitizedCmd, statusID, author, replyParent)
+	note := s.buildActivityPubNote(&sanitizedCmd, statusID, author, replyParentStatus(replyParent))
 
 	publishedAt := time.Now()
 	note.Published = &publishedAt
@@ -363,7 +386,7 @@ func (s *Service) CreateNote(ctx context.Context, cmd *CreateNoteCommand) (*Note
 		note.Tag = append(note.Tag, mentionTags...)
 		s.addMentionAudience(note, mentionTags)
 	}
-	s.addReplyAudience(note, replyParent)
+	s.addReplyAudience(note, replyParentStatus(replyParent))
 
 	// Attach media if provided
 	attachments, mediaIDsToMark, err := s.prepareMediaAttachments(ctx, author, sanitizedCmd.MediaIDs)
@@ -376,10 +399,10 @@ func (s *Service) CreateNote(ctx context.Context, cmd *CreateNoteCommand) (*Note
 
 	status := s.composeStatus(&sanitizedCmd, author, statusID, note, normalizedHashtags, attachments, publishedAt)
 	status.ConversationID = resolveConversationID(ctx, status, func(context.Context, string) (*models.Status, error) {
-		if replyParent == nil {
+		if replyParent == nil || replyParent.Status == nil {
 			return nil, fmt.Errorf("reply parent unavailable")
 		}
-		return replyParent, nil
+		return replyParent.Status, nil
 	})
 
 	// Store the status
@@ -404,7 +427,7 @@ func (s *Service) CreateNote(ctx context.Context, cmd *CreateNoteCommand) (*Note
 
 	// Ensure AuthorUsername is populated before emitting events
 	s.ensureAuthorUsername(ctx, status)
-	s.notifyReply(ctx, status, replyParent)
+	s.notifyReply(ctx, status, replyParentStatus(replyParent))
 	s.notifyMentions(ctx, status, mentionedUsers)
 
 	// Emit events and queue federation
@@ -412,8 +435,9 @@ func (s *Service) CreateNote(ctx context.Context, cmd *CreateNoteCommand) (*Note
 	s.queueFederationDelivery(ctx, status, "Create")
 
 	return &NoteResult{
-		Note:   status,
-		Events: events,
+		Note:                   status,
+		Events:                 events,
+		ReplyParentAcquisition: replyParent,
 	}, nil
 }
 
@@ -494,12 +518,28 @@ func (s *Service) lookupParentStatus(ctx context.Context, statusID string) (*mod
 	if s.noteRepo == nil || statusID == "" {
 		return nil, fmt.Errorf("note repository unavailable")
 	}
-	return s.noteRepo.GetStatus(ctx, statusID)
+	return s.resolveStatusForRead(ctx, statusID)
 }
 
-func (s *Service) resolveCreateReplyParent(ctx context.Context, cmd *CreateNoteCommand) (*models.Status, error) {
+func (s *Service) resolveCreateReplyParent(ctx context.Context, author *storage.Account, cmd *CreateNoteCommand) (*ResolvedReplyParent, error) {
 	if cmd == nil || strings.TrimSpace(cmd.InReplyToID) == "" {
 		return nil, nil
+	}
+
+	if s.replyParents != nil {
+		parent, err := s.replyParents.ResolveReplyParent(ctx, author, cmd.InReplyToID, cmd.Visibility)
+		if err != nil {
+			return nil, err
+		}
+		if parent != nil && parent.Status != nil {
+			if parent.CanonicalStatusID == "" {
+				parent.CanonicalStatusID = parent.Status.StatusID
+			}
+			if parent.CanonicalObjectURL == "" {
+				parent.CanonicalObjectURL = s.replyParentObjectID(parent.Status)
+			}
+			return parent, nil
+		}
 	}
 
 	parent, err := s.lookupParentStatus(ctx, cmd.InReplyToID)
@@ -507,7 +547,13 @@ func (s *Service) resolveCreateReplyParent(ctx context.Context, cmd *CreateNoteC
 		return nil, ErrInvalidInReplyToID
 	}
 
-	return parent, nil
+	return &ResolvedReplyParent{
+		Status:             parent,
+		CanonicalObjectURL: s.replyParentObjectID(parent),
+		CanonicalStatusID:  parent.StatusID,
+		Visibility:         parent.Visibility,
+		Remote:             !s.replyParentIsLocal(parent),
+	}, nil
 }
 
 func replyConversationID(cmd *CreateNoteCommand, parent *models.Status) string {
@@ -526,6 +572,13 @@ func replyConversationID(cmd *CreateNoteCommand, parent *models.Status) string {
 	}
 
 	return strings.TrimSpace(cmd.InReplyToID)
+}
+
+func replyParentStatus(parent *ResolvedReplyParent) *models.Status {
+	if parent == nil {
+		return nil
+	}
+	return parent.Status
 }
 
 func (s *Service) markMediaAsUsed(ctx context.Context, statusID string, mediaIDs []string) {

--- a/pkg/services/notes/service_internal_test.go
+++ b/pkg/services/notes/service_internal_test.go
@@ -353,6 +353,43 @@ func (s *stubFederation) ResolveActor(_ context.Context, handle string) (*activi
 	return nil, errors.New("not found")
 }
 
+type replyParentResolutionCall struct {
+	raw        string
+	visibility string
+	authorID   string
+	username   string
+}
+
+type stubReplyParentResolver struct {
+	resolved map[string]*ResolvedReplyParent
+	err      error
+	calls    []replyParentResolutionCall
+}
+
+func (s *stubReplyParentResolver) ResolveReplyParent(_ context.Context, author *storage.Account, rawInReplyTo string, requestedVisibility string) (*ResolvedReplyParent, error) {
+	call := replyParentResolutionCall{
+		raw:        rawInReplyTo,
+		visibility: requestedVisibility,
+	}
+	if author != nil {
+		if author.User != nil {
+			call.username = author.User.Username
+		}
+		if author.Actor != nil {
+			call.authorID = author.Actor.ID
+		}
+	}
+	s.calls = append(s.calls, call)
+
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.resolved != nil {
+		return s.resolved[rawInReplyTo], nil
+	}
+	return nil, nil
+}
+
 func TestEmitReblogEventsPublishesBoostedEvents(t *testing.T) {
 	publisher := &stubPublisher{}
 	service := &Service{

--- a/pkg/services/notes/service_round15_mainline_test.go
+++ b/pkg/services/notes/service_round15_mainline_test.go
@@ -709,6 +709,7 @@ func newNotesServiceHarness(t *testing.T) (*Service, *stubPublisher, *stubFedera
 		publisher,
 		analytics,
 		federation,
+		nil,
 		notifier,
 		logger,
 		domain,
@@ -756,6 +757,7 @@ func newNotesServiceHarnessWithDB(t *testing.T, db core.DB) *Service {
 		&stubPublisher{},
 		&stubAnalytics{},
 		&stubFederation{},
+		nil,
 		&stubNotificationService{},
 		logger,
 		domain,
@@ -1069,6 +1071,155 @@ func TestService_round15_create_note_reply_to_remote_parent_skips_local_notifica
 	for _, cmd := range notifier.cmds {
 		require.NotEqual(t, common.NotificationTypeReply, cmd.Type)
 	}
+}
+
+func TestService_round15_create_note_remote_parent_resolver_reuses_resolved_parent(t *testing.T) {
+	t.Run("public unresolved remote parent url is canonicalized once", func(t *testing.T) {
+		service, _, federation, notifier, _ := newNotesServiceHarness(t)
+
+		parentURL := "https://remote.example/users/steward/statuses/unresolved-parent-public"
+		remoteParent := &models.Status{
+			StatusID:       models.CanonicalStatusIDForDomain(parentURL, "example.com"),
+			AuthorID:       "https://remote.example/users/steward",
+			AuthorUsername: "steward@remote.example",
+			ConversationID: "remote-conversation-public",
+			Visibility:     models.VisibilityPublic,
+			ToRecipients:   []string{activitypub.PublicAddress},
+			CcRecipients:   []string{"https://remote.example/users/steward/followers"},
+			PublishedAt:    time.Now().UTC(),
+			CreatedAt:      time.Now().UTC(),
+			UpdatedAt:      time.Now().UTC(),
+			ModifiedAt:     time.Now().UTC(),
+			Note: &activitypub.Note{
+				BaseObject: activitypub.BaseObject{
+					ID:   parentURL,
+					To:   []string{activitypub.PublicAddress},
+					CC:   []string{"https://remote.example/users/steward/followers"},
+					Type: activitypub.NoteType,
+				},
+				AttributedTo: "https://remote.example/users/steward",
+				Content:      "seed",
+				Visibility:   models.VisibilityPublic,
+			},
+		}
+
+		resolver := &stubReplyParentResolver{
+			resolved: map[string]*ResolvedReplyParent{
+				parentURL: {
+					Status:             remoteParent,
+					CanonicalObjectURL: parentURL,
+					CanonicalStatusID:  remoteParent.StatusID,
+					Visibility:         remoteParent.Visibility,
+					Fetched:            true,
+					Remote:             true,
+				},
+			},
+		}
+		service.replyParents = resolver
+
+		created, err := service.CreateNote(context.Background(), &CreateNoteCommand{
+			AuthorID:    "alice",
+			Content:     "reply without mention",
+			Visibility:  VisibilityPublic,
+			InReplyToID: parentURL,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, created)
+		require.NotNil(t, created.ReplyParentAcquisition)
+		require.Len(t, resolver.calls, 1)
+		require.Len(t, federation.activities, 1)
+
+		assert.Equal(t, "alice", resolver.calls[0].username)
+		assert.Equal(t, parentURL, resolver.calls[0].raw)
+		assert.Equal(t, VisibilityPublic, resolver.calls[0].visibility)
+		assert.Equal(t, remoteParent.StatusID, created.Note.InReplyToID)
+		assert.Equal(t, parentURL, created.Note.Note.InReplyTo)
+		assert.Equal(t, remoteParent.ConversationID, created.Note.ConversationID)
+		assert.True(t, created.ReplyParentAcquisition.Fetched)
+		assert.True(t, created.ReplyParentAcquisition.Remote)
+		assert.Equal(t, remoteParent.StatusID, created.ReplyParentAcquisition.CanonicalStatusID)
+
+		expectedCC := []string{
+			"https://example.com/users/alice/followers",
+			remoteParent.AuthorID,
+		}
+		assert.Equal(t, []string{activitypub.PublicAddress}, created.Note.ToRecipients)
+		assert.Equal(t, expectedCC, created.Note.CcRecipients)
+
+		federatedNote, ok := federation.activities[0].Object.(*activitypub.Note)
+		require.True(t, ok)
+		assert.Equal(t, parentURL, federatedNote.InReplyTo)
+		assert.Equal(t, expectedCC, federatedNote.CC)
+
+		for _, cmd := range notifier.cmds {
+			require.NotEqual(t, common.NotificationTypeReply, cmd.Type)
+		}
+	})
+
+	t.Run("private unresolved remote parent url preserves protected audience", func(t *testing.T) {
+		service, _, federation, _, _ := newNotesServiceHarness(t)
+
+		parentURL := "https://remote.example/users/steward/statuses/unresolved-parent-private"
+		remoteParent := &models.Status{
+			StatusID:       models.CanonicalStatusIDForDomain(parentURL, "example.com"),
+			AuthorID:       "https://remote.example/users/steward",
+			AuthorUsername: "steward@remote.example",
+			ConversationID: "remote-conversation-private",
+			Visibility:     models.VisibilityPrivate,
+			ToRecipients:   []string{"https://remote.example/users/steward/followers"},
+			PublishedAt:    time.Now().UTC(),
+			CreatedAt:      time.Now().UTC(),
+			UpdatedAt:      time.Now().UTC(),
+			ModifiedAt:     time.Now().UTC(),
+			Note: &activitypub.Note{
+				BaseObject: activitypub.BaseObject{
+					ID:   parentURL,
+					To:   []string{"https://remote.example/users/steward/followers"},
+					Type: activitypub.NoteType,
+				},
+				AttributedTo: "https://remote.example/users/steward",
+				Content:      "seed",
+				Visibility:   models.VisibilityPrivate,
+			},
+		}
+
+		service.replyParents = &stubReplyParentResolver{
+			resolved: map[string]*ResolvedReplyParent{
+				parentURL: {
+					Status:             remoteParent,
+					CanonicalObjectURL: parentURL,
+					CanonicalStatusID:  remoteParent.StatusID,
+					Visibility:         remoteParent.Visibility,
+					Fetched:            true,
+					Remote:             true,
+				},
+			},
+		}
+
+		created, err := service.CreateNote(context.Background(), &CreateNoteCommand{
+			AuthorID:    "alice",
+			Content:     "private reply without mention",
+			Visibility:  models.VisibilityPrivate,
+			InReplyToID: parentURL,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, created)
+		require.Len(t, federation.activities, 1)
+
+		expectedTo := []string{"https://example.com/users/alice/followers"}
+		expectedBTo := []string{remoteParent.AuthorID}
+
+		assert.Equal(t, remoteParent.StatusID, created.Note.InReplyToID)
+		assert.Equal(t, parentURL, created.Note.Note.InReplyTo)
+		assert.Equal(t, remoteParent.ConversationID, created.Note.ConversationID)
+		assert.Equal(t, expectedTo, created.Note.ToRecipients)
+		assert.Equal(t, expectedBTo, created.Note.BtoRecipients)
+
+		federatedNote, ok := federation.activities[0].Object.(*activitypub.Note)
+		require.True(t, ok)
+		assert.Equal(t, parentURL, federatedNote.InReplyTo)
+		assert.Equal(t, expectedBTo, federatedNote.BTo)
+	})
 }
 
 func TestService_round15_create_note_derives_canonical_audience_defaults(t *testing.T) {

--- a/pkg/services/notes/service_round16_logging_test.go
+++ b/pkg/services/notes/service_round16_logging_test.go
@@ -52,6 +52,7 @@ func TestServiceRound16_CreateNote_LogsRootCausesForStatusPersistenceFailures(t 
 		nil,
 		nil,
 		nil,
+		nil,
 		logger,
 		"example.com",
 	)

--- a/pkg/services/registry.go
+++ b/pkg/services/registry.go
@@ -74,6 +74,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	pkgconfig "github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/federation"
+	"github.com/equaltoai/lesser/pkg/federation/remotenotes"
 	notifpush "github.com/equaltoai/lesser/pkg/notifications"
 	"github.com/equaltoai/lesser/pkg/services/accounts"
 	"github.com/equaltoai/lesser/pkg/services/ai"
@@ -1224,6 +1225,7 @@ func (r *Registry) Notes() *notes.Service {
 				r.publisherOrNoop(),
 				analyticsService,                         // Analytics service
 				r.createNotesFederationAdapterUnlocked(), // Federation service adapter
+				r.createNotesReplyParentResolverUnlocked(domainName),
 				notificationsService,
 				r.logger,
 				domainName,
@@ -2221,6 +2223,21 @@ func (r *Registry) createAccountsFederationAdapterUnlocked() *queueFederationAda
 
 func (r *Registry) createNotesFederationAdapterUnlocked() *queueFederationAdapter {
 	return r.createFederationAdapterUnlocked()
+}
+
+func (r *Registry) createNotesReplyParentResolverUnlocked(domainName string) notes.ReplyParentResolver {
+	if r == nil || r.storage == nil {
+		return nil
+	}
+
+	return remotenotes.NewReplyParentResolver(
+		r.storage.Status(),
+		r.storage.Object(),
+		r.storage.DomainBlock(),
+		federation.NewAuthorizedFetchService(r.storage, domainName, r.logger),
+		domainName,
+		r.logger,
+	)
 }
 
 func (r *Registry) createRelationshipsFederationAdapterUnlocked() *queueFederationAdapter {

--- a/tools/openapi/main.go
+++ b/tools/openapi/main.go
@@ -656,6 +656,7 @@ func ensureFoundationResponses(spec *openAPISpec) {
 	addResponse("Forbidden", "Forbidden", errorContent)
 	addResponse("NotFound", "Not Found", errorContent)
 	addResponse("Conflict", "Conflict", errorContent)
+	addResponse("RequestTimeout", "Request Timeout", errorContent)
 	addResponse("UnprocessableEntity", "Unprocessable Entity", errorContent)
 	desiredTooMany := response{
 		Description: "Too Many Requests",

--- a/tools/openapi/operation_overrides.go
+++ b/tools/openapi/operation_overrides.go
@@ -12,6 +12,7 @@ func applyOperationOverrides(op *operation, route routeDef) {
 	applyOAuthOverrides(op, route)
 	applyAppRegistrationOverrides(op, route)
 	applyMediaOverrides(op, route)
+	applyStatusOverrides(op, route)
 }
 
 func applyGraphQLOverrides(op *operation, route routeDef) {
@@ -78,6 +79,24 @@ func applyOAuthOverrides(op *operation, route routeDef) {
 	case route.Method == methodGET && route.Path == "/oauth/login":
 		applyOAuthLoginOverrides(op)
 	}
+}
+
+func applyStatusOverrides(op *operation, route routeDef) {
+	if op == nil {
+		return
+	}
+
+	if route.Method != methodPOST || route.Path != "/api/v1/statuses" {
+		return
+	}
+
+	op.Description = "Create a status. `in_reply_to_id` accepts local status IDs and canonical remote status URLs. When a canonical remote URL is not yet materialized locally, Lesser performs request-scoped remote parent acquisition on the write path only. Direct replies continue through the conversations service."
+	if op.Responses == nil {
+		op.Responses = map[string]response{}
+	}
+
+	ensureResponseRef(op.Responses, "408", "RequestTimeout")
+	ensureResponseRef(op.Responses, "503", "ServiceUnavailable")
 }
 
 func applyOAuthTokenOverrides(op *operation) {

--- a/tools/openapi/route_schema_bindings.go
+++ b/tools/openapi/route_schema_bindings.go
@@ -15,7 +15,6 @@ func bindPayloadSchemas(repoRoot string, spec *openAPISpec, routes []routeDef) e
 	if err != nil {
 		return err
 	}
-	applySchemaOverrides(spec)
 
 	liftPkg := builder.pkgs[packagePathLift]
 	if liftPkg == nil {
@@ -33,6 +32,7 @@ func bindPayloadSchemas(repoRoot string, spec *openAPISpec, routes []routeDef) e
 		}
 	}
 
+	applySchemaOverrides(spec)
 	overrideOAuthClientSchemas(spec.Components.Schemas)
 	applyScopeDefaults(routes)
 

--- a/tools/openapi/schema_overrides.go
+++ b/tools/openapi/schema_overrides.go
@@ -10,6 +10,14 @@ func applySchemaOverrides(spec *openAPISpec) {
 }
 
 func overrideCreateStatusRequest(schemas map[string]any) {
+	overrideSchemaProperty(
+		schemas,
+		"CreateStatusRequest",
+		"in_reply_to_id",
+		"Reply parent reference. Accepts a local status ID or a canonical remote status URL. Canonical remote URLs are resolved locally first and materialized on the create path when needed. Direct replies remain conversations-owned.",
+		false,
+	)
+
 	raw, ok := schemas["CreateStatusRequest"]
 	if !ok {
 		return


### PR DESCRIPTION
## Summary
- add a request-scoped remote reply-parent resolver/materializer so create-status can accept canonical remote parent URLs and materialize unresolved parents on the write path
- reuse one resolved parent across Notes create flow for canonical `inReplyTo`, conversation inheritance, delivery targeting, and notification gating, while keeping read paths storage/cache-only
- map remote parent acquisition failures to explicit `400` / `408` / `422` / `503` responses and publish the broadened create-status contract in OpenAPI + docs

## Validation
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

## Notes
- `./lesser verify smoke` is still environment-blocked here because no `SMOKE_BASE_URL`, `SMOKE_USERNAME`, or `SMOKE_OBJECT_ID` target was available.
- Direct / DM reply integrity remains conversations-owned and out of scope for this Notes-service lane.
