### PR TITLE
fix(federation): repair canonical status object fetchability

### DIFF
--- a/cmd/lesser/main.go
+++ b/cmd/lesser/main.go
@@ -164,7 +164,7 @@ func printUsageTo(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  lesser build lambda <name>                     # build a single bin/<name>.zip")
 	_, _ = fmt.Fprintln(w, "  lesser generate openapi|graphql-coverage|inventory|schema")
 	_, _ = fmt.Fprintln(w, "  lesser schema [--out <path>] | lesser export-schema")
-	_, _ = fmt.Fprintln(w, "  lesser verify [all|ci|docs|ai-training|schema|audit|supply-chain|graphql-coverage|openapi|mcp-auth-cutover|account-hydration|status-contract|remote-note-materialization|artifact-deploy|inventory|lambda-set|unit|smoke|cdk] [--smoke] [--cdk]")
+	_, _ = fmt.Fprintln(w, "  lesser verify [all|ci|docs|ai-training|schema|audit|supply-chain|graphql-coverage|openapi|mcp-auth-cutover|account-hydration|status-contract|remote-note-materialization|unresolved-remote-parent|artifact-deploy|inventory|lambda-set|unit|smoke|cdk] [--smoke] [--cdk]")
 	_, _ = fmt.Fprintln(w, "  lesser test [all|unit|integration|race]")
 	_, _ = fmt.Fprintln(w, "  lesser test coverage [--scope all|pkg] [--exclude-generated=true|false] [--include-testing] [--include-tools]")
 	_, _ = fmt.Fprintln(w, "  lesser coverage scoreboard [--profile <path>] [--mode package|file] [--package <prefix>] [--top <n>] [--min-total <pct>] [--exclude-generated=true|false]")

--- a/cmd/lesser/verify_cmd.go
+++ b/cmd/lesser/verify_cmd.go
@@ -27,6 +27,7 @@ const (
 )
 
 var runVerifyRemoteNoteMaterializationFn = runVerifyRemoteNoteMaterialization
+var runVerifyUnresolvedRemoteParentFn = runVerifyUnresolvedRemoteParent
 
 func runVerify(argv []string) error {
 	if len(argv) == 0 {
@@ -63,6 +64,8 @@ func runVerify(argv []string) error {
 		return runVerifyStatusContract(argv[1:])
 	case "remote-note-materialization":
 		return runVerifyRemoteNoteMaterializationFn(argv[1:])
+	case "unresolved-remote-parent":
+		return runVerifyUnresolvedRemoteParentFn(argv[1:])
 	case "artifact-deploy":
 		return runVerifyArtifactDeployFn(argv[1:])
 	case "inventory":

--- a/cmd/lesser/verify_unresolved_remote_parent.go
+++ b/cmd/lesser/verify_unresolved_remote_parent.go
@@ -1,0 +1,305 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/deploy/naming"
+)
+
+type verifyUnresolvedRemoteParentConfig struct {
+	BaseURL        string
+	Stage          string
+	Token          string
+	ParentURL      string
+	Visibility     string
+	Expected       string
+	Content        string
+	TimeoutSeconds int
+}
+
+type verifyUnresolvedRemoteParentSummary struct {
+	BaseURL         string
+	Stage           string
+	ParentURL       string
+	Visibility      string
+	Expected        string
+	Classification  string
+	HTTPStatus      int
+	CreatedStatusID string
+	ErrorCode       string
+}
+
+type verifyUnresolvedRemoteParentErrorResponse struct {
+	Error            string `json:"error"`
+	Code             string `json:"code"`
+	ErrorDescription string `json:"error_description"`
+}
+
+type verifyUnresolvedRemoteParentCreateResponse struct {
+	ID string `json:"id"`
+}
+
+var (
+	newVerifyUnresolvedRemoteParentClientFn = newVerifyUnresolvedRemoteParentHTTPClient
+	executeVerifyUnresolvedRemoteParentFn   = executeVerifyUnresolvedRemoteParent
+	verifyUnresolvedRemoteParentNowFn       = time.Now
+)
+
+func runVerifyUnresolvedRemoteParent(argv []string) error {
+	fs := flag.NewFlagSet("lesser verify unresolved-remote-parent", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	var cfg verifyUnresolvedRemoteParentConfig
+	fs.StringVar(&cfg.BaseURL, "base-url", "", "target Lesser base url (required; dev/staging only)")
+	fs.StringVar(&cfg.Stage, "stage", valueDev, "target stage (dev|staging; live is blocked)")
+	fs.StringVar(&cfg.Token, "token", "", "bearer token used to call POST /api/v1/statuses (required)")
+	fs.StringVar(&cfg.ParentURL, "parent-url", "", "reply parent reference to probe (required)")
+	fs.StringVar(&cfg.Visibility, "visibility", "public", "status visibility to exercise (public|unlisted|private)")
+	fs.StringVar(&cfg.Expected, "expect", "success", "expected outcome (success|bad-request|timeout|unavailable|unusable)")
+	fs.StringVar(&cfg.Content, "content", "", "explicit status text override")
+	fs.IntVar(&cfg.TimeoutSeconds, "timeout-seconds", 15, "per-request timeout seconds")
+
+	if err := fs.Parse(argv); err != nil {
+		return err
+	}
+	if err := validateVerifyUnresolvedRemoteParentConfig(cfg); err != nil {
+		return err
+	}
+	cfg.Content = resolveVerifyUnresolvedRemoteParentContent(cfg.Content, verifyUnresolvedRemoteParentNowFn().UTC().Format(time.RFC3339))
+
+	client := newVerifyUnresolvedRemoteParentClientFn(cfg.TimeoutSeconds)
+	summary, err := executeVerifyUnresolvedRemoteParentFn(context.Background(), client, cfg)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("verify unresolved-remote-parent complete")
+	fmt.Printf("base_url: %s\n", summary.BaseURL)
+	fmt.Printf("stage: %s\n", summary.Stage)
+	fmt.Printf("parent_url: %s\n", summary.ParentURL)
+	fmt.Printf("visibility: %s\n", summary.Visibility)
+	fmt.Printf("expected: %s\n", summary.Expected)
+	fmt.Printf("classification: %s\n", summary.Classification)
+	fmt.Printf("http_status: %d\n", summary.HTTPStatus)
+	if summary.CreatedStatusID != "" {
+		fmt.Printf("created_status_id: %s\n", summary.CreatedStatusID)
+	}
+	if summary.ErrorCode != "" {
+		fmt.Printf("error_code: %s\n", summary.ErrorCode)
+	}
+	return nil
+}
+
+func validateVerifyUnresolvedRemoteParentConfig(cfg verifyUnresolvedRemoteParentConfig) error {
+	cfg.BaseURL = strings.TrimSpace(cfg.BaseURL)
+	cfg.Token = strings.TrimSpace(cfg.Token)
+	cfg.ParentURL = strings.TrimSpace(cfg.ParentURL)
+	cfg.Visibility = strings.ToLower(strings.TrimSpace(cfg.Visibility))
+	cfg.Expected = strings.ToLower(strings.TrimSpace(cfg.Expected))
+
+	if cfg.BaseURL == "" {
+		return fmt.Errorf("--base-url is required")
+	}
+	if cfg.Token == "" {
+		return fmt.Errorf("--token is required")
+	}
+	if cfg.ParentURL == "" {
+		return fmt.Errorf("--parent-url is required")
+	}
+	if err := validateVerifyUnresolvedRemoteParentTarget(cfg.Stage, cfg.BaseURL); err != nil {
+		return err
+	}
+	if cfg.Visibility == "direct" {
+		return fmt.Errorf("--visibility=direct is not supported; direct replies remain conversations-owned")
+	}
+	if !containsFold([]string{"public", "unlisted", "private"}, cfg.Visibility) {
+		return fmt.Errorf("--visibility must be one of public, unlisted, or private")
+	}
+	if !containsFold([]string{"success", "bad-request", "timeout", "unavailable", "unusable"}, cfg.Expected) {
+		return fmt.Errorf("--expect must be one of success, bad-request, timeout, unavailable, or unusable")
+	}
+	if cfg.TimeoutSeconds <= 0 {
+		return fmt.Errorf("--timeout-seconds must be greater than zero")
+	}
+	if !strings.EqualFold(cfg.Expected, "bad-request") {
+		if err := common.ValidateURL(cfg.ParentURL, "parent_url"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateVerifyUnresolvedRemoteParentTarget(stage, baseURL string) error {
+	if naming.IsLiveEnvironment(stage) {
+		return fmt.Errorf("verify unresolved-remote-parent writes synthetic data and must not run against live")
+	}
+	parsed, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil || parsed == nil || parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("--base-url must be an absolute URL")
+	}
+
+	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+	switch strings.ToLower(strings.TrimSpace(stage)) {
+	case valueDev:
+		if !strings.HasPrefix(host, "dev.") {
+			return fmt.Errorf("verify unresolved-remote-parent dev targets must use a dev subdomain base url")
+		}
+	case valueStaging:
+		if !strings.HasPrefix(host, "staging.") {
+			return fmt.Errorf("verify unresolved-remote-parent staging targets must use a staging subdomain base url")
+		}
+	default:
+		return fmt.Errorf("--stage must be dev or staging")
+	}
+	return nil
+}
+
+func newVerifyUnresolvedRemoteParentHTTPClient(timeoutSeconds int) *http.Client {
+	timeout := time.Duration(timeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = defaultHTTPTimeout
+	}
+	return &http.Client{Timeout: timeout}
+}
+
+func executeVerifyUnresolvedRemoteParent(ctx context.Context, client *http.Client, cfg verifyUnresolvedRemoteParentConfig) (verifyUnresolvedRemoteParentSummary, error) {
+	endpoint, err := resolveVerifyMCPAuthCutoverEndpoint(cfg.BaseURL, "/api/v1/statuses")
+	if err != nil {
+		return verifyUnresolvedRemoteParentSummary{}, err
+	}
+
+	payload := map[string]any{
+		"status":         cfg.Content,
+		"visibility":     cfg.Visibility,
+		"sensitive":      false,
+		"in_reply_to_id": cfg.ParentURL,
+	}
+	status, body, err := verifyUnresolvedRemoteParentJSONRequest(ctx, client, http.MethodPost, endpoint, strings.TrimSpace(cfg.Token), payload)
+	if err != nil {
+		return verifyUnresolvedRemoteParentSummary{}, err
+	}
+
+	summary := verifyUnresolvedRemoteParentSummary{
+		BaseURL:        strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/"),
+		Stage:          strings.ToLower(strings.TrimSpace(cfg.Stage)),
+		ParentURL:      strings.TrimSpace(cfg.ParentURL),
+		Visibility:     strings.ToLower(strings.TrimSpace(cfg.Visibility)),
+		Expected:       strings.ToLower(strings.TrimSpace(cfg.Expected)),
+		Classification: classifyVerifyUnresolvedRemoteParentStatus(status),
+		HTTPStatus:     status,
+	}
+	if errResp, ok := decodeVerifyUnresolvedRemoteParentError(body); ok {
+		summary.ErrorCode = firstNonEmptyString(errResp.Code, errResp.Error)
+	}
+
+	if summary.Classification != summary.Expected {
+		return summary, fmt.Errorf("expected %s but got %s (%d): %s", summary.Expected, summary.Classification, status, verifyUnresolvedRemoteParentBodyMessage(body))
+	}
+
+	if summary.Classification != "success" {
+		return summary, nil
+	}
+
+	var created verifyUnresolvedRemoteParentCreateResponse
+	if err := json.Unmarshal(body, &created); err != nil {
+		return summary, fmt.Errorf("decode create-status response: %w", err)
+	}
+	if strings.TrimSpace(created.ID) == "" {
+		return summary, fmt.Errorf("create-status response missing id")
+	}
+	summary.CreatedStatusID = strings.TrimSpace(created.ID)
+	return summary, nil
+}
+
+func verifyUnresolvedRemoteParentJSONRequest(ctx context.Context, client *http.Client, method, endpoint, token string, payload any) (int, []byte, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return 0, nil, err
+	}
+	return verifyUnresolvedRemoteParentDoRequest(ctx, client, method, endpoint, token, body)
+}
+
+func verifyUnresolvedRemoteParentDoRequest(ctx context.Context, client *http.Client, method, endpoint, token string, body []byte) (int, []byte, error) {
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	if strings.TrimSpace(token) != "" {
+		req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(token))
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	if err != nil {
+		return 0, nil, err
+	}
+	return resp.StatusCode, raw, nil
+}
+
+func classifyVerifyUnresolvedRemoteParentStatus(status int) string {
+	switch {
+	case status >= 200 && status < 300:
+		return "success"
+	case status == http.StatusBadRequest:
+		return "bad-request"
+	case status == http.StatusRequestTimeout:
+		return "timeout"
+	case status == http.StatusServiceUnavailable:
+		return "unavailable"
+	case status == http.StatusUnprocessableEntity:
+		return "unusable"
+	default:
+		return fmt.Sprintf("unexpected-%d", status)
+	}
+}
+
+func decodeVerifyUnresolvedRemoteParentError(body []byte) (verifyUnresolvedRemoteParentErrorResponse, bool) {
+	if len(body) == 0 {
+		return verifyUnresolvedRemoteParentErrorResponse{}, false
+	}
+	var out verifyUnresolvedRemoteParentErrorResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return verifyUnresolvedRemoteParentErrorResponse{}, false
+	}
+	if strings.TrimSpace(out.Error) == "" && strings.TrimSpace(out.Code) == "" && strings.TrimSpace(out.ErrorDescription) == "" {
+		return verifyUnresolvedRemoteParentErrorResponse{}, false
+	}
+	return out, true
+}
+
+func verifyUnresolvedRemoteParentBodyMessage(body []byte) string {
+	if errResp, ok := decodeVerifyUnresolvedRemoteParentError(body); ok {
+		return firstNonEmptyString(errResp.ErrorDescription, errResp.Error, errResp.Code)
+	}
+	message := strings.TrimSpace(string(body))
+	if message == "" {
+		return "empty response body"
+	}
+	return message
+}
+
+func resolveVerifyUnresolvedRemoteParentContent(content, suffix string) string {
+	content = strings.TrimSpace(content)
+	if content != "" {
+		return content
+	}
+	return fmt.Sprintf("verify unresolved remote parent %s", strings.TrimSpace(suffix))
+}

--- a/cmd/lesser/verify_unresolved_remote_parent_test.go
+++ b/cmd/lesser/verify_unresolved_remote_parent_test.go
@@ -226,3 +226,90 @@ func TestVerifyUnresolvedRemoteParentBodyMessage(t *testing.T) {
 func jsonNewDecoder(r io.Reader) *json.Decoder {
 	return json.NewDecoder(r)
 }
+
+func TestValidateVerifyUnresolvedRemoteParentTarget(t *testing.T) {
+	require.ErrorContains(t, validateVerifyUnresolvedRemoteParentTarget(valueDev, "://bad"), "absolute URL")
+	require.NoError(t, validateVerifyUnresolvedRemoteParentTarget(valueStaging, "https://staging.example.com"))
+	require.ErrorContains(t, validateVerifyUnresolvedRemoteParentTarget("qa", "https://dev.example.com"), "--stage must be dev or staging")
+}
+
+func TestNewVerifyUnresolvedRemoteParentHTTPClient_DefaultTimeout(t *testing.T) {
+	client := newVerifyUnresolvedRemoteParentHTTPClient(0)
+	require.Equal(t, defaultHTTPTimeout, client.Timeout)
+}
+
+func TestExecuteVerifyUnresolvedRemoteParent_EdgeCases(t *testing.T) {
+	t.Run("invalid endpoint bubbles up", func(t *testing.T) {
+		_, err := executeVerifyUnresolvedRemoteParent(context.Background(), http.DefaultClient, verifyUnresolvedRemoteParentConfig{
+			BaseURL:    "://bad",
+			Stage:      valueDev,
+			Token:      "tok",
+			ParentURL:  "https://remote.example/users/alice/statuses/1",
+			Visibility: "public",
+			Expected:   "success",
+			Content:    "hello",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("success without id fails", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"url":"https://dev.example.com/users/alice/statuses/1"}`))
+		}))
+		defer server.Close()
+
+		_, err := executeVerifyUnresolvedRemoteParent(context.Background(), server.Client(), verifyUnresolvedRemoteParentConfig{
+			BaseURL:    server.URL,
+			Stage:      valueDev,
+			Token:      "tok",
+			ParentURL:  "https://remote.example/users/alice/statuses/1",
+			Visibility: "public",
+			Expected:   "success",
+			Content:    "hello",
+		})
+		require.ErrorContains(t, err, "missing id")
+	})
+
+	t.Run("success with malformed json fails", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`not-json`))
+		}))
+		defer server.Close()
+
+		_, err := executeVerifyUnresolvedRemoteParent(context.Background(), server.Client(), verifyUnresolvedRemoteParentConfig{
+			BaseURL:    server.URL,
+			Stage:      valueDev,
+			Token:      "tok",
+			ParentURL:  "https://remote.example/users/alice/statuses/1",
+			Visibility: "public",
+			Expected:   "success",
+			Content:    "hello",
+		})
+		require.ErrorContains(t, err, "decode create-status response")
+	})
+}
+
+func TestVerifyUnresolvedRemoteParentDoRequest_WithoutAuthHeader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Empty(t, r.Header.Get("Authorization"))
+		_, _ = w.Write([]byte(`ok`))
+	}))
+	defer server.Close()
+
+	status, body, err := verifyUnresolvedRemoteParentDoRequest(context.Background(), server.Client(), http.MethodGet, server.URL, "", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, []byte("ok"), body)
+}
+
+func TestDecodeVerifyUnresolvedRemoteParentErrorAndContentHelpers(t *testing.T) {
+	_, ok := decodeVerifyUnresolvedRemoteParentError(nil)
+	require.False(t, ok)
+	_, ok = decodeVerifyUnresolvedRemoteParentError([]byte(`not-json`))
+	require.False(t, ok)
+	require.Equal(t, "empty response body", verifyUnresolvedRemoteParentBodyMessage(nil))
+	require.Equal(t, "custom", resolveVerifyUnresolvedRemoteParentContent("custom", "ignored"))
+	require.Equal(t, "verify unresolved remote parent suffix", resolveVerifyUnresolvedRemoteParentContent("", "suffix"))
+}

--- a/cmd/lesser/verify_unresolved_remote_parent_test.go
+++ b/cmd/lesser/verify_unresolved_remote_parent_test.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunVerify_DispatchesUnresolvedRemoteParent(t *testing.T) {
+	previous := runVerifyUnresolvedRemoteParentFn
+	t.Cleanup(func() { runVerifyUnresolvedRemoteParentFn = previous })
+
+	var called bool
+	runVerifyUnresolvedRemoteParentFn = func(argv []string) error {
+		called = true
+		require.Equal(t, []string{"--base-url", "https://dev.example.com", "--token", "tok", "--parent-url", "https://remote.example/users/alice/statuses/1"}, argv)
+		return nil
+	}
+
+	require.NoError(t, runVerify([]string{"unresolved-remote-parent", "--base-url", "https://dev.example.com", "--token", "tok", "--parent-url", "https://remote.example/users/alice/statuses/1"}))
+	require.True(t, called)
+}
+
+func TestValidateVerifyUnresolvedRemoteParentConfig(t *testing.T) {
+	t.Run("requires core flags", func(t *testing.T) {
+		require.ErrorContains(t, validateVerifyUnresolvedRemoteParentConfig(verifyUnresolvedRemoteParentConfig{}), "--base-url is required")
+		require.ErrorContains(t, validateVerifyUnresolvedRemoteParentConfig(verifyUnresolvedRemoteParentConfig{BaseURL: "https://dev.example.com"}), "--token is required")
+		require.ErrorContains(t, validateVerifyUnresolvedRemoteParentConfig(verifyUnresolvedRemoteParentConfig{BaseURL: "https://dev.example.com", Token: "tok"}), "--parent-url is required")
+	})
+
+	t.Run("blocks live and wrong stage hosts", func(t *testing.T) {
+		require.ErrorContains(t, validateVerifyUnresolvedRemoteParentConfig(verifyUnresolvedRemoteParentConfig{
+			BaseURL:        "https://example.com",
+			Stage:          "live",
+			Token:          "tok",
+			ParentURL:      "https://remote.example/users/alice/statuses/1",
+			Visibility:     "public",
+			Expected:       "success",
+			TimeoutSeconds: 15,
+		}), "must not run against live")
+		require.ErrorContains(t, validateVerifyUnresolvedRemoteParentConfig(verifyUnresolvedRemoteParentConfig{
+			BaseURL:        "https://staging.example.com",
+			Stage:          valueDev,
+			Token:          "tok",
+			ParentURL:      "https://remote.example/users/alice/statuses/1",
+			Visibility:     "public",
+			Expected:       "success",
+			TimeoutSeconds: 15,
+		}), "dev subdomain")
+	})
+
+	t.Run("rejects invalid visibility and bad url for success probes", func(t *testing.T) {
+		require.ErrorContains(t, validateVerifyUnresolvedRemoteParentConfig(verifyUnresolvedRemoteParentConfig{
+			BaseURL:        "https://dev.example.com",
+			Stage:          valueDev,
+			Token:          "tok",
+			ParentURL:      "https://remote.example/users/alice/statuses/1",
+			Visibility:     "direct",
+			Expected:       "success",
+			TimeoutSeconds: 15,
+		}), "conversations-owned")
+		require.ErrorContains(t, validateVerifyUnresolvedRemoteParentConfig(verifyUnresolvedRemoteParentConfig{
+			BaseURL:        "https://dev.example.com",
+			Stage:          valueDev,
+			Token:          "tok",
+			ParentURL:      "not-a-url",
+			Visibility:     "public",
+			Expected:       "success",
+			TimeoutSeconds: 15,
+		}), "parent_url")
+	})
+
+	t.Run("bad request probes may use intentionally invalid parent references", func(t *testing.T) {
+		require.NoError(t, validateVerifyUnresolvedRemoteParentConfig(verifyUnresolvedRemoteParentConfig{
+			BaseURL:        "https://dev.example.com",
+			Stage:          valueDev,
+			Token:          "tok",
+			ParentURL:      "not-a-url",
+			Visibility:     "public",
+			Expected:       "bad-request",
+			TimeoutSeconds: 15,
+		}))
+	})
+}
+
+func TestRunVerifyUnresolvedRemoteParent_Success(t *testing.T) {
+	previousClient := newVerifyUnresolvedRemoteParentClientFn
+	previousExecute := executeVerifyUnresolvedRemoteParentFn
+	previousNow := verifyUnresolvedRemoteParentNowFn
+	t.Cleanup(func() {
+		newVerifyUnresolvedRemoteParentClientFn = previousClient
+		executeVerifyUnresolvedRemoteParentFn = previousExecute
+		verifyUnresolvedRemoteParentNowFn = previousNow
+	})
+
+	verifyUnresolvedRemoteParentNowFn = func() time.Time {
+		return time.Date(2026, time.April, 22, 23, 15, 0, 0, time.UTC)
+	}
+	newVerifyUnresolvedRemoteParentClientFn = func(int) *http.Client { return http.DefaultClient }
+	executeVerifyUnresolvedRemoteParentFn = func(_ context.Context, _ *http.Client, cfg verifyUnresolvedRemoteParentConfig) (verifyUnresolvedRemoteParentSummary, error) {
+		require.Equal(t, "verify unresolved remote parent 2026-04-22T23:15:00Z", cfg.Content)
+		return verifyUnresolvedRemoteParentSummary{
+			BaseURL:         "https://dev.example.com",
+			Stage:           valueDev,
+			ParentURL:       cfg.ParentURL,
+			Visibility:      cfg.Visibility,
+			Expected:        cfg.Expected,
+			Classification:  "success",
+			HTTPStatus:      http.StatusCreated,
+			CreatedStatusID: "123",
+		}, nil
+	}
+
+	stdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = stdout })
+
+	err = runVerifyUnresolvedRemoteParent([]string{
+		"--base-url", "https://dev.example.com",
+		"--token", "tok",
+		"--parent-url", "https://remote.example/users/alice/statuses/1",
+	})
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	var out bytes.Buffer
+	_, err = io.Copy(&out, r)
+	require.NoError(t, err)
+	require.Contains(t, out.String(), "verify unresolved-remote-parent complete")
+	require.Contains(t, out.String(), "created_status_id: 123")
+}
+
+func TestExecuteVerifyUnresolvedRemoteParent(t *testing.T) {
+	t.Run("success captures created status id", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, http.MethodPost, r.Method)
+			require.Equal(t, "/api/v1/statuses", r.URL.Path)
+			require.Equal(t, "Bearer tok", r.Header.Get("Authorization"))
+			var payload map[string]any
+			require.NoError(t, jsonNewDecoder(r.Body).Decode(&payload))
+			require.Equal(t, "hello", payload["status"])
+			require.Equal(t, "public", payload["visibility"])
+			require.Equal(t, "https://remote.example/users/alice/statuses/1", payload["in_reply_to_id"])
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"status-1"}`))
+		}))
+		defer server.Close()
+
+		summary, err := executeVerifyUnresolvedRemoteParent(context.Background(), server.Client(), verifyUnresolvedRemoteParentConfig{
+			BaseURL:    server.URL,
+			Stage:      valueDev,
+			Token:      "tok",
+			ParentURL:  "https://remote.example/users/alice/statuses/1",
+			Visibility: "public",
+			Expected:   "success",
+			Content:    "hello",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "success", summary.Classification)
+		require.Equal(t, "status-1", summary.CreatedStatusID)
+	})
+
+	t.Run("unusable response preserves error code", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"error":"remote reply parent is not usable","code":"unprocessable_entity"}`))
+		}))
+		defer server.Close()
+
+		summary, err := executeVerifyUnresolvedRemoteParent(context.Background(), server.Client(), verifyUnresolvedRemoteParentConfig{
+			BaseURL:    server.URL,
+			Stage:      valueDev,
+			Token:      "tok",
+			ParentURL:  "https://remote.example/users/alice/statuses/1",
+			Visibility: "private",
+			Expected:   "unusable",
+			Content:    "hello",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "unusable", summary.Classification)
+		require.Equal(t, "unprocessable_entity", summary.ErrorCode)
+	})
+
+	t.Run("mismatch returns descriptive error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "upstream timeout", http.StatusRequestTimeout)
+		}))
+		defer server.Close()
+
+		_, err := executeVerifyUnresolvedRemoteParent(context.Background(), server.Client(), verifyUnresolvedRemoteParentConfig{
+			BaseURL:    server.URL,
+			Stage:      valueDev,
+			Token:      "tok",
+			ParentURL:  "https://remote.example/users/alice/statuses/1",
+			Visibility: "public",
+			Expected:   "success",
+			Content:    "hello",
+		})
+		require.ErrorContains(t, err, "expected success but got timeout")
+	})
+}
+
+func TestClassifyVerifyUnresolvedRemoteParentStatus(t *testing.T) {
+	require.Equal(t, "success", classifyVerifyUnresolvedRemoteParentStatus(http.StatusCreated))
+	require.Equal(t, "bad-request", classifyVerifyUnresolvedRemoteParentStatus(http.StatusBadRequest))
+	require.Equal(t, "timeout", classifyVerifyUnresolvedRemoteParentStatus(http.StatusRequestTimeout))
+	require.Equal(t, "unusable", classifyVerifyUnresolvedRemoteParentStatus(http.StatusUnprocessableEntity))
+	require.Equal(t, "unavailable", classifyVerifyUnresolvedRemoteParentStatus(http.StatusServiceUnavailable))
+	require.Equal(t, "unexpected-500", classifyVerifyUnresolvedRemoteParentStatus(http.StatusInternalServerError))
+}
+
+func TestVerifyUnresolvedRemoteParentBodyMessage(t *testing.T) {
+	require.Equal(t, "remote fetch timed out", verifyUnresolvedRemoteParentBodyMessage([]byte(`{"error_description":"remote fetch timed out"}`)))
+	require.Equal(t, "plain text", verifyUnresolvedRemoteParentBodyMessage([]byte("plain text")))
+}
+
+func jsonNewDecoder(r io.Reader) *json.Decoder {
+	return json.NewDecoder(r)
+}

--- a/cmd/objects/main.go
+++ b/cmd/objects/main.go
@@ -152,11 +152,7 @@ func NewHandler() *Handler {
 
 // HandleGetObject handles GET requests for ActivityPub objects
 func (h *Handler) HandleGetObject(ctx *apptheory.Context) (*apptheory.Response, error) {
-	// Extract object ID from path parameters
-	objectID := ""
-	if ctx != nil {
-		objectID = ctx.Param("id")
-	}
+	objectID, lookupID := h.resolveObjectLookup(ctx)
 	if err := common.ValidateRequiredParam("objectID", objectID); err != nil {
 		return objectsJSONError(http.StatusUnprocessableEntity, "missing object id"), nil
 	}
@@ -244,11 +240,6 @@ func (h *Handler) HandleGetObject(ctx *apptheory.Context) (*apptheory.Response, 
 		zap.String("request_id", requestID),
 	)
 
-	lookupID := objectID
-	if !strings.HasPrefix(lookupID, "http://") && !strings.HasPrefix(lookupID, "https://") {
-		lookupID = fmt.Sprintf("%s/objects/%s", cfg.BaseURL(), objectID)
-	}
-
 	// Get the object from storage
 	objInterface, err := h.objectRepo.GetObject(runCtx, lookupID)
 	if err != nil {
@@ -299,6 +290,30 @@ func (h *Handler) HandleGetObject(ctx *apptheory.Context) (*apptheory.Response, 
 		zap.String("request_id", requestID),
 	)
 	return objectsActivityJSON(http.StatusOK, objInterface)
+}
+
+func (h *Handler) resolveObjectLookup(ctx *apptheory.Context) (string, string) {
+	if ctx == nil {
+		return "", ""
+	}
+
+	objectID := strings.TrimSpace(ctx.Param("id"))
+	if objectID == "" {
+		return "", ""
+	}
+
+	username := strings.TrimSpace(ctx.Param("username"))
+	if username != "" {
+		canonicalID := fmt.Sprintf("%s/users/%s/statuses/%s", cfg.BaseURL(), username, objectID)
+		return canonicalID, canonicalID
+	}
+
+	lookupID := objectID
+	if !strings.HasPrefix(lookupID, "http://") && !strings.HasPrefix(lookupID, "https://") {
+		lookupID = fmt.Sprintf("%s/objects/%s", cfg.BaseURL(), objectID)
+	}
+
+	return objectID, lookupID
 }
 
 // generateObjectHTML creates HTML representation of an ActivityPub object
@@ -815,8 +830,9 @@ func buildApp(handler *Handler, lambdaLogger *zap.Logger) *apptheory.App {
 		}
 	})
 
-	// ActivityPub federation endpoint.
+	// ActivityPub federation endpoints.
 	app.Get("/objects/:id", handler.HandleGetObject)
+	app.Get("/users/:username/statuses/:id", handler.HandleGetObject)
 
 	return app
 }

--- a/cmd/objects/round12_objects_test.go
+++ b/cmd/objects/round12_objects_test.go
@@ -396,6 +396,72 @@ func TestHandleGetObject_FetchResponses_Round12(t *testing.T) {
 		require.Equal(t, 200, resp.Status)
 		require.Equal(t, []string{"application/activity+json"}, resp.Headers["content-type"])
 	})
+
+	t.Run("canonical status route resolves published status url", func(t *testing.T) {
+		now := time.Now().UTC()
+		note := &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:        "https://example.com/users/alice/statuses/123",
+				Type:      activitypub.NoteType,
+				Published: &now,
+			},
+			Content:      "hello from canonical route",
+			AttributedTo: "https://example.com/users/alice",
+		}
+
+		objRepo := &fakeObjectRepo{obj: note}
+		h := &Handler{
+			instanceRepo:           instanceRepo,
+			objectRepo:             objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method:  http.MethodGet,
+				Path:    "/users/alice/statuses/123",
+				Headers: map[string][]string{"accept": {"application/activity+json"}},
+			},
+			Params: map[string]string{
+				"username": "alice",
+				"id":       "123",
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, 200, resp.Status)
+		require.Equal(t, "https://example.com/users/alice/statuses/123", objRepo.gotID)
+
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "https://example.com/users/alice/statuses/123", body["id"])
+	})
+
+	t.Run("canonical status route preserves authorized fetch behavior", func(t *testing.T) {
+		objRepo := &fakeObjectRepo{obj: map[string]any{"id": "https://example.com/users/alice/statuses/123", "type": "Note"}}
+		h := &Handler{
+			instanceRepo:           instanceRepo,
+			objectRepo:             objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{enabled: true, verifyErr: errors.New("missing signature")},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method: http.MethodGet,
+				Path:   "/users/alice/statuses/123",
+				Headers: map[string][]string{
+					"accept": {"application/activity+json"},
+					"host":   {"example.com"},
+				},
+			},
+			Params: map[string]string{
+				"username": "alice",
+				"id":       "123",
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, 401, resp.Status)
+		require.Empty(t, objRepo.gotID)
+	})
 }
 
 func TestExtractObjectData_Round12(t *testing.T) {
@@ -567,6 +633,40 @@ func TestNewHandler_MainAndInit_Round12(t *testing.T) {
 		main()
 		require.True(t, called)
 		require.Contains(t, fakeRepo.gotID, "https://example.com/objects/123")
+	})
+
+	t.Run("build app serves canonical status routes", func(t *testing.T) {
+		fakeRepo := &fakeObjectRepo{obj: map[string]any{"id": "https://example.com/users/alice/statuses/123", "type": "Note"}}
+		app := buildApp(&Handler{
+			objectRepo:             fakeRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
+			instanceRepo:           &fakeInstanceRepo{state: &storageModels.InstanceState{Locked: false}},
+		}, zap.NewNop())
+
+		event := events.APIGatewayV2HTTPRequest{
+			Version:  "2.0",
+			RouteKey: "GET /users/alice/statuses/123",
+			RawPath:  "/users/alice/statuses/123",
+			Headers:  map[string]string{"accept": "application/activity+json"},
+			RequestContext: events.APIGatewayV2HTTPRequestContext{
+				RequestID: "req-canonical",
+				HTTP: events.APIGatewayV2HTTPRequestContextHTTPDescription{
+					Method: "GET",
+					Path:   "/users/alice/statuses/123",
+				},
+			},
+		}
+
+		raw, err := json.Marshal(event)
+		require.NoError(t, err)
+
+		resp, err := app.HandleLambda(context.Background(), raw)
+		require.NoError(t, err)
+		lambdaResp, ok := resp.(events.APIGatewayV2HTTPResponse)
+		require.True(t, ok)
+		require.Equal(t, 200, lambdaResp.StatusCode)
+		require.Equal(t, "https://example.com/users/alice/statuses/123", fakeRepo.gotID)
+		require.Equal(t, "application/activity+json", lambdaResp.Headers["content-type"])
 	})
 }
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -217,7 +217,9 @@ For canonical remote URLs, Lesser:
 - uses the resolved parent for reply threading, audience derivation, and delivery targeting
 
 This acquisition behavior is write-path only. It does **not** introduce live remote fetches on read paths such as
-timelines, thread context, or GraphQL public reads.
+timelines, thread context, or GraphQL public reads. Local statuses published by Lesser are also dereferenceable as
+ActivityPub objects at their canonical `/users/{username}/statuses/{id}` URLs, so unresolved reply-parent acquisition
+can fetch the exact object ID that Lesser publishes.
 
 Direct / DM replies remain conversations-owned and are out of scope for this Notes-service path.
 
@@ -232,6 +234,18 @@ curl -s -X POST "https://<stage-domain>/api/v1/statuses" \
     "in_reply_to_id": "https://remote.example/users/steward/statuses/seed-1"
   }' | jq .
 ```
+
+### Pattern: fetch a published local Note by canonical ActivityPub URL
+
+For Lesser-authored notes, the published object ID is fetchable as published:
+
+```bash
+curl -s -H "Accept: application/activity+json" \
+  "https://<stage-domain>/users/alice/statuses/<status-id>" | jq .
+```
+
+`GET /objects/{id}` remains available, but remote peers should be able to dereference the canonical published Note URL
+directly.
 
 ### Pattern: paginate list endpoints (Link header)
 
@@ -265,8 +279,8 @@ Create-status reply-parent acquisition can also return:
 
 - `400 Bad Request`: invalid `in_reply_to_id` shape or unsupported identifier form
 - `408 Request Timeout`: remote parent acquisition timed out
-- `422 Unprocessable Entity`: the remote parent resolved but cannot be used as a reply parent
-- `503 Service Unavailable`: remote parent acquisition could not reach a usable upstream
+- `422 Unprocessable Entity`: the remote parent was fetched but cannot be used as a reply parent
+- `503 Service Unavailable`: Lesser could not dereference or fetch a usable upstream parent
 
 ## GraphQL
 

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -15302,7 +15302,7 @@ paths:
     /api/v1/statuses:
         post:
             operationId: post_api_v1_statuses
-            description: Create a status. `in_reply_to_id` accepts local status IDs and canonical remote status URLs. When a canonical remote URL is not yet materialized locally, Lesser performs request-scoped remote parent acquisition on the write path only. Direct replies continue through the conversations service.
+            description: Create a status. `in_reply_to_id` accepts local status IDs and canonical remote status URLs. When a canonical remote URL is not yet materialized locally, Lesser performs request-scoped remote parent acquisition on the write path only. Direct replies continue through the conversations service. Failure classes distinguish invalid references (400), acquisition timeouts (408), fetched-but-unusable parents (422), and upstream unavailability (503).
             tags:
                 - statuses
             security:
@@ -19578,4 +19578,32 @@ paths:
             x-lesser-lambda: outbox
             x-lesser-routeSources:
                 - infra/cdk/inventory/lambdas.go:outbox
+    /users/{username}/statuses/{id}:
+        get:
+            operationId: get_users_by_username_statuses_by_id
+            tags:
+                - activitypub
+            parameters:
+                - name: id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: username
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "404":
+                    $ref: '#/components/responses/NotFound'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+            x-lesser-lambda: objects
+            x-lesser-routeSources:
+                - infra/cdk/inventory/lambdas.go:objects
 

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -20,8 +20,12 @@ curl -s "https://example.com/.well-known/webfinger?resource=acct:alice@example.c
 
 ```bash
 curl -s -H "Accept: application/activity+json" "https://example.com/users/alice" | jq .
+curl -s -H "Accept: application/activity+json" "https://example.com/users/alice/statuses/<id>" | jq .
 curl -s -H "Accept: application/activity+json" "https://example.com/objects/<id>" | jq .
 ```
+
+`/users/{username}/statuses/{id}` is the canonical local Note object URL Lesser publishes. `/objects/{id}` remains an
+additional object route.
 
 ### Inbox surface truth
 

--- a/docs/operations/release-notes.md
+++ b/docs/operations/release-notes.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Canonical local status-object fetchability
+
+Local Lesser-authored Note IDs published as `https://<domain>/users/{username}/statuses/{id}` are now fetchable as
+ActivityPub objects at that same canonical URL. `GET /objects/{id}` remains available as a secondary route, but the
+published Note ID is now truthful and dereferenceable as published.
+
 ## Remote reply-parent acquisition on create-status
 
 `POST /api/v1/statuses` now accepts canonical remote status URLs in `in_reply_to_id` in addition to local status IDs.
@@ -22,8 +28,8 @@ acquisition on the create path. The resolved parent is reused for:
 
 - `400 Bad Request` — invalid `in_reply_to_id` shape or unsupported identifier form
 - `408 Request Timeout` — remote parent acquisition timed out
-- `422 Unprocessable Entity` — the parent resolved but is not usable as a reply parent
-- `503 Service Unavailable` — remote parent acquisition could not reach a usable upstream
+- `422 Unprocessable Entity` — the parent was fetched but is not usable as a reply parent
+- `503 Service Unavailable` — Lesser could not dereference or fetch a usable upstream parent
 
 ### Monitoring focus
 

--- a/docs/specs/01-lambda-inventory-matrix.md
+++ b/docs/specs/01-lambda-inventory-matrix.md
@@ -63,7 +63,7 @@ The inventory set is enforced by:
 | moderation-processor | processor-stream | Stream: table=main-table; start=LATEST; batch=10; window=5s; parallel=2; maxRetry=3; bisect=true; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
 | note-processor | processor-stream | Stream: table=main-table; start=LATEST; batch=25; window=5s; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
 | notification-processor | processor-sqs | SQS: queue=notification-processor-queue; partialFailure=true | — | basic | memory=512MB; timeout=30s; logs=7d |
-| objects | api-http | HTTP: GET /objects/{id} | — | encryption | memory=512MB; timeout=30s; logs=7d |
+| objects | api-http | HTTP: GET /objects/{id}<br>HTTP: GET /users/{username}/statuses/{id} | — | encryption | memory=512MB; timeout=30s; logs=7d |
 | outbox | api-http | HTTP: GET /users/{username}/outbox<br>HTTP: POST /users/{username}/outbox | — | encryption | memory=512MB; timeout=30s; logs=7d |
 | push-delivery | processor-sqs | SQS: queue=push-delivery-queue; partialFailure=true | VAPID_PUBLIC_KEY<br>VAPID_SUBJECT<br>VAPID_SECRET_ARN | basic | memory=512MB; timeout=30s; logs=7d |
 | report-trust-updater | processor-stream | Stream: table=main-table; start=LATEST; batch=25; window=5s; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |

--- a/infra/cdk/inventory/lambdas.go
+++ b/infra/cdk/inventory/lambdas.go
@@ -336,6 +336,7 @@ var LambdaInventory = Inventory{
 			Role: RoleClassEncryption,
 			HTTPRoutes: []HTTPRoute{
 				{Method: "GET", Path: "/objects/{id}"},
+				{Method: "GET", Path: "/users/{username}/statuses/{id}"},
 			},
 		},
 		{

--- a/pkg/federation/remotenotes/reply_parent_resolver.go
+++ b/pkg/federation/remotenotes/reply_parent_resolver.go
@@ -422,7 +422,7 @@ func mapReplyParentFetchError(parentURL string, err error) error {
 			commonerrors.CodeUnprocessableEntity, commonerrors.CodeValidationFailed,
 			commonerrors.CodeInvalidInput, commonerrors.CodeInvalidFormat,
 			commonerrors.CodeActivityParsingFailed, commonerrors.CodeRemoteFetchFailed:
-			return unusableReplyParent(parentURL, appErr.Message)
+			return serviceUnavailableReplyParent(parentURL, err)
 		}
 	}
 

--- a/pkg/federation/remotenotes/reply_parent_resolver_helpers_test.go
+++ b/pkg/federation/remotenotes/reply_parent_resolver_helpers_test.go
@@ -136,12 +136,19 @@ func TestReplyParentErrorMappingAndHelpers(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, commonerrors.CodeExternalServiceUnavailable, serviceUnavailable.Code)
 
-		unusable, ok := commonerrors.AsAppError(mapReplyParentFetchError(
+		notFound, ok := commonerrors.AsAppError(mapReplyParentFetchError(
 			"https://remote.example/statuses/seed-1",
 			commonerrors.RemoteFetchNotFound("https://remote.example/statuses/seed-1"),
 		))
 		require.True(t, ok)
-		assert.Equal(t, commonerrors.CodeUnprocessableEntity, unusable.Code)
+		assert.Equal(t, commonerrors.CodeExternalServiceUnavailable, notFound.Code)
+
+		unauthorized, ok := commonerrors.AsAppError(mapReplyParentFetchError(
+			"https://remote.example/statuses/seed-1",
+			commonerrors.RemoteFetchUnauthorized("https://remote.example/statuses/seed-1"),
+		))
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeExternalServiceUnavailable, unauthorized.Code)
 	})
 
 	t.Run("falls back to service unavailable for unknown fetch failures", func(t *testing.T) {

--- a/pkg/federation/remotenotes/reply_parent_resolver_test.go
+++ b/pkg/federation/remotenotes/reply_parent_resolver_test.go
@@ -212,13 +212,37 @@ func TestReplyParentResolver_ResolveReplyParent(t *testing.T) {
 		assert.Equal(t, 503, appErr.HTTPStatusCode)
 	})
 
-	t.Run("fetched but unusable parent maps to 422", func(t *testing.T) {
+	t.Run("not found parent maps to 503", func(t *testing.T) {
 		parentURL := "https://remote.example/users/steward/statuses/missing"
 		resolver := NewReplyParentResolver(
 			&stubStatusRepo{},
 			&stubObjectRepo{},
 			&stubDomainBlockRepo{},
 			&stubFetcher{err: commonerrors.RemoteFetchNotFound(parentURL)},
+			"example.com",
+			zap.NewNop(),
+		)
+
+		_, err := resolver.ResolveReplyParent(context.Background(), localAuthorAccount("alice"), parentURL, models.VisibilityPublic)
+		appErr, ok := commonerrors.AsAppError(err)
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeExternalServiceUnavailable, appErr.Code)
+		assert.Equal(t, 503, appErr.HTTPStatusCode)
+	})
+
+	t.Run("fetched but semantically unusable parent maps to 422", func(t *testing.T) {
+		parentURL := "https://remote.example/users/steward/statuses/article"
+		resolver := NewReplyParentResolver(
+			&stubStatusRepo{},
+			&stubObjectRepo{},
+			&stubDomainBlockRepo{},
+			&stubFetcher{obj: map[string]any{
+				"@context":     []any{"https://www.w3.org/ns/activitystreams"},
+				"id":           parentURL,
+				"type":         "Article",
+				"content":      "not a note",
+				"attributedTo": "https://remote.example/users/steward",
+			}},
 			"example.com",
 			zap.NewNop(),
 		)

--- a/tools/openapi/operation_overrides.go
+++ b/tools/openapi/operation_overrides.go
@@ -90,7 +90,7 @@ func applyStatusOverrides(op *operation, route routeDef) {
 		return
 	}
 
-	op.Description = "Create a status. `in_reply_to_id` accepts local status IDs and canonical remote status URLs. When a canonical remote URL is not yet materialized locally, Lesser performs request-scoped remote parent acquisition on the write path only. Direct replies continue through the conversations service."
+	op.Description = "Create a status. `in_reply_to_id` accepts local status IDs and canonical remote status URLs. When a canonical remote URL is not yet materialized locally, Lesser performs request-scoped remote parent acquisition on the write path only. Direct replies continue through the conversations service. Failure classes distinguish invalid references (400), acquisition timeouts (408), fetched-but-unusable parents (422), and upstream unavailability (503)."
 	if op.Responses == nil {
 		op.Responses = map[string]response{}
 	}


### PR DESCRIPTION
## Milestone
Project 20 — canonical status-object fetchability repair

## Classification
federation-trust, contract-stability, operational-reliability, bug-fix, test-coverage, docs

## Surfaces affected
- `cmd/objects/main.go`
- `infra/cdk/inventory/lambdas.go`
- `pkg/federation/remotenotes/reply_parent_resolver.go`
- `cmd/lesser/verify_unresolved_remote_parent.go`
- `docs/contracts/openapi.yaml`
- `docs/api-reference.md`
- `docs/federation.md`
- `docs/operations/release-notes.md`

## Specialist walks referenced
- Federation trust: completed for canonical status-object route parity and reply-parent fetch classification
- Contract / API: completed for canonical published Note URL repair and `400` / `408` / `422` / `503` semantics
- Schema: not touched
- Framework: idiomatic Lesser/AppTheory/TableTheory consumption

## Consumer impact
- Remote ActivityPub peers can dereference published local Note IDs at their canonical `/users/{username}/statuses/{id}` URLs
- `POST /api/v1/statuses` unresolved reply-parent flows now depend on truthful local object identity and expose clearer failure classes
- Operators gain a dedicated `lesser verify unresolved-remote-parent` probe for dev/staging evidence

## Tasks
- [x] serve published status URLs as canonical local Note objects
- [x] separate reply-parent fetch failure classes from fetched-but-unusable parents
- [x] clarify API docs and release notes for canonical object fetchability and reply-parent errors
- [x] add a dev/staging `lesser verify unresolved-remote-parent` probe with focused coverage

## Validation
- `go test ./...`
- `go vet ./...`
- `gofmt -l .` (empty)
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`
- Targeted: `go test ./cmd/objects/... ./pkg/federation/remotenotes/... ./cmd/lesser/... -count=1`
- `go run ./tools/openapi --check --strict`
- Smoke: waived by Aron for this milestone; release will go PR → release without smoke

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
none

## Advisor-brief authorization
Arch brief from April 22, 2026 at 11:03 PM EDT reviewed in-session and authorized by Aron for investigation and implementation.