### PR TITLE
fix(notes): maintain local canonical note projection lifecycle

### DIFF
--- a/cmd/lesser/verify_unresolved_remote_parent.go
+++ b/cmd/lesser/verify_unresolved_remote_parent.go
@@ -29,15 +29,17 @@ type verifyUnresolvedRemoteParentConfig struct {
 }
 
 type verifyUnresolvedRemoteParentSummary struct {
-	BaseURL         string
-	Stage           string
-	ParentURL       string
-	Visibility      string
-	Expected        string
-	Classification  string
-	HTTPStatus      int
-	CreatedStatusID string
-	ErrorCode       string
+	BaseURL                  string
+	Stage                    string
+	ParentURL                string
+	Visibility               string
+	Expected                 string
+	Classification           string
+	HTTPStatus               int
+	CreatedStatusID          string
+	CanonicalObjectURL       string
+	CanonicalFetchHTTPStatus int
+	ErrorCode                string
 }
 
 type verifyUnresolvedRemoteParentErrorResponse struct {
@@ -47,7 +49,8 @@ type verifyUnresolvedRemoteParentErrorResponse struct {
 }
 
 type verifyUnresolvedRemoteParentCreateResponse struct {
-	ID string `json:"id"`
+	ID  string `json:"id"`
+	URI string `json:"uri"`
 }
 
 var (
@@ -94,6 +97,12 @@ func runVerifyUnresolvedRemoteParent(argv []string) error {
 	fmt.Printf("http_status: %d\n", summary.HTTPStatus)
 	if summary.CreatedStatusID != "" {
 		fmt.Printf("created_status_id: %s\n", summary.CreatedStatusID)
+	}
+	if summary.CanonicalObjectURL != "" {
+		fmt.Printf("canonical_object_url: %s\n", summary.CanonicalObjectURL)
+	}
+	if summary.CanonicalFetchHTTPStatus != 0 {
+		fmt.Printf("canonical_fetch_http_status: %d\n", summary.CanonicalFetchHTTPStatus)
 	}
 	if summary.ErrorCode != "" {
 		fmt.Printf("error_code: %s\n", summary.ErrorCode)
@@ -219,6 +228,32 @@ func executeVerifyUnresolvedRemoteParent(ctx context.Context, client *http.Clien
 		return summary, fmt.Errorf("create-status response missing id")
 	}
 	summary.CreatedStatusID = strings.TrimSpace(created.ID)
+
+	canonicalObjectURL := strings.TrimSpace(created.URI)
+	if canonicalObjectURL == "" {
+		return summary, fmt.Errorf("create-status response missing canonical uri")
+	}
+	summary.CanonicalObjectURL = canonicalObjectURL
+
+	fetchStatus, fetchBody, err := verifyUnresolvedRemoteParentFetchCanonicalObject(ctx, client, canonicalObjectURL)
+	if err != nil {
+		return summary, err
+	}
+	summary.CanonicalFetchHTTPStatus = fetchStatus
+	if fetchStatus != http.StatusOK {
+		return summary, fmt.Errorf("canonical object fetch returned %d: %s", fetchStatus, verifyUnresolvedRemoteParentBodyMessage(fetchBody))
+	}
+
+	var fetched struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(fetchBody, &fetched); err != nil {
+		return summary, fmt.Errorf("decode canonical object response: %w", err)
+	}
+	if strings.TrimSpace(fetched.ID) != canonicalObjectURL {
+		return summary, fmt.Errorf("canonical object fetch returned mismatched id %q", strings.TrimSpace(fetched.ID))
+	}
+
 	return summary, nil
 }
 
@@ -240,6 +275,26 @@ func verifyUnresolvedRemoteParentDoRequest(ctx context.Context, client *http.Cli
 	if strings.TrimSpace(token) != "" {
 		req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(token))
 	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	if err != nil {
+		return 0, nil, err
+	}
+	return resp.StatusCode, raw, nil
+}
+
+func verifyUnresolvedRemoteParentFetchCanonicalObject(ctx context.Context, client *http.Client, endpoint string) (int, []byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Accept", "application/activity+json")
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/cmd/lesser/verify_unresolved_remote_parent_test.go
+++ b/cmd/lesser/verify_unresolved_remote_parent_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -108,14 +109,16 @@ func TestRunVerifyUnresolvedRemoteParent_Success(t *testing.T) {
 	executeVerifyUnresolvedRemoteParentFn = func(_ context.Context, _ *http.Client, cfg verifyUnresolvedRemoteParentConfig) (verifyUnresolvedRemoteParentSummary, error) {
 		require.Equal(t, "verify unresolved remote parent 2026-04-22T23:15:00Z", cfg.Content)
 		return verifyUnresolvedRemoteParentSummary{
-			BaseURL:         "https://dev.example.com",
-			Stage:           valueDev,
-			ParentURL:       cfg.ParentURL,
-			Visibility:      cfg.Visibility,
-			Expected:        cfg.Expected,
-			Classification:  "success",
-			HTTPStatus:      http.StatusCreated,
-			CreatedStatusID: "123",
+			BaseURL:                  "https://dev.example.com",
+			Stage:                    valueDev,
+			ParentURL:                cfg.ParentURL,
+			Visibility:               cfg.Visibility,
+			Expected:                 cfg.Expected,
+			Classification:           "success",
+			HTTPStatus:               http.StatusCreated,
+			CreatedStatusID:          "123",
+			CanonicalObjectURL:       "https://dev.example.com/users/alice/statuses/123",
+			CanonicalFetchHTTPStatus: http.StatusOK,
 		}, nil
 	}
 
@@ -137,21 +140,31 @@ func TestRunVerifyUnresolvedRemoteParent_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, out.String(), "verify unresolved-remote-parent complete")
 	require.Contains(t, out.String(), "created_status_id: 123")
+	require.Contains(t, out.String(), "canonical_object_url: https://dev.example.com/users/alice/statuses/123")
+	require.Contains(t, out.String(), "canonical_fetch_http_status: 200")
 }
 
 func TestExecuteVerifyUnresolvedRemoteParent(t *testing.T) {
 	t.Run("success captures created status id", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			require.Equal(t, http.MethodPost, r.Method)
-			require.Equal(t, "/api/v1/statuses", r.URL.Path)
-			require.Equal(t, "Bearer tok", r.Header.Get("Authorization"))
-			var payload map[string]any
-			require.NoError(t, jsonNewDecoder(r.Body).Decode(&payload))
-			require.Equal(t, "hello", payload["status"])
-			require.Equal(t, "public", payload["visibility"])
-			require.Equal(t, "https://remote.example/users/alice/statuses/1", payload["in_reply_to_id"])
-			w.WriteHeader(http.StatusCreated)
-			_, _ = w.Write([]byte(`{"id":"status-1"}`))
+		var server *httptest.Server
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodPost && r.URL.Path == "/api/v1/statuses":
+				require.Equal(t, "Bearer tok", r.Header.Get("Authorization"))
+				var payload map[string]any
+				require.NoError(t, jsonNewDecoder(r.Body).Decode(&payload))
+				require.Equal(t, "hello", payload["status"])
+				require.Equal(t, "public", payload["visibility"])
+				require.Equal(t, "https://remote.example/users/alice/statuses/1", payload["in_reply_to_id"])
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(fmt.Sprintf(`{"id":"status-1","uri":"%s/users/alice/statuses/status-1"}`, server.URL)))
+			case r.Method == http.MethodGet && r.URL.Path == "/users/alice/statuses/status-1":
+				require.Equal(t, "application/activity+json", r.Header.Get("Accept"))
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(fmt.Sprintf(`{"id":"%s/users/alice/statuses/status-1","type":"Note"}`, server.URL)))
+			default:
+				http.NotFound(w, r)
+			}
 		}))
 		defer server.Close()
 
@@ -167,6 +180,8 @@ func TestExecuteVerifyUnresolvedRemoteParent(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "success", summary.Classification)
 		require.Equal(t, "status-1", summary.CreatedStatusID)
+		require.Equal(t, server.URL+"/users/alice/statuses/status-1", summary.CanonicalObjectURL)
+		require.Equal(t, http.StatusOK, summary.CanonicalFetchHTTPStatus)
 	})
 
 	t.Run("unusable response preserves error code", func(t *testing.T) {
@@ -252,10 +267,10 @@ func TestExecuteVerifyUnresolvedRemoteParent_EdgeCases(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("success without id fails", func(t *testing.T) {
+	t.Run("success without canonical uri fails", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusCreated)
-			_, _ = w.Write([]byte(`{"url":"https://dev.example.com/users/alice/statuses/1"}`))
+			_, _ = w.Write([]byte(`{"id":"status-1","url":"https://dev.example.com/users/alice/statuses/1"}`))
 		}))
 		defer server.Close()
 
@@ -268,7 +283,7 @@ func TestExecuteVerifyUnresolvedRemoteParent_EdgeCases(t *testing.T) {
 			Expected:   "success",
 			Content:    "hello",
 		})
-		require.ErrorContains(t, err, "missing id")
+		require.ErrorContains(t, err, "missing canonical uri")
 	})
 
 	t.Run("success with malformed json fails", func(t *testing.T) {

--- a/cmd/objects/main.go
+++ b/cmd/objects/main.go
@@ -117,6 +117,8 @@ type Handler struct {
 
 type objectGetter interface {
 	GetObject(ctx context.Context, id string) (any, error)
+	IsTombstoned(ctx context.Context, id string) (bool, error)
+	GetTombstone(ctx context.Context, objectID string) (*storageModels.Tombstone, error)
 }
 
 type authorizedFetchVerifier interface {
@@ -244,6 +246,9 @@ func (h *Handler) HandleGetObject(ctx *apptheory.Context) (*apptheory.Response, 
 	objInterface, err := h.objectRepo.GetObject(runCtx, lookupID)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
+			if tombstoneResp, handled, tombErr := h.handleTombstonedObject(runCtx, lookupID, objectID, requestID, wantsHTML); handled {
+				return tombstoneResp, tombErr
+			}
 			logger.Debug("object not found",
 				zap.String("object_id", objectID),
 				zap.String("request_id", requestID),
@@ -290,6 +295,47 @@ func (h *Handler) HandleGetObject(ctx *apptheory.Context) (*apptheory.Response, 
 		zap.String("request_id", requestID),
 	)
 	return objectsActivityJSON(http.StatusOK, objInterface)
+}
+
+func (h *Handler) handleTombstonedObject(ctx context.Context, lookupID, objectID, requestID string, wantsHTML bool) (*apptheory.Response, bool, error) {
+	if h.objectRepo == nil {
+		return nil, false, nil
+	}
+
+	tombstoned, err := h.objectRepo.IsTombstoned(ctx, lookupID)
+	if err != nil || !tombstoned {
+		return nil, false, nil
+	}
+
+	tombstone, err := h.objectRepo.GetTombstone(ctx, lookupID)
+	if err != nil {
+		logger.Warn("failed to load tombstone details for deleted object",
+			zap.String("object_id", objectID),
+			zap.String("request_id", requestID),
+			zap.Error(err),
+		)
+		return objectsJSONError(http.StatusGone, fmt.Sprintf("object %s deleted", objectID)), true, nil
+	}
+
+	logger.Debug("returning tombstone for deleted object",
+		zap.String("object_id", objectID),
+		zap.String("request_id", requestID),
+	)
+
+	if wantsHTML {
+		return objectsJSONError(http.StatusGone, fmt.Sprintf("object %s deleted", objectID)), true, nil
+	}
+
+	resp, err := objectsActivityJSON(http.StatusGone, &activitypub.Tombstone{
+		BaseObject: activitypub.BaseObject{
+			Context: activitypub.Context,
+			ID:      tombstone.ID,
+			Type:    "Tombstone",
+		},
+		FormerType: tombstone.FormerType,
+		Deleted:    tombstone.Deleted.Format(time.RFC3339),
+	})
+	return resp, true, err
 }
 
 func (h *Handler) resolveObjectLookup(ctx *apptheory.Context) (string, string) {

--- a/cmd/objects/round12_objects_test.go
+++ b/cmd/objects/round12_objects_test.go
@@ -24,9 +24,12 @@ import (
 )
 
 type fakeObjectRepo struct {
-	obj   any
-	err   error
-	gotID string
+	obj        any
+	err        error
+	gotID      string
+	tombstoned bool
+	tombErr    error
+	tombstone  *storageModels.Tombstone
 }
 
 func (f *fakeObjectRepo) GetObject(_ context.Context, id string) (any, error) {
@@ -35,6 +38,25 @@ func (f *fakeObjectRepo) GetObject(_ context.Context, id string) (any, error) {
 		return nil, f.err
 	}
 	return f.obj, nil
+}
+
+func (f *fakeObjectRepo) GetTombstone(_ context.Context, id string) (*storageModels.Tombstone, error) {
+	f.gotID = id
+	if f.tombErr != nil {
+		return nil, f.tombErr
+	}
+	if f.tombstone == nil {
+		return nil, errors.New("not found")
+	}
+	return f.tombstone, nil
+}
+
+func (f *fakeObjectRepo) IsTombstoned(_ context.Context, id string) (bool, error) {
+	f.gotID = id
+	if f.tombErr != nil {
+		return false, f.tombErr
+	}
+	return f.tombstoned, nil
 }
 
 type fakeAuthorizedFetch struct {
@@ -461,6 +483,46 @@ func TestHandleGetObject_FetchResponses_Round12(t *testing.T) {
 		require.NotNil(t, resp)
 		require.Equal(t, 401, resp.Status)
 		require.Empty(t, objRepo.gotID)
+	})
+
+	t.Run("canonical status route returns tombstone when object was deleted", func(t *testing.T) {
+		deletedAt := time.Date(2026, time.April, 23, 10, 0, 0, 0, time.UTC)
+		objRepo := &fakeObjectRepo{
+			err:        errors.New("not found"),
+			tombstoned: true,
+			tombstone: &storageModels.Tombstone{
+				ID:         "https://example.com/users/alice/statuses/123",
+				FormerType: activitypub.NoteType,
+				Deleted:    deletedAt,
+				DeletedBy:  "https://example.com/users/alice",
+			},
+		}
+		h := &Handler{
+			instanceRepo:           instanceRepo,
+			objectRepo:             objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method:  http.MethodGet,
+				Path:    "/users/alice/statuses/123",
+				Headers: map[string][]string{"accept": {"application/activity+json"}},
+			},
+			Params: map[string]string{
+				"username": "alice",
+				"id":       "123",
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusGone, resp.Status)
+		require.Equal(t, []string{"application/activity+json"}, resp.Headers["content-type"])
+
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "Tombstone", body["type"])
+		require.Equal(t, "https://example.com/users/alice/statuses/123", body["id"])
+		require.Equal(t, activitypub.NoteType, body["formerType"])
 	})
 }
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -282,6 +282,10 @@ Create-status reply-parent acquisition can also return:
 - `422 Unprocessable Entity`: the remote parent was fetched but cannot be used as a reply parent
 - `503 Service Unavailable`: Lesser could not dereference or fetch a usable upstream parent
 
+Successful create-status responses continue to include the status `uri`, which is the canonical ActivityPub object URL
+for the created local note. The `lesser verify unresolved-remote-parent` probe now treats that canonical `uri` as the
+required fetchability evidence for local-note proof runs.
+
 ## GraphQL
 
 GraphQL HTTP is served from:

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -24,8 +24,10 @@ curl -s -H "Accept: application/activity+json" "https://example.com/users/alice/
 curl -s -H "Accept: application/activity+json" "https://example.com/objects/<id>" | jq .
 ```
 
-`/users/{username}/statuses/{id}` is the canonical local Note object URL Lesser publishes. `/objects/{id}` remains an
-additional object route.
+`/users/{username}/statuses/{id}` is the canonical local Note object URL Lesser publishes. Local note create/edit/delete
+now maintain the backing object projection for that canonical route, including tombstone replacement on delete.
+`/objects/{id}` remains a separate object route; use the canonical `/users/{username}/statuses/{id}` URL when proving
+fresh local-note fetchability.
 
 ### Inbox surface truth
 

--- a/docs/operations/release-notes.md
+++ b/docs/operations/release-notes.md
@@ -2,9 +2,15 @@
 
 ## Canonical local status-object fetchability
 
-Local Lesser-authored Note IDs published as `https://<domain>/users/{username}/statuses/{id}` are now fetchable as
-ActivityPub objects at that same canonical URL. `GET /objects/{id}` remains available as a secondary route, but the
-published Note ID is now truthful and dereferenceable as published.
+Fresh local Lesser-authored Note IDs published as `https://<domain>/users/{username}/statuses/{id}` now stay backed by
+companion object rows through the local note lifecycle:
+
+- create projects the local Note into object storage
+- edit keeps the object row aligned and preserves edit-history semantics
+- delete replaces the object row with a tombstone rather than leaving stale Note state behind
+
+The canonical published Note ID is now truthful and dereferenceable as published. `GET /objects/{id}` remains a
+separate object route; the canonical proof surface for local notes is `/users/{username}/statuses/{id}`.
 
 ## Remote reply-parent acquisition on create-status
 

--- a/pkg/services/notes/service.go
+++ b/pkg/services/notes/service.go
@@ -502,7 +502,7 @@ func (s *Service) localNoteProjectionPayload(status *models.Status) (*activitypu
 		return nil, "", fmt.Errorf("status is required")
 	}
 	if s.objectRepo == nil {
-		return nil, "", fmt.Errorf("object repository unavailable")
+		return nil, "", nil
 	}
 	if status.Note == nil {
 		return nil, "", fmt.Errorf("status %s missing ActivityPub note", status.StatusID)
@@ -520,6 +520,9 @@ func (s *Service) projectLocalNoteObjectOnCreate(ctx context.Context, status *mo
 	note, _, err := s.localNoteProjectionPayload(status)
 	if err != nil {
 		return err
+	}
+	if note == nil {
+		return nil
 	}
 	return s.objectRepo.CreateObject(ctx, note)
 }
@@ -545,6 +548,9 @@ func (s *Service) syncLocalNoteObjectProjectionOnUpdate(ctx context.Context, sta
 	if err != nil {
 		return err
 	}
+	if note == nil {
+		return nil
+	}
 	return s.objectRepo.UpdateObjectWithHistory(ctx, note, s.localActorID(updaterID))
 }
 
@@ -552,6 +558,9 @@ func (s *Service) replaceLocalNoteObjectProjectionWithTombstone(ctx context.Cont
 	_, objectID, err := s.localNoteProjectionPayload(status)
 	if err != nil {
 		return err
+	}
+	if objectID == "" {
+		return nil
 	}
 	return s.objectRepo.ReplaceObjectWithTombstone(ctx, objectID, activitypub.NoteType, s.localActorID(deleterID))
 }

--- a/pkg/services/notes/service.go
+++ b/pkg/services/notes/service.go
@@ -405,8 +405,18 @@ func (s *Service) CreateNote(ctx context.Context, cmd *CreateNoteCommand) (*Note
 		return replyParent.Status, nil
 	})
 
+	if err := s.projectLocalNoteObjectOnCreate(ctx, status); err != nil {
+		requestErr := errors.Join(ErrCreateStatus, err)
+		s.logger.Error("failed to project created note object",
+			zap.String("status_id", statusID),
+			zap.Strings("root_causes", common.ErrorLeafMessages(err)),
+			zap.Error(requestErr))
+		return nil, requestErr
+	}
+
 	// Store the status
 	if err := s.noteRepo.CreateStatus(ctx, status); err != nil {
+		s.cleanupFailedLocalNoteObjectProjection(ctx, status)
 		requestErr := errors.Join(ErrCreateStatus, err)
 		s.logger.Error("failed to persist created status",
 			zap.String("status_id", statusID),
@@ -485,6 +495,73 @@ func (s *Service) composeStatus(cmd *CreateNoteCommand, author *storage.Account,
 	}
 
 	return status
+}
+
+func (s *Service) localNoteProjectionPayload(status *models.Status) (*activitypub.Note, string, error) {
+	if status == nil {
+		return nil, "", fmt.Errorf("status is required")
+	}
+	if s.objectRepo == nil {
+		return nil, "", fmt.Errorf("object repository unavailable")
+	}
+	if status.Note == nil {
+		return nil, "", fmt.Errorf("status %s missing ActivityPub note", status.StatusID)
+	}
+
+	objectID := strings.TrimSpace(status.Note.ID)
+	if objectID == "" {
+		return nil, "", fmt.Errorf("status %s missing ActivityPub note id", status.StatusID)
+	}
+
+	return status.Note, objectID, nil
+}
+
+func (s *Service) projectLocalNoteObjectOnCreate(ctx context.Context, status *models.Status) error {
+	note, _, err := s.localNoteProjectionPayload(status)
+	if err != nil {
+		return err
+	}
+	return s.objectRepo.CreateObject(ctx, note)
+}
+
+func (s *Service) cleanupFailedLocalNoteObjectProjection(ctx context.Context, status *models.Status) {
+	if s.objectRepo == nil || status == nil || status.Note == nil {
+		return
+	}
+	objectID := strings.TrimSpace(status.Note.ID)
+	if objectID == "" {
+		return
+	}
+	if err := s.objectRepo.DeleteObject(ctx, objectID); err != nil && s.logger != nil {
+		s.logger.Warn("failed to clean up projected note object after status create failure",
+			zap.String("status_id", status.StatusID),
+			zap.String("object_id", objectID),
+			zap.Error(err))
+	}
+}
+
+func (s *Service) syncLocalNoteObjectProjectionOnUpdate(ctx context.Context, status *models.Status, updaterID string) error {
+	note, _, err := s.localNoteProjectionPayload(status)
+	if err != nil {
+		return err
+	}
+	return s.objectRepo.UpdateObjectWithHistory(ctx, note, s.localActorID(updaterID))
+}
+
+func (s *Service) replaceLocalNoteObjectProjectionWithTombstone(ctx context.Context, status *models.Status, deleterID string) error {
+	_, objectID, err := s.localNoteProjectionPayload(status)
+	if err != nil {
+		return err
+	}
+	return s.objectRepo.ReplaceObjectWithTombstone(ctx, objectID, activitypub.NoteType, s.localActorID(deleterID))
+}
+
+func (s *Service) localActorID(username string) string {
+	trimmed := strings.TrimSpace(username)
+	if trimmed == "" {
+		return ""
+	}
+	return fmt.Sprintf("https://%s/users/%s", s.domainName, trimmed)
 }
 
 type parentStatusFetcher func(context.Context, string) (*models.Status, error)
@@ -685,6 +762,9 @@ func (s *Service) UpdateNote(ctx context.Context, cmd *UpdateNoteCommand) (*Note
 	if err := s.noteRepo.UpdateStatus(ctx, status); err != nil {
 		return nil, ErrUpdateStatus
 	}
+	if err := s.syncLocalNoteObjectProjectionOnUpdate(ctx, status, cmd.UpdaterID); err != nil {
+		return nil, errors.Join(ErrUpdateStatus, err)
+	}
 
 	s.logger.Info("updated note successfully",
 		zap.String("status_id", cmd.StatusID))
@@ -756,6 +836,9 @@ func (s *Service) DeleteNote(ctx context.Context, cmd *DeleteNoteCommand) error 
 	// No need to call UpdateKeys() here - keys are already set from creation and we're only updating Deleted flag
 	if err := s.noteRepo.UpdateStatus(ctx, status); err != nil {
 		return ErrDeleteStatus
+	}
+	if err := s.replaceLocalNoteObjectProjectionWithTombstone(ctx, status, cmd.DeleterID); err != nil {
+		return errors.Join(ErrDeleteStatus, err)
 	}
 
 	s.logger.Info("deleted note successfully",

--- a/pkg/services/notes/service_round15_mainline_test.go
+++ b/pkg/services/notes/service_round15_mainline_test.go
@@ -1631,6 +1631,150 @@ func TestService_round15_local_note_projection_helpers_noop_without_object_repo(
 	require.NoError(t, service.replaceLocalNoteObjectProjectionWithTombstone(context.Background(), status, "alice"))
 }
 
+func TestService_round15_local_note_projection_payload_validation(t *testing.T) {
+	service := &Service{
+		domainName: "example.com",
+		objectRepo: testingmocks.NewMockObjectRepository(),
+	}
+
+	note, objectID, err := service.localNoteProjectionPayload(nil)
+	require.Error(t, err)
+	require.Nil(t, note)
+	require.Empty(t, objectID)
+
+	statusWithoutNote := &models.Status{StatusID: "status-1"}
+	note, objectID, err = service.localNoteProjectionPayload(statusWithoutNote)
+	require.Error(t, err)
+	require.Nil(t, note)
+	require.Empty(t, objectID)
+
+	statusWithoutID := &models.Status{
+		StatusID: "status-2",
+		Note: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{Type: activitypub.NoteType},
+		},
+	}
+	note, objectID, err = service.localNoteProjectionPayload(statusWithoutID)
+	require.Error(t, err)
+	require.Nil(t, note)
+	require.Empty(t, objectID)
+
+	validStatus := &models.Status{
+		StatusID: "status-3",
+		Note: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:   "https://example.com/users/alice/statuses/status-3",
+				Type: activitypub.NoteType,
+			},
+			Content:      "hello",
+			AttributedTo: "https://example.com/users/alice",
+		},
+	}
+	note, objectID, err = service.localNoteProjectionPayload(validStatus)
+	require.NoError(t, err)
+	require.NotNil(t, note)
+	require.Equal(t, validStatus.Note.ID, objectID)
+}
+
+func TestService_round15_local_actor_id_helper(t *testing.T) {
+	service := &Service{domainName: "example.com"}
+	require.Empty(t, service.localActorID(""))
+	require.Equal(t, "https://example.com/users/alice", service.localActorID("alice"))
+}
+
+func TestService_round15_cleanup_failed_local_projection_and_parent_helpers(t *testing.T) {
+	ctx := context.Background()
+	objectRepo := testingmocks.NewMockObjectRepository()
+	service := &Service{
+		domainName: "example.com",
+		objectRepo: objectRepo,
+		logger:     zap.NewNop(),
+	}
+
+	objectRepo.On("DeleteObject", mock.Anything, "https://example.com/users/alice/statuses/status-1").Return(nil).Once()
+	service.cleanupFailedLocalNoteObjectProjection(ctx, &models.Status{
+		StatusID: "status-1",
+		Note: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:   "https://example.com/users/alice/statuses/status-1",
+				Type: activitypub.NoteType,
+			},
+			AttributedTo: "https://example.com/users/alice",
+		},
+	})
+	service.cleanupFailedLocalNoteObjectProjection(ctx, &models.Status{StatusID: "status-2"})
+	service.cleanupFailedLocalNoteObjectProjection(ctx, &models.Status{
+		StatusID: "status-3",
+		Note: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{Type: activitypub.NoteType},
+		},
+	})
+	objectRepo.AssertExpectations(t)
+
+	parentFromNote := &models.Status{
+		StatusID: "status-1",
+		AuthorID: "https://example.com/users/alice",
+		Note: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:   "https://example.com/users/alice/statuses/status-1",
+				Type: activitypub.NoteType,
+			},
+			AttributedTo: "https://example.com/users/alice",
+		},
+	}
+	require.Equal(t, parentFromNote.Note.ID, service.replyParentObjectID(parentFromNote))
+	require.Equal(t, "https://example.com/users/alice", service.replyParentActorID(parentFromNote))
+
+	parentFromURL := &models.Status{
+		StatusID: "status-2",
+		URLs:     []string{"mailto:ignore", "https://remote.example/objects/2"},
+		AuthorID: "https://remote.example/users/bob",
+	}
+	require.Equal(t, "https://remote.example/objects/2", service.replyParentObjectID(parentFromURL))
+	require.Equal(t, "https://remote.example/users/bob", service.replyParentActorID(parentFromURL))
+
+	parentFromStatusID := &models.Status{
+		StatusID: "https://remote.example/objects/3",
+		Note:     &activitypub.Note{},
+	}
+	require.Equal(t, "https://remote.example/objects/3", service.replyParentObjectID(parentFromStatusID))
+
+	localFallback := &models.Status{
+		StatusID:       "status-4",
+		AuthorUsername: "alice",
+		AuthorID:       "https://example.com/users/alice",
+	}
+	require.Equal(t, "https://example.com/users/alice/statuses/status-4", service.replyParentObjectID(localFallback))
+
+	require.Empty(t, service.replyParentObjectID(&models.Status{StatusID: "status-5"}))
+	require.Empty(t, service.replyParentActorID(&models.Status{}))
+}
+
+func TestService_round15_resolve_viewer_actor_id_variants(t *testing.T) {
+	service := &Service{domainName: "example.com"}
+
+	username, actorID := service.resolveViewerActorID("")
+	require.Empty(t, username)
+	require.Empty(t, actorID)
+
+	username, actorID = service.resolveViewerActorID("alice")
+	require.Equal(t, "alice", username)
+	require.Equal(t, "https://example.com/users/alice", actorID)
+
+	username, actorID = service.resolveViewerActorID("https://remote.example/users/bob/")
+	require.Equal(t, "bob", username)
+	require.Equal(t, "https://remote.example/users/bob", actorID)
+
+	username, actorID = service.resolveViewerActorID("https://remote.example")
+	require.Equal(t, "https://remote.example", username)
+	require.Equal(t, "https://remote.example", actorID)
+
+	noDomain := &Service{}
+	username, actorID = noDomain.resolveViewerActorID("carol")
+	require.Equal(t, "carol", username)
+	require.Equal(t, "carol", actorID)
+}
+
 func TestService_round15_community_note_content_is_escaped_at_write_time(t *testing.T) {
 	service, _, _, _, _ := newNotesServiceHarness(t)
 	ctx := context.Background()

--- a/pkg/services/notes/service_round15_mainline_test.go
+++ b/pkg/services/notes/service_round15_mainline_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
 	"github.com/equaltoai/lesser/pkg/streaming"
+	testinginmemory "github.com/equaltoai/lesser/pkg/testing/inmemory"
+	testingmocks "github.com/equaltoai/lesser/pkg/testing/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -1529,6 +1531,78 @@ func TestService_round15_html_by_contract_is_sanitized_at_write_time(t *testing.
 	require.NotContains(t, updated.Note.Content, "onerror=")
 	require.NotContains(t, updated.Note.Content, "onclick=")
 	require.NotContains(t, updated.Note.Content, "javascript:")
+}
+
+func TestService_round15_local_note_object_projection_lifecycle(t *testing.T) {
+	ctx := context.Background()
+	statusRepo := testinginmemory.NewStatusRepository()
+	objectRepo := testingmocks.NewMockObjectRepository()
+	accountRepo := &stubAccountRepo{domain: "example.com"}
+	objectRepo.On("CreateObject", mock.Anything, mock.Anything).Return(nil).Once()
+	objectRepo.On("UpdateObjectWithHistory", mock.Anything, mock.Anything, "https://example.com/users/alice").Return(nil).Once()
+	objectRepo.On("ReplaceObjectWithTombstone", mock.Anything, mock.Anything, activitypub.NoteType, "https://example.com/users/alice").Return(nil).Once()
+	service := NewService(
+		statusRepo,
+		accountRepo,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		objectRepo,
+		nil,
+		nil,
+		nil,
+		nil,
+		&stubPublisher{},
+		&stubAnalytics{},
+		&stubFederation{},
+		nil,
+		&stubNotificationService{},
+		zap.NewNop(),
+		"example.com",
+	)
+
+	created, err := service.CreateNote(ctx, &CreateNoteCommand{
+		AuthorID:     "alice",
+		Content:      "fresh local projection",
+		Visibility:   VisibilityPublic,
+		ToRecipients: []string{activitypub.PublicAddress},
+		CcRecipients: []string{"https://example.com/users/alice/followers"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	require.NotNil(t, created.Note)
+	require.NotNil(t, created.Note.Note)
+
+	objectID := created.Note.Note.ID
+	objectRepo.AssertCalled(t, "CreateObject", mock.Anything, mock.MatchedBy(func(value any) bool {
+		note, ok := value.(*activitypub.Note)
+		return ok && note.ID == objectID && note.Content == "fresh local projection"
+	}))
+
+	updated, err := service.UpdateNote(ctx, &UpdateNoteCommand{
+		StatusID:    created.Note.StatusID,
+		Content:     "edited local projection",
+		Sensitive:   true,
+		SpoilerText: "cw",
+		Language:    "en",
+		UpdaterID:   "alice",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	objectRepo.AssertCalled(t, "UpdateObjectWithHistory", mock.Anything, mock.MatchedBy(func(value any) bool {
+		note, ok := value.(*activitypub.Note)
+		return ok && note.ID == objectID && note.Content == "edited local projection" && note.Sensitive && note.Summary == "cw"
+	}), "https://example.com/users/alice")
+
+	require.NoError(t, service.DeleteNote(ctx, &DeleteNoteCommand{
+		StatusID:  created.Note.StatusID,
+		DeleterID: "alice",
+	}))
+	objectRepo.AssertCalled(t, "ReplaceObjectWithTombstone", mock.Anything, objectID, activitypub.NoteType, "https://example.com/users/alice")
+	objectRepo.AssertExpectations(t)
 }
 
 func TestService_round15_community_note_content_is_escaped_at_write_time(t *testing.T) {

--- a/pkg/services/notes/service_round15_mainline_test.go
+++ b/pkg/services/notes/service_round15_mainline_test.go
@@ -1605,6 +1605,32 @@ func TestService_round15_local_note_object_projection_lifecycle(t *testing.T) {
 	objectRepo.AssertExpectations(t)
 }
 
+func TestService_round15_local_note_projection_helpers_noop_without_object_repo(t *testing.T) {
+	service := &Service{domainName: "example.com"}
+	status := &models.Status{
+		StatusID:       "status-1",
+		AuthorID:       "https://example.com/users/alice",
+		AuthorUsername: "alice",
+		Note: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:   "https://example.com/users/alice/statuses/status-1",
+				Type: activitypub.NoteType,
+			},
+			Content:      "hello",
+			AttributedTo: "https://example.com/users/alice",
+		},
+	}
+
+	projected, objectID, err := service.localNoteProjectionPayload(status)
+	require.NoError(t, err)
+	require.Nil(t, projected)
+	require.Empty(t, objectID)
+
+	require.NoError(t, service.projectLocalNoteObjectOnCreate(context.Background(), status))
+	require.NoError(t, service.syncLocalNoteObjectProjectionOnUpdate(context.Background(), status, "alice"))
+	require.NoError(t, service.replaceLocalNoteObjectProjectionWithTombstone(context.Background(), status, "alice"))
+}
+
 func TestService_round15_community_note_content_is_escaped_at_write_time(t *testing.T) {
 	service, _, _, _, _ := newNotesServiceHarness(t)
 	ctx := context.Background()

--- a/pkg/services/notes/service_round16_logging_test.go
+++ b/pkg/services/notes/service_round16_logging_test.go
@@ -33,6 +33,15 @@ func TestServiceRound16_CreateNote_LogsRootCausesForStatusPersistenceFailures(t 
 		On("CreateStatus", ctx, mock.AnythingOfType("*models.Status")).
 		Return(apperrors.FailedToCreate("item", stdErrors.New("dynamo conditional check failed"))).
 		Once()
+	objectRepo := testingmocks.NewMockObjectRepository()
+	objectRepo.
+		On("CreateObject", ctx, mock.Anything).
+		Return(nil).
+		Once()
+	objectRepo.
+		On("DeleteObject", ctx, mock.AnythingOfType("string")).
+		Return(nil).
+		Once()
 
 	service := NewService(
 		noteRepo,
@@ -43,7 +52,7 @@ func TestServiceRound16_CreateNote_LogsRootCausesForStatusPersistenceFailures(t 
 		nil,
 		nil,
 		nil,
-		nil,
+		objectRepo,
 		nil,
 		nil,
 		nil,

--- a/pkg/testing/inmemory/object_repository.go
+++ b/pkg/testing/inmemory/object_repository.go
@@ -3,6 +3,7 @@ package inmemory
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
@@ -154,7 +155,24 @@ func (r *ObjectRepository) UpdateObject(_ context.Context, object any) error {
 
 	entry, exists := r.objects[objectID]
 	if !exists {
-		return storage.ErrNotFound
+		now := time.Now()
+		objectType, actorID, inReplyTo := "", "", ""
+		_, objectType, actorID, inReplyTo = extractObjectMetadata(object)
+		r.objects[objectID] = &objectEntry{
+			object:     object,
+			objectType: objectType,
+			actorID:    actorID,
+			inReplyTo:  inReplyTo,
+			createdAt:  now,
+			updatedAt:  now,
+		}
+		if actorID != "" {
+			r.objectsByActor[actorID] = append(r.objectsByActor[actorID], objectID)
+		}
+		if inReplyTo != "" {
+			r.repliesByParent[inReplyTo] = append(r.repliesByParent[inReplyTo], objectID)
+		}
+		return nil
 	}
 
 	entry.object = object
@@ -171,14 +189,29 @@ func (r *ObjectRepository) UpdateObjectWithHistory(_ context.Context, object any
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	objectID, _, _, _ := extractObjectMetadata(object)
+	objectID, objectType, actorID, inReplyTo := extractObjectMetadata(object)
 	if objectID == "" {
 		return fmt.Errorf("object ID is required")
 	}
 
 	entry, exists := r.objects[objectID]
 	if !exists {
-		return storage.ErrNotFound
+		now := time.Now()
+		r.objects[objectID] = &objectEntry{
+			object:     object,
+			objectType: objectType,
+			actorID:    actorID,
+			inReplyTo:  inReplyTo,
+			createdAt:  now,
+			updatedAt:  now,
+		}
+		if actorID != "" {
+			r.objectsByActor[actorID] = append(r.objectsByActor[actorID], objectID)
+		}
+		if inReplyTo != "" {
+			r.repliesByParent[inReplyTo] = append(r.repliesByParent[inReplyTo], objectID)
+		}
+		return nil
 	}
 
 	// Store previous state in history
@@ -195,6 +228,9 @@ func (r *ObjectRepository) UpdateObjectWithHistory(_ context.Context, object any
 
 	// Update the object
 	entry.object = object
+	entry.objectType = objectType
+	entry.actorID = actorID
+	entry.inReplyTo = inReplyTo
 	entry.updatedAt = time.Now()
 
 	return nil
@@ -1049,9 +1085,22 @@ func extractObjectMetadata(object any) (id, objectType, actorID, inReplyTo strin
 		return
 	}
 
-	// Try to extract using reflection for struct types
-	// This is a simplified version - real implementation would use reflection
-	return "", "", "", ""
+	var payload struct {
+		ID           string `json:"id"`
+		Type         string `json:"type"`
+		AttributedTo string `json:"attributedTo"`
+		InReplyTo    string `json:"inReplyTo"`
+	}
+
+	raw, err := json.Marshal(object)
+	if err != nil {
+		return "", "", "", ""
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return "", "", "", ""
+	}
+
+	return payload.ID, payload.Type, payload.AttributedTo, payload.InReplyTo
 }
 
 // removeString removes a string from a slice

--- a/pkg/testing/inmemory/object_repository_round22_test.go
+++ b/pkg/testing/inmemory/object_repository_round22_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -71,4 +72,95 @@ func TestObjectRepository_round22_update_paths_create_missing_objects(t *testing
 		require.NoError(t, err)
 		require.Len(t, replies, 1)
 	})
+}
+
+func TestObjectRepository_round22_update_with_history_tracks_existing_objects(t *testing.T) {
+	repo := NewObjectRepository()
+	original := &activitypub.Note{
+		BaseObject: activitypub.BaseObject{
+			ID:        "https://example.com/users/alice/statuses/status-3",
+			Type:      activitypub.NoteType,
+			InReplyTo: "https://example.com/users/alice/statuses/root-a",
+		},
+		Content:      "before",
+		AttributedTo: "https://example.com/users/alice",
+	}
+	require.NoError(t, repo.CreateObject(context.Background(), original))
+
+	updated := &activitypub.Note{
+		BaseObject: activitypub.BaseObject{
+			ID:        original.ID,
+			Type:      activitypub.NoteType,
+			InReplyTo: "https://example.com/users/alice/statuses/root-b",
+		},
+		Content:      "after",
+		AttributedTo: "https://example.com/users/alice",
+	}
+	require.NoError(t, repo.UpdateObjectWithHistory(context.Background(), updated, "https://example.com/users/alice"))
+
+	stored, err := repo.GetObject(context.Background(), original.ID)
+	require.NoError(t, err)
+	storedNote, ok := stored.(*activitypub.Note)
+	require.True(t, ok)
+	require.Equal(t, "after", storedNote.Content)
+
+	history, err := repo.GetUpdateHistory(context.Background(), original.ID, 10)
+	require.NoError(t, err)
+	require.Len(t, history, 1)
+	require.Equal(t, "https://example.com/users/alice", history[0].UpdatedBy)
+}
+
+func TestObjectRepository_round22_extract_object_metadata_helpers(t *testing.T) {
+	id, objectType, actorID, inReplyTo := extractObjectMetadata(map[string]any{
+		"id":           "https://example.com/objects/1",
+		"type":         activitypub.NoteType,
+		"attributedTo": "https://example.com/users/alice",
+		"inReplyTo":    "https://example.com/objects/root",
+	})
+	require.Equal(t, "https://example.com/objects/1", id)
+	require.Equal(t, activitypub.NoteType, objectType)
+	require.Equal(t, "https://example.com/users/alice", actorID)
+	require.Equal(t, "https://example.com/objects/root", inReplyTo)
+
+	note := &activitypub.Note{
+		BaseObject: activitypub.BaseObject{
+			ID:        "https://example.com/objects/2",
+			Type:      activitypub.NoteType,
+			InReplyTo: "https://example.com/objects/root-2",
+		},
+		AttributedTo: "https://example.com/users/bob",
+	}
+	id, objectType, actorID, inReplyTo = extractObjectMetadata(note)
+	require.Equal(t, "https://example.com/objects/2", id)
+	require.Equal(t, activitypub.NoteType, objectType)
+	require.Equal(t, "https://example.com/users/bob", actorID)
+	require.Equal(t, "https://example.com/objects/root-2", inReplyTo)
+
+	id, objectType, actorID, inReplyTo = extractObjectMetadata(make(chan int))
+	require.Empty(t, id)
+	require.Empty(t, objectType)
+	require.Empty(t, actorID)
+	require.Empty(t, inReplyTo)
+}
+
+func TestObjectRepository_round22_helper_storage_paths(t *testing.T) {
+	repo := NewObjectRepository()
+
+	repo.SetMissingReplies("status-1", []string{"reply-1", "reply-2"})
+	missing, err := repo.GetMissingReplies(context.Background(), "status-1")
+	require.NoError(t, err)
+	require.Equal(t, []string{"reply-1", "reply-2"}, []string{missing[0].StatusID, missing[1].StatusID})
+
+	ctxValue := &storage.ThreadContext{
+		StatusID:    "status-1",
+		Ancestors:   []string{"ancestor-1"},
+		Descendants: []string{"desc-1"},
+	}
+	repo.SetThreadContext("status-1", ctxValue)
+	threadCtx, err := repo.GetThreadContext(context.Background(), "status-1")
+	require.NoError(t, err)
+	require.Equal(t, ctxValue, threadCtx)
+
+	require.Equal(t, []string{"a", "c"}, removeString([]string{"a", "b", "c"}, "b"))
+	require.Equal(t, []string{"a", "c"}, removeString([]string{"a", "c"}, "z"))
 }

--- a/pkg/testing/inmemory/object_repository_round22_test.go
+++ b/pkg/testing/inmemory/object_repository_round22_test.go
@@ -1,0 +1,74 @@
+package inmemory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/stretchr/testify/require"
+)
+
+func TestObjectRepository_round22_update_paths_create_missing_objects(t *testing.T) {
+	t.Run("UpdateObject creates a missing note and indexes metadata", func(t *testing.T) {
+		repo := NewObjectRepository()
+		note := &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:        "https://example.com/users/alice/statuses/status-1",
+				Type:      activitypub.NoteType,
+				InReplyTo: "https://example.com/users/alice/statuses/root",
+			},
+			Content:      "hello world",
+			AttributedTo: "https://example.com/users/alice",
+		}
+
+		require.NoError(t, repo.UpdateObject(context.Background(), note))
+
+		stored, err := repo.GetObject(context.Background(), note.ID)
+		require.NoError(t, err)
+		storedNote, ok := stored.(*activitypub.Note)
+		require.True(t, ok)
+		require.Equal(t, note.ID, storedNote.ID)
+		require.Equal(t, note.Content, storedNote.Content)
+
+		byActor, _, err := repo.GetObjectsByActor(context.Background(), note.AttributedTo, "", 10)
+		require.NoError(t, err)
+		require.Len(t, byActor, 1)
+
+		replies, _, err := repo.GetReplies(context.Background(), note.InReplyTo, 10, "")
+		require.NoError(t, err)
+		require.Len(t, replies, 1)
+	})
+
+	t.Run("UpdateObjectWithHistory creates a missing note before history exists", func(t *testing.T) {
+		repo := NewObjectRepository()
+		note := &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:        "https://example.com/users/alice/statuses/status-2",
+				Type:      activitypub.NoteType,
+				InReplyTo: "https://example.com/users/alice/statuses/root",
+			},
+			Content:      "edited content",
+			AttributedTo: "https://example.com/users/alice",
+		}
+
+		require.NoError(t, repo.UpdateObjectWithHistory(context.Background(), note, "https://example.com/users/alice"))
+
+		stored, err := repo.GetObject(context.Background(), note.ID)
+		require.NoError(t, err)
+		storedNote, ok := stored.(*activitypub.Note)
+		require.True(t, ok)
+		require.Equal(t, note.Content, storedNote.Content)
+
+		history, err := repo.GetUpdateHistory(context.Background(), note.ID, 10)
+		require.NoError(t, err)
+		require.Empty(t, history)
+
+		byActor, _, err := repo.GetObjectsByActor(context.Background(), note.AttributedTo, "", 10)
+		require.NoError(t, err)
+		require.Len(t, byActor, 1)
+
+		replies, _, err := repo.GetReplies(context.Background(), note.InReplyTo, 10, "")
+		require.NoError(t, err)
+		require.Len(t, replies, 1)
+	})
+}


### PR DESCRIPTION
## Milestone
Project 20 local note canonical-object projection repair — make the local first-party note lifecycle own the backing object-row projection that canonical ActivityPub object fetches already depend on.

## Classification
- federation-trust
- contract-stability
- operational-reliability
- bug-fix
- test-coverage
- docs

## Surfaces affected
- `pkg/services/notes/service.go`
- `pkg/testing/inmemory/object_repository.go`
- `cmd/objects/`
- `cmd/lesser/verify_unresolved_remote_parent.go`
- `docs/federation.md`
- `docs/api-reference.md`
- `docs/operations/release-notes.md`

## Specialist walks referenced
- Federation trust: completed for local note canonical-object projection parity
- Contract / API: completed for the local note canonical-object backing model
- Schema: not touched
- Framework: idiomatic; no framework escalation needed

## Consumer impact
- operators validating Project 20 unresolved remote-parent flows
- remote ActivityPub peers dereferencing fresh local Note IDs
- REST callers creating replies against canonical local Note URLs

## Tasks
- [x] lock the broken local note canonical-object lifecycle in tests
- [x] project companion object rows on local create/update/delete
- [x] keep canonical object serving tombstone-aware and verifier-backed
- [x] document the repaired local object projection contract
- [x] align legacy/in-memory repos with the new lifecycle expectations

## Validation
- `go test ./...`
- `go vet ./...`
- `gofmt -l .` (empty)
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`
- Targeted: `go test ./graph ./pkg/services/conversations ./pkg/testing/inmemory ./pkg/services/notes ./cmd/objects ./cmd/lesser -count=1`
- Smoke: waived per Aron’s instruction; release evidence comes from CI plus the dedicated unresolved-remote-parent verifier

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None.

## Advisor-brief authorization (if applicable)
Arch (`arch@lessersoul.ai`) narrowed the remaining Project 20 blocker on April 23, 2026 to a split local note persistence contract. Aron explicitly authorized investigation and implementation of this milestone in-session.
