### PR TITLE
fix federation interaction object identity

### DIFF
--- a/cmd/inbox/internal/routing/inbox.go
+++ b/cmd/inbox/internal/routing/inbox.go
@@ -2473,21 +2473,16 @@ func (ih *InboxHandler) processLikeActivity(ctx context.Context, activity *activ
 		return nil
 	}
 
-	// Extract the object being liked
-	var objectID string
-	switch obj := activity.Object.(type) {
-	case string:
-		objectID = obj
-	case map[string]any:
-		if id, ok := obj["id"].(string); ok {
-			objectID = id
-		}
-	}
+	// Extract and canonicalize the object being liked when it maps to a local
+	// known status. Unknown remote objects remain permissive and are stored as
+	// received.
+	objectID := extractObjectID(activity.Object)
 
 	if err := common.ValidateRequiredParam("objectID", objectID); err != nil {
 		log.Warn("like activity has no object ID")
 		return nil // Don't fail, just ignore malformed likes
 	}
+	objectID, obj := ih.canonicalizeKnownInteractionObject(ctx, objectID)
 
 	// Extract actor handle from actor ID
 	actorHandle := ih.extractHandleFromActorID(activity.Actor)
@@ -2498,17 +2493,8 @@ func (ih *InboxHandler) processLikeActivity(ctx context.Context, activity *activ
 		zap.String("object", objectID),
 		zap.String("activity_id", activity.ID))
 
-	// Verify the object exists (optional - could be remote object)
-	obj, err := ih.objectRepository.GetObject(ctx, objectID)
-	if err != nil {
-		log.Debug("object not found for like, assuming remote object",
-			zap.String("object_id", objectID),
-			zap.Error(err))
-		// Continue processing - this could be a remote object we don't have
-	}
-
 	// Store the like
-	_, err = ih.likeRepository.CreateLike(ctx, activity.Actor, objectID, targetActor.ID)
+	_, err := ih.likeRepository.CreateLike(ctx, activity.Actor, objectID, targetActor.ID)
 	if err != nil {
 		log.Error("failed to create like",
 			zap.String("actor", activity.Actor),
@@ -2556,21 +2542,16 @@ func (ih *InboxHandler) processAnnounceActivity(ctx context.Context, activity *a
 		return nil
 	}
 
-	// Extract the object being announced
-	var objectID string
-	switch obj := activity.Object.(type) {
-	case string:
-		objectID = obj
-	case map[string]any:
-		if id, ok := obj["id"].(string); ok {
-			objectID = id
-		}
-	}
+	// Extract and canonicalize the object being announced when it maps to a
+	// local known status. Unknown remote objects remain permissive and are
+	// stored as received.
+	objectID := extractObjectID(activity.Object)
 
 	if err := common.ValidateRequiredParam("objectID", objectID); err != nil {
 		log.Warn("announce activity has no object ID")
 		return nil // Don't fail, just ignore malformed announces
 	}
+	objectID, obj := ih.canonicalizeKnownInteractionObject(ctx, objectID)
 
 	// Extract actor handle from actor ID
 	actorHandle := ih.extractHandleFromActorID(activity.Actor)
@@ -2580,15 +2561,6 @@ func (ih *InboxHandler) processAnnounceActivity(ctx context.Context, activity *a
 		zap.String("actor_handle", actorHandle),
 		zap.String("object", objectID),
 		zap.String("activity_id", activity.ID))
-
-	// Verify the object exists (optional - could be remote object)
-	obj, err := ih.objectRepository.GetObject(ctx, objectID)
-	if err != nil {
-		log.Debug("object not found for announce, assuming remote object",
-			zap.String("object_id", objectID),
-			zap.Error(err))
-		// Continue processing - this could be a remote object we don't have
-	}
 
 	// Create storage.Announce struct for SocialRepository
 	announce := &storage.Announce{
@@ -2602,7 +2574,7 @@ func (ih *InboxHandler) processAnnounceActivity(ctx context.Context, activity *a
 	}
 
 	// Store the announce using social repository
-	err = ih.socialRepository.CreateAnnounce(ctx, announce)
+	err := ih.socialRepository.CreateAnnounce(ctx, announce)
 	if err != nil {
 		// Handle duplicate announces gracefully
 		if strings.Contains(err.Error(), "already announced") {
@@ -2640,6 +2612,55 @@ func (ih *InboxHandler) processAnnounceActivity(ctx context.Context, activity *a
 	log.Info("successfully processed announce activity",
 		zap.String("actor", activity.Actor),
 		zap.String("object", objectID))
+
+	return nil
+}
+
+func (ih *InboxHandler) canonicalizeKnownInteractionObject(ctx context.Context, objectID string) (string, any) {
+	objectID = strings.TrimSpace(objectID)
+	if objectID == "" {
+		return "", nil
+	}
+
+	if status := ih.resolveKnownInteractionStatus(ctx, objectID); status != nil {
+		if canonical := models.CanonicalActivityPubObjectIDForStatus(status, ih.baseURL); canonical != "" {
+			if status.Note != nil {
+				return canonical, status.Note
+			}
+			return canonical, status
+		}
+	}
+
+	if ih.objectRepository == nil {
+		return objectID, nil
+	}
+	obj, err := ih.objectRepository.GetObject(ctx, objectID)
+	if err != nil {
+		common.WithContext(ctx).Debug("object not found for interaction, assuming unknown remote object",
+			zap.String("object_id", objectID),
+			zap.Error(err))
+		return objectID, nil
+	}
+
+	return objectID, obj
+}
+
+func (ih *InboxHandler) resolveKnownInteractionStatus(ctx context.Context, objectID string) *models.Status {
+	if ih.statusRepository == nil {
+		return nil
+	}
+
+	if status, err := ih.statusRepository.GetStatusByURL(ctx, objectID); err == nil &&
+		models.CanonicalActivityPubObjectIDForStatus(status, ih.baseURL) != "" {
+		return status
+	}
+
+	for _, candidate := range models.StatusLookupCandidatesForDomain(objectID, ih.baseURL) {
+		status, err := ih.statusRepository.GetStatus(ctx, candidate)
+		if err == nil && models.CanonicalActivityPubObjectIDForStatus(status, ih.baseURL) != "" {
+			return status
+		}
+	}
 
 	return nil
 }
@@ -2691,7 +2712,8 @@ func (ih *InboxHandler) processUndoActivity(ctx context.Context, activity *activ
 		}
 	case activitypub.LikeType:
 		// Undo like
-		if objectID, ok := originalActivity.Object.(string); ok {
+		if objectID := extractObjectID(originalActivity.Object); objectID != "" {
+			objectID, _ = ih.canonicalizeKnownInteractionObject(ctx, objectID)
 			err := ih.likeRepository.DeleteLike(ctx, activity.Actor, objectID)
 			if err != nil {
 				log.Warn("failed to remove like", zap.Error(err))
@@ -2700,7 +2722,8 @@ func (ih *InboxHandler) processUndoActivity(ctx context.Context, activity *activ
 		}
 	case activitypub.AnnounceType:
 		// Undo announce (boost/reblog)
-		if objectID, ok := originalActivity.Object.(string); ok {
+		if objectID := extractObjectID(originalActivity.Object); objectID != "" {
+			objectID, _ = ih.canonicalizeKnownInteractionObject(ctx, objectID)
 			err := ih.socialRepository.DeleteAnnounce(ctx, activity.Actor, objectID)
 			if err != nil {
 				log.Warn("failed to remove announce", zap.Error(err))

--- a/cmd/inbox/internal/routing/interaction_identity_test.go
+++ b/cmd/inbox/internal/routing/interaction_identity_test.go
@@ -1,0 +1,69 @@
+package routing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/storage/interfaces"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type canonicalizingStatusRepo struct {
+	interfaces.StatusRepository
+	status *models.Status
+}
+
+func (r *canonicalizingStatusRepo) GetStatusByURL(context.Context, string) (*models.Status, error) {
+	return nil, storage.ErrNotFound
+}
+
+func (r *canonicalizingStatusRepo) GetStatus(_ context.Context, statusID string) (*models.Status, error) {
+	if r.status != nil && r.status.StatusID == statusID {
+		return r.status, nil
+	}
+	return nil, storage.ErrNotFound
+}
+
+func TestInboxInteractionIdentity_CanonicalizesKnownLocalStatusAlias(t *testing.T) {
+	status := &models.Status{
+		StatusID:       "status-1",
+		AuthorID:       "https://example.com/users/alice",
+		AuthorUsername: "alice",
+		Note: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:   "https://example.com/users/alice/statuses/status-1",
+				Type: activitypub.NoteType,
+			},
+			AttributedTo: "https://example.com/users/alice",
+		},
+	}
+	handler := &InboxHandler{
+		statusRepository: &canonicalizingStatusRepo{status: status},
+		baseURL:          "https://example.com",
+	}
+
+	canonical, obj := handler.canonicalizeKnownInteractionObject(context.Background(), "https://example.com/objects/status-1")
+
+	assert.Equal(t, status.Note.ID, canonical)
+	require.NotNil(t, obj)
+	note, ok := obj.(*activitypub.Note)
+	require.True(t, ok)
+	assert.Equal(t, status.Note.ID, note.ID)
+}
+
+func TestInboxInteractionIdentity_LeavesUnknownRemoteObjectAsReceived(t *testing.T) {
+	handler := &InboxHandler{
+		statusRepository: &canonicalizingStatusRepo{},
+		baseURL:          "https://example.com",
+	}
+
+	objectID := "https://remote.example/users/bob/statuses/unknown"
+	canonical, obj := handler.canonicalizeKnownInteractionObject(context.Background(), objectID)
+
+	assert.Equal(t, objectID, canonical)
+	assert.Nil(t, obj)
+}

--- a/pkg/services/notes/service.go
+++ b/pkg/services/notes/service.go
@@ -2976,53 +2976,46 @@ type UsersResult struct {
 	Pagination *interfaces.PaginatedResult[*storage.Account] `json:"pagination"`
 }
 
-// noteActionParams contains parameters for note actions
-type noteActionParams struct {
-	statusID     string
-	actorID      string
-	actorType    string
-	actionFn     func(context.Context, string, string, string) error
-	emitEventsFn func(context.Context, *models.Status, string) []*streaming.Event
-	errorMsg     string
+type statusInteractionIdentity struct {
+	localStatusID    string
+	activityObjectID string
+	actorURL         string
+	targetActorID    string
+	statusAuthorID   string
 }
 
-// executeNoteActionGeneric handles the common pattern for note actions
-func (s *Service) executeNoteActionGeneric(ctx context.Context, params noteActionParams) (*LikeResult, error) {
-	// Get the status first to validate it exists
-	note, err := s.noteRepo.GetStatus(ctx, params.statusID)
+// LikeNote adds a like to a status
+func (s *Service) LikeNote(ctx context.Context, cmd *LikeNoteCommand) (*LikeResult, error) {
+	note, _, identity, err := s.prepareStatusInteraction(ctx, cmd.StatusID, cmd.LikerID, "liker")
 	if err != nil {
-		return nil, ErrStatusNotFound
+		return nil, err
 	}
 
-	// Get actor's account
-	actor, err := s.accountRepo.GetAccount(ctx, params.actorID)
+	like, err := s.createLike(ctx, identity.actorURL, identity.activityObjectID, identity.statusAuthorID)
 	if err != nil {
-		s.logger.Error("failed to get actor account",
-			zap.String("actor_id", params.actorID),
-			zap.String("actor_type", params.actorType),
-			zap.Error(err))
-		return nil, errors.Join(ErrGetAuthorAccount, err)
-	}
-
-	// Create actor and object URLs
-	actorURL := fmt.Sprintf("https://%s/users/%s", s.domainName, actor.User.Username)
-	objectURL := fmt.Sprintf("https://%s/users/%s/statuses/%s", s.domainName, note.AuthorUsername, params.statusID)
-
-	// Execute the action through repository interface
-	if err := params.actionFn(ctx, actorURL, objectURL, note.AuthorUsername); err != nil {
-		s.logger.Error("action execution failed",
-			zap.String("error_msg", params.errorMsg),
-			zap.String("actor_id", params.actorID),
-			zap.String("status_id", params.statusID),
+		s.logger.Error("failed to like status",
+			zap.String("actor_id", cmd.LikerID),
+			zap.String("status_id", cmd.StatusID),
+			zap.String("activity_object_id", identity.activityObjectID),
 			zap.Error(err))
 		return nil, errors.Join(ErrExecuteAction, err)
 	}
 
-	// Refresh status so counters and derived state stay consistent
-	note = s.refreshStatus(ctx, params.statusID, note)
+	if s.noteRepo == nil {
+		return nil, ErrStatusRepositoryUnavailable
+	}
 
-	// Emit events
-	events := params.emitEventsFn(ctx, note, params.actorID)
+	if err := s.noteRepo.LikeStatus(ctx, cmd.LikerID, identity.localStatusID); err != nil {
+		s.logger.Error("failed to increment like counter",
+			zap.String("status_id", identity.localStatusID),
+			zap.String("liker", cmd.LikerID),
+			zap.Error(err))
+		return nil, errors.Join(ErrExecuteAction, err)
+	}
+
+	note = s.refreshStatus(ctx, identity.localStatusID, note)
+	events := s.emitLikeEvents(ctx, note, cmd.LikerID)
+	s.queueLikeActivity(ctx, note, like, identity)
 
 	return &LikeResult{
 		Status: note,
@@ -3030,62 +3023,43 @@ func (s *Service) executeNoteActionGeneric(ctx context.Context, params noteActio
 	}, nil
 }
 
-// LikeNote adds a like to a status
-func (s *Service) LikeNote(ctx context.Context, cmd *LikeNoteCommand) (*LikeResult, error) {
-	result, err := s.executeNoteActionGeneric(ctx, noteActionParams{
-		statusID:     cmd.StatusID,
-		actorID:      cmd.LikerID,
-		actorType:    "liker",
-		actionFn:     s.createLike,
-		emitEventsFn: s.emitLikeEvents,
-		errorMsg:     "failed to like status",
-	})
+// UnlikeNote removes a like from a status
+func (s *Service) UnlikeNote(ctx context.Context, cmd *UnlikeNoteCommand) (*LikeResult, error) {
+	note, _, identity, err := s.prepareStatusInteraction(ctx, cmd.StatusID, cmd.UnlikerID, "unliker")
 	if err != nil {
 		return nil, err
 	}
 
-	if s.noteRepo == nil {
-		return nil, ErrStatusRepositoryUnavailable
-	}
-
-	if err := s.noteRepo.LikeStatus(ctx, cmd.LikerID, cmd.StatusID); err != nil {
-		s.logger.Error("failed to increment like counter",
+	like := s.getLikeForUndo(ctx, identity.actorURL, identity.activityObjectID)
+	if err := s.deleteLike(ctx, identity.actorURL, identity.activityObjectID, ""); err != nil {
+		s.logger.Error("failed to unlike status",
+			zap.String("actor_id", cmd.UnlikerID),
 			zap.String("status_id", cmd.StatusID),
-			zap.String("liker", cmd.LikerID),
+			zap.String("activity_object_id", identity.activityObjectID),
 			zap.Error(err))
 		return nil, errors.Join(ErrExecuteAction, err)
 	}
 
-	return result, nil
-}
-
-// UnlikeNote removes a like from a status
-func (s *Service) UnlikeNote(ctx context.Context, cmd *UnlikeNoteCommand) (*LikeResult, error) {
-	result, err := s.executeNoteActionGeneric(ctx, noteActionParams{
-		statusID:     cmd.StatusID,
-		actorID:      cmd.UnlikerID,
-		actorType:    "unliker",
-		actionFn:     s.deleteLike,
-		emitEventsFn: s.emitUnlikeEvents,
-		errorMsg:     "failed to unlike status",
-	})
-	if err != nil {
-		return nil, err
-	}
-
 	if s.noteRepo == nil {
 		return nil, ErrStatusRepositoryUnavailable
 	}
 
-	if err := s.noteRepo.UnlikeStatus(ctx, cmd.UnlikerID, cmd.StatusID); err != nil {
+	if err := s.noteRepo.UnlikeStatus(ctx, cmd.UnlikerID, identity.localStatusID); err != nil {
 		s.logger.Error("failed to decrement like counter",
-			zap.String("status_id", cmd.StatusID),
+			zap.String("status_id", identity.localStatusID),
 			zap.String("unliker", cmd.UnlikerID),
 			zap.Error(err))
 		return nil, errors.Join(ErrExecuteAction, err)
 	}
 
-	return result, nil
+	note = s.refreshStatus(ctx, identity.localStatusID, note)
+	events := s.emitUnlikeEvents(ctx, note, cmd.UnlikerID)
+	s.queueUndoLikeActivity(ctx, note, like, identity)
+
+	return &LikeResult{
+		Status: note,
+		Events: events,
+	}, nil
 }
 
 // GetLikers retrieves users who liked a status
@@ -3106,6 +3080,150 @@ func (s *Service) GetLikers(ctx context.Context, query *GetLikersQuery) (*UsersR
 		Users:      users,
 		Pagination: pagination,
 	}, nil
+}
+
+func (s *Service) prepareStatusInteraction(
+	ctx context.Context,
+	statusID string,
+	actorID string,
+	actorType string,
+) (*models.Status, *storage.Account, statusInteractionIdentity, error) {
+	note, err := s.noteRepo.GetStatus(ctx, statusID)
+	if err != nil {
+		return nil, nil, statusInteractionIdentity{}, ErrStatusNotFound
+	}
+
+	actor, err := s.accountRepo.GetAccount(ctx, actorID)
+	if err != nil {
+		s.logger.Error("failed to get actor account",
+			zap.String("actor_id", actorID),
+			zap.String("actor_type", actorType),
+			zap.Error(err))
+		return nil, nil, statusInteractionIdentity{}, errors.Join(ErrGetAuthorAccount, err)
+	}
+
+	identity, err := s.statusInteractionIdentity(note, actor)
+	if err != nil {
+		s.logger.Error("failed to resolve status interaction identity",
+			zap.String("actor_id", actorID),
+			zap.String("actor_type", actorType),
+			zap.String("status_id", statusID),
+			zap.Error(err))
+		return nil, nil, statusInteractionIdentity{}, errors.Join(ErrExecuteAction, err)
+	}
+
+	return note, actor, identity, nil
+}
+
+func (s *Service) statusInteractionIdentity(status *models.Status, actor *storage.Account) (statusInteractionIdentity, error) {
+	if status == nil {
+		return statusInteractionIdentity{}, errors.New("status is required")
+	}
+
+	localStatusID := strings.TrimSpace(status.StatusID)
+	if localStatusID == "" {
+		return statusInteractionIdentity{}, errors.New("status id is required")
+	}
+
+	actorURL := s.accountActorURL(actor)
+	if actorURL == "" {
+		return statusInteractionIdentity{}, errors.New("actor url is required")
+	}
+
+	activityObjectID := models.CanonicalActivityPubObjectIDForStatus(status, s.domainName)
+	if activityObjectID == "" {
+		return statusInteractionIdentity{}, fmt.Errorf("canonical ActivityPub object id is required for status %s", localStatusID)
+	}
+
+	statusAuthorID := strings.TrimSpace(status.AuthorUsername)
+	if statusAuthorID == "" {
+		statusAuthorID = strings.TrimSpace(status.AuthorID)
+	}
+
+	return statusInteractionIdentity{
+		localStatusID:    localStatusID,
+		activityObjectID: activityObjectID,
+		actorURL:         actorURL,
+		targetActorID:    s.statusAuthorActorID(status),
+		statusAuthorID:   statusAuthorID,
+	}, nil
+}
+
+func (s *Service) accountActorURL(account *storage.Account) string {
+	if account == nil {
+		return ""
+	}
+	if account.Actor != nil {
+		if actorID := strings.TrimSpace(account.Actor.ID); actorID != "" {
+			return actorID
+		}
+	}
+	if account.User == nil {
+		return ""
+	}
+	username := strings.TrimSpace(account.User.Username)
+	if username == "" {
+		return ""
+	}
+	return s.localActorID(username)
+}
+
+func (s *Service) statusAuthorActorID(status *models.Status) string {
+	if status == nil {
+		return ""
+	}
+	if status.Note != nil {
+		if actorID := strings.TrimSpace(status.Note.AttributedTo); actorID != "" {
+			return actorID
+		}
+	}
+	if actorID := strings.TrimSpace(status.AuthorID); actorID != "" {
+		return actorID
+	}
+	if author := strings.TrimSpace(status.AuthorUsername); author != "" && !strings.Contains(author, "@") {
+		return s.localActorID(author)
+	}
+	return ""
+}
+
+func interactionToRecipients(identity statusInteractionIdentity) []string {
+	return appendUniqueStrings(nil, identity.targetActorID)
+}
+
+func interactionAnnounceToRecipients(status *models.Status, identity statusInteractionIdentity) []string {
+	recipients := appendUniqueStrings(nil, identity.targetActorID)
+	if status != nil {
+		recipients = appendUniqueStrings(recipients, status.ToRecipients...)
+	}
+	return recipients
+}
+
+func appendUniqueStrings(values []string, candidates ...string) []string {
+	seen := make(map[string]struct{}, len(values)+len(candidates))
+	result := make([]string, 0, len(values)+len(candidates))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	for _, value := range candidates {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
 }
 
 // Reblog/Announce Commands and Queries
@@ -3150,12 +3268,16 @@ func (s *Service) ReblogNote(ctx context.Context, cmd *ReblogNoteCommand) (*Like
 		return nil, ErrGetRebloggerAccount
 	}
 
-	// Create actor and object URLs for the reblog
-	actorURL := fmt.Sprintf("https://%s/users/%s", s.domainName, reblogger.User.Username)
-	objectURL := fmt.Sprintf("https://%s/users/%s/statuses/%s", s.domainName, note.AuthorUsername, cmd.StatusID)
+	identity, err := s.statusInteractionIdentity(note, reblogger)
+	if err != nil {
+		s.logger.Error("failed to resolve reblog object identity",
+			zap.String("status_id", cmd.StatusID),
+			zap.Error(err))
+		return nil, ErrReblogStatus
+	}
 
 	// Create the reblog through repository interface
-	announce, err := s.createReblog(ctx, actorURL, objectURL, cmd.RebloggerID, cmd.StatusID)
+	announce, err := s.createReblog(ctx, identity.actorURL, identity.activityObjectID, cmd.RebloggerID, identity.localStatusID)
 	if err != nil {
 		return nil, ErrReblogStatus
 	}
@@ -3181,14 +3303,30 @@ func (s *Service) ReblogNote(ctx context.Context, cmd *ReblogNoteCommand) (*Like
 
 // UnreblogNote removes a reblog/announce of a status
 func (s *Service) UnreblogNote(ctx context.Context, cmd *UnreblogNoteCommand) (*LikeResult, error) {
-	return s.executeNoteActionGeneric(ctx, noteActionParams{
-		statusID:     cmd.StatusID,
-		actorID:      cmd.UnrebloggerID,
-		actorType:    "unreblogger",
-		actionFn:     s.deleteReblog,
-		emitEventsFn: s.emitUnreblogEvents,
-		errorMsg:     "failed to unreblog status",
-	})
+	note, _, identity, err := s.prepareStatusInteraction(ctx, cmd.StatusID, cmd.UnrebloggerID, "unreblogger")
+	if err != nil {
+		return nil, err
+	}
+
+	announce := s.getAnnounceForUndo(ctx, identity.actorURL, identity.activityObjectID)
+	if err := s.deleteReblog(ctx, identity.actorURL, identity.activityObjectID, identity.localStatusID); err != nil {
+		s.logger.Error("failed to unreblog status",
+			zap.String("actor_id", cmd.UnrebloggerID),
+			zap.String("status_id", cmd.StatusID),
+			zap.String("activity_object_id", identity.activityObjectID),
+			zap.Error(err))
+		return nil, errors.Join(ErrExecuteAction, err)
+	}
+
+	note = s.refreshStatus(ctx, identity.localStatusID, note)
+	events := s.emitUnreblogEvents(ctx, note, cmd.UnrebloggerID)
+	s.queueUndoAnnounceActivity(ctx, note, announce, identity)
+
+	return &LikeResult{
+		Status:   note,
+		Events:   events,
+		Announce: announce,
+	}, nil
 }
 
 // GetRebloggers retrieves users who reblogged a status
@@ -3400,12 +3538,12 @@ func (s *Service) UnmuteNote(ctx context.Context, cmd *UnmuteNoteCommand) (*Like
 
 // Private helper methods - these need to be implemented to interface with repositories
 
-func (s *Service) createLike(ctx context.Context, actorURL, objectURL, statusAuthorID string) error {
-	_, err := s.likeRepo.CreateLike(ctx, actorURL, objectURL, statusAuthorID)
+func (s *Service) createLike(ctx context.Context, actorURL, objectURL, statusAuthorID string) (*models.Like, error) {
+	like, err := s.likeRepo.CreateLike(ctx, actorURL, objectURL, statusAuthorID)
 	if err != nil {
-		return ErrCreateLike
+		return nil, ErrCreateLike
 	}
-	return nil
+	return like, nil
 }
 
 func (s *Service) deleteLike(ctx context.Context, actorURL, objectURL, _ string) error {
@@ -3443,7 +3581,7 @@ func (s *Service) getLikers(ctx context.Context, statusID string, pagination int
 	return accounts, result, nil
 }
 
-func (s *Service) createReblog(ctx context.Context, actorURL, objectURL, _, _ string) (*storage.Announce, error) {
+func (s *Service) createReblog(ctx context.Context, actorURL, objectURL, _, localStatusID string) (*storage.Announce, error) {
 	// Idempotency: if an announce already exists for this actor/object, skip creating duplicates
 	if existing, err := s.socialRepo.GetAnnounce(ctx, actorURL, objectURL); err == nil {
 		s.logger.Debug("announce already persisted, skipping duplicate reblog",
@@ -3515,9 +3653,11 @@ func (s *Service) createReblog(ctx context.Context, actorURL, objectURL, _, _ st
 		return nil, ErrCreateReblog
 	}
 
-	statusID := extractStatusIDFromObjectURL(objectURL)
+	if strings.TrimSpace(localStatusID) == "" {
+		localStatusID = extractStatusIDFromObjectURL(objectURL)
+	}
 
-	if err := common.ValidateRequiredParam("reblog_status_id", statusID); err != nil {
+	if err := common.ValidateRequiredParam("reblog_status_id", localStatusID); err != nil {
 		s.logger.Error("failed to resolve status id from object url",
 			zap.String("object_url", objectURL),
 			zap.Error(err))
@@ -3525,16 +3665,16 @@ func (s *Service) createReblog(ctx context.Context, actorURL, objectURL, _, _ st
 	}
 
 	engagementCreated := true
-	if err := s.noteRepo.ReblogStatus(ctx, actorURL, statusID, announce.ID); err != nil {
+	if err := s.noteRepo.ReblogStatus(ctx, actorURL, localStatusID, announce.ID); err != nil {
 		if isAlreadyExistsError(err) {
 			s.logger.Debug("reblog engagement already recorded",
 				zap.String("actor_url", actorURL),
-				zap.String("status_id", statusID))
+				zap.String("status_id", localStatusID))
 			engagementCreated = false
 		} else {
 			s.logger.Error("failed to record reblog engagement",
 				zap.String("actor_url", actorURL),
-				zap.String("status_id", statusID),
+				zap.String("status_id", localStatusID),
 				zap.Error(err))
 			return nil, ErrReblogStatus
 		}
@@ -3548,7 +3688,7 @@ func (s *Service) createReblog(ctx context.Context, actorURL, objectURL, _, _ st
 	return announce, nil
 }
 
-func (s *Service) deleteReblog(ctx context.Context, actorURL, objectURL, _ string) error {
+func (s *Service) deleteReblog(ctx context.Context, actorURL, objectURL, localStatusID string) error {
 	if err := s.socialRepo.DeleteAnnounce(ctx, actorURL, objectURL); err != nil {
 		return ErrDeleteReblog
 	}
@@ -3560,24 +3700,26 @@ func (s *Service) deleteReblog(ctx context.Context, actorURL, objectURL, _ strin
 		return nil
 	}
 
-	statusID := extractStatusIDFromObjectURL(objectURL)
+	if strings.TrimSpace(localStatusID) == "" {
+		localStatusID = extractStatusIDFromObjectURL(objectURL)
+	}
 
-	if err := common.ValidateRequiredParam("reblog_status_id", statusID); err != nil {
+	if err := common.ValidateRequiredParam("reblog_status_id", localStatusID); err != nil {
 		s.logger.Error("failed to resolve status id from object url for unreblog",
 			zap.String("object_url", objectURL),
 			zap.Error(err))
 		return ErrDeleteReblog
 	}
 
-	if err := s.noteRepo.UnreblogStatus(ctx, actorURL, statusID); err != nil {
+	if err := s.noteRepo.UnreblogStatus(ctx, actorURL, localStatusID); err != nil {
 		s.logger.Error("failed to remove reblog engagement",
 			zap.String("actor_url", actorURL),
-			zap.String("status_id", statusID),
+			zap.String("status_id", localStatusID),
 			zap.Error(err))
 		return ErrDeleteReblog
 	}
 
-	s.deleteBoostStatus(ctx, actorURL, statusID)
+	s.deleteBoostStatus(ctx, actorURL, localStatusID)
 
 	return nil
 }
@@ -3799,6 +3941,81 @@ func (s *Service) buildStatusURL(status *models.Status) string {
 	return fmt.Sprintf("https://%s/users/%s/statuses/%s", domain, author, status.StatusID)
 }
 
+func (s *Service) getLikeForUndo(ctx context.Context, actorURL, objectURL string) *models.Like {
+	if s.likeRepo == nil {
+		return nil
+	}
+	like, err := s.likeRepo.GetLike(ctx, actorURL, objectURL)
+	if err != nil {
+		s.logger.Debug("like activity unavailable for undo delivery",
+			zap.String("actor_url", actorURL),
+			zap.String("object_url", objectURL),
+			zap.Error(err))
+		return nil
+	}
+	if like == nil || strings.TrimSpace(like.ID) == "" {
+		return nil
+	}
+	return like
+}
+
+func (s *Service) getAnnounceForUndo(ctx context.Context, actorURL, objectURL string) *storage.Announce {
+	if s.socialRepo == nil {
+		return nil
+	}
+	announce, err := s.socialRepo.GetAnnounce(ctx, actorURL, objectURL)
+	if err != nil {
+		s.logger.Debug("announce activity unavailable for undo delivery",
+			zap.String("actor_url", actorURL),
+			zap.String("object_url", objectURL),
+			zap.Error(err))
+		return nil
+	}
+	if announce == nil || strings.TrimSpace(announce.ID) == "" {
+		return nil
+	}
+	return announce
+}
+
+func (s *Service) queueLikeActivity(ctx context.Context, status *models.Status, like *models.Like, identity statusInteractionIdentity) {
+	if s.federation == nil || status == nil || like == nil {
+		return
+	}
+	if strings.TrimSpace(like.ID) == "" || strings.TrimSpace(identity.activityObjectID) == "" {
+		return
+	}
+
+	published := like.Published
+	if published.IsZero() {
+		published = time.Now()
+	}
+	publishedCopy := published
+
+	activity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Context:   activitypub.Context,
+			Type:      activitypub.LikeType,
+			ID:        like.ID,
+			Published: &publishedCopy,
+			To:        interactionToRecipients(identity),
+		},
+		Actor:  identity.actorURL,
+		Object: identity.activityObjectID,
+	}
+
+	if err := s.federation.QueueActivity(ctx, activity); err != nil {
+		s.logger.Error("failed to queue like activity",
+			zap.String("status_id", status.StatusID),
+			zap.String("actor", identity.actorURL),
+			zap.Error(err))
+		return
+	}
+
+	s.logger.Debug("queued like activity",
+		zap.String("status_id", status.StatusID),
+		zap.String("like_id", like.ID))
+}
+
 func (s *Service) queueAnnounceActivity(ctx context.Context, status *models.Status, announce *storage.Announce) {
 	if s.federation == nil || status == nil || announce == nil {
 		return
@@ -3816,8 +4033,10 @@ func (s *Service) queueAnnounceActivity(ctx context.Context, status *models.Stat
 			Type:      activitypub.AnnounceType,
 			ID:        announce.ID,
 			Published: &publishedCopy,
-			To:        status.ToRecipients,
-			CC:        status.CcRecipients,
+			To: interactionAnnounceToRecipients(status, statusInteractionIdentity{
+				targetActorID: s.statusAuthorActorID(status),
+			}),
+			CC: status.CcRecipients,
 		},
 		Actor:  announce.Actor,
 		Object: announce.Object,
@@ -3834,6 +4053,146 @@ func (s *Service) queueAnnounceActivity(ctx context.Context, status *models.Stat
 	s.logger.Debug("queued announce activity",
 		zap.String("status_id", status.StatusID),
 		zap.String("announce_id", announce.ID))
+}
+
+func (s *Service) queueUndoLikeActivity(ctx context.Context, status *models.Status, like *models.Like, identity statusInteractionIdentity) {
+	if s.federation == nil || status == nil || like == nil {
+		return
+	}
+	likeActivity := s.likeActivityForUndo(like, identity)
+	if likeActivity == nil {
+		return
+	}
+	s.queueUndoInteractionActivity(ctx, status, likeActivity, interactionToRecipients(identity), "like")
+}
+
+func (s *Service) queueUndoAnnounceActivity(
+	ctx context.Context,
+	status *models.Status,
+	announce *storage.Announce,
+	identity statusInteractionIdentity,
+) {
+	if s.federation == nil || status == nil || announce == nil {
+		return
+	}
+	announceActivity := s.announceActivityForUndo(status, announce, identity)
+	if announceActivity == nil {
+		return
+	}
+	s.queueUndoInteractionActivity(ctx, status, announceActivity, announceActivity.To, "announce")
+}
+
+func (s *Service) likeActivityForUndo(like *models.Like, identity statusInteractionIdentity) *activitypub.Activity {
+	if like == nil {
+		return nil
+	}
+	activityID := strings.TrimSpace(like.ID)
+	objectID := strings.TrimSpace(like.Object)
+	if objectID == "" {
+		objectID = strings.TrimSpace(identity.activityObjectID)
+	}
+	actorURL := strings.TrimSpace(like.Actor)
+	if actorURL == "" {
+		actorURL = strings.TrimSpace(identity.actorURL)
+	}
+	if activityID == "" || objectID == "" || actorURL == "" {
+		return nil
+	}
+
+	published := like.Published
+	if published.IsZero() {
+		published = time.Now()
+	}
+	publishedCopy := published
+
+	return &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Context:   activitypub.Context,
+			Type:      activitypub.LikeType,
+			ID:        activityID,
+			Published: &publishedCopy,
+			To:        interactionToRecipients(identity),
+		},
+		Actor:  actorURL,
+		Object: objectID,
+	}
+}
+
+func (s *Service) announceActivityForUndo(
+	status *models.Status,
+	announce *storage.Announce,
+	identity statusInteractionIdentity,
+) *activitypub.Activity {
+	if announce == nil {
+		return nil
+	}
+	activityID := strings.TrimSpace(announce.ID)
+	objectID := strings.TrimSpace(announce.Object)
+	actorURL := strings.TrimSpace(announce.Actor)
+	if actorURL == "" {
+		actorURL = strings.TrimSpace(identity.actorURL)
+	}
+	if activityID == "" || objectID == "" || actorURL == "" {
+		return nil
+	}
+
+	published := announce.Published
+	if published.IsZero() {
+		published = time.Now()
+	}
+	publishedCopy := published
+
+	return &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Context:   activitypub.Context,
+			Type:      activitypub.AnnounceType,
+			ID:        activityID,
+			Published: &publishedCopy,
+			To:        interactionAnnounceToRecipients(status, identity),
+			CC:        status.CcRecipients,
+		},
+		Actor:  actorURL,
+		Object: objectID,
+	}
+}
+
+func (s *Service) queueUndoInteractionActivity(
+	ctx context.Context,
+	status *models.Status,
+	original *activitypub.Activity,
+	recipients []string,
+	interactionType string,
+) {
+	if original == nil || strings.TrimSpace(original.ID) == "" {
+		return
+	}
+
+	published := time.Now()
+	activity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Context:   activitypub.Context,
+			Type:      activitypub.UndoType,
+			ID:        fmt.Sprintf("%s#undo", strings.TrimSpace(original.ID)),
+			Published: &published,
+			To:        recipients,
+		},
+		Actor:  original.Actor,
+		Object: original,
+	}
+
+	if err := s.federation.QueueActivity(ctx, activity); err != nil {
+		s.logger.Error("failed to queue undo interaction activity",
+			zap.String("status_id", status.StatusID),
+			zap.String("interaction_type", interactionType),
+			zap.String("actor", original.Actor),
+			zap.Error(err))
+		return
+	}
+
+	s.logger.Debug("queued undo interaction activity",
+		zap.String("status_id", status.StatusID),
+		zap.String("interaction_type", interactionType),
+		zap.String("activity_id", activity.ID))
 }
 
 func (s *Service) pinStatus(ctx context.Context, userID, statusID string) error {

--- a/pkg/services/notes/service_interaction_identity_test.go
+++ b/pkg/services/notes/service_interaction_identity_test.go
@@ -1,0 +1,282 @@
+package notes
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestServiceInteractionIdentity_RemoteLikeQueuesCanonicalObject(t *testing.T) {
+	ctx := context.Background()
+	service, _, federation, _, _ := newNotesServiceHarness(t)
+	remoteURL := "https://remote.example/users/steward/statuses/interaction-like"
+	remoteStatus := remoteInteractionStatus(remoteURL)
+	originalRepo := service.noteRepo
+	service.noteRepo = &delegatingStatusRepo{
+		StatusRepository: originalRepo,
+		getStatus: func(ctx context.Context, statusID string) (*models.Status, error) {
+			if statusID == remoteStatus.StatusID {
+				return remoteStatus, nil
+			}
+			return originalRepo.GetStatus(ctx, statusID)
+		},
+	}
+
+	result, err := service.LikeNote(ctx, &LikeNoteCommand{
+		StatusID: remoteStatus.StatusID,
+		LikerID:  "alice",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, federation.activities, 1)
+	activity := federation.activities[0]
+	assert.Equal(t, activitypub.LikeType, activity.Type)
+	assert.Equal(t, "https://example.com/users/alice", activity.Actor)
+	assert.Equal(t, remoteURL, activity.Object)
+	assert.Contains(t, activity.To, remoteStatus.AuthorID)
+}
+
+func TestServiceInteractionIdentity_RemoteAnnounceStoresAndQueuesCanonicalObject(t *testing.T) {
+	ctx := context.Background()
+	service, _, federation, _, _ := newNotesServiceHarness(t)
+	remoteURL := "https://remote.example/users/steward/statuses/interaction-announce"
+	remoteStatus := remoteInteractionStatus(remoteURL)
+	originalRepo := service.noteRepo
+	service.noteRepo = &delegatingStatusRepo{
+		StatusRepository: originalRepo,
+		getStatus: func(ctx context.Context, statusID string) (*models.Status, error) {
+			if statusID == remoteStatus.StatusID {
+				return remoteStatus, nil
+			}
+			return originalRepo.GetStatus(ctx, statusID)
+		},
+	}
+
+	result, err := service.ReblogNote(ctx, &ReblogNoteCommand{
+		StatusID:    remoteStatus.StatusID,
+		RebloggerID: "bob",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Announce)
+	assert.Equal(t, remoteURL, result.Announce.Object)
+	require.Len(t, federation.activities, 1)
+	activity := federation.activities[0]
+	assert.Equal(t, activitypub.AnnounceType, activity.Type)
+	assert.Equal(t, "https://example.com/users/bob", activity.Actor)
+	assert.Equal(t, remoteURL, activity.Object)
+	assert.Contains(t, activity.To, remoteStatus.AuthorID)
+}
+
+func TestServiceInteractionIdentity_QueuesUndoLikeAndUndoAnnounceWithCanonicalObject(t *testing.T) {
+	now := time.Now().UTC()
+	remoteURL := "https://remote.example/users/steward/statuses/interaction-undo"
+	remoteStatus := remoteInteractionStatus(remoteURL)
+	identity := statusInteractionIdentity{
+		localStatusID:    remoteStatus.StatusID,
+		activityObjectID: remoteURL,
+		actorURL:         "https://example.com/users/alice",
+		targetActorID:    remoteStatus.AuthorID,
+		statusAuthorID:   remoteStatus.AuthorUsername,
+	}
+
+	t.Run("undo like embeds stored like activity", func(t *testing.T) {
+		federation := &stubFederation{}
+		service := &Service{federation: federation, logger: zap.NewNop()}
+		like := &models.Like{
+			ID:        "https://example.com/users/alice/activities/like-1",
+			Actor:     identity.actorURL,
+			Object:    remoteURL,
+			Published: now,
+		}
+
+		service.queueUndoLikeActivity(context.Background(), remoteStatus, like, identity)
+
+		require.Len(t, federation.activities, 1)
+		undo := federation.activities[0]
+		assert.Equal(t, activitypub.UndoType, undo.Type)
+		assert.Equal(t, identity.actorURL, undo.Actor)
+		assert.Contains(t, undo.To, remoteStatus.AuthorID)
+		original, ok := undo.Object.(*activitypub.Activity)
+		require.True(t, ok)
+		assert.Equal(t, activitypub.LikeType, original.Type)
+		assert.Equal(t, like.ID, original.ID)
+		assert.Equal(t, remoteURL, original.Object)
+	})
+
+	t.Run("undo announce embeds stored announce activity", func(t *testing.T) {
+		federation := &stubFederation{}
+		service := &Service{federation: federation, logger: zap.NewNop()}
+		announce := &storage.Announce{
+			ID:        "https://example.com/users/alice/activities/announce-1",
+			Actor:     identity.actorURL,
+			Object:    remoteURL,
+			Published: now,
+		}
+
+		service.queueUndoAnnounceActivity(context.Background(), remoteStatus, announce, identity)
+
+		require.Len(t, federation.activities, 1)
+		undo := federation.activities[0]
+		assert.Equal(t, activitypub.UndoType, undo.Type)
+		assert.Equal(t, identity.actorURL, undo.Actor)
+		assert.Contains(t, undo.To, remoteStatus.AuthorID)
+		original, ok := undo.Object.(*activitypub.Activity)
+		require.True(t, ok)
+		assert.Equal(t, activitypub.AnnounceType, original.Type)
+		assert.Equal(t, announce.ID, original.ID)
+		assert.Equal(t, remoteURL, original.Object)
+	})
+}
+
+func TestServiceInteractionIdentity_RemoteUnreblogQueuesUndoAnnounce(t *testing.T) {
+	ctx := context.Background()
+	service, _, federation, _, _ := newNotesServiceHarness(t)
+	remoteURL := "https://remote.example/users/steward/statuses/interaction-unreblog"
+	remoteStatus := remoteInteractionStatus(remoteURL)
+	originalRepo := service.noteRepo
+	service.noteRepo = &delegatingStatusRepo{
+		StatusRepository: originalRepo,
+		getStatus: func(ctx context.Context, statusID string) (*models.Status, error) {
+			if statusID == remoteStatus.StatusID {
+				return remoteStatus, nil
+			}
+			return originalRepo.GetStatus(ctx, statusID)
+		},
+	}
+
+	actorURL := "https://example.com/users/bob"
+	announce := &storage.Announce{
+		ID:        "https://example.com/users/bob/activities/announce-1",
+		Actor:     actorURL,
+		Object:    remoteURL,
+		Published: time.Now().UTC(),
+	}
+	socialRepo, ok := service.socialRepo.(*stubSocialRepo)
+	require.True(t, ok)
+	socialRepo.announces = map[string]*storage.Announce{
+		actorURL + "|" + remoteURL: announce,
+	}
+
+	result, err := service.UnreblogNote(ctx, &UnreblogNoteCommand{
+		StatusID:      remoteStatus.StatusID,
+		UnrebloggerID: "bob",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, federation.activities, 1)
+	undo := federation.activities[0]
+	assert.Equal(t, activitypub.UndoType, undo.Type)
+	original, ok := undo.Object.(*activitypub.Activity)
+	require.True(t, ok)
+	assert.Equal(t, activitypub.AnnounceType, original.Type)
+	assert.Equal(t, announce.ID, original.ID)
+	assert.Equal(t, remoteURL, original.Object)
+}
+
+func TestServiceInteractionIdentity_HelperFallbackBranches(t *testing.T) {
+	service := &Service{domainName: "example.com", logger: zap.NewNop()}
+
+	assert.Empty(t, service.accountActorURL(nil))
+	assert.Empty(t, service.accountActorURL(&storage.Account{}))
+	assert.Empty(t, service.accountActorURL(&storage.Account{User: &storage.User{Username: "   "}}))
+	assert.Equal(t,
+		"https://example.com/users/carol",
+		service.accountActorURL(&storage.Account{User: &storage.User{Username: " carol "}}),
+	)
+
+	assert.Empty(t, service.statusAuthorActorID(nil))
+	assert.Equal(t,
+		"https://example.com/users/dana",
+		service.statusAuthorActorID(&models.Status{AuthorID: " https://example.com/users/dana "}),
+	)
+	assert.Equal(t,
+		"https://example.com/users/erin",
+		service.statusAuthorActorID(&models.Status{AuthorUsername: " erin "}),
+	)
+	assert.Empty(t, service.statusAuthorActorID(&models.Status{AuthorUsername: "erin@remote.example"}))
+
+	identity, err := service.statusInteractionIdentity(
+		&models.Status{
+			StatusID:       "local-1",
+			AuthorID:       "https://example.com/users/frank",
+			AuthorUsername: "",
+		},
+		&storage.Account{User: &storage.User{Username: "grace"}},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "local-1", identity.localStatusID)
+	assert.Equal(t, "https://example.com/users/grace", identity.actorURL)
+	assert.Equal(t, "https://example.com/users/frank", identity.targetActorID)
+	assert.Equal(t, "https://example.com/users/frank", identity.statusAuthorID)
+}
+
+func TestServiceInteractionIdentity_UndoActivityFallbackBranches(t *testing.T) {
+	service := &Service{logger: zap.NewNop()}
+	status := remoteInteractionStatus("https://remote.example/users/steward/statuses/fallback")
+	identity := statusInteractionIdentity{
+		activityObjectID: status.Note.ID,
+		actorURL:         "https://example.com/users/alice",
+		targetActorID:    status.AuthorID,
+	}
+
+	likeActivity := service.likeActivityForUndo(&models.Like{ID: "like-1"}, identity)
+	require.NotNil(t, likeActivity)
+	assert.Equal(t, activitypub.LikeType, likeActivity.Type)
+	assert.Equal(t, identity.actorURL, likeActivity.Actor)
+	assert.Equal(t, identity.activityObjectID, likeActivity.Object)
+	assert.Contains(t, likeActivity.To, status.AuthorID)
+	assert.NotNil(t, likeActivity.Published)
+	assert.Nil(t, service.likeActivityForUndo(&models.Like{ID: "like-without-object"}, statusInteractionIdentity{}))
+
+	announceActivity := service.announceActivityForUndo(
+		status,
+		&storage.Announce{ID: "announce-1", Object: identity.activityObjectID},
+		identity,
+	)
+	require.NotNil(t, announceActivity)
+	assert.Equal(t, activitypub.AnnounceType, announceActivity.Type)
+	assert.Equal(t, identity.actorURL, announceActivity.Actor)
+	assert.Equal(t, identity.activityObjectID, announceActivity.Object)
+	assert.Contains(t, announceActivity.To, status.AuthorID)
+	assert.Contains(t, announceActivity.CC, "https://remote.example/users/steward/followers")
+	assert.NotNil(t, announceActivity.Published)
+	assert.Nil(t, service.announceActivityForUndo(status, &storage.Announce{ID: "announce-without-object"}, identity))
+}
+
+func remoteInteractionStatus(remoteURL string) *models.Status {
+	now := time.Now().UTC()
+	return &models.Status{
+		StatusID:       models.CanonicalStatusIDForDomain(remoteURL, "example.com"),
+		AuthorID:       "https://remote.example/users/steward",
+		AuthorUsername: "steward@remote.example",
+		Visibility:     models.VisibilityPublic,
+		ToRecipients:   []string{activitypub.PublicAddress},
+		CcRecipients:   []string{"https://remote.example/users/steward/followers"},
+		PublishedAt:    now,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		ModifiedAt:     now,
+		Note: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:   remoteURL,
+				Type: activitypub.NoteType,
+				To:   []string{activitypub.PublicAddress},
+				CC:   []string{"https://remote.example/users/steward/followers"},
+			},
+			AttributedTo: "https://remote.example/users/steward",
+			Content:      "remote seed",
+			Visibility:   models.VisibilityPublic,
+		},
+	}
+}

--- a/pkg/services/notes/service_round15_mainline_test.go
+++ b/pkg/services/notes/service_round15_mainline_test.go
@@ -2508,58 +2508,8 @@ func TestService_round15_bookmarks_update_history_and_boost_delete_edges(t *test
 	}
 }
 
-func TestService_round15_executeNoteAction_and_mute_errors(t *testing.T) {
+func TestService_round15_mute_errors(t *testing.T) {
 	ctx := context.Background()
-
-	// executeNoteActionGeneric: account lookup error.
-	{
-		service, _, _, _, _ := newNotesServiceHarness(t)
-		service.accountRepo = &stubAccountRepoError{err: fmt.Errorf("boom")}
-
-		_, err := service.executeNoteActionGeneric(ctx, noteActionParams{
-			statusID:     "status-1",
-			actorID:      "alice",
-			actorType:    "liker",
-			actionFn:     func(context.Context, string, string, string) error { return nil },
-			emitEventsFn: func(context.Context, *models.Status, string) []*streaming.Event { return nil },
-			errorMsg:     "boom",
-		})
-		assert.Error(t, err)
-	}
-
-	// executeNoteActionGeneric: action error.
-	{
-		service, _, _, _, _ := newNotesServiceHarness(t)
-		_, err := service.executeNoteActionGeneric(ctx, noteActionParams{
-			statusID:     "status-1",
-			actorID:      "alice",
-			actorType:    "liker",
-			actionFn:     func(context.Context, string, string, string) error { return fmt.Errorf("boom") },
-			emitEventsFn: func(context.Context, *models.Status, string) []*streaming.Event { return nil },
-			errorMsg:     "boom",
-		})
-		assert.Error(t, err)
-	}
-
-	// executeNoteActionGeneric: status not found.
-	{
-		mockDB := new(mocks.MockDB)
-		mockQuery := new(mocks.MockQuery)
-		mockUpdateBuilder := new(mocks.MockUpdateBuilder)
-		mockQuery.On("First", mock.Anything).Return(fmt.Errorf("boom")).Once()
-		setupPermissiveDynamormMocks(mockDB, mockQuery, mockUpdateBuilder, &permissiveQueryState{})
-
-		service := newNotesServiceHarnessWithDB(t, transactionalMockDB{MockDB: mockDB})
-		_, err := service.executeNoteActionGeneric(ctx, noteActionParams{
-			statusID:     "status-1",
-			actorID:      "alice",
-			actorType:    "liker",
-			actionFn:     func(context.Context, string, string, string) error { return nil },
-			emitEventsFn: func(context.Context, *models.Status, string) []*streaming.Event { return nil },
-			errorMsg:     "boom",
-		})
-		assert.ErrorIs(t, err, ErrStatusNotFound)
-	}
 
 	// muteStatus/unmuteStatus: repo missing and hard errors.
 	{

--- a/pkg/storage/models/status_identity.go
+++ b/pkg/storage/models/status_identity.go
@@ -3,6 +3,7 @@ package models
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"net"
 	"net/url"
 	"strings"
@@ -24,6 +25,36 @@ func CanonicalStatusID(raw string) string {
 // attempted for a direct status read against the current local domain.
 func StatusLookupCandidates(raw string) []string {
 	return StatusLookupCandidatesForDomain(raw, config.Get().Domain)
+}
+
+// CanonicalActivityPubObjectIDForStatus returns the ActivityPub object ID that
+// should be used when a federated interaction refers to a status. This is
+// intentionally distinct from StatusID: remote statuses use a local remote_*
+// StatusID for storage and counters, while their ActivityPub object identity
+// remains the source instance's Note ID.
+func CanonicalActivityPubObjectIDForStatus(status *Status, localDomain string) string {
+	if status == nil {
+		return ""
+	}
+
+	if status.Note != nil {
+		if noteID := strings.TrimSpace(status.Note.ID); noteID != "" {
+			return noteID
+		}
+	}
+
+	for _, rawURL := range status.URLs {
+		rawURL = strings.TrimSpace(rawURL)
+		if isHTTPStatusURL(rawURL) {
+			return rawURL
+		}
+	}
+
+	if statusAppearsRemote(status, localDomain) {
+		return ""
+	}
+
+	return localActivityPubObjectIDForStatus(status, localDomain)
 }
 
 // StatusLookupCandidatesForDomain returns the meaningful status identifiers that
@@ -64,6 +95,91 @@ func StatusLookupCandidatesForDomain(raw string, localDomain string) []string {
 
 	appendCandidate(raw)
 	return candidates
+}
+
+func isHTTPStatusURL(raw string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed == nil {
+		return false
+	}
+	return (parsed.Scheme == "http" || parsed.Scheme == "https") && parsed.Host != ""
+}
+
+func statusAppearsRemote(status *Status, localDomain string) bool {
+	if status == nil {
+		return false
+	}
+	if IsCanonicalRemoteStatusID(status.StatusID) {
+		return true
+	}
+	if strings.Contains(strings.TrimSpace(status.AuthorUsername), "@") {
+		return true
+	}
+
+	actorID := strings.TrimSpace(status.AuthorID)
+	if actorID == "" && status.Note != nil {
+		actorID = strings.TrimSpace(status.Note.AttributedTo)
+	}
+	if actorID == "" {
+		return false
+	}
+
+	_, parsed, ok := normalizeStatusIdentifierURL(actorID)
+	if !ok {
+		return false
+	}
+	return !isLocalStatusIdentifierHostForDomain(parsed.Hostname(), localDomain)
+}
+
+func localActivityPubObjectIDForStatus(status *Status, localDomain string) string {
+	if status == nil {
+		return ""
+	}
+
+	statusID := strings.TrimSpace(status.StatusID)
+	if statusID == "" {
+		return ""
+	}
+
+	domain := normalizedLocalDomain(localDomain)
+	if domain == "" {
+		return ""
+	}
+
+	author := strings.TrimSpace(status.AuthorUsername)
+	if author == "" {
+		author = usernameFromActorIDForStatusIdentity(status.AuthorID)
+	}
+	if author == "" && status.Note != nil {
+		author = usernameFromActorIDForStatusIdentity(status.Note.AttributedTo)
+	}
+	if author == "" || strings.Contains(author, "@") {
+		return ""
+	}
+
+	return fmt.Sprintf("https://%s/users/%s/statuses/%s", domain, author, statusID)
+}
+
+func usernameFromActorIDForStatusIdentity(actorID string) string {
+	actorID = strings.TrimSpace(actorID)
+	if actorID == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(actorID)
+	if err == nil && parsed != nil && parsed.Path != "" {
+		parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+		if len(parts) > 0 {
+			return strings.TrimSpace(parts[len(parts)-1])
+		}
+	}
+
+	trimmed := strings.TrimSuffix(actorID, "/")
+	if trimmed == "" {
+		return ""
+	}
+	parts := strings.Split(trimmed, "/")
+	return strings.TrimSpace(parts[len(parts)-1])
 }
 
 // CanonicalStatusIDForDomain normalizes a status identifier against the
@@ -177,6 +293,15 @@ func isLocalStatusIdentifierHostForDomain(host string, localDomain string) bool 
 		return false
 	}
 
+	localDomain = normalizedLocalDomain(localDomain)
+	if localDomain == "" {
+		return false
+	}
+
+	return host == localDomain
+}
+
+func normalizedLocalDomain(localDomain string) string {
 	localDomain = strings.ToLower(strings.TrimSpace(localDomain))
 	localDomain = strings.TrimPrefix(strings.TrimPrefix(localDomain, "https://"), "http://")
 	if idx := strings.Index(localDomain, "/"); idx >= 0 {
@@ -185,9 +310,5 @@ func isLocalStatusIdentifierHostForDomain(host string, localDomain string) bool 
 	if idx := strings.Index(localDomain, ":"); idx >= 0 {
 		localDomain = localDomain[:idx]
 	}
-	if localDomain == "" {
-		return false
-	}
-
-	return host == localDomain
+	return localDomain
 }

--- a/pkg/storage/models/status_identity_test.go
+++ b/pkg/storage/models/status_identity_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
@@ -57,6 +58,124 @@ func TestStatusLookupCandidatesForDomain(t *testing.T) {
 	config.ResetForTests()
 	t.Cleanup(config.ResetForTests)
 	assert.Equal(t, []string{"123"}, StatusLookupCandidates(localURL))
+}
+
+func TestCanonicalActivityPubObjectIDForStatus(t *testing.T) {
+	t.Run("nil status has no object id", func(t *testing.T) {
+		assert.Empty(t, CanonicalActivityPubObjectIDForStatus(nil, "example.com"))
+	})
+
+	t.Run("prefers remote note id over local remote status id", func(t *testing.T) {
+		remoteURL := "https://remote.example/users/alice/statuses/123"
+		status := &Status{
+			StatusID:       CanonicalStatusIDForDomain(remoteURL, "example.com"),
+			AuthorID:       "https://remote.example/users/alice",
+			AuthorUsername: "alice@remote.example",
+			Note:           &activitypub.Note{BaseObject: activitypub.BaseObject{ID: remoteURL}},
+		}
+
+		assert.Equal(t, remoteURL, CanonicalActivityPubObjectIDForStatus(status, "example.com"))
+	})
+
+	t.Run("uses explicit url when note id is absent", func(t *testing.T) {
+		remoteURL := "https://remote.example/users/alice/statuses/456"
+		status := &Status{
+			StatusID:       CanonicalStatusIDForDomain(remoteURL, "example.com"),
+			AuthorID:       "https://remote.example/users/alice",
+			AuthorUsername: "alice@remote.example",
+			URLs:           []string{remoteURL},
+		}
+
+		assert.Equal(t, remoteURL, CanonicalActivityPubObjectIDForStatus(status, "example.com"))
+	})
+
+	t.Run("builds local canonical fallback only for local statuses", func(t *testing.T) {
+		status := &Status{
+			StatusID:       "local-1",
+			AuthorID:       "https://example.com/users/alice",
+			AuthorUsername: "alice",
+		}
+
+		assert.Equal(t,
+			"https://example.com/users/alice/statuses/local-1",
+			CanonicalActivityPubObjectIDForStatus(status, "https://example.com"),
+		)
+	})
+
+	t.Run("does not synthesize a local object id for remote statuses", func(t *testing.T) {
+		status := &Status{
+			StatusID:       "remote_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			AuthorID:       "https://remote.example/users/alice",
+			AuthorUsername: "alice@remote.example",
+		}
+
+		assert.Empty(t, CanonicalActivityPubObjectIDForStatus(status, "example.com"))
+	})
+}
+
+func TestStatusInteractionIdentityHelpers(t *testing.T) {
+	t.Run("status appears remote from canonical remote id", func(t *testing.T) {
+		status := &Status{StatusID: "remote_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}
+		assert.True(t, statusAppearsRemote(status, "example.com"))
+	})
+
+	t.Run("status appears remote from acct author", func(t *testing.T) {
+		status := &Status{StatusID: "status-1", AuthorUsername: "alice@remote.example"}
+		assert.True(t, statusAppearsRemote(status, "example.com"))
+	})
+
+	t.Run("status appears remote from actor host", func(t *testing.T) {
+		status := &Status{StatusID: "status-1", AuthorID: "https://remote.example/users/alice"}
+		assert.True(t, statusAppearsRemote(status, "https://example.com"))
+	})
+
+	t.Run("status appears local from actor host", func(t *testing.T) {
+		status := &Status{StatusID: "status-1", AuthorID: "https://example.com/users/alice"}
+		assert.False(t, statusAppearsRemote(status, "https://example.com"))
+	})
+
+	t.Run("local object id derives author from note attribution", func(t *testing.T) {
+		status := &Status{
+			StatusID: "status-1",
+			Note: &activitypub.Note{
+				AttributedTo: "https://example.com/users/alice",
+			},
+		}
+		assert.Equal(t,
+			"https://example.com/users/alice/statuses/status-1",
+			localActivityPubObjectIDForStatus(status, "example.com"),
+		)
+	})
+
+	t.Run("local object id refuses acct-style remote author", func(t *testing.T) {
+		status := &Status{StatusID: "status-1", AuthorUsername: "alice@remote.example"}
+		assert.Empty(t, localActivityPubObjectIDForStatus(status, "example.com"))
+	})
+
+	t.Run("local object id handles missing essentials", func(t *testing.T) {
+		assert.Empty(t, localActivityPubObjectIDForStatus(nil, "example.com"))
+		assert.Empty(t, localActivityPubObjectIDForStatus(&Status{AuthorUsername: "alice"}, "example.com"))
+		assert.Empty(t, localActivityPubObjectIDForStatus(&Status{StatusID: "status-1", AuthorUsername: "alice"}, ""))
+		assert.Empty(t, localActivityPubObjectIDForStatus(&Status{StatusID: "status-1"}, "example.com"))
+	})
+
+	t.Run("username extraction handles urls and raw identifiers", func(t *testing.T) {
+		assert.Empty(t, usernameFromActorIDForStatusIdentity(""))
+		assert.Equal(t, "alice", usernameFromActorIDForStatusIdentity("https://example.com/users/alice"))
+		assert.Equal(t, "urn:actor:alice", usernameFromActorIDForStatusIdentity("urn:actor:alice"))
+	})
+
+	t.Run("http status url detection", func(t *testing.T) {
+		assert.True(t, isHTTPStatusURL("https://example.com/users/alice/statuses/1"))
+		assert.True(t, isHTTPStatusURL("http://example.com/users/alice/statuses/1"))
+		assert.False(t, isHTTPStatusURL("mailto:alice@example.com"))
+		assert.False(t, isHTTPStatusURL("not a url"))
+	})
+
+	t.Run("normalized local domain strips scheme port and path", func(t *testing.T) {
+		assert.Equal(t, "example.com", normalizedLocalDomain("https://Example.com:443/base"))
+		assert.Equal(t, "example.com", normalizedLocalDomain("http://Example.com:80"))
+	})
 }
 
 func TestIsCanonicalRemoteStatusID(t *testing.T) {


### PR DESCRIPTION
## Summary
- split local status-row identity from canonical ActivityPub object identity for status interactions
- queue outbound Like delivery and store Announce objects with the canonical object URL
- explicitly handle Undo Like / Undo Announce with the stored original activity embedded in `Undo.object`
- canonicalize known inbound Like / Announce / Undo objects while leaving unknown remote objects permissive

## Federation / API impact
- Federation trust surface is preserved: signing and verification paths are unchanged; this corrects object identity before activities enter existing delivery/storage paths.
- Mastodon REST/OpenAPI and GraphQL contracts are unchanged.
- DynamoDB PK/SK/GSI shapes and TableTheory tags are unchanged.

## Validation
- `go test ./pkg/storage/models ./pkg/services/notes ./cmd/inbox/internal/routing`
- `go test ./cmd/api/handlers ./pkg/services ./pkg/storage/repositories`
- `go test ./pkg/federation ./cmd/federation-delivery`
- `go build -o lesser ./cmd/lesser && ./lesser build lambdas && ./lesser verify ci`
