### PR TITLE
[codex] fix private canonical object fetch gate

### DIFF
--- a/cmd/objects/main.go
+++ b/cmd/objects/main.go
@@ -113,6 +113,7 @@ type Handler struct {
 	objectRepo             objectGetter
 	authorizedFetchService authorizedFetchVerifier
 	instanceRepo           instanceStateGetter
+	relationshipRepo       relationshipChecker
 }
 
 type objectGetter interface {
@@ -128,6 +129,10 @@ type authorizedFetchVerifier interface {
 
 type instanceStateGetter interface {
 	GetInstanceState(ctx context.Context) (*storageModels.InstanceState, error)
+}
+
+type relationshipChecker interface {
+	IsFollowing(ctx context.Context, followerUsername, targetActorID string) (bool, error)
 }
 
 // NewHandler creates a new objects handler using standardized services
@@ -149,6 +154,7 @@ func NewHandler() *Handler {
 		objectRepo:             objectRepo,
 		authorizedFetchService: authorizedFetchService,
 		instanceRepo:           repos.Instance(),
+		relationshipRepo:       repos.Relationship(),
 	}
 }
 
@@ -192,6 +198,7 @@ func (h *Handler) HandleGetObject(ctx *apptheory.Context) (*apptheory.Response, 
 	wantsHTML := strings.Contains(acceptHeader, "text/html")
 
 	authorizedFetchEnabled := h.authorizedFetchService != nil && h.authorizedFetchService.IsAuthorizedFetchEnabled(runCtx)
+	var verifiedFetchActor *activitypub.Actor
 
 	// Enforce authorized fetch whenever this handler would return ActivityPub JSON.
 	// Do not rely on client-controlled Accept header substring checks as a security gate.
@@ -213,7 +220,7 @@ func (h *Handler) HandleGetObject(ctx *apptheory.Context) (*apptheory.Response, 
 		}
 
 		// Verify authorized fetch
-		_, err = h.authorizedFetchService.VerifyAuthorizedFetch(runCtx, httpReq)
+		verifiedFetchActor, err = h.authorizedFetchService.VerifyAuthorizedFetch(runCtx, httpReq)
 		if err != nil {
 			// Check if signature is missing vs invalid
 			if strings.Contains(err.Error(), "missing signature") {
@@ -265,10 +272,10 @@ func (h *Handler) HandleGetObject(ctx *apptheory.Context) (*apptheory.Response, 
 
 	// Return HTML for browsers
 	if wantsHTML {
-		if authorizedFetchEnabled && !objectsIsPubliclyAddressed(objInterface) {
-			// When Authorized Fetch is enabled, do not expose HTML renderings for non-public objects.
-			// This avoids leaking followers-only (or otherwise restricted) content to unauthenticated browsers.
-			logger.Debug("suppressing HTML response for non-public object while authorized fetch is enabled",
+		if !objectsIsPubliclyAddressed(objInterface) {
+			// Never expose browser HTML renderings for non-public objects.
+			// This avoids leaking followers-only, direct, or otherwise restricted content.
+			logger.Debug("suppressing HTML response for non-public object",
 				zap.String("object_id", objectID),
 				zap.String("request_id", requestID),
 			)
@@ -289,12 +296,87 @@ func (h *Handler) HandleGetObject(ctx *apptheory.Context) (*apptheory.Response, 
 		}, nil
 	}
 
+	if !objectsIsPubliclyAddressed(objInterface) {
+		if verifiedFetchActor == nil {
+			var resp *apptheory.Response
+			var err error
+			verifiedFetchActor, resp, err = h.verifyObjectAuthorizedFetch(runCtx, ctx, objectID, requestID, true)
+			if err != nil {
+				return nil, err
+			}
+			if resp != nil {
+				return resp, nil
+			}
+		}
+
+		allowed, err := h.authorizedActorCanFetchObject(runCtx, objInterface, verifiedFetchActor)
+		if err != nil {
+			logger.Warn("failed to evaluate non-public object fetch authorization",
+				zap.String("object_id", objectID),
+				zap.String("request_id", requestID),
+				zap.Error(err),
+			)
+		}
+		if err != nil || !allowed {
+			logger.Debug("suppressing ActivityPub JSON response for unauthorized non-public object fetch",
+				zap.String("object_id", objectID),
+				zap.String("request_id", requestID),
+			)
+			return objectsJSONError(http.StatusNotFound, fmt.Sprintf("object %s not found", objectID)), nil
+		}
+	}
+
 	// Return ActivityPub JSON (default)
 	logger.Debug("returning ActivityPub JSON representation",
 		zap.String("object_id", objectID),
 		zap.String("request_id", requestID),
 	)
 	return objectsActivityJSON(http.StatusOK, objInterface)
+}
+
+func (h *Handler) verifyObjectAuthorizedFetch(
+	ctx context.Context,
+	reqCtx *apptheory.Context,
+	objectID string,
+	requestID string,
+	hideUnauthorized bool,
+) (*activitypub.Actor, *apptheory.Response, error) {
+	if h.authorizedFetchService == nil {
+		return nil, objectsJSONError(http.StatusNotFound, fmt.Sprintf("object %s not found", objectID)), nil
+	}
+
+	httpReq, err := h.convertAppTheoryRequest(reqCtx)
+	if err != nil {
+		logger.Error("failed to convert request for authorized object fetch",
+			zap.String("object_id", objectID),
+			zap.String("request_id", requestID),
+			zap.Error(err),
+		)
+		if hideUnauthorized {
+			return nil, objectsJSONError(http.StatusNotFound, fmt.Sprintf("object %s not found", objectID)), nil
+		}
+		return nil, objectsJSONError(http.StatusBadRequest, "malformed request"), nil
+	}
+
+	actor, err := h.authorizedFetchService.VerifyAuthorizedFetch(ctx, httpReq)
+	if err == nil {
+		return actor, nil, nil
+	}
+
+	if hideUnauthorized {
+		logger.Debug("authorized object fetch verification failed for non-public object",
+			zap.String("object_id", objectID),
+			zap.String("request_id", requestID),
+			zap.Error(err),
+		)
+		return nil, objectsJSONError(http.StatusNotFound, fmt.Sprintf("object %s not found", objectID)), nil
+	}
+
+	if strings.Contains(err.Error(), "missing signature") {
+		return nil, objectsJSONError(http.StatusUnauthorized, "signature required for authorized fetch"), nil
+	}
+
+	return nil, objectsJSONError(http.StatusForbidden, "signature verification failed"), nil
 }
 
 func (h *Handler) handleTombstonedObject(ctx context.Context, lookupID, objectID, requestID string, wantsHTML bool) (*apptheory.Response, bool, error) {
@@ -975,6 +1057,138 @@ func objectsIsPubliclyAddressed(obj any) bool {
 	return objectsRecipientsContainPublic(addressing.To) || objectsRecipientsContainPublic(addressing.CC)
 }
 
+func (h *Handler) authorizedActorCanFetchObject(ctx context.Context, obj any, actor *activitypub.Actor) (bool, error) {
+	if objectsIsPubliclyAddressed(obj) {
+		return true, nil
+	}
+	if actor == nil {
+		return false, nil
+	}
+
+	actorID := objectsActorID(actor)
+	if actorID == "" {
+		return false, nil
+	}
+
+	objectActorID := objectsAttributedActorID(obj)
+	if objectActorID != "" && objectsActorIdentifiersMatch(actorID, objectActorID) {
+		return true, nil
+	}
+
+	recipients := objectsAllRecipients(obj)
+	if objectsRecipientsContainActor(recipients, actor) {
+		return true, nil
+	}
+
+	if objectActorID == "" || !objectsRecipientsContainFollowersCollection(recipients, objectActorID) {
+		return false, nil
+	}
+	if h.relationshipRepo == nil {
+		return false, nil
+	}
+
+	return h.relationshipRepo.IsFollowing(ctx, actorID, objectActorID)
+}
+
+func objectsActorID(actor *activitypub.Actor) string {
+	if actor == nil {
+		return ""
+	}
+	if actorID := strings.TrimSpace(actor.ID); actorID != "" {
+		return actorID
+	}
+	if actorURL := strings.TrimSpace(actor.URL); actorURL != "" {
+		return actorURL
+	}
+	return strings.TrimSpace(actor.PreferredUsername)
+}
+
+func objectsAttributedActorID(obj any) string {
+	if obj == nil {
+		return ""
+	}
+
+	if note, ok := obj.(*activitypub.Note); ok {
+		return strings.TrimSpace(note.AttributedTo)
+	}
+	if activity, ok := obj.(*activitypub.Activity); ok {
+		return strings.TrimSpace(activity.Actor)
+	}
+	if objMap, ok := obj.(map[string]any); ok {
+		if attributedTo, ok := objMap["attributedTo"].(string); ok && strings.TrimSpace(attributedTo) != "" {
+			return strings.TrimSpace(attributedTo)
+		}
+		if actor, ok := objMap["actor"].(string); ok && strings.TrimSpace(actor) != "" {
+			return strings.TrimSpace(actor)
+		}
+	}
+
+	body, err := json.Marshal(obj)
+	if err != nil {
+		return ""
+	}
+	var actorFields struct {
+		AttributedTo string `json:"attributedTo"`
+		Actor        string `json:"actor"`
+	}
+	if err := json.Unmarshal(body, &actorFields); err != nil {
+		return ""
+	}
+	if strings.TrimSpace(actorFields.AttributedTo) != "" {
+		return strings.TrimSpace(actorFields.AttributedTo)
+	}
+	return strings.TrimSpace(actorFields.Actor)
+}
+
+func objectsAllRecipients(obj any) []string {
+	if obj == nil {
+		return nil
+	}
+
+	if note, ok := obj.(*activitypub.Note); ok {
+		return objectsAppendRecipients(nil, note.To, note.CC, note.BTo, note.BCC)
+	}
+	if activity, ok := obj.(*activitypub.Activity); ok {
+		return objectsAppendRecipients(nil, activity.To, activity.CC, activity.BTo, activity.BCC)
+	}
+	if objMap, ok := obj.(map[string]any); ok {
+		return objectsAppendRecipients(nil,
+			objectsStringSliceFromAny(objMap["to"]),
+			objectsStringSliceFromAny(objMap["cc"]),
+			objectsStringSliceFromAny(objMap["bto"]),
+			objectsStringSliceFromAny(objMap["bcc"]),
+		)
+	}
+
+	body, err := json.Marshal(obj)
+	if err != nil {
+		return nil
+	}
+	var addressing struct {
+		To  []string `json:"to"`
+		CC  []string `json:"cc"`
+		BTo []string `json:"bto"`
+		BCC []string `json:"bcc"`
+	}
+	if err := json.Unmarshal(body, &addressing); err != nil {
+		return nil
+	}
+	return objectsAppendRecipients(nil, addressing.To, addressing.CC, addressing.BTo, addressing.BCC)
+}
+
+func objectsAppendRecipients(base []string, recipientSets ...[]string) []string {
+	for _, recipients := range recipientSets {
+		for _, recipient := range recipients {
+			recipient = strings.TrimSpace(recipient)
+			if recipient == "" {
+				continue
+			}
+			base = append(base, recipient)
+		}
+	}
+	return base
+}
+
 func objectsRecipientsContainPublic(recipients []string) bool {
 	for _, recipient := range recipients {
 		if strings.TrimSpace(recipient) == activitypub.PublicAddress {
@@ -982,6 +1196,56 @@ func objectsRecipientsContainPublic(recipients []string) bool {
 		}
 	}
 	return false
+}
+
+func objectsRecipientsContainActor(recipients []string, actor *activitypub.Actor) bool {
+	actorID := objectsActorID(actor)
+	if actorID == "" {
+		return false
+	}
+	for _, recipient := range recipients {
+		if objectsActorIdentifiersMatch(recipient, actorID) {
+			return true
+		}
+	}
+	return false
+}
+
+func objectsRecipientsContainFollowersCollection(recipients []string, authorActorID string) bool {
+	followersCollection := strings.TrimRight(strings.TrimSpace(authorActorID), "/") + "/followers"
+	if followersCollection == "/followers" {
+		return false
+	}
+	for _, recipient := range recipients {
+		if strings.TrimRight(strings.TrimSpace(recipient), "/") == followersCollection {
+			return true
+		}
+	}
+	return false
+}
+
+func objectsActorIdentifiersMatch(left, right string) bool {
+	left = strings.TrimSpace(left)
+	right = strings.TrimSpace(right)
+	if left == "" || right == "" {
+		return false
+	}
+	if strings.TrimRight(left, "/") == strings.TrimRight(right, "/") {
+		return true
+	}
+
+	leftNormalized := storageModels.NormalizeRelationshipIdentity(left, objectsLocalDomain())
+	rightNormalized := storageModels.NormalizeRelationshipIdentity(right, objectsLocalDomain())
+	return leftNormalized != "" && leftNormalized == rightNormalized
+}
+
+func objectsLocalDomain() string {
+	if cfg != nil {
+		if domain := strings.TrimSpace(cfg.Domain); domain != "" {
+			return domain
+		}
+	}
+	return strings.TrimSpace(config.Get().Domain)
 }
 
 func objectsStringSliceFromAny(value any) []string {

--- a/cmd/objects/round12_objects_test.go
+++ b/cmd/objects/round12_objects_test.go
@@ -62,12 +62,29 @@ func (f *fakeObjectRepo) IsTombstoned(_ context.Context, id string) (bool, error
 type fakeAuthorizedFetch struct {
 	enabled   bool
 	verifyErr error
+	actor     *activitypub.Actor
+	calls     int
 }
 
 func (f *fakeAuthorizedFetch) IsAuthorizedFetchEnabled(context.Context) bool { return f.enabled }
 
 func (f *fakeAuthorizedFetch) VerifyAuthorizedFetch(context.Context, *http.Request) (*activitypub.Actor, error) {
-	return nil, f.verifyErr
+	f.calls++
+	return f.actor, f.verifyErr
+}
+
+type fakeRelationshipChecker struct {
+	following map[string]bool
+	err       error
+	calls     int
+}
+
+func (f *fakeRelationshipChecker) IsFollowing(_ context.Context, followerUsername, targetActorID string) (bool, error) {
+	f.calls++
+	if f.err != nil {
+		return false, f.err
+	}
+	return f.following[followerUsername+"|"+targetActorID], nil
 }
 
 type fakeInstanceRepo struct {
@@ -305,6 +322,7 @@ func TestHandleGetObject_FetchResponses_Round12(t *testing.T) {
 				Sensitive: true,
 				Published: &now,
 				Updated:   &now,
+				To:        []string{activitypub.PublicAddress},
 			},
 			Content:      "Hello <b>world</b>",
 			AttributedTo: "https://example.com/users/alice",
@@ -399,7 +417,7 @@ func TestHandleGetObject_FetchResponses_Round12(t *testing.T) {
 	})
 
 	t.Run("activitypub json response", func(t *testing.T) {
-		objRepo := &fakeObjectRepo{obj: map[string]any{"id": "x", "type": "Note"}}
+		objRepo := &fakeObjectRepo{obj: map[string]any{"id": "x", "type": "Note", "to": []any{activitypub.PublicAddress}}}
 		h := &Handler{
 			instanceRepo:           instanceRepo,
 			objectRepo:             objRepo,
@@ -426,6 +444,7 @@ func TestHandleGetObject_FetchResponses_Round12(t *testing.T) {
 				ID:        "https://example.com/users/alice/statuses/123",
 				Type:      activitypub.NoteType,
 				Published: &now,
+				To:        []string{activitypub.PublicAddress},
 			},
 			Content:      "hello from canonical route",
 			AttributedTo: "https://example.com/users/alice",
@@ -636,6 +655,7 @@ func TestNewHandler_MainAndInit_Round12(t *testing.T) {
 		require.NotNil(t, h.objectRepo)
 		require.NotNil(t, h.authorizedFetchService)
 		require.NotNil(t, h.instanceRepo)
+		require.NotNil(t, h.relationshipRepo)
 	})
 
 	t.Run("initializeObjects + main register routes", func(t *testing.T) {
@@ -653,7 +673,7 @@ func TestNewHandler_MainAndInit_Round12(t *testing.T) {
 		require.NotNil(t, lambdaCtx)
 		require.NotNil(t, repos)
 
-		fakeRepo := &fakeObjectRepo{obj: map[string]any{"id": "x", "type": "Note"}}
+		fakeRepo := &fakeObjectRepo{obj: map[string]any{"id": "x", "type": "Note", "to": []any{activitypub.PublicAddress}}}
 		newHandlerFn = func() *Handler {
 			return &Handler{
 				objectRepo:             fakeRepo,
@@ -698,7 +718,11 @@ func TestNewHandler_MainAndInit_Round12(t *testing.T) {
 	})
 
 	t.Run("build app serves canonical status routes", func(t *testing.T) {
-		fakeRepo := &fakeObjectRepo{obj: map[string]any{"id": "https://example.com/users/alice/statuses/123", "type": "Note"}}
+		fakeRepo := &fakeObjectRepo{obj: map[string]any{
+			"id":   "https://example.com/users/alice/statuses/123",
+			"type": "Note",
+			"to":   []any{activitypub.PublicAddress},
+		}}
 		app := buildApp(&Handler{
 			objectRepo:             fakeRepo,
 			authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
@@ -729,6 +753,323 @@ func TestNewHandler_MainAndInit_Round12(t *testing.T) {
 		require.Equal(t, 200, lambdaResp.StatusCode)
 		require.Equal(t, "https://example.com/users/alice/statuses/123", fakeRepo.gotID)
 		require.Equal(t, "application/activity+json", lambdaResp.Headers["content-type"])
+	})
+}
+
+func TestHandleGetObject_PrivateVisibilityGate_Round29(t *testing.T) {
+	origCfg := cfg
+	origLogger := logger
+	t.Cleanup(func() {
+		cfg = origCfg
+		logger = origLogger
+	})
+
+	cfg = &config.Config{Domain: "example.com"}
+	logger = zap.NewNop()
+
+	instanceRepo := &fakeInstanceRepo{state: &storageModels.InstanceState{Locked: false}}
+	authorID := "https://example.com/users/alice"
+	followersCollection := authorID + "/followers"
+	privateNote := func() *activitypub.Note {
+		return &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:   "https://example.com/users/alice/statuses/private-1",
+				Type: activitypub.NoteType,
+				To:   []string{followersCollection},
+			},
+			Content:      "followers only",
+			AttributedTo: authorID,
+		}
+	}
+	requestCtx := func() *apptheory.Context {
+		return &apptheory.Context{
+			Request: apptheory.Request{
+				Method: http.MethodGet,
+				Path:   "/users/alice/statuses/private-1",
+				Headers: map[string][]string{
+					"accept": {"application/activity+json"},
+					"host":   {"example.com"},
+				},
+			},
+			Params: map[string]string{
+				"username": "alice",
+				"id":       "private-1",
+			},
+		}
+	}
+
+	t.Run("non-public canonical object is hidden from unsigned fetch even when authorized fetch is globally disabled", func(t *testing.T) {
+		authFetch := &fakeAuthorizedFetch{enabled: false, verifyErr: errors.New("missing signature")}
+		h := &Handler{
+			instanceRepo:           instanceRepo,
+			objectRepo:             &fakeObjectRepo{obj: privateNote()},
+			authorizedFetchService: authFetch,
+		}
+
+		resp, err := h.HandleGetObject(requestCtx())
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusNotFound, resp.Status)
+		require.Equal(t, 1, authFetch.calls)
+	})
+
+	t.Run("signed unrelated actor remains hidden from followers-only object", func(t *testing.T) {
+		authFetch := &fakeAuthorizedFetch{
+			enabled: true,
+			actor: &activitypub.Actor{
+				BaseObject:        activitypub.BaseObject{ID: "https://remote.example/users/charlie"},
+				PreferredUsername: "charlie",
+			},
+		}
+		h := &Handler{
+			instanceRepo:           instanceRepo,
+			objectRepo:             &fakeObjectRepo{obj: privateNote()},
+			authorizedFetchService: authFetch,
+			relationshipRepo:       &fakeRelationshipChecker{},
+		}
+
+		resp, err := h.HandleGetObject(requestCtx())
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusNotFound, resp.Status)
+		require.Equal(t, 1, authFetch.calls)
+	})
+
+	t.Run("accepted follower can fetch followers-only object", func(t *testing.T) {
+		actorID := "https://remote.example/users/bob"
+		authFetch := &fakeAuthorizedFetch{
+			enabled: true,
+			actor: &activitypub.Actor{
+				BaseObject:        activitypub.BaseObject{ID: actorID},
+				PreferredUsername: "bob",
+			},
+		}
+		relationships := &fakeRelationshipChecker{
+			following: map[string]bool{actorID + "|" + authorID: true},
+		}
+		h := &Handler{
+			instanceRepo:           instanceRepo,
+			objectRepo:             &fakeObjectRepo{obj: privateNote()},
+			authorizedFetchService: authFetch,
+			relationshipRepo:       relationships,
+		}
+
+		resp, err := h.HandleGetObject(requestCtx())
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusOK, resp.Status)
+		require.Equal(t, []string{"application/activity+json"}, resp.Headers["content-type"])
+		require.Equal(t, 1, relationships.calls)
+	})
+
+	t.Run("explicitly addressed actor can fetch non-public object without follower lookup", func(t *testing.T) {
+		actorID := "https://remote.example/users/bob"
+		note := privateNote()
+		note.To = []string{actorID}
+		relationships := &fakeRelationshipChecker{}
+		h := &Handler{
+			instanceRepo: instanceRepo,
+			objectRepo:   &fakeObjectRepo{obj: note},
+			authorizedFetchService: &fakeAuthorizedFetch{
+				enabled: true,
+				actor: &activitypub.Actor{
+					BaseObject:        activitypub.BaseObject{ID: actorID},
+					PreferredUsername: "bob",
+				},
+			},
+			relationshipRepo: relationships,
+		}
+
+		resp, err := h.HandleGetObject(requestCtx())
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusOK, resp.Status)
+		require.Equal(t, 0, relationships.calls)
+	})
+
+	t.Run("author can fetch own non-public object", func(t *testing.T) {
+		relationships := &fakeRelationshipChecker{}
+		h := &Handler{
+			instanceRepo: instanceRepo,
+			objectRepo:   &fakeObjectRepo{obj: privateNote()},
+			authorizedFetchService: &fakeAuthorizedFetch{
+				enabled: true,
+				actor: &activitypub.Actor{
+					BaseObject:        activitypub.BaseObject{ID: authorID},
+					PreferredUsername: "alice",
+				},
+			},
+			relationshipRepo: relationships,
+		}
+
+		resp, err := h.HandleGetObject(requestCtx())
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusOK, resp.Status)
+		require.Equal(t, 0, relationships.calls)
+	})
+}
+
+func TestObjectAuthorizationHelpers_Round29(t *testing.T) {
+	origCfg := cfg
+	origLogger := logger
+	t.Cleanup(func() {
+		cfg = origCfg
+		logger = origLogger
+	})
+	cfg = &config.Config{Domain: "example.com"}
+	logger = zap.NewNop()
+
+	authorID := "https://example.com/users/alice"
+	bobID := "https://remote.example/users/bob"
+	publicNote := &activitypub.Note{
+		BaseObject:   activitypub.BaseObject{ID: "public", Type: activitypub.NoteType, To: []string{activitypub.PublicAddress}},
+		AttributedTo: authorID,
+	}
+	privateNote := &activitypub.Note{
+		BaseObject:   activitypub.BaseObject{ID: "private", Type: activitypub.NoteType, To: []string{authorID + "/followers"}},
+		AttributedTo: authorID,
+	}
+
+	t.Run("authorized actor helper covers deny and allow branches", func(t *testing.T) {
+		h := &Handler{}
+		allowed, err := h.authorizedActorCanFetchObject(context.Background(), publicNote, nil)
+		require.NoError(t, err)
+		require.True(t, allowed)
+
+		allowed, err = h.authorizedActorCanFetchObject(context.Background(), privateNote, nil)
+		require.NoError(t, err)
+		require.False(t, allowed)
+
+		allowed, err = h.authorizedActorCanFetchObject(context.Background(), privateNote, &activitypub.Actor{})
+		require.NoError(t, err)
+		require.False(t, allowed)
+
+		allowed, err = h.authorizedActorCanFetchObject(context.Background(), privateNote, &activitypub.Actor{
+			BaseObject: activitypub.BaseObject{ID: authorID + "/"},
+		})
+		require.NoError(t, err)
+		require.True(t, allowed)
+
+		allowed, err = h.authorizedActorCanFetchObject(context.Background(), map[string]any{
+			"id":           "direct",
+			"type":         "Note",
+			"attributedTo": authorID,
+			"to":           []any{bobID},
+		}, &activitypub.Actor{BaseObject: activitypub.BaseObject{ID: bobID}})
+		require.NoError(t, err)
+		require.True(t, allowed)
+
+		allowed, err = h.authorizedActorCanFetchObject(context.Background(), privateNote, &activitypub.Actor{
+			BaseObject: activitypub.BaseObject{ID: bobID},
+		})
+		require.NoError(t, err)
+		require.False(t, allowed)
+
+		relErr := errors.New("relationship down")
+		allowed, err = (&Handler{relationshipRepo: &fakeRelationshipChecker{err: relErr}}).
+			authorizedActorCanFetchObject(context.Background(), privateNote, &activitypub.Actor{
+				BaseObject: activitypub.BaseObject{ID: bobID},
+			})
+		require.ErrorIs(t, err, relErr)
+		require.False(t, allowed)
+	})
+
+	t.Run("authorized fetch helper covers response branches", func(t *testing.T) {
+		reqCtx := &apptheory.Context{
+			Request: apptheory.Request{
+				Method:  http.MethodGet,
+				Path:    "/objects/private",
+				Headers: map[string][]string{"host": {"example.com"}},
+			},
+		}
+
+		actor, resp, err := (&Handler{}).verifyObjectAuthorizedFetch(context.Background(), reqCtx, "private", "req", true)
+		require.NoError(t, err)
+		require.Nil(t, actor)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusNotFound, resp.Status)
+
+		actor, resp, err = (&Handler{authorizedFetchService: &fakeAuthorizedFetch{actor: &activitypub.Actor{
+			BaseObject: activitypub.BaseObject{ID: bobID},
+		}}}).verifyObjectAuthorizedFetch(context.Background(), reqCtx, "private", "req", false)
+		require.NoError(t, err)
+		require.NotNil(t, actor)
+		require.Nil(t, resp)
+
+		_, resp, err = (&Handler{authorizedFetchService: &fakeAuthorizedFetch{verifyErr: errors.New("missing signature")}}).
+			verifyObjectAuthorizedFetch(context.Background(), reqCtx, "private", "req", false)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusUnauthorized, resp.Status)
+
+		_, resp, err = (&Handler{authorizedFetchService: &fakeAuthorizedFetch{verifyErr: errors.New("bad signature")}}).
+			verifyObjectAuthorizedFetch(context.Background(), reqCtx, "private", "req", false)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusForbidden, resp.Status)
+
+		badCtx := &apptheory.Context{Request: apptheory.Request{Method: "bad method", Path: "/objects/private"}}
+		_, resp, err = (&Handler{authorizedFetchService: &fakeAuthorizedFetch{}}).
+			verifyObjectAuthorizedFetch(context.Background(), badCtx, "private", "req", false)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.Status)
+
+		_, resp, err = (&Handler{authorizedFetchService: &fakeAuthorizedFetch{}}).
+			verifyObjectAuthorizedFetch(context.Background(), badCtx, "private", "req", true)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNotFound, resp.Status)
+	})
+
+	t.Run("identity and recipient extraction helpers cover object shapes", func(t *testing.T) {
+		require.Empty(t, objectsActorID(nil))
+		require.Equal(t, "https://example.com/users/carol", objectsActorID(&activitypub.Actor{
+			URL: "https://example.com/users/carol",
+		}))
+		require.Equal(t, "dana", objectsActorID(&activitypub.Actor{PreferredUsername: "dana"}))
+
+		require.Empty(t, objectsAttributedActorID(nil))
+		require.Equal(t, authorID, objectsAttributedActorID(privateNote))
+		require.Equal(t, authorID, objectsAttributedActorID(&activitypub.Activity{Actor: authorID}))
+		require.Equal(t, authorID, objectsAttributedActorID(map[string]any{"attributedTo": authorID}))
+		require.Equal(t, bobID, objectsAttributedActorID(map[string]any{"actor": bobID}))
+		require.Equal(t, authorID, objectsAttributedActorID(struct {
+			AttributedTo string `json:"attributedTo"`
+		}{AttributedTo: authorID}))
+		require.Empty(t, objectsAttributedActorID(map[string]any{"bad": make(chan int)}))
+
+		require.Empty(t, objectsAllRecipients(nil))
+		require.Equal(t, []string{authorID + "/followers"}, objectsAllRecipients(privateNote))
+		require.Equal(t, []string{bobID}, objectsAllRecipients(&activitypub.Activity{
+			BaseObject: activitypub.BaseObject{BTo: []string{bobID}},
+		}))
+		require.Equal(t, []string{bobID, authorID}, objectsAllRecipients(map[string]any{
+			"to":  bobID,
+			"bcc": []any{authorID, ""},
+		}))
+		require.Equal(t, []string{bobID}, objectsAllRecipients(struct {
+			CC []string `json:"cc"`
+		}{CC: []string{bobID}}))
+		require.Empty(t, objectsAllRecipients(map[string]any{"bad": make(chan int)}))
+	})
+
+	t.Run("recipient matching helpers cover edge cases", func(t *testing.T) {
+		require.False(t, objectsRecipientsContainActor([]string{bobID}, nil))
+		require.True(t, objectsRecipientsContainActor([]string{"bob@remote.example"}, &activitypub.Actor{
+			BaseObject: activitypub.BaseObject{ID: bobID},
+		}))
+		require.False(t, objectsRecipientsContainFollowersCollection([]string{"/followers"}, ""))
+		require.True(t, objectsRecipientsContainFollowersCollection([]string{authorID + "/followers/"}, authorID))
+		require.False(t, objectsActorIdentifiersMatch("", authorID))
+		require.True(t, objectsActorIdentifiersMatch("https://example.com/users/Alice", "alice"))
+
+		oldCfg := cfg
+		cfg = nil
+		require.NotEmpty(t, objectsLocalDomain())
+		cfg = oldCfg
 	})
 }
 

--- a/pkg/federation/circuit/serverless_breaker_additional_test.go
+++ b/pkg/federation/circuit/serverless_breaker_additional_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -111,7 +112,7 @@ func TestServerlessCircuitBreaker_IsOpen_EvaluatesStates(t *testing.T) {
 		repo := NewMockCircuitBreakerRepository()
 		repo.updateErr = errors.New("update failed")
 
-		cb := NewServerlessCircuitBreaker(repo, models.DefaultCircuitBreakerConfig(), logger)
+		cb := NewServerlessCircuitBreaker(repo, models.DefaultCircuitBreakerConfig(), zap.NewNop())
 		instanceID := "half.timeout.err"
 
 		require.NoError(t, repo.SaveCircuitState(ctx, &models.CircuitBreakerState{
@@ -240,7 +241,7 @@ func TestServerlessCircuitBreaker_RecordSuccess_TransitionsAndAsyncMetrics(t *te
 		repo.recordStateErr = errors.New("state change failed")
 		repo.recordMetricErr = errors.New("metric failed")
 
-		cb := NewServerlessCircuitBreaker(repo, config, logger)
+		cb := NewServerlessCircuitBreaker(repo, config, zap.NewNop())
 		instanceID := "success.half.close"
 
 		require.NoError(t, repo.SaveCircuitState(ctx, &models.CircuitBreakerState{


### PR DESCRIPTION
## Summary
- Gate non-public ActivityPub object JSON fetches by verified actor and object audience.
- Keep public/unlisted canonical objects fetchable, while allowing authors, explicitly addressed actors, and accepted followers for restricted objects.
- Hide non-public browser HTML responses and return 404 for denied non-public JSON fetches to avoid existence leaks.

## Root cause
Arch's v1.2.46 report pointed at the canonical object fetch path. Local investigation confirmed `cmd/objects` verified Authorized Fetch signatures when the global flag was enabled, but discarded the verified actor and returned stored object JSON without an audience check. When global Authorized Fetch was disabled, non-public canonical objects could be fetched anonymously.

## Federation / API impact
- Federation privacy/trust is strengthened on the canonical object surface.
- Existing HTTP Signature verification remains on the same path and is reused for object authorization.
- Mastodon REST/OpenAPI, GraphQL, ActivityPub actor shape, and DynamoDB schema are unchanged.

## Validation
- `go build -o lesser ./cmd/lesser && ./lesser build lambdas && ./lesser verify ci`