### PR TITLE
[codex] fix federation create delivery notifications

### DIFF
--- a/cmd/inbox/internal/routing/inbox.go
+++ b/cmd/inbox/internal/routing/inbox.go
@@ -2541,13 +2541,15 @@ func remoteCreateNotificationCreatedAt(activity *activitypub.Activity, note *act
 }
 
 func deterministicRemoteCreateNotificationID(kind string, parts ...string) string {
-	normalized := make([]string, 0, len(parts)+1)
-	normalized = append(normalized, strings.ToLower(strings.TrimSpace(kind)))
+	normalizedKind := strings.ToLower(strings.TrimSpace(kind))
+	var normalized strings.Builder
+	normalized.WriteString(normalizedKind)
 	for _, part := range parts {
-		normalized = append(normalized, strings.TrimSpace(part))
+		normalized.WriteByte('\x00')
+		normalized.WriteString(strings.TrimSpace(part))
 	}
-	sum := sha256.Sum256([]byte(strings.Join(normalized, "\x00")))
-	return fmt.Sprintf("remote-create-%s-%s", strings.ToLower(strings.TrimSpace(kind)), hex.EncodeToString(sum[:]))
+	sum := sha256.Sum256([]byte(normalized.String()))
+	return fmt.Sprintf("remote-create-%s-%s", normalizedKind, hex.EncodeToString(sum[:]))
 }
 
 func remoteCreatePostSnapshot(note *activitypub.Note, status *models.Status) map[string]interface{} {

--- a/cmd/inbox/internal/routing/inbox.go
+++ b/cmd/inbox/internal/routing/inbox.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	stdErrors "errors"
 	"fmt"
@@ -83,6 +85,7 @@ type InboxHandler struct {
 	instanceRepository           *repositories.InstanceRepository
 	publicKeyCacheRepository     *repositories.PublicKeyCacheRepository
 	notificationRepository       interfaces.NotificationRepository
+	inboxProcessingRepository    inboxProcessingRecorder
 	signatureService             *federation.SignatureService
 	logger                       *zap.Logger
 	authMiddleware               *auth.Middleware
@@ -106,6 +109,11 @@ type inboxRemoteActorResolver interface {
 
 type inboxActivityDeliverer interface {
 	DeliverActivity(ctx context.Context, activity *activitypub.Activity, targetInbox string, signingActor *activitypub.Actor) error
+}
+
+type inboxProcessingRecorder interface {
+	TryRecordTarget(ctx context.Context, activityID, targetActorID, activityType string) (bool, error)
+	ForgetTarget(ctx context.Context, activityID, targetActorID string) error
 }
 
 // extractedServices holds services extracted from lambda context
@@ -153,6 +161,7 @@ type repositoryCollection struct {
 	instanceRepo           *repositories.InstanceRepository
 	publicKeyCacheRepo     *repositories.PublicKeyCacheRepository
 	notificationRepo       interfaces.NotificationRepository
+	inboxProcessingRepo    inboxProcessingRecorder
 }
 
 // extractServicesFromContext extracts services from lambda context
@@ -325,6 +334,7 @@ func initializeRepositories(repoFactory storageCore.RepositoryStorage, coreDB dy
 	// Initialize legacy repositories that don't use factory pattern yet
 	repos.socialRepo = repositories.NewSocialRepository(coreDB, cfg.DynamoTableName, logger, nil)
 	repos.federationActivityRepo = repositories.NewFederationActivityRepository(coreDB, cfg.DynamoTableName, logger, nil)
+	repos.inboxProcessingRepo = repositories.NewInboxProcessingRepository(coreDB, cfg.DynamoTableName, logger, nil)
 	costTrackingBaseRepo := repositories.NewBaseRepository[*models.FederationCostTracking](coreDB, cfg.DynamoTableName, logger)
 	budgetBaseRepo := repositories.NewBaseRepository[*models.FederationBudget](coreDB, cfg.DynamoTableName, logger)
 	repos.federationCostRepo = repositories.NewFederationCostRepositoryFromBase(costTrackingBaseRepo, budgetBaseRepo, nil)
@@ -402,6 +412,7 @@ func NewInboxHandler(lambdaCtx *common.LambdaContext) (*InboxHandler, error) {
 		instanceRepository:           repositories.instanceRepo,
 		publicKeyCacheRepository:     repositories.publicKeyCacheRepo,
 		notificationRepository:       repositories.notificationRepo,
+		inboxProcessingRepository:    repositories.inboxProcessingRepo,
 		signatureService:             federationServices.signatureService,
 		logger:                       logger,
 		authMiddleware:               federationServices.authMiddleware,
@@ -1013,15 +1024,6 @@ func (ih *InboxHandler) verifyDigestEnhanced(ctx *apptheory.Context, req *InboxR
 
 // storeAndProcessActivity stores the activity and processes it based on type
 func (ih *InboxHandler) storeAndProcessActivity(ctx *apptheory.Context, req *InboxRequest) error {
-	// Store the activity
-	if err := ih.activityRepository.CreateActivity(ctx.Context(), req.Activity); err != nil {
-		ih.logger.Error("failed to store activity", zap.Error(err))
-		ih.recordFailureCost(req, fmt.Sprintf("Failed to store activity: %v", err), 3)
-		return errors.InternalWithCause(err, "failed to store activity")
-	}
-
-	req.CostParams.DynamoDBWriteCount = 1 // Activity storage
-
 	targetActors := req.TargetActors
 	if len(targetActors) == 0 && req.Actor != nil {
 		targetActors = []*activitypub.Actor{req.Actor}
@@ -1032,11 +1034,48 @@ func (ih *InboxHandler) storeAndProcessActivity(ctx *apptheory.Context, req *Inb
 	}
 
 	processingStart := time.Now()
+	targetsToProcess := make([]*activitypub.Actor, 0, len(targetActors))
 	for _, targetActor := range targetActors {
 		if targetActor == nil {
 			continue
 		}
+		shouldProcess, err := ih.shouldProcessInboundActivityTarget(ctx.Context(), req.Activity, targetActor)
+		if err != nil {
+			processingDuration := time.Since(processingStart)
+			req.CostParams.ProcessingTimeMs += processingDuration.Milliseconds()
+			ih.recordFailureCost(req, fmt.Sprintf("Failed to claim %s activity for idempotent processing: %v", req.Activity.Type, err), 0)
+			return errors.InternalWithCause(err, fmt.Sprintf("failed to claim %s activity", req.Activity.Type))
+		}
+		if !shouldProcess {
+			continue
+		}
+		targetsToProcess = append(targetsToProcess, targetActor)
+	}
+
+	if len(targetsToProcess) == 0 {
+		processingDuration := time.Since(processingStart)
+		req.CostParams.ProcessingTimeMs += processingDuration.Milliseconds()
+		return nil
+	}
+
+	// Store the activity after target idempotency has confirmed there is at
+	// least one local actor that still needs this activity processed. Duplicate
+	// deliveries that race through shared-inbox and actor-inbox lanes therefore
+	// do not create duplicate activity rows.
+	if err := ih.activityRepository.CreateActivity(ctx.Context(), req.Activity); err != nil {
+		for _, targetActor := range targetsToProcess {
+			ih.releaseInboundActivityTargetClaim(ctx.Context(), req.Activity, targetActor)
+		}
+		ih.logger.Error("failed to store activity", zap.Error(err))
+		ih.recordFailureCost(req, fmt.Sprintf("Failed to store activity: %v", err), 3)
+		return errors.InternalWithCause(err, "failed to store activity")
+	}
+
+	req.CostParams.DynamoDBWriteCount = 1 // Activity storage
+
+	for _, targetActor := range targetsToProcess {
 		if err := ih.processActivityByTypeForTarget(ctx.Context(), req.Activity, targetActor, req.CostParams); err != nil {
+			ih.releaseInboundActivityTargetClaim(ctx.Context(), req.Activity, targetActor)
 			processingDuration := time.Since(processingStart)
 			req.CostParams.ProcessingTimeMs += processingDuration.Milliseconds()
 			ih.recordFailureCost(req, fmt.Sprintf("Failed to process %s activity: %v", req.Activity.Type, err), 0)
@@ -1047,6 +1086,57 @@ func (ih *InboxHandler) storeAndProcessActivity(ctx *apptheory.Context, req *Inb
 	processingDuration := time.Since(processingStart)
 	req.CostParams.ProcessingTimeMs += processingDuration.Milliseconds()
 	return nil
+}
+
+func (ih *InboxHandler) shouldProcessInboundActivityTarget(ctx context.Context, activity *activitypub.Activity, targetActor *activitypub.Actor) (bool, error) {
+	if ih.inboxProcessingRepository == nil || activity == nil || targetActor == nil {
+		return true, nil
+	}
+
+	activityID := strings.TrimSpace(activity.ID)
+	targetActorID := strings.TrimSpace(targetActor.ID)
+	if activityID == "" || targetActorID == "" {
+		return true, nil
+	}
+
+	created, err := ih.inboxProcessingRepository.TryRecordTarget(ctx, activityID, targetActorID, activity.Type)
+	if err != nil {
+		ih.logger.Error("failed to record inbound activity processing receipt",
+			zap.String("activity_id", activityID),
+			zap.String("activity_type", activity.Type),
+			zap.String("target_actor", targetActorID),
+			zap.Error(err))
+		return false, err
+	}
+	if !created {
+		ih.logger.Info("duplicate inbound activity target processing skipped",
+			zap.String("activity_id", activityID),
+			zap.String("activity_type", activity.Type),
+			zap.String("target_actor", targetActorID))
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (ih *InboxHandler) releaseInboundActivityTargetClaim(ctx context.Context, activity *activitypub.Activity, targetActor *activitypub.Actor) {
+	if ih.inboxProcessingRepository == nil || activity == nil || targetActor == nil {
+		return
+	}
+
+	activityID := strings.TrimSpace(activity.ID)
+	targetActorID := strings.TrimSpace(targetActor.ID)
+	if activityID == "" || targetActorID == "" {
+		return
+	}
+
+	if err := ih.inboxProcessingRepository.ForgetTarget(ctx, activityID, targetActorID); err != nil {
+		ih.logger.Warn("failed to release inbound activity processing receipt after processing error",
+			zap.String("activity_id", activityID),
+			zap.String("activity_type", activity.Type),
+			zap.String("target_actor", targetActorID),
+			zap.Error(err))
+	}
 }
 
 func (ih *InboxHandler) processActivityByTypeForTarget(ctx context.Context, activity *activitypub.Activity, targetActor *activitypub.Actor, costParams *federation.CostCalculationParams) error {
@@ -2137,9 +2227,8 @@ func (ih *InboxHandler) buildCanonicalRemoteStatus(note *activitypub.Note) *mode
 	return federation.BuildCanonicalRemoteStatus(note, ih.baseURL)
 }
 
-func (ih *InboxHandler) materializeRemoteNoteStatus(ctx context.Context, note *activitypub.Note) error {
-	_, err := federation.MaterializeRemoteNote(ctx, ih.objectRepository, ih.statusRepository, note, ih.baseURL)
-	return err
+func (ih *InboxHandler) materializeRemoteNoteStatus(ctx context.Context, note *activitypub.Note) (*models.Status, error) {
+	return federation.MaterializeRemoteNote(ctx, ih.objectRepository, ih.statusRepository, note, ih.baseURL)
 }
 
 func (ih *InboxHandler) upsertRemoteNoteStatus(ctx context.Context, note *activitypub.Note) error {
@@ -2155,7 +2244,8 @@ func (ih *InboxHandler) upsertRemoteNoteStatus(ctx context.Context, note *activi
 	existing, err := ih.statusRepository.GetStatus(ctx, status.StatusID)
 	if err != nil {
 		if isRemoteStatusNotFound(err) {
-			return ih.materializeRemoteNoteStatus(ctx, note)
+			_, materializeErr := ih.materializeRemoteNoteStatus(ctx, note)
+			return materializeErr
 		}
 		return err
 	}
@@ -2287,15 +2377,354 @@ func (ih *InboxHandler) processRemoteCreateActivity(ctx context.Context, activit
 			}
 		}
 
-		if err := ih.materializeRemoteNoteStatus(ctx, &note); err != nil {
+		status, err := ih.materializeRemoteNoteStatus(ctx, &note)
+		if err != nil {
 			log.Error("failed to materialize remote note status",
 				zap.String("note_id", note.ID),
 				zap.Error(err))
 			return err
 		}
+		ih.createRemoteCreateNotifications(ctx, activity, targetActor, &note, status)
 	}
 
 	return nil
+}
+
+func (ih *InboxHandler) createRemoteCreateNotifications(
+	ctx context.Context,
+	activity *activitypub.Activity,
+	targetActor *activitypub.Actor,
+	note *activitypub.Note,
+	status *models.Status,
+) {
+	if ih.notificationRepository == nil || activity == nil || targetActor == nil || note == nil || status == nil {
+		return
+	}
+
+	recipient := strings.TrimSpace(targetActor.PreferredUsername)
+	if recipient == "" {
+		recipient = ih.extractUsernameFromActorID(targetActor.ID)
+	}
+	if recipient == "" {
+		return
+	}
+
+	actorID := strings.TrimSpace(activity.Actor)
+	if actorID == "" {
+		actorID = strings.TrimSpace(note.AttributedTo)
+	}
+	if actorID == "" || strings.EqualFold(actorID, strings.TrimSpace(targetActor.ID)) {
+		return
+	}
+
+	if ih.remoteNoteMentionsTargetActor(note, targetActor) {
+		ih.createRemoteCreateNotification(ctx, remoteCreateNotificationInput{
+			kind:        common.NotificationTypeMention,
+			recipient:   recipient,
+			actorID:     actorID,
+			activity:    activity,
+			note:        note,
+			status:      status,
+			title:       fmt.Sprintf("%s mentioned you", ih.remoteNotificationActorLabel(actorID)),
+			body:        fmt.Sprintf("%s mentioned you", ih.remoteNotificationActorLabel(actorID)),
+			groupKey:    fmt.Sprintf("remote-mention:%s:%s", recipient, status.StatusID),
+			extraData:   map[string]interface{}{"mentioner": actorID},
+			stableParts: []string{recipient, actorID, strings.TrimSpace(activity.ID), strings.TrimSpace(note.ID), status.StatusID},
+		})
+	}
+
+	parentStatus, parentID := ih.remoteCreateReplyParent(ctx, note, targetActor)
+	if parentStatus == nil || parentID == "" {
+		return
+	}
+
+	ih.createRemoteCreateNotification(ctx, remoteCreateNotificationInput{
+		kind:      common.NotificationTypeReply,
+		recipient: recipient,
+		actorID:   actorID,
+		activity:  activity,
+		note:      note,
+		status:    status,
+		title:     fmt.Sprintf("%s replied to your post", ih.remoteNotificationActorLabel(actorID)),
+		body:      fmt.Sprintf("%s replied to your post", ih.remoteNotificationActorLabel(actorID)),
+		groupKey:  fmt.Sprintf("remote-reply:%s:%s:%s", recipient, parentID, status.StatusID),
+		extraData: map[string]interface{}{
+			"parent_status_id": parentID,
+			"replier":          actorID,
+		},
+		stableParts: []string{recipient, actorID, strings.TrimSpace(activity.ID), strings.TrimSpace(note.ID), status.StatusID, parentID},
+	})
+}
+
+type remoteCreateNotificationInput struct {
+	kind        string
+	recipient   string
+	actorID     string
+	activity    *activitypub.Activity
+	note        *activitypub.Note
+	status      *models.Status
+	title       string
+	body        string
+	groupKey    string
+	extraData   map[string]interface{}
+	stableParts []string
+}
+
+func (ih *InboxHandler) createRemoteCreateNotification(ctx context.Context, input remoteCreateNotificationInput) {
+	if input.status == nil || input.note == nil || input.activity == nil {
+		return
+	}
+
+	createdAt := remoteCreateNotificationCreatedAt(input.activity, input.note, input.status)
+	notification := models.NewNotificationBuilder().
+		ForUser(input.recipient).
+		OfType(input.kind).
+		FromActor(input.actorID, "remote_actor").
+		AboutTarget(input.status.StatusID, "status").
+		WithContent(input.title, input.body).
+		WithGroupKey(input.groupKey).
+		Build()
+	notification.ID = deterministicRemoteCreateNotificationID(input.kind, input.stableParts...)
+	notification.CreatedAt = createdAt
+	notification.UpdatedAt = createdAt
+
+	if notification.Data == nil {
+		notification.Data = make(map[string]interface{})
+	}
+	for key, value := range input.extraData {
+		notification.Data[key] = value
+	}
+	notification.Data["activity_id"] = strings.TrimSpace(input.activity.ID)
+	notification.Data["remote_actor_id"] = input.actorID
+	notification.Data["remote_note_id"] = strings.TrimSpace(input.note.ID)
+	notification.Data["status_id"] = input.status.StatusID
+	notification.Data["status_url"] = strings.TrimSpace(input.note.ID)
+	notification.Data["postSnapshot"] = remoteCreatePostSnapshot(input.note, input.status)
+
+	if err := ih.notificationRepository.CreateNotification(ctx, notification); err != nil {
+		if isRemoteCreateNotificationDuplicate(err) {
+			ih.logger.Debug("remote create notification already exists",
+				zap.String("notification_id", notification.ID),
+				zap.String("notification_type", input.kind),
+				zap.String("recipient", input.recipient))
+			return
+		}
+		ih.logger.Warn("failed to create remote create notification",
+			zap.String("notification_id", notification.ID),
+			zap.String("notification_type", input.kind),
+			zap.String("recipient", input.recipient),
+			zap.String("activity_id", input.activity.ID),
+			zap.Error(err))
+		return
+	}
+
+	ih.logger.Info("created remote create notification",
+		zap.String("notification_id", notification.ID),
+		zap.String("notification_type", input.kind),
+		zap.String("recipient", input.recipient),
+		zap.String("activity_id", input.activity.ID))
+}
+
+func remoteCreateNotificationCreatedAt(activity *activitypub.Activity, note *activitypub.Note, status *models.Status) time.Time {
+	switch {
+	case note != nil && note.Published != nil && !note.Published.IsZero():
+		return note.Published.UTC()
+	case activity != nil && activity.Published != nil && !activity.Published.IsZero():
+		return activity.Published.UTC()
+	case status != nil && !status.PublishedAt.IsZero():
+		return status.PublishedAt.UTC()
+	case status != nil && !status.CreatedAt.IsZero():
+		return status.CreatedAt.UTC()
+	default:
+		return time.Now().UTC()
+	}
+}
+
+func deterministicRemoteCreateNotificationID(kind string, parts ...string) string {
+	normalized := make([]string, 0, len(parts)+1)
+	normalized = append(normalized, strings.ToLower(strings.TrimSpace(kind)))
+	for _, part := range parts {
+		normalized = append(normalized, strings.TrimSpace(part))
+	}
+	sum := sha256.Sum256([]byte(strings.Join(normalized, "\x00")))
+	return fmt.Sprintf("remote-create-%s-%s", strings.ToLower(strings.TrimSpace(kind)), hex.EncodeToString(sum[:]))
+}
+
+func remoteCreatePostSnapshot(note *activitypub.Note, status *models.Status) map[string]interface{} {
+	snapshot := map[string]interface{}{}
+	if note != nil {
+		snapshot["id"] = strings.TrimSpace(note.ID)
+		snapshot["content"] = note.Content
+		snapshot["attributedTo"] = strings.TrimSpace(note.AttributedTo)
+		snapshot["url"] = strings.TrimSpace(note.ID)
+		if note.InReplyTo != "" {
+			snapshot["inReplyToId"] = strings.TrimSpace(note.InReplyTo)
+		}
+		if note.Visibility != "" {
+			snapshot["visibility"] = strings.TrimSpace(note.Visibility)
+		}
+		if note.Published != nil && !note.Published.IsZero() {
+			snapshot["createdAt"] = note.Published.UTC().Format(time.RFC3339)
+		}
+	}
+	if status != nil {
+		snapshot["statusId"] = status.StatusID
+		if snapshot["visibility"] == nil && status.Visibility != "" {
+			snapshot["visibility"] = status.Visibility
+		}
+		if snapshot["createdAt"] == nil && !status.PublishedAt.IsZero() {
+			snapshot["createdAt"] = status.PublishedAt.UTC().Format(time.RFC3339)
+		}
+	}
+	return snapshot
+}
+
+func (ih *InboxHandler) remoteNoteMentionsTargetActor(note *activitypub.Note, targetActor *activitypub.Actor) bool {
+	if note == nil || targetActor == nil {
+		return false
+	}
+
+	targetIDs := ih.localTargetActorIDs(targetActor)
+	targetUsername := strings.ToLower(strings.TrimSpace(targetActor.PreferredUsername))
+	targetDomain := ih.localDomain()
+
+	for _, tag := range note.Tag {
+		if !strings.EqualFold(strings.TrimSpace(tag.Type), "Mention") {
+			continue
+		}
+
+		href := strings.TrimSpace(tag.Href)
+		if href != "" {
+			if _, ok := targetIDs[strings.ToLower(strings.TrimRight(href, "/"))]; ok {
+				return true
+			}
+			if username, domain := actorURLUsernameDomain(href); username != "" &&
+				strings.EqualFold(username, targetUsername) &&
+				(targetDomain == "" || strings.EqualFold(domain, targetDomain)) {
+				return true
+			}
+		}
+
+		name := strings.TrimSpace(tag.Name)
+		if name == "" || targetUsername == "" {
+			continue
+		}
+		name = strings.TrimPrefix(name, "@")
+		parts := strings.Split(name, "@")
+		if len(parts) == 1 && strings.EqualFold(parts[0], targetUsername) {
+			return true
+		}
+		if len(parts) >= 2 && strings.EqualFold(parts[0], targetUsername) &&
+			(targetDomain == "" || strings.EqualFold(parts[len(parts)-1], targetDomain)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (ih *InboxHandler) localTargetActorIDs(targetActor *activitypub.Actor) map[string]struct{} {
+	targets := make(map[string]struct{}, 2)
+	add := func(value string) {
+		value = strings.ToLower(strings.TrimRight(strings.TrimSpace(value), "/"))
+		if value != "" {
+			targets[value] = struct{}{}
+		}
+	}
+	if targetActor != nil {
+		add(targetActor.ID)
+		if username := strings.TrimSpace(targetActor.PreferredUsername); username != "" {
+			add(strings.TrimRight(ih.baseURL, "/") + "/users/" + username)
+		}
+	}
+	return targets
+}
+
+func (ih *InboxHandler) remoteCreateReplyParent(ctx context.Context, note *activitypub.Note, targetActor *activitypub.Actor) (*models.Status, string) {
+	if ih.statusRepository == nil || note == nil || strings.TrimSpace(note.InReplyTo) == "" || targetActor == nil {
+		return nil, ""
+	}
+
+	for _, candidate := range models.StatusLookupCandidatesForDomain(note.InReplyTo, ih.localDomain()) {
+		parent, err := ih.statusRepository.GetStatus(ctx, candidate)
+		if err != nil {
+			if !isRemoteStatusNotFound(err) {
+				ih.logger.Debug("failed to resolve remote create reply parent for notification",
+					zap.String("in_reply_to", note.InReplyTo),
+					zap.String("candidate", candidate),
+					zap.Error(err))
+			}
+			continue
+		}
+		if ih.replyParentBelongsToTarget(parent, targetActor) {
+			return parent, parent.StatusID
+		}
+	}
+
+	return nil, ""
+}
+
+func (ih *InboxHandler) replyParentBelongsToTarget(parent *models.Status, targetActor *activitypub.Actor) bool {
+	if parent == nil || targetActor == nil {
+		return false
+	}
+
+	targetID := strings.TrimRight(strings.TrimSpace(targetActor.ID), "/")
+	targetUsername := strings.TrimSpace(targetActor.PreferredUsername)
+	if targetID != "" && strings.EqualFold(strings.TrimRight(strings.TrimSpace(parent.AuthorID), "/"), targetID) {
+		return true
+	}
+	if parent.Note != nil && targetID != "" && strings.EqualFold(strings.TrimRight(strings.TrimSpace(parent.Note.AttributedTo), "/"), targetID) {
+		return true
+	}
+	if targetUsername != "" && strings.EqualFold(strings.TrimSpace(parent.AuthorUsername), targetUsername) {
+		return true
+	}
+	return false
+}
+
+func (ih *InboxHandler) remoteNotificationActorLabel(actorID string) string {
+	if handle := ih.extractHandleFromActorID(actorID); handle != "" {
+		return handle
+	}
+	if username := ih.extractUsernameFromActorID(actorID); username != "" {
+		return username
+	}
+	return strings.TrimSpace(actorID)
+}
+
+func (ih *InboxHandler) localDomain() string {
+	if cfg := ih.getConfig(); cfg != nil && strings.TrimSpace(cfg.Domain) != "" {
+		return strings.TrimSpace(cfg.Domain)
+	}
+	if parsed, err := url.Parse(strings.TrimSpace(ih.baseURL)); err == nil && parsed != nil {
+		return parsed.Hostname()
+	}
+	return ""
+}
+
+func actorURLUsernameDomain(raw string) (string, string) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed == nil || parsed.Hostname() == "" {
+		return "", ""
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) == 0 {
+		return "", parsed.Hostname()
+	}
+	username := strings.TrimPrefix(parts[len(parts)-1], "@")
+	return username, parsed.Hostname()
+}
+
+func isRemoteCreateNotificationDuplicate(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.HasCode(err, errors.CodeAlreadyExists) ||
+		errors.HasCode(err, errors.CodeConflict) ||
+		stdErrors.Is(err, storage.ErrAlreadyExists) ||
+		dynamormerrors.IsConditionFailed(err) ||
+		strings.Contains(strings.ToLower(err.Error()), "already exists")
 }
 
 // processRemoteUpdateActivity processes an incoming Update activity from a remote instance

--- a/cmd/inbox/internal/routing/project20_create_idempotency_notifications_test.go
+++ b/cmd/inbox/internal/routing/project20_create_idempotency_notifications_test.go
@@ -1,0 +1,531 @@
+package routing
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/storage/interfaces"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/equaltoai/lesser/pkg/testing/inmemory"
+	"github.com/stretchr/testify/require"
+	dynamormerrors "github.com/theory-cloud/tabletheory/pkg/errors"
+)
+
+type recordingInboxProcessingRecorder struct {
+	seen     map[string]string
+	released []string
+}
+
+func newRecordingInboxProcessingRecorder() *recordingInboxProcessingRecorder {
+	return &recordingInboxProcessingRecorder{seen: make(map[string]string)}
+}
+
+func (r *recordingInboxProcessingRecorder) TryRecordTarget(_ context.Context, activityID, targetActorID, activityType string) (bool, error) {
+	key := activityID + "\x00" + targetActorID
+	if _, exists := r.seen[key]; exists {
+		return false, nil
+	}
+	r.seen[key] = activityType
+	return true, nil
+}
+
+func (r *recordingInboxProcessingRecorder) ForgetTarget(_ context.Context, activityID, targetActorID string) error {
+	r.released = append(r.released, activityID+"\x00"+targetActorID)
+	return nil
+}
+
+func TestInboxHandler_Project20_TargetReceiptIdempotencyIncludesCreateAndUndoInteractions(t *testing.T) {
+	env := newInboxTestEnv(t)
+	recorder := newRecordingInboxProcessingRecorder()
+	env.handler.inboxProcessingRepository = recorder
+
+	activities := []*activitypub.Activity{
+		{
+			BaseObject: activitypub.BaseObject{ID: "https://remote.example/activities/create-1", Type: activitypub.CreateType},
+			Actor:      env.remoteActorID,
+			Object:     "https://remote.example/objects/note-1",
+		},
+		{
+			BaseObject: activitypub.BaseObject{ID: "https://remote.example/activities/undo-like-1", Type: activitypub.UndoType},
+			Actor:      env.remoteActorID,
+			Object: map[string]any{
+				"id":     "https://remote.example/activities/like-1",
+				"type":   activitypub.LikeType,
+				"actor":  env.remoteActorID,
+				"object": env.cfg.BaseURL() + "/objects/1",
+			},
+		},
+		{
+			BaseObject: activitypub.BaseObject{ID: "https://remote.example/activities/undo-announce-1", Type: activitypub.UndoType},
+			Actor:      env.remoteActorID,
+			Object: map[string]any{
+				"id":     "https://remote.example/activities/announce-1",
+				"type":   activitypub.AnnounceType,
+				"actor":  env.remoteActorID,
+				"object": env.cfg.BaseURL() + "/objects/1",
+			},
+		},
+	}
+
+	for _, activity := range activities {
+		first, err := env.handler.shouldProcessInboundActivityTarget(context.Background(), activity, env.local)
+		require.NoError(t, err)
+		require.True(t, first, activity.ID)
+
+		second, err := env.handler.shouldProcessInboundActivityTarget(context.Background(), activity, env.local)
+		require.NoError(t, err)
+		require.False(t, second, activity.ID)
+	}
+
+	require.Equal(t, activitypub.CreateType, recorder.seen["https://remote.example/activities/create-1\x00"+env.local.ID])
+	require.Equal(t, activitypub.UndoType, recorder.seen["https://remote.example/activities/undo-like-1\x00"+env.local.ID])
+	require.Equal(t, activitypub.UndoType, recorder.seen["https://remote.example/activities/undo-announce-1\x00"+env.local.ID])
+}
+
+func TestInboxHandler_Project20_RemoteCreateMentionNotificationIsDeterministic(t *testing.T) {
+	env := newInboxTestEnv(t)
+	notifications := inmemory.NewNotificationRepository()
+	env.handler.notificationRepository = notifications
+	env.handler.statusRepository = newProject20StatusRepo()
+
+	published := time.Date(2026, 4, 24, 15, 30, 0, 0, time.UTC)
+	note := &activitypub.Note{
+		BaseObject: activitypub.BaseObject{
+			Context:   activitypub.Context,
+			ID:        "https://remote.example/users/bob/statuses/mention-1",
+			Type:      activitypub.NoteType,
+			Published: &published,
+			To:        []string{env.local.ID},
+			CC:        []string{activitypub.PublicAddress},
+		},
+		AttributedTo: env.remoteActorID,
+		Content:      "<p>hello @alice</p>",
+		Tag: []activitypub.Tag{{
+			Type: "Mention",
+			Href: env.local.ID,
+			Name: "@alice@localhost",
+		}},
+	}
+	activity := remoteCreateActivityForNote(t, env.remoteActorID, note, "https://remote.example/activities/create-mention-1")
+
+	require.NoError(t, env.handler.processRemoteCreateActivity(context.Background(), activity, env.local))
+	require.NoError(t, env.handler.processRemoteCreateActivity(context.Background(), activity, env.local))
+
+	result, err := notifications.GetUserNotifications(context.Background(), "alice", interfaces.PaginationOptions{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, result.Items, 1)
+	require.Equal(t, common.NotificationTypeMention, result.Items[0].Type)
+	require.Equal(t, env.remoteActorID, result.Items[0].ActorID)
+	require.Equal(t, "remote_actor", result.Items[0].ActorType)
+	require.Equal(t, "status", result.Items[0].TargetType)
+	require.NotEmpty(t, result.Items[0].TargetID)
+	require.Contains(t, result.Items[0].Data, "postSnapshot")
+}
+
+func TestInboxHandler_Project20_RemoteCreateReplyNotificationTargetsLocalParentAuthor(t *testing.T) {
+	env := newInboxTestEnv(t)
+	notifications := inmemory.NewNotificationRepository()
+	parentURL := env.cfg.BaseURL() + "/users/alice/statuses/parent-1"
+	env.handler.notificationRepository = notifications
+	env.handler.statusRepository = newProject20StatusRepo(&models.Status{
+		StatusID:       "parent-1",
+		AuthorID:       env.local.ID,
+		AuthorUsername: "alice",
+	})
+
+	published := time.Date(2026, 4, 24, 15, 45, 0, 0, time.UTC)
+	note := &activitypub.Note{
+		BaseObject: activitypub.BaseObject{
+			Context:   activitypub.Context,
+			ID:        "https://remote.example/users/bob/statuses/reply-1",
+			Type:      activitypub.NoteType,
+			Published: &published,
+			InReplyTo: parentURL,
+			To:        []string{env.local.ID},
+		},
+		AttributedTo: env.remoteActorID,
+		Content:      "<p>replying from remote</p>",
+	}
+	activity := remoteCreateActivityForNote(t, env.remoteActorID, note, "https://remote.example/activities/create-reply-1")
+
+	require.NoError(t, env.handler.processRemoteCreateActivity(context.Background(), activity, env.local))
+
+	result, err := notifications.GetUserNotifications(context.Background(), "alice", interfaces.PaginationOptions{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, result.Items, 1)
+	require.Equal(t, common.NotificationTypeReply, result.Items[0].Type)
+	require.Equal(t, "parent-1", result.Items[0].Data["parent_status_id"])
+	require.Contains(t, result.Items[0].Data, "postSnapshot")
+}
+
+type project20StatusRepo struct {
+	interfaces.StatusRepository
+	statuses map[string]*models.Status
+}
+
+func newProject20StatusRepo(statuses ...*models.Status) *project20StatusRepo {
+	repo := &project20StatusRepo{statuses: make(map[string]*models.Status)}
+	for _, status := range statuses {
+		if status != nil {
+			repo.statuses[status.StatusID] = status
+		}
+	}
+	return repo
+}
+
+func (r *project20StatusRepo) CreateStatus(_ context.Context, status *models.Status) error {
+	if status == nil {
+		return fmt.Errorf("status is required")
+	}
+	if err := status.BeforeCreate(); err != nil {
+		return err
+	}
+	r.statuses[status.StatusID] = status
+	return nil
+}
+
+func (r *project20StatusRepo) GetStatus(_ context.Context, statusID string) (*models.Status, error) {
+	if status, ok := r.statuses[statusID]; ok {
+		return status, nil
+	}
+	return nil, storage.ErrNotFound
+}
+
+func remoteCreateActivityForNote(t *testing.T, actorID string, note *activitypub.Note, activityID string) *activitypub.Activity {
+	t.Helper()
+
+	body, err := json.Marshal(note)
+	require.NoError(t, err)
+
+	var object map[string]any
+	require.NoError(t, json.Unmarshal(body, &object))
+
+	return &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			ID:   activityID,
+			Type: activitypub.CreateType,
+			To:   note.To,
+			CC:   note.CC,
+		},
+		Actor:  actorID,
+		Object: object,
+	}
+}
+
+func TestInboxHandler_Project20_RemoteNotificationHelperBranches(t *testing.T) {
+	env := newInboxTestEnv(t)
+	oldDomain := env.cfg.Domain
+	oldBaseURL := env.handler.baseURL
+	defer func() {
+		env.cfg.Domain = oldDomain
+		env.handler.baseURL = oldBaseURL
+	}()
+	published := time.Date(2026, 4, 24, 16, 30, 0, 0, time.UTC)
+	activityPublished := published.Add(time.Minute)
+	created := published.Add(2 * time.Minute)
+	note := &activitypub.Note{
+		BaseObject: activitypub.BaseObject{
+			ID:        "https://remote.example/users/bob/statuses/helper-1",
+			Type:      activitypub.NoteType,
+			Published: &published,
+			InReplyTo: env.cfg.BaseURL() + "/users/alice/statuses/parent-1",
+		},
+		AttributedTo: env.remoteActorID,
+		Content:      "<p>helper</p>",
+		Visibility:   models.VisibilityPublic,
+	}
+	status := &models.Status{
+		StatusID:    "remote-helper-1",
+		Visibility:  models.VisibilityPublic,
+		PublishedAt: published.Add(3 * time.Minute),
+		CreatedAt:   created,
+	}
+
+	require.Equal(t, published, remoteCreateNotificationCreatedAt(&activitypub.Activity{}, note, status))
+	require.Equal(t, activityPublished, remoteCreateNotificationCreatedAt(&activitypub.Activity{
+		BaseObject: activitypub.BaseObject{Published: &activityPublished},
+	}, &activitypub.Note{}, status))
+	require.Equal(t, status.PublishedAt, remoteCreateNotificationCreatedAt(&activitypub.Activity{}, &activitypub.Note{}, status))
+	statusWithoutPublished := &models.Status{CreatedAt: created}
+	require.Equal(t, created, remoteCreateNotificationCreatedAt(&activitypub.Activity{}, &activitypub.Note{}, statusWithoutPublished))
+	require.False(t, remoteCreateNotificationCreatedAt(nil, nil, nil).IsZero())
+
+	firstID := deterministicRemoteCreateNotificationID(common.NotificationTypeMention, "alice", env.remoteActorID, note.ID)
+	secondID := deterministicRemoteCreateNotificationID(common.NotificationTypeMention, "alice", env.remoteActorID, note.ID)
+	require.Equal(t, firstID, secondID)
+	require.NotEqual(t, firstID, deterministicRemoteCreateNotificationID(common.NotificationTypeReply, "alice", env.remoteActorID, note.ID))
+
+	snapshot := remoteCreatePostSnapshot(note, status)
+	require.Equal(t, note.ID, snapshot["id"])
+	require.Equal(t, note.Content, snapshot["content"])
+	require.Equal(t, note.AttributedTo, snapshot["attributedTo"])
+	require.Equal(t, note.InReplyTo, snapshot["inReplyToId"])
+	require.Equal(t, models.VisibilityPublic, snapshot["visibility"])
+	require.Equal(t, status.StatusID, snapshot["statusId"])
+	require.NotEmpty(t, snapshot["createdAt"])
+	require.Empty(t, remoteCreatePostSnapshot(nil, nil))
+
+	require.True(t, env.handler.remoteNoteMentionsTargetActor(&activitypub.Note{Tag: []activitypub.Tag{{
+		Type: "Mention",
+		Href: env.local.ID,
+	}}}, env.local))
+	require.True(t, env.handler.remoteNoteMentionsTargetActor(&activitypub.Note{Tag: []activitypub.Tag{{
+		Type: "Mention",
+		Href: env.cfg.BaseURL() + "/users/alice",
+	}}}, env.local))
+	require.True(t, env.handler.remoteNoteMentionsTargetActor(&activitypub.Note{Tag: []activitypub.Tag{{
+		Type: "Mention",
+		Name: "@alice@localhost",
+	}}}, env.local))
+	require.True(t, env.handler.remoteNoteMentionsTargetActor(&activitypub.Note{Tag: []activitypub.Tag{{
+		Type: "Mention",
+		Name: "@alice",
+	}}}, env.local))
+	require.False(t, env.handler.remoteNoteMentionsTargetActor(nil, env.local))
+	require.False(t, env.handler.remoteNoteMentionsTargetActor(&activitypub.Note{}, nil))
+	require.False(t, env.handler.remoteNoteMentionsTargetActor(&activitypub.Note{Tag: []activitypub.Tag{{
+		Type: "Hashtag",
+		Name: "#alice",
+	}}}, env.local))
+
+	targetIDs := env.handler.localTargetActorIDs(env.local)
+	_, hasPrimary := targetIDs[env.local.ID]
+	require.True(t, hasPrimary)
+	require.Empty(t, env.handler.localTargetActorIDs(nil))
+
+	parent := &models.Status{StatusID: "parent-1", AuthorID: env.local.ID}
+	require.True(t, env.handler.replyParentBelongsToTarget(parent, env.local))
+	parent = &models.Status{StatusID: "parent-1", Note: &activitypub.Note{AttributedTo: env.local.ID}}
+	require.True(t, env.handler.replyParentBelongsToTarget(parent, env.local))
+	parent = &models.Status{StatusID: "parent-1", AuthorUsername: "alice"}
+	require.True(t, env.handler.replyParentBelongsToTarget(parent, env.local))
+	require.False(t, env.handler.replyParentBelongsToTarget(nil, env.local))
+	require.False(t, env.handler.replyParentBelongsToTarget(parent, nil))
+	require.False(t, env.handler.replyParentBelongsToTarget(&models.Status{AuthorUsername: "mallory"}, env.local))
+
+	env.cfg.Domain = ""
+	env.handler.baseURL = "https://fallback.example"
+	require.Equal(t, "fallback.example", env.handler.localDomain())
+
+	username, domain := actorURLUsernameDomain("https://remote.example/users/@bob")
+	require.Equal(t, "bob", username)
+	require.Equal(t, "remote.example", domain)
+	username, domain = actorURLUsernameDomain("not a url")
+	require.Empty(t, username)
+	require.Empty(t, domain)
+
+	require.True(t, isRemoteCreateNotificationDuplicate(storage.ErrAlreadyExists))
+	require.True(t, isRemoteCreateNotificationDuplicate(dynamormerrors.ErrConditionFailed))
+	require.False(t, isRemoteCreateNotificationDuplicate(nil))
+}
+
+func TestInboxHandler_Project20_IdempotencyHelperFallbackBranches(t *testing.T) {
+	env := newInboxTestEnv(t)
+	env.handler.inboxProcessingRepository = nil
+	shouldProcess, err := env.handler.shouldProcessInboundActivityTarget(context.Background(), nil, nil)
+	require.NoError(t, err)
+	require.True(t, shouldProcess)
+
+	shouldProcess, err = env.handler.shouldProcessInboundActivityTarget(context.Background(), &activitypub.Activity{}, env.local)
+	require.NoError(t, err)
+	require.True(t, shouldProcess)
+
+	env.handler.releaseInboundActivityTargetClaim(context.Background(), nil, nil)
+}
+
+func TestInboxHandler_Project20_RemoteCreateNotificationCreateAndReleaseBranches(t *testing.T) {
+	env := newInboxTestEnv(t)
+	notifications := inmemory.NewNotificationRepository()
+	env.handler.notificationRepository = notifications
+
+	published := time.Date(2026, 4, 24, 17, 0, 0, 0, time.UTC)
+	activity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			ID:        "https://remote.example/activities/create-direct-1",
+			Type:      activitypub.CreateType,
+			Published: &published,
+		},
+		Actor: env.remoteActorID,
+	}
+	note := &activitypub.Note{
+		BaseObject: activitypub.BaseObject{
+			ID:        "https://remote.example/users/bob/statuses/direct-1",
+			Type:      activitypub.NoteType,
+			Published: &published,
+		},
+		AttributedTo: env.remoteActorID,
+		Content:      "<p>direct helper</p>",
+	}
+	status := &models.Status{
+		StatusID:    "remote-direct-1",
+		PublishedAt: published,
+		CreatedAt:   published,
+	}
+
+	input := remoteCreateNotificationInput{
+		kind:      common.NotificationTypeMention,
+		recipient: "alice",
+		actorID:   env.remoteActorID,
+		activity:  activity,
+		note:      note,
+		status:    status,
+		title:     "bob mentioned you",
+		body:      "bob mentioned you",
+		groupKey:  "remote-mention:alice:remote-direct-1",
+		extraData: map[string]interface{}{
+			"extra": "value",
+		},
+		stableParts: []string{"alice", env.remoteActorID, activity.ID, note.ID, status.StatusID},
+	}
+
+	env.handler.createRemoteCreateNotification(context.Background(), input)
+	env.handler.createRemoteCreateNotification(context.Background(), input)
+
+	result, err := notifications.GetUserNotifications(context.Background(), "alice", interfaces.PaginationOptions{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, result.Items, 1)
+	require.Equal(t, "value", result.Items[0].Data["extra"])
+	require.Equal(t, activity.ID, result.Items[0].Data["activity_id"])
+
+	failingNotifications := &project20FailingNotificationRepo{err: fmt.Errorf("write failed")}
+	env.handler.notificationRepository = failingNotifications
+	env.handler.createRemoteCreateNotification(context.Background(), input)
+	require.Len(t, failingNotifications.created, 1)
+
+	recorder := newRecordingInboxProcessingRecorder()
+	env.handler.inboxProcessingRepository = recorder
+	claimed, err := env.handler.shouldProcessInboundActivityTarget(context.Background(), activity, env.local)
+	require.NoError(t, err)
+	require.True(t, claimed)
+	env.handler.releaseInboundActivityTargetClaim(context.Background(), activity, env.local)
+	require.Equal(t, []string{activity.ID + "\x00" + env.local.ID}, recorder.released)
+}
+
+func TestInboxHandler_Project20_RemoteCreateNotificationGuardBranches(t *testing.T) {
+	env := newInboxTestEnv(t)
+	env.handler.notificationRepository = inmemory.NewNotificationRepository()
+	status := &models.Status{StatusID: "remote-guard-1", CreatedAt: time.Date(2026, 4, 24, 17, 15, 0, 0, time.UTC)}
+	note := &activitypub.Note{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://remote.example/users/bob/statuses/guard-1",
+			Type: activitypub.NoteType,
+		},
+		AttributedTo: env.remoteActorID,
+		Content:      "<p>guard</p>",
+	}
+	activity := remoteCreateActivityForNote(t, env.remoteActorID, note, "https://remote.example/activities/create-guard-1")
+
+	env.handler.createRemoteCreateNotifications(context.Background(), nil, env.local, note, status)
+	env.handler.createRemoteCreateNotifications(context.Background(), activity, nil, note, status)
+	env.handler.createRemoteCreateNotifications(context.Background(), activity, env.local, nil, status)
+	env.handler.createRemoteCreateNotifications(context.Background(), activity, env.local, note, nil)
+
+	namelessTarget := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{ID: "not-an-actor-url", Type: activitypub.PersonType},
+	}
+	env.handler.createRemoteCreateNotifications(context.Background(), activity, namelessTarget, note, status)
+
+	selfActivity := remoteCreateActivityForNote(t, env.local.ID, note, "https://remote.example/activities/create-self-guard-1")
+	env.handler.createRemoteCreateNotifications(context.Background(), selfActivity, env.local, note, status)
+
+	result, err := env.handler.notificationRepository.GetUserNotifications(
+		context.Background(),
+		"alice",
+		interfaces.PaginationOptions{Limit: 10},
+	)
+	require.NoError(t, err)
+	require.Empty(t, result.Items)
+}
+
+func TestInboxHandler_Project20_RemoteReplyParentFailureBranches(t *testing.T) {
+	env := newInboxTestEnv(t)
+	note := &activitypub.Note{
+		BaseObject: activitypub.BaseObject{
+			ID:        "https://remote.example/users/bob/statuses/reply-missing-1",
+			Type:      activitypub.NoteType,
+			InReplyTo: env.cfg.BaseURL() + "/users/alice/statuses/missing-parent",
+		},
+		AttributedTo: env.remoteActorID,
+	}
+
+	env.handler.statusRepository = nil
+	parent, parentID := env.handler.remoteCreateReplyParent(context.Background(), note, env.local)
+	require.Nil(t, parent)
+	require.Empty(t, parentID)
+
+	env.handler.statusRepository = &project20ErroringStatusRepo{err: fmt.Errorf("backend unavailable")}
+	parent, parentID = env.handler.remoteCreateReplyParent(context.Background(), note, env.local)
+	require.Nil(t, parent)
+	require.Empty(t, parentID)
+
+	env.handler.statusRepository = newProject20StatusRepo(&models.Status{
+		StatusID:       "missing-parent",
+		AuthorID:       "https://other.localhost/users/mallory",
+		AuthorUsername: "mallory",
+	})
+	parent, parentID = env.handler.remoteCreateReplyParent(context.Background(), note, env.local)
+	require.Nil(t, parent)
+	require.Empty(t, parentID)
+}
+
+func TestInboxHandler_Project20_IdempotencyRepositoryErrorBranches(t *testing.T) {
+	env := newInboxTestEnv(t)
+	recorder := &project20ErroringInboxProcessingRecorder{err: fmt.Errorf("receipt unavailable")}
+	env.handler.inboxProcessingRepository = recorder
+
+	activity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://remote.example/activities/create-error-branch-1",
+			Type: activitypub.CreateType,
+		},
+		Actor:  env.remoteActorID,
+		Object: "https://remote.example/objects/error-branch-1",
+	}
+
+	shouldProcess, err := env.handler.shouldProcessInboundActivityTarget(context.Background(), activity, env.local)
+	require.Error(t, err)
+	require.False(t, shouldProcess)
+
+	env.handler.releaseInboundActivityTargetClaim(context.Background(), activity, env.local)
+	require.Equal(t, 1, recorder.forgetCalls)
+}
+
+type project20FailingNotificationRepo struct {
+	interfaces.NotificationRepository
+	err     error
+	created []*models.Notification
+}
+
+func (r *project20FailingNotificationRepo) CreateNotification(_ context.Context, notification *models.Notification) error {
+	r.created = append(r.created, notification)
+	return r.err
+}
+
+type project20ErroringStatusRepo struct {
+	interfaces.StatusRepository
+	err error
+}
+
+func (r *project20ErroringStatusRepo) GetStatus(_ context.Context, _ string) (*models.Status, error) {
+	return nil, r.err
+}
+
+type project20ErroringInboxProcessingRecorder struct {
+	err         error
+	forgetCalls int
+}
+
+func (r *project20ErroringInboxProcessingRecorder) TryRecordTarget(_ context.Context, _, _, _ string) (bool, error) {
+	return false, r.err
+}
+
+func (r *project20ErroringInboxProcessingRecorder) ForgetTarget(_ context.Context, _, _ string) error {
+	r.forgetCalls++
+	return r.err
+}

--- a/pkg/federation/delivery.go
+++ b/pkg/federation/delivery.go
@@ -611,21 +611,12 @@ func (d *DeliveryService) deliverResolvedRecipientTargets(ctx context.Context, a
 	return nil
 }
 
-// DeliverToFollowers delivers an activity to all followers of an actor
-func (d *DeliveryService) DeliverToFollowers(ctx context.Context, activity *activitypub.Activity, actor *activitypub.Actor) error {
-	log := common.WithContext(ctx).With(
-		zap.String("activity_id", activity.ID),
-		zap.String("actor", actor.ID),
-	)
-
-	log.Info("delivering activity to followers")
-
-	targets, err := d.resolveFollowerTargets(ctx, actor, log)
-	if err != nil {
-		return err
+func (d *DeliveryService) deliverResolvedFollowerTargets(ctx context.Context, activity *activitypub.Activity, actor *activitypub.Actor, targets map[string]*activitypub.Actor, log *zap.Logger) error {
+	if len(targets) == 0 {
+		return nil
 	}
 
-	// Deliver to each unique inbox
+	// Deliver to each unique inbox.
 	var deliveryErrors []error
 	inboxMap := make(map[string][]string)
 	for actorID, follower := range targets {
@@ -640,28 +631,103 @@ func (d *DeliveryService) DeliverToFollowers(ctx context.Context, activity *acti
 	}
 
 	for inbox, followerIDs := range inboxMap {
-		log.Info("delivering to inbox",
-			zap.String("inbox", inbox),
-			zap.Int("follower_count", len(followerIDs)))
+		if log != nil {
+			log.Info("delivering to inbox",
+				zap.String("inbox", inbox),
+				zap.Int("follower_count", len(followerIDs)))
+		}
 
-		// For shared inboxes, use the first follower as the target actor ID for privacy checks
+		// For shared inboxes, use the first follower as the target actor ID for privacy checks.
 		targetActorID := followerIDs[0]
 		if err := d.DeliverActivityWithPrivacy(ctx, activity, inbox, actor, targetActorID); err != nil {
-			log.Error("failed to deliver to inbox",
-				zap.String("inbox", inbox),
-				zap.Error(err))
+			if log != nil {
+				log.Error("failed to deliver to inbox",
+					zap.String("inbox", inbox),
+					zap.Error(err))
+			}
 			deliveryErrors = append(deliveryErrors, err)
-			// Continue delivering to other inboxes
+			// Continue delivering to other inboxes.
 		}
 	}
 
 	if err := common.ValidateSliceNotEmpty("delivery_errors", deliveryErrors); err == nil {
-		log.Error("failed to deliver to multiple inboxes",
-			zap.Int("failed_inbox_count", len(deliveryErrors)))
+		if log != nil {
+			log.Error("failed to deliver to multiple inboxes",
+				zap.Int("failed_inbox_count", len(deliveryErrors)))
+		}
 		return ErrDeliveryToInboxesFailed
 	}
 
 	return nil
+}
+
+// DeliverToFollowers delivers an activity to all followers of an actor
+func (d *DeliveryService) DeliverToFollowers(ctx context.Context, activity *activitypub.Activity, actor *activitypub.Actor) error {
+	log := common.WithContext(ctx).With(
+		zap.String("activity_id", activity.ID),
+		zap.String("actor", actor.ID),
+	)
+
+	log.Info("delivering activity to followers")
+
+	targets, err := d.resolveFollowerTargets(ctx, actor, log)
+	if err != nil {
+		return err
+	}
+
+	return d.deliverResolvedFollowerTargets(ctx, activity, actor, targets, log)
+}
+
+// DeliverToFollowersAndRecipients delivers public/unlisted activities to
+// followers and explicit recipients while suppressing duplicate deliveries to
+// actors that appear in both target sets.
+func (d *DeliveryService) DeliverToFollowersAndRecipients(ctx context.Context, activity *activitypub.Activity, actor *activitypub.Actor) error {
+	log := common.WithContext(ctx).With(
+		zap.String("activity_id", activity.ID),
+		zap.String("actor", actor.ID),
+	)
+
+	log.Info("delivering activity to followers and explicit recipients")
+
+	followerTargets, err := d.resolveFollowerTargets(ctx, actor, log)
+	if err != nil {
+		log.Error("failed to resolve followers for activity delivery",
+			zap.String("activity_id", activity.ID),
+			zap.String("activity_type", activity.Type),
+			zap.Error(err))
+		followerTargets = map[string]*activitypub.Actor{}
+	}
+
+	if err == nil {
+		if err := d.deliverResolvedFollowerTargets(ctx, activity, actor, followerTargets, log); err != nil {
+			log.Error("failed to deliver activity to followers",
+				zap.String("activity_id", activity.ID),
+				zap.String("activity_type", activity.Type),
+				zap.Error(err))
+		}
+	}
+
+	recipientTargets, err := d.resolveRecipientTargets(ctx, activity, actor, log)
+	if err != nil {
+		return err
+	}
+
+	duplicateRecipientCount := 0
+	for actorID := range followerTargets {
+		if _, exists := recipientTargets[actorID]; exists {
+			delete(recipientTargets, actorID)
+			duplicateRecipientCount++
+		}
+	}
+	if duplicateRecipientCount > 0 {
+		log.Info("suppressed duplicate explicit deliveries already covered by follower fanout",
+			zap.Int("duplicate_recipient_count", duplicateRecipientCount))
+	}
+
+	log.Info("delivering to remaining explicit recipients with privacy controls",
+		zap.Int("resolved_recipients", len(recipientTargets)))
+
+	return d.deliverResolvedRecipientTargets(ctx, activity, actor, recipientTargets, log)
 }
 
 // DeliverToRecipients delivers an activity to specific recipients (to, cc, bto, bcc)

--- a/pkg/federation/project20_delivery_dedupe_test.go
+++ b/pkg/federation/project20_delivery_dedupe_test.go
@@ -1,0 +1,160 @@
+package federation
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	appConfig "github.com/equaltoai/lesser/pkg/config"
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestDeliveryService_Project20_DeliverToFollowersAndRecipientsSuppressesFollowerDuplicate(t *testing.T) {
+	privateKey := mustTestRSAPrivateKeyPEM(t)
+	remoteActor := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://remote.example/users/bob",
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: "bob",
+		Inbox:             "https://remote.example/users/bob/inbox",
+		Endpoints:         &activitypub.Endpoints{SharedInbox: "https://remote.example/inbox"},
+	}
+	store := &federationStoreStub{
+		getActorPrivateKeyFn: func(_ context.Context, _ string) (string, error) { return privateKey, nil },
+		getFollowersFn: func(_ context.Context, _ string, _ int, _ string) ([]string, string, error) {
+			return []string{"bob@remote.example"}, "", nil
+		},
+		getCachedActorFn: func(_ context.Context, key string) (*activitypub.Actor, error) {
+			switch key {
+			case "bob@remote.example", remoteActor.ID:
+				return remoteActor, nil
+			default:
+				return nil, storage.ErrNotFound
+			}
+		},
+		recordActivityFn: func(_ context.Context, _ *storage.FederationActivity) error { return nil },
+	}
+	httpDoer := &httpDoerStub{
+		doFn: func(_ *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusAccepted,
+				Body:       io.NopCloser(&emptyReader{}),
+				Header:     make(http.Header),
+			}, nil
+		},
+	}
+	actor := testSigningActor()
+	actor.Followers = actor.ID + "/followers"
+	d := &DeliveryService{
+		store:      store,
+		httpClient: httpDoer,
+		logger:     zap.NewNop(),
+		cfg:        &appConfig.Config{Domain: "example.com"},
+	}
+
+	err := d.DeliverToFollowersAndRecipients(context.Background(), &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://example.com/activities/create-1",
+			Type: activitypub.CreateType,
+			To:   []string{activitypub.PublicAddress},
+			CC:   []string{actor.Followers, remoteActor.ID},
+		},
+		Actor:  actor.ID,
+		Object: "https://example.com/objects/note-1",
+	}, actor)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		httpDoer.mu.Lock()
+		defer httpDoer.mu.Unlock()
+		return len(httpDoer.requests) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	httpDoer.mu.Lock()
+	defer httpDoer.mu.Unlock()
+	require.Equal(t, "https://remote.example/inbox", httpDoer.requests[0].URL.String())
+}
+
+func TestDeliveryService_Project20_FollowerResolutionFailureStillDeliversExplicitRecipients(t *testing.T) {
+	privateKey := mustTestRSAPrivateKeyPEM(t)
+	remoteActor := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://remote.example/users/bob",
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: "bob",
+		Inbox:             "https://remote.example/users/bob/inbox",
+		Endpoints:         &activitypub.Endpoints{SharedInbox: "https://remote.example/inbox"},
+	}
+	store := &federationStoreStub{
+		getActorPrivateKeyFn: func(_ context.Context, _ string) (string, error) { return privateKey, nil },
+		getFollowersFn: func(_ context.Context, _ string, _ int, _ string) ([]string, string, error) {
+			return nil, "", errors.New("followers unavailable")
+		},
+		getCachedActorFn: func(_ context.Context, key string) (*activitypub.Actor, error) {
+			if key == remoteActor.ID {
+				return remoteActor, nil
+			}
+			return nil, storage.ErrNotFound
+		},
+		recordActivityFn: func(_ context.Context, _ *storage.FederationActivity) error { return nil },
+	}
+	httpDoer := &httpDoerStub{
+		doFn: func(_ *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusAccepted,
+				Body:       io.NopCloser(&emptyReader{}),
+				Header:     make(http.Header),
+			}, nil
+		},
+	}
+	actor := testSigningActor()
+	actor.Followers = actor.ID + "/followers"
+	d := &DeliveryService{
+		store:      store,
+		httpClient: httpDoer,
+		logger:     zap.NewNop(),
+		cfg:        &appConfig.Config{Domain: "example.com"},
+	}
+
+	err := d.DeliverToFollowersAndRecipients(context.Background(), &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://example.com/activities/create-2",
+			Type: activitypub.CreateType,
+			To:   []string{activitypub.PublicAddress},
+			CC:   []string{actor.Followers, remoteActor.ID},
+		},
+		Actor:  actor.ID,
+		Object: "https://example.com/objects/note-2",
+	}, actor)
+	require.NoError(t, err)
+
+	httpDoer.mu.Lock()
+	defer httpDoer.mu.Unlock()
+	require.Len(t, httpDoer.requests, 1)
+	require.Equal(t, "https://remote.example/users/bob/inbox", httpDoer.requests[0].URL.String())
+}
+
+func TestDeliveryService_Project20_EmptyFollowerTargetsNoop(t *testing.T) {
+	d := &DeliveryService{logger: zap.NewNop()}
+	require.NoError(t, d.deliverResolvedFollowerTargets(
+		context.Background(),
+		&activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "act-empty", Type: activitypub.CreateType}},
+		testSigningActor(),
+		nil,
+		zap.NewNop(),
+	))
+}
+
+type emptyReader struct{}
+
+func (r *emptyReader) Read(_ []byte) (int, error) {
+	return 0, io.EOF
+}

--- a/pkg/services/registry.go
+++ b/pkg/services/registry.go
@@ -2498,6 +2498,10 @@ type queueFederationAdapter struct {
 	logger     *zap.Logger
 }
 
+type followerRecipientFederationService interface {
+	DeliverToFollowersAndRecipients(ctx context.Context, activity *activitypub.Activity, actor *activitypub.Actor) error
+}
+
 // severanceFederationAdapter adapts FederationService to severance.FederationService
 type severanceFederationAdapter struct {
 	federation FederationService
@@ -2626,6 +2630,17 @@ func (a *queueFederationAdapter) QueueActivity(ctx context.Context, activity *ac
 	}
 
 	if a.isPublicOrUnlisted(activity) {
+		if combined, ok := a.federation.(followerRecipientFederationService); ok {
+			if err := combined.DeliverToFollowersAndRecipients(ctx, activity, actor); err != nil {
+				a.logger.Error("failed to deliver activity to followers and explicit recipients",
+					zap.String("activity_id", activity.ID),
+					zap.String("activity_type", activity.Type),
+					zap.Error(err))
+				return err
+			}
+			return nil
+		}
+
 		if err := a.federation.DeliverToFollowers(ctx, activity, actor); err != nil {
 			a.logger.Error("failed to deliver activity to followers",
 				zap.String("activity_id", activity.ID),

--- a/pkg/storage/models/inbox_processing_receipt.go
+++ b/pkg/storage/models/inbox_processing_receipt.go
@@ -1,0 +1,115 @@
+package models
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	inboxProcessingReceiptPKPrefix = "INBOX_ACTIVITY#"
+	inboxProcessingReceiptSKPrefix = "TARGET#"
+	inboxProcessingReceiptTTL      = 30 * 24 * time.Hour
+)
+
+// InboxProcessingReceipt records that one ActivityPub activity has been routed
+// to one local target actor. It is a short-lived idempotency guard for inbox
+// side effects when the same remote Create/Like/Announce/Undo reaches both a
+// shared inbox and an actor inbox.
+type InboxProcessingReceipt struct {
+	_ struct{} `theorydb:"naming:camelCase"`
+
+	PK string `theorydb:"pk,attr:PK" json:"-"`
+	SK string `theorydb:"sk,attr:SK" json:"-"`
+
+	ActivityID    string    `theorydb:"attr:activityID" json:"activity_id"`
+	TargetActorID string    `theorydb:"attr:targetActorID" json:"target_actor_id"`
+	ActivityType  string    `theorydb:"attr:activityType" json:"activity_type,omitempty"`
+	CreatedAt     time.Time `theorydb:"attr:createdAt" json:"created_at"`
+	TTL           int64     `theorydb:"ttl,attr:ttl" json:"-"`
+	Version       int       `theorydb:"version,attr:version" json:"version"`
+}
+
+// TableName returns the DynamoDB table backing InboxProcessingReceipt.
+func (InboxProcessingReceipt) TableName() string {
+	return MainTableName
+}
+
+// NewInboxProcessingReceipt builds a target-scoped inbox idempotency receipt.
+func NewInboxProcessingReceipt(activityID, targetActorID, activityType string, now time.Time) *InboxProcessingReceipt {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	now = now.UTC()
+
+	return &InboxProcessingReceipt{
+		ActivityID:    strings.TrimSpace(activityID),
+		TargetActorID: strings.TrimSpace(targetActorID),
+		ActivityType:  strings.TrimSpace(activityType),
+		CreatedAt:     now,
+		TTL:           now.Add(inboxProcessingReceiptTTL).Unix(),
+	}
+}
+
+// BeforeCreate derives keys and TTL before persistence.
+func (r *InboxProcessingReceipt) BeforeCreate() error {
+	return r.UpdateKeys()
+}
+
+// BeforeUpdate derives keys before persistence.
+func (r *InboxProcessingReceipt) BeforeUpdate() error {
+	return r.UpdateKeys()
+}
+
+// GetPK returns the partition key.
+func (r *InboxProcessingReceipt) GetPK() string {
+	if r == nil {
+		return ""
+	}
+	return r.PK
+}
+
+// GetSK returns the sort key.
+func (r *InboxProcessingReceipt) GetSK() string {
+	if r == nil {
+		return ""
+	}
+	return r.SK
+}
+
+// UpdateKeys derives the receipt's storage keys.
+func (r *InboxProcessingReceipt) UpdateKeys() error {
+	if r == nil {
+		return fmt.Errorf("nil inbox processing receipt")
+	}
+
+	r.ActivityID = strings.TrimSpace(r.ActivityID)
+	r.TargetActorID = strings.TrimSpace(r.TargetActorID)
+	r.ActivityType = strings.TrimSpace(r.ActivityType)
+	if r.ActivityID == "" {
+		return fmt.Errorf("activity id is required")
+	}
+	if r.TargetActorID == "" {
+		return fmt.Errorf("target actor id is required")
+	}
+
+	if r.CreatedAt.IsZero() {
+		r.CreatedAt = time.Now().UTC()
+	} else {
+		r.CreatedAt = r.CreatedAt.UTC()
+	}
+	if r.TTL == 0 {
+		r.TTL = r.CreatedAt.Add(inboxProcessingReceiptTTL).Unix()
+	}
+
+	r.PK = inboxProcessingReceiptPKPrefix + inboxProcessingReceiptHash(r.ActivityID)
+	r.SK = inboxProcessingReceiptSKPrefix + inboxProcessingReceiptHash(r.TargetActorID)
+	return nil
+}
+
+func inboxProcessingReceiptHash(value string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(value)))
+	return hex.EncodeToString(sum[:])
+}

--- a/pkg/storage/models/inbox_processing_receipt_test.go
+++ b/pkg/storage/models/inbox_processing_receipt_test.go
@@ -1,0 +1,58 @@
+package models
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInboxProcessingReceipt_UpdateKeys(t *testing.T) {
+	now := time.Date(2026, 4, 24, 16, 0, 0, 0, time.UTC)
+	receipt := NewInboxProcessingReceipt(
+		"https://remote.example/activities/create-1",
+		"https://example.com/users/alice",
+		"Create",
+		now,
+	)
+
+	require.NoError(t, receipt.UpdateKeys())
+	require.True(t, strings.HasPrefix(receipt.PK, "INBOX_ACTIVITY#"))
+	require.True(t, strings.HasPrefix(receipt.SK, "TARGET#"))
+	require.NotContains(t, receipt.PK, "https://")
+	require.NotContains(t, receipt.SK, "https://")
+	require.Equal(t, "https://remote.example/activities/create-1", receipt.ActivityID)
+	require.Equal(t, "https://example.com/users/alice", receipt.TargetActorID)
+	require.Equal(t, "Create", receipt.ActivityType)
+	require.Equal(t, now.Add(30*24*time.Hour).Unix(), receipt.TTL)
+}
+
+func TestInboxProcessingReceipt_UpdateKeysRequiresActivityAndTarget(t *testing.T) {
+	require.Error(t, (&InboxProcessingReceipt{TargetActorID: "https://example.com/users/alice"}).UpdateKeys())
+	require.Error(t, (&InboxProcessingReceipt{ActivityID: "https://remote.example/activities/create-1"}).UpdateKeys())
+}
+
+func TestInboxProcessingReceipt_BeforeHooksAndNilKeyAccessors(t *testing.T) {
+	var nilReceipt *InboxProcessingReceipt
+	require.Empty(t, nilReceipt.GetPK())
+	require.Empty(t, nilReceipt.GetSK())
+
+	receipt := &InboxProcessingReceipt{
+		ActivityID:    "https://remote.example/activities/create-2",
+		TargetActorID: "https://example.com/users/alice",
+		ActivityType:  "Undo",
+	}
+	require.NoError(t, receipt.BeforeCreate())
+	require.NotZero(t, receipt.CreatedAt)
+	require.NotZero(t, receipt.TTL)
+	require.NotEmpty(t, receipt.GetPK())
+	require.NotEmpty(t, receipt.GetSK())
+
+	receipt.PK = ""
+	receipt.SK = ""
+	require.NoError(t, receipt.BeforeUpdate())
+	require.NotEmpty(t, receipt.GetPK())
+	require.NotEmpty(t, receipt.GetSK())
+	require.Equal(t, MainTableName, receipt.TableName())
+}

--- a/pkg/storage/repositories/inbox_processing_repository.go
+++ b/pkg/storage/repositories/inbox_processing_repository.go
@@ -1,0 +1,73 @@
+package repositories
+
+import (
+	"context"
+	stdErrors "errors"
+	"strings"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/cost"
+	apperrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	dynamormerrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	"go.uber.org/zap"
+)
+
+// InboxProcessingRepository records target-scoped inbox idempotency receipts.
+type InboxProcessingRepository struct {
+	*BaseRepository[*models.InboxProcessingReceipt]
+}
+
+// NewInboxProcessingRepository creates a repository for inbox processing receipts.
+func NewInboxProcessingRepository(
+	db core.DB,
+	tableName string,
+	logger *zap.Logger,
+	costService *cost.TrackingService,
+) *InboxProcessingRepository {
+	return &InboxProcessingRepository{
+		BaseRepository: NewBaseRepositoryWithCostTracking[*models.InboxProcessingReceipt](
+			db,
+			tableName,
+			logger,
+			costService,
+			"InboxProcessingRepository",
+		),
+	}
+}
+
+// TryRecordTarget records an activity/target pair. It returns false when the
+// pair has already been claimed and therefore should not be processed again.
+func (r *InboxProcessingRepository) TryRecordTarget(ctx context.Context, activityID, targetActorID, activityType string) (bool, error) {
+	receipt := models.NewInboxProcessingReceipt(activityID, targetActorID, activityType, time.Now().UTC())
+	if err := r.CreateIfNotExists(ctx, receipt); err != nil {
+		if isInboxProcessingAlreadyRecorded(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// ForgetTarget removes a previously claimed activity/target pair so a retry can
+// attempt the side effect again after a processing failure.
+func (r *InboxProcessingRepository) ForgetTarget(ctx context.Context, activityID, targetActorID string) error {
+	receipt := models.NewInboxProcessingReceipt(activityID, targetActorID, "", time.Now().UTC())
+	if err := receipt.UpdateKeys(); err != nil {
+		return err
+	}
+	return r.Delete(ctx, receipt.GetPK(), receipt.GetSK())
+}
+
+func isInboxProcessingAlreadyRecorded(err error) bool {
+	if err == nil {
+		return false
+	}
+	return apperrors.HasCode(err, apperrors.CodeAlreadyExists) ||
+		apperrors.HasCode(err, apperrors.CodeConflict) ||
+		stdErrors.Is(err, storage.ErrAlreadyExists) ||
+		dynamormerrors.IsConditionFailed(err) ||
+		strings.Contains(strings.ToLower(err.Error()), "already exists")
+}

--- a/pkg/storage/repositories/inbox_processing_repository_test.go
+++ b/pkg/storage/repositories/inbox_processing_repository_test.go
@@ -1,0 +1,51 @@
+package repositories
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	dynamormerrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	"github.com/theory-cloud/tabletheory/pkg/mocks"
+	"go.uber.org/zap"
+)
+
+func TestInboxProcessingRepository_TryRecordTargetAndForget(t *testing.T) {
+	ctx := context.Background()
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+	repo := NewInboxProcessingRepository(mockDB, "tbl", zap.NewNop(), nil)
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB)
+	mockDB.On("Model", mock.Anything).Return(mockQuery)
+
+	mockQuery.On("IfNotExists").Return(mockQuery).Once()
+	mockQuery.On("Create").Return(nil).Once()
+	created, err := repo.TryRecordTarget(ctx, "https://remote.example/activities/create-1", "https://example.com/users/alice", "Create")
+	require.NoError(t, err)
+	require.True(t, created)
+
+	mockQuery.On("IfNotExists").Return(mockQuery).Once()
+	mockQuery.On("Create").Return(dynamormerrors.ErrConditionFailed).Once()
+	created, err = repo.TryRecordTarget(ctx, "https://remote.example/activities/create-1", "https://example.com/users/alice", "Create")
+	require.NoError(t, err)
+	require.False(t, created)
+
+	mockQuery.On("Where", "PK", "=", mock.MatchedBy(func(value string) bool {
+		return strings.HasPrefix(value, "INBOX_ACTIVITY#")
+	})).Return(mockQuery).Once()
+	mockQuery.On("Where", "SK", "=", mock.MatchedBy(func(value string) bool {
+		return strings.HasPrefix(value, "TARGET#")
+	})).Return(mockQuery).Once()
+	mockQuery.On("Delete").Return(nil).Once()
+	require.NoError(t, repo.ForgetTarget(ctx, "https://remote.example/activities/create-1", "https://example.com/users/alice"))
+}
+
+func TestInboxProcessingRepository_TryRecordTargetValidationError(t *testing.T) {
+	repo := NewInboxProcessingRepository(new(mocks.MockDB), "tbl", zap.NewNop(), nil)
+	created, err := repo.TryRecordTarget(context.Background(), "", "https://example.com/users/alice", "Create")
+	require.Error(t, err)
+	require.False(t, created)
+}


### PR DESCRIPTION
## Summary
- Adds target-scoped inbox processing receipts so duplicate ActivityPub deliveries to shared inbox + actor inbox skip repeated local side effects.
- Dedupe public/unlisted follower fanout against explicit recipients before outbound delivery.
- Creates deterministic remote Create mention/reply notifications for local actors, including Undo Like / Undo Announce in the target idempotency path.

## Stewardship notes
- Federation trust: no HTTP Signature signing/verification or actor object shape changes.
- Schema: additive single-table receipt item only; no GSI or existing PK/SK changes.
- API contract: notification behavior is additive; no OpenAPI/GraphQL contract changes.

## Validation
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`