### PR TITLE
fix(federation): expose combined delivery adapter

### DIFF
--- a/pkg/services/core_services_round27_coverage_test.go
+++ b/pkg/services/core_services_round27_coverage_test.go
@@ -727,6 +727,22 @@ func TestFederationService_round27_coverage(t *testing.T) {
 		require.ErrorIs(t, err, ErrUnsupportedDatabaseType)
 	})
 
+	t.Run("DeliverToFollowersAndRecipients_no_db", func(t *testing.T) {
+		err := svc.DeliverToFollowersAndRecipients(ctx, &activitypub.Activity{}, actor)
+		require.ErrorIs(t, err, ErrNoDatabaseAvailable)
+	})
+
+	t.Run("DeliverToFollowersAndRecipients_unsupported_db", func(t *testing.T) {
+		withDB := &federationService{
+			deps:    svc.deps,
+			storage: &repositoryStorageAdapter{repos: fakeStorageAdapterRepos{rawDB: struct{}{}, table: "tbl", logger: zap.NewNop()}},
+			logger:  zap.NewNop(),
+		}
+
+		err := withDB.DeliverToFollowersAndRecipients(ctx, &activitypub.Activity{}, actor)
+		require.ErrorIs(t, err, ErrUnsupportedDatabaseType)
+	})
+
 	t.Run("DetermineRecipients_missing_actor_returns_error", func(t *testing.T) {
 		_, err := svc.DetermineRecipients(ctx, &activitypub.Activity{}, "public")
 		require.ErrorIs(t, err, ErrActivityMissingActor)

--- a/pkg/services/federation.go
+++ b/pkg/services/federation.go
@@ -28,8 +28,7 @@ func NewFederationService(deps *ServiceDependencies) FederationService {
 	}
 }
 
-// DeliverToFollowers delivers an activity to all followers of the actor
-func (f *federationService) DeliverToFollowers(ctx context.Context, activity *activitypub.Activity, actor *activitypub.Actor) error {
+func (f *federationService) newDeliveryService() (*federation.DeliveryService, error) {
 	// Use storage directly if it implements FederationStorage
 	var federationStorage federation.FederationStorage
 
@@ -40,37 +39,43 @@ func (f *federationService) DeliverToFollowers(ctx context.Context, activity *ac
 			federationStorage = federation.NewDynamORMFederationStorage(coreDB, f.storage.GetTableName(), f.deps.Config.Config.Domain, f.deps.Logger.(*zap.Logger))
 		} else {
 			// Fall back to a basic implementation or return error
-			return ErrUnsupportedDatabaseType
+			return nil, ErrUnsupportedDatabaseType
 		}
 	} else {
-		return ErrNoDatabaseAvailable
+		return nil, ErrNoDatabaseAvailable
 	}
 
 	deliveryService := federation.NewDeliveryService(federationStorage, f.deps.Config.Config)
+	return deliveryService, nil
+}
+
+// DeliverToFollowers delivers an activity to all followers of the actor
+func (f *federationService) DeliverToFollowers(ctx context.Context, activity *activitypub.Activity, actor *activitypub.Actor) error {
+	deliveryService, err := f.newDeliveryService()
+	if err != nil {
+		return err
+	}
 	return deliveryService.DeliverToFollowers(ctx, activity, actor)
 }
 
 // DeliverToRecipients delivers an activity to specific recipients
 func (f *federationService) DeliverToRecipients(ctx context.Context, activity *activitypub.Activity, actor *activitypub.Actor) error {
-	// Use storage directly if it implements FederationStorage
-	var federationStorage federation.FederationStorage
-
-	// Try to get DB from storage for DynamORM federation storage
-	if db := f.storage.GetDB(); db != nil {
-		// Check if it's a core.DB type
-		if coreDB, ok := db.(core.DB); ok {
-			federationStorage = federation.NewDynamORMFederationStorage(coreDB, f.storage.GetTableName(), f.deps.Config.Config.Domain, f.deps.Logger.(*zap.Logger))
-		} else {
-			// Fall back to a basic implementation or return error
-			return ErrUnsupportedDatabaseType
-		}
-	} else {
-		return ErrNoDatabaseAvailable
+	deliveryService, err := f.newDeliveryService()
+	if err != nil {
+		return err
 	}
-
-	deliveryService := federation.NewDeliveryService(federationStorage, f.deps.Config.Config)
-
 	return deliveryService.DeliverToRecipients(ctx, activity, actor)
+}
+
+// DeliverToFollowersAndRecipients delivers public/unlisted activities through
+// the shared federation delivery path that de-dupes follower fanout against
+// explicit recipients before sending.
+func (f *federationService) DeliverToFollowersAndRecipients(ctx context.Context, activity *activitypub.Activity, actor *activitypub.Actor) error {
+	deliveryService, err := f.newDeliveryService()
+	if err != nil {
+		return err
+	}
+	return deliveryService.DeliverToFollowersAndRecipients(ctx, activity, actor)
 }
 
 // DetermineRecipients determines who should receive an activity based on its type and visibility

--- a/pkg/services/registry_round17_more_coverage_test.go
+++ b/pkg/services/registry_round17_more_coverage_test.go
@@ -912,6 +912,33 @@ func TestRegistry_Adapters_And_JobQueueImplementations(t *testing.T) {
 		assert.Equal(t, 1, fed.deliverRecipientsCalls)
 	})
 
+	t.Run("queueFederationAdapter_uses_combined_sender_dedupe_when_available", func(t *testing.T) {
+		fed := &combinedStubFederationService{}
+		storage := newPermissiveRegistryStorage(t, "example.com", logger)
+		adapter := &queueFederationAdapter{
+			federation: fed,
+			storage:    storage,
+			logger:     logger,
+		}
+
+		activity := &activitypub.Activity{
+			BaseObject: activitypub.BaseObject{
+				Type: "Create",
+				To:   []string{activitypub.PublicAddress, "https://remote.example/users/bob"},
+				CC:   []string{"https://example.com/users/alice/followers"},
+			},
+			Actor: "https://example.com/users/alice",
+		}
+
+		require.NoError(t, adapter.QueueActivity(context.Background(), activity))
+		assert.Equal(t, 1, fed.deliverCombinedCalls)
+		assert.Equal(t, 0, fed.deliverFollowersCalls)
+		assert.Equal(t, 0, fed.deliverRecipientsCalls)
+		require.NotNil(t, fed.lastActor)
+		assert.Equal(t, activity.Actor, fed.lastActor.ID)
+		assert.Equal(t, activity, fed.lastActivity)
+	})
+
 	t.Run("queueFederationAdapter_delivers_direct_mentions_to_recipients_only", func(t *testing.T) {
 		fed := &stubFederationService{}
 		storage := newPermissiveRegistryStorage(t, "example.com", logger)
@@ -1018,6 +1045,18 @@ func (s *stubFederationService) DetermineRecipients(context.Context, *activitypu
 }
 func (s *stubFederationService) GetInstanceRelationships(context.Context, string) (*model.InstanceRelations, error) {
 	return nil, nil
+}
+
+type combinedStubFederationService struct {
+	stubFederationService
+	deliverCombinedCalls int
+}
+
+func (s *combinedStubFederationService) DeliverToFollowersAndRecipients(_ context.Context, activity *activitypub.Activity, actor *activitypub.Actor) error {
+	s.deliverCombinedCalls++
+	s.lastActivity = activity
+	s.lastActor = actor
+	return nil
 }
 
 type noopNotificationService struct{}


### PR DESCRIPTION
## Milestone
Project 20 v1.2.48 closure seams — expose the existing combined federation delivery path through the production service adapter.

## Classification
federation-trust / operational-reliability / bug-fix

## Surfaces affected
- `pkg/services/federation.go`
- `pkg/services` unit coverage for federation service construction and queue adapter delivery routing

## Specialist walks referenced
- Federation trust: `protect-federation-trust` completed. This patch does not change HTTP Signature signing/verification, actor identity, inbox/outbox object shape, moderation gates, relay behavior, or delivery retry semantics. It only exposes the already-existing lower `pkg/federation.DeliveryService.DeliverToFollowersAndRecipients` method through `services.federationService` so `queueFederationAdapter` reaches the combined sender de-dupe path in production.
- Contract / API: `preserve-mastodon-api-compat` checked. No `/api/v1/*`, GraphQL, OpenAPI, ActivityPub actor-shape, or notification semantic change in lesser.
- Schema: none. No TableTheory tags, PK/SK patterns, GSI use, or persisted model shape changed.
- Framework: none.

## Consumer impact
- Remote ActivityPub peers: fewer duplicate outbound delivery attempts when a public/unlisted Create is addressed through both followers and explicit recipients.
- Operators: no deploy-time configuration or data migration required.
- Mastodon clients / API consumers: no observable REST or GraphQL contract change.
- Sibling repos: lesser-body PR #148 separately repairs MCP `notifications_read.since` timestamp behavior; this lesser PR does not depend on body being published.

## Tasks
- [x] Expose combined follower/recipient delivery on the production federation service adapter.
- [x] Add coverage that `queueFederationAdapter` uses the combined sender de-dupe path when available.
- [x] Add coverage for federation service combined-delivery construction errors.

## Validation
- `git diff --check`
- `go test ./pkg/services ./pkg/federation`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
- Body steward handoff sent before implementation for the separate `notifications_read.since` cursor/timestamp repair.
- Expected rollout sequence per operator: deploy lesser first, update lesser-body next, then connect MCP.

## Advisor-brief authorization
Arch report was user-authorized for investigation and follow-up in this Codex session.
