### PR TITLE
fix auth ui csp hash

### DIFF
--- a/infra/cdk/constructs/frontend_response_headers.go
+++ b/infra/cdk/constructs/frontend_response_headers.go
@@ -126,7 +126,11 @@ func buildFrontendStaticCSP(domainName *string) string {
 
 func authUIInlineScriptHashes() []string {
 	return []string{
+		// Astro/Svelte island runtime snippets generated into auth-ui/dist/*.html.
+		// Refresh after auth-ui dependency bumps with:
+		//   pnpm --dir auth-ui install --frozen-lockfile && pnpm --dir auth-ui build
 		"'sha256-QzWFZi+FLIx23tnm9SBU4aEgx4x8DsuASP07mfqol/c='",
+		"'sha256-BrDhGE1lwa85arfXcrBxSo+n37uVSX5CAROXnIM6Q+g='",
 		"'sha256-QJZDUlo/qa5AJCrG6vHyWcatjwCeWidEHQfJc601lzw='",
 		"'sha256-eIXWvAmxkr251LJZkjniEK5LcPF3NkapbJepohwYRIc='",
 		"'sha256-IV0HjYu959C/EiJIL2l/9Ty8PA4757JXhA/g112YXVE='",

--- a/infra/cdk/stacks/frontend_csp_test.go
+++ b/infra/cdk/stacks/frontend_csp_test.go
@@ -15,6 +15,7 @@ func TestFrontendStaticCSPIsStrictAndBehaviorScoped(t *testing.T) {
 	}
 	requireContainsAll(t, csp, []string{
 		"'sha256-QzWFZi+FLIx23tnm9SBU4aEgx4x8DsuASP07mfqol/c='",
+		"'sha256-BrDhGE1lwa85arfXcrBxSo+n37uVSX5CAROXnIM6Q+g='",
 		"'sha256-QJZDUlo/qa5AJCrG6vHyWcatjwCeWidEHQfJc601lzw='",
 		"'sha256-eIXWvAmxkr251LJZkjniEK5LcPF3NkapbJepohwYRIc='",
 		"'sha256-IV0HjYu959C/EiJIL2l/9Ty8PA4757JXhA/g112YXVE='",


### PR DESCRIPTION
## Summary
- add the new Astro/Svelte auth UI inline runtime hash to the CloudFront CSP allowlist
- keep the Auth UI CSP strict; no `unsafe-inline`
- update the frontend CSP synthesis test to pin the new hash

## Root cause
The deployed `/auth/login` page includes an inline Astro island runtime snippet with hash `sha256-BrDhGE1lwa85arfXcrBxSo+n37uVSX5CAROXnIM6Q+g=`, generated after the auth-ui dependency refresh. The CloudFront response headers policy still allowed only the previous generated hashes, so browser CSP enforcement blocked hydration and broke the login flow.

## Validation
- `pnpm --dir auth-ui install --frozen-lockfile`
- `pnpm --dir auth-ui build`
- `(cd infra/cdk && go test ./constructs ./stacks)`
- `git diff --check`
- `go build -o lesser ./cmd/lesser && ./lesser build lambdas && ./lesser verify ci`

## Rollout
Deploy Lesser to dev first so the CloudFront response headers policy updates, then verify `/auth/login` hydrates without CSP errors before any staging/live promotion.
