### PR TITLE
feat: add first-class federated conversations

### DIFF
--- a/cmd/api/handlers/conversation_list_prefetch.go
+++ b/cmd/api/handlers/conversation_list_prefetch.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	apimodels "github.com/equaltoai/lesser/cmd/api/models"
+	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/storage"
 	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/transformations"
@@ -51,17 +52,22 @@ func conversationParticipantUsernames(conv *storageModels.Conversation, viewerUs
 	}
 
 	viewerUsername = strings.ToLower(strings.TrimSpace(viewerUsername))
-	seen := make(map[string]struct{}, len(conv.Participants))
-	usernames := make([]string, 0, len(conv.Participants))
-	for _, participant := range conv.Participants {
-		candidate := strings.ToLower(strings.TrimSpace(participant))
+	refs := conversationParticipantRefsForProjection(conv)
+	seen := make(map[string]struct{}, len(refs))
+	usernames := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		candidate := strings.TrimSpace(ref.ParticipantID)
+		if ref.ParticipantType != storageModels.ConversationParticipantTypeRemoteActor {
+			candidate = strings.ToLower(candidate)
+		}
 		if candidate == "" || candidate == viewerUsername {
 			continue
 		}
-		if _, ok := seen[candidate]; ok {
+		key := strings.ToLower(candidate)
+		if _, ok := seen[key]; ok {
 			continue
 		}
-		seen[candidate] = struct{}{}
+		seen[key] = struct{}{}
 		usernames = append(usernames, candidate)
 	}
 
@@ -72,6 +78,40 @@ func conversationParticipantUsernames(conv *storageModels.Conversation, viewerUs
 	}
 
 	return usernames
+}
+
+func conversationParticipantRefsForProjection(conv *storageModels.Conversation) []storageModels.ConversationParticipantRef {
+	if conv == nil {
+		return nil
+	}
+	if len(conv.ParticipantRefs) > 0 {
+		return storageModels.NormalizeConversationParticipantRefs(conv.ParticipantRefs)
+	}
+	refs := make([]storageModels.ConversationParticipantRef, 0, len(conv.Participants))
+	for _, participant := range conv.Participants {
+		participant = strings.TrimSpace(participant)
+		if participant == "" {
+			continue
+		}
+		participantType := storageModels.ConversationParticipantTypeLocalUser
+		if strings.Contains(participant, "://") {
+			participantType = storageModels.ConversationParticipantTypeRemoteActor
+		}
+		refs = append(refs, storageModels.ConversationParticipantRef{
+			ParticipantType: participantType,
+			ParticipantID:   participant,
+		})
+	}
+	if conv.ViewerState != nil && conv.ViewerState.CounterpartID != "" {
+		refs = append(refs, storageModels.ConversationParticipantRef{
+			ParticipantType: conv.ViewerState.CounterpartType,
+			ParticipantID:   conv.ViewerState.CounterpartID,
+			Acct:            conv.ViewerState.CounterpartAcct,
+			Domain:          conv.ViewerState.CounterpartDomain,
+			ResolvedAt:      conv.ViewerState.CounterpartResolvedAt,
+		})
+	}
+	return storageModels.NormalizeConversationParticipantRefs(refs)
 }
 
 func conversationAPIAccountPrefetchKeys(account *storage.Account) []string {
@@ -163,6 +203,8 @@ func (h *Handler) loadConversationAPIPrefetch(ctx context.Context, conversations
 		}
 	}
 
+	h.addRemoteConversationAPIAccountsToPrefetch(ctx, conversations, prefetch)
+
 	if len(statusIDs) > 0 && h.repos.Status() != nil {
 		if statuses, err := h.repos.Status().GetStatusesByIDs(ctx, statusIDs); err == nil {
 			prefetch.statusesByID = buildConversationAPIStatusMap(statuses)
@@ -170,6 +212,26 @@ func (h *Handler) loadConversationAPIPrefetch(ctx context.Context, conversations
 	}
 
 	return prefetch
+}
+
+func (h *Handler) addRemoteConversationAPIAccountsToPrefetch(ctx context.Context, conversations []*storageModels.Conversation, prefetch *conversationAPIPrefetch) {
+	if h == nil || h.repos == nil || h.repos.Actor() == nil || prefetch == nil {
+		return
+	}
+	for _, conv := range conversations {
+		for _, ref := range conversationParticipantRefsForProjection(conv) {
+			if ref.ParticipantType != storageModels.ConversationParticipantTypeRemoteActor {
+				continue
+			}
+			account := h.conversationAPIRemoteAccountForParticipantRef(ctx, ref)
+			if account == nil {
+				continue
+			}
+			for _, key := range conversationAPIAccountPrefetchKeys(account) {
+				prefetch.accountsByKey[key] = account
+			}
+		}
+	}
 }
 
 func (h *Handler) conversationAPIAccountForParticipant(ctx context.Context, participant string, prefetch *conversationAPIPrefetch) *storage.Account {
@@ -203,10 +265,90 @@ func (h *Handler) conversationAPIAccountForParticipant(ctx context.Context, part
 	}
 }
 
+func (h *Handler) conversationAPIAccountForParticipantRef(ctx context.Context, ref storageModels.ConversationParticipantRef, prefetch *conversationAPIPrefetch) *storage.Account {
+	ref = storageModels.NormalizeConversationParticipantRef(ref)
+	if ref.ParticipantID == "" {
+		return nil
+	}
+	if prefetch != nil {
+		if account := prefetch.accountsByKey[strings.ToLower(ref.ParticipantID)]; account != nil {
+			return account
+		}
+		if ref.Acct != "" {
+			if account := prefetch.accountsByKey[strings.ToLower(ref.Acct)]; account != nil {
+				return account
+			}
+		}
+	}
+	if ref.ParticipantType == storageModels.ConversationParticipantTypeRemoteActor {
+		return h.conversationAPIRemoteAccountForParticipantRef(ctx, ref)
+	}
+	return h.conversationAPIAccountForParticipant(ctx, ref.ParticipantID, prefetch)
+}
+
+func (h *Handler) conversationAPIRemoteAccountForParticipantRef(ctx context.Context, ref storageModels.ConversationParticipantRef) *storage.Account {
+	ref = storageModels.NormalizeConversationParticipantRef(ref)
+	if ref.ParticipantID == "" || h == nil {
+		return nil
+	}
+	localDomain := ""
+	if h.cfg != nil {
+		localDomain = h.cfg.Domain
+	}
+
+	if h.repos != nil && h.repos.Actor() != nil {
+		candidates := []string{ref.ParticipantID, ref.Acct}
+		for _, candidate := range candidates {
+			candidate = strings.TrimSpace(candidate)
+			if candidate == "" {
+				continue
+			}
+			actor, err := h.repos.Actor().GetCachedRemoteActor(ctx, candidate)
+			if err == nil && actor != nil {
+				return storageAccountFromActor(actor, localDomain)
+			}
+		}
+	}
+
+	return storageAccountFromActor(conversationAPISyntheticRemoteActor(ref), localDomain)
+}
+
+func conversationAPISyntheticRemoteActor(ref storageModels.ConversationParticipantRef) *activitypub.Actor {
+	ref = storageModels.NormalizeConversationParticipantRef(ref)
+	username := strings.TrimSpace(ref.Acct)
+	if username != "" {
+		if handleUser, _, ok := strings.Cut(username, "@"); ok {
+			username = handleUser
+		}
+	}
+	if username == "" {
+		username = strings.TrimSpace(extractUsernameFromActorID(ref.ParticipantID))
+	}
+	if username == "" {
+		username = strings.TrimSpace(ref.ParticipantID)
+	}
+	return &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   ref.ParticipantID,
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: username,
+		Name:              username,
+		URL:               ref.ParticipantID,
+	}
+}
+
 func (h *Handler) conversationAPIAccounts(ctx context.Context, conv *storageModels.Conversation, viewerUsername string, prefetch *conversationAPIPrefetch) []apimodels.Account {
 	accounts := make([]apimodels.Account, 0, len(conv.Participants))
-	for _, participant := range conversationParticipantUsernames(conv, viewerUsername) {
-		account := h.conversationAPIAccountForParticipant(ctx, participant, prefetch)
+	for _, ref := range conversationParticipantRefsForProjection(conv) {
+		participant := ref.ParticipantID
+		if ref.ParticipantType != storageModels.ConversationParticipantTypeRemoteActor {
+			participant = strings.ToLower(strings.TrimSpace(participant))
+		}
+		if participant == "" || participant == strings.ToLower(strings.TrimSpace(viewerUsername)) {
+			continue
+		}
+		account := h.conversationAPIAccountForParticipantRef(ctx, ref, prefetch)
 		if account == nil || account.Actor == nil {
 			continue
 		}

--- a/cmd/api/handlers/federated_conversations_projection_test.go
+++ b/cmd/api/handlers/federated_conversations_projection_test.go
@@ -1,0 +1,244 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/config"
+	"github.com/equaltoai/lesser/pkg/storage"
+	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
+	testmocks "github.com/equaltoai/lesser/pkg/testing/mocks"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConversationAPIAccounts_RemoteParticipantUsesSyntheticAccountFallback(t *testing.T) {
+	h := &Handler{cfg: &config.Config{Domain: "example.com"}}
+	remoteActorID := "https://remote.example/users/bob"
+	conversation := &storageModels.Conversation{
+		ID:           "conv-remote",
+		Participants: []string{"alice", remoteActorID},
+		ParticipantRefs: []storageModels.ConversationParticipantRef{
+			{
+				ParticipantType: storageModels.ConversationParticipantTypeLocalUser,
+				ParticipantID:   "alice",
+			},
+			{
+				ParticipantType: storageModels.ConversationParticipantTypeRemoteActor,
+				ParticipantID:   remoteActorID,
+				Acct:            "bob@remote.example",
+				Domain:          "remote.example",
+			},
+		},
+	}
+
+	accounts := h.conversationAPIAccounts(context.Background(), conversation, "alice", nil)
+
+	require.Len(t, accounts, 1)
+	require.Equal(t, remoteActorID, accounts[0].ID)
+	require.Equal(t, "bob", accounts[0].Username)
+	require.Equal(t, "bob@remote.example", accounts[0].Acct)
+	require.Equal(t, remoteActorID, accounts[0].URL)
+}
+
+func TestConversationAPIProjectionHelpers_RemoteParticipantBranches(t *testing.T) {
+	ctx := context.Background()
+	remoteActorID := "https://remote.example/users/bob"
+	conversation := &storageModels.Conversation{
+		ID:           "conv-remote",
+		Participants: []string{" Alice ", remoteActorID},
+		ViewerState: &storageModels.UserConversationState{
+			CounterpartType: storageModels.ConversationParticipantTypeRemoteActor,
+			CounterpartID:   "https://remote.example/users/carol",
+			CounterpartAcct: "carol@remote.example",
+		},
+	}
+
+	refs := conversationParticipantRefsForProjection(conversation)
+	require.Len(t, refs, 3)
+	require.ElementsMatch(t, []string{remoteActorID, "https://remote.example/users/carol"}, conversationParticipantUsernames(conversation, "alice"))
+
+	localAccount := &storage.Account{
+		User: &storage.User{ID: "alice-id", Username: "Alice"},
+		Actor: &activitypub.Actor{
+			BaseObject:        activitypub.BaseObject{ID: "https://example.com/users/Alice", Type: activitypub.PersonType},
+			URL:               "https://example.com/@Alice",
+			PreferredUsername: "Alice",
+		},
+	}
+	keys := conversationAPIAccountPrefetchKeys(localAccount)
+	require.Contains(t, keys, "alice")
+	require.Contains(t, keys, "alice-id")
+	require.Contains(t, keys, "https://example.com/users/alice")
+	require.Nil(t, conversationAPIAccountPrefetchKeys(nil))
+
+	statusesByID := buildConversationAPIStatusMap([]*storageModels.Status{
+		nil,
+		{StatusID: ""},
+		{StatusID: "status-1"},
+	})
+	require.Len(t, statusesByID, 1)
+	require.Contains(t, statusesByID, "status-1")
+
+	remoteAccount := storageAccountFromActor(&activitypub.Actor{
+		BaseObject:        activitypub.BaseObject{ID: remoteActorID, Type: activitypub.PersonType},
+		PreferredUsername: "bob",
+		Name:              "Bob Remote",
+		URL:               remoteActorID,
+	}, "example.com")
+	prefetch := &conversationAPIPrefetch{
+		accountsByKey: buildConversationAPIAccountMap([]*storage.Account{localAccount, remoteAccount}),
+	}
+	h := &Handler{cfg: &config.Config{Domain: "example.com"}}
+
+	require.Same(t, localAccount, h.conversationAPIAccountForParticipantRef(ctx, storageModels.ConversationParticipantRef{
+		ParticipantType: storageModels.ConversationParticipantTypeLocalUser,
+		ParticipantID:   "Alice",
+	}, prefetch))
+	require.Same(t, remoteAccount, h.conversationAPIAccountForParticipantRef(ctx, storageModels.ConversationParticipantRef{
+		ParticipantType: storageModels.ConversationParticipantTypeRemoteActor,
+		ParticipantID:   remoteActorID,
+		Acct:            "bob@remote.example",
+	}, prefetch))
+
+	require.Equal(t, "zoe", conversationAPISyntheticRemoteActor(storageModels.ConversationParticipantRef{
+		ParticipantType: storageModels.ConversationParticipantTypeRemoteActor,
+		ParticipantID:   "https://remote.example/actors/@zoe",
+	}).PreferredUsername)
+	require.Equal(t, "opaque-remote-id", conversationAPISyntheticRemoteActor(storageModels.ConversationParticipantRef{
+		ParticipantType: storageModels.ConversationParticipantTypeRemoteActor,
+		ParticipantID:   "opaque-remote-id",
+	}).PreferredUsername)
+}
+
+func TestConversationAPIRemoteAccountForParticipantRef_UsesCachedRemoteActor(t *testing.T) {
+	ctx := context.Background()
+	remoteActorID := "https://remote.example/users/bob"
+	repos := &MockRepositoryStorage{}
+	actorRepo := &testmocks.MockActorRepository{}
+	repos.On("Actor").Return(actorRepo).Maybe()
+	actorRepo.On("GetCachedRemoteActor", ctx, remoteActorID).Return(&activitypub.Actor{
+		BaseObject:        activitypub.BaseObject{ID: remoteActorID, Type: activitypub.PersonType},
+		PreferredUsername: "bob",
+		Name:              "Cached Bob",
+		URL:               remoteActorID,
+	}, nil).Once()
+
+	h := &Handler{cfg: &config.Config{Domain: "example.com"}, repos: repos}
+	account := h.conversationAPIRemoteAccountForParticipantRef(ctx, storageModels.ConversationParticipantRef{
+		ParticipantType: storageModels.ConversationParticipantTypeRemoteActor,
+		ParticipantID:   remoteActorID,
+		Acct:            "bob@remote.example",
+	})
+
+	require.NotNil(t, account)
+	require.Equal(t, "bob@remote.example", account.User.Username)
+	require.Equal(t, "Cached Bob", account.User.DisplayName)
+	require.Equal(t, remoteActorID, account.Actor.ID)
+	actorRepo.AssertExpectations(t)
+	repos.AssertExpectations(t)
+}
+
+func TestConversationAPIProjectionHelpers_EdgeBranches(t *testing.T) {
+	ctx := context.Background()
+
+	require.Nil(t, prefetchedConversationAccount(nil, "alice"))
+	require.Nil(t, prefetchedConversationAccount(withPrefetchedConversationAccounts(ctx, nil), "alice"))
+	require.Empty(t, conversationPreviewStatusID(nil))
+	require.Nil(t, conversationParticipantUsernames(nil, "alice"))
+	require.Nil(t, conversationParticipantRefsForProjection(nil))
+
+	viewerOnly := &storageModels.Conversation{
+		ParticipantRefs: []storageModels.ConversationParticipantRef{{
+			ParticipantType: storageModels.ConversationParticipantTypeLocalUser,
+			ParticipantID:   "alice",
+		}},
+		ViewerState: &storageModels.UserConversationState{
+			CounterpartID: "Bob",
+		},
+	}
+	require.Equal(t, []string{"bob"}, conversationParticipantUsernames(viewerOnly, "alice"))
+
+	remoteCaseDuplicates := &storageModels.Conversation{
+		ParticipantRefs: []storageModels.ConversationParticipantRef{
+			{ParticipantType: storageModels.ConversationParticipantTypeRemoteActor, ParticipantID: "https://remote.example/users/Bob"},
+			{ParticipantType: storageModels.ConversationParticipantTypeRemoteActor, ParticipantID: "https://remote.example/users/bob"},
+		},
+	}
+	require.Equal(t, []string{"https://remote.example/users/Bob"}, conversationParticipantUsernames(remoteCaseDuplicates, "alice"))
+
+	duplicatesAndBlanks := &storageModels.Conversation{
+		Participants: []string{" Alice ", "", "ALICE"},
+	}
+	require.Empty(t, conversationParticipantUsernames(duplicatesAndBlanks, "alice"))
+	require.Len(t, conversationParticipantRefsForProjection(duplicatesAndBlanks), 1)
+
+	var nilHandler *Handler
+	require.Empty(t, nilHandler.loadConversationAPIPrefetch(ctx, []*storageModels.Conversation{{}}, "alice").accountsByKey)
+	nilHandler.addRemoteConversationAPIAccountsToPrefetch(ctx, []*storageModels.Conversation{{}}, &conversationAPIPrefetch{accountsByKey: map[string]*storage.Account{}})
+	require.Nil(t, nilHandler.conversationAPIAccountForParticipant(ctx, "alice", nil))
+	require.Nil(t, nilHandler.conversationAPIRemoteAccountForParticipantRef(ctx, storageModels.ConversationParticipantRef{
+		ParticipantType: storageModels.ConversationParticipantTypeRemoteActor,
+		ParticipantID:   "",
+	}))
+	require.Nil(t, (&Handler{}).conversationAPIAccountForParticipantRef(ctx, storageModels.ConversationParticipantRef{}, nil))
+	require.NotNil(t, conversationAPIStatusContext(nil, nil))
+
+	derivedAccount := &storage.Account{
+		User:  &storage.User{Username: "bob"},
+		Actor: &activitypub.Actor{BaseObject: activitypub.BaseObject{ID: "https://example.com/users/bob", Type: activitypub.PersonType}},
+	}
+	prefetch := &conversationAPIPrefetch{accountsByKey: map[string]*storage.Account{"bob": derivedAccount}}
+	repos := &MockRepositoryStorage{}
+	actorRepo := &testmocks.MockActorRepository{}
+	repos.On("Actor").Return(actorRepo).Maybe()
+	h := &Handler{cfg: &config.Config{Domain: "example.com"}, repos: repos}
+	require.Same(t, derivedAccount, h.conversationAPIAccountForParticipant(ctx, "bob", prefetch))
+	require.Same(t, derivedAccount, h.conversationAPIAccountForParticipant(ctx, "https://example.com/users/bob", prefetch))
+
+	acctOnlyRemote := &storage.Account{
+		User:  &storage.User{Username: "acct-only@remote.example"},
+		Actor: &activitypub.Actor{BaseObject: activitypub.BaseObject{ID: "https://remote.example/users/acct-only", Type: activitypub.PersonType}},
+	}
+	require.Same(t, acctOnlyRemote, h.conversationAPIAccountForParticipantRef(ctx, storageModels.ConversationParticipantRef{
+		ParticipantType: storageModels.ConversationParticipantTypeRemoteActor,
+		ParticipantID:   "https://remote.example/users/acct-only",
+		Acct:            "acct-only@remote.example",
+	}, &conversationAPIPrefetch{accountsByKey: map[string]*storage.Account{"acct-only@remote.example": acctOnlyRemote}}))
+
+	actorRepo.On("GetActor", ctx, "missing").Return(nil, storage.ErrNotFound).Once()
+	require.Nil(t, h.conversationAPIAccountForParticipant(ctx, "missing", nil))
+
+	actorRepo.On("GetCachedRemoteActor", ctx, "https://remote.example/users/missing").Return(nil, storage.ErrNotFound).Once()
+	account := h.conversationAPIRemoteAccountForParticipantRef(ctx, storageModels.ConversationParticipantRef{
+		ParticipantType: storageModels.ConversationParticipantTypeRemoteActor,
+		ParticipantID:   "https://remote.example/users/missing",
+	})
+	require.NotNil(t, account)
+	require.Equal(t, "missing@remote.example", account.User.Username)
+	actorRepo.On("GetCachedRemoteActor", ctx, "https://remote.example/users/prefetch-missing").Return(nil, storage.ErrNotFound).Once()
+	remotePrefetch := &conversationAPIPrefetch{accountsByKey: map[string]*storage.Account{}}
+	h.addRemoteConversationAPIAccountsToPrefetch(ctx, []*storageModels.Conversation{{
+		ParticipantRefs: []storageModels.ConversationParticipantRef{{
+			ParticipantType: storageModels.ConversationParticipantTypeRemoteActor,
+			ParticipantID:   "https://remote.example/users/prefetch-missing",
+		}},
+	}}, remotePrefetch)
+	require.NotEmpty(t, remotePrefetch.accountsByKey)
+	require.Empty(t, conversationAPISyntheticRemoteActor(storageModels.ConversationParticipantRef{}).PreferredUsername)
+
+	require.Nil(t, h.conversationAPIStatus(ctx, &storageModels.Conversation{}, nil))
+	statusRepo := &testmocks.MockStatusRepositoryInterface{}
+	statusRepos := &MockRepositoryStorage{}
+	statusRepos.On("Status").Return(statusRepo).Maybe()
+	statusRepo.On("GetStatus", ctx, "status-missing").Return(nil, storage.ErrNotFound).Once()
+	require.Nil(t, (&Handler{repos: statusRepos}).conversationAPIStatus(ctx, &storageModels.Conversation{LastStatusID: "status-missing"}, &conversationAPIPrefetch{statusesByID: map[string]*storageModels.Status{}}))
+	require.Empty(t, (&Handler{cfg: &config.Config{Domain: "example.com"}}).conversationAPIAccounts(ctx, &storageModels.Conversation{
+		Participants: []string{"alice", "missing"},
+	}, "alice", nil))
+
+	actorRepo.AssertExpectations(t)
+	repos.AssertExpectations(t)
+	statusRepo.AssertExpectations(t)
+	statusRepos.AssertExpectations(t)
+}

--- a/cmd/api/handlers/misc.go
+++ b/cmd/api/handlers/misc.go
@@ -763,17 +763,9 @@ func (h *Handler) convertNotificationsToAPI(ctx *apptheory.Context, notification
 // convertSingleNotification converts a single notification to API format
 func (h *Handler) convertSingleNotification(ctx *apptheory.Context, notif *storage.Notification) *models.Notification {
 	// Get the account that triggered the notification
-	actor, err := h.repos.Actor().GetActor(ctx.Context(), notif.AccountID)
-	if err != nil {
-		h.logger.Warn("failed to get actor for notification; using fallback actor",
-			zap.String("notification_id", notif.ID),
-			zap.String("account_id", notif.AccountID),
-			zap.Error(err),
-		)
-		actor = h.fallbackNotificationActor(notif.AccountID)
-		if actor == nil {
-			return nil
-		}
+	actor := h.notificationActor(ctx.Context(), notif.AccountID)
+	if actor == nil {
+		return nil
 	}
 
 	account := transformations.ActorToAccountBase(actor, h.cfg.BaseURL())
@@ -892,6 +884,9 @@ func (h *Handler) notificationSnapshotActor(ctx *apptheory.Context, snapshot map
 	}
 
 	fallbackActor := h.fallbackNotificationActor(attributedTo)
+	if cached := h.cachedRemoteNotificationActor(ctx.Context(), attributedTo); cached != nil {
+		return cached
+	}
 	username := extractUsernameFromNotificationActorID(attributedTo)
 	if username == "" {
 		return fallbackActor
@@ -903,6 +898,48 @@ func (h *Handler) notificationSnapshotActor(ctx *apptheory.Context, snapshot map
 	}
 
 	return statusActor
+}
+
+func (h *Handler) notificationActor(ctx context.Context, actorID string) *activitypub.Actor {
+	actorID = strings.TrimSpace(actorID)
+	if actorID == "" {
+		return nil
+	}
+
+	if h != nil && h.repos != nil && h.repos.Actor() != nil {
+		if actor, err := h.repos.Actor().GetActor(ctx, actorID); err == nil && actor != nil {
+			return actor
+		} else if err != nil && h.logger != nil {
+			h.logger.Warn("failed to get local actor for notification; trying remote cache/fallback",
+				zap.String("account_id", actorID),
+				zap.Error(err))
+		}
+		if actor := h.cachedRemoteNotificationActor(ctx, actorID); actor != nil {
+			return actor
+		}
+	}
+	return h.fallbackNotificationActor(actorID)
+}
+
+func (h *Handler) cachedRemoteNotificationActor(ctx context.Context, actorID string) *activitypub.Actor {
+	if h == nil || h.repos == nil || h.repos.Actor() == nil {
+		return nil
+	}
+	candidates := []string{actorID}
+	if username := extractUsernameFromNotificationActorID(actorID); username != "" && username != actorID {
+		candidates = append(candidates, username)
+	}
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		actor, err := h.repos.Actor().GetCachedRemoteActor(ctx, candidate)
+		if err == nil && actor != nil {
+			return actor
+		}
+	}
+	return nil
 }
 
 func notificationSnapshotObjectMap(snapshot map[string]interface{}) map[string]interface{} {
@@ -1119,16 +1156,9 @@ func (h *Handler) HandleGetNotificationLift(ctx *apptheory.Context) (*apptheory.
 	}
 
 	// Get the account that triggered the notification
-	actor, err := h.repos.Actor().GetActor(ctx.Context(), notification.ActorID)
-	if err != nil {
-		h.logger.Warn("failed to get actor for notification; using fallback actor",
-			zap.String("notification_id", notification.ID),
-			zap.String("actor_id", notification.ActorID),
-			zap.Error(err))
-		actor = h.fallbackNotificationActor(notification.ActorID)
-		if actor == nil {
-			return common.RespondFailedToGet(ctx, "notification details")
-		}
+	actor := h.notificationActor(ctx.Context(), notification.ActorID)
+	if actor == nil {
+		return common.RespondFailedToGet(ctx, "notification details")
 	}
 
 	account := transformations.ActorToAccountBase(actor, h.cfg.BaseURL())

--- a/cmd/inbox/internal/routing/federated_conversations_inbound_test.go
+++ b/cmd/inbox/internal/routing/federated_conversations_inbound_test.go
@@ -1,0 +1,321 @@
+package routing
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/storage/interfaces"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/equaltoai/lesser/pkg/streaming"
+	"github.com/equaltoai/lesser/pkg/testing/inmemory"
+	"github.com/stretchr/testify/require"
+)
+
+type inboundDirectCapturePublisher struct {
+	events []streaming.Event
+}
+
+func (p *inboundDirectCapturePublisher) PublishToUser(_ context.Context, userID string, event *streaming.Event) error {
+	captured := *event
+	captured.Stream = fmt.Sprintf("user:%s:direct", userID)
+	p.events = append(p.events, captured)
+	return nil
+}
+
+func (p *inboundDirectCapturePublisher) PublishToStream(_ context.Context, streamName string, event *streaming.Event) error {
+	captured := *event
+	captured.Stream = streamName
+	p.events = append(p.events, captured)
+	return nil
+}
+
+func (p *inboundDirectCapturePublisher) PublishToConversation(_ context.Context, conversationID string, event *streaming.Event) error {
+	captured := *event
+	captured.Stream = fmt.Sprintf("conversation:%s", conversationID)
+	p.events = append(p.events, captured)
+	return nil
+}
+
+func (p *inboundDirectCapturePublisher) Close() error {
+	return nil
+}
+
+func TestInboxHandler_FederatedConversation_RemoteDirectMaterializesStateNotificationAndStream(t *testing.T) {
+	env := newInboxTestEnv(t)
+	ctx := context.Background()
+	notifications := inmemory.NewNotificationRepository()
+	conversations := inmemory.NewConversationRepository()
+	statuses := inmemory.NewStatusRepository()
+	objects := inmemory.NewObjectRepository()
+	publisher := &inboundDirectCapturePublisher{}
+	env.handler.notificationRepository = notifications
+	env.handler.conversationRepository = conversations
+	env.handler.statusRepository = statuses
+	env.handler.objectRepository = objects
+	env.handler.publisher = publisher
+
+	published := time.Date(2026, 4, 27, 14, 0, 0, 0, time.UTC)
+	note := &activitypub.Note{
+		BaseObject: activitypub.BaseObject{
+			Context:   activitypub.Context,
+			ID:        "https://remote.example/users/bob/statuses/direct-1",
+			Type:      activitypub.NoteType,
+			Published: &published,
+			To:        []string{env.local.ID},
+		},
+		AttributedTo: env.remoteActorID,
+		Content:      "<p>direct hello @alice</p>",
+		Tag: []activitypub.Tag{{
+			Type: "Mention",
+			Href: env.local.ID,
+			Name: "@alice@localhost",
+		}},
+	}
+	activity := remoteCreateActivityForNote(t, env.remoteActorID, note, "https://remote.example/activities/direct-1")
+
+	require.NoError(t, env.handler.processRemoteCreateActivity(ctx, activity, env.local))
+
+	statusID := models.CanonicalStatusIDForDomain(note.ID, env.handler.localDomain())
+	status, err := statuses.GetStatus(ctx, statusID)
+	require.NoError(t, err)
+	require.Equal(t, models.VisibilityDirect, status.Visibility)
+	require.NotEmpty(t, status.ConversationID)
+	require.Equal(t, []string{env.local.ID}, status.ToRecipients)
+
+	stateResult, err := conversations.ListUserConversationStatesByFolder(ctx, "alice", interfaces.UserConversationFolder(models.UserConversationFolderInbox), interfaces.PaginationOptions{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, stateResult.Items, 1)
+	state := stateResult.Items[0]
+	require.Equal(t, status.ConversationID, state.ConversationID)
+	require.Equal(t, env.remoteActorID, state.CounterpartID)
+	require.Equal(t, models.ConversationParticipantTypeRemoteActor, state.CounterpartType)
+	require.Equal(t, "bob@remote.example", state.CounterpartAcct)
+	require.True(t, state.Unread)
+	require.Equal(t, statusID, state.PreviewStatusID)
+
+	conversation, err := conversations.GetConversation(ctx, status.ConversationID)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"alice", env.remoteActorID}, conversation.Participants)
+	require.Len(t, conversation.ParticipantRefs, 2)
+
+	result, err := notifications.GetUserNotifications(ctx, "alice", interfaces.PaginationOptions{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, result.Items, 1)
+	notification := result.Items[0]
+	require.Equal(t, common.NotificationTypeMention, notification.Type)
+	require.Equal(t, env.remoteActorID, notification.ActorID)
+	require.Equal(t, "remote_actor", notification.ActorType)
+	require.Equal(t, statusID, notification.TargetID)
+	require.Equal(t, status.ConversationID, notification.Data["conversationID"])
+	require.Equal(t, models.VisibilityDirect, notification.Data["visibility"])
+
+	require.Len(t, publisher.events, 2)
+	require.Contains(t, []string{publisher.events[0].Stream, publisher.events[1].Stream}, "conversation:"+status.ConversationID)
+	require.Contains(t, []string{publisher.events[0].Stream, publisher.events[1].Stream}, "user:alice:direct")
+}
+
+func TestInboxHandler_FederatedConversation_UnsupportedRemoteDirectGroupIsNotMaterialized(t *testing.T) {
+	env := newInboxTestEnv(t)
+	ctx := context.Background()
+	notifications := inmemory.NewNotificationRepository()
+	conversations := inmemory.NewConversationRepository()
+	statuses := inmemory.NewStatusRepository()
+	objects := inmemory.NewObjectRepository()
+	env.handler.notificationRepository = notifications
+	env.handler.conversationRepository = conversations
+	env.handler.statusRepository = statuses
+	env.handler.objectRepository = objects
+
+	published := time.Date(2026, 4, 27, 14, 30, 0, 0, time.UTC)
+	otherRecipient := "https://remote.example/users/carol"
+	note := &activitypub.Note{
+		BaseObject: activitypub.BaseObject{
+			Context:   activitypub.Context,
+			ID:        "https://remote.example/users/bob/statuses/direct-group-1",
+			Type:      activitypub.NoteType,
+			Published: &published,
+			To:        []string{env.local.ID, otherRecipient},
+		},
+		AttributedTo: env.remoteActorID,
+		Content:      "<p>group direct hello @alice @carol</p>",
+		Tag: []activitypub.Tag{{
+			Type: "Mention",
+			Href: env.local.ID,
+			Name: "@alice@localhost",
+		}},
+	}
+	activity := remoteCreateActivityForNote(t, env.remoteActorID, note, "https://remote.example/activities/direct-group-1")
+
+	require.NoError(t, env.handler.processRemoteCreateActivity(ctx, activity, env.local))
+
+	statusID := models.CanonicalStatusIDForDomain(note.ID, env.handler.localDomain())
+	_, err := statuses.GetStatus(ctx, statusID)
+	require.ErrorIs(t, err, storage.ErrNotFound)
+
+	stateResult, err := conversations.ListUserConversationStatesByFolder(ctx, "alice", interfaces.UserConversationFolder(models.UserConversationFolderInbox), interfaces.PaginationOptions{Limit: 10})
+	require.NoError(t, err)
+	require.Empty(t, stateResult.Items)
+
+	result, err := notifications.GetUserNotifications(ctx, "alice", interfaces.PaginationOptions{Limit: 10})
+	require.NoError(t, err)
+	require.Empty(t, result.Items)
+}
+
+func TestInboxHandler_FederatedConversation_ClassifyInboundDirectBranches(t *testing.T) {
+	env := newInboxTestEnv(t)
+	published := time.Date(2026, 4, 27, 15, 0, 0, 0, time.UTC)
+	baseNote := &activitypub.Note{
+		BaseObject: activitypub.BaseObject{
+			Context:   activitypub.Context,
+			ID:        "https://remote.example/users/bob/statuses/direct-classify",
+			Type:      activitypub.NoteType,
+			Published: &published,
+			To:        []string{env.local.ID},
+		},
+		AttributedTo: env.remoteActorID,
+		Content:      "<p>direct hello</p>",
+	}
+	baseActivity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Context: activitypub.Context,
+			ID:      "https://remote.example/activities/direct-classify",
+			Type:    activitypub.CreateType,
+			To:      []string{env.local.ID},
+		},
+		Object: baseNote,
+	}
+
+	info := env.handler.classifyInboundDirectCreate(baseActivity, baseNote, env.local)
+	require.True(t, info.isDirect)
+	require.False(t, info.unsupportedGroup)
+	require.Equal(t, "alice", info.localParticipantID)
+	require.Equal(t, env.remoteActorID, info.remoteActorID)
+	require.Equal(t, "bob@remote.example", info.remoteAcct)
+	require.Len(t, info.participantRefs, 2)
+
+	publicNote := *baseNote
+	publicNote.To = []string{activitypub.PublicAddress}
+	publicActivity := *baseActivity
+	publicActivity.Actor = env.remoteActorID
+	publicActivity.To = []string{activitypub.PublicAddress}
+	require.False(t, env.handler.classifyInboundDirectCreate(&publicActivity, &publicNote, env.local).isDirect)
+
+	followersNote := *baseNote
+	followersNote.To = []string{env.local.ID, env.remoteActorID + "/followers"}
+	followersActivity := *baseActivity
+	followersActivity.Actor = env.remoteActorID
+	followersActivity.To = []string{env.local.ID, env.remoteActorID + "/followers"}
+	require.False(t, env.handler.classifyInboundDirectCreate(&followersActivity, &followersNote, env.local).isDirect)
+
+	groupNote := *baseNote
+	groupNote.To = []string{env.local.ID, "https://remote.example/users/carol"}
+	groupActivity := *baseActivity
+	groupActivity.Actor = env.remoteActorID
+	groupActivity.To = []string{env.local.ID, "https://remote.example/users/carol"}
+	groupInfo := env.handler.classifyInboundDirectCreate(&groupActivity, &groupNote, env.local)
+	require.False(t, groupInfo.isDirect)
+	require.True(t, groupInfo.unsupportedGroup)
+	require.Len(t, groupInfo.specificRecipients, 2)
+
+	require.False(t, env.handler.classifyInboundDirectCreate(nil, baseNote, env.local).isDirect)
+	require.False(t, env.handler.classifyInboundDirectCreate(baseActivity, nil, env.local).isDirect)
+	require.False(t, env.handler.classifyInboundDirectCreate(baseActivity, baseNote, nil).isDirect)
+}
+
+func TestInboxHandler_FederatedConversation_PrepareAndPersistUpdateBranch(t *testing.T) {
+	env := newInboxTestEnv(t)
+	ctx := context.Background()
+	conversations := inmemory.NewConversationRepository()
+	statuses := inmemory.NewStatusRepository()
+	env.handler.conversationRepository = conversations
+	env.handler.statusRepository = statuses
+
+	published := time.Date(2026, 4, 27, 16, 0, 0, 0, time.UTC)
+	note := &activitypub.Note{
+		BaseObject: activitypub.BaseObject{
+			Context:   activitypub.Context,
+			ID:        "https://remote.example/users/bob/statuses/direct-existing",
+			Type:      activitypub.NoteType,
+			Published: &published,
+			To:        []string{env.local.ID},
+		},
+		AttributedTo: env.remoteActorID,
+		Content:      "<p>existing direct</p>",
+	}
+	activity := remoteCreateActivityForNote(t, env.remoteActorID, note, "https://remote.example/activities/direct-existing")
+	info := env.handler.classifyInboundDirectCreate(activity, note, env.local)
+	require.True(t, info.isDirect)
+
+	statusID := models.CanonicalStatusIDForDomain(note.ID, env.handler.localDomain())
+	require.NoError(t, statuses.CreateStatus(ctx, &models.Status{
+		StatusID:       statusID,
+		AuthorID:       env.remoteActorID,
+		Content:        note.Content,
+		Visibility:     models.VisibilityDirect,
+		ConversationID: "conv-from-status",
+		PublishedAt:    published,
+		CreatedAt:      published,
+		UpdatedAt:      published,
+	}))
+
+	conversation, createConversation, err := env.handler.prepareInboundDirectConversation(ctx, activity, note, env.local, info)
+	require.NoError(t, err)
+	require.True(t, createConversation)
+	require.Equal(t, "conv-from-status", conversation.ID)
+
+	existing := &models.Conversation{
+		ID:              conversation.ID,
+		Participants:    models.ConversationParticipantIDsFromRefs(info.participantRefs),
+		ParticipantRefs: info.participantRefs,
+		CreatedAt:       published.Add(-time.Minute),
+		UpdatedAt:       published.Add(-time.Minute),
+	}
+	require.NoError(t, conversations.CreateConversationWithParticipantStates(ctx, existing, existing.Participants, nil))
+
+	status := &models.Status{
+		StatusID:       "remote-direct-update-status",
+		ConversationID: conversation.ID,
+		PublishedAt:    published.Add(time.Minute),
+	}
+	require.NoError(t, env.handler.persistInboundDirectConversation(ctx, existing, false, status, info))
+
+	stored, err := conversations.GetConversation(ctx, conversation.ID)
+	require.NoError(t, err)
+	require.Equal(t, status.StatusID, stored.LastStatusID)
+	require.Equal(t, int64(1), stored.TotalMessageCount)
+
+	stateResult, err := conversations.ListUserConversationStatesByFolder(ctx, "alice", interfaces.UserConversationFolder(models.UserConversationFolderInbox), interfaces.PaginationOptions{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, stateResult.Items, 1)
+	require.Equal(t, status.StatusID, stateResult.Items[0].PreviewStatusID)
+	require.Equal(t, env.remoteActorID, stateResult.Items[0].CounterpartID)
+}
+
+func TestInboxHandler_FederatedConversation_HelperFallbackBranches(t *testing.T) {
+	env := newInboxTestEnv(t)
+	ctx := context.Background()
+	require.Empty(t, env.handler.remoteNotificationActorLabel(""))
+
+	fallbackRef := inboundDirectRemoteParticipantRef(inboundDirectCreateInfo{
+		remoteActorID: "https://remote.example/users/fallback",
+		remoteAcct:    "fallback@remote.example",
+		remoteDomain:  "remote.example",
+	})
+	require.Equal(t, models.ConversationParticipantTypeRemoteActor, fallbackRef.ParticipantType)
+	require.Equal(t, "https://remote.example/users/fallback", fallbackRef.ParticipantID)
+
+	status := &models.Status{StatusID: "status-early", PublishedAt: time.Now().UTC()}
+	conversation := &models.Conversation{ID: "conv-early"}
+	env.handler.createRemoteDirectNotification(ctx, nil, env.local, nil, status, nil, inboundDirectCreateInfo{})
+	env.handler.createRemoteDirectNotification(ctx, nil, env.local, nil, status, conversation, inboundDirectCreateInfo{})
+	env.handler.createRemoteDirectNotification(ctx, nil, &activitypub.Actor{}, nil, status, conversation, inboundDirectCreateInfo{
+		localParticipantID: "",
+		remoteActorID:      "",
+	})
+	env.handler.emitInboundDirectConversationEvent(ctx, conversation, status, "alice")
+}

--- a/cmd/inbox/internal/routing/inbox.go
+++ b/cmd/inbox/internal/routing/inbox.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"runtime/debug"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -38,6 +39,8 @@ import (
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
 	"github.com/equaltoai/lesser/pkg/storage/theorydb"
+	"github.com/equaltoai/lesser/pkg/streaming"
+	"github.com/google/uuid"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	dynamormCore "github.com/theory-cloud/tabletheory/pkg/core"
 	dynamormerrors "github.com/theory-cloud/tabletheory/pkg/errors"
@@ -76,6 +79,7 @@ type InboxHandler struct {
 	relationshipRepository       interfaces.ConcreteRelationshipRepository
 	objectRepository             interfaces.ObjectRepository
 	statusRepository             interfaces.StatusRepository
+	conversationRepository       interfaces.ConversationRepository
 	likeRepository               *repositories.LikeRepository
 	socialRepository             *repositories.SocialRepository
 	federationActivityRepository *repositories.FederationActivityRepository
@@ -95,6 +99,7 @@ type InboxHandler struct {
 	deliveryService              *federation.DeliveryService
 	remoteActorResolver          inboxRemoteActorResolver
 	activityDeliverer            inboxActivityDeliverer
+	publisher                    streaming.Publisher
 	tableName                    string
 	storageAdapter               storageCore.RepositoryStorage
 	baseURL                      string
@@ -127,6 +132,7 @@ type extractedServices struct {
 	authMiddleware   *auth.Middleware
 	emfMetrics       *observability.EMFMetrics
 	alertManager     *monitoring.AlertManager
+	streamQueue      streaming.StreamQueueService
 }
 
 // federationServices holds federation-related services
@@ -152,6 +158,7 @@ type repositoryCollection struct {
 	followRepo             interfaces.ConcreteRelationshipRepository
 	objectRepo             interfaces.ObjectRepository
 	statusRepo             interfaces.StatusRepository
+	conversationRepo       interfaces.ConversationRepository
 	likeRepo               *repositories.LikeRepository
 	socialRepo             *repositories.SocialRepository
 	federationActivityRepo *repositories.FederationActivityRepository
@@ -194,6 +201,11 @@ func extractServicesFromContext(lambdaCtx *common.LambdaContext) extractedServic
 	}
 	if lambdaCtx.AlertManager != nil {
 		services.alertManager = lambdaCtx.AlertManager.(*monitoring.AlertManager)
+	}
+	if lambdaCtx.StreamQueue != nil {
+		if streamQueue, ok := lambdaCtx.StreamQueue.(streaming.StreamQueueService); ok {
+			services.streamQueue = streamQueue
+		}
 	}
 
 	return services
@@ -316,6 +328,7 @@ func initializeRepositories(repoFactory storageCore.RepositoryStorage, coreDB dy
 		followRepo:       repoFactory.Relationship(),
 		objectRepo:       repoFactory.Object(),
 		statusRepo:       repoFactory.Status(),
+		conversationRepo: repoFactory.Conversation(),
 		likeRepo:         repoFactory.Like(),
 		domainBlockRepo:  repoFactory.DomainBlock(),
 		userRepo:         repoFactory.User(),
@@ -371,6 +384,13 @@ func initializeRepositories(repoFactory storageCore.RepositoryStorage, coreDB dy
 	return repos
 }
 
+func inboxPublisherFromStreamQueue(streamQueue streaming.StreamQueueService, logger *zap.Logger) streaming.Publisher {
+	if streamQueue == nil {
+		return streaming.NewNoopPublisher()
+	}
+	return streaming.NewQueuePublisher(streamQueue, logger)
+}
+
 // NewInboxHandler creates a new inbox handler using standardized initialization
 func NewInboxHandler(lambdaCtx *common.LambdaContext) (*InboxHandler, error) {
 	logger := lambdaCtx.Logger
@@ -403,6 +423,7 @@ func NewInboxHandler(lambdaCtx *common.LambdaContext) (*InboxHandler, error) {
 		relationshipRepository:       repositories.followRepo,
 		objectRepository:             repositories.objectRepo,
 		statusRepository:             repositories.statusRepo,
+		conversationRepository:       repositories.conversationRepo,
 		likeRepository:               repositories.likeRepo,
 		socialRepository:             repositories.socialRepo,
 		federationActivityRepository: repositories.federationActivityRepo,
@@ -422,6 +443,7 @@ func NewInboxHandler(lambdaCtx *common.LambdaContext) (*InboxHandler, error) {
 		deliveryService:              federationServices.deliveryService,
 		remoteActorResolver:          federation.NewRemoteSearchService(repoFactory),
 		activityDeliverer:            federationServices.deliveryService,
+		publisher:                    inboxPublisherFromStreamQueue(services.streamQueue, logger),
 		tableName:                    cfg.DynamoTableName,
 		storageAdapter:               repoFactory,
 		baseURL:                      cfg.BaseURL(),
@@ -2369,9 +2391,30 @@ func (ih *InboxHandler) processRemoteCreateActivity(ctx context.Context, activit
 			return err
 		}
 
+		directInfo := ih.classifyInboundDirectCreate(activity, &note, targetActor)
+		if directInfo.unsupportedGroup {
+			ih.logUnsupportedInboundDirectGroup(activity, &note, targetActor, directInfo)
+			return nil
+		}
+
+		var directConversation *models.Conversation
+		var createDirectConversation bool
+		if directInfo.isDirect {
+			directConversation, createDirectConversation, err = ih.prepareInboundDirectConversation(ctx, activity, &note, targetActor, directInfo)
+			if err != nil {
+				log.Error("failed to prepare inbound direct conversation",
+					zap.String("activity_id", activity.ID),
+					zap.String("target_actor", targetActor.ID),
+					zap.Error(err))
+				return err
+			}
+			note.ConversationID = directConversation.ID
+			note.Visibility = models.VisibilityDirect
+		}
+
 		// Store the note (it will be marked as remote)
 		if err := ih.objectRepository.CreateObject(ctx, &note); err != nil {
-			if !dynamormerrors.IsConditionFailed(err) {
+			if !dynamormerrors.IsConditionFailed(err) && !stdErrors.Is(err, storage.ErrAlreadyExists) {
 				log.Error("failed to store remote note", zap.Error(err))
 				return err
 			}
@@ -2384,10 +2427,402 @@ func (ih *InboxHandler) processRemoteCreateActivity(ctx context.Context, activit
 				zap.Error(err))
 			return err
 		}
-		ih.createRemoteCreateNotifications(ctx, activity, targetActor, &note, status)
+		if directInfo.isDirect {
+			if err := ih.persistInboundDirectConversation(ctx, directConversation, createDirectConversation, status, directInfo); err != nil {
+				log.Error("failed to persist inbound direct conversation",
+					zap.String("activity_id", activity.ID),
+					zap.String("conversation_id", directConversation.ID),
+					zap.Error(err))
+				return err
+			}
+			ih.createRemoteDirectNotification(ctx, activity, targetActor, &note, status, directConversation, directInfo)
+			ih.emitInboundDirectConversationEvent(ctx, directConversation, status, directInfo.localParticipantID)
+		} else {
+			ih.createRemoteCreateNotifications(ctx, activity, targetActor, &note, status)
+		}
 	}
 
 	return nil
+}
+
+type inboundDirectCreateInfo struct {
+	isDirect           bool
+	unsupportedGroup   bool
+	participantRefs    []models.ConversationParticipantRef
+	localParticipantID string
+	remoteActorID      string
+	remoteAcct         string
+	remoteDomain       string
+	specificRecipients []string
+}
+
+type inboundDirectConversationLookupRepository interface {
+	GetConversationByParticipantRefs(ctx context.Context, refs []models.ConversationParticipantRef) (*models.Conversation, error)
+}
+
+func (ih *InboxHandler) classifyInboundDirectCreate(activity *activitypub.Activity, note *activitypub.Note, targetActor *activitypub.Actor) inboundDirectCreateInfo {
+	info := inboundDirectCreateInfo{}
+	if activity == nil || note == nil || targetActor == nil {
+		return info
+	}
+
+	targetIDs := ih.localTargetActorIDs(targetActor)
+	actorID := strings.TrimRight(strings.TrimSpace(activity.Actor), "/")
+	if actorID == "" {
+		actorID = strings.TrimRight(strings.TrimSpace(note.AttributedTo), "/")
+	}
+
+	recipients, hasPublic, hasCollection, targetsLocalActor := ih.inboundDirectSpecificRecipients(activity, note, targetIDs, actorID)
+	info.specificRecipients = recipients
+	if hasPublic || hasCollection || !targetsLocalActor {
+		return info
+	}
+	if len(recipients) > 1 {
+		info.unsupportedGroup = true
+		return info
+	}
+	if len(recipients) != 1 {
+		return info
+	}
+
+	localParticipantID := strings.TrimSpace(targetActor.PreferredUsername)
+	if localParticipantID == "" {
+		localParticipantID = ih.extractUsernameFromActorID(targetActor.ID)
+	}
+	if localParticipantID == "" || actorID == "" {
+		return info
+	}
+
+	identity := federation.DescribeActorIdentity(&activitypub.Actor{
+		BaseObject: activitypub.BaseObject{ID: actorID, Type: activitypub.PersonType},
+	}, ih.localDomain())
+	now := remoteCreateNotificationCreatedAt(activity, note, nil)
+	remoteRef := models.NormalizeConversationParticipantRef(models.ConversationParticipantRef{
+		ParticipantType: models.ConversationParticipantTypeRemoteActor,
+		ParticipantID:   actorID,
+		Acct:            identity.Acct,
+		Domain:          identity.Domain,
+		ResolvedAt:      &now,
+	})
+
+	info.isDirect = true
+	info.localParticipantID = localParticipantID
+	info.remoteActorID = actorID
+	info.remoteAcct = remoteRef.Acct
+	info.remoteDomain = remoteRef.Domain
+	info.participantRefs = models.NormalizeConversationParticipantRefs([]models.ConversationParticipantRef{
+		{
+			ParticipantType: models.ConversationParticipantTypeLocalUser,
+			ParticipantID:   localParticipantID,
+		},
+		remoteRef,
+	})
+	return info
+}
+
+func (ih *InboxHandler) inboundDirectSpecificRecipients(
+	activity *activitypub.Activity,
+	note *activitypub.Note,
+	targetIDs map[string]struct{},
+	actorID string,
+) ([]string, bool, bool, bool) {
+	seen := map[string]string{}
+	hasPublic := false
+	hasCollection := false
+	targetsLocalActor := false
+	actorKey := strings.ToLower(strings.TrimRight(actorID, "/"))
+
+	visit := func(raw string) {
+		recipient := strings.TrimRight(strings.TrimSpace(raw), "/")
+		if recipient == "" {
+			return
+		}
+		recipientKey := strings.ToLower(recipient)
+		if recipientKey == strings.ToLower(strings.TrimRight(activitypub.PublicAddress, "/")) {
+			hasPublic = true
+			return
+		}
+		if isInboundDirectCollectionRecipient(recipient) {
+			hasCollection = true
+			return
+		}
+		if _, ok := targetIDs[recipientKey]; ok {
+			targetsLocalActor = true
+		}
+		if actorKey != "" && recipientKey == actorKey {
+			return
+		}
+		seen[recipientKey] = recipient
+	}
+
+	for _, recipient := range activity.To {
+		visit(recipient)
+	}
+	for _, recipient := range activity.CC {
+		visit(recipient)
+	}
+	for _, recipient := range activity.BTo {
+		visit(recipient)
+	}
+	for _, recipient := range activity.BCC {
+		visit(recipient)
+	}
+	for _, recipient := range note.To {
+		visit(recipient)
+	}
+	for _, recipient := range note.CC {
+		visit(recipient)
+	}
+	for _, recipient := range note.BTo {
+		visit(recipient)
+	}
+	for _, recipient := range note.BCC {
+		visit(recipient)
+	}
+
+	recipients := make([]string, 0, len(seen))
+	for _, recipient := range seen {
+		recipients = append(recipients, recipient)
+	}
+	sort.Strings(recipients)
+	return recipients, hasPublic, hasCollection, targetsLocalActor
+}
+
+func isInboundDirectCollectionRecipient(recipient string) bool {
+	recipient = strings.ToLower(strings.TrimSpace(recipient))
+	return strings.Contains(recipient, "/followers") ||
+		strings.Contains(recipient, "/following") ||
+		strings.HasSuffix(recipient, "/collections/featured") ||
+		strings.HasSuffix(recipient, "/featured")
+}
+
+func (ih *InboxHandler) logUnsupportedInboundDirectGroup(activity *activitypub.Activity, note *activitypub.Note, targetActor *activitypub.Actor, info inboundDirectCreateInfo) {
+	if ih.logger == nil {
+		return
+	}
+	ih.logger.Info("unsupported_direct_group",
+		zap.String("activity_id", strings.TrimSpace(activity.ID)),
+		zap.String("note_id", strings.TrimSpace(note.ID)),
+		zap.String("actor_id", strings.TrimSpace(activity.Actor)),
+		zap.String("target_actor", strings.TrimSpace(targetActor.ID)),
+		zap.Strings("specific_recipients", info.specificRecipients),
+		zap.Int("specific_recipient_count", len(info.specificRecipients)))
+}
+
+func (ih *InboxHandler) prepareInboundDirectConversation(
+	ctx context.Context,
+	activity *activitypub.Activity,
+	note *activitypub.Note,
+	_ *activitypub.Actor,
+	info inboundDirectCreateInfo,
+) (*models.Conversation, bool, error) {
+	if ih.conversationRepository == nil {
+		return nil, false, fmt.Errorf("conversation repository not configured")
+	}
+
+	participants := models.ConversationParticipantIDsFromRefs(info.participantRefs)
+	if len(participants) != 2 {
+		return nil, false, fmt.Errorf("inbound direct conversation requires exactly two participants")
+	}
+
+	if typedRepo, ok := ih.conversationRepository.(inboundDirectConversationLookupRepository); ok {
+		conversation, err := typedRepo.GetConversationByParticipantRefs(ctx, info.participantRefs)
+		if err == nil && conversation != nil && strings.TrimSpace(conversation.ID) != "" {
+			return conversation, false, nil
+		}
+		if err != nil && !isInboundDirectNotFound(err) {
+			return nil, false, err
+		}
+	} else {
+		conversation, err := ih.conversationRepository.GetConversationByParticipants(ctx, participants)
+		if err == nil && conversation != nil && strings.TrimSpace(conversation.ID) != "" {
+			return conversation, false, nil
+		}
+		if err != nil && !isInboundDirectNotFound(err) {
+			return nil, false, err
+		}
+	}
+
+	conversationID := ""
+	statusID := models.CanonicalStatusIDForDomain(note.ID, ih.localDomain())
+	if statusID != "" && ih.statusRepository != nil {
+		if existing, err := ih.statusRepository.GetStatus(ctx, statusID); err == nil && existing != nil {
+			conversationID = strings.TrimSpace(existing.ConversationID)
+		}
+	}
+	if conversationID == "" {
+		conversationID = uuid.NewString()
+	}
+
+	now := remoteCreateNotificationCreatedAt(activity, note, nil)
+	return &models.Conversation{
+		ID:              conversationID,
+		Participants:    participants,
+		ParticipantRefs: info.participantRefs,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastMessageTime: now,
+	}, true, nil
+}
+
+func (ih *InboxHandler) persistInboundDirectConversation(
+	ctx context.Context,
+	conversation *models.Conversation,
+	createConversation bool,
+	status *models.Status,
+	info inboundDirectCreateInfo,
+) error {
+	if ih.conversationRepository == nil || conversation == nil || status == nil {
+		return nil
+	}
+
+	publishedAt := status.PublishedAt.UTC()
+	if publishedAt.IsZero() {
+		publishedAt = time.Now().UTC()
+	}
+
+	if conversation.LastStatusID != status.StatusID {
+		conversation.TotalMessageCount++
+	}
+	conversation.LastStatusID = status.StatusID
+	conversation.LastMessageTime = publishedAt
+	conversation.UpdatedAt = publishedAt
+	conversation.ParticipantRefs = models.NormalizeConversationParticipantRefs(conversation.ParticipantRefs)
+	if len(conversation.ParticipantRefs) == 0 {
+		conversation.ParticipantRefs = info.participantRefs
+	}
+	conversation.Participants = models.ConversationParticipantIDsFromRefs(conversation.ParticipantRefs)
+
+	remoteRef := inboundDirectRemoteParticipantRef(info)
+	state := &models.UserConversationState{
+		ViewerID:                 info.localParticipantID,
+		ConversationID:           conversation.ID,
+		CounterpartID:            info.remoteActorID,
+		CounterpartType:          remoteRef.ParticipantType,
+		CounterpartAcct:          remoteRef.Acct,
+		CounterpartDomain:        remoteRef.Domain,
+		CounterpartResolvedAt:    remoteRef.ResolvedAt,
+		Folder:                   models.UserConversationFolderInbox,
+		RequestState:             models.DmRequestStateAccepted,
+		PreviewStatusID:          status.StatusID,
+		PreviewStatusPublishedAt: publishedAt,
+		SortAt:                   publishedAt,
+		Unread:                   true,
+		CreatedAt:                conversation.CreatedAt,
+		UpdatedAt:                publishedAt,
+	}
+
+	if createConversation {
+		if err := ih.conversationRepository.CreateConversationWithParticipantStates(ctx, conversation, conversation.Participants, []*models.UserConversationState{state}); err != nil {
+			if !stdErrors.Is(err, storage.ErrAlreadyExists) {
+				return err
+			}
+			createConversation = false
+		}
+	}
+	if !createConversation {
+		if err := ih.conversationRepository.UpdateConversation(ctx, conversation); err != nil && !isInboundDirectNotFound(err) {
+			return err
+		}
+		if err := ih.conversationRepository.PutUserConversationState(ctx, state); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func inboundDirectRemoteParticipantRef(info inboundDirectCreateInfo) models.ConversationParticipantRef {
+	for _, ref := range models.NormalizeConversationParticipantRefs(info.participantRefs) {
+		if ref.ParticipantType == models.ConversationParticipantTypeRemoteActor {
+			return ref
+		}
+	}
+	return models.NormalizeConversationParticipantRef(models.ConversationParticipantRef{
+		ParticipantType: models.ConversationParticipantTypeRemoteActor,
+		ParticipantID:   info.remoteActorID,
+		Acct:            info.remoteAcct,
+		Domain:          info.remoteDomain,
+	})
+}
+
+func isInboundDirectNotFound(err error) bool {
+	return isRemoteStatusNotFound(err) || stdErrors.Is(err, storage.ErrNotFound)
+}
+
+func (ih *InboxHandler) createRemoteDirectNotification(
+	ctx context.Context,
+	activity *activitypub.Activity,
+	targetActor *activitypub.Actor,
+	note *activitypub.Note,
+	status *models.Status,
+	conversation *models.Conversation,
+	info inboundDirectCreateInfo,
+) {
+	if conversation == nil || status == nil {
+		return
+	}
+	recipient := info.localParticipantID
+	if recipient == "" && targetActor != nil {
+		recipient = strings.TrimSpace(targetActor.PreferredUsername)
+	}
+	if recipient == "" || info.remoteActorID == "" {
+		return
+	}
+
+	ih.createRemoteCreateNotification(ctx, remoteCreateNotificationInput{
+		kind:      common.NotificationTypeMention,
+		recipient: recipient,
+		actorID:   info.remoteActorID,
+		activity:  activity,
+		note:      note,
+		status:    status,
+		title:     fmt.Sprintf("%s sent you a direct message", ih.remoteNotificationActorLabel(info.remoteActorID)),
+		body:      fmt.Sprintf("%s sent you a direct message", ih.remoteNotificationActorLabel(info.remoteActorID)),
+		groupKey:  fmt.Sprintf("remote-direct:%s:%s", recipient, conversation.ID),
+		extraData: map[string]interface{}{
+			"conversationID":  conversation.ID,
+			"conversation_id": conversation.ID,
+			"visibility":      models.VisibilityDirect,
+			"actorID":         info.remoteActorID,
+			"actor_id":        info.remoteActorID,
+			"targetID":        status.StatusID,
+			"target_id":       status.StatusID,
+		},
+		stableParts: []string{strings.TrimSpace(activity.ID), recipient},
+	})
+}
+
+func (ih *InboxHandler) emitInboundDirectConversationEvent(ctx context.Context, conversation *models.Conversation, status *models.Status, localRecipient string) {
+	if ih.publisher == nil || conversation == nil || status == nil || localRecipient == "" {
+		return
+	}
+
+	event := &streaming.Event{
+		Type:      "conversation.message",
+		Timestamp: time.Now().UTC(),
+		Payload: map[string]interface{}{
+			"message":      status,
+			"conversation": conversation,
+		},
+	}
+
+	conversationEvent := *event
+	conversationEvent.Stream = fmt.Sprintf("conversation:%s", conversation.ID)
+	if err := ih.publisher.PublishToConversation(ctx, conversation.ID, &conversationEvent); err != nil && ih.logger != nil {
+		ih.logger.Warn("failed to publish inbound direct conversation event",
+			zap.String("conversation_id", conversation.ID),
+			zap.Error(err))
+	}
+
+	userEvent := *event
+	userEvent.Stream = fmt.Sprintf("user:%s:direct", localRecipient)
+	if err := ih.publisher.PublishToUser(ctx, localRecipient, &userEvent); err != nil && ih.logger != nil {
+		ih.logger.Warn("failed to publish inbound direct user event",
+			zap.String("conversation_id", conversation.ID),
+			zap.String("recipient", localRecipient),
+			zap.Error(err))
+	}
 }
 
 func (ih *InboxHandler) createRemoteCreateNotifications(

--- a/cmd/inbox/internal/routing/project20_create_idempotency_notifications_test.go
+++ b/cmd/inbox/internal/routing/project20_create_idempotency_notifications_test.go
@@ -128,11 +128,13 @@ func TestInboxHandler_Project20_RemoteCreateMentionNotificationIsDeterministic(t
 	require.Contains(t, result.Items[0].Data, "postSnapshot")
 }
 
-func TestInboxHandler_Project20_RemoteCreateReplyNotificationTargetsLocalParentAuthor(t *testing.T) {
+func TestInboxHandler_Project20_RemoteDirectReplyCreatesMentionNotification(t *testing.T) {
 	env := newInboxTestEnv(t)
 	notifications := inmemory.NewNotificationRepository()
+	conversations := inmemory.NewConversationRepository()
 	parentURL := env.cfg.BaseURL() + "/users/alice/statuses/parent-1"
 	env.handler.notificationRepository = notifications
+	env.handler.conversationRepository = conversations
 	env.handler.statusRepository = newProject20StatusRepo(&models.Status{
 		StatusID:       "parent-1",
 		AuthorID:       env.local.ID,
@@ -159,9 +161,16 @@ func TestInboxHandler_Project20_RemoteCreateReplyNotificationTargetsLocalParentA
 	result, err := notifications.GetUserNotifications(context.Background(), "alice", interfaces.PaginationOptions{Limit: 10})
 	require.NoError(t, err)
 	require.Len(t, result.Items, 1)
-	require.Equal(t, common.NotificationTypeReply, result.Items[0].Type)
-	require.Equal(t, "parent-1", result.Items[0].Data["parent_status_id"])
+	require.Equal(t, common.NotificationTypeMention, result.Items[0].Type)
+	require.Equal(t, models.VisibilityDirect, result.Items[0].Data["visibility"])
+	require.NotEmpty(t, result.Items[0].Data["conversationID"])
 	require.Contains(t, result.Items[0].Data, "postSnapshot")
+
+	stateResult, err := conversations.ListUserConversationStatesByFolder(context.Background(), "alice", interfaces.UserConversationFolder(models.UserConversationFolderInbox), interfaces.PaginationOptions{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, stateResult.Items, 1)
+	require.Equal(t, result.Items[0].Data["conversationID"], stateResult.Items[0].ConversationID)
+	require.Equal(t, env.remoteActorID, stateResult.Items[0].CounterpartID)
 }
 
 type project20StatusRepo struct {

--- a/cmd/inbox/internal/routing/round10_test_helpers_test.go
+++ b/cmd/inbox/internal/routing/round10_test_helpers_test.go
@@ -84,7 +84,7 @@ func (db *extendedMockDB) TransactionFunc(fn func(tx any) error) error { return 
 func (db *extendedMockDB) Transact() dynamormCore.TransactionBuilder { return nil }
 
 func (db *extendedMockDB) TransactWrite(_ context.Context, fn func(dynamormCore.TransactionBuilder) error) error {
-	return fn(nil)
+	return fn(&mocks.MockTransactionBuilder{})
 }
 
 func newInboxTestEnv(t *testing.T) *inboxTestEnv {

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -2306,7 +2306,7 @@ components:
                 status:
                     type: string
                 visibility:
-                    description: Status visibility. `direct` messages must mention exactly one recipient using an @mention in the status content.
+                    description: Status visibility. `direct` messages must mention exactly one local or remote recipient using an @mention in the status content; group direct messages are not supported in v1.
                     enum:
                         - public
                         - unlisted

--- a/graph/conversation_list_prefetch.go
+++ b/graph/conversation_list_prefetch.go
@@ -69,17 +69,22 @@ func conversationListParticipantUsernames(conv *storagemodels.Conversation, view
 	}
 
 	viewerUsername = strings.ToLower(strings.TrimSpace(viewerUsername))
-	seen := make(map[string]struct{}, len(conv.Participants))
-	usernames := make([]string, 0, len(conv.Participants))
-	for _, participant := range conv.Participants {
-		candidate := strings.ToLower(strings.TrimSpace(participant))
+	refs := conversationListParticipantRefsForProjection(conv)
+	seen := make(map[string]struct{}, len(refs))
+	usernames := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		candidate := strings.TrimSpace(ref.ParticipantID)
+		if ref.ParticipantType != storagemodels.ConversationParticipantTypeRemoteActor {
+			candidate = strings.ToLower(candidate)
+		}
 		if candidate == "" || candidate == viewerUsername {
 			continue
 		}
-		if _, ok := seen[candidate]; ok {
+		key := strings.ToLower(candidate)
+		if _, ok := seen[key]; ok {
 			continue
 		}
-		seen[candidate] = struct{}{}
+		seen[key] = struct{}{}
 		usernames = append(usernames, candidate)
 	}
 
@@ -90,6 +95,40 @@ func conversationListParticipantUsernames(conv *storagemodels.Conversation, view
 	}
 
 	return usernames
+}
+
+func conversationListParticipantRefsForProjection(conv *storagemodels.Conversation) []storagemodels.ConversationParticipantRef {
+	if conv == nil {
+		return nil
+	}
+	if len(conv.ParticipantRefs) > 0 {
+		return storagemodels.NormalizeConversationParticipantRefs(conv.ParticipantRefs)
+	}
+	refs := make([]storagemodels.ConversationParticipantRef, 0, len(conv.Participants))
+	for _, participant := range conv.Participants {
+		participant = strings.TrimSpace(participant)
+		if participant == "" {
+			continue
+		}
+		participantType := storagemodels.ConversationParticipantTypeLocalUser
+		if strings.Contains(participant, "://") {
+			participantType = storagemodels.ConversationParticipantTypeRemoteActor
+		}
+		refs = append(refs, storagemodels.ConversationParticipantRef{
+			ParticipantType: participantType,
+			ParticipantID:   participant,
+		})
+	}
+	if conv.ViewerState != nil && conv.ViewerState.CounterpartID != "" {
+		refs = append(refs, storagemodels.ConversationParticipantRef{
+			ParticipantType: conv.ViewerState.CounterpartType,
+			ParticipantID:   conv.ViewerState.CounterpartID,
+			Acct:            conv.ViewerState.CounterpartAcct,
+			Domain:          conv.ViewerState.CounterpartDomain,
+			ResolvedAt:      conv.ViewerState.CounterpartResolvedAt,
+		})
+	}
+	return storagemodels.NormalizeConversationParticipantRefs(refs)
 }
 
 func conversationAccountPrefetchKeys(account *storage.Account) []string {
@@ -186,6 +225,8 @@ func (r *Resolver) loadConversationListPrefetch(ctx context.Context, viewerUsern
 		}
 	}
 
+	r.addRemoteConversationAccountsToPrefetch(ctx, conversations, prefetch)
+
 	if len(statusIDs) > 0 && storageRepo.Status() != nil {
 		if statuses, err := storageRepo.Status().GetStatusesByIDs(ctx, statusIDs); err == nil {
 			prefetch.statusesByID = buildConversationStatusMap(statuses)
@@ -196,6 +237,30 @@ func (r *Resolver) loadConversationListPrefetch(ctx context.Context, viewerUsern
 	}
 
 	return prefetch
+}
+
+func (r *Resolver) addRemoteConversationAccountsToPrefetch(ctx context.Context, conversations []*storagemodels.Conversation, prefetch *conversationListPrefetch) {
+	if r == nil || r.Registry == nil || prefetch == nil {
+		return
+	}
+	storageRepo := r.Registry.GetStorage()
+	if storageRepo == nil || storageRepo.Actor() == nil {
+		return
+	}
+	for _, conv := range conversations {
+		for _, ref := range conversationListParticipantRefsForProjection(conv) {
+			if ref.ParticipantType != storagemodels.ConversationParticipantTypeRemoteActor {
+				continue
+			}
+			account := r.conversationRemoteAccountForParticipantRef(ctx, ref)
+			if account == nil {
+				continue
+			}
+			for _, key := range conversationAccountPrefetchKeys(account) {
+				prefetch.accountsByKey[key] = account
+			}
+		}
+	}
 }
 
 func (r *Resolver) conversationAccountByIdentifier(ctx context.Context, participantID string) *storage.Account {
@@ -232,27 +297,98 @@ func (r *Resolver) prefetchedConversationAccount(prefetch *conversationListPrefe
 	return nil
 }
 
-func (r *Resolver) conversationAccountsFromPrefetch(ctx context.Context, participantIDs []string, viewerUsername string, prefetch *conversationListPrefetch) []*activitypub.Actor {
+func (r *Resolver) prefetchedConversationAccountForRef(prefetch *conversationListPrefetch, ref storagemodels.ConversationParticipantRef) *storage.Account {
+	ref = storagemodels.NormalizeConversationParticipantRef(ref)
+	if prefetch == nil || ref.ParticipantID == "" {
+		return nil
+	}
+	if account := prefetch.accountsByKey[strings.ToLower(ref.ParticipantID)]; account != nil {
+		return account
+	}
+	if ref.Acct != "" {
+		if account := prefetch.accountsByKey[strings.ToLower(ref.Acct)]; account != nil {
+			return account
+		}
+	}
+	return r.prefetchedConversationAccount(prefetch, ref.ParticipantID)
+}
+
+func (r *Resolver) conversationRemoteAccountForParticipantRef(ctx context.Context, ref storagemodels.ConversationParticipantRef) *storage.Account {
+	ref = storagemodels.NormalizeConversationParticipantRef(ref)
+	if ref.ParticipantID == "" || r == nil || r.Registry == nil {
+		return nil
+	}
+	store := r.Registry.GetStorage()
+	if store != nil && store.Actor() != nil {
+		for _, candidate := range []string{ref.ParticipantID, ref.Acct} {
+			candidate = strings.TrimSpace(candidate)
+			if candidate == "" {
+				continue
+			}
+			actor, err := store.Actor().GetCachedRemoteActor(ctx, candidate)
+			if err == nil && actor != nil {
+				return &storage.Account{Actor: actor}
+			}
+		}
+	}
+	return &storage.Account{Actor: conversationGraphSyntheticRemoteActor(ref)}
+}
+
+func conversationGraphSyntheticRemoteActor(ref storagemodels.ConversationParticipantRef) *activitypub.Actor {
+	ref = storagemodels.NormalizeConversationParticipantRef(ref)
+	username := strings.TrimSpace(ref.Acct)
+	if username != "" {
+		if handleUser, _, ok := strings.Cut(username, "@"); ok {
+			username = handleUser
+		}
+	}
+	if username == "" {
+		username = strings.TrimSpace(extractUsernameFromActorIdentifier(ref.ParticipantID))
+	}
+	if username == "" {
+		username = strings.TrimSpace(ref.ParticipantID)
+	}
+	return &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   ref.ParticipantID,
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: username,
+		Name:              username,
+		URL:               ref.ParticipantID,
+	}
+}
+
+func (r *Resolver) conversationAccountsFromParticipantRefs(ctx context.Context, refs []storagemodels.ConversationParticipantRef, viewerUsername string, prefetch *conversationListPrefetch) []*activitypub.Actor {
 	if r == nil {
 		return nil
 	}
 
-	actors := make([]*activitypub.Actor, 0, len(participantIDs))
-	seen := make(map[string]struct{}, len(participantIDs))
+	refs = storagemodels.NormalizeConversationParticipantRefs(refs)
+	actors := make([]*activitypub.Actor, 0, len(refs))
+	seen := make(map[string]struct{}, len(refs))
 	viewerUsername = strings.ToLower(strings.TrimSpace(viewerUsername))
-	for _, participant := range participantIDs {
-		candidate := strings.ToLower(strings.TrimSpace(participant))
+	for _, ref := range refs {
+		candidate := strings.TrimSpace(ref.ParticipantID)
+		if ref.ParticipantType != storagemodels.ConversationParticipantTypeRemoteActor {
+			candidate = strings.ToLower(candidate)
+		}
 		if candidate == "" || candidate == viewerUsername {
 			continue
 		}
-		if _, ok := seen[candidate]; ok {
+		key := strings.ToLower(candidate)
+		if _, ok := seen[key]; ok {
 			continue
 		}
-		seen[candidate] = struct{}{}
+		seen[key] = struct{}{}
 
-		account := r.prefetchedConversationAccount(prefetch, participant)
+		account := r.prefetchedConversationAccountForRef(prefetch, ref)
 		if account == nil {
-			account = r.conversationAccountByIdentifier(ctx, participant)
+			if ref.ParticipantType == storagemodels.ConversationParticipantTypeRemoteActor {
+				account = r.conversationRemoteAccountForParticipantRef(ctx, ref)
+			} else {
+				account = r.conversationAccountByIdentifier(ctx, ref.ParticipantID)
+			}
 		}
 		if account == nil {
 			continue
@@ -300,7 +436,7 @@ func (r *Resolver) convertConversationListToGraphQL(ctx context.Context, conv *s
 
 	viewerUsername := getUsernameFromContext(ctx)
 	viewerMetadata := conversationListViewerMetadata(conv.ViewerState)
-	accounts := r.conversationAccountsFromPrefetch(ctx, conv.Participants, viewerUsername, prefetch)
+	accounts := r.conversationAccountsFromParticipantRefs(ctx, conversationListParticipantRefsForProjection(conv), viewerUsername, prefetch)
 	lastStatus := r.conversationListLastStatus(ctx, conv, viewerUsername, prefetch)
 
 	return &model.Conversation{

--- a/graph/conversation_list_prefetch_test.go
+++ b/graph/conversation_list_prefetch_test.go
@@ -148,7 +148,38 @@ func TestRound12_ConversationAccountsFromPrefetch_UsesFederatedParticipantKeys(t
 		statusesReady: true,
 	}
 
-	actors := resolver.conversationAccountsFromPrefetch(round12AuthContext("alice"), []string{"alice", remoteID}, "alice", prefetch)
+	actors := resolver.conversationAccountsFromParticipantRefs(round12AuthContext("alice"), []storagemodels.ConversationParticipantRef{
+		{
+			ParticipantType: storagemodels.ConversationParticipantTypeLocalUser,
+			ParticipantID:   "alice",
+		},
+		{
+			ParticipantType: storagemodels.ConversationParticipantTypeRemoteActor,
+			ParticipantID:   remoteID,
+		},
+	}, "alice", prefetch)
+	require.Len(t, actors, 1)
+	require.Equal(t, remoteID, actors[0].ID)
+	require.Equal(t, "bob", actors[0].PreferredUsername)
+}
+
+func TestConversationAccountsFromParticipantRefs_UsesSyntheticRemoteFallback(t *testing.T) {
+	resolver, _, _, _, _ := newRound12GraphResolverWithMocks(t)
+	remoteID := "https://remote.example/users/bob"
+
+	actors := resolver.conversationAccountsFromParticipantRefs(round12AuthContext("alice"), []storagemodels.ConversationParticipantRef{
+		{
+			ParticipantType: storagemodels.ConversationParticipantTypeLocalUser,
+			ParticipantID:   "alice",
+		},
+		{
+			ParticipantType: storagemodels.ConversationParticipantTypeRemoteActor,
+			ParticipantID:   remoteID,
+			Acct:            "bob@remote.example",
+			Domain:          "remote.example",
+		},
+	}, "alice", &conversationListPrefetch{accountsByKey: map[string]*storage.Account{}})
+
 	require.Len(t, actors, 1)
 	require.Equal(t, remoteID, actors[0].ID)
 	require.Equal(t, "bob", actors[0].PreferredUsername)

--- a/pkg/federation/remote_note_materialization.go
+++ b/pkg/federation/remote_note_materialization.go
@@ -2,9 +2,11 @@ package federation
 
 import (
 	"context"
+	stdErrors "errors"
 	"fmt"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	dynamormerrors "github.com/theory-cloud/tabletheory/pkg/errors"
 )
@@ -36,7 +38,7 @@ func MaterializeRemoteNote(
 	}
 
 	if objectRepo != nil {
-		if err := objectRepo.CreateObject(ctx, note); err != nil && !dynamormerrors.IsConditionFailed(err) {
+		if err := objectRepo.CreateObject(ctx, note); err != nil && !dynamormerrors.IsConditionFailed(err) && !stdErrors.Is(err, storage.ErrAlreadyExists) {
 			return nil, err
 		}
 	}

--- a/pkg/services/conversations/service.go
+++ b/pkg/services/conversations/service.go
@@ -59,6 +59,10 @@ type FederationService interface {
 	QueueActivity(ctx context.Context, activity *activitypub.Activity) error
 }
 
+type remoteActorResolver interface {
+	ResolveActor(ctx context.Context, handle string) (*activitypub.Actor, error)
+}
+
 type directMessageTombstoneRepository interface {
 	CreateTombstone(ctx context.Context, viewerUsername, statusID string) error
 	TombstonesByStatusID(ctx context.Context, viewerUsername string, statusIDs []string) (map[string]bool, error)
@@ -176,15 +180,17 @@ type apiRateLimitInfoReader interface {
 
 // SendDirectMessageCommand contains all data needed to send a direct message
 type SendDirectMessageCommand struct {
-	SenderID         string                            `json:"sender_id" validate:"required"`
-	Recipients       []string                          `json:"recipients" validate:"required,min=1"`
-	Content          string                            `json:"content" validate:"required,max=5000"`
-	Sensitive        bool                              `json:"sensitive"`
-	SpoilerText      string                            `json:"spoiler_text"`
-	Language         string                            `json:"language"`
-	MediaIDs         []string                          `json:"media_ids"`
-	InReplyToID      string                            `json:"in_reply_to_id"` // Can reply to messages in the conversation
-	AgentAttribution *activitypub.AgentPostAttribution `json:"agent_attribution,omitempty"`
+	SenderID               string                             `json:"sender_id" validate:"required"`
+	Recipients             []string                           `json:"recipients" validate:"required,min=1"`
+	Content                string                             `json:"content" validate:"required,max=5000"`
+	Sensitive              bool                               `json:"sensitive"`
+	SpoilerText            string                             `json:"spoiler_text"`
+	Language               string                             `json:"language"`
+	MediaIDs               []string                           `json:"media_ids"`
+	InReplyToID            string                             `json:"in_reply_to_id"` // Can reply to messages in the conversation
+	AgentAttribution       *activitypub.AgentPostAttribution  `json:"agent_attribution,omitempty"`
+	ResolvedRecipientActor *activitypub.Actor                 `json:"-"`
+	ResolvedRecipientRef   *models.ConversationParticipantRef `json:"-"`
 }
 
 // MarkConversationReadCommand contains data needed to mark a conversation as read
@@ -482,6 +488,21 @@ func (s *Service) getDirectMessageAccounts(ctx context.Context, cmd *SendDirectM
 	}
 
 	recipientAccounts := make(map[string]*storage.Account, 1)
+	if isRemoteDirectMessageRecipientIdentifier(recipientID, s.domainName) {
+		recipient, recipientRef, err := s.resolveRemoteDirectMessageRecipient(ctx, recipientID)
+		if err != nil {
+			s.logger.Error("invalid remote recipient", zap.String("recipient_id", recipientID), zap.Error(err))
+			s.auditDMEvent(ctx, cmd, "", false, "resolve_remote_recipient_failed", map[string]any{
+				"recipient_id": recipientID,
+			})
+			return nil, nil, nil, errors.Join(ErrInvalidRecipient, err)
+		}
+		cmd.ResolvedRecipientActor = recipient.Actor
+		cmd.ResolvedRecipientRef = recipientRef
+		recipientAccounts[recipientRef.ParticipantID] = recipient
+		return sender, recipient, recipientAccounts, nil
+	}
+
 	recipient, err := s.accountRepo.GetAccount(ctx, recipientID)
 	if err != nil {
 		s.logger.Error("invalid recipient", zap.String("recipient_id", recipientID), zap.Error(err))
@@ -494,6 +515,93 @@ func (s *Service) getDirectMessageAccounts(ctx context.Context, cmd *SendDirectM
 	recipientAccounts[resolvedRecipientID] = recipient
 
 	return sender, recipient, recipientAccounts, nil
+}
+
+func isRemoteDirectMessageRecipientIdentifier(recipientID, localDomain string) bool {
+	recipientID = strings.TrimSpace(recipientID)
+	if recipientID == "" {
+		return false
+	}
+
+	normalizedLocalDomain := normalizeDirectMessageMentionDomain(localDomain)
+	if parsed, err := url.Parse(recipientID); err == nil && parsed.Scheme != "" && parsed.Hostname() != "" {
+		return normalizeDirectMessageMentionDomain(parsed.Hostname()) != normalizedLocalDomain
+	}
+
+	_, domain := directMessageMentionHandleParts(recipientID)
+	return domain != "" && normalizeDirectMessageMentionDomain(domain) != normalizedLocalDomain
+}
+
+func (s *Service) resolveRemoteDirectMessageRecipient(ctx context.Context, recipientID string) (*storage.Account, *models.ConversationParticipantRef, error) {
+	resolver, ok := s.federation.(remoteActorResolver)
+	if !ok || resolver == nil {
+		return nil, nil, errDirectMessageRemoteRecipientActorRequired
+	}
+
+	actor, err := resolver.ResolveActor(ctx, recipientID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if actor == nil || strings.TrimSpace(actor.ID) == "" {
+		return nil, nil, errDirectMessageRemoteRecipientActorRequired
+	}
+
+	username, domain := normalizeDirectMessageMentionAccount(recipientID, nil, s.domainName)
+	if username == "" || domain == "" {
+		identity := federationActorIdentityForDirectMessage(actor, s.domainName)
+		username = identity.username
+		domain = identity.domain
+	}
+	acct := strings.TrimSpace(username)
+	if domain != "" && !strings.Contains(acct, "@") {
+		acct += "@" + domain
+	}
+	now := time.Now().UTC()
+	ref := models.NormalizeConversationParticipantRef(models.ConversationParticipantRef{
+		ParticipantType: models.ConversationParticipantTypeRemoteActor,
+		ParticipantID:   actor.ID,
+		Acct:            acct,
+		Domain:          domain,
+		ResolvedAt:      &now,
+	})
+
+	displayName := actor.Name
+	if displayName == "" {
+		displayName = username
+	}
+	account := &storage.Account{
+		User: &storage.User{
+			ID:          actor.ID,
+			Username:    actor.ID,
+			DisplayName: displayName,
+			URL:         actor.URL,
+		},
+		Actor: actor,
+	}
+	return account, &ref, nil
+}
+
+type directMessageActorIdentity struct {
+	username string
+	domain   string
+}
+
+func federationActorIdentityForDirectMessage(actor *activitypub.Actor, localDomain string) directMessageActorIdentity {
+	if actor == nil {
+		return directMessageActorIdentity{}
+	}
+	username := strings.TrimSpace(actor.PreferredUsername)
+	domain := ""
+	if parsed, err := url.Parse(strings.TrimSpace(actor.ID)); err == nil && parsed.Hostname() != "" {
+		domain = normalizeDirectMessageMentionDomain(parsed.Hostname())
+	}
+	if username == "" {
+		username = extractUsernameFromActorIdentifier(actor.ID)
+	}
+	if domain == normalizeDirectMessageMentionDomain(localDomain) {
+		domain = ""
+	}
+	return directMessageActorIdentity{username: username, domain: domain}
 }
 
 func cloneDirectMessageCommandWithResolvedParticipants(
@@ -509,8 +617,14 @@ func cloneDirectMessageCommandWithResolvedParticipants(
 	cloned.SenderID = resolvedLegacyLocalAccountID(cmd.SenderID, sender)
 	cloned.Recipients = append([]string(nil), cmd.Recipients...)
 	if len(cloned.Recipients) > 0 {
-		cloned.Recipients[0] = resolvedLegacyLocalAccountID(cloned.Recipients[0], recipient)
+		if cmd.ResolvedRecipientRef != nil && cmd.ResolvedRecipientRef.ParticipantID != "" {
+			cloned.Recipients[0] = cmd.ResolvedRecipientRef.ParticipantID
+		} else {
+			cloned.Recipients[0] = resolvedLegacyLocalAccountID(cloned.Recipients[0], recipient)
+		}
 	}
+	cloned.ResolvedRecipientActor = cmd.ResolvedRecipientActor
+	cloned.ResolvedRecipientRef = cmd.ResolvedRecipientRef
 
 	return &cloned
 }
@@ -632,10 +746,15 @@ func (s *Service) createDirectMessageStatus(_ context.Context, cmd *SendDirectMe
 	return status, messageID, nil
 }
 
-func (s *Service) resolveDirectMessageConversationForSend(ctx context.Context, senderID, recipientID string) (*models.Conversation, bool, error) {
-	participants := models.CanonicalConversationParticipants([]string{senderID, recipientID})
+func (s *Service) resolveDirectMessageConversationForCommand(ctx context.Context, cmd *SendDirectMessageCommand, recipientID string) (*models.Conversation, bool, error) {
+	senderID := cmd.SenderID
+	participantRefs := buildDirectMessageParticipantRefs(senderID, recipientID, cmd.ResolvedRecipientRef)
+	participants := models.ConversationParticipantIDsFromRefs(participantRefs)
+	if len(participants) == 0 {
+		participants = models.CanonicalConversationParticipants([]string{senderID, recipientID})
+	}
 
-	conversation, err := s.conversationRepo.GetConversationByParticipants(ctx, participants)
+	conversation, err := s.lookupDirectMessageConversationForSend(ctx, participants, participantRefs)
 	if err == nil && conversation != nil {
 		return conversation, false, nil
 	}
@@ -645,11 +764,46 @@ func (s *Service) resolveDirectMessageConversationForSend(ctx context.Context, s
 
 	now := time.Now().UTC()
 	return &models.Conversation{
-		ID:           uuid.New().String(),
-		Participants: participants,
-		CreatedAt:    now,
-		UpdatedAt:    now,
+		ID:              uuid.New().String(),
+		Participants:    participants,
+		ParticipantRefs: participantRefs,
+		CreatedAt:       now,
+		UpdatedAt:       now,
 	}, true, nil
+}
+
+type typedConversationLookupRepository interface {
+	GetConversationByParticipantRefs(ctx context.Context, refs []models.ConversationParticipantRef) (*models.Conversation, error)
+}
+
+func (s *Service) lookupDirectMessageConversationForSend(ctx context.Context, participants []string, participantRefs []models.ConversationParticipantRef) (*models.Conversation, error) {
+	if len(participantRefs) > 0 {
+		for _, ref := range participantRefs {
+			if ref.ParticipantType == models.ConversationParticipantTypeRemoteActor {
+				if typedRepo, ok := s.conversationRepo.(typedConversationLookupRepository); ok {
+					return typedRepo.GetConversationByParticipantRefs(ctx, participantRefs)
+				}
+				break
+			}
+		}
+	}
+	return s.conversationRepo.GetConversationByParticipants(ctx, participants)
+}
+
+func buildDirectMessageParticipantRefs(senderID, recipientID string, recipientRef *models.ConversationParticipantRef) []models.ConversationParticipantRef {
+	refs := []models.ConversationParticipantRef{{
+		ParticipantType: models.ConversationParticipantTypeLocalUser,
+		ParticipantID:   senderID,
+	}}
+	if recipientRef != nil {
+		refs = append(refs, *recipientRef)
+	} else {
+		refs = append(refs, models.ConversationParticipantRef{
+			ParticipantType: models.ConversationParticipantTypeLocalUser,
+			ParticipantID:   recipientID,
+		})
+	}
+	return models.NormalizeConversationParticipantRefs(refs)
 }
 
 func (s *Service) getUserConversationStateForSend(ctx context.Context, conversationID, participantID string) (*models.UserConversationState, error) {
@@ -712,6 +866,16 @@ func userConversationStateFromContract(conversation *models.Conversation, viewer
 	if stateContract.CounterpartID != "" {
 		state.CounterpartID = stateContract.CounterpartID
 	}
+	if stateContract.CounterpartType != "" {
+		state.CounterpartType = stateContract.CounterpartType
+	}
+	if stateContract.CounterpartAcct != "" {
+		state.CounterpartAcct = stateContract.CounterpartAcct
+	}
+	if stateContract.CounterpartDomain != "" {
+		state.CounterpartDomain = stateContract.CounterpartDomain
+	}
+	state.CounterpartResolvedAt = stateContract.CounterpartResolvedAt
 	if stateContract.Folder != "" {
 		state.Folder = stateContract.Folder
 	}
@@ -750,6 +914,10 @@ func userConversationStateContractFromModel(state *models.UserConversationState)
 		ViewerID:                 state.ViewerID,
 		ConversationID:           state.ConversationID,
 		CounterpartID:            state.CounterpartID,
+		CounterpartType:          state.CounterpartType,
+		CounterpartAcct:          state.CounterpartAcct,
+		CounterpartDomain:        state.CounterpartDomain,
+		CounterpartResolvedAt:    state.CounterpartResolvedAt,
 		Folder:                   state.Folder,
 		RequestState:             state.RequestState,
 		PreviewStatusID:          state.PreviewStatusID,
@@ -770,7 +938,42 @@ func userConversationStateForSend(conversation *models.Conversation, viewerID, c
 	return userConversationStateFromContract(conversation, viewerID, counterpartID, userConversationStateContractFromModel(state))
 }
 
+func conversationParticipantRefByID(conversation *models.Conversation, participantID string) *models.ConversationParticipantRef {
+	if conversation == nil || participantID == "" {
+		return nil
+	}
+	canonicalParticipantID := models.CanonicalConversationParticipantID(participantID)
+	for _, ref := range models.NormalizeConversationParticipantRefs(conversation.ParticipantRefs) {
+		if models.CanonicalConversationParticipantID(ref.ParticipantID) == canonicalParticipantID {
+			refCopy := ref
+			return &refCopy
+		}
+	}
+	return nil
+}
+
+func applyConversationCounterpartRef(state *models.UserConversationState, ref *models.ConversationParticipantRef) {
+	if state == nil || ref == nil {
+		return
+	}
+	state.CounterpartType = ref.ParticipantType
+	state.CounterpartAcct = ref.Acct
+	state.CounterpartDomain = ref.Domain
+	state.CounterpartResolvedAt = ref.ResolvedAt
+}
+
+func isRemoteConversationParticipant(conversation *models.Conversation, participantID string) bool {
+	if ref := conversationParticipantRefByID(conversation, participantID); ref != nil {
+		return ref.ParticipantType == models.ConversationParticipantTypeRemoteActor
+	}
+	return strings.Contains(strings.TrimSpace(participantID), "://")
+}
+
 func (s *Service) evaluateDirectMessageRequestPolicyForState(ctx context.Context, cmd *SendDirectMessageCommand, conversationID, recipientID string, recipientRequestState models.DmRequestState) (willBeRequest bool, deliversToInbox bool, _ error) {
+	if cmd != nil && cmd.ResolvedRecipientRef != nil && cmd.ResolvedRecipientRef.ParticipantType == models.ConversationParticipantTypeRemoteActor {
+		return false, false, nil
+	}
+
 	deliversToInbox = s.shouldDeliverToInbox(ctx, recipientID, cmd.SenderID)
 
 	switch recipientRequestState {
@@ -816,6 +1019,7 @@ func buildDirectMessageParticipantStatesForSend(
 
 	senderState = userConversationStateForSend(conversation, senderID, recipientID, senderState)
 	senderState.CounterpartID = recipientID
+	applyConversationCounterpartRef(senderState, conversationParticipantRefByID(conversation, recipientID))
 	senderState.Folder = models.UserConversationFolderInbox
 	senderState.RequestState = models.DmRequestStateAccepted
 	senderState.RequestedAt = nil
@@ -828,8 +1032,13 @@ func buildDirectMessageParticipantStatesForSend(
 		senderState.AcceptedAt = &t
 	}
 
+	if isRemoteConversationParticipant(conversation, recipientID) {
+		return []*models.UserConversationState{senderState}
+	}
+
 	recipientState = userConversationStateForSend(conversation, recipientID, senderID, recipientState)
 	recipientState.CounterpartID = senderID
+	applyConversationCounterpartRef(recipientState, conversationParticipantRefByID(conversation, senderID))
 	recipientState.DeletedAt = nil
 	recipientState.Unread = true
 	recipientState.LastReadAt = nil
@@ -892,6 +1101,11 @@ func buildExpectedDirectMessageParticipantStates(
 	senderState *models.UserConversationState,
 	recipientState *models.UserConversationState,
 ) []*models.UserConversationState {
+	if isRemoteConversationParticipant(conversation, recipientID) {
+		return []*models.UserConversationState{
+			userConversationStateForSend(conversation, senderID, recipientID, senderState),
+		}
+	}
 	return []*models.UserConversationState{
 		userConversationStateForSend(conversation, senderID, recipientID, senderState),
 		userConversationStateForSend(conversation, recipientID, senderID, recipientState),
@@ -1007,14 +1221,15 @@ func (s *Service) executeDirectMessageSendAttempt(
 	recipientAccounts map[string]*storage.Account,
 	recipientID string,
 ) (*directMessageSendAttempt, bool, error) {
-	conversation, createConversation, err := s.resolveDirectMessageConversationForSend(ctx, cmd.SenderID, recipientID)
+	conversation, createConversation, err := s.resolveDirectMessageConversationForCommand(ctx, cmd, recipientID)
 	if err != nil {
 		return nil, false, err
 	}
 
 	var recipientRequestState models.DmRequestState
 	var recipientState *models.UserConversationState
-	if !createConversation {
+	recipientIsRemote := isRemoteConversationParticipant(conversation, recipientID)
+	if !createConversation && !recipientIsRemote {
 		recipientState, err = s.getUserConversationStateForSend(ctx, conversation.ID, recipientID)
 		if err != nil {
 			return nil, false, errors.Join(ErrCreateDirectMessage, err)
@@ -1219,10 +1434,33 @@ func (s *Service) validateSendMessageReplyTarget(ctx context.Context, inReplyToI
 	return nil
 }
 
-func (s *Service) getSendMessageAccounts(ctx context.Context, senderID, recipientID string) (*storage.Account, *storage.Account, error) {
+func (s *Service) getSendMessageAccountsForSend(ctx context.Context, sendCmd *SendDirectMessageCommand, conversation *models.Conversation, senderID, recipientID string) (*storage.Account, *storage.Account, error) {
 	sender, err := s.accountRepo.GetAccount(ctx, senderID)
 	if err != nil {
 		return nil, nil, errors.Join(ErrGetSenderAccount, err)
+	}
+
+	if ref := conversationParticipantRefByID(conversation, recipientID); ref != nil && ref.ParticipantType == models.ConversationParticipantTypeRemoteActor {
+		actor := sendCmd.ResolvedRecipientActor
+		if actor == nil {
+			actor = &activitypub.Actor{
+				BaseObject: activitypub.BaseObject{
+					ID:   ref.ParticipantID,
+					Type: activitypub.PersonType,
+				},
+				PreferredUsername: remoteUsernameFromParticipantRef(ref),
+			}
+		}
+		sendCmd.ResolvedRecipientActor = actor
+		sendCmd.ResolvedRecipientRef = ref
+		return sender, &storage.Account{
+			User: &storage.User{
+				ID:          ref.ParticipantID,
+				Username:    ref.ParticipantID,
+				DisplayName: remoteUsernameFromParticipantRef(ref),
+			},
+			Actor: actor,
+		}, nil
 	}
 
 	recipient, err := s.accountRepo.GetAccount(ctx, recipientID)
@@ -1231,6 +1469,42 @@ func (s *Service) getSendMessageAccounts(ctx context.Context, senderID, recipien
 	}
 
 	return sender, recipient, nil
+}
+
+func remoteUsernameFromParticipantRef(ref *models.ConversationParticipantRef) string {
+	if ref == nil {
+		return ""
+	}
+	if ref.Acct != "" {
+		if username, _ := directMessageMentionHandleParts(ref.Acct); username != "" {
+			return username
+		}
+	}
+	return extractUsernameFromActorIdentifier(ref.ParticipantID)
+}
+
+func extractUsernameFromActorIdentifier(identifier string) string {
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return ""
+	}
+	if username, _ := directMessageMentionHandleParts(identifier); username != "" && !strings.Contains(identifier, "://") {
+		return username
+	}
+	if parsed, err := url.Parse(identifier); err == nil && parsed.Scheme != "" {
+		path := strings.Trim(parsed.Path, "/")
+		if path == "" {
+			return ""
+		}
+		parts := strings.Split(path, "/")
+		for i, part := range parts {
+			if (part == "users" || part == "actors" || part == "profiles") && i+1 < len(parts) {
+				return strings.TrimPrefix(parts[i+1], "@")
+			}
+		}
+		return strings.TrimPrefix(parts[len(parts)-1], "@")
+	}
+	return strings.TrimPrefix(identifier, "@")
 }
 
 func (s *Service) createSendMessageStatus(_ context.Context, cmd *SendMessageCommand, sendCmd *SendDirectMessageCommand, sender *storage.Account, recipient *storage.Account, conversationID, recipientID string) (*models.Status, string, error) {
@@ -1280,18 +1554,21 @@ func (s *Service) executeSendMessageAttempt(ctx context.Context, cmd *SendMessag
 		return nil, false, err
 	}
 
-	sender, recipient, err := s.getSendMessageAccounts(ctx, cmd.SenderID, recipientID)
+	sender, recipient, err := s.getSendMessageAccountsForSend(ctx, sendCmd, conversation, cmd.SenderID, recipientID)
 	if err != nil {
 		return nil, false, err
 	}
 
 	recipientRequestState := models.DmRequestState("")
-	recipientState, err := s.getUserConversationStateForSend(ctx, conversation.ID, recipientID)
-	if err != nil {
-		return nil, false, errors.Join(ErrCreateDirectMessage, err)
-	}
-	if recipientState != nil {
-		recipientRequestState = recipientState.RequestState
+	var recipientState *models.UserConversationState
+	if !isRemoteConversationParticipant(conversation, recipientID) {
+		recipientState, err = s.getUserConversationStateForSend(ctx, conversation.ID, recipientID)
+		if err != nil {
+			return nil, false, errors.Join(ErrCreateDirectMessage, err)
+		}
+		if recipientState != nil {
+			recipientRequestState = recipientState.RequestState
+		}
 	}
 
 	willBeRequest, deliversToInbox, err := s.evaluateDirectMessageRequestPolicyForState(ctx, sendCmd, conversation.ID, recipientID, recipientRequestState)
@@ -2009,7 +2286,7 @@ func (s *Service) emitMessageSentEvents(ctx context.Context, message *models.Sta
 	}
 
 	// Also emit to each participant's direct stream
-	for _, participantID := range conversation.Participants {
+	for _, participantID := range models.ConversationLocalParticipantIDs(conversation) {
 		participantEvent := *event
 		participantEvent.Stream = fmt.Sprintf("user:%s:direct", participantID)
 		if err := s.publisher.PublishToUser(ctx, participantID, &participantEvent); err != nil {
@@ -2058,7 +2335,7 @@ func (s *Service) queueFederationDelivery(ctx context.Context, message *models.S
 	// Only federate if there are remote recipients
 	hasRemoteRecipients := false
 	for _, recipientURL := range message.ToRecipients {
-		if !strings.Contains(recipientURL, s.domainName) {
+		if isRemoteDirectMessageActorID(recipientURL, s.domainName) {
 			hasRemoteRecipients = true
 			break
 		}
@@ -2087,6 +2364,19 @@ func (s *Service) queueFederationDelivery(ctx context.Context, message *models.S
 			zap.String("message_id", message.StatusID),
 			zap.Error(err))
 	}
+}
+
+func isRemoteDirectMessageActorID(actorID, localDomain string) bool {
+	actorID = strings.TrimSpace(actorID)
+	if actorID == "" {
+		return false
+	}
+
+	actorDomain := directMessageMentionActorDomain(actorID)
+	if actorDomain == "" {
+		return false
+	}
+	return actorDomain != normalizeDirectMessageMentionDomain(localDomain)
 }
 
 func (s *Service) isParticipant(userID string, participants []string) bool {

--- a/pkg/services/conversations/service_federated_helpers_test.go
+++ b/pkg/services/conversations/service_federated_helpers_test.go
@@ -1,0 +1,117 @@
+package conversations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestFederatedDirectMessageIdentityHelpers(t *testing.T) {
+	actor := &activitypub.Actor{
+		BaseObject:        activitypub.BaseObject{ID: "https://remote.example/users/bob", Type: activitypub.PersonType},
+		PreferredUsername: "bob",
+	}
+	identity := federationActorIdentityForDirectMessage(actor, "example.com")
+	require.Equal(t, "bob", identity.username)
+	require.Equal(t, "remote.example", identity.domain)
+
+	localIdentity := federationActorIdentityForDirectMessage(&activitypub.Actor{
+		BaseObject: activitypub.BaseObject{ID: "https://example.com/users/alice", Type: activitypub.PersonType},
+	}, "example.com")
+	require.Equal(t, "alice", localIdentity.username)
+	require.Empty(t, localIdentity.domain)
+	require.Empty(t, federationActorIdentityForDirectMessage(nil, "example.com").username)
+
+	ref := &models.ConversationParticipantRef{
+		ParticipantType: models.ConversationParticipantTypeRemoteActor,
+		ParticipantID:   "https://remote.example/actors/carol",
+		Acct:            "carol@remote.example",
+	}
+	require.Equal(t, "carol", remoteUsernameFromParticipantRef(ref))
+	require.Equal(t, "dave", remoteUsernameFromParticipantRef(&models.ConversationParticipantRef{ParticipantID: "https://remote.example/users/dave"}))
+	require.Empty(t, remoteUsernameFromParticipantRef(nil))
+}
+
+func TestFederatedDirectMessageRecipientIdentifierHelpers(t *testing.T) {
+	require.True(t, isRemoteDirectMessageRecipientIdentifier("bob@remote.example", "example.com"))
+	require.True(t, isRemoteDirectMessageRecipientIdentifier("https://remote.example/users/bob", "example.com"))
+	require.False(t, isRemoteDirectMessageRecipientIdentifier("alice", "example.com"))
+	require.False(t, isRemoteDirectMessageRecipientIdentifier("alice@example.com", "example.com"))
+	require.False(t, isRemoteDirectMessageRecipientIdentifier("", "example.com"))
+
+	require.True(t, isRemoteDirectMessageActorID("https://remote.example/users/bob", "example.com"))
+	require.False(t, isRemoteDirectMessageActorID("https://example.com/users/alice", "example.com"))
+	require.False(t, isRemoteDirectMessageActorID("alice", "example.com"))
+	require.False(t, isRemoteDirectMessageActorID("", "example.com"))
+}
+
+func TestFederatedDirectMessageUsernameExtraction(t *testing.T) {
+	require.Equal(t, "bob", extractUsernameFromActorIdentifier("bob@remote.example"))
+	require.Equal(t, "bob", extractUsernameFromActorIdentifier("https://remote.example/users/bob"))
+	require.Equal(t, "carol", extractUsernameFromActorIdentifier("https://remote.example/actors/@carol"))
+	require.Equal(t, "dave", extractUsernameFromActorIdentifier("https://remote.example/profiles/dave"))
+	require.Equal(t, "erin", extractUsernameFromActorIdentifier("@erin"))
+	require.Empty(t, extractUsernameFromActorIdentifier("https://remote.example"))
+	require.Empty(t, extractUsernameFromActorIdentifier(""))
+}
+
+func TestGetSendMessageAccountsForSend_LocalConversationParticipant(t *testing.T) {
+	ctx := context.Background()
+	accountRepo := &mockAccountRepository{}
+	service := NewService(nil, nil, nil, accountRepo, nil, nil, nil, nil, nil, nil, zaptest.NewLogger(t), "example.com")
+	conversation := &models.Conversation{
+		ID:           "conv-local",
+		Participants: []string{"alice", "bob"},
+		ParticipantRefs: []models.ConversationParticipantRef{
+			{ParticipantType: models.ConversationParticipantTypeLocalUser, ParticipantID: "alice"},
+			{ParticipantType: models.ConversationParticipantTypeLocalUser, ParticipantID: "bob"},
+		},
+	}
+	sendCmd := &SendDirectMessageCommand{SenderID: "alice", Recipients: []string{"bob"}}
+
+	accountRepo.On("GetAccount", ctx, "alice").Return(createTestAccount("alice", "alice"), nil).Once()
+	accountRepo.On("GetAccount", ctx, "bob").Return(createTestAccount("bob", "bob"), nil).Once()
+
+	sender, recipient, err := service.getSendMessageAccountsForSend(ctx, sendCmd, conversation, "alice", "bob")
+	require.NoError(t, err)
+	require.Equal(t, "alice", sender.User.Username)
+	require.Equal(t, "bob", recipient.User.Username)
+	require.Nil(t, sendCmd.ResolvedRecipientRef)
+	require.Nil(t, sendCmd.ResolvedRecipientActor)
+	accountRepo.AssertExpectations(t)
+}
+
+func TestGetSendMessageAccountsForSend_RemoteConversationParticipant(t *testing.T) {
+	ctx := context.Background()
+	accountRepo := &mockAccountRepository{}
+	service := NewService(nil, nil, nil, accountRepo, nil, nil, nil, nil, nil, nil, zaptest.NewLogger(t), "example.com")
+	remoteID := "https://remote.example/users/bob"
+	conversation := &models.Conversation{
+		ID:           "conv-remote",
+		Participants: []string{"alice", remoteID},
+		ParticipantRefs: []models.ConversationParticipantRef{
+			{ParticipantType: models.ConversationParticipantTypeLocalUser, ParticipantID: "alice"},
+			{ParticipantType: models.ConversationParticipantTypeRemoteActor, ParticipantID: remoteID, Acct: "bob@remote.example", Domain: "remote.example"},
+		},
+	}
+	sendCmd := &SendDirectMessageCommand{SenderID: "alice", Recipients: []string{remoteID}}
+
+	accountRepo.On("GetAccount", ctx, "alice").Return(createTestAccount("alice", "alice"), nil).Once()
+
+	sender, recipient, err := service.getSendMessageAccountsForSend(ctx, sendCmd, conversation, "alice", remoteID)
+	require.NoError(t, err)
+	require.Equal(t, "alice", sender.User.Username)
+	require.Equal(t, remoteID, recipient.User.ID)
+	require.Equal(t, remoteID, recipient.User.Username)
+	require.Equal(t, "bob", recipient.User.DisplayName)
+	require.NotNil(t, recipient.Actor)
+	require.Equal(t, remoteID, recipient.Actor.ID)
+	require.Equal(t, "bob", recipient.Actor.PreferredUsername)
+	require.Equal(t, models.ConversationParticipantTypeRemoteActor, sendCmd.ResolvedRecipientRef.ParticipantType)
+	require.Same(t, recipient.Actor, sendCmd.ResolvedRecipientActor)
+	accountRepo.AssertExpectations(t)
+}

--- a/pkg/services/conversations/service_round36_helper_coverage_test.go
+++ b/pkg/services/conversations/service_round36_helper_coverage_test.go
@@ -611,7 +611,10 @@ func TestService_resolveDirectMessageConversationForSend_ReturnsLookupErrors(t *
 		Return((*models.Conversation)(nil), errors.New("boom")).
 		Once()
 
-	_, _, err := service.resolveDirectMessageConversationForSend(ctx, "alice", "bob")
+	_, _, err := service.resolveDirectMessageConversationForCommand(ctx, &SendDirectMessageCommand{
+		SenderID:   "alice",
+		Recipients: []string{"bob"},
+	}, "bob")
 	require.ErrorIs(t, err, ErrLookupExistingConversation)
 	conversationRepo.AssertExpectations(t)
 }
@@ -627,7 +630,10 @@ func TestService_resolveDirectMessageConversationForSend_CreatesCanonicalConvers
 		Return((*models.Conversation)(nil), errors.New("not found")).
 		Once()
 
-	conversation, createConversation, err := service.resolveDirectMessageConversationForSend(ctx, "bob", "alice")
+	conversation, createConversation, err := service.resolveDirectMessageConversationForCommand(ctx, &SendDirectMessageCommand{
+		SenderID:   "bob",
+		Recipients: []string{"alice"},
+	}, "alice")
 	require.NoError(t, err)
 	require.True(t, createConversation)
 	require.NotNil(t, conversation)

--- a/pkg/services/conversations/service_round37_more_coverage_test.go
+++ b/pkg/services/conversations/service_round37_more_coverage_test.go
@@ -592,7 +592,10 @@ func TestService_getSendMessageAccounts_ReturnsErrors(t *testing.T) {
 
 		accountRepo.On("GetAccount", ctx, "alice").Return((*storage.Account)(nil), errors.New("boom")).Once()
 
-		_, _, err := service.getSendMessageAccounts(ctx, "alice", "bob")
+		_, _, err := service.getSendMessageAccountsForSend(ctx, &SendDirectMessageCommand{
+			SenderID:   "alice",
+			Recipients: []string{"bob"},
+		}, nil, "alice", "bob")
 		require.ErrorIs(t, err, ErrGetSenderAccount)
 	})
 
@@ -603,7 +606,10 @@ func TestService_getSendMessageAccounts_ReturnsErrors(t *testing.T) {
 		accountRepo.On("GetAccount", ctx, "alice").Return(createTestAccount("alice", "alice"), nil).Once()
 		accountRepo.On("GetAccount", ctx, "bob").Return((*storage.Account)(nil), errors.New("boom")).Once()
 
-		_, _, err := service.getSendMessageAccounts(ctx, "alice", "bob")
+		_, _, err := service.getSendMessageAccountsForSend(ctx, &SendDirectMessageCommand{
+			SenderID:   "alice",
+			Recipients: []string{"bob"},
+		}, nil, "alice", "bob")
 		require.ErrorIs(t, err, ErrInvalidRecipient)
 	})
 }

--- a/pkg/services/conversations/service_round44_transition_coverage_test.go
+++ b/pkg/services/conversations/service_round44_transition_coverage_test.go
@@ -106,7 +106,10 @@ func TestService_resolveDirectMessageConversationForSend_ReturnsExistingConversa
 		Return(existingConversation, nil).
 		Once()
 
-	conversation, createConversation, err := service.resolveDirectMessageConversationForSend(ctx, "bob", "alice")
+	conversation, createConversation, err := service.resolveDirectMessageConversationForCommand(ctx, &SendDirectMessageCommand{
+		SenderID:   "bob",
+		Recipients: []string{"alice"},
+	}, "alice")
 	require.NoError(t, err)
 	require.False(t, createConversation)
 	require.Same(t, existingConversation, conversation)

--- a/pkg/services/conversations/service_test.go
+++ b/pkg/services/conversations/service_test.go
@@ -99,6 +99,14 @@ func (m *mockConversationRepository) GetConversationByParticipants(ctx context.C
 	return args.Get(0).(*models.Conversation), args.Error(1)
 }
 
+func (m *mockConversationRepository) GetConversationByParticipantRefs(ctx context.Context, refs []models.ConversationParticipantRef) (*models.Conversation, error) {
+	args := m.Called(ctx, refs)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.Conversation), args.Error(1)
+}
+
 func (m *mockConversationRepository) GetUserConversationState(ctx context.Context, viewerID, conversationID string) (*interfaces.UserConversationStateContract, error) {
 	args := m.Called(ctx, viewerID, conversationID)
 	if args.Get(0) == nil {
@@ -723,11 +731,27 @@ func (m *mockPublisher) GetEvents() []streaming.Event {
 
 type mockFederationService struct {
 	activities []*activitypub.Activity
+	actors     map[string]*activitypub.Actor
+	resolveErr error
 }
 
 func (m *mockFederationService) QueueActivity(ctx context.Context, activity *activitypub.Activity) error {
 	m.activities = append(m.activities, activity)
 	return nil
+}
+
+func (m *mockFederationService) ResolveActor(ctx context.Context, handle string) (*activitypub.Actor, error) {
+	if m.resolveErr != nil {
+		return nil, m.resolveErr
+	}
+	if m.actors == nil {
+		return nil, errDirectMessageRemoteRecipientActorRequired
+	}
+	actor := m.actors[handle]
+	if actor == nil {
+		return nil, errDirectMessageRemoteRecipientActorRequired
+	}
+	return actor, nil
 }
 
 func (m *mockFederationService) GetQueuedActivities() []*activitypub.Activity {
@@ -877,13 +901,6 @@ func TestService_SendDirectMessage_WithRemoteRecipient(t *testing.T) {
 
 	// Test data - create a remote recipient (different domain)
 	senderAccount := createTestAccount("sender123", "alice")
-	remoteRecipientAccount := &storage.Account{
-		User: &storage.User{
-			Username: "bob",
-			Email:    "bob@remote.com",
-		},
-	}
-
 	cmd := &SendDirectMessageCommand{
 		SenderID:   "sender123",
 		Recipients: []string{"bob@remote.com"},
@@ -892,10 +909,6 @@ func TestService_SendDirectMessage_WithRemoteRecipient(t *testing.T) {
 
 	// Mock expectations
 	accountRepo.On("GetAccount", ctx, "sender123").Return(senderAccount, nil)
-	accountRepo.On("GetAccount", ctx, "bob@remote.com").Return(remoteRecipientAccount, nil)
-
-	// No existing conversation
-	conversationRepo.On("GetConversationByParticipants", ctx, []string{"bob@remote.com", "sender123"}).Return(nil, fmt.Errorf("not found"))
 
 	// Execute
 	result, err := service.SendDirectMessage(ctx, cmd)
@@ -908,6 +921,95 @@ func TestService_SendDirectMessage_WithRemoteRecipient(t *testing.T) {
 	// Verify federation was NOT queued because the send failed closed.
 	activities := federation.GetQueuedActivities()
 	assert.Len(t, activities, 0)
+
+	conversationRepo.AssertExpectations(t)
+	accountRepo.AssertExpectations(t)
+}
+
+func TestService_SendDirectMessage_WithResolvedRemoteRecipient(t *testing.T) {
+	service, conversationRepo, _, accountRepo, publisher, federation := createTestService()
+	ctx := context.Background()
+
+	senderAccount := createTestAccount("sender123", "alice")
+	remoteActorID := "https://remote.com/users/bob"
+	federation.actors = map[string]*activitypub.Actor{
+		"bob@remote.com": {
+			BaseObject: activitypub.BaseObject{
+				ID:   remoteActorID,
+				Type: activitypub.PersonType,
+			},
+			PreferredUsername: "bob",
+			Name:              "Bob Remote",
+			URL:               "https://remote.com/@bob",
+		},
+	}
+
+	cmd := &SendDirectMessageCommand{
+		SenderID:   "sender123",
+		Recipients: []string{"bob@remote.com"},
+		Content:    "Hello remote user!",
+	}
+
+	accountRepo.On("GetAccount", ctx, "sender123").Return(senderAccount, nil).Once()
+	conversationRepo.On("GetConversationByParticipantRefs", ctx, mock.MatchedBy(func(refs []models.ConversationParticipantRef) bool {
+		refs = models.NormalizeConversationParticipantRefs(refs)
+		if len(refs) != 2 {
+			return false
+		}
+		local := refs[0]
+		remote := refs[1]
+		return local.ParticipantType == models.ConversationParticipantTypeLocalUser &&
+			local.ParticipantID == "sender123" &&
+			remote.ParticipantType == models.ConversationParticipantTypeRemoteActor &&
+			remote.ParticipantID == remoteActorID &&
+			remote.Acct == "bob@remote.com" &&
+			remote.Domain == "remote.com" &&
+			remote.ResolvedAt != nil
+	})).Return(nil, fmt.Errorf("not found")).Once()
+	conversationRepo.On("ApplyDirectMessageSend", ctx, mock.MatchedBy(func(transition *models.DirectMessageSendTransition) bool {
+		if transition == nil || transition.Conversation == nil || transition.Status == nil {
+			return false
+		}
+		if !transition.CreateConversation || len(transition.ParticipantStates) != 1 {
+			return false
+		}
+		if len(transition.Conversation.ParticipantRefs) != 2 {
+			return false
+		}
+		state := transition.ParticipantStates[0]
+		return transition.Conversation.ParticipantRefs[1].ParticipantID == remoteActorID &&
+			transition.Status.Visibility == VisibilityDirect &&
+			len(transition.Status.ToRecipients) == 1 &&
+			transition.Status.ToRecipients[0] == remoteActorID &&
+			state.ViewerID == "sender123" &&
+			state.CounterpartID == remoteActorID &&
+			state.CounterpartType == models.ConversationParticipantTypeRemoteActor &&
+			state.CounterpartAcct == "bob@remote.com" &&
+			state.CounterpartDomain == "remote.com" &&
+			state.RequestState == models.DmRequestStateAccepted &&
+			state.Folder == models.UserConversationFolderInbox &&
+			!state.Unread
+	}), mock.Anything).Return(nil).Once()
+
+	result, err := service.SendDirectMessage(ctx, cmd)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Conversation)
+	require.Contains(t, result.Conversation.Participants, "sender123")
+	require.Contains(t, result.Conversation.Participants, remoteActorID)
+	require.Len(t, result.Conversation.ParticipantRefs, 2)
+	require.Len(t, result.Events, 2) // conversation stream + local sender direct stream
+
+	activities := federation.GetQueuedActivities()
+	require.Len(t, activities, 1)
+	require.Equal(t, "Create", activities[0].Type)
+	require.Equal(t, []string{remoteActorID}, activities[0].To)
+
+	events := publisher.GetEvents()
+	require.Len(t, events, 2)
+	require.Contains(t, []string{events[0].Stream, events[1].Stream}, "conversation:"+result.Conversation.ID)
+	require.Contains(t, []string{events[0].Stream, events[1].Stream}, "user:sender123:direct")
 
 	conversationRepo.AssertExpectations(t)
 	accountRepo.AssertExpectations(t)

--- a/pkg/services/registry.go
+++ b/pkg/services/registry.go
@@ -1344,8 +1344,7 @@ func (r *Registry) Conversations() *conversations.Service {
 				}
 			}
 
-			// Create a simple federation service adapter for conversations
-			federationService := &simpleFederationService{logger: r.logger}
+			federationService := r.createFederationAdapterUnlocked()
 
 			r.conversationsService = conversations.NewService(
 				conversationRepo,
@@ -2721,23 +2720,6 @@ func (a *queueFederationAdapter) extractUsernameFromActorURI(actorURI string) st
 	}
 
 	return username
-}
-
-// simpleFederationService provides a basic federation service implementation for conversations
-type simpleFederationService struct {
-	logger *zap.Logger
-}
-
-// QueueActivity queues an activity for federation delivery
-func (s *simpleFederationService) QueueActivity(_ context.Context, activity *activitypub.Activity) error {
-	// For now, just log the activity - in a full implementation this would queue for delivery
-	if s.logger != nil {
-		s.logger.Info("federation activity queued",
-			zap.String("type", activity.Type),
-			zap.String("actor", activity.Actor),
-			zap.String("object", fmt.Sprintf("%v", activity.Object)))
-	}
-	return nil
 }
 
 // getJobQueue returns the job queue service, creating it if necessary

--- a/pkg/services/registry_round17_more_coverage_test.go
+++ b/pkg/services/registry_round17_more_coverage_test.go
@@ -986,13 +986,6 @@ func TestRegistry_Adapters_And_JobQueueImplementations(t *testing.T) {
 		assert.Equal(t, 1, fed.deliverRecipientsCalls)
 	})
 
-	t.Run("simpleFederationService_queue_activity_noop", func(t *testing.T) {
-		svc := &simpleFederationService{logger: logger}
-		assert.NoError(t, svc.QueueActivity(context.Background(), &activitypub.Activity{
-			BaseObject: activitypub.BaseObject{Type: "Create"},
-			Actor:      "actor",
-		}))
-	})
 }
 
 type captureJobQueue struct {

--- a/pkg/storage/interfaces/direct_message_contract.go
+++ b/pkg/storage/interfaces/direct_message_contract.go
@@ -30,6 +30,10 @@ type UserConversationStateContract struct {
 	ViewerID                 string
 	ConversationID           string
 	CounterpartID            string
+	CounterpartType          models.ConversationParticipantType
+	CounterpartAcct          string
+	CounterpartDomain        string
+	CounterpartResolvedAt    *time.Time
 	Folder                   UserConversationFolder
 	RequestState             models.DmRequestState
 	PreviewStatusID          string

--- a/pkg/storage/models/conversation.go
+++ b/pkg/storage/models/conversation.go
@@ -22,6 +22,30 @@ const (
 	DmRequestStateDeclined DmRequestState = "DECLINED"
 )
 
+// ConversationParticipantType identifies the durable identity class for a
+// conversation participant. It is intentionally explicit so remote actor URLs,
+// local usernames, and future agent identities do not depend on ID-shape
+// inference as the source of truth.
+type ConversationParticipantType string
+
+const (
+	// ConversationParticipantTypeLocalUser represents a local lesser account.
+	ConversationParticipantTypeLocalUser ConversationParticipantType = "local_user"
+	// ConversationParticipantTypeRemoteActor represents a federated ActivityPub actor.
+	ConversationParticipantTypeRemoteActor ConversationParticipantType = "remote_actor"
+)
+
+// ConversationParticipantRef is the typed participant identity stored alongside
+// the legacy participant ID list. Participants remains the compatibility field;
+// ParticipantRefs is the durable source of truth for federated conversations.
+type ConversationParticipantRef struct {
+	ParticipantType ConversationParticipantType `theorydb:"attr:participantType" json:"participant_type"`
+	ParticipantID   string                      `theorydb:"attr:participantID" json:"participant_id"`
+	Acct            string                      `theorydb:"attr:acct,omitempty" json:"acct,omitempty"`
+	Domain          string                      `theorydb:"attr:domain,omitempty" json:"domain,omitempty"`
+	ResolvedAt      *time.Time                  `theorydb:"attr:resolvedAt,omitempty" json:"resolved_at,omitempty"`
+}
+
 // Conversation represents a direct message conversation between users
 type Conversation struct {
 	_ struct{} `theorydb:"naming:camelCase"`
@@ -36,12 +60,13 @@ type Conversation struct {
 	GSI1SK string `theorydb:"index:gsi1,sk,attr:gsi1SK,omitempty" json:"gsi1SK,omitempty"`
 
 	// Core fields from legacy
-	ID           string    `theorydb:"attr:id" json:"id"`
-	Participants []string  `theorydb:"attr:participants" json:"participants"` // Actor IDs/usernames
-	LastStatusID string    `theorydb:"attr:lastStatusID" json:"last_status_id,omitempty"`
-	Unread       bool      `theorydb:"-" json:"unread"` // Per-viewer projection only; not stored on the shared row
-	CreatedAt    time.Time `theorydb:"attr:createdAt" json:"created_at"`
-	UpdatedAt    time.Time `theorydb:"attr:updatedAt" json:"updated_at"`
+	ID              string                       `theorydb:"attr:id" json:"id"`
+	Participants    []string                     `theorydb:"attr:participants" json:"participants"` // Compatibility IDs: local usernames or remote actor URIs.
+	ParticipantRefs []ConversationParticipantRef `theorydb:"attr:participantRefs,omitempty" json:"participant_refs,omitempty"`
+	LastStatusID    string                       `theorydb:"attr:lastStatusID" json:"last_status_id,omitempty"`
+	Unread          bool                         `theorydb:"-" json:"unread"` // Per-viewer projection only; not stored on the shared row
+	CreatedAt       time.Time                    `theorydb:"attr:createdAt" json:"created_at"`
+	UpdatedAt       time.Time                    `theorydb:"attr:updatedAt" json:"updated_at"`
 
 	// Message counting fields
 	TotalMessageCount int64     `theorydb:"attr:totalMessageCount" json:"total_message_count"`       // Total messages in conversation
@@ -77,6 +102,115 @@ func CanonicalConversationParticipants(participants []string) []string {
 
 	sort.Strings(normalized)
 	return normalized
+}
+
+// NormalizeConversationParticipantRef canonicalizes a typed participant ref for durable storage.
+func NormalizeConversationParticipantRef(ref ConversationParticipantRef) ConversationParticipantRef {
+	ref.ParticipantID = strings.TrimSpace(ref.ParticipantID)
+	ref.Acct = strings.TrimSpace(strings.TrimPrefix(ref.Acct, "@"))
+	ref.Domain = strings.ToLower(strings.TrimSpace(ref.Domain))
+
+	switch ref.ParticipantType {
+	case ConversationParticipantTypeRemoteActor:
+		if ref.Acct != "" {
+			ref.Acct = strings.ToLower(ref.Acct)
+		}
+	case ConversationParticipantTypeLocalUser:
+		ref.ParticipantID = CanonicalConversationParticipantID(ref.ParticipantID)
+	default:
+		if strings.Contains(ref.ParticipantID, "://") {
+			ref.ParticipantType = ConversationParticipantTypeRemoteActor
+		} else {
+			ref.ParticipantType = ConversationParticipantTypeLocalUser
+			ref.ParticipantID = CanonicalConversationParticipantID(ref.ParticipantID)
+		}
+	}
+
+	if ref.ResolvedAt != nil {
+		resolvedAt := ref.ResolvedAt.UTC()
+		ref.ResolvedAt = &resolvedAt
+	}
+
+	return ref
+}
+
+// NormalizeConversationParticipantRefs canonicalizes, de-duplicates, and sorts typed participants.
+func NormalizeConversationParticipantRefs(refs []ConversationParticipantRef) []ConversationParticipantRef {
+	if len(refs) == 0 {
+		return nil
+	}
+
+	byKey := make(map[string]ConversationParticipantRef, len(refs))
+	for _, ref := range refs {
+		normalized := NormalizeConversationParticipantRef(ref)
+		if normalized.ParticipantID == "" || normalized.ParticipantType == "" {
+			continue
+		}
+		key := string(normalized.ParticipantType) + "\x00" + normalized.ParticipantID
+		byKey[key] = normalized
+	}
+
+	keys := make([]string, 0, len(byKey))
+	for key := range byKey {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	normalized := make([]ConversationParticipantRef, 0, len(keys))
+	for _, key := range keys {
+		normalized = append(normalized, byKey[key])
+	}
+	return normalized
+}
+
+// ConversationParticipantIDsFromRefs returns the compatibility participant ID list for typed refs.
+func ConversationParticipantIDsFromRefs(refs []ConversationParticipantRef) []string {
+	if len(refs) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(refs))
+	for _, ref := range NormalizeConversationParticipantRefs(refs) {
+		if ref.ParticipantID != "" {
+			ids = append(ids, ref.ParticipantID)
+		}
+	}
+	return CanonicalConversationParticipants(ids)
+}
+
+// ConversationHasRemoteParticipants reports whether the conversation includes a remote actor.
+func ConversationHasRemoteParticipants(conversation *Conversation) bool {
+	if conversation == nil {
+		return false
+	}
+	for _, ref := range NormalizeConversationParticipantRefs(conversation.ParticipantRefs) {
+		if ref.ParticipantType == ConversationParticipantTypeRemoteActor {
+			return true
+		}
+	}
+	for _, participantID := range conversation.Participants {
+		if strings.Contains(strings.TrimSpace(participantID), "://") {
+			return true
+		}
+	}
+	return false
+}
+
+// ConversationLocalParticipantIDs returns local-user participants that should own viewer state rows.
+func ConversationLocalParticipantIDs(conversation *Conversation) []string {
+	if conversation == nil {
+		return nil
+	}
+	if len(conversation.ParticipantRefs) == 0 {
+		return CanonicalConversationParticipants(conversation.Participants)
+	}
+
+	localParticipants := make([]string, 0, len(conversation.ParticipantRefs))
+	for _, ref := range NormalizeConversationParticipantRefs(conversation.ParticipantRefs) {
+		if ref.ParticipantType == ConversationParticipantTypeLocalUser && ref.ParticipantID != "" {
+			localParticipants = append(localParticipants, ref.ParticipantID)
+		}
+	}
+	return CanonicalConversationParticipants(localParticipants)
 }
 
 // TableName returns the DynamoDB table name

--- a/pkg/storage/models/conversation_participant_refs_test.go
+++ b/pkg/storage/models/conversation_participant_refs_test.go
@@ -1,0 +1,73 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConversationParticipantRefs_NormalizeAndProject(t *testing.T) {
+	resolvedAt := time.Date(2026, 4, 27, 12, 0, 0, 0, time.FixedZone("offset", -4*60*60))
+
+	remote := NormalizeConversationParticipantRef(ConversationParticipantRef{
+		ParticipantType: ConversationParticipantTypeRemoteActor,
+		ParticipantID:   "https://Remote.Example/users/Bob",
+		Acct:            "@Bob@Remote.Example",
+		Domain:          "Remote.Example",
+		ResolvedAt:      &resolvedAt,
+	})
+	require.Equal(t, ConversationParticipantTypeRemoteActor, remote.ParticipantType)
+	require.Equal(t, "https://Remote.Example/users/Bob", remote.ParticipantID)
+	require.Equal(t, "bob@remote.example", remote.Acct)
+	require.Equal(t, "remote.example", remote.Domain)
+	require.NotNil(t, remote.ResolvedAt)
+	require.Equal(t, resolvedAt.UTC(), *remote.ResolvedAt)
+
+	local := NormalizeConversationParticipantRef(ConversationParticipantRef{
+		ParticipantType: ConversationParticipantTypeLocalUser,
+		ParticipantID:   " Alice ",
+		Acct:            "@Alice",
+		Domain:          "LOCALHOST",
+	})
+	require.Equal(t, ConversationParticipantTypeLocalUser, local.ParticipantType)
+	require.Equal(t, "alice", local.ParticipantID)
+	require.Equal(t, "Alice", local.Acct)
+	require.Equal(t, "localhost", local.Domain)
+
+	inferredRemote := NormalizeConversationParticipantRef(ConversationParticipantRef{ParticipantID: "https://remote.example/actors/carol"})
+	require.Equal(t, ConversationParticipantTypeRemoteActor, inferredRemote.ParticipantType)
+	require.Equal(t, "https://remote.example/actors/carol", inferredRemote.ParticipantID)
+
+	inferredLocal := NormalizeConversationParticipantRef(ConversationParticipantRef{ParticipantID: "Carol"})
+	require.Equal(t, ConversationParticipantTypeLocalUser, inferredLocal.ParticipantType)
+	require.Equal(t, "carol", inferredLocal.ParticipantID)
+}
+
+func TestConversationParticipantRefs_CollectionsAndCompatibilityIDs(t *testing.T) {
+	refs := NormalizeConversationParticipantRefs([]ConversationParticipantRef{
+		{ParticipantType: ConversationParticipantTypeRemoteActor, ParticipantID: "https://remote.example/users/bob", Acct: "bob@remote.example"},
+		{ParticipantType: ConversationParticipantTypeLocalUser, ParticipantID: "Alice"},
+		{ParticipantType: ConversationParticipantTypeLocalUser, ParticipantID: "alice", Acct: "duplicate"},
+		{ParticipantType: ConversationParticipantTypeLocalUser},
+	})
+	require.Len(t, refs, 2)
+	require.Equal(t, ConversationParticipantTypeLocalUser, refs[0].ParticipantType)
+	require.Equal(t, "alice", refs[0].ParticipantID)
+	require.Equal(t, ConversationParticipantTypeRemoteActor, refs[1].ParticipantType)
+	require.Equal(t, "https://remote.example/users/bob", refs[1].ParticipantID)
+
+	ids := ConversationParticipantIDsFromRefs(refs)
+	require.Equal(t, []string{"alice", "https://remote.example/users/bob"}, ids)
+
+	conv := &Conversation{ParticipantRefs: refs, Participants: []string{"ignored"}}
+	require.True(t, ConversationHasRemoteParticipants(conv))
+	require.Equal(t, []string{"alice"}, ConversationLocalParticipantIDs(conv))
+
+	require.True(t, ConversationHasRemoteParticipants(&Conversation{Participants: []string{"alice", "https://remote.example/users/bob"}}))
+	require.False(t, ConversationHasRemoteParticipants(&Conversation{Participants: []string{"alice", "bob"}}))
+	require.Equal(t, []string{"alice", "bob"}, ConversationLocalParticipantIDs(&Conversation{Participants: []string{"Bob", "alice"}}))
+	require.Nil(t, ConversationLocalParticipantIDs(nil))
+	require.Nil(t, ConversationParticipantIDsFromRefs(nil))
+	require.Nil(t, NormalizeConversationParticipantRefs(nil))
+}

--- a/pkg/storage/models/user_conversation_state.go
+++ b/pkg/storage/models/user_conversation_state.go
@@ -36,22 +36,26 @@ type UserConversationState struct {
 	GSI3PK string `theorydb:"index:gsi3,pk,attr:gsi3PK,omitempty" json:"gsi3PK,omitempty"`
 	GSI3SK string `theorydb:"index:gsi3,sk,attr:gsi3SK,omitempty" json:"gsi3SK,omitempty"`
 
-	ViewerID                 string                 `theorydb:"attr:viewerID" json:"viewer_id"`
-	ConversationID           string                 `theorydb:"attr:conversationID" json:"conversation_id"`
-	CounterpartID            string                 `theorydb:"attr:counterpartID" json:"counterpart_id"`
-	Folder                   UserConversationFolder `theorydb:"attr:folder" json:"folder"`
-	RequestState             DmRequestState         `theorydb:"attr:requestState,omitempty" json:"request_state,omitempty"`
-	PreviewStatusID          string                 `theorydb:"attr:previewStatusID,omitempty" json:"preview_status_id,omitempty"`
-	PreviewStatusPublishedAt time.Time              `theorydb:"attr:previewStatusPublishedAt,omitempty" json:"preview_status_published_at,omitempty"`
-	SortAt                   time.Time              `theorydb:"attr:sortAt" json:"sort_at"`
-	Unread                   bool                   `theorydb:"attr:unread" json:"unread"`
-	LastReadAt               *time.Time             `theorydb:"attr:lastReadAt" json:"last_read_at,omitempty"`
-	DeletedAt                *time.Time             `theorydb:"attr:deletedAt" json:"deleted_at,omitempty"`
-	RequestedAt              *time.Time             `theorydb:"attr:requestedAt" json:"requested_at,omitempty"`
-	AcceptedAt               *time.Time             `theorydb:"attr:acceptedAt" json:"accepted_at,omitempty"`
-	DeclinedAt               *time.Time             `theorydb:"attr:declinedAt" json:"declined_at,omitempty"`
-	CreatedAt                time.Time              `theorydb:"attr:createdAt" json:"created_at"`
-	UpdatedAt                time.Time              `theorydb:"attr:updatedAt" json:"updated_at"`
+	ViewerID                 string                      `theorydb:"attr:viewerID" json:"viewer_id"`
+	ConversationID           string                      `theorydb:"attr:conversationID" json:"conversation_id"`
+	CounterpartID            string                      `theorydb:"attr:counterpartID" json:"counterpart_id"`
+	CounterpartType          ConversationParticipantType `theorydb:"attr:counterpartType,omitempty" json:"counterpart_type,omitempty"`
+	CounterpartAcct          string                      `theorydb:"attr:counterpartAcct,omitempty" json:"counterpart_acct,omitempty"`
+	CounterpartDomain        string                      `theorydb:"attr:counterpartDomain,omitempty" json:"counterpart_domain,omitempty"`
+	CounterpartResolvedAt    *time.Time                  `theorydb:"attr:counterpartResolvedAt,omitempty" json:"counterpart_resolved_at,omitempty"`
+	Folder                   UserConversationFolder      `theorydb:"attr:folder" json:"folder"`
+	RequestState             DmRequestState              `theorydb:"attr:requestState,omitempty" json:"request_state,omitempty"`
+	PreviewStatusID          string                      `theorydb:"attr:previewStatusID,omitempty" json:"preview_status_id,omitempty"`
+	PreviewStatusPublishedAt time.Time                   `theorydb:"attr:previewStatusPublishedAt,omitempty" json:"preview_status_published_at,omitempty"`
+	SortAt                   time.Time                   `theorydb:"attr:sortAt" json:"sort_at"`
+	Unread                   bool                        `theorydb:"attr:unread" json:"unread"`
+	LastReadAt               *time.Time                  `theorydb:"attr:lastReadAt" json:"last_read_at,omitempty"`
+	DeletedAt                *time.Time                  `theorydb:"attr:deletedAt" json:"deleted_at,omitempty"`
+	RequestedAt              *time.Time                  `theorydb:"attr:requestedAt" json:"requested_at,omitempty"`
+	AcceptedAt               *time.Time                  `theorydb:"attr:acceptedAt" json:"accepted_at,omitempty"`
+	DeclinedAt               *time.Time                  `theorydb:"attr:declinedAt" json:"declined_at,omitempty"`
+	CreatedAt                time.Time                   `theorydb:"attr:createdAt" json:"created_at"`
+	UpdatedAt                time.Time                   `theorydb:"attr:updatedAt" json:"updated_at"`
 }
 
 // TableName returns the DynamoDB table name.
@@ -81,6 +85,8 @@ func (s *UserConversationState) prepareForWrite(isCreate bool) error {
 	}
 	s.ViewerID = CanonicalConversationParticipantID(s.ViewerID)
 	s.CounterpartID = CanonicalConversationParticipantID(s.CounterpartID)
+	s.CounterpartAcct = strings.ToLower(strings.TrimSpace(strings.TrimPrefix(s.CounterpartAcct, "@")))
+	s.CounterpartDomain = strings.ToLower(strings.TrimSpace(s.CounterpartDomain))
 	s.ConversationID = strings.TrimSpace(s.ConversationID)
 
 	if err := common.ValidateRequiredParam("ViewerID", s.ViewerID); err != nil {
@@ -130,6 +136,7 @@ func (s *UserConversationState) prepareForWrite(isCreate bool) error {
 	s.RequestedAt = normalizeOptionalConversationTime(s.RequestedAt)
 	s.AcceptedAt = normalizeOptionalConversationTime(s.AcceptedAt)
 	s.DeclinedAt = normalizeOptionalConversationTime(s.DeclinedAt)
+	s.CounterpartResolvedAt = normalizeOptionalConversationTime(s.CounterpartResolvedAt)
 
 	return nil
 }

--- a/pkg/storage/repositories/conversation_participant_lookup_test.go
+++ b/pkg/storage/repositories/conversation_participant_lookup_test.go
@@ -1,0 +1,45 @@
+package repositories
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConversationParticipantLookupV2Helpers(t *testing.T) {
+	refs := []models.ConversationParticipantRef{
+		{ParticipantType: models.ConversationParticipantTypeRemoteActor, ParticipantID: "https://remote.example/users/bob", Acct: "bob@remote.example"},
+		{ParticipantType: models.ConversationParticipantTypeLocalUser, ParticipantID: "Alice"},
+	}
+	conversation := &models.Conversation{ID: "conv-1", ParticipantRefs: refs}
+
+	key := conversationParticipantLookupV2PK(refs)
+	require.True(t, strings.HasPrefix(key, "CONVERSATION_PARTICIPANTS_V2#"))
+	require.Equal(t, key, conversationParticipantLookupPKForConversation(conversation, nil))
+	require.True(t, useConversationParticipantLookupV2(conversation, nil))
+	require.Equal(t, "conv-1", conversationIDFromModel(conversation))
+	require.Empty(t, conversationIDFromModel(nil))
+
+	lookup := newConversationParticipantLookupForConversation(conversation, nil)
+	require.Equal(t, key, lookup.PK)
+	require.Equal(t, conversationParticipantLookupSK, lookup.SK)
+	require.Equal(t, key, lookup.GSI1PK)
+	require.Equal(t, "conv-1", lookup.ConversationID)
+}
+
+func TestConversationParticipantRefsForLookupLegacyAndRemoteFallbacks(t *testing.T) {
+	localRefs := conversationParticipantRefsForLookup(nil, []string{"Bob", "alice"})
+	require.Equal(t, []models.ConversationParticipantRef{
+		{ParticipantType: models.ConversationParticipantTypeLocalUser, ParticipantID: "alice"},
+		{ParticipantType: models.ConversationParticipantTypeLocalUser, ParticipantID: "bob"},
+	}, localRefs)
+	require.False(t, useConversationParticipantLookupV2(nil, []string{"alice", "bob"}))
+	require.Equal(t, conversationParticipantLookupPK([]string{"alice", "bob"}), conversationParticipantLookupPKForConversation(nil, []string{"Bob", "alice"}))
+
+	remoteRefs := conversationParticipantRefsForLookup(nil, []string{"alice", "https://remote.example/users/bob"})
+	require.Equal(t, models.ConversationParticipantTypeRemoteActor, remoteRefs[1].ParticipantType)
+	require.True(t, useConversationParticipantLookupV2(nil, []string{"alice", "https://remote.example/users/bob"}))
+	require.True(t, strings.HasPrefix(conversationParticipantLookupPKForConversation(nil, []string{"alice", "https://remote.example/users/bob"}), "CONVERSATION_PARTICIPANTS_V2#"))
+}

--- a/pkg/storage/repositories/conversation_repository.go
+++ b/pkg/storage/repositories/conversation_repository.go
@@ -2,7 +2,10 @@ package repositories
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -51,6 +54,63 @@ func conversationParticipantLookupPK(participants []string) string {
 	return fmt.Sprintf("CONVERSATION_PARTICIPANTS#%s", strings.Join(models.CanonicalConversationParticipants(participants), ","))
 }
 
+func conversationParticipantLookupV2PK(refs []models.ConversationParticipantRef) string {
+	normalized := models.NormalizeConversationParticipantRefs(refs)
+	parts := make([]string, 0, len(normalized))
+	for _, ref := range normalized {
+		if ref.ParticipantType == "" || ref.ParticipantID == "" {
+			continue
+		}
+		parts = append(parts, string(ref.ParticipantType)+"\x00"+ref.ParticipantID)
+	}
+	sort.Strings(parts)
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x1f")))
+	return "CONVERSATION_PARTICIPANTS_V2#" + hex.EncodeToString(sum[:])
+}
+
+func conversationParticipantRefsForLookup(conversation *models.Conversation, participants []string) []models.ConversationParticipantRef {
+	if conversation != nil && len(conversation.ParticipantRefs) > 0 {
+		return models.NormalizeConversationParticipantRefs(conversation.ParticipantRefs)
+	}
+
+	canonicalParticipants := models.CanonicalConversationParticipants(participants)
+	refs := make([]models.ConversationParticipantRef, 0, len(canonicalParticipants))
+	for _, participantID := range canonicalParticipants {
+		participantType := models.ConversationParticipantTypeLocalUser
+		if strings.Contains(participantID, "://") {
+			participantType = models.ConversationParticipantTypeRemoteActor
+		}
+		refs = append(refs, models.ConversationParticipantRef{
+			ParticipantType: participantType,
+			ParticipantID:   participantID,
+		})
+	}
+	return models.NormalizeConversationParticipantRefs(refs)
+}
+
+func useConversationParticipantLookupV2(conversation *models.Conversation, participants []string) bool {
+	if conversation != nil && len(conversation.ParticipantRefs) > 0 {
+		for _, ref := range models.NormalizeConversationParticipantRefs(conversation.ParticipantRefs) {
+			if ref.ParticipantType == models.ConversationParticipantTypeRemoteActor {
+				return true
+			}
+		}
+	}
+	for _, participantID := range participants {
+		if strings.Contains(strings.TrimSpace(participantID), "://") {
+			return true
+		}
+	}
+	return false
+}
+
+func conversationParticipantLookupPKForConversation(conversation *models.Conversation, participants []string) string {
+	if useConversationParticipantLookupV2(conversation, participants) {
+		return conversationParticipantLookupV2PK(conversationParticipantRefsForLookup(conversation, participants))
+	}
+	return conversationParticipantLookupPK(participants)
+}
+
 func newConversationParticipantLookup(conversationID string, participants []string) *models.ConversationParticipantKey {
 	participantKey := conversationParticipantLookupPK(participants)
 	return &models.ConversationParticipantKey{
@@ -59,6 +119,23 @@ func newConversationParticipantLookup(conversationID string, participants []stri
 		GSI1PK:         participantKey,
 		ConversationID: conversationID,
 	}
+}
+
+func newConversationParticipantLookupForConversation(conversation *models.Conversation, participants []string) *models.ConversationParticipantKey {
+	participantKey := conversationParticipantLookupPKForConversation(conversation, participants)
+	return &models.ConversationParticipantKey{
+		PK:             participantKey,
+		SK:             conversationParticipantLookupSK,
+		GSI1PK:         participantKey,
+		ConversationID: conversationIDFromModel(conversation),
+	}
+}
+
+func conversationIDFromModel(conversation *models.Conversation) string {
+	if conversation == nil {
+		return ""
+	}
+	return conversation.ID
 }
 
 func newConversationTransactWriteFn(db core.DB) func(ctx context.Context, fn func(core.TransactionBuilder) error) error {
@@ -119,8 +196,11 @@ func (r *ConversationRepository) createConversation(ctx context.Context, convers
 	}
 
 	// Set participants if provided
+	conversation.ParticipantRefs = models.NormalizeConversationParticipantRefs(conversation.ParticipantRefs)
 	if err := common.ValidateSliceNotEmpty("participants", participants); err == nil {
 		conversation.Participants = models.CanonicalConversationParticipants(participants)
+	} else if len(conversation.ParticipantRefs) > 0 {
+		conversation.Participants = models.ConversationParticipantIDsFromRefs(conversation.ParticipantRefs)
 	} else {
 		conversation.Participants = models.CanonicalConversationParticipants(conversation.Participants)
 	}
@@ -141,7 +221,7 @@ func (r *ConversationRepository) createConversation(ctx context.Context, convers
 		return r.createConversationLegacy(ctx, log, conversation, preparedStates, explicitParticipantStates)
 	}
 
-	lookupKey := newConversationParticipantLookup(conversation.ID, conversation.Participants)
+	lookupKey := newConversationParticipantLookupForConversation(conversation, conversation.Participants)
 	if err := r.transactWriteFn(ctx, func(tx core.TransactionBuilder) error {
 		tx = tx.WithContext(ctx)
 		tx.Create(conversation)
@@ -185,7 +265,7 @@ func (r *ConversationRepository) createConversationLegacy(ctx context.Context, l
 		return ErrorHandler.HandleCreateError(stateErr, EntityConversation, conversation.ID)
 	}
 
-	lookupKey := newConversationParticipantLookup(conversation.ID, conversation.Participants)
+	lookupKey := newConversationParticipantLookupForConversation(conversation, conversation.Participants)
 	if err := r.GetDB().Model(lookupKey).WithContext(ctx).IfNotExists().Create(); err != nil {
 		if errors.IsConditionFailed(err) {
 			log.Info("participant lookup already exists; cleaning up duplicate conversation create",
@@ -221,7 +301,7 @@ func canonicalConversationParticipantsForStates(conversation *models.Conversatio
 		return nil, storage.ErrInvalidInput
 	}
 
-	canonicalParticipants := models.CanonicalConversationParticipants(conversation.Participants)
+	canonicalParticipants := models.ConversationLocalParticipantIDs(conversation)
 	if len(canonicalParticipants) == 0 {
 		return nil, storage.ErrInvalidInput
 	}
@@ -337,9 +417,22 @@ func (r *ConversationRepository) GetConversation(ctx context.Context, id string)
 
 // UpdateConversation updates a conversation (KEEP - Complex conversation update logic)
 func (r *ConversationRepository) UpdateConversation(ctx context.Context, conversation *models.Conversation) error {
-	// For updating, we recreate all records (matching legacy behavior)
-	// This ensures participant records are updated with new timestamps
-	return r.CreateConversation(ctx, conversation, conversation.Participants)
+	if conversation == nil {
+		return ErrorHandler.HandleUpdateError(storage.ErrInvalidInput, EntityConversation, "nil")
+	}
+	conversation.ParticipantRefs = models.NormalizeConversationParticipantRefs(conversation.ParticipantRefs)
+	if len(conversation.ParticipantRefs) > 0 {
+		conversation.Participants = models.ConversationParticipantIDsFromRefs(conversation.ParticipantRefs)
+	} else {
+		conversation.Participants = models.CanonicalConversationParticipants(conversation.Participants)
+	}
+	if err := conversation.UpdateKeys(); err != nil {
+		return ErrorHandler.HandleUpdateError(err, EntityConversation, conversation.ID)
+	}
+	if err := r.GetDB().WithContext(ctx).Model(conversation).Update(); err != nil {
+		return ErrorHandler.HandleUpdateError(err, EntityConversation, conversation.ID)
+	}
+	return nil
 }
 
 // DeleteConversation deletes a conversation by ID (KEEP - Complex cleanup logic)
@@ -456,6 +549,51 @@ func (r *ConversationRepository) GetConversationByParticipants(ctx context.Conte
 			return nil, ErrorHandler.HandleGetError(err, EntityConversation, record.ConversationID)
 		}
 		log.Error("failed to load conversation after participant lookup",
+			zap.String("conversation_id", record.ConversationID),
+			zap.Error(err))
+		return nil, ErrorHandler.HandleGetError(err, EntityConversation, record.ConversationID)
+	}
+
+	return &conversation, nil
+}
+
+// GetConversationByParticipantRefs finds a conversation with exact typed participants.
+// It is used for federated conversations where remote actor URLs make the legacy
+// comma-joined participant lookup ambiguous.
+func (r *ConversationRepository) GetConversationByParticipantRefs(ctx context.Context, refs []models.ConversationParticipantRef) (*models.Conversation, error) {
+	normalized := models.NormalizeConversationParticipantRefs(refs)
+	log := r.logger.With(zap.Any("participant_refs", normalized))
+
+	lookupKey := &models.ConversationParticipantKey{
+		PK: conversationParticipantLookupV2PK(normalized),
+		SK: conversationParticipantLookupSK,
+	}
+
+	var record models.ConversationParticipantKey
+	err := r.GetDB().Model(&models.ConversationParticipantKey{}).WithContext(ctx).
+		ConsistentRead().
+		Where("PK", "=", lookupKey.PK).
+		Where("SK", "=", lookupKey.SK).
+		First(&record)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, ErrorHandler.HandleGetError(err, EntityConversation, "participant refs")
+		}
+		log.Error("failed to query conversation by typed participants", zap.Error(err))
+		return nil, ErrorHandler.HandleQueryError(err, EntityConversation, "participant refs")
+	}
+
+	var conversation models.Conversation
+	err = r.GetDB().Model(&models.Conversation{}).WithContext(ctx).
+		ConsistentRead().
+		Where("PK", "=", fmt.Sprintf("CONVERSATION#%s", record.ConversationID)).
+		Where("SK", "=", "METADATA").
+		First(&conversation)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, ErrorHandler.HandleGetError(err, EntityConversation, record.ConversationID)
+		}
+		log.Error("failed to load conversation after typed participant lookup",
 			zap.String("conversation_id", record.ConversationID),
 			zap.Error(err))
 		return nil, ErrorHandler.HandleGetError(err, EntityConversation, record.ConversationID)

--- a/pkg/storage/repositories/conversation_repository_coverage_test.go
+++ b/pkg/storage/repositories/conversation_repository_coverage_test.go
@@ -179,6 +179,52 @@ func TestRound07_ConversationRepository_GetConversationByParticipants_Canonicali
 	conversationQuery.AssertExpectations(t)
 }
 
+func TestRound07_ConversationRepository_GetConversationByParticipantRefs_LoadsTypedLookup(t *testing.T) {
+	mockDB := new(mocks.MockDB)
+	lookupQuery := new(mocks.MockQuery)
+	conversationQuery := new(mocks.MockQuery)
+
+	refs := []models.ConversationParticipantRef{
+		{ParticipantType: models.ConversationParticipantTypeRemoteActor, ParticipantID: "https://remote.example/users/bob", Acct: "bob@remote.example"},
+		{ParticipantType: models.ConversationParticipantTypeLocalUser, ParticipantID: "Alice"},
+	}
+	normalized := models.NormalizeConversationParticipantRefs(refs)
+	lookupPK := conversationParticipantLookupV2PK(normalized)
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB).Maybe()
+	mockDB.On("Model", mock.AnythingOfType("*models.ConversationParticipantKey")).Return(lookupQuery).Once()
+	mockDB.On("Model", mock.AnythingOfType("*models.Conversation")).Return(conversationQuery).Once()
+
+	lookupQuery.On("WithContext", mock.Anything).Return(lookupQuery).Once()
+	lookupQuery.On("ConsistentRead").Return(lookupQuery).Once()
+	lookupQuery.On("Where", "PK", "=", lookupPK).Return(lookupQuery).Once()
+	lookupQuery.On("Where", "SK", "=", conversationParticipantLookupSK).Return(lookupQuery).Once()
+	lookupQuery.On("First", mock.AnythingOfType("*models.ConversationParticipantKey")).Run(func(args mock.Arguments) {
+		record := args.Get(0).(*models.ConversationParticipantKey)
+		record.ConversationID = "conv-typed"
+	}).Return(nil).Once()
+
+	conversationQuery.On("WithContext", mock.Anything).Return(conversationQuery).Once()
+	conversationQuery.On("ConsistentRead").Return(conversationQuery).Once()
+	conversationQuery.On("Where", "PK", "=", "CONVERSATION#conv-typed").Return(conversationQuery).Once()
+	conversationQuery.On("Where", "SK", "=", "METADATA").Return(conversationQuery).Once()
+	conversationQuery.On("First", mock.AnythingOfType("*models.Conversation")).Run(func(args mock.Arguments) {
+		conv := args.Get(0).(*models.Conversation)
+		conv.ID = "conv-typed"
+		conv.ParticipantRefs = normalized
+	}).Return(nil).Once()
+
+	repo := NewConversationRepository(mockDB, "test-table", zap.NewNop(), nil)
+	conv, err := repo.GetConversationByParticipantRefs(context.Background(), refs)
+	require.NoError(t, err)
+	require.NotNil(t, conv)
+	require.Equal(t, "conv-typed", conv.ID)
+	require.Equal(t, normalized, conv.ParticipantRefs)
+
+	lookupQuery.AssertExpectations(t)
+	conversationQuery.AssertExpectations(t)
+}
+
 func TestRound07_ConversationRepository_GetConversationByParticipants_ConversationLoadErrorBranches(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/storage/repositories/conversation_send_repository.go
+++ b/pkg/storage/repositories/conversation_send_repository.go
@@ -55,7 +55,7 @@ func (r *ConversationRepository) ApplyDirectMessageSend(ctx context.Context, tra
 			for _, state := range prepared.participantStates {
 				tx.Create(state)
 			}
-			tx.Create(newConversationParticipantLookup(prepared.conversation.ID, prepared.conversation.Participants))
+			tx.Create(newConversationParticipantLookupForConversation(prepared.conversation, prepared.conversation.Participants))
 		} else {
 			tx.UpdateWithBuilder(prepared.expectedConversation, func(update core.UpdateBuilder) error {
 				// DynamoDB ADD initializes a missing numeric attribute, so this remains
@@ -126,6 +126,10 @@ func prepareDirectMessageSendTransition(transition *models.DirectMessageSendTran
 	}
 
 	expectedConversation.Participants = models.CanonicalConversationParticipants(expectedConversation.Participants)
+	expectedConversation.ParticipantRefs = models.NormalizeConversationParticipantRefs(expectedConversation.ParticipantRefs)
+	if len(expectedConversation.ParticipantRefs) > 0 {
+		expectedConversation.Participants = models.ConversationParticipantIDsFromRefs(expectedConversation.ParticipantRefs)
+	}
 	if len(expectedConversation.Participants) == 0 {
 		return nil, storage.ErrInvalidInput
 	}
@@ -199,6 +203,9 @@ func cloneConversationModel(conversation *models.Conversation) *models.Conversat
 	if conversation.Participants != nil {
 		cloned.Participants = append([]string(nil), conversation.Participants...)
 	}
+	if conversation.ParticipantRefs != nil {
+		cloned.ParticipantRefs = append([]models.ConversationParticipantRef(nil), conversation.ParticipantRefs...)
+	}
 
 	return &cloned
 }
@@ -241,6 +248,21 @@ func applyDirectMessageParticipantStateUpdate(update core.UpdateBuilder, state *
 		Set("Unread", state.Unread).
 		Set("UpdatedAt", state.UpdatedAt)
 
+	if state.CounterpartType != "" {
+		update.Set("CounterpartType", state.CounterpartType)
+	} else {
+		update.Remove("CounterpartType")
+	}
+	if state.CounterpartAcct != "" {
+		update.Set("CounterpartAcct", state.CounterpartAcct)
+	} else {
+		update.Remove("CounterpartAcct")
+	}
+	if state.CounterpartDomain != "" {
+		update.Set("CounterpartDomain", state.CounterpartDomain)
+	} else {
+		update.Remove("CounterpartDomain")
+	}
 	if state.RequestState != "" {
 		update.Set("RequestState", state.RequestState)
 	} else {
@@ -280,5 +302,10 @@ func applyDirectMessageParticipantStateUpdate(update core.UpdateBuilder, state *
 		update.Set("DeclinedAt", *state.DeclinedAt)
 	} else {
 		update.Remove("DeclinedAt")
+	}
+	if state.CounterpartResolvedAt != nil {
+		update.Set("CounterpartResolvedAt", *state.CounterpartResolvedAt)
+	} else {
+		update.Remove("CounterpartResolvedAt")
 	}
 }

--- a/pkg/storage/repositories/conversation_state_repository.go
+++ b/pkg/storage/repositories/conversation_state_repository.go
@@ -41,6 +41,20 @@ func counterpartForConversation(viewerID string, participants []string) string {
 	return ""
 }
 
+func counterpartRefForConversation(conversation *models.Conversation, counterpartID string) *models.ConversationParticipantRef {
+	if conversation == nil || counterpartID == "" {
+		return nil
+	}
+	canonicalCounterpartID := models.CanonicalConversationParticipantID(counterpartID)
+	for _, ref := range models.NormalizeConversationParticipantRefs(conversation.ParticipantRefs) {
+		if models.CanonicalConversationParticipantID(ref.ParticipantID) == canonicalCounterpartID {
+			refCopy := ref
+			return &refCopy
+		}
+	}
+	return nil
+}
+
 func defaultUserConversationState(conversation *models.Conversation, viewerID string) *models.UserConversationState {
 	now := time.Now().UTC()
 	sortAt := now
@@ -56,14 +70,21 @@ func defaultUserConversationState(conversation *models.Conversation, viewerID st
 		}
 	}
 
+	counterpartID := counterpartForConversation(viewerID, participants)
 	state := &models.UserConversationState{
 		ViewerID:       viewerID,
 		ConversationID: conversationID,
-		CounterpartID:  counterpartForConversation(viewerID, participants),
+		CounterpartID:  counterpartID,
 		Folder:         models.UserConversationFolderHidden,
 		SortAt:         sortAt,
 		CreatedAt:      now,
 		UpdatedAt:      now,
+	}
+	if ref := counterpartRefForConversation(conversation, counterpartID); ref != nil {
+		state.CounterpartType = ref.ParticipantType
+		state.CounterpartAcct = ref.Acct
+		state.CounterpartDomain = ref.Domain
+		state.CounterpartResolvedAt = ref.ResolvedAt
 	}
 	if conversation != nil {
 		state.CreatedAt = conversation.CreatedAt.UTC()
@@ -130,6 +151,10 @@ func stateContractFromModel(state *models.UserConversationState) *interfaces.Use
 		ViewerID:                 state.ViewerID,
 		ConversationID:           state.ConversationID,
 		CounterpartID:            state.CounterpartID,
+		CounterpartType:          state.CounterpartType,
+		CounterpartAcct:          state.CounterpartAcct,
+		CounterpartDomain:        state.CounterpartDomain,
+		CounterpartResolvedAt:    state.CounterpartResolvedAt,
 		Folder:                   state.Folder,
 		RequestState:             state.RequestState,
 		PreviewStatusID:          state.PreviewStatusID,
@@ -226,7 +251,7 @@ func (r *ConversationRepository) initializeUserConversationStates(ctx context.Co
 		return storage.ErrInvalidInput
 	}
 
-	for _, participantID := range conversation.Participants {
+	for _, participantID := range models.ConversationLocalParticipantIDs(conversation) {
 		state := defaultUserConversationState(conversation, participantID)
 		existing, err := r.getUserConversationStateModel(ctx, participantID, conversation.ID)
 		if err == nil && existing != nil {

--- a/pkg/testing/inmemory/conversation_repository.go
+++ b/pkg/testing/inmemory/conversation_repository.go
@@ -49,15 +49,21 @@ func (r *ConversationRepository) CreateConversation(_ context.Context, conversat
 	if _, exists := r.conversations[conversation.ID]; exists {
 		return storage.ErrAlreadyExists
 	}
+	conversation.ParticipantRefs = models.NormalizeConversationParticipantRefs(conversation.ParticipantRefs)
+	if len(conversation.ParticipantRefs) > 0 {
+		conversation.Participants = models.ConversationParticipantIDsFromRefs(conversation.ParticipantRefs)
+	} else {
+		conversation.Participants = models.CanonicalConversationParticipants(participants)
+	}
 	r.conversations[conversation.ID] = conversation
-	r.participants[conversation.ID] = participants
-	for _, p := range participants {
+	r.participants[conversation.ID] = append([]string(nil), conversation.Participants...)
+	for _, p := range models.ConversationLocalParticipantIDs(conversation) {
 		r.userConversations[p] = append(r.userConversations[p], conversation.ID)
 		key := p + ":" + conversation.ID
 		r.states[key] = &models.UserConversationState{
 			ViewerID:       p,
 			ConversationID: conversation.ID,
-			CounterpartID:  counterpartIDForInMemoryState(p, participants),
+			CounterpartID:  counterpartIDForInMemoryState(p, conversation.Participants),
 			Folder:         models.UserConversationFolderInbox,
 			SortAt:         conversation.UpdatedAt,
 			CreatedAt:      conversation.CreatedAt,
@@ -255,6 +261,12 @@ func (r *ConversationRepository) GetConversationByParticipants(_ context.Context
 	return nil, storage.ErrNotFound
 }
 
+// GetConversationByParticipantRefs finds a conversation with exact typed participants.
+func (r *ConversationRepository) GetConversationByParticipantRefs(_ context.Context, refs []models.ConversationParticipantRef) (*models.Conversation, error) {
+	participants := models.ConversationParticipantIDsFromRefs(refs)
+	return r.GetConversationByParticipants(context.Background(), participants)
+}
+
 func counterpartIDForInMemoryState(viewerID string, participants []string) string {
 	for _, participantID := range participants {
 		if participantID != viewerID {
@@ -278,6 +290,10 @@ func (r *ConversationRepository) GetUserConversationState(_ context.Context, vie
 		ViewerID:                 state.ViewerID,
 		ConversationID:           state.ConversationID,
 		CounterpartID:            state.CounterpartID,
+		CounterpartType:          state.CounterpartType,
+		CounterpartAcct:          state.CounterpartAcct,
+		CounterpartDomain:        state.CounterpartDomain,
+		CounterpartResolvedAt:    state.CounterpartResolvedAt,
 		Folder:                   state.Folder,
 		RequestState:             state.RequestState,
 		PreviewStatusID:          state.PreviewStatusID,
@@ -322,6 +338,10 @@ func (r *ConversationRepository) ListUserConversationStatesByFolder(_ context.Co
 			ViewerID:                 state.ViewerID,
 			ConversationID:           state.ConversationID,
 			CounterpartID:            state.CounterpartID,
+			CounterpartType:          state.CounterpartType,
+			CounterpartAcct:          state.CounterpartAcct,
+			CounterpartDomain:        state.CounterpartDomain,
+			CounterpartResolvedAt:    state.CounterpartResolvedAt,
 			Folder:                   state.Folder,
 			RequestState:             state.RequestState,
 			PreviewStatusID:          state.PreviewStatusID,
@@ -355,6 +375,10 @@ func (r *ConversationRepository) ListUnreadUserConversationStates(_ context.Cont
 			ViewerID:                 state.ViewerID,
 			ConversationID:           state.ConversationID,
 			CounterpartID:            state.CounterpartID,
+			CounterpartType:          state.CounterpartType,
+			CounterpartAcct:          state.CounterpartAcct,
+			CounterpartDomain:        state.CounterpartDomain,
+			CounterpartResolvedAt:    state.CounterpartResolvedAt,
 			Folder:                   state.Folder,
 			RequestState:             state.RequestState,
 			PreviewStatusID:          state.PreviewStatusID,
@@ -389,6 +413,10 @@ func (r *ConversationRepository) ListConversationParticipantStates(_ context.Con
 			ViewerID:                 state.ViewerID,
 			ConversationID:           state.ConversationID,
 			CounterpartID:            state.CounterpartID,
+			CounterpartType:          state.CounterpartType,
+			CounterpartAcct:          state.CounterpartAcct,
+			CounterpartDomain:        state.CounterpartDomain,
+			CounterpartResolvedAt:    state.CounterpartResolvedAt,
 			Folder:                   state.Folder,
 			RequestState:             state.RequestState,
 			PreviewStatusID:          state.PreviewStatusID,

--- a/tools/openapi/schema_overrides.go
+++ b/tools/openapi/schema_overrides.go
@@ -39,7 +39,7 @@ func overrideCreateStatusRequest(schemas map[string]any) {
 	}
 
 	visibility["enum"] = []string{"public", "unlisted", "private", "direct"}
-	visibility["description"] = "Status visibility. `direct` messages must mention exactly one recipient using an @mention in the status content."
+	visibility["description"] = "Status visibility. `direct` messages must mention exactly one local or remote recipient using an @mention in the status content; group direct messages are not supported in v1."
 }
 
 func overrideOAuthClientSchemas(schemas map[string]any) {


### PR DESCRIPTION
## Milestone
first-class federated conversations — complete 1:1 cross-instance direct conversation support.

## Classification
federation-trust / Mastodon API compatibility / schema / contract-stability / operational-reliability

## Surfaces affected
- Conversation storage models and repository lookup/state paths
- Direct-message send service and federation delivery adapter wiring
- Inbox remote `Create` materialization for direct messages
- Notification and streaming events for inbound direct messages
- Mastodon REST conversation/account projection and notification actor projection
- GraphQL conversation projection
- OpenAPI direct-visibility contract text
- In-memory/test repositories and coverage fixtures

## Specialist walks referenced
- Federation trust: completed; HTTP Signature verification/signing paths remain enforced, outbound uses real queue federation adapter, unsupported inbound groups are accepted but not materialized.
- Contract / API: completed; remote conversation counterparts project as Mastodon Account objects, no local USER shadows, OpenAPI regenerated.
- Schema: completed; additive `participantRefs` and optional counterpart metadata only, no PK/GSI changes; V2 hashed participant lookup is additive alongside legacy lookup.
- Framework: idiomatic; no AppTheory/TableTheory local patches.

## Consumer impact
- Operators gain first-class 1:1 federated direct conversations without group-DM semantics.
- Mastodon clients continue to receive Mastodon-compatible conversation accounts and `mention` notifications for user-visible inbound directs.
- Remote ActivityPub peers get signed outbound direct `Create` delivery through the existing federation delivery plane.
- Sibling repos: no release artifact or namespace contract changes; `body`/MCP benefits from canonical conversation state and notifications.

## Tasks
- [x] Add typed conversation participant refs and V2 participant lookup.
- [x] Federate outbound direct conversations through the real federation adapter.
- [x] Materialize inbound federated direct conversations, state, notifications, and stream events.
- [x] Project remote conversation accounts for REST and GraphQL clients.

## Validation
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (empty)
- [x] `go build -o lesser ./cmd/lesser && ./lesser build lambdas && ./lesser verify ci`
- [x] OpenAPI contract regenerated/verified by `./lesser verify ci`
- [x] GraphQL schema contract verified up to date by `./lesser verify ci`
- [ ] `./lesser verify --smoke` with a deployed `SMOKE_BASE_URL` before promoting from draft

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None required for this PR. If clients want a lesser-specific direct-notification extension later, coordinate with `greater` and `sim`; v1 uses Mastodon-compatible `mention` notifications.

## Advisor-brief authorization
Arch report was investigated only after Aron authorized the issue investigation and subsequent scoped milestone.
