### PR TITLE
fix: preserve local state owners for federated directs

### DIFF
--- a/pkg/storage/interfaces/conversation.go
+++ b/pkg/storage/interfaces/conversation.go
@@ -79,7 +79,7 @@ type ConversationRepository interface {
 	GetUnreadConversationCount(ctx context.Context, username string) (int, error)
 
 	// ApplyDirectMessageSend atomically writes the canonical DM send transition:
-	// shared conversation metadata, both per-user state rows, and a caller-supplied
+	// shared conversation metadata, per-local-user state owner rows, and a caller-supplied
 	// staged status write owned by the canonical StatusRepository contract.
 	ApplyDirectMessageSend(ctx context.Context, transition *models.DirectMessageSendTransition, stageStatusCreate DirectMessageStatusStageFn) error
 

--- a/pkg/storage/models/direct_message_send_transition.go
+++ b/pkg/storage/models/direct_message_send_transition.go
@@ -1,8 +1,8 @@
 package models
 
 // DirectMessageSendTransition is the repository-owned DM send write set.
-// It captures the status row, shared conversation metadata, and both
-// canonical participant state rows that must move together for one send.
+// It captures the status row, shared conversation metadata, and the
+// per-local-user canonical state owner rows that must move together for one send.
 type DirectMessageSendTransition struct {
 	Conversation              *Conversation
 	Status                    *Status

--- a/pkg/storage/repositories/conversation_repository_round44_transaction_test.go
+++ b/pkg/storage/repositories/conversation_repository_round44_transaction_test.go
@@ -515,6 +515,91 @@ func TestRound44_ConversationRepository_ApplyDirectMessageSend_CreatesNewConvers
 	require.Equal(t, "conv-send", status.ConversationID)
 }
 
+func TestRound44_ConversationRepository_ApplyDirectMessageSend_CreatesRemoteConversationWithLocalStateOnly(t *testing.T) {
+	ctx := context.Background()
+	repo := NewConversationRepository(new(mocks.MockDB), "test-table", zap.NewNop(), nil)
+	builder := &recordingConversationTransactionBuilder{}
+
+	repo.transactWriteFn = func(txCtx context.Context, fn func(core.TransactionBuilder) error) error {
+		require.Equal(t, ctx, txCtx)
+		return fn(builder)
+	}
+
+	publishedAt := time.Date(2026, 4, 27, 13, 30, 0, 0, time.UTC)
+	remoteActorID := "https://dev.theory.greater.website/users/steward"
+	err := repo.ApplyDirectMessageSend(ctx, &models.DirectMessageSendTransition{
+		Conversation: &models.Conversation{
+			ID:           "conv-remote",
+			Participants: []string{"ops", remoteActorID},
+			ParticipantRefs: []models.ConversationParticipantRef{
+				{ParticipantType: models.ConversationParticipantTypeLocalUser, ParticipantID: "ops"},
+				{
+					ParticipantType: models.ConversationParticipantTypeRemoteActor,
+					ParticipantID:   remoteActorID,
+					Acct:            "steward@dev.theory.greater.website",
+					Domain:          "dev.theory.greater.website",
+				},
+			},
+			CreatedAt: publishedAt,
+			UpdatedAt: publishedAt,
+		},
+		Status: &models.Status{
+			StatusID:       "status-remote",
+			AuthorID:       "ops",
+			AuthorUsername: "ops",
+			Content:        "hello remote",
+			Visibility:     models.VisibilityDirect,
+			ConversationID: "conv-remote",
+			PublishedAt:    publishedAt,
+		},
+		ParticipantStates: []*models.UserConversationState{
+			{
+				ViewerID:          "ops",
+				ConversationID:    "conv-remote",
+				CounterpartID:     remoteActorID,
+				CounterpartType:   models.ConversationParticipantTypeRemoteActor,
+				CounterpartAcct:   "steward@dev.theory.greater.website",
+				CounterpartDomain: "dev.theory.greater.website",
+				Folder:            models.UserConversationFolderInbox,
+				RequestState:      models.DmRequestStateAccepted,
+				Unread:            false,
+				LastReadAt:        &publishedAt,
+				AcceptedAt:        &publishedAt,
+			},
+		},
+		CreateConversation: true,
+	}, recordStatusStageWithPut)
+	require.NoError(t, err)
+
+	require.Len(t, builder.created, 4)
+	require.Equal(t, []string{"create", "create", "create", "put"}, builder.ops)
+
+	conversation, ok := builder.created[0].(*models.Conversation)
+	require.True(t, ok)
+	require.ElementsMatch(t, []string{"ops", remoteActorID}, conversation.Participants)
+	require.Len(t, conversation.ParticipantRefs, 2)
+	require.Equal(t, "status-remote", conversation.LastStatusID)
+	require.EqualValues(t, 1, conversation.TotalMessageCount)
+
+	state, ok := builder.created[1].(*models.UserConversationState)
+	require.True(t, ok)
+	require.Equal(t, "ops", state.ViewerID)
+	require.Equal(t, remoteActorID, state.CounterpartID)
+	require.Equal(t, models.ConversationParticipantTypeRemoteActor, state.CounterpartType)
+	require.Equal(t, "steward@dev.theory.greater.website", state.CounterpartAcct)
+	require.False(t, state.Unread)
+
+	lookup, ok := builder.created[2].(*models.ConversationParticipantKey)
+	require.True(t, ok)
+	require.Equal(t, conversationParticipantLookupPKForConversation(conversation, conversation.Participants), lookup.PK)
+	require.Equal(t, "conv-remote", lookup.ConversationID)
+
+	status, ok := builder.created[3].(*models.Status)
+	require.True(t, ok)
+	require.Equal(t, "status-remote", status.StatusID)
+	require.Equal(t, "conv-remote", status.ConversationID)
+}
+
 func TestRound44_ConversationRepository_ApplyDirectMessageSend_UpdatesExistingConversationWriteSet(t *testing.T) {
 	ctx := context.Background()
 	repo := NewConversationRepository(new(mocks.MockDB), "test-table", zap.NewNop(), nil)
@@ -632,6 +717,101 @@ func TestRound44_ConversationRepository_ApplyDirectMessageSend_UpdatesExistingCo
 	status, ok := builder.created[0].(*models.Status)
 	require.True(t, ok)
 	require.Equal(t, "status-existing", status.StatusID)
+}
+
+func TestRound44_ConversationRepository_ApplyDirectMessageSend_UpdatesRemoteConversationWithLocalStateOnly(t *testing.T) {
+	ctx := context.Background()
+	repo := NewConversationRepository(new(mocks.MockDB), "test-table", zap.NewNop(), nil)
+	builder := &recordingConversationTransactionBuilder{}
+
+	repo.transactWriteFn = func(txCtx context.Context, fn func(core.TransactionBuilder) error) error {
+		require.Equal(t, ctx, txCtx)
+		return fn(builder)
+	}
+
+	publishedAt := time.Date(2026, 4, 27, 14, 15, 0, 0, time.UTC)
+	previousAt := publishedAt.Add(-time.Hour)
+	remoteActorID := "https://dev.theory.greater.website/users/steward"
+	conversation := &models.Conversation{
+		ID:                "conv-remote-existing",
+		Participants:      []string{"ops", remoteActorID},
+		CreatedAt:         previousAt,
+		UpdatedAt:         previousAt,
+		TotalMessageCount: 2,
+		ParticipantRefs: []models.ConversationParticipantRef{
+			{ParticipantType: models.ConversationParticipantTypeLocalUser, ParticipantID: "ops"},
+			{
+				ParticipantType: models.ConversationParticipantTypeRemoteActor,
+				ParticipantID:   remoteActorID,
+				Acct:            "steward@dev.theory.greater.website",
+				Domain:          "dev.theory.greater.website",
+			},
+		},
+	}
+	localState := &models.UserConversationState{
+		ViewerID:          "ops",
+		ConversationID:    conversation.ID,
+		CounterpartID:     remoteActorID,
+		CounterpartType:   models.ConversationParticipantTypeRemoteActor,
+		CounterpartAcct:   "steward@dev.theory.greater.website",
+		CounterpartDomain: "dev.theory.greater.website",
+		Folder:            models.UserConversationFolderInbox,
+		RequestState:      models.DmRequestStateAccepted,
+		Unread:            false,
+		LastReadAt:        &publishedAt,
+		AcceptedAt:        &previousAt,
+		CreatedAt:         previousAt,
+		UpdatedAt:         publishedAt,
+	}
+	expectedLocalState := *localState
+	expectedLocalState.UpdatedAt = previousAt
+
+	err := repo.ApplyDirectMessageSend(ctx, &models.DirectMessageSendTransition{
+		Conversation: conversation,
+		Status: &models.Status{
+			StatusID:       "status-remote-existing",
+			AuthorID:       "ops",
+			AuthorUsername: "ops",
+			Content:        "again remote",
+			Visibility:     models.VisibilityDirect,
+			ConversationID: conversation.ID,
+			PublishedAt:    publishedAt,
+		},
+		ParticipantStates:         []*models.UserConversationState{localState},
+		ExpectedParticipantStates: []*models.UserConversationState{&expectedLocalState},
+	}, recordStatusStageWithPut)
+	require.NoError(t, err)
+
+	require.Len(t, builder.created, 1)
+	require.Len(t, builder.updates, 2)
+	require.Equal(t, []string{"update_builder", "update_builder", "put"}, builder.ops)
+
+	conversationUpdate := builder.updates[0]
+	expectedConversation, ok := conversationUpdate.model.(*models.Conversation)
+	require.True(t, ok)
+	require.Equal(t, conversation.ID, expectedConversation.ID)
+	require.EqualValues(t, 2, expectedConversation.TotalMessageCount)
+	require.Equal(t, previousAt, expectedConversation.UpdatedAt)
+	require.EqualValues(t, 1, conversationUpdate.builder.adds["TotalMessageCount"])
+	require.Contains(t, conversationUpdate.conditions, core.TransactCondition{Kind: core.TransactConditionKindPrimaryKeyExists})
+	require.Contains(t, conversationUpdate.conditions, core.TransactCondition{Field: "UpdatedAt", Operator: "=", Value: previousAt})
+
+	stateUpdate := builder.updates[1]
+	expectedState, ok := stateUpdate.model.(*models.UserConversationState)
+	require.True(t, ok)
+	require.Equal(t, "ops", expectedState.ViewerID)
+	require.Equal(t, remoteActorID, expectedState.CounterpartID)
+	require.Equal(t, "status-remote-existing", stateUpdate.builder.sets["PreviewStatusID"])
+	require.Equal(t, models.ConversationParticipantTypeRemoteActor, stateUpdate.builder.sets["CounterpartType"])
+	require.Equal(t, "steward@dev.theory.greater.website", stateUpdate.builder.sets["CounterpartAcct"])
+	require.False(t, stateUpdate.builder.sets["Unread"].(bool))
+	require.Contains(t, stateUpdate.conditions, core.TransactCondition{Kind: core.TransactConditionKindPrimaryKeyExists})
+	require.Contains(t, stateUpdate.conditions, core.TransactCondition{Field: "UpdatedAt", Operator: "=", Value: previousAt})
+
+	status, ok := builder.created[0].(*models.Status)
+	require.True(t, ok)
+	require.Equal(t, "status-remote-existing", status.StatusID)
+	require.Equal(t, conversation.ID, status.ConversationID)
 }
 
 func TestRound44_ConversationRepository_ApplyDirectMessageSend_MapsExistingConversationConflictsToVersionConflict(t *testing.T) {

--- a/pkg/storage/repositories/conversation_send_repository.go
+++ b/pkg/storage/repositories/conversation_send_repository.go
@@ -165,7 +165,12 @@ func prepareDirectMessageSendTransition(transition *models.DirectMessageSendTran
 		return nil, err
 	}
 
-	participantStates, err := normalizeExplicitConversationParticipantStates(conversation, conversation.Participants, transition.ParticipantStates)
+	stateOwnerParticipants := models.ConversationLocalParticipantIDs(conversation)
+	if len(stateOwnerParticipants) == 0 {
+		return nil, storage.ErrInvalidInput
+	}
+
+	participantStates, err := normalizeExplicitConversationParticipantStates(conversation, stateOwnerParticipants, transition.ParticipantStates)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +190,7 @@ func prepareDirectMessageSendTransition(transition *models.DirectMessageSendTran
 		return nil, storage.ErrInvalidInput
 	}
 
-	expectedParticipantStates, err := normalizeExplicitConversationParticipantStates(expectedConversation, expectedConversation.Participants, transition.ExpectedParticipantStates)
+	expectedParticipantStates, err := normalizeExplicitConversationParticipantStates(expectedConversation, stateOwnerParticipants, transition.ExpectedParticipantStates)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/testing/inmemory/conversation_repository.go
+++ b/pkg/testing/inmemory/conversation_repository.go
@@ -132,7 +132,7 @@ func (r *ConversationRepository) ApplyDirectMessageSend(_ context.Context, trans
 		}
 		r.conversations[conversation.ID] = conversation
 		r.participants[conversation.ID] = append([]string(nil), conversation.Participants...)
-		for _, participantID := range conversation.Participants {
+		for _, participantID := range models.ConversationLocalParticipantIDs(conversation) {
 			r.userConversations[participantID] = append(r.userConversations[participantID], conversation.ID)
 		}
 	} else {
@@ -151,7 +151,7 @@ func (r *ConversationRepository) ApplyDirectMessageSend(_ context.Context, trans
 	}
 
 	senderID := transition.Status.AuthorID
-	for _, participantID := range conversation.Participants {
+	for _, participantID := range models.ConversationLocalParticipantIDs(conversation) {
 		r.readStatus[conversation.ID+":"+participantID] = participantID == senderID
 	}
 


### PR DESCRIPTION
## Summary
- normalize transactional DM send state rows against local conversation participants only
- preserve remote actor participants for identity/lookup while requiring only local UserConversationState rows
- align in-memory repository behavior and comments with per-local-user state ownership
- add repository create/update regression coverage for federated direct conversations

## Validation
- go test ./pkg/storage/repositories -run 'TestRound44_ConversationRepository_ApplyDirectMessageSend_(CreatesRemoteConversationWithLocalStateOnly|UpdatesRemoteConversationWithLocalStateOnly)' -count=1 -v\n- go test ./pkg/storage/repositories ./pkg/services/conversations ./pkg/testing/inmemory\n- go test ./...\n- go vet ./...\n- gofmt -l . (empty)\n- go build -o lesser ./cmd/lesser && ./lesser build lambdas && ./lesser verify ci\n\n## Schema / contract notes\n- no PK/SK/GSI/TableTheory tag changes\n- no API shape changes; fixes 500 before persistence/federation enqueue\n- Conversation.Participants remains identity/lookup participants; UserConversationState rows are per-local-user owners only\n\n## Source\n- Arch advisor brief delivery-e364381a9c65762a, directly authorized by Aron