### PR TITLE
fix(security): close Codex Security M1

### DIFF
--- a/cmd/api/handlers/misc.go
+++ b/cmd/api/handlers/misc.go
@@ -178,6 +178,9 @@ func (h *Handler) convertActorToAccount(ctx context.Context, actor *activitypub.
 // searchStatusByURL searches for a status by direct URL
 func (h *Handler) searchStatusByURL(ctx *apptheory.Context, statusURL string, viewerUsername string, result *models.SearchResult) {
 	if fullStatus, err := h.resolveStatusBySearchURL(ctx.Context(), statusURL); err == nil && fullStatus != nil {
+		if !h.statusVisibleInSearch(fullStatus, viewerUsername) {
+			return
+		}
 		apiStatus, convErr := h.convertStorageStatusToAPI(fullStatus, viewerUsername)
 		if convErr == nil && apiStatus != nil {
 			result.Statuses = append(result.Statuses, *apiStatus)
@@ -192,7 +195,7 @@ func (h *Handler) searchStatusByContent(ctx *apptheory.Context, params *SearchPa
 		AccountID: params.AccountID,
 	}
 
-	statusResults, err := h.repos.Search().SearchStatusesWithOptions(ctx.Context(), params.Query, searchOptions)
+	statusResults, err := h.repos.Search().SearchStatusesWithPrivacy(ctx.Context(), params.Query, searchOptions, h.searchViewerActorID(viewerUsername))
 	if err != nil {
 		h.logger.Warn("status search failed", zap.Error(err))
 		return
@@ -202,6 +205,9 @@ func (h *Handler) searchStatusByContent(ctx *apptheory.Context, params *SearchPa
 
 	// Convert search results to API format
 	for _, sr := range statusResults {
+		if len(result.Statuses) >= params.Limit {
+			break
+		}
 		status := h.convertStatusResultToAPI(ctx, sr, viewerUsername)
 		if strings.TrimSpace(status.ID) == "" {
 			continue
@@ -218,13 +224,22 @@ func (h *Handler) searchStatusByContent(ctx *apptheory.Context, params *SearchPa
 
 // convertStatusResultToAPI converts status result to API format
 func (h *Handler) convertStatusResultToAPI(ctx *apptheory.Context, sr *storage.StatusSearchResult, viewerUsername string) models.Status {
+	if sr == nil {
+		return models.Status{}
+	}
 	if status, err := h.resolveStatusFromSearchResult(ctx.Context(), sr); err == nil && status != nil {
+		if !h.statusVisibleInSearch(status, viewerUsername) {
+			return models.Status{}
+		}
 		apiStatus, convErr := h.convertStorageStatusToAPI(status, viewerUsername)
 		if convErr == nil && apiStatus != nil {
 			return *apiStatus
 		}
 	}
 
+	if !searchResultVisibleInSearch(sr, viewerUsername) {
+		return models.Status{}
+	}
 	return h.convertThinStatusResultToAPI(ctx, sr)
 }
 
@@ -384,7 +399,7 @@ func (h *Handler) addAuthorMatchedStatuses(ctx *apptheory.Context, params *Searc
 			if len(result.Statuses) >= params.Limit {
 				return
 			}
-			if !statusVisibleInSearch(status, viewerUsername) {
+			if !h.statusVisibleInSearch(status, viewerUsername) {
 				continue
 			}
 
@@ -402,16 +417,58 @@ func (h *Handler) addAuthorMatchedStatuses(ctx *apptheory.Context, params *Searc
 	}
 }
 
-func statusVisibleInSearch(status *storagemodels.Status, viewerUsername string) bool {
+func (h *Handler) statusVisibleInSearch(status *storagemodels.Status, viewerUsername string) bool {
+	return statusVisibleInSearchForViewer(status, viewerUsername, h.searchViewerActorID(viewerUsername))
+}
+
+func statusVisibleInSearchForViewer(status *storagemodels.Status, viewerUsername, viewerActorID string) bool {
 	if status == nil {
+		return false
+	}
+	if status.Deleted {
 		return false
 	}
 
 	switch status.Visibility {
 	case storagemodels.VisibilityPublic, storagemodels.VisibilityUnlisted:
 		return true
+	}
+
+	viewerUsername = strings.TrimSpace(viewerUsername)
+	if viewerUsername == "" {
+		return false
+	}
+	if strings.EqualFold(viewerUsername, strings.TrimSpace(status.AuthorUsername)) {
+		return true
+	}
+	viewerActorID = strings.TrimSpace(viewerActorID)
+	if viewerActorID == "" {
+		return false
+	}
+	return status.IsVisibleTo(viewerActorID)
+}
+
+func (h *Handler) searchViewerActorID(viewerUsername string) string {
+	viewerUsername = strings.TrimSpace(viewerUsername)
+	if viewerUsername == "" || h == nil || h.cfg == nil {
+		return ""
+	}
+	return h.cfg.ActorURL(viewerUsername)
+}
+
+func searchResultVisibleInSearch(result *storage.StatusSearchResult, viewerUsername string) bool {
+	if result == nil {
+		return false
+	}
+
+	switch strings.TrimSpace(strings.ToLower(result.Visibility)) {
+	case storagemodels.VisibilityPublic, storagemodels.VisibilityUnlisted:
+		return true
+	case storagemodels.VisibilityPrivate, storagemodels.VisibilityDirect:
+		return strings.TrimSpace(viewerUsername) != "" &&
+			strings.EqualFold(strings.TrimSpace(viewerUsername), strings.TrimSpace(result.AuthorUsername))
 	default:
-		return strings.TrimSpace(viewerUsername) != "" && strings.EqualFold(strings.TrimSpace(viewerUsername), strings.TrimSpace(status.AuthorUsername))
+		return false
 	}
 }
 

--- a/cmd/api/handlers/misc_round11_test.go
+++ b/cmd/api/handlers/misc_round11_test.go
@@ -61,6 +61,17 @@ func TestMiscSearchAndHelpers_Round11(t *testing.T) {
 				URL:          cfg.BaseURL() + "/objects/obj-1",
 			},
 		},
+		statusByID: map[string]storagemodels.Status{
+			"s1": {
+				StatusID:       "s1",
+				AuthorUsername: "alice",
+				AuthorID:       "https://example.com/users/alice",
+				Content:        "hello",
+				Visibility:     storagemodels.VisibilityPublic,
+				CreatedAt:      now.Add(-1 * time.Hour),
+				UpdatedAt:      now.Add(-30 * time.Minute),
+			},
+		},
 	}
 	handler, _, _ := round11NewHandler(t, cfg, state)
 
@@ -73,11 +84,12 @@ func TestMiscSearchAndHelpers_Round11(t *testing.T) {
 	requireStatus(t, http.StatusOK)(handler.HandleSearchV2Lift(ctxSearch2))
 
 	status := handler.convertStatusResultToAPI(ctxSearch, &storage.StatusSearchResult{
-		StatusID:  "s1",
-		Content:   "hi",
-		URL:       "https://example.com/s1",
-		Published: now,
-		AuthorID:  "https://example.com/users/alice",
+		StatusID:   "s1",
+		Content:    "hi",
+		URL:        "https://example.com/s1",
+		Published:  now,
+		AuthorID:   "https://example.com/users/alice",
+		Visibility: storagemodels.VisibilityPublic,
 	}, "")
 	require.Equal(t, "hello", status.Content)
 }

--- a/cmd/api/handlers/misc_round22_helper_coverage_test.go
+++ b/cmd/api/handlers/misc_round22_helper_coverage_test.go
@@ -230,7 +230,7 @@ func TestMiscRound22_AddAuthorMatchedStatusesAppendsVisibleTimelineStatuses(t *t
 	require.Equal(t, statusID, result.Statuses[0].ID)
 	require.Contains(t, seen, statusID)
 	status := state.statusByID[statusID]
-	require.True(t, statusVisibleInSearch(&status, ""))
+	require.True(t, statusVisibleInSearchForViewer(&status, "", ""))
 }
 
 func TestMiscRound22_SearchStatusByURLUsesStoredStatusWhenAvailable(t *testing.T) {
@@ -295,6 +295,69 @@ func TestMiscRound22_SearchStatusByURLUsesStoredStatusWhenAvailable(t *testing.T
 	require.Equal(t, cfg.BaseURL()+"/@simulacrum/"+statusID, result.Statuses[0].URL)
 }
 
+func TestMiscRound22_SearchStatusByURLEnforcesViewerVisibility(t *testing.T) {
+	cfg := round11TestConfig()
+	now := time.Date(2026, 3, 11, 13, 5, 0, 0, time.UTC)
+	authorID := cfg.ActorURL("simulacrum")
+	statusID := "private-url-status"
+	statusURL := authorID + "/statuses/" + statusID
+
+	state := &round10QueryState{
+		usersByUsername: map[string]storagemodels.User{
+			"simulacrum": {
+				Username:     "simulacrum",
+				DisplayName:  "Simulacrum",
+				CreatedAt:    now.Add(-24 * time.Hour),
+				UpdatedAt:    now.Add(-24 * time.Hour),
+				Discoverable: true,
+				Role:         "user",
+			},
+		},
+		actorsByUser: map[string]storagemodels.Actor{
+			"simulacrum": {
+				Username: "simulacrum",
+				Actor: &activitypub.Actor{
+					BaseObject:        activitypub.BaseObject{ID: authorID, Type: "Service"},
+					PreferredUsername: "simulacrum",
+					Name:              "Simulacrum",
+					Discoverable:      true,
+				},
+				NumericID: common.GenerateNumericID("simulacrum"),
+			},
+		},
+		statusByID: map[string]storagemodels.Status{
+			statusID: {
+				StatusID:       statusID,
+				AuthorID:       authorID,
+				AuthorUsername: "simulacrum",
+				Content:        "private url content",
+				Visibility:     storagemodels.VisibilityPrivate,
+				PublishedAt:    now,
+				CreatedAt:      now,
+				UpdatedAt:      now,
+				Note: &activitypub.Note{
+					BaseObject:   activitypub.BaseObject{ID: statusURL, Type: activitypub.NoteType},
+					Content:      "private url content",
+					AttributedTo: authorID,
+				},
+			},
+		},
+	}
+
+	handler, _, _ := round11NewHandler(t, cfg, state)
+	ctx, err := round10NewLiftContext(http.MethodGet, "/api/v2/search", nil, nil, nil)
+	require.NoError(t, err)
+
+	publicResult := apimodels.SearchResult{Statuses: []apimodels.Status{}}
+	handler.searchStatusByURL(ctx, statusURL, "", &publicResult)
+	require.Empty(t, publicResult.Statuses)
+
+	authorResult := apimodels.SearchResult{Statuses: []apimodels.Status{}}
+	handler.searchStatusByURL(ctx, statusURL, "simulacrum", &authorResult)
+	require.Len(t, authorResult.Statuses, 1)
+	require.Equal(t, statusID, authorResult.Statuses[0].ID)
+}
+
 func TestMiscRound22_ResolveStatusBySearchURLUsesCanonicalRemoteStatusID(t *testing.T) {
 	cfg := round11TestConfig()
 	remoteURL := "https://remote.example/users/bob/statuses/abc-123"
@@ -350,15 +413,35 @@ func TestMiscRound22_SearchHelperPureFunctions(t *testing.T) {
 	require.False(t, shouldAugmentStatusSearchByAuthor("#simulacrum"))
 	require.False(t, shouldAugmentStatusSearchByAuthor("https://remote.example/@simulacrum"))
 
-	require.False(t, statusVisibleInSearch(nil, ""))
-	require.True(t, statusVisibleInSearch(&storagemodels.Status{Visibility: storagemodels.VisibilityPublic}, ""))
-	require.True(t, statusVisibleInSearch(&storagemodels.Status{Visibility: storagemodels.VisibilityUnlisted}, ""))
-	require.True(t, statusVisibleInSearch(&storagemodels.Status{
+	require.False(t, statusVisibleInSearchForViewer(nil, "", ""))
+	require.True(t, statusVisibleInSearchForViewer(&storagemodels.Status{Visibility: storagemodels.VisibilityPublic}, "", ""))
+	require.True(t, statusVisibleInSearchForViewer(&storagemodels.Status{Visibility: storagemodels.VisibilityUnlisted}, "", ""))
+	require.True(t, statusVisibleInSearchForViewer(&storagemodels.Status{
 		Visibility:     storagemodels.VisibilityPrivate,
 		AuthorUsername: "Simulacrum",
-	}, "simulacrum"))
-	require.False(t, statusVisibleInSearch(&storagemodels.Status{
+	}, "simulacrum", ""))
+	require.False(t, statusVisibleInSearchForViewer(&storagemodels.Status{
 		Visibility:     storagemodels.VisibilityPrivate,
+		AuthorUsername: "simulacrum",
+	}, "other", ""))
+	require.False(t, statusVisibleInSearchForViewer(&storagemodels.Status{
+		Visibility: storagemodels.VisibilityPublic,
+		Deleted:    true,
+	}, "", ""))
+	require.True(t, statusVisibleInSearchForViewer(&storagemodels.Status{
+		Visibility:   storagemodels.VisibilityDirect,
+		ToRecipients: []string{"https://example.com/users/bob"},
+	}, "bob", "https://example.com/users/bob"))
+
+	require.False(t, searchResultVisibleInSearch(nil, ""))
+	require.False(t, searchResultVisibleInSearch(&storage.StatusSearchResult{Visibility: ""}, ""))
+	require.True(t, searchResultVisibleInSearch(&storage.StatusSearchResult{Visibility: storagemodels.VisibilityPublic}, ""))
+	require.True(t, searchResultVisibleInSearch(&storage.StatusSearchResult{
+		Visibility:     storagemodels.VisibilityPrivate,
+		AuthorUsername: "simulacrum",
+	}, "simulacrum"))
+	require.False(t, searchResultVisibleInSearch(&storage.StatusSearchResult{
+		Visibility:     storagemodels.VisibilityDirect,
 		AuthorUsername: "simulacrum",
 	}, "other"))
 }
@@ -373,6 +456,10 @@ func TestMiscRound22_SearchV2ExactActorRequiresResolve(t *testing.T) {
 	require.False(t, handler.searchV2ExactActorRequiresResolve("https://example.com/users/alice"))
 	require.True(t, handler.searchV2ExactActorRequiresResolve("https://remote.example/users/bob"))
 	require.False(t, handler.searchV2ExactActorRequiresResolve("https://remote.example/objects/note-1"))
+
+	require.Equal(t, cfg.ActorURL("alice"), handler.searchViewerActorID(" alice "))
+	require.Equal(t, "", handler.searchViewerActorID(""))
+	require.Equal(t, "", (*Handler)(nil).searchViewerActorID("alice"))
 }
 
 func TestMiscRound22_ConvertStatusResultToAPIFallsBackWhenResolutionMisses(t *testing.T) {
@@ -383,16 +470,80 @@ func TestMiscRound22_ConvertStatusResultToAPIFallsBackWhenResolutionMisses(t *te
 	ctx, err := round10NewLiftContext(http.MethodGet, "/api/v2/search", nil, nil, nil)
 	require.NoError(t, err)
 
+	nilResult := handler.convertStatusResultToAPI(ctx, nil, "")
+	require.Empty(t, nilResult.ID)
+
 	result := handler.convertStatusResultToAPI(ctx, &storage.StatusSearchResult{
-		StatusID:  "missing-status",
-		Content:   "thin fallback content",
-		URL:       cfg.BaseURL() + "/@ghost/missing-status",
-		Published: time.Date(2026, 3, 11, 12, 40, 0, 0, time.UTC),
+		StatusID:   "missing-status",
+		Content:    "thin fallback content",
+		URL:        cfg.BaseURL() + "/@ghost/missing-status",
+		Published:  time.Date(2026, 3, 11, 12, 40, 0, 0, time.UTC),
+		Visibility: storagemodels.VisibilityPublic,
 	}, "")
 
 	require.Equal(t, "missing-status", result.ID)
 	require.Equal(t, "thin fallback content", result.Content)
 	require.Equal(t, cfg.BaseURL()+"/@ghost/missing-status", result.URL)
+
+	hidden := handler.convertStatusResultToAPI(ctx, &storage.StatusSearchResult{
+		StatusID:   "missing-direct-status",
+		Content:    "hidden thin fallback",
+		URL:        cfg.BaseURL() + "/@ghost/missing-direct-status",
+		Published:  time.Date(2026, 3, 11, 12, 41, 0, 0, time.UTC),
+		Visibility: storagemodels.VisibilityDirect,
+	}, "")
+	require.Empty(t, hidden.ID)
+}
+
+func TestMiscRound22_ConvertStatusSearchResultsSkipsInvisibleStatuses(t *testing.T) {
+	cfg := round11TestConfig()
+	now := time.Date(2026, 3, 11, 13, 20, 0, 0, time.UTC)
+	authorID := cfg.ActorURL("simulacrum")
+	statusID := "hidden-search-result"
+	statusURL := authorID + "/statuses/" + statusID
+
+	state := &round10QueryState{
+		statusByID: map[string]storagemodels.Status{
+			statusID: {
+				StatusID:       statusID,
+				AuthorID:       authorID,
+				AuthorUsername: "simulacrum",
+				Content:        "hidden hydrated result",
+				Visibility:     storagemodels.VisibilityDirect,
+				PublishedAt:    now,
+				CreatedAt:      now,
+				UpdatedAt:      now,
+				Note: &activitypub.Note{
+					BaseObject:   activitypub.BaseObject{ID: statusURL, Type: activitypub.NoteType},
+					Content:      "hidden hydrated result",
+					AttributedTo: authorID,
+				},
+			},
+		},
+	}
+
+	handler, _, _ := round11NewHandler(t, cfg, state)
+	results := handler.convertStatusSearchResults(context.Background(), []storage.StatusSearchResult{
+		{
+			StatusID:   statusID,
+			URL:        statusURL,
+			Content:    "hidden hydrated result",
+			Visibility: storagemodels.VisibilityDirect,
+			Published:  now,
+		},
+		{
+			StatusID:   "missing-hidden",
+			Content:    "hidden thin result",
+			Visibility: storagemodels.VisibilityPrivate,
+			Published:  now,
+		},
+	}, "")
+
+	require.Empty(t, results)
+	require.True(t, handler.statusVisibleInSearch(&storagemodels.Status{
+		Visibility:   storagemodels.VisibilityDirect,
+		ToRecipients: []string{cfg.ActorURL("bob")},
+	}, "bob"))
 }
 
 func TestMiscRound22_ResolveStatusFromSearchResultHandlesFallbacks(t *testing.T) {
@@ -523,6 +674,83 @@ func TestMiscRound22_SearchStatusByContentAugmentsAuthorTimeline(t *testing.T) {
 
 	require.NotEmpty(t, result.Statuses)
 	require.Equal(t, statusID, result.Statuses[0].ID)
+}
+
+func TestMiscRound22_SearchStatusByContentFiltersNonPublicResults(t *testing.T) {
+	cfg := round11TestConfig()
+	now := time.Date(2026, 3, 11, 13, 10, 0, 0, time.UTC)
+	authorID := cfg.ActorURL("simulacrum")
+
+	publicStatus := storagemodels.Status{
+		StatusID:       "public-search-status",
+		AuthorID:       authorID,
+		AuthorUsername: "simulacrum",
+		Content:        "shared codex phrase",
+		Visibility:     storagemodels.VisibilityPublic,
+		PublishedAt:    now,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		Note: &activitypub.Note{
+			BaseObject:   activitypub.BaseObject{ID: authorID + "/statuses/public-search-status", Type: activitypub.NoteType},
+			Content:      "shared codex phrase",
+			AttributedTo: authorID,
+		},
+	}
+	privateStatus := storagemodels.Status{
+		StatusID:       "private-search-status",
+		AuthorID:       authorID,
+		AuthorUsername: "simulacrum",
+		Content:        "shared codex phrase private",
+		Visibility:     storagemodels.VisibilityDirect,
+		PublishedAt:    now.Add(time.Minute),
+		CreatedAt:      now.Add(time.Minute),
+		UpdatedAt:      now.Add(time.Minute),
+		Note: &activitypub.Note{
+			BaseObject:   activitypub.BaseObject{ID: authorID + "/statuses/private-search-status", Type: activitypub.NoteType},
+			Content:      "shared codex phrase private",
+			AttributedTo: authorID,
+		},
+	}
+
+	state := &round10QueryState{
+		usersByUsername: map[string]storagemodels.User{
+			"simulacrum": {
+				Username:     "simulacrum",
+				DisplayName:  "Simulacrum",
+				CreatedAt:    now.Add(-24 * time.Hour),
+				UpdatedAt:    now.Add(-24 * time.Hour),
+				Discoverable: true,
+				Role:         "user",
+			},
+		},
+		actorsByUser: map[string]storagemodels.Actor{
+			"simulacrum": {
+				Username: "simulacrum",
+				Actor: &activitypub.Actor{
+					BaseObject:        activitypub.BaseObject{ID: authorID, Type: "Service"},
+					PreferredUsername: "simulacrum",
+					Name:              "Simulacrum",
+					Discoverable:      true,
+				},
+				NumericID: common.GenerateNumericID("simulacrum"),
+			},
+		},
+		statusByID: map[string]storagemodels.Status{
+			publicStatus.StatusID:  publicStatus,
+			privateStatus.StatusID: privateStatus,
+		},
+		statusList: []storagemodels.Status{privateStatus, publicStatus},
+	}
+
+	handler, _, _ := round11NewHandler(t, cfg, state)
+	ctx, err := round10NewLiftContext(http.MethodGet, "/api/v2/search", nil, nil, nil)
+	require.NoError(t, err)
+
+	result := apimodels.SearchResult{Statuses: []apimodels.Status{}}
+	handler.searchStatusByContent(ctx, &SearchParams{Query: "shared codex phrase", Limit: 5}, "", &result)
+
+	require.Len(t, result.Statuses, 1)
+	require.Equal(t, publicStatus.StatusID, result.Statuses[0].ID)
 }
 
 func TestMiscRound22_AddAuthorMatchedStatusesSkipsSeenAndInvisibleTimelineStatuses(t *testing.T) {

--- a/cmd/api/handlers/notes.go
+++ b/cmd/api/handlers/notes.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"fmt"
-	"html"
 	"strings"
 	"time"
 
@@ -230,7 +229,7 @@ func (h *Handler) HandleGetNotesLift(ctx *apptheory.Context) (*apptheory.Respons
 			ID:               note.ID,
 			ObjectID:         note.ObjectID,
 			AuthorID:         note.AuthorID,
-			Content:          note.Content,
+			Content:          safeCommunityNoteHTML(note.Content),
 			Language:         note.Language,
 			Sources:          note.Sources,
 			HelpfulVotes:     note.HelpfulVotes,
@@ -476,7 +475,7 @@ func validateVoteCommunityNoteRequest(req *apimodels.VoteCommunityNoteRequest) e
 }
 
 func safeCommunityNoteHTML(content string) string {
-	return htmlsafe.Escape(html.UnescapeString(strings.TrimSpace(content)))
+	return htmlsafe.EscapePlainTextHTML(content)
 }
 
 // Helper functions

--- a/cmd/api/handlers/notes.go
+++ b/cmd/api/handlers/notes.go
@@ -2,12 +2,15 @@ package handlers
 
 import (
 	"fmt"
+	"html"
+	"strings"
 	"time"
 
 	apimodels "github.com/equaltoai/lesser/cmd/api/models"
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/notes"
 	"github.com/equaltoai/lesser/pkg/reputation"
+	"github.com/equaltoai/lesser/pkg/security/htmlsafe"
 	servicenotes "github.com/equaltoai/lesser/pkg/services/notes"
 	"github.com/equaltoai/lesser/pkg/storage"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
@@ -54,6 +57,9 @@ func (h *Handler) HandleCreateNoteLift(ctx *apptheory.Context) (*apptheory.Respo
 	if err != nil {
 		return common.RespondBadRequest(ctx, "invalid request body")
 	}
+	if err := validateCreateCommunityNoteRequest(&req); err != nil {
+		return common.RespondBadRequest(ctx, err.Error())
+	}
 
 	// Validate sources
 	if len(req.Sources) > notes.MaxSources {
@@ -74,7 +80,7 @@ func (h *Handler) HandleCreateNoteLift(ctx *apptheory.Context) (*apptheory.Respo
 	// Convert Source structs to string URLs
 	sourceURLs := make([]string, len(req.Sources))
 	for i, src := range req.Sources {
-		sourceURLs[i] = src.URL
+		sourceURLs[i] = strings.TrimSpace(src.URL)
 	}
 
 	// Create note
@@ -95,12 +101,17 @@ func (h *Handler) HandleCreateNoteLift(ctx *apptheory.Context) (*apptheory.Respo
 	}
 
 	// Store note using Notes service
-	if _, err := h.registry.Notes().CreateCommunityNote(ctx.Context(), &servicenotes.CreateCommunityNoteCommand{
+	created, err := h.registry.Notes().CreateCommunityNote(ctx.Context(), &servicenotes.CreateCommunityNoteCommand{
 		Note: note,
-	}); err != nil {
+	})
+	if err != nil {
 		h.logger.Error("Failed to store note", zap.Error(err))
 		return common.RespondInternalServerError(ctx)
 	}
+	if created != nil && created.Note != nil {
+		note = created.Note
+	}
+	note.Content = safeCommunityNoteHTML(note.Content)
 
 	// Add rate limit info to response
 	response := apimodels.CreateCommunityNoteResponse{
@@ -263,6 +274,9 @@ func (h *Handler) HandleVoteNoteLift(ctx *apptheory.Context) (*apptheory.Respons
 	if err := common.ParseRequestWithFallback(ctx, &req); err != nil {
 		return common.RespondBadRequest(ctx, "invalid request body")
 	}
+	if err := validateVoteCommunityNoteRequest(&req); err != nil {
+		return common.RespondBadRequest(ctx, err.Error())
+	}
 
 	// Initialize services
 	repService, err := h.getNoteReputationService()
@@ -299,6 +313,7 @@ func (h *Handler) HandleVoteNoteLift(ctx *apptheory.Context) (*apptheory.Respons
 		VoterID:   userID,
 		VoteType:  req.VoteType,
 		Weight:    weight,
+		Rationale: strings.TrimSpace(req.Reason),
 		CreatedAt: time.Now(),
 	}
 
@@ -362,7 +377,7 @@ func (h *Handler) HandleGetUserNotesLift(ctx *apptheory.Context) (*apptheory.Res
 	for i, note := range userNotes {
 		statuses[i] = apimodels.UserNoteStatus{
 			ID:        note.ID,
-			Content:   fmt.Sprintf("<p>Community Note: %s</p>", note.Content),
+			Content:   fmt.Sprintf("<p>Community Note: %s</p>", safeCommunityNoteHTML(note.Content)),
 			CreatedAt: note.CreatedAt.Format(time.RFC3339),
 			Account: apimodels.UserNoteAccount{
 				ID:       note.AuthorID,
@@ -398,6 +413,70 @@ func (h *Handler) HandleGetUserNotesLift(ctx *apptheory.Context) (*apptheory.Res
 	setHeader(resp, "X-Cost-Micros", fmt.Sprintf("%d", 100*len(userNotes)))
 	setHeader(resp, "X-Cost-Details", fmt.Sprintf("DynamoDB: %d reads", len(userNotes)))
 	return resp, nil
+}
+
+func validateCreateCommunityNoteRequest(req *apimodels.CreateCommunityNoteRequest) error {
+	if req == nil {
+		return common.ValidationError{Field: "body", Message: "required"}
+	}
+	req.ObjectID = strings.TrimSpace(req.ObjectID)
+	req.ObjectType = strings.TrimSpace(req.ObjectType)
+	req.Content = strings.TrimSpace(req.Content)
+	req.Language = strings.TrimSpace(req.Language)
+
+	if err := common.ValidateRequiredParam("object_id", req.ObjectID); err != nil {
+		return err
+	}
+	if err := common.ValidateRequiredParam("object_type", req.ObjectType); err != nil {
+		return err
+	}
+	if err := common.ValidateRequiredParam("content", req.Content); err != nil {
+		return err
+	}
+	if len(req.Content) < notes.MinNoteLength {
+		return common.ValidationError{Field: "content", Message: fmt.Sprintf("must be at least %d characters", notes.MinNoteLength)}
+	}
+	if len(req.Content) > notes.MaxNoteLength {
+		return common.ValidationError{Field: "content", Message: fmt.Sprintf("cannot be longer than %d characters", notes.MaxNoteLength)}
+	}
+	if len(req.Language) != 2 {
+		return common.ValidationError{Field: "language", Message: "must be a 2-letter code"}
+	}
+	if len(req.Sources) > notes.MaxSources {
+		return common.ValidationError{Field: "sources", Message: fmt.Sprintf("maximum %d sources allowed", notes.MaxSources)}
+	}
+	for i := range req.Sources {
+		req.Sources[i].URL = strings.TrimSpace(req.Sources[i].URL)
+		if err := common.ValidateRequiredParam(fmt.Sprintf("sources[%d].url", i), req.Sources[i].URL); err != nil {
+			return err
+		}
+		if err := common.ValidateURL(req.Sources[i].URL, fmt.Sprintf("sources[%d].url", i)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateVoteCommunityNoteRequest(req *apimodels.VoteCommunityNoteRequest) error {
+	if req == nil {
+		return common.ValidationError{Field: "body", Message: "required"}
+	}
+	req.VoteType = strings.TrimSpace(req.VoteType)
+	req.Reason = strings.TrimSpace(req.Reason)
+
+	switch notes.VoteType(req.VoteType) {
+	case notes.VoteHelpful, notes.VoteNotHelpful, notes.VoteNeutral:
+	default:
+		return common.ValidationError{Field: "vote_type", Message: "must be one of helpful, not_helpful, neutral"}
+	}
+	if len(req.Reason) > notes.MaxReasonLength {
+		return common.ValidationError{Field: "reason", Message: fmt.Sprintf("cannot be longer than %d characters", notes.MaxReasonLength)}
+	}
+	return nil
+}
+
+func safeCommunityNoteHTML(content string) string {
+	return htmlsafe.Escape(html.UnescapeString(strings.TrimSpace(content)))
 }
 
 // Helper functions

--- a/cmd/api/handlers/notes_round12_test.go
+++ b/cmd/api/handlers/notes_round12_test.go
@@ -2,8 +2,10 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -45,7 +47,7 @@ func TestNotesHandlersRound12(t *testing.T) {
 			if query.NoteID == "missing" {
 				return nil, errors.New("not found")
 			}
-			note := &storage.CommunityNote{ID: query.NoteID, AuthorID: "https://example.com/users/bob", Content: "note", CreatedAt: time.Now().Add(-1 * time.Hour)}
+			note := &storage.CommunityNote{ID: query.NoteID, AuthorID: "https://example.com/users/bob", Content: `<script>alert(1)</script><b>note</b>`, CreatedAt: time.Now().Add(-1 * time.Hour)}
 			if query.NoteID == "own" {
 				note.AuthorID = aliceActorID
 			}
@@ -63,7 +65,7 @@ func TestNotesHandlersRound12(t *testing.T) {
 			}
 			return &servicenotes.GetCommunityNotesByAuthorResult{
 				Notes: []*storage.CommunityNote{
-					{ID: "n1", ObjectID: "obj1", ObjectType: "Note", AuthorID: query.AuthorID, Content: "note", CreatedAt: time.Now().Add(-1 * time.Hour), HelpfulVotes: 2, NotHelpfulVotes: 1, Score: 0.5},
+					{ID: "n1", ObjectID: "obj1", ObjectType: "Note", AuthorID: query.AuthorID, Content: `<script>alert(1)</script><b>note</b>`, CreatedAt: time.Now().Add(-1 * time.Hour), HelpfulVotes: 2, NotHelpfulVotes: 1, Score: 0.5},
 				},
 				NextCursor: "",
 			}, nil
@@ -76,7 +78,7 @@ func TestNotesHandlersRound12(t *testing.T) {
 	lowerHeaders := map[string]string{"authorization": "Bearer " + token}
 
 	t.Run("create note unauthorized", func(t *testing.T) {
-		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/notes", nil, nil, apimodels.CreateCommunityNoteRequest{ObjectID: "obj1", ObjectType: "Note", Content: "content", Language: "en"})
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/notes", nil, nil, apimodels.CreateCommunityNoteRequest{ObjectID: "obj1", ObjectType: "Note", Content: "valid note content", Language: "en"})
 		require.NoError(t, err)
 		requireStatus(t, http.StatusUnauthorized)(h.HandleCreateNoteLift(ctx))
 	})
@@ -86,7 +88,7 @@ func TestNotesHandlersRound12(t *testing.T) {
 		badCfg.ReputationPrivateKey = "not a pem"
 		badHandler, _, _ := round11NewHandler(t, badCfg, state, &RegistryStub{NotesSvc: notesSvc})
 
-		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/notes", headers, nil, apimodels.CreateCommunityNoteRequest{ObjectID: "obj1", ObjectType: "Note", Content: "content", Language: "en"})
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/notes", headers, nil, apimodels.CreateCommunityNoteRequest{ObjectID: "obj1", ObjectType: "Note", Content: "valid note content", Language: "en"})
 		require.NoError(t, err)
 		requireStatus(t, http.StatusInternalServerError)(badHandler.HandleCreateNoteLift(ctx))
 	})
@@ -100,13 +102,23 @@ func TestNotesHandlersRound12(t *testing.T) {
 		}
 		lowHandler, _, _ := round11NewHandler(t, cfg, lowState, &RegistryStub{NotesSvc: notesSvc})
 
-		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/notes", headers, nil, apimodels.CreateCommunityNoteRequest{ObjectID: "obj1", ObjectType: "Note", Content: "content", Language: "en"})
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/notes", headers, nil, apimodels.CreateCommunityNoteRequest{ObjectID: "obj1", ObjectType: "Note", Content: "valid note content", Language: "en"})
 		require.NoError(t, err)
 		requireStatus(t, http.StatusForbidden)(lowHandler.HandleCreateNoteLift(ctx))
 	})
 
 	t.Run("create note invalid body", func(t *testing.T) {
 		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/api/v1/notes", headers, nil, []byte("{"))
+		requireStatus(t, http.StatusBadRequest)(h.HandleCreateNoteLift(ctx))
+	})
+
+	t.Run("create note rejects invalid payload fields", func(t *testing.T) {
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/notes", headers, nil, apimodels.CreateCommunityNoteRequest{ObjectID: "obj1", ObjectType: "Note", Content: "short", Language: "en"})
+		require.NoError(t, err)
+		requireStatus(t, http.StatusBadRequest)(h.HandleCreateNoteLift(ctx))
+
+		ctx, err = round10NewLiftContext(http.MethodPost, "/api/v1/notes", headers, nil, apimodels.CreateCommunityNoteRequest{ObjectID: "obj1", ObjectType: "Note", Content: "valid note content", Language: "en", Sources: []apimodels.CommunityNoteSource{{URL: "javascript:alert(1)"}}})
+		require.NoError(t, err)
 		requireStatus(t, http.StatusBadRequest)(h.HandleCreateNoteLift(ctx))
 	})
 
@@ -143,7 +155,7 @@ func TestNotesHandlersRound12(t *testing.T) {
 		}
 		rateHandler, _, _ := round11NewHandler(t, cfg, rateState, &RegistryStub{NotesSvc: notesSvc})
 
-		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/notes", lowerHeaders, nil, apimodels.CreateCommunityNoteRequest{ObjectID: "obj1", ObjectType: "Note", Content: "content", Language: "en"})
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/notes", lowerHeaders, nil, apimodels.CreateCommunityNoteRequest{ObjectID: "obj1", ObjectType: "Note", Content: "valid note content", Language: "en"})
 		require.NoError(t, err)
 		requireStatus(t, http.StatusTooManyRequests)(rateHandler.HandleCreateNoteLift(ctx))
 	})
@@ -156,13 +168,13 @@ func TestNotesHandlersRound12(t *testing.T) {
 		}
 		failHandler, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{NotesSvc: failSvc})
 
-		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/notes", headers, nil, apimodels.CreateCommunityNoteRequest{ObjectID: "obj1", ObjectType: "Note", Content: "content", Language: "en"})
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/notes", headers, nil, apimodels.CreateCommunityNoteRequest{ObjectID: "obj1", ObjectType: "Note", Content: "valid note content", Language: "en"})
 		require.NoError(t, err)
 		requireStatus(t, http.StatusInternalServerError)(failHandler.HandleCreateNoteLift(ctx))
 	})
 
 	t.Run("create note success", func(t *testing.T) {
-		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/notes", lowerHeaders, nil, apimodels.CreateCommunityNoteRequest{ObjectID: "obj1", ObjectType: "Note", Content: "content", Language: "en"})
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/notes", lowerHeaders, nil, apimodels.CreateCommunityNoteRequest{ObjectID: "obj1", ObjectType: "Note", Content: "valid note content", Language: "en"})
 		require.NoError(t, err)
 		resp := requireStatus(t, http.StatusCreated)(h.HandleCreateNoteLift(ctx))
 		require.NotEmpty(t, resp.Headers["x-cost-micros"])
@@ -217,6 +229,18 @@ func TestNotesHandlersRound12(t *testing.T) {
 
 	t.Run("vote invalid request body", func(t *testing.T) {
 		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/api/v1/notes/n1/vote", headers, nil, []byte("{"))
+		ctx.Params["id"] = "n1"
+		requireStatus(t, http.StatusBadRequest)(h.HandleVoteNoteLift(ctx))
+	})
+
+	t.Run("vote rejects invalid payload fields", func(t *testing.T) {
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/notes/n1/vote", headers, nil, apimodels.VoteCommunityNoteRequest{VoteType: "admin"})
+		require.NoError(t, err)
+		ctx.Params["id"] = "n1"
+		requireStatus(t, http.StatusBadRequest)(h.HandleVoteNoteLift(ctx))
+
+		ctx, err = round10NewLiftContext(http.MethodPost, "/api/v1/notes/n1/vote", headers, nil, apimodels.VoteCommunityNoteRequest{VoteType: "helpful", Reason: strings.Repeat("x", 201)})
+		require.NoError(t, err)
 		ctx.Params["id"] = "n1"
 		requireStatus(t, http.StatusBadRequest)(h.HandleVoteNoteLift(ctx))
 	})
@@ -284,11 +308,18 @@ func TestNotesHandlersRound12(t *testing.T) {
 		requireStatus(t, http.StatusInternalServerError)(h.HandleGetUserNotesLift(ctx))
 	})
 
-	t.Run("get user notes success", func(t *testing.T) {
+	t.Run("get user notes success escapes rendered content", func(t *testing.T) {
 		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/accounts/alice/notes", nil, nil, nil)
 		require.NoError(t, err)
 		ctx.Params["id"] = "alice"
-		requireStatus(t, http.StatusOK)(h.HandleGetUserNotesLift(ctx))
+		resp := requireStatus(t, http.StatusOK)(h.HandleGetUserNotesLift(ctx))
+
+		var statuses []apimodels.UserNoteStatus
+		require.NoError(t, json.Unmarshal(resp.Body, &statuses))
+		require.Len(t, statuses, 1)
+		require.NotContains(t, statuses[0].Content, "<script")
+		require.NotContains(t, statuses[0].Content, "<b>note</b>")
+		require.Contains(t, statuses[0].Content, "&lt;b&gt;note&lt;/b&gt;")
 	})
 }
 

--- a/cmd/api/handlers/notes_round12_test.go
+++ b/cmd/api/handlers/notes_round12_test.go
@@ -38,7 +38,7 @@ func TestNotesHandlersRound12(t *testing.T) {
 		GetVisibleCommunityNotesFunc: func(_ context.Context, _ *servicenotes.GetVisibleCommunityNotesQuery) (*servicenotes.GetVisibleCommunityNotesResult, error) {
 			return &servicenotes.GetVisibleCommunityNotesResult{
 				Notes: []*storage.CommunityNote{
-					{ID: "n1", ObjectID: "obj1", ObjectType: "Note", AuthorID: "https://example.com/users/bob", Content: "visible", Language: "en", Sources: []string{"https://a"}, HelpfulVotes: 1, NotHelpfulVotes: 0, Score: 0.7, VisibilityStatus: "visible", CreatedAt: time.Now().Add(-2 * time.Hour)},
+					{ID: "n1", ObjectID: "obj1", ObjectType: "Note", AuthorID: "https://example.com/users/bob", Content: `<script>alert(1)</script><b>legacy</b>`, Language: "en", Sources: []string{"https://a"}, HelpfulVotes: 1, NotHelpfulVotes: 0, Score: 0.7, VisibilityStatus: "visible", CreatedAt: time.Now().Add(-2 * time.Hour)},
 					{ID: "n2", ObjectID: "obj1", ObjectType: "Note", AuthorID: "https://example.com/users/carol", Content: "pending", Language: "en", Sources: []string{"https://b"}, HelpfulVotes: 0, NotHelpfulVotes: 0, Score: 0.1, VisibilityStatus: "pending", CreatedAt: time.Now().Add(-1 * time.Hour)},
 				},
 			}, nil
@@ -204,14 +204,26 @@ func TestNotesHandlersRound12(t *testing.T) {
 		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/notes/obj1", nil, nil, nil)
 		require.NoError(t, err)
 		ctx.Params["object_id"] = "obj1"
-		requireStatus(t, http.StatusOK)(h.HandleGetNotesLift(ctx))
+		resp := requireStatus(t, http.StatusOK)(h.HandleGetNotesLift(ctx))
+
+		var payload apimodels.CommunityNotesResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &payload))
+		require.Len(t, payload.Notes, 2)
+		require.NotContains(t, payload.Notes[0].Content, "<script")
+		require.NotContains(t, payload.Notes[0].Content, "<b>legacy</b>")
+		require.Contains(t, payload.Notes[0].Content, "&lt;b&gt;legacy&lt;/b&gt;")
 	})
 
 	t.Run("get notes success authenticated (lowercase header)", func(t *testing.T) {
 		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/notes/obj1", lowerHeaders, nil, nil)
 		require.NoError(t, err)
 		ctx.Params["object_id"] = "obj1"
-		requireStatus(t, http.StatusOK)(h.HandleGetNotesLift(ctx))
+		resp := requireStatus(t, http.StatusOK)(h.HandleGetNotesLift(ctx))
+
+		var payload apimodels.CommunityNotesResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &payload))
+		require.Len(t, payload.Notes, 2)
+		require.NotContains(t, payload.Notes[0].Content, "<script")
 	})
 
 	t.Run("vote missing note id", func(t *testing.T) {

--- a/cmd/api/handlers/search.go
+++ b/cmd/api/handlers/search.go
@@ -468,6 +468,9 @@ func (h *Handler) convertStatusSearchResults(ctx context.Context, statuses []sto
 		}
 
 		if fullStatus, err := h.resolveStatusFromSearchResult(ctx, &status); err == nil && fullStatus != nil {
+			if !h.statusVisibleInSearch(fullStatus, viewerUsername) {
+				continue
+			}
 			if apiStatus, convErr := h.convertStorageStatusToAPI(fullStatus, viewerUsername); convErr == nil && apiStatus != nil {
 				result.ID = apiStatus.ID
 				result.Content = apiStatus.Content
@@ -476,6 +479,8 @@ func (h *Handler) convertStatusSearchResults(ctx context.Context, statuses []sto
 				result.AccountUsername = apiStatus.Account.Username
 				result.CreatedAt = apiStatus.CreatedAt
 			}
+		} else if !searchResultVisibleInSearch(&status, viewerUsername) {
+			continue
 		}
 
 		// Add highlights if available

--- a/cmd/api/models/notes_endpoints.go
+++ b/cmd/api/models/notes_endpoints.go
@@ -8,22 +8,22 @@ import (
 
 // CommunityNoteSource represents a note source entry (request-side).
 type CommunityNoteSource struct {
-	URL string `json:"url"`
+	URL string `json:"url" validate:"required,url"`
 }
 
 // CreateCommunityNoteRequest represents POST /api/v1/notes.
 type CreateCommunityNoteRequest struct {
-	ObjectID   string                `json:"object_id"`
-	ObjectType string                `json:"object_type"`
-	Content    string                `json:"content"`
-	Language   string                `json:"language"`
-	Sources    []CommunityNoteSource `json:"sources,omitempty"`
+	ObjectID   string                `json:"object_id" validate:"required"`
+	ObjectType string                `json:"object_type" validate:"required"`
+	Content    string                `json:"content" validate:"required,min=10,max=500"`
+	Language   string                `json:"language" validate:"required,len=2"`
+	Sources    []CommunityNoteSource `json:"sources,omitempty" validate:"max=5,dive"`
 }
 
 // VoteCommunityNoteRequest represents POST /api/v1/notes/{id}/vote.
 type VoteCommunityNoteRequest struct {
-	VoteType string `json:"vote_type"`
-	Reason   string `json:"reason,omitempty"`
+	VoteType string `json:"vote_type" validate:"required,oneof=helpful not_helpful neutral"`
+	Reason   string `json:"reason,omitempty" validate:"max=200"`
 }
 
 // CommunityNoteRateLimit represents rate limit details for note creation.

--- a/cmd/outbox/main.go
+++ b/cmd/outbox/main.go
@@ -717,8 +717,9 @@ func (op *OutboxProcessor) HandleOutboxGet(ctx *apptheory.Context) (*apptheory.R
 		return outboxJSONError(http.StatusInternalServerError, "failed to get outbox activities"), nil
 	}
 
-	orderedItems := make([]any, len(activities))
-	for i, activity := range activities {
+	publicActivities := filterPublicOutboxActivities(activities)
+	orderedItems := make([]any, len(publicActivities))
+	for i, activity := range publicActivities {
 		orderedItems[i] = activity
 	}
 
@@ -750,14 +751,37 @@ func (op *OutboxProcessor) countOutboxActivities(ctx context.Context, username s
 	pk := "ACTOR#" + username
 	const skPrefix = "ACTIVITY#"
 
-	count, err := op.db.WithContext(ctx).Model(&models.Activity{}).
+	var activities []*models.Activity
+	err := op.db.WithContext(ctx).Model(&models.Activity{}).
 		Where("PK", "=", pk).
 		Where("SK", "BEGINS_WITH", skPrefix).
-		Count()
+		OrderBy("SK", "DESC").
+		All(&activities)
 	if err != nil {
 		return 0, err
 	}
-	return int(count), nil
+
+	count := 0
+	for _, record := range activities {
+		if record != nil && activitypub.IsPublicAddressedActivity(record.Activity) {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func filterPublicOutboxActivities(activities []*activitypub.Activity) []*activitypub.Activity {
+	if len(activities) == 0 {
+		return activities
+	}
+
+	filtered := make([]*activitypub.Activity, 0, len(activities))
+	for _, activity := range activities {
+		if activitypub.IsPublicAddressedActivity(activity) {
+			filtered = append(filtered, activity)
+		}
+	}
+	return filtered
 }
 
 // HandleOutboxPost handles POST requests to the ActivityPub outbox endpoint

--- a/cmd/outbox/round12_outbox_test.go
+++ b/cmd/outbox/round12_outbox_test.go
@@ -178,7 +178,7 @@ func TestOutboxProcessor_DeliverActivityWithRetry_Round12(t *testing.T) {
 	}
 
 	msg := ActivityDeliveryMessage{
-		Activity:    &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "https://example.com/activities/1", Type: activitypub.CreateType}},
+		Activity:    &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "https://example.com/activities/1", Type: activitypub.CreateType, To: []string{activitypub.PublicAddress}}},
 		Actor:       &activitypub.Actor{BaseObject: activitypub.BaseObject{ID: "https://example.com/users/alice"}},
 		TargetInbox: "https://remote.example/inbox",
 	}
@@ -235,7 +235,7 @@ func TestOutboxProcessor_TrackDeliveryStatus_Round12(t *testing.T) {
 	}
 
 	err := op.trackDeliveryStatus(context.Background(), ActivityDeliveryMessage{
-		Activity:    &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "https://example.com/activities/1", Type: activitypub.CreateType}},
+		Activity:    &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "https://example.com/activities/1", Type: activitypub.CreateType, To: []string{activitypub.PublicAddress}}},
 		TargetInbox: "https://remote.example/inbox",
 	}, DeliveryResult{Success: true, StatusCode: 200, Duration: 5 * time.Millisecond, Attempt: 1})
 	require.NoError(t, err)
@@ -716,7 +716,14 @@ func TestOutboxApp_HTTPHandlers_Round12(t *testing.T) {
 	mockDB.On("WithContext", mock.Anything).Return(mockDB).Maybe()
 	mockDB.On("Model", mock.Anything).Return(mockQuery).Maybe()
 	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery).Maybe()
-	mockQuery.On("Count").Return(int64(3), nil).Maybe()
+	mockQuery.On("OrderBy", mock.Anything, mock.Anything).Return(mockQuery).Maybe()
+	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
+		out := args.Get(0).(*[]*models.Activity)
+		*out = append(*out,
+			&models.Activity{Activity: &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "public", To: []string{activitypub.PublicAddress}}}},
+			&models.Activity{Activity: &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "direct", To: []string{"https://example.com/users/bob"}}}},
+		)
+	}).Return(nil).Maybe()
 
 	actorRepo := testmocks.NewMockActorRepository()
 	activityRepo := testmocks.NewMockActivityRepository()
@@ -760,7 +767,7 @@ func TestOutboxApp_HTTPHandlers_Round12(t *testing.T) {
 		Outbox: "",
 	}, nil).Maybe()
 	activityRepo.On("GetOutboxActivities", mock.Anything, "alice", mock.Anything, mock.Anything).Return([]*activitypub.Activity{
-		{BaseObject: activitypub.BaseObject{ID: "https://example.com/activities/1", Type: activitypub.CreateType}},
+		{BaseObject: activitypub.BaseObject{ID: "https://example.com/activities/1", Type: activitypub.CreateType, To: []string{activitypub.PublicAddress}}},
 	}, "next", nil).Maybe()
 
 	app := buildOutboxApp(processor)
@@ -859,7 +866,7 @@ func TestOutboxProcessor_TrackDeliveryStatus_ErrorBranches_Round12(t *testing.T)
 		logger:                       zap.NewNop(),
 	}
 
-	activity := &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "https://example.com/activities/1", Type: activitypub.CreateType}}
+	activity := &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "https://example.com/activities/1", Type: activitypub.CreateType, To: []string{activitypub.PublicAddress}}}
 	activity.Object = make(chan int)
 
 	require.NoError(t, op.trackDeliveryStatus(context.Background(), ActivityDeliveryMessage{
@@ -944,7 +951,8 @@ func TestOutboxProcessor_HandleOutboxGet_CountAndActivitiesErrors_Round12(t *tes
 	mockDB.On("WithContext", mock.Anything).Return(mockDB).Maybe()
 	mockDB.On("Model", mock.Anything).Return(mockQuery).Maybe()
 	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery).Maybe()
-	mockQuery.On("Count").Return(int64(0), errors.New("count failed")).Maybe()
+	mockQuery.On("OrderBy", mock.Anything, mock.Anything).Return(mockQuery).Maybe()
+	mockQuery.On("All", mock.Anything).Return(errors.New("count failed")).Maybe()
 
 	actorRepo := testmocks.NewMockActorRepository()
 	activityRepo := testmocks.NewMockActivityRepository()
@@ -1157,6 +1165,52 @@ func TestOutboxActivityValidationMap_OmitsNilObject_Round12(t *testing.T) {
 	payload := outboxActivityValidationMap(activity)
 	_, has := payload["object"]
 	require.False(t, has)
+}
+
+func TestOutboxProcessor_HandleOutboxGet_FiltersNonPublicActivities_Round12(t *testing.T) {
+	actorRepo := testmocks.NewMockActorRepository()
+	activityRepo := testmocks.NewMockActivityRepository()
+	instanceRepo := &round12InstanceRepo{state: &models.InstanceState{Locked: false}}
+
+	op := &OutboxProcessor{
+		actorRepository:    actorRepo,
+		activityRepository: activityRepo,
+		instanceRepository: instanceRepo,
+		logger:             zap.NewNop(),
+		lambdaCtx: &common.LambdaContext{
+			Logger: zap.NewNop(),
+			Config: &config.Config{Domain: "example.com", Region: "us-east-1", JWTSecret: "secret"},
+		},
+	}
+
+	actorRepo.On("GetActorByUsername", mock.Anything, "alice").Return(&activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:      "https://example.com/users/alice",
+			Type:    activitypub.PersonType,
+			Context: activitypub.DefaultContext,
+		},
+		Outbox: "https://example.com/users/alice/outbox",
+	}, nil).Once()
+	activityRepo.On("GetOutboxActivities", mock.Anything, "alice", mock.Anything, mock.Anything).Return([]*activitypub.Activity{
+		{BaseObject: activitypub.BaseObject{ID: "https://example.com/activities/public", Type: activitypub.CreateType, To: []string{activitypub.PublicAddress}}},
+		{BaseObject: activitypub.BaseObject{ID: "https://example.com/activities/direct", Type: activitypub.CreateType, To: []string{"https://example.com/users/bob"}}},
+		{BaseObject: activitypub.BaseObject{ID: "https://example.com/activities/unlisted", Type: activitypub.CreateType, CC: []string{activitypub.PublicAddress}}},
+	}, "", nil).Once()
+
+	app := buildOutboxApp(op)
+	resp := serveOutbox(app, "GET", "/users/alice/outbox", map[string]string{"page": "true"}, nil, "")
+	require.Equal(t, 200, resp.Status)
+
+	body := mustUnmarshalBody[activitypub.OrderedCollectionPage](t, resp)
+	items, ok := body.OrderedItems.([]any)
+	require.True(t, ok)
+	require.Len(t, items, 2)
+	first, ok := items[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "https://example.com/activities/public", first["id"])
+	second, ok := items[1].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "https://example.com/activities/unlisted", second["id"])
 }
 
 func TestOutboxProcessor_GetBearerToken_InvalidHeader_Round12(t *testing.T) {

--- a/cmd/status-indexer/main.go
+++ b/cmd/status-indexer/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/ai"
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
@@ -165,6 +166,12 @@ func (si *StatusIndexer) processRecord(ctx context.Context, record events.Dynamo
 
 	// Extract object details
 	details := si.extractObjectDetails(objectMap)
+	if !si.isSearchIndexableVisibility(details) {
+		si.logger.Debug("skipping non-public status for search indexing",
+			zap.String("status_id", details.objectID),
+			zap.String("visibility", details.visibility))
+		return nil
+	}
 
 	// Process the status if valid
 	if details.objectID != "" && details.content != "" {
@@ -178,11 +185,14 @@ func (si *StatusIndexer) processRecord(ctx context.Context, record events.Dynamo
 
 // statusDetails holds extracted status information
 type statusDetails struct {
-	objectID       string
-	content        string
-	authorID       string
-	authorUsername string
-	published      time.Time
+	objectID         string
+	content          string
+	authorID         string
+	authorUsername   string
+	published        time.Time
+	visibility       string
+	publicAddressed  bool
+	audienceObserved bool
 }
 
 // shouldProcessEvent checks if the event should be processed
@@ -276,10 +286,67 @@ func (si *StatusIndexer) extractObjectDetails(objectMap map[string]events.Dynamo
 		details.published, _ = time.Parse(time.RFC3339, pub.String())
 	}
 
+	// Extract explicit visibility when the object row has it. If it is absent,
+	// fall back to ActivityPub audience addressing.
+	if vis, ok := objectMap["visibility"]; ok && vis.DataType() == events.DataTypeString {
+		details.visibility = strings.ToLower(strings.TrimSpace(vis.String()))
+	}
+	details.publicAddressed, details.audienceObserved = si.publicSearchAddressing(objectMap)
+
 	// Extract username from author ID
 	details.authorUsername = si.extractUsernameFromAuthorID(details.authorID)
 
 	return details
+}
+
+func (si *StatusIndexer) isSearchIndexableVisibility(details statusDetails) bool {
+	switch strings.ToLower(strings.TrimSpace(details.visibility)) {
+	case models.VisibilityPrivate, models.VisibilityDirect:
+		return false
+	case models.VisibilityPublic, models.VisibilityUnlisted:
+		if details.audienceObserved {
+			return details.publicAddressed
+		}
+		return true
+	default:
+		return details.publicAddressed
+	}
+}
+
+func (si *StatusIndexer) publicSearchAddressing(objectMap map[string]events.DynamoDBAttributeValue) (bool, bool) {
+	observed := false
+	for _, key := range []string{"to", "cc"} {
+		attr, ok := objectMap[key]
+		if !ok {
+			continue
+		}
+		observed = true
+		for _, recipient := range dynamoStringValues(attr) {
+			if recipient == activitypub.PublicAddress {
+				return true, observed
+			}
+		}
+	}
+	return false, observed
+}
+
+func dynamoStringValues(attr events.DynamoDBAttributeValue) []string {
+	switch attr.DataType() {
+	case events.DataTypeString:
+		return []string{attr.String()}
+	case events.DataTypeStringSet:
+		return attr.StringSet()
+	case events.DataTypeList:
+		values := make([]string, 0, len(attr.List()))
+		for _, item := range attr.List() {
+			if item.DataType() == events.DataTypeString {
+				values = append(values, item.String())
+			}
+		}
+		return values
+	default:
+		return nil
+	}
 }
 
 // extractUsernameFromAuthorID extracts username from author ID URL

--- a/cmd/status-indexer/round12_status_indexer_test.go
+++ b/cmd/status-indexer/round12_status_indexer_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/ai"
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
@@ -68,6 +69,53 @@ func newMockDB(t *testing.T) (*dynamormmocks.MockDB, *dynamormmocks.MockQuery) {
 	q.On("First", mock.Anything).Return(errors.New("not found"))
 
 	return db, q
+}
+
+func TestNewStatusIndexer_Round12(t *testing.T) {
+	db, _ := newMockDB(t)
+	logger := zap.NewNop()
+	embed := &fakeEmbeddingGenerator{embedding: []float32{0.1, 0.2}}
+
+	si := NewStatusIndexer(db, "lesser-dev", "example.com", embed, logger)
+
+	require.Same(t, db, si.db)
+	require.Equal(t, "lesser-dev", si.tableName)
+	require.Equal(t, "example.com", si.domain)
+	require.Same(t, logger, si.logger)
+	require.Same(t, embed, si.aiService)
+	require.NotNil(t, si.likeRepo)
+	require.NotNil(t, si.hashtagsRepo)
+	require.NotNil(t, si.objectRepo)
+}
+
+func TestResolveStatusIndexerDB_Round12(t *testing.T) {
+	db, _ := newMockDB(t)
+
+	existingCtx := &common.LambdaContext{DynamoDB: db}
+	got, err := resolveStatusIndexerDB(existingCtx, &config.Config{Region: "us-east-1"}, nil)
+	require.NoError(t, err)
+	require.Same(t, db, got)
+
+	_, err = resolveStatusIndexerDB(nil, nil, zap.NewNop())
+	require.ErrorContains(t, err, "lambda config is required")
+
+	_, err = resolveStatusIndexerDB(&common.LambdaContext{}, &config.Config{}, zap.NewNop())
+	require.ErrorContains(t, err, "AWS region is required")
+
+	origNewLambdaClient := newLambdaClientFn
+	t.Cleanup(func() { newLambdaClientFn = origNewLambdaClient })
+
+	newLambdaClientFn = func(ctx context.Context, region string) (dynamormCore.DB, error) {
+		require.NotNil(t, ctx)
+		require.Equal(t, "us-west-2", region)
+		return db, nil
+	}
+
+	fallbackCtx := &common.LambdaContext{}
+	got, err = resolveStatusIndexerDB(fallbackCtx, &config.Config{Region: " us-west-2 "}, zap.NewNop())
+	require.NoError(t, err)
+	require.Same(t, db, got)
+	require.Same(t, db, fallbackCtx.DynamoDB)
 }
 
 func TestStatusIndexer_Helpers_Round12(t *testing.T) {
@@ -161,6 +209,45 @@ func TestStatusIndexer_Helpers_Round12(t *testing.T) {
 	require.Equal(t, "Hello world #Go!", details.content)
 	require.Equal(t, "https://example.com/users/alice", details.authorID)
 	require.Equal(t, "alice", details.authorUsername)
+	require.False(t, details.publicAddressed)
+
+	publicObjectMap := map[string]events.DynamoDBAttributeValue{
+		"type":         events.NewStringAttribute("Note"),
+		"id":           events.NewStringAttribute("status-public"),
+		"content":      events.NewStringAttribute("public content"),
+		"attributedTo": events.NewStringAttribute("https://example.com/users/alice"),
+		"to":           events.NewListAttribute([]events.DynamoDBAttributeValue{events.NewStringAttribute(activitypub.PublicAddress)}),
+	}
+	publicDetails := si.extractObjectDetails(publicObjectMap)
+	require.True(t, publicDetails.publicAddressed)
+	require.True(t, publicDetails.audienceObserved)
+	require.True(t, si.isSearchIndexableVisibility(publicDetails))
+	ccObjectMap := map[string]events.DynamoDBAttributeValue{
+		"cc": events.NewStringSetAttribute([]string{activitypub.PublicAddress}),
+	}
+	ccPublic, ccObserved := si.publicSearchAddressing(ccObjectMap)
+	require.True(t, ccPublic)
+	require.True(t, ccObserved)
+	emptyPublic, emptyObserved := si.publicSearchAddressing(map[string]events.DynamoDBAttributeValue{})
+	require.False(t, emptyPublic)
+	require.False(t, emptyObserved)
+	require.True(t, si.isSearchIndexableVisibility(statusDetails{visibility: models.VisibilityPublic}))
+	require.True(t, si.isSearchIndexableVisibility(statusDetails{visibility: models.VisibilityUnlisted}))
+	require.False(t, si.isSearchIndexableVisibility(statusDetails{visibility: models.VisibilityPrivate, publicAddressed: true}))
+	require.False(t, si.isSearchIndexableVisibility(statusDetails{visibility: models.VisibilityDirect}))
+	require.False(t, si.isSearchIndexableVisibility(statusDetails{
+		visibility:       models.VisibilityPublic,
+		audienceObserved: true,
+		publicAddressed:  false,
+	}))
+	require.False(t, si.isSearchIndexableVisibility(statusDetails{}))
+	require.Equal(t, []string{"one"}, dynamoStringValues(events.NewStringAttribute("one")))
+	require.ElementsMatch(t, []string{"one", "two"}, dynamoStringValues(events.NewStringSetAttribute([]string{"one", "two"})))
+	require.Equal(t, []string{"one"}, dynamoStringValues(events.NewListAttribute([]events.DynamoDBAttributeValue{
+		events.NewStringAttribute("one"),
+		events.NewNumberAttribute("2"),
+	})))
+	require.Nil(t, dynamoStringValues(events.NewNumberAttribute("1")))
 
 	require.Equal(t, "", si.extractUsernameFromAuthorID(""))
 	require.Equal(t, "bob", si.extractUsernameFromAuthorID("https://remote.example/users/bob"))
@@ -337,6 +424,8 @@ func TestStatusIndexer_processRecord_Round12(t *testing.T) {
 		"content":      events.NewStringAttribute("Hello world"),
 		"attributedTo": events.NewStringAttribute("https://example.com/users/alice"),
 		"published":    events.NewStringAttribute(time.Now().UTC().Format(time.RFC3339)),
+		"visibility":   events.NewStringAttribute(models.VisibilityPublic),
+		"to":           events.NewListAttribute([]events.DynamoDBAttributeValue{events.NewStringAttribute(activitypub.PublicAddress)}),
 	}
 	require.NoError(t, si.processRecord(context.Background(), record))
 
@@ -354,11 +443,45 @@ func TestStatusIndexer_processRecord_Round12(t *testing.T) {
 					"content":      events.NewStringAttribute("Hello legacy"),
 					"attributedTo": events.NewStringAttribute("https://example.com/users/alice"),
 					"published":    events.NewStringAttribute(time.Now().UTC().Format(time.RFC3339)),
+					"visibility":   events.NewStringAttribute(models.VisibilityPublic),
 				}),
 			},
 		},
 	}
 	require.NoError(t, si.processRecord(context.Background(), legacyRecord))
+}
+
+func TestStatusIndexer_processRecord_SkipsNonPublicObjects(t *testing.T) {
+	db, _ := newMockDB(t)
+	embed := &fakeEmbeddingGenerator{embedding: []float32{0.1, 0.2}}
+
+	si := &StatusIndexer{
+		db:        db,
+		logger:    zap.NewNop(),
+		aiService: embed,
+		likeRepo:  &fakeLikeCounter{},
+	}
+
+	record := events.DynamoDBEventRecord{
+		EventName: "INSERT",
+		Change: events.DynamoDBStreamRecord{
+			Keys: map[string]events.DynamoDBAttributeValue{
+				"PK": events.NewStringAttribute("object#status-private"),
+				"SK": events.NewStringAttribute("object#status-private"),
+			},
+			NewImage: map[string]events.DynamoDBAttributeValue{
+				"type":         events.NewStringAttribute("Note"),
+				"id":           events.NewStringAttribute("status-private"),
+				"content":      events.NewStringAttribute("private #secret content"),
+				"attributedTo": events.NewStringAttribute("https://example.com/users/alice"),
+				"visibility":   events.NewStringAttribute(models.VisibilityDirect),
+				"to":           events.NewListAttribute([]events.DynamoDBAttributeValue{events.NewStringAttribute("https://example.com/users/bob")}),
+			},
+		},
+	}
+
+	require.NoError(t, si.processRecord(context.Background(), record))
+	require.Equal(t, 0, embed.calls)
 }
 
 func TestHandleStatusIndexerStreamRecord_Round12(t *testing.T) {

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -1912,6 +1912,7 @@ components:
             additionalProperties: false
             properties:
                 url:
+                    format: uri
                     type: string
             required:
                 - url
@@ -2121,8 +2122,12 @@ components:
             additionalProperties: false
             properties:
                 content:
+                    maxLength: 500
+                    minLength: 10
                     type: string
                 language:
+                    maxLength: 2
+                    minLength: 2
                     type: string
                 object_id:
                     type: string
@@ -2131,6 +2136,7 @@ components:
                 sources:
                     items:
                         $ref: '#/components/schemas/CommunityNoteSource'
+                    maxItems: 5
                     type: array
             required:
                 - content
@@ -7768,8 +7774,13 @@ components:
             additionalProperties: false
             properties:
                 reason:
+                    maxLength: 200
                     type: string
                 vote_type:
+                    enum:
+                        - helpful
+                        - not_helpful
+                        - neutral
                     type: string
             required:
                 - vote_type

--- a/graph/moderation_resolvers_round12_test.go
+++ b/graph/moderation_resolvers_round12_test.go
@@ -135,17 +135,33 @@ func TestRound12ModerationResolvers_QueryAndMutation(t *testing.T) {
 	// Mutation: add community note.
 	notePayload, err := mut.AddCommunityNote(userCtx, model.CommunityNoteInput{
 		ObjectID: "status-1",
-		Content:  "fact check",
+		Content:  `<script>alert(1)</script><b>fact check</b>`,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, notePayload)
 	require.NotNil(t, notePayload.Note)
 	require.NotNil(t, notePayload.Object)
+	require.NotContains(t, notePayload.Note.Content, "<script")
+	require.NotContains(t, notePayload.Note.Content, "<b>fact check</b>")
+	require.Contains(t, notePayload.Note.Content, "&lt;b&gt;fact check&lt;/b&gt;")
+
+	require.NoError(t, storageRepo.CommunityNote().CreateCommunityNote(context.Background(), &storage.CommunityNote{
+		ID:               "legacy-raw-note",
+		ObjectID:         "status-1",
+		ObjectType:       "status",
+		AuthorID:         "https://localhost/users/bob",
+		Content:          `<script>alert(1)</script><b>legacy</b>`,
+		VisibilityStatus: "visible",
+		CreatedAt:        time.Now().Add(-time.Minute),
+		UpdatedAt:        time.Now().Add(-time.Minute),
+	}))
 
 	// Mutation: voting paths (author cannot vote).
-	note, err := mut.VoteCommunityNote(userCtx, "note-1", true)
+	note, err := mut.VoteCommunityNote(userCtx, "legacy-raw-note", true)
 	require.NoError(t, err)
 	require.NotNil(t, note)
+	require.NotContains(t, note.Content, "<script")
+	require.Contains(t, note.Content, "&lt;b&gt;legacy note&lt;/b&gt;")
 
 	_, err = mut.VoteCommunityNote(round12AuthContext("bob"), "note-1", false)
 	require.Error(t, err)

--- a/graph/moderation_resolvers_round12_test.go
+++ b/graph/moderation_resolvers_round12_test.go
@@ -170,9 +170,9 @@ func TestRound12ModerationResolvers_QueryAndMutation(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 
-	// Mutation: ML training is permission-gated.
+	// Mutation: ML training is admin-gated before feature flag or service access.
 	_, err = mut.TrainModerationModel(userCtx, nil, nil)
-	require.Error(t, err)
+	require.ErrorIs(t, err, ErrAdminPrivilegesRequired)
 }
 
 func TestRound12ModerationResolvers_DashboardStorageNil(t *testing.T) {

--- a/graph/mutation_resolvers_moderation.go
+++ b/graph/mutation_resolvers_moderation.go
@@ -11,6 +11,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/moderation"
+	"github.com/equaltoai/lesser/pkg/security/htmlsafe"
 	"github.com/equaltoai/lesser/pkg/services/moderationml"
 	servicenotes "github.com/equaltoai/lesser/pkg/services/notes"
 	"github.com/equaltoai/lesser/pkg/storage"
@@ -174,7 +175,7 @@ func (r *mutationResolver) AddCommunityNote(ctx context.Context, input model.Com
 	graphqlNote := &model.CommunityNote{
 		ID:         note.ID,
 		Author:     r.convertAccountToActor(author),
-		Content:    note.Content,
+		Content:    htmlsafe.EscapePlainTextHTML(note.Content),
 		Helpful:    note.HelpfulVotes,
 		NotHelpful: note.NotHelpfulVotes,
 		CreatedAt:  model.Time(note.CreatedAt),
@@ -321,7 +322,7 @@ func (r *mutationResolver) VoteCommunityNote(ctx context.Context, id string, hel
 	return &model.CommunityNote{
 		ID:         note.ID,
 		Author:     authorActor,
-		Content:    note.Content,
+		Content:    htmlsafe.EscapePlainTextHTML(note.Content),
 		Helpful:    note.HelpfulVotes,
 		NotHelpful: note.NotHelpfulVotes,
 		CreatedAt:  model.Time(note.CreatedAt),

--- a/graph/mutation_resolvers_moderation.go
+++ b/graph/mutation_resolvers_moderation.go
@@ -330,13 +330,13 @@ func (r *mutationResolver) VoteCommunityNote(ctx context.Context, id string, hel
 
 // TrainModerationModel implements MutationResolver.
 func (r *mutationResolver) TrainModerationModel(ctx context.Context, samples []*model.ModerationSampleInput, options *model.BedrockTrainingOptions) (*model.TrainingResult, error) {
-	// 1. Require authentication
-	username, err := r.requireAuth(ctx)
+	// 1. Require admin privileges
+	username, err := r.requireAdmin(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// 2. Check feature flag (admin permissions checked via feature flag)
+	// 2. Check feature flag after admin authorization
 	if err := common.MustCheckModerationMLAccess(ctx, username); err != nil {
 		return nil, err
 	}

--- a/graph/query_resolvers_accounts_lists.go
+++ b/graph/query_resolvers_accounts_lists.go
@@ -12,6 +12,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
+	"github.com/equaltoai/lesser/pkg/security/htmlsafe"
 	"github.com/equaltoai/lesser/pkg/services/accounts"
 	"github.com/equaltoai/lesser/pkg/services/notes"
 	storageTypes "github.com/equaltoai/lesser/pkg/storage"
@@ -341,7 +342,7 @@ func (r *queryResolver) CommunityNotesByAuthor(ctx context.Context, username str
 			Node: &model.CommunityNote{
 				ID:         note.ID,
 				Author:     authorActor,
-				Content:    note.Content,
+				Content:    htmlsafe.EscapePlainTextHTML(note.Content),
 				Helpful:    note.HelpfulVotes,
 				NotHelpful: note.NotHelpfulVotes,
 				CreatedAt:  model.Time(note.CreatedAt),

--- a/graph/query_resolvers_hashtags.go
+++ b/graph/query_resolvers_hashtags.go
@@ -176,6 +176,9 @@ func (r *queryResolver) MultiHashtagTimeline(ctx context.Context, hashtags []str
 			if post == nil {
 				continue
 			}
+			if post.Visibility != "" && post.Visibility != models.VisibilityPublic {
+				continue
+			}
 
 			if _, exists := allPosts[post.StatusID]; !exists {
 				allPosts[post.StatusID] = &model.Object{
@@ -311,6 +314,12 @@ func (r *queryResolver) buildHashtagTimelineEdges(ctx context.Context, posts []*
 		var status *models.Status
 		if statusByID != nil {
 			status = statusByID[post.StatusID]
+		}
+		if status != nil && status.Visibility != "" && status.Visibility != models.VisibilityPublic {
+			continue
+		}
+		if status == nil && post.Visibility != "" && post.Visibility != models.VisibilityPublic {
+			continue
 		}
 
 		if requireMedia && (status == nil || !status.HasMedia()) {

--- a/graph/query_resolvers_hashtags_test.go
+++ b/graph/query_resolvers_hashtags_test.go
@@ -187,6 +187,27 @@ func TestBuildHashtagTimelineEdges_MediaFilter(t *testing.T) {
 	assert.NotNil(t, edges[0].Node)
 }
 
+func TestBuildHashtagTimelineEdges_FiltersNonPublicVisibility(t *testing.T) {
+	ctx := context.Background()
+	resolver := &Resolver{}
+	query := &queryResolver{resolver}
+
+	posts := []*storage.StatusSearchResult{
+		{StatusID: "public", Content: "public", Visibility: models.VisibilityPublic},
+		{StatusID: "private", Content: "private", Visibility: models.VisibilityPrivate},
+		{StatusID: "direct", Content: "direct", Visibility: models.VisibilityDirect},
+	}
+
+	statusByID := map[string]*models.Status{
+		"public":  {StatusID: "public", Visibility: models.VisibilityPublic},
+		"private": {StatusID: "private", Visibility: models.VisibilityPrivate},
+	}
+
+	edges := query.buildHashtagTimelineEdges(ctx, posts, statusByID, false)
+	assert.Len(t, edges, 1)
+	assert.Equal(t, model.Cursor("public"), edges[0].Cursor)
+}
+
 func TestBuildPostConnection(t *testing.T) {
 	edges := []*model.PostEdge{
 		{Cursor: "a"},

--- a/graph/round12_test_harness_test.go
+++ b/graph/round12_test_harness_test.go
@@ -404,7 +404,7 @@ func round12PopulateStruct(dest any, state *round12PermissiveQueryState) {
 		v.ObjectID = "status-1"
 		v.ObjectType = "status"
 		v.AuthorID = config.Get().ActorURL("bob")
-		v.Content = "note content"
+		v.Content = `<script>alert(1)</script><b>legacy note</b>`
 		v.Language = "en"
 		v.VisibilityStatus = "pending"
 		v.Score = 0

--- a/pkg/activitypub/public_addressing.go
+++ b/pkg/activitypub/public_addressing.go
@@ -1,0 +1,54 @@
+package activitypub
+
+// IsPublicAddressedActivity reports whether an activity is addressed to the
+// ActivityStreams Public collection in a recipient-visible field. It treats
+// either top-level activity addressing or embedded object addressing as public.
+func IsPublicAddressedActivity(activity *Activity) bool {
+	if activity == nil {
+		return false
+	}
+	if hasPublicAddress(activity.To) || hasPublicAddress(activity.CC) {
+		return true
+	}
+	return isPublicAddressedObject(activity.Object)
+}
+
+func isPublicAddressedObject(object any) bool {
+	switch obj := object.(type) {
+	case nil:
+		return false
+	case *Note:
+		return obj != nil && (hasPublicAddress(obj.To) || hasPublicAddress(obj.CC))
+	case Note:
+		return hasPublicAddress(obj.To) || hasPublicAddress(obj.CC)
+	case map[string]any:
+		return hasPublicAddressValue(obj["to"]) || hasPublicAddressValue(obj["cc"])
+	default:
+		return false
+	}
+}
+
+func hasPublicAddressValue(value any) bool {
+	switch recipients := value.(type) {
+	case string:
+		return recipients == PublicAddress
+	case []string:
+		return hasPublicAddress(recipients)
+	case []any:
+		for _, recipient := range recipients {
+			if s, ok := recipient.(string); ok && s == PublicAddress {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasPublicAddress(recipients []string) bool {
+	for _, recipient := range recipients {
+		if recipient == PublicAddress {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/activitypub/public_addressing_test.go
+++ b/pkg/activitypub/public_addressing_test.go
@@ -1,0 +1,34 @@
+package activitypub
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsPublicAddressedActivity(t *testing.T) {
+	t.Run("top level to", func(t *testing.T) {
+		activity := &Activity{BaseObject: BaseObject{To: []string{PublicAddress}}}
+		require.True(t, IsPublicAddressedActivity(activity))
+	})
+
+	t.Run("top level cc", func(t *testing.T) {
+		activity := &Activity{BaseObject: BaseObject{CC: []string{PublicAddress}}}
+		require.True(t, IsPublicAddressedActivity(activity))
+	})
+
+	t.Run("embedded note", func(t *testing.T) {
+		activity := &Activity{Object: &Note{BaseObject: BaseObject{To: []string{PublicAddress}}}}
+		require.True(t, IsPublicAddressedActivity(activity))
+	})
+
+	t.Run("embedded map", func(t *testing.T) {
+		activity := &Activity{Object: map[string]any{"cc": []any{PublicAddress}}}
+		require.True(t, IsPublicAddressedActivity(activity))
+	})
+
+	t.Run("private", func(t *testing.T) {
+		activity := &Activity{BaseObject: BaseObject{To: []string{"https://example.com/users/bob"}}}
+		require.False(t, IsPublicAddressedActivity(activity))
+	})
+}

--- a/pkg/notes/service.go
+++ b/pkg/notes/service.go
@@ -197,34 +197,42 @@ func (s *Service) UpdateNoteScore(ctx context.Context, noteID string, score floa
 	return nil
 }
 
-// CheckNoteRateLimit checks if a user can create more notes
+const communityNoteRateLimitPageSize = 100
+
+// CheckNoteRateLimit checks if a user can create more notes.
 func (s *Service) CheckNoteRateLimit(ctx context.Context, userID string, limit int) (bool, int) {
-	// Get user's note count in the last 24 hours
-	// Since we don't have this method on CommunityNote repository, we'll use GetNotesByAuthor
-	// Safe conversion with bounds check
-	queryLimit := limit + 1
-	var queryLimit32 int32
-	if queryLimit > int(^int32(0)) {
-		queryLimit32 = ^int32(0) // Max int32
-	} else if queryLimit < 0 {
-		queryLimit32 = 0
-	} else {
-		queryLimit32 = int32(queryLimit)
-	}
-	notes, err := s.GetNotesByAuthor(ctx, userID, queryLimit32)
-	if err != nil {
+	if limit <= 0 || s == nil || s.repo == nil {
 		return false, 0
 	}
 
-	// Count notes from last 24 hours
 	cutoff := time.Now().Add(-24 * time.Hour)
 	count := 0
-	for _, note := range notes {
-		if note.CreatedAt.After(cutoff) {
-			count++
+	cursor := ""
+
+	for {
+		notes, nextCursor, err := s.repo.GetCommunityNotesByAuthor(ctx, userID, communityNoteRateLimitPageSize, cursor)
+		if err != nil {
+			return false, 0
 		}
+
+		for _, note := range notes {
+			if note != nil && note.CreatedAt.After(cutoff) {
+				count++
+				if count >= limit {
+					return false, 0
+				}
+			}
+		}
+
+		if nextCursor == "" || nextCursor == cursor {
+			break
+		}
+		cursor = nextCursor
 	}
 
-	// Check if under limit
-	return count < limit, limit - count
+	remaining := limit - count
+	if remaining < 0 {
+		remaining = 0
+	}
+	return true, remaining
 }

--- a/pkg/notes/service_test.go
+++ b/pkg/notes/service_test.go
@@ -3,6 +3,7 @@ package notes
 import (
 	"context"
 	"errors"
+	"strconv"
 	"testing"
 	"time"
 
@@ -68,8 +69,29 @@ func (s *stubCommunityNoteRepo) GetUserCommunityNoteVotes(_ context.Context, _ s
 	return s.userVotes, s.userVotesErr
 }
 
-func (s *stubCommunityNoteRepo) GetCommunityNotesByAuthor(_ context.Context, _ string, _ int, _ string) ([]*storage.CommunityNote, string, error) {
-	return s.notesByAuthor, "", s.notesByAuthorErr
+func (s *stubCommunityNoteRepo) GetCommunityNotesByAuthor(_ context.Context, _ string, limit int, cursor string) ([]*storage.CommunityNote, string, error) {
+	if s.notesByAuthorErr != nil {
+		return nil, "", s.notesByAuthorErr
+	}
+	start := 0
+	if cursor != "" {
+		parsed, err := strconv.Atoi(cursor)
+		if err == nil && parsed >= 0 {
+			start = parsed
+		}
+	}
+	if start >= len(s.notesByAuthor) {
+		return []*storage.CommunityNote{}, "", nil
+	}
+	end := len(s.notesByAuthor)
+	if limit > 0 && start+limit < end {
+		end = start + limit
+	}
+	nextCursor := ""
+	if end < len(s.notesByAuthor) {
+		nextCursor = strconv.Itoa(end)
+	}
+	return s.notesByAuthor[start:end], nextCursor, nil
 }
 
 func (s *stubCommunityNoteRepo) UpdateCommunityNoteScore(_ context.Context, noteID string, score float64, status string) error {
@@ -102,6 +124,26 @@ func TestService_CreateNote_StoresDefaults(t *testing.T) {
 	assert.Equal(t, 0.0, note.Score)
 	assert.True(t, note.UpdatedAt.After(time.Time{}))
 	assert.Equal(t, note.ID, repo.createdNote.ID)
+}
+
+func TestService_CheckNoteRateLimit_PaginatesPastOldNotes(t *testing.T) {
+	now := time.Now()
+	oldNotes := make([]*storage.CommunityNote, communityNoteRateLimitPageSize)
+	for i := range oldNotes {
+		oldNotes[i] = &storage.CommunityNote{ID: strconv.Itoa(i), CreatedAt: now.Add(-48 * time.Hour)}
+	}
+	recentNotes := []*storage.CommunityNote{
+		{ID: "recent-1", CreatedAt: now.Add(-2 * time.Hour)},
+		{ID: "recent-2", CreatedAt: now.Add(-1 * time.Hour)},
+	}
+	repo := &stubCommunityNoteRepo{
+		notesByAuthor: append(oldNotes, recentNotes...),
+	}
+	svc := &Service{repo: repo, logger: zap.NewNop()}
+
+	allowed, remaining := svc.CheckNoteRateLimit(context.Background(), "alice", 2)
+	assert.False(t, allowed)
+	assert.Equal(t, 0, remaining)
 }
 
 func TestService_StoreNote_ErrorWrapped(t *testing.T) {

--- a/pkg/security/htmlsafe/htmlsafe.go
+++ b/pkg/security/htmlsafe/htmlsafe.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"html"
 	"html/template"
+	"strings"
 
 	"github.com/equaltoai/lesser/pkg/common"
 )
@@ -12,6 +13,16 @@ import (
 // Escape escapes untrusted text for safe inclusion into HTML contexts.
 func Escape(s string) string {
 	return html.EscapeString(s)
+}
+
+// EscapePlainTextHTML normalizes untrusted plain text for HTML-by-contract fields.
+//
+// Some Lesser API fields are rendered as HTML by Mastodon-compatible clients even
+// when the source value is user-authored plain text. Unescape first so legacy
+// already-escaped values do not become double-escaped, then escape the normalized
+// text for safe HTML inclusion.
+func EscapePlainTextHTML(s string) string {
+	return Escape(html.UnescapeString(strings.TrimSpace(s)))
 }
 
 // SanitizeHTMLByContract sanitizes HTML that is meant to be rendered as HTML by clients (e.g. Mastodon fields).

--- a/pkg/security/htmlsafe/htmlsafe_test.go
+++ b/pkg/security/htmlsafe/htmlsafe_test.go
@@ -10,6 +10,12 @@ func TestEscape(t *testing.T) {
 	require.Equal(t, "&lt;div&gt;hello&lt;/div&gt;", Escape("<div>hello</div>"))
 }
 
+func TestEscapePlainTextHTML_NormalizesLegacyContent(t *testing.T) {
+	require.Equal(t, "&lt;b&gt;hello&lt;/b&gt;", EscapePlainTextHTML(" <b>hello</b> "))
+	require.Equal(t, "&lt;b&gt;hello&lt;/b&gt;", EscapePlainTextHTML(" &lt;b&gt;hello&lt;/b&gt; "))
+	require.NotContains(t, EscapePlainTextHTML("<script>alert(1)</script><b>hello</b>"), "<script")
+}
+
 func TestSanitizeHTMLByContract_PlainTextIsStable(t *testing.T) {
 	require.Equal(t, "hello", SanitizeHTMLByContract("hello"))
 }

--- a/pkg/services/conversations/service.go
+++ b/pkg/services/conversations/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
+	"github.com/equaltoai/lesser/pkg/security/htmlsafe"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
 	"github.com/equaltoai/lesser/pkg/storage/models"
@@ -718,12 +719,13 @@ func (s *Service) previewDirectMessageRequestRateLimit(ctx context.Context, cmd 
 func (s *Service) createDirectMessageStatus(_ context.Context, cmd *SendDirectMessageCommand, sender *storage.Account, recipientAccounts map[string]*storage.Account, conversationID, _ string) (*models.Status, string, error) {
 	messageID := uuid.New().String()
 	now := time.Now().UTC()
+	noteCmd := sanitizedDirectMessageCommand(cmd)
 
 	status := &models.Status{
 		StatusID:       messageID,
 		AuthorID:       cmd.SenderID,
 		AuthorUsername: sender.User.Username,
-		Content:        cmd.Content,
+		Content:        noteCmd.Content,
 		Visibility:     VisibilityDirect,
 		Sensitive:      cmd.Sensitive,
 		Language:       cmd.Language,
@@ -736,7 +738,7 @@ func (s *Service) createDirectMessageStatus(_ context.Context, cmd *SendDirectMe
 	}
 
 	var err error
-	status.Note, err = s.buildActivityPubNote(cmd, messageID, sender, conversationID, recipientAccounts)
+	status.Note, err = s.buildActivityPubNote(noteCmd, messageID, sender, conversationID, recipientAccounts)
 	if err != nil {
 		return nil, "", err
 	}
@@ -1510,11 +1512,13 @@ func extractUsernameFromActorIdentifier(identifier string) string {
 func (s *Service) createSendMessageStatus(_ context.Context, cmd *SendMessageCommand, sendCmd *SendDirectMessageCommand, sender *storage.Account, recipient *storage.Account, conversationID, recipientID string) (*models.Status, string, error) {
 	messageID := uuid.New().String()
 	now := time.Now().UTC()
+	noteCmd := sanitizedDirectMessageCommand(sendCmd)
+
 	status := &models.Status{
 		StatusID:       messageID,
 		AuthorID:       cmd.SenderID,
 		AuthorUsername: sender.User.Username,
-		Content:        cmd.Content,
+		Content:        noteCmd.Content,
 		Visibility:     VisibilityDirect,
 		Sensitive:      cmd.Sensitive,
 		Language:       cmd.Language,
@@ -1527,7 +1531,7 @@ func (s *Service) createSendMessageStatus(_ context.Context, cmd *SendMessageCom
 	}
 
 	var err error
-	status.Note, err = s.buildActivityPubNote(sendCmd, messageID, sender, conversationID, map[string]*storage.Account{
+	status.Note, err = s.buildActivityPubNote(noteCmd, messageID, sender, conversationID, map[string]*storage.Account{
 		recipientID: recipient,
 	})
 	if err != nil {
@@ -2063,6 +2067,19 @@ func (s *Service) validateSendMessageCommandBasic(ctx context.Context, cmd *Send
 	}
 
 	return nil
+}
+
+func sanitizedDirectMessageCommand(cmd *SendDirectMessageCommand) *SendDirectMessageCommand {
+	if cmd == nil {
+		return nil
+	}
+
+	sanitized := *cmd
+	sanitized.Content = strings.TrimSpace(htmlsafe.SanitizeHTMLByContract(cmd.Content))
+	sanitized.SpoilerText = strings.TrimSpace(htmlsafe.SanitizeHTMLByContract(cmd.SpoilerText))
+	sanitized.Recipients = append([]string(nil), cmd.Recipients...)
+	sanitized.MediaIDs = append([]string(nil), cmd.MediaIDs...)
+	return &sanitized
 }
 
 func (s *Service) buildActivityPubNote(cmd *SendDirectMessageCommand, messageID string, sender *storage.Account, conversationID string, recipientAccounts map[string]*storage.Account) (*activitypub.Note, error) {

--- a/pkg/services/conversations/service_round37_more_coverage_test.go
+++ b/pkg/services/conversations/service_round37_more_coverage_test.go
@@ -451,6 +451,34 @@ func TestService_createDirectMessageStatus_BuildsStatusWithoutPersistence(t *tes
 	}, status.Note.Tag[0])
 }
 
+func TestService_createDirectMessageStatus_SanitizesContentAndSummary(t *testing.T) {
+	ctx := context.Background()
+
+	service := NewService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, zaptest.NewLogger(t), "example.com")
+	rawContent := `<p onclick="steal()">hello</p><img src=x onerror="steal()"><script>alert(1)</script>`
+	rawSpoiler := `<span onclick="steal()">cw</span><script>alert(2)</script>`
+
+	status, _, err := service.createDirectMessageStatus(ctx, &SendDirectMessageCommand{
+		SenderID:    "alice",
+		Recipients:  []string{"bob"},
+		Content:     rawContent,
+		SpoilerText: rawSpoiler,
+	}, createTestAccount("alice", "alice"), map[string]*storage.Account{
+		"bob": createTestAccount("bob", "bob"),
+	}, "conv123", "bob")
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	require.Equal(t, status.Content, status.Note.Content)
+	require.Contains(t, status.Content, "hello")
+	require.NotContains(t, status.Content, "<script")
+	require.NotContains(t, status.Content, "onclick")
+	require.NotContains(t, status.Content, "onerror")
+	require.NotContains(t, status.Content, "<img")
+	require.Contains(t, status.Note.Summary, "cw")
+	require.NotContains(t, status.Note.Summary, "<script")
+	require.NotContains(t, status.Note.Summary, "onclick")
+}
+
 func TestService_createDirectMessageStatus_SetsAllCreationTimestamps(t *testing.T) {
 	ctx := context.Background()
 
@@ -645,6 +673,38 @@ func TestService_createSendMessageStatus_SetsAllCreationTimestamps(t *testing.T)
 	require.Equal(t, []string{"https://example.com/users/bob"}, status.Mentions)
 	require.Equal(t, status.ToRecipients, status.Note.To)
 	require.Len(t, status.Note.Tag, 1)
+}
+
+func TestService_createSendMessageStatus_SanitizesContent(t *testing.T) {
+	ctx := context.Background()
+
+	service := NewService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, zaptest.NewLogger(t), "example.com")
+	rawContent := `<p onclick="steal()">hello again</p><img src=x onerror="steal()"><script>alert(1)</script>`
+
+	status, _, err := service.createSendMessageStatus(
+		ctx,
+		&SendMessageCommand{
+			SenderID: "alice",
+			Content:  rawContent,
+		},
+		&SendDirectMessageCommand{
+			SenderID:   "alice",
+			Recipients: []string{"bob"},
+			Content:    rawContent,
+		},
+		createTestAccount("alice", "alice"),
+		createTestAccount("bob", "bob"),
+		"conv123",
+		"bob",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	require.Equal(t, status.Content, status.Note.Content)
+	require.Contains(t, status.Content, "hello again")
+	require.NotContains(t, status.Content, "<script")
+	require.NotContains(t, status.Content, "onclick")
+	require.NotContains(t, status.Content, "onerror")
+	require.NotContains(t, status.Content, "<img")
 }
 
 func TestService_createSendMessageStatus_RejectsRemoteHandleWithoutActorID(t *testing.T) {

--- a/pkg/services/notes/service.go
+++ b/pkg/services/notes/service.go
@@ -4738,7 +4738,7 @@ func (s *Service) CreateCommunityNote(ctx context.Context, cmd *CreateCommunityN
 	if cmd != nil && cmd.Note != nil {
 		// Community notes are surfaced via an HTML-by-contract field in Mastodon-compatible responses.
 		// Treat stored note content as plain text and escape so it is always safe to embed.
-		cmd.Note.Content = htmlsafe.Escape(strings.TrimSpace(cmd.Note.Content))
+		cmd.Note.Content = htmlsafe.EscapePlainTextHTML(cmd.Note.Content)
 	}
 
 	// Create community note through repository
@@ -4770,7 +4770,7 @@ func (s *Service) GetVisibleCommunityNotes(ctx context.Context, query *GetVisibl
 	}
 
 	return &GetVisibleCommunityNotesResult{
-		Notes: notes,
+		Notes: safeCommunityNotesForPresentation(notes),
 	}, nil
 }
 
@@ -4793,7 +4793,7 @@ func (s *Service) GetCommunityNote(ctx context.Context, query *GetCommunityNoteQ
 	}
 
 	return &GetCommunityNoteResult{
-		Note: note,
+		Note: safeCommunityNoteForPresentation(note),
 	}, nil
 }
 
@@ -4841,9 +4841,29 @@ func (s *Service) GetCommunityNotesByAuthor(ctx context.Context, query *GetCommu
 	}
 
 	return &GetCommunityNotesByAuthorResult{
-		Notes:      notes,
+		Notes:      safeCommunityNotesForPresentation(notes),
 		NextCursor: nextCursor,
 	}, nil
+}
+
+func safeCommunityNoteForPresentation(note *storage.CommunityNote) *storage.CommunityNote {
+	if note == nil {
+		return nil
+	}
+	safe := *note
+	safe.Content = htmlsafe.EscapePlainTextHTML(note.Content)
+	return &safe
+}
+
+func safeCommunityNotesForPresentation(notes []*storage.CommunityNote) []*storage.CommunityNote {
+	if notes == nil {
+		return nil
+	}
+	safe := make([]*storage.CommunityNote, 0, len(notes))
+	for _, note := range notes {
+		safe = append(safe, safeCommunityNoteForPresentation(note))
+	}
+	return safe
 }
 
 // CountNotesByAuthorQuery represents a request to count notes by an author

--- a/pkg/services/notes/service_round15_mainline_test.go
+++ b/pkg/services/notes/service_round15_mainline_test.go
@@ -1797,6 +1797,26 @@ func TestService_round15_community_note_content_is_escaped_at_write_time(t *test
 	require.NotContains(t, created.Note.Content, "<img")
 }
 
+func TestService_round15_community_note_content_is_escaped_for_read_boundaries(t *testing.T) {
+	raw := &storage.CommunityNote{
+		ID:      "legacy-note",
+		Content: `<script>alert(1)</script><b>legacy</b>`,
+	}
+
+	safe := safeCommunityNoteForPresentation(raw)
+	require.NotNil(t, safe)
+	require.NotSame(t, raw, safe)
+	require.NotContains(t, safe.Content, "<script")
+	require.Contains(t, safe.Content, "&lt;b&gt;legacy&lt;/b&gt;")
+	require.Contains(t, raw.Content, "<script>")
+
+	notes := safeCommunityNotesForPresentation([]*storage.CommunityNote{raw, nil})
+	require.Len(t, notes, 2)
+	require.NotContains(t, notes[0].Content, "<script")
+	require.Nil(t, notes[1])
+	require.Nil(t, safeCommunityNotesForPresentation(nil))
+}
+
 func TestService_round15_view_permissions_and_timelines(t *testing.T) {
 	service, _, _, _, _ := newNotesServiceHarness(t)
 

--- a/pkg/storage/repositories/activity_repository.go
+++ b/pkg/storage/repositories/activity_repository.go
@@ -242,44 +242,97 @@ func (r *ActivityRepository) GetInboxActivities(ctx context.Context, username st
 	return result, nextCursor, nil
 }
 
-// GetOutboxActivities retrieves activities created by a user - matches legacy implementation
+// GetOutboxActivities retrieves public-addressed activities created by a user.
+//
+// The ActivityPub outbox endpoint is unauthenticated and externally visible, so
+// followers-only and direct activities must not be returned from this read path
+// even though they share the same actor partition as public activities.
 func (r *ActivityRepository) GetOutboxActivities(ctx context.Context, username string, limit int, cursor string) ([]*activitypub.Activity, string, error) {
 	username = strings.ToLower(strings.TrimSpace(username))
 	safeLimit := clampActivityLimit(limit)
+	cursorData := ""
+	if cursor != "" {
+		var cursorErr error
+		cursorData, cursorErr = activityDecodeCursor(cursor)
+		if cursorErr != nil {
+			r.logger.Warn("invalid cursor provided",
+				zap.String("cursor", cursor),
+				zap.Error(cursorErr))
+		}
+	}
 
-	// Use BaseRepository QueryWithSKPrefix for outbox activities
+	result := make([]*activitypub.Activity, 0, safeLimit)
+	var nextCursor string
+	for {
+		activities, hasMore, batchCursor, err := r.queryOutboxActivityRecords(ctx, username, safeLimit, cursorData)
+		if err != nil {
+			r.logger.Error("failed to query outbox activities",
+				zap.String("username", username),
+				zap.Error(err))
+			return nil, "", ErrorHandler.HandleQueryError(err, "activity", "outbox")
+		}
+		if len(activities) == 0 {
+			break
+		}
+
+		for i, record := range activities {
+			if record == nil || !activitypub.IsPublicAddressedActivity(record.Activity) {
+				continue
+			}
+			result = append(result, record.Activity)
+			if len(result) == safeLimit {
+				if hasMore || i < len(activities)-1 {
+					nextCursor = activityEncodeCursor(map[string]string{
+						"PK": record.PK,
+						"SK": record.SK,
+					})
+				}
+				r.logger.Debug("retrieved outbox activities",
+					zap.String("username", username),
+					zap.Int("count", len(result)),
+					zap.Bool("has_more", nextCursor != ""))
+				return result, nextCursor, nil
+			}
+		}
+
+		if !hasMore {
+			break
+		}
+		if batchCursor == "" || batchCursor == cursorData {
+			r.logger.Warn("stopping public outbox pagination because cursor did not advance",
+				zap.String("username", username))
+			break
+		}
+		cursorData = batchCursor
+	}
+
+	r.logger.Debug("retrieved outbox activities",
+		zap.String("username", username),
+		zap.Int("count", len(result)),
+		zap.Bool("has_more", nextCursor != ""))
+
+	return result, nextCursor, nil
+}
+
+func (r *ActivityRepository) queryOutboxActivityRecords(ctx context.Context, username string, safeLimit int, cursorData string) ([]*models.Activity, bool, string, error) {
 	pk := "ACTOR#" + username
-	skPrefix := "ACTIVITY#"
+	const skPrefix = "ACTIVITY#"
 
-	// Use BaseRepository method with custom cursor handling for compatibility
 	var activities []*models.Activity
 	query := r.db.WithContext(ctx).Model(&models.Activity{}).
 		Where("PK", "=", pk).
 		Where("SK", "BEGINS_WITH", skPrefix).
 		Limit(safeLimit+1).
-		OrderBy("SK", "DESC") // Newest first
+		OrderBy("SK", "DESC")
 
-	if cursor != "" {
-		decodedCursor, cursorErr := activityDecodeCursor(cursor)
-		if cursorErr != nil {
-			r.logger.Warn("invalid cursor provided",
-				zap.String("cursor", cursor),
-				zap.Error(cursorErr))
-		} else {
-			query = query.Cursor(decodedCursor)
-		}
+	if cursorData != "" {
+		query = query.Cursor(cursorData)
 	}
 
-	err := query.All(&activities)
-
-	if err != nil {
-		r.logger.Error("failed to query outbox activities",
-			zap.String("username", username),
-			zap.Error(err))
-		return nil, "", ErrorHandler.HandleQueryError(err, "activity", "outbox")
+	if err := query.All(&activities); err != nil {
+		return nil, false, "", err
 	}
 
-	// Track cost using BaseRepository method
 	if r.costService != nil {
 		itemCount := int64(len(activities))
 		estimatedRU := itemCount
@@ -291,35 +344,21 @@ func (r *ActivityRepository) GetOutboxActivities(ctx context.Context, username s
 		}
 	}
 
-	// Convert to ActivityPub activities
 	hasMore := len(activities) > safeLimit
 	if hasMore {
 		activities = activities[:safeLimit]
 	}
 
-	result := make([]*activitypub.Activity, 0, len(activities))
-	for _, record := range activities {
-		result = append(result, record.Activity)
-	}
-
-	// Encode next cursor if there are more results
-	var nextCursor string
-	if hasMore && len(result) > 0 {
-		// There might be more results
+	nextCursor := ""
+	if hasMore && len(activities) > 0 {
 		lastItem := activities[len(activities)-1]
-		cursorData := map[string]string{
+		nextCursor = activityQueryCursor(map[string]string{
 			"PK": lastItem.PK,
 			"SK": lastItem.SK,
-		}
-		nextCursor = activityEncodeCursor(cursorData)
+		})
 	}
 
-	r.logger.Debug("retrieved outbox activities",
-		zap.String("username", username),
-		zap.Int("count", len(result)),
-		zap.Bool("has_more", nextCursor != ""))
-
-	return result, nextCursor, nil
+	return activities, hasMore, nextCursor, nil
 }
 
 // GetCollection retrieves a collection for an actor - matches legacy implementation
@@ -640,6 +679,14 @@ func activityEncodeCursor(data map[string]string) string {
 		return ""
 	}
 	return base64.URLEncoding.EncodeToString(jsonData)
+}
+
+func activityQueryCursor(data map[string]string) string {
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return ""
+	}
+	return string(jsonData)
 }
 
 // activityDecodeCursor decodes a string cursor to a map

--- a/pkg/storage/repositories/activity_repository_round09_coverage_test.go
+++ b/pkg/storage/repositories/activity_repository_round09_coverage_test.go
@@ -179,9 +179,9 @@ func TestActivityRepository_Round09_Coverage(t *testing.T) {
 			Run(func(args mock.Arguments) {
 				out := args.Get(0).(*[]*models.Activity)
 				*out = append(*out,
-					&models.Activity{PK: "ACTOR#alice", SK: "ACTIVITY#z#1", GSI1PK: "INBOX#alice", GSI1SK: "z", Activity: &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "1"}}},
-					&models.Activity{PK: "ACTOR#alice", SK: "ACTIVITY#y#2", GSI1PK: "INBOX#alice", GSI1SK: "y", Activity: &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "2"}}},
-					&models.Activity{PK: "ACTOR#alice", SK: "ACTIVITY#x#3", GSI1PK: "INBOX#alice", GSI1SK: "x", Activity: &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "3"}}},
+					&models.Activity{PK: "ACTOR#alice", SK: "ACTIVITY#z#1", GSI1PK: "INBOX#alice", GSI1SK: "z", Activity: &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "1", To: []string{activitypub.PublicAddress}}}},
+					&models.Activity{PK: "ACTOR#alice", SK: "ACTIVITY#y#2", GSI1PK: "INBOX#alice", GSI1SK: "y", Activity: &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "2", To: []string{activitypub.PublicAddress}}}},
+					&models.Activity{PK: "ACTOR#alice", SK: "ACTIVITY#x#3", GSI1PK: "INBOX#alice", GSI1SK: "x", Activity: &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "3", To: []string{activitypub.PublicAddress}}}},
 				)
 			}).
 			Return(nil).
@@ -316,10 +316,42 @@ func TestActivityRepository_Round09_Coverage(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("GetOutboxActivities filters non-public activities", func(t *testing.T) {
+		mockDB := new(mocks.MockDB)
+		mockQuery := new(mocks.MockQuery)
+		mockQuery.
+			On("All", mock.Anything).
+			Run(func(args mock.Arguments) {
+				out := args.Get(0).(*[]*models.Activity)
+				*out = append(*out,
+					&models.Activity{PK: "ACTOR#alice", SK: "ACTIVITY#z#public", Activity: &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "public", To: []string{activitypub.PublicAddress}}}},
+					&models.Activity{PK: "ACTOR#alice", SK: "ACTIVITY#y#direct", Activity: &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "direct", To: []string{"https://example.com/users/bob"}}}},
+					&models.Activity{PK: "ACTOR#alice", SK: "ACTIVITY#x#unlisted", Activity: &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "unlisted", CC: []string{activitypub.PublicAddress}}}},
+					&models.Activity{PK: "ACTOR#alice", SK: "ACTIVITY#w#object", Activity: &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "object"}, Object: &activitypub.Note{BaseObject: activitypub.BaseObject{To: []string{activitypub.PublicAddress}}}}},
+				)
+			}).
+			Return(nil).
+			Once()
+		setupPermissiveRound08Mocks(mockDB, mockQuery, nil, baseTime)
+		repo := NewActivityRepository(mockDB, "test-table", zap.NewNop(), nil)
+
+		outbox, cursor, err := repo.GetOutboxActivities(ctx, "alice", 10, "")
+		require.NoError(t, err)
+		require.Empty(t, cursor)
+		require.Len(t, outbox, 3)
+		require.Equal(t, "public", outbox[0].ID)
+		require.Equal(t, "unlisted", outbox[1].ID)
+		require.Equal(t, "object", outbox[2].ID)
+	})
+
 	t.Run("GetOutboxActivities decodes valid cursor and handles query error", func(t *testing.T) {
 		mockDB := new(mocks.MockDB)
 		mockQuery := new(mocks.MockQuery)
 		mockQuery.On("Cursor", mock.Anything).Return(mockQuery).Maybe()
+		mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
+			out := args.Get(0).(*[]*models.Activity)
+			*out = nil
+		}).Return(nil).Once()
 		setupPermissiveRound08Mocks(mockDB, mockQuery, nil, baseTime)
 		repo := NewActivityRepository(mockDB, "test-table", zap.NewNop(), nil)
 

--- a/pkg/storage/repositories/community_note_repository.go
+++ b/pkg/storage/repositories/community_note_repository.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/cost"
+	"github.com/equaltoai/lesser/pkg/security/htmlsafe"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/google/uuid"
@@ -127,7 +128,7 @@ func (r *CommunityNoteRepository) GetCommunityNote(ctx context.Context, noteID s
 		ObjectID:         model.ObjectID,
 		ObjectType:       model.ObjectType,
 		AuthorID:         model.AuthorID,
-		Content:          model.Content,
+		Content:          htmlsafe.EscapePlainTextHTML(model.Content),
 		Language:         model.Language,
 		Sources:          model.Sources,
 		HelpfulVotes:     model.HelpfulVotes,
@@ -172,7 +173,7 @@ func (r *CommunityNoteRepository) GetVisibleCommunityNotes(ctx context.Context, 
 				ObjectID:         model.ObjectID,
 				ObjectType:       model.ObjectType,
 				AuthorID:         model.AuthorID,
-				Content:          model.Content,
+				Content:          htmlsafe.EscapePlainTextHTML(model.Content),
 				Language:         model.Language,
 				Sources:          model.Sources,
 				HelpfulVotes:     model.HelpfulVotes,
@@ -332,7 +333,7 @@ func (r *CommunityNoteRepository) GetCommunityNotesByAuthor(ctx context.Context,
 			ObjectID:         model.ObjectID,
 			ObjectType:       model.ObjectType,
 			AuthorID:         model.AuthorID,
-			Content:          model.Content,
+			Content:          htmlsafe.EscapePlainTextHTML(model.Content),
 			Language:         model.Language,
 			Sources:          model.Sources,
 			HelpfulVotes:     model.HelpfulVotes,

--- a/pkg/storage/repositories/community_note_repository_round09_coverage_test.go
+++ b/pkg/storage/repositories/community_note_repository_round09_coverage_test.go
@@ -78,12 +78,14 @@ func TestCommunityNoteRepository_round09_votes_and_notes(t *testing.T) {
 		mockQuery.On("Where", "SK", "=", "METADATA").Return(mockQuery).Once()
 		mockQuery.On("First", mock.Anything).Run(func(args mock.Arguments) {
 			dest := args.Get(0).(*models.CommunityNote)
-			*dest = models.CommunityNote{ID: "n1", ObjectID: "obj", ObjectType: "status", AuthorID: "u1", Content: "c", VisibilityStatus: "visible"}
+			*dest = models.CommunityNote{ID: "n1", ObjectID: "obj", ObjectType: "status", AuthorID: "u1", Content: `<script>alert(1)</script><b>legacy</b>`, VisibilityStatus: "visible"}
 		}).Return(nil).Once()
 
 		n, err := repo.GetCommunityNote(ctx, "n1")
 		require.NoError(t, err)
 		assert.Equal(t, "n1", n.ID)
+		assert.NotContains(t, n.Content, "<script")
+		assert.Contains(t, n.Content, "&lt;b&gt;legacy&lt;/b&gt;")
 
 		mockQuery.On("Index", "gsi1").Return(mockQuery).Once()
 		mockQuery.On("Where", "gsi1PK", "=", "OBJECT#obj#NOTES").Return(mockQuery).Once()
@@ -91,7 +93,7 @@ func TestCommunityNoteRepository_round09_votes_and_notes(t *testing.T) {
 		mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
 			dest := args.Get(0).(*[]models.CommunityNote)
 			*dest = []models.CommunityNote{
-				{ID: "n1", VisibilityStatus: "visible"},
+				{ID: "n1", Content: `<img src=x onerror=alert(1)>`, VisibilityStatus: "visible"},
 				{ID: "n2", VisibilityStatus: "hidden"},
 				{ID: "n3", VisibilityStatus: "prominent"},
 			}
@@ -100,6 +102,7 @@ func TestCommunityNoteRepository_round09_votes_and_notes(t *testing.T) {
 		notes, err := repo.GetVisibleCommunityNotes(ctx, "obj")
 		require.NoError(t, err)
 		assert.Len(t, notes, 2)
+		assert.NotContains(t, notes[0].Content, "<img")
 
 		mockQuery.On("Index", "gsi1").Return(mockQuery).Once()
 		mockQuery.On("Where", "gsi1PK", "=", "OBJECT#none#NOTES").Return(mockQuery).Once()
@@ -191,11 +194,12 @@ func TestCommunityNoteRepository_round09_vote_paths_and_author_listing(t *testin
 		mockQuery.On("Where", "gsi3SK", "<", "123#n1").Return(mockQuery).Once()
 		mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
 			dest := args.Get(0).(*[]models.CommunityNote)
-			*dest = []models.CommunityNote{{ID: "n1", GSI3SK: "123#n1"}, {ID: "n2", GSI3SK: "122#n2"}}
+			*dest = []models.CommunityNote{{ID: "n1", Content: `<script>alert(1)</script>`, GSI3SK: "123#n1"}, {ID: "n2", GSI3SK: "122#n2"}}
 		}).Return(nil).Once()
 		notes, next, err := repo.GetCommunityNotesByAuthor(ctx, "u1", 2, "123#n1")
 		require.NoError(t, err)
 		assert.Len(t, notes, 2)
+		assert.NotContains(t, notes[0].Content, "<script")
 		assert.Equal(t, "122#n2", next)
 
 		mockQuery.On("Index", "gsi3").Return(mockQuery).Once()

--- a/pkg/storage/repositories/hashtag_repository.go
+++ b/pkg/storage/repositories/hashtag_repository.go
@@ -167,6 +167,14 @@ func NewTrendingCalculator(config TrendingCalculatorConfig, logger *zap.Logger) 
 
 // IndexHashtag indexes a hashtag when used in a status
 func (r *HashtagRepository) IndexHashtag(ctx context.Context, hashtag string, statusID string, authorID string, visibility string) error {
+	if !isPublicHashtagVisibility(visibility) {
+		r.logger.Debug("skipping non-public hashtag metadata indexing",
+			zap.String("hashtag", hashtag),
+			zap.String("status_id", statusID),
+			zap.String("visibility", visibility))
+		return nil
+	}
+
 	now := time.Now()
 	tagLower := strings.ToLower(strings.TrimPrefix(hashtag, "#"))
 	pk := fmt.Sprintf("HASHTAG#%s", tagLower)
@@ -242,6 +250,14 @@ func (r *HashtagRepository) IndexStatusHashtags(ctx context.Context, statusID st
 
 	if err := common.ValidateSliceNotEmpty("hashtags", hashtags); err != nil {
 		return nil // Nothing to index
+	}
+
+	if !isPublicHashtagVisibility(visibility) {
+		r.logger.Debug("skipping non-public hashtag timeline indexing",
+			zap.String("status_id", statusID),
+			zap.String("visibility", visibility),
+			zap.Int("hashtag_count", len(hashtags)))
+		return nil
 	}
 
 	now := time.Now()
@@ -341,6 +357,10 @@ func (r *HashtagRepository) truncateContent(content string, maxLength int) strin
 	}
 
 	return truncated + "..."
+}
+
+func isPublicHashtagVisibility(visibility string) bool {
+	return strings.EqualFold(strings.TrimSpace(visibility), models.VisibilityPublic)
 }
 
 // GetHashtagInfo retrieves information about a specific hashtag
@@ -520,14 +540,14 @@ func (r *HashtagRepository) GetHashtagTimelineAdvanced(ctx context.Context, hash
 	var results []*storage.StatusSearchResult
 	var err error
 
-	if visibility != "" && visibility != models.VisibilityPublic {
-		// Use visibility-filtered index for non-public content
-		results, err = r.getHashtagTimelineByVisibility(ctx, tagLower, maxID, limit, visibility)
-	} else {
-		// Use main hashtag timeline index for public/all content
-		results, err = r.getHashtagTimelineFromIndex(ctx, tagLower, maxID, limit)
+	if visibility != "" && !isPublicHashtagVisibility(visibility) {
+		r.logger.Debug("refusing non-public hashtag timeline without viewer authorization",
+			zap.String("hashtag", tagLower),
+			zap.String("visibility", visibility))
+		return []*storage.StatusSearchResult{}, nil
 	}
 
+	results, err = r.getHashtagTimelineByVisibility(ctx, tagLower, maxID, limit, models.VisibilityPublic)
 	if err != nil {
 		return nil, ErrorHandler.HandleQueryError(err, "hashtag timeline", tagLower)
 	}
@@ -537,51 +557,6 @@ func (r *HashtagRepository) GetHashtagTimelineAdvanced(ctx context.Context, hash
 		zap.Int("results", len(results)),
 		zap.Int("limit", limit),
 		zap.String("visibility", visibility))
-
-	return results, nil
-}
-
-// getHashtagTimelineFromIndex retrieves timeline using the main hashtag index
-func (r *HashtagRepository) getHashtagTimelineFromIndex(ctx context.Context, hashtag string, maxID *string, limit int) ([]*storage.StatusSearchResult, error) {
-	// Build query for hashtag timeline index
-	query := r.db.WithContext(ctx).Model(&models.HashtagStatusIndex{}).
-		Where("PK", "=", fmt.Sprintf("HASHTAG_TIMELINE#%s", hashtag))
-
-	// Apply the maxID cursor when provided
-	if maxID != nil && *maxID != "" {
-		query = query.Where("SK", ">", *maxID)
-	}
-
-	// Set limit and order (SK already contains descending timestamp)
-	query = query.Limit(limit).OrderBy("SK", "ASC") // ASC because timestamp is already reversed
-
-	var indexEntries []models.HashtagStatusIndex
-	err := query.All(&indexEntries)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return []*storage.StatusSearchResult{}, nil
-		}
-		r.logger.Error("hashtag timeline index query failed",
-			zap.String("hashtag", hashtag),
-			zap.Error(err))
-		return nil, ErrorHandler.HandleQueryError(err, "hashtag timeline index", hashtag)
-	}
-
-	// Convert index entries to search results
-	results := make([]*storage.StatusSearchResult, len(indexEntries))
-	for i, entry := range indexEntries {
-		results[i] = &storage.StatusSearchResult{
-			ID:             entry.SK,
-			StatusID:       entry.StatusID,
-			Content:        entry.Content,
-			URL:            entry.StatusURL,
-			AuthorID:       entry.AuthorID,
-			AuthorUsername: entry.AuthorHandle,
-			Published:      entry.Published,
-			Score:          1.0, // All results have equal relevance in timeline
-			Highlights:     []string{"hashtag_timeline"},
-		}
-	}
 
 	return results, nil
 }
@@ -614,9 +589,12 @@ func (r *HashtagRepository) getHashtagTimelineByVisibility(ctx context.Context, 
 	}
 
 	// Convert to search results
-	results := make([]*storage.StatusSearchResult, len(indexEntries))
-	for i, entry := range indexEntries {
-		results[i] = &storage.StatusSearchResult{
+	results := make([]*storage.StatusSearchResult, 0, len(indexEntries))
+	for _, entry := range indexEntries {
+		if !isPublicHashtagVisibility(entry.Visibility) {
+			continue
+		}
+		results = append(results, &storage.StatusSearchResult{
 			ID:             entry.GSI2SK,
 			StatusID:       entry.StatusID,
 			Content:        entry.Content,
@@ -624,9 +602,10 @@ func (r *HashtagRepository) getHashtagTimelineByVisibility(ctx context.Context, 
 			AuthorID:       entry.AuthorID,
 			AuthorUsername: entry.AuthorHandle,
 			Published:      entry.Published,
+			Visibility:     entry.Visibility,
 			Score:          1.0,
 			Highlights:     []string{"hashtag_timeline_filtered"},
-		}
+		})
 	}
 
 	return results, nil

--- a/pkg/storage/repositories/hashtag_repository_additional_coverage_test.go
+++ b/pkg/storage/repositories/hashtag_repository_additional_coverage_test.go
@@ -93,6 +93,20 @@ func TestHashtagRepository_PureHelpers(t *testing.T) {
 	assert.Nil(t, convertNotificationFiltersToStorage(nil))
 }
 
+func TestHashtagRepository_SkipsNonPublicIndexing(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+	repo := NewHashtagRepository(db, "test-table", zap.NewNop(), "example.com")
+
+	require.NoError(t, repo.IndexHashtag(ctx, "#Secret", "status-private", "alice", models.VisibilityPrivate))
+	require.NoError(t, repo.IndexStatusHashtags(ctx, "status-private", "alice", "alice", "https://example.com/s/private", "secret", []string{"#Secret"}, time.Now(), models.VisibilityPrivate))
+
+	db.AssertNotCalled(t, "WithContext", mock.Anything)
+	db.AssertNotCalled(t, "Model", mock.Anything)
+	q.AssertNotCalled(t, "Create")
+}
+
 func TestHashtagRepository_Sweep_IndexTimelineStatsAndCleanup(t *testing.T) {
 	ctx := context.Background()
 	db, q := newPermissiveDynamORM(t)
@@ -126,8 +140,21 @@ func TestHashtagRepository_Sweep_IndexTimelineStatsAndCleanup(t *testing.T) {
 					AuthorHandle: "alice",
 					StatusURL:    "https://example.com/s/1",
 					Content:      "hello",
+					Visibility:   models.VisibilityPublic,
 					Published:    time.Now().Add(-1 * time.Hour),
 					GSI2SK:       "TS#1",
+				},
+				{
+					PK:           "HASHTAG_TIMELINE#golang",
+					SK:           "TS#2",
+					StatusID:     "s2",
+					AuthorID:     "a2",
+					AuthorHandle: "bob",
+					StatusURL:    "https://example.com/s/2",
+					Content:      "private",
+					Visibility:   models.VisibilityPrivate,
+					Published:    time.Now().Add(-2 * time.Hour),
+					GSI2SK:       "TS#2",
 				},
 			}
 		case *[]*models.HashtagUsage:
@@ -179,17 +206,18 @@ func TestHashtagRepository_Sweep_IndexTimelineStatsAndCleanup(t *testing.T) {
 	// Timelines.
 	publicResults, err := repo.GetHashtagTimelineAdvanced(ctx, "#GoLang", nil, 2, models.VisibilityPublic)
 	require.NoError(t, err)
-	require.NotEmpty(t, publicResults)
+	require.Len(t, publicResults, 1)
+	require.Equal(t, "s1", publicResults[0].StatusID)
 
 	privateVis := "private"
 	privateResults, err := repo.GetHashtagTimelineAdvanced(ctx, "#GoLang", nil, 2, privateVis)
 	require.NoError(t, err)
-	require.NotEmpty(t, privateResults)
+	require.Empty(t, privateResults)
 
 	// Multi-hashtag merge path.
 	merged, err := repo.GetMultiHashtagTimeline(ctx, []string{"#GoLang"}, nil, 1, privateVis)
 	require.NoError(t, err)
-	require.Len(t, merged, 1)
+	require.Empty(t, merged)
 
 	// Suggestions and metadata range queries.
 	suggestions, err := repo.GetSuggestedHashtags(ctx, "alice", 1)

--- a/pkg/storage/repositories/search_repository.go
+++ b/pkg/storage/repositories/search_repository.go
@@ -700,10 +700,10 @@ func (r *SearchRepository) SearchStatusesWithPrivacy(ctx context.Context, query 
 		return nil, err
 	}
 
-	// Apply privacy filters
-	if searcherActorID != "" {
-		results = r.filterStatusesByPrivacy(ctx, results, searcherActorID)
-	}
+	// Apply privacy filters. This is required even for unauthenticated searches
+	// because the public /api/v1/search surface can otherwise expose private or
+	// direct statuses that were indexed before this check existed.
+	results = r.filterStatusesByPrivacy(ctx, results, searcherActorID)
 
 	return results, nil
 }
@@ -719,10 +719,9 @@ func (r *SearchRepository) SearchStatusesWithPrivacyPaginated(ctx context.Contex
 		return nil, nil, err
 	}
 
-	// Apply privacy filters
-	if searcherActorID != "" {
-		results = r.filterStatusesByPrivacy(ctx, results, searcherActorID)
-	}
+	// Apply privacy filters for both authenticated and unauthenticated searchers.
+	preFilterCount := len(results)
+	results = r.filterStatusesByPrivacy(ctx, results, searcherActorID)
 
 	// Apply original limit after filtering
 	finalResults := results
@@ -747,7 +746,7 @@ func (r *SearchRepository) SearchStatusesWithPrivacyPaginated(ctx context.Contex
 	finalPagination := CreatePaginationResult(hasNextPage, nextCursor, len(results))
 
 	r.logger.Debug("search results after privacy filtering",
-		zap.Int("original_count", len(results)+len(results)-len(finalResults)),
+		zap.Int("original_count", preFilterCount),
 		zap.Int("filtered_count", len(finalResults)),
 		zap.String("searcher", searcherActorID))
 
@@ -763,8 +762,10 @@ func (r *SearchRepository) filterStatusesByPrivacy(ctx context.Context, results 
 			continue
 		}
 
-		// Check if searcher is blocked by the author or has blocked the author
-		if r.deps != nil {
+		// Check if searcher is blocked by the author or has blocked the author.
+		// Anonymous searches still need visibility filtering below, but cannot
+		// perform viewer-specific block checks.
+		if r.deps != nil && strings.TrimSpace(searcherActorID) != "" {
 			isBlocked, err := r.deps.IsBlockedBidirectional(ctx, searcherActorID, result.AuthorID)
 			if err != nil {
 				r.logger.Debug("failed to check block status for status search",
@@ -808,14 +809,17 @@ func (r *SearchRepository) filterStatusesByPrivacy(ctx context.Context, results 
 }
 
 // isStatusPrivate checks if a status should be excluded from search due to privacy
-func (r *SearchRepository) isStatusPrivate(_ *storage.StatusSearchResult) bool {
-	// Currently implements a conservative approach allowing all public/unlisted content in search results.
-	// Direct messages and private posts are excluded through other filtering mechanisms.
-	//
-	// Future enhancement: Include visibility field in search index to enable more granular filtering
-	// without requiring additional database queries for each result.
+func (r *SearchRepository) isStatusPrivate(result *storage.StatusSearchResult) bool {
+	if result == nil {
+		return true
+	}
 
-	return false // Allow all content - private/direct content is filtered at other layers
+	switch strings.TrimSpace(strings.ToLower(result.Visibility)) {
+	case models.VisibilityPublic, models.VisibilityUnlisted:
+		return false
+	default:
+		return true
+	}
 }
 
 // statusSearchResult wraps search result with sync protection
@@ -1388,6 +1392,9 @@ func (r *SearchRepository) statusModelToSearchResult(status *models.Status, scor
 		AuthorID:       status.AuthorID,
 		AuthorUsername: status.AuthorUsername,
 		Published:      status.PublishedAt,
+		Visibility:     status.Visibility,
+		Language:       status.Language,
+		Tags:           status.Hashtags,
 		Score:          score,
 		Highlights:     []string{strategy},
 	}
@@ -1785,6 +1792,8 @@ func (r *SearchRepository) SearchStatusesByHashtag(ctx context.Context, hashtag 
 			AuthorID:       indexEntry.AuthorID,
 			AuthorUsername: indexEntry.AuthorHandle,
 			Published:      indexEntry.Published,
+			Visibility:     indexEntry.Visibility,
+			Language:       indexEntry.Language,
 			Score:          1.0, // Exact hashtag match
 			Highlights:     []string{"hashtag_match"},
 		}

--- a/pkg/storage/repositories/search_repository.go
+++ b/pkg/storage/repositories/search_repository.go
@@ -762,6 +762,15 @@ func (r *SearchRepository) filterStatusesByPrivacy(ctx context.Context, results 
 			continue
 		}
 
+		// Check visibility before viewer-specific dependency checks. If block
+		// lookup is unavailable, non-public statuses must still stay excluded.
+		if r.isStatusPrivate(result) {
+			r.logger.Debug("excluding private/direct status from search",
+				zap.String("status_id", result.StatusID),
+				zap.String("author", result.AuthorID))
+			continue
+		}
+
 		// Check if searcher is blocked by the author or has blocked the author.
 		// Anonymous searches still need visibility filtering below, but cannot
 		// perform viewer-specific block checks.
@@ -772,7 +781,8 @@ func (r *SearchRepository) filterStatusesByPrivacy(ctx context.Context, results 
 					zap.String("searcher", searcherActorID),
 					zap.String("author", result.AuthorID),
 					zap.Error(err))
-				// On error, include the result (fail open)
+				// On block-check errors, preserve availability only for statuses
+				// that have already passed visibility filtering above.
 				filteredResults = append(filteredResults, result)
 				continue
 			}
@@ -785,15 +795,6 @@ func (r *SearchRepository) filterStatusesByPrivacy(ctx context.Context, results 
 					zap.String("searcher", searcherActorID))
 				continue
 			}
-		}
-
-		// Check visibility - for now, only allow public and unlisted content in search
-		// Private and direct messages should not appear in search results
-		if r.isStatusPrivate(result) {
-			r.logger.Debug("excluding private/direct status from search",
-				zap.String("status_id", result.StatusID),
-				zap.String("author", result.AuthorID))
-			continue
 		}
 
 		// Status passed all privacy checks

--- a/pkg/storage/repositories/search_repository_additional_coverage_test.go
+++ b/pkg/storage/repositories/search_repository_additional_coverage_test.go
@@ -367,6 +367,7 @@ func TestSearchRepository_FilterStatusesByPrivacy_BlockedAndFailOpen(t *testing.
 	results := repo.filterStatusesByPrivacy(context.Background(), []*storage.StatusSearchResult{
 		{StatusID: "s1", AuthorID: "blocked-author", Visibility: models.VisibilityPublic},
 		{StatusID: "s2", AuthorID: "error-author", Visibility: models.VisibilityPublic},
+		{StatusID: "s2-direct", AuthorID: "error-author", Visibility: models.VisibilityDirect},
 		{StatusID: "s3", AuthorID: "ok-author", Visibility: models.VisibilityPublic},
 	}, "searcher")
 

--- a/pkg/storage/repositories/search_repository_additional_coverage_test.go
+++ b/pkg/storage/repositories/search_repository_additional_coverage_test.go
@@ -365,14 +365,31 @@ func TestSearchRepository_FilterStatusesByPrivacy_BlockedAndFailOpen(t *testing.
 	})
 
 	results := repo.filterStatusesByPrivacy(context.Background(), []*storage.StatusSearchResult{
-		{StatusID: "s1", AuthorID: "blocked-author"},
-		{StatusID: "s2", AuthorID: "error-author"},
-		{StatusID: "s3", AuthorID: "ok-author"},
+		{StatusID: "s1", AuthorID: "blocked-author", Visibility: models.VisibilityPublic},
+		{StatusID: "s2", AuthorID: "error-author", Visibility: models.VisibilityPublic},
+		{StatusID: "s3", AuthorID: "ok-author", Visibility: models.VisibilityPublic},
 	}, "searcher")
 
 	require.Len(t, results, 2)
 	assert.Equal(t, "s2", results[0].StatusID)
 	assert.Equal(t, "s3", results[1].StatusID)
+}
+
+func TestSearchRepository_FilterStatusesByPrivacy_ExcludesNonPublicAndUnknown(t *testing.T) {
+	repo := NewSearchRepository(nil, "test-table", zap.NewNop(), nil)
+
+	results := repo.filterStatusesByPrivacy(context.Background(), []*storage.StatusSearchResult{
+		{StatusID: "public", Visibility: models.VisibilityPublic},
+		{StatusID: "unlisted", Visibility: models.VisibilityUnlisted},
+		{StatusID: "private", Visibility: models.VisibilityPrivate},
+		{StatusID: "direct", Visibility: models.VisibilityDirect},
+		{StatusID: "legacy-empty"},
+		nil,
+	}, "")
+
+	require.Len(t, results, 2)
+	assert.Equal(t, "public", results[0].StatusID)
+	assert.Equal(t, "unlisted", results[1].StatusID)
 }
 
 func TestSearchRepository_UpdateSearchSuggestion_AppliesAllUpdateFields(t *testing.T) {
@@ -509,6 +526,22 @@ func TestSearchRepository_StatusModelToSearchResult_ReturnsNilForNilInput(t *tes
 	repo := NewSearchRepository(nil, "test-table", zap.NewNop(), nil)
 
 	assert.Nil(t, repo.statusModelToSearchResult(nil, 1, "s"))
+
+	status := &models.Status{
+		StatusID:       "status-1",
+		Content:        "hello",
+		AuthorID:       "author",
+		AuthorUsername: "alice",
+		Visibility:     models.VisibilityPrivate,
+		Language:       "en",
+		Hashtags:       []string{"go"},
+		PublishedAt:    time.Now(),
+	}
+	result := repo.statusModelToSearchResult(status, 1, "s")
+	require.NotNil(t, result)
+	assert.Equal(t, models.VisibilityPrivate, result.Visibility)
+	assert.Equal(t, "en", result.Language)
+	assert.Equal(t, []string{"go"}, result.Tags)
 }
 
 func TestSearchRepository_CompareRelevance_CoversLengthTieBreaker(t *testing.T) {
@@ -783,6 +816,7 @@ func TestSearchRepository_SearchStatusesWithPrivacyPaginated_SetsNextCursorWhenM
 				Content:        "hello world",
 				AuthorID:       "https://example.com/users/alice",
 				AuthorUsername: "alice",
+				Visibility:     models.VisibilityPublic,
 				PublishedAt:    now.Add(time.Duration(-i) * time.Minute),
 			})
 		}

--- a/pkg/testing/inmemory/hashtag_repository.go
+++ b/pkg/testing/inmemory/hashtag_repository.go
@@ -43,8 +43,12 @@ func NewHashtagRepository() *HashtagRepository {
 	}
 }
 
-// IndexHashtag indexes a hashtag when used in a status
-func (r *HashtagRepository) IndexHashtag(_ context.Context, hashtag string, statusID string, _ string, _ string) error {
+// IndexHashtag indexes a hashtag when used in a public status.
+func (r *HashtagRepository) IndexHashtag(_ context.Context, hashtag string, statusID string, _ string, visibility string) error {
+	if visibility != models.VisibilityPublic {
+		return nil
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -53,8 +57,12 @@ func (r *HashtagRepository) IndexHashtag(_ context.Context, hashtag string, stat
 	return nil
 }
 
-// IndexStatusHashtags indexes a status with its hashtags for efficient search
-func (r *HashtagRepository) IndexStatusHashtags(_ context.Context, statusID string, _ string, _ string, _ string, _ string, hashtags []string, _ time.Time, _ string) error {
+// IndexStatusHashtags indexes a public status with its hashtags for efficient search.
+func (r *HashtagRepository) IndexStatusHashtags(_ context.Context, statusID string, _ string, _ string, _ string, _ string, hashtags []string, _ time.Time, visibility string) error {
+	if visibility != models.VisibilityPublic {
+		return nil
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/pkg/testing/inmemory/search_repository.go
+++ b/pkg/testing/inmemory/search_repository.go
@@ -9,6 +9,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
+	"github.com/equaltoai/lesser/pkg/storage/models"
 )
 
 // SearchRepository is a thread-safe in-memory implementation of interfaces.SearchRepository.
@@ -106,12 +107,24 @@ func (r *SearchRepository) SearchStatusesWithOptionsPaginated(ctx context.Contex
 
 // SearchStatusesWithPrivacy searches for statuses with privacy enforcement
 func (r *SearchRepository) SearchStatusesWithPrivacy(ctx context.Context, query string, options storage.StatusSearchOptions, _ string) ([]*storage.StatusSearchResult, error) {
-	return r.SearchStatuses(ctx, query, options.Limit)
+	results, err := r.SearchStatuses(ctx, query, options.Limit)
+	if err != nil {
+		return nil, err
+	}
+	return filterPublicStatusSearchResults(results), nil
 }
 
 // SearchStatusesWithPrivacyPaginated searches for statuses with privacy and pagination
 func (r *SearchRepository) SearchStatusesWithPrivacyPaginated(ctx context.Context, query string, options storage.StatusSearchOptions, _ string) ([]*storage.StatusSearchResult, *interfaces.PaginationResult, error) {
-	return r.SearchStatusesWithOptionsPaginated(ctx, query, options)
+	results, _, err := r.SearchStatusesWithOptionsPaginated(ctx, query, options)
+	if err != nil {
+		return nil, nil, err
+	}
+	results = filterPublicStatusSearchResults(results)
+	return results, &interfaces.PaginationResult{
+		HasNextPage: false,
+		TotalCount:  len(results),
+	}, nil
 }
 
 // SearchStatusesAdvanced searches for statuses with advanced filtering
@@ -146,6 +159,20 @@ func (r *SearchRepository) Clear() {
 	defer r.mu.Unlock()
 	r.actors = make(map[string]*activitypub.Actor)
 	r.statuses = make(map[string]*storage.StatusSearchResult)
+}
+
+func filterPublicStatusSearchResults(results []*storage.StatusSearchResult) []*storage.StatusSearchResult {
+	filtered := make([]*storage.StatusSearchResult, 0, len(results))
+	for _, result := range results {
+		if result == nil {
+			continue
+		}
+		switch strings.TrimSpace(strings.ToLower(result.Visibility)) {
+		case models.VisibilityPublic, models.VisibilityUnlisted:
+			filtered = append(filtered, result)
+		}
+	}
+	return filtered
 }
 
 // Ensure SearchRepository implements interfaces.SearchRepository

--- a/tools/openapi/schema_overrides.go
+++ b/tools/openapi/schema_overrides.go
@@ -7,6 +7,7 @@ func applySchemaOverrides(spec *openAPISpec) {
 
 	overrideCreateStatusRequest(spec.Components.Schemas)
 	overrideOAuthClientSchemas(spec.Components.Schemas)
+	overrideCommunityNoteSchemas(spec.Components.Schemas)
 }
 
 func overrideCreateStatusRequest(schemas map[string]any) {
@@ -49,7 +50,41 @@ func overrideOAuthClientSchemas(schemas map[string]any) {
 	overrideSchemaProperty(schemas, "OAuthTokenRequest", "resource", "Canonical target resource URI. For remote MCP authorization, this must match the actor-scoped MCP URL used during the authorize request.", false)
 }
 
+func overrideCommunityNoteSchemas(schemas map[string]any) {
+	mutateSchemaProperty(schemas, "CommunityNoteSource", "url", func(property map[string]any) {
+		property["format"] = "uri"
+	})
+	mutateSchemaProperty(schemas, "CreateCommunityNoteRequest", "content", func(property map[string]any) {
+		property["minLength"] = 10
+		property["maxLength"] = 500
+	})
+	mutateSchemaProperty(schemas, "CreateCommunityNoteRequest", "language", func(property map[string]any) {
+		property["minLength"] = 2
+		property["maxLength"] = 2
+	})
+	mutateSchemaProperty(schemas, "CreateCommunityNoteRequest", "sources", func(property map[string]any) {
+		property["maxItems"] = 5
+	})
+	mutateSchemaProperty(schemas, "VoteCommunityNoteRequest", "vote_type", func(property map[string]any) {
+		property["enum"] = []string{"helpful", "not_helpful", "neutral"}
+	})
+	mutateSchemaProperty(schemas, "VoteCommunityNoteRequest", "reason", func(property map[string]any) {
+		property["maxLength"] = 200
+	})
+}
+
 func overrideSchemaProperty(schemas map[string]any, schemaName, propertyName, description string, deprecated bool) {
+	mutateSchemaProperty(schemas, schemaName, propertyName, func(propertyMap map[string]any) {
+		if description != "" {
+			propertyMap["description"] = description
+		}
+		if deprecated {
+			propertyMap["deprecated"] = true
+		}
+	})
+}
+
+func mutateSchemaProperty(schemas map[string]any, schemaName, propertyName string, mutate func(map[string]any)) {
 	raw, ok := schemas[schemaName]
 	if !ok {
 		return
@@ -75,10 +110,7 @@ func overrideSchemaProperty(schemas map[string]any, schemaName, propertyName, de
 		return
 	}
 
-	if description != "" {
-		propertyMap["description"] = description
-	}
-	if deprecated {
-		propertyMap["deprecated"] = true
+	if mutate != nil {
+		mutate(propertyMap)
 	}
 }


### PR DESCRIPTION
## Milestone
Codex Security M1 — High-severity public confidentiality and XSS

Closes #810
Closes #811
Closes #812
Closes #813
Closes #814
Closes #815
Closes #816

## Classification
security / federation-trust / Mastodon API contract stability / GraphQL authorization / XSS hardening

## Surfaces affected
- Direct conversation message creation and delivery rendering (`pkg/services/conversations`)
- Public ActivityPub outbox reads (`cmd/outbox`, activity repository public filtering)
- GraphQL moderation model training mutation
- Hashtag indexing and public hashtag timeline reads
- Community note creation, validation, voting, repository/service read boundaries, REST/GraphQL rendering, and rendered HTML output
- Mastodon-compatible search and status URL lookup (`/api/v1/search`, `/api/v2/search`, status indexer)
- OpenAPI contract constraints for community note inputs

## Specialist walks referenced
- Federation trust: public outbox and ActivityPub/search visibility changes keep non-public activities out of public discovery while preserving signed delivery/inbound semantics.
- Contract / API: REST and GraphQL behavior changes are tightening/authorization fixes; response shapes remain compatible. OpenAPI constraints were regenerated through the generator override path.
- Schema: no PK/SK, GSI, TableTheory tag, or storage schema shape changes.
- Framework: idiomatic AppTheory/TableTheory usage; no framework patching.

## Consumer impact
- Operators: closes high-severity confidentiality/XSS findings without deployment-shape changes.
- Mastodon clients: no response-shape break; direct/search/note surfaces now suppress or sanitize content that should not be exposed.
- Remote ActivityPub peers: public outbox remains available, but non-public activities are not returned from public reads.
- Sibling repos: none.

## Tasks
- [x] #811
- [x] #812
- [x] #813
- [x] #814
- [x] #815
- [x] #816

## Review follow-up
- [x] Sanitize legacy/raw community note content on REST read paths, service read boundaries, repository conversion, and GraphQL community-note presentation paths.
- [x] Reorder status-search privacy filtering so private/direct/unknown visibility is excluded before block-check dependency failures can fail open.
- [x] Restore local coverage gates with added regression/coverage tests.

## Validation
- `gofmt -l .` (empty)
- `go test ./...`
- `go vet ./...`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas` (`✓ Built 38 Lambda artifact(s), skipped 0`)
- `./lesser verify ci` (`✓ verify ci complete`; pkg coverage 90.005%, cmd coverage 90.009%)
- Targeted during review follow-up: `go test ./pkg/security/htmlsafe ./cmd/api/handlers ./pkg/services/notes ./pkg/storage/repositories ./graph -run 'TestEscapePlainTextHTML|TestNotesHandlersRound12|TestService_round15_community_note_content|TestCommunityNoteRepository_round09|TestSearchRepository_FilterStatusesByPrivacy|TestRound12ModerationResolvers_QueryAndMutation|TestRound12QueryAccountsLists_CommunityNotesAndHelpers' -count=1`
- External smoke/deploy: not run — Aron clarified no smoke test instance is available.

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None required for M1; all changes are local to lesser and preserve public contract shapes.

## Advisor-brief authorization
Not applicable.
