### PR TITLE
fix(security): complete federation trust boundaries M3

### DIFF
--- a/cmd/activity-processor/handler.go
+++ b/cmd/activity-processor/handler.go
@@ -77,6 +77,8 @@ const (
 	VisibilityPublic = "public"
 	// VisibilityDirect represents a direct message visibility level
 	VisibilityDirect = "direct"
+	// VisibilityPrivate represents a followers-only visibility level
+	VisibilityPrivate = "private"
 
 	// ModerationEventTypeFlagCreated represents a flag creation event
 	ModerationEventTypeFlagCreated = "flag_created"
@@ -813,7 +815,7 @@ func (h *ActivityHandler) processStatusForTimelines(ctx context.Context, status 
 			// Don't fail the entire operation - continue processing
 		}
 
-	case "private":
+	case VisibilityPrivate:
 		h.Logger.Debug("Status is private, adding to followers' home timelines",
 			zap.String("status_id", status.StatusID))
 		// Private posts only go to followers' home timelines
@@ -1817,12 +1819,14 @@ func (h *ActivityHandler) processUndoReject(ctx context.Context, undoActivity *a
 	return nil
 }
 
+//nolint:unused // Used by processUndoReject; production reachability is through stream dispatch.
 type undoRejectFollowState struct {
 	ID     string
 	Actor  string
 	Target string
 }
 
+//nolint:unused // Used by processUndoReject; production reachability is through stream dispatch.
 func (h *ActivityHandler) extractRejectStateForUndoReject(rejectActivity interface{}) (string, interface{}, error) {
 	switch reject := rejectActivity.(type) {
 	case *activitypub.Activity:
@@ -1844,6 +1848,7 @@ func (h *ActivityHandler) extractRejectStateForUndoReject(rejectActivity interfa
 	}
 }
 
+//nolint:unused // Used by processUndoReject; production reachability is through stream dispatch.
 func (h *ActivityHandler) resolveUndoRejectFollowState(ctx context.Context, followActivity interface{}) (undoRejectFollowState, error) {
 	switch follow := followActivity.(type) {
 	case string:
@@ -1869,6 +1874,7 @@ func (h *ActivityHandler) resolveUndoRejectFollowState(ctx context.Context, foll
 	}
 }
 
+//nolint:unused // Used by processUndoReject; production reachability is through stream dispatch.
 func (h *ActivityHandler) followStateFromActivity(activity *activitypub.Activity) (undoRejectFollowState, error) {
 	if activity == nil || activity.Type != ActivityTypeFollow {
 		return undoRejectFollowState{}, services.ErrExtractActivityTypeFromUndo
@@ -1881,6 +1887,7 @@ func (h *ActivityHandler) followStateFromActivity(activity *activitypub.Activity
 	return validateUndoRejectFollowState(state)
 }
 
+//nolint:unused // Used by processUndoReject; production reachability is through stream dispatch.
 func (h *ActivityHandler) followStateFromMap(activity map[string]interface{}) (undoRejectFollowState, error) {
 	activityType, _ := activity["type"].(string)
 	if activityType != ActivityTypeFollow {
@@ -1897,6 +1904,7 @@ func (h *ActivityHandler) followStateFromMap(activity map[string]interface{}) (u
 	return validateUndoRejectFollowState(state)
 }
 
+//nolint:unused // Used by processUndoReject; production reachability is through stream dispatch.
 func (h *ActivityHandler) followTargetFromObject(object interface{}) string {
 	switch obj := object.(type) {
 	case string:
@@ -1909,6 +1917,7 @@ func (h *ActivityHandler) followTargetFromObject(object interface{}) string {
 	return ""
 }
 
+//nolint:unused // Used by processUndoReject; production reachability is through stream dispatch.
 func validateUndoRejectFollowState(state undoRejectFollowState) (undoRejectFollowState, error) {
 	if err := common.ValidateRequiredParam("followActivityID", state.ID); err != nil {
 		return undoRejectFollowState{}, services.ErrExtractUsernamesFromReject

--- a/cmd/activity-processor/handler.go
+++ b/cmd/activity-processor/handler.go
@@ -1759,22 +1759,15 @@ func (h *ActivityHandler) processUndoReject(ctx context.Context, undoActivity *a
 		zap.String("username", username),
 	)
 
-	var rejectActor string
-	var followActivity interface{}
-
-	switch reject := rejectActivity.(type) {
-	case *activitypub.Activity:
-		rejectActor = reject.Actor
-		followActivity = reject.Object
-	case map[string]interface{}:
-		if actor, ok := reject["actor"].(string); ok {
-			rejectActor = actor
-		}
-		followActivity = reject["object"]
-	default:
-		h.Logger.Error("Undo Reject activity has invalid reject target type",
-			zap.Any("reject_activity", rejectActivity))
-		return services.ErrUndoInvalidObjectType
+	rejectActor, followActivity, err := h.extractRejectStateForUndoReject(rejectActivity)
+	if err != nil {
+		return err
+	}
+	if rejectActor != undoActivity.Actor {
+		h.Logger.Warn("Undo Reject actor does not match referenced Reject actor",
+			zap.String("undo_actor", undoActivity.Actor),
+			zap.String("reject_actor", rejectActor))
+		return services.ErrActorNotAuthorizedUndo
 	}
 
 	rejecter := h.extractUsernameFromActorURI(rejectActor)
@@ -1784,64 +1777,34 @@ func (h *ActivityHandler) processUndoReject(ctx context.Context, undoActivity *a
 		return services.ErrExtractUsernamesFromReject
 	}
 
-	var follower string
-	var followActivityID string
-
-	resolveFollowActivity := func(activity *activitypub.Activity) {
-		if activity == nil {
-			return
-		}
-
-		if follower == "" && activity.Actor != "" {
-			follower = h.extractUsernameFromActorURI(activity.Actor)
-		}
-
-		if followActivityID == "" && activity.ID != "" {
-			followActivityID = activity.ID
-		}
+	followState, err := h.resolveUndoRejectFollowState(ctx, followActivity)
+	if err != nil {
+		return err
+	}
+	if followState.Target != rejectActor && h.extractUsernameFromActorURI(followState.Target) != rejecter {
+		h.Logger.Warn("Undo Reject referenced Follow target does not match Reject actor",
+			zap.String("reject_actor", rejectActor),
+			zap.String("follow_target", followState.Target),
+			zap.String("follow_activity_id", followState.ID))
+		return services.ErrActorNotAuthorizedUndo
 	}
 
-	switch follow := followActivity.(type) {
-	case string:
-		followActivityID = follow
-
-		if resolved, err := h.getActivityByID(ctx, follow); err == nil {
-			resolveFollowActivity(resolved)
-		} else {
-			h.Logger.Warn("Failed to resolve follow activity for Undo Reject",
-				zap.String("follow_activity_id", follow),
-				zap.Error(err))
-		}
-	case *activitypub.Activity:
-		resolveFollowActivity(follow)
-	case map[string]interface{}:
-		if actor, ok := follow["actor"].(string); ok {
-			follower = h.extractUsernameFromActorURI(actor)
-		}
-		if id, ok := follow["id"].(string); ok {
-			followActivityID = id
-		}
-	default:
-		h.Logger.Warn("Undo Reject follow activity has unexpected type",
-			zap.Any("follow_activity", follow))
-	}
-
-	if follower == "" {
-		follower = username
-	}
-
+	follower := h.extractUsernameFromActorURI(followState.Actor)
 	if err := common.ValidateRequiredParam("follower", follower); err != nil {
 		h.Logger.Error("Failed to resolve follower for Undo Reject",
 			zap.String("rejecter", rejecter),
-			zap.String("username_context", username))
-		return err
+			zap.String("follow_actor", followState.Actor))
+		return services.ErrExtractUsernamesFromReject
+	}
+	if err := common.ValidateRequiredParam("followActivityID", followState.ID); err != nil {
+		return services.ErrExtractUsernamesFromReject
 	}
 
-	if err := h.RelationshipRepo.CreateRelationship(ctx, follower, rejecter, followActivityID); err != nil {
+	if err := h.RelationshipRepo.CreateRelationship(ctx, follower, rejecter, followState.ID); err != nil {
 		h.Logger.Error("Failed to recreate follow relationship after Undo Reject",
 			zap.String("follower", follower),
 			zap.String("rejecter", rejecter),
-			zap.String("follow_activity_id", followActivityID),
+			zap.String("follow_activity_id", followState.ID),
 			zap.Error(err))
 		return followRelationshipCreationFailed(err)
 	}
@@ -1849,9 +1812,114 @@ func (h *ActivityHandler) processUndoReject(ctx context.Context, undoActivity *a
 	h.Logger.Info("Successfully processed Undo Reject activity",
 		zap.String("follower", follower),
 		zap.String("followee", rejecter),
-		zap.String("follow_activity_id", followActivityID))
+		zap.String("follow_activity_id", followState.ID))
 
 	return nil
+}
+
+type undoRejectFollowState struct {
+	ID     string
+	Actor  string
+	Target string
+}
+
+func (h *ActivityHandler) extractRejectStateForUndoReject(rejectActivity interface{}) (string, interface{}, error) {
+	switch reject := rejectActivity.(type) {
+	case *activitypub.Activity:
+		if reject.Type != ActivityTypeReject {
+			return "", nil, services.ErrExtractActivityTypeFromUndo
+		}
+		return reject.Actor, reject.Object, nil
+	case map[string]interface{}:
+		activityType, _ := reject["type"].(string)
+		if activityType != ActivityTypeReject {
+			return "", nil, services.ErrExtractActivityTypeFromUndo
+		}
+		actor, _ := reject["actor"].(string)
+		return actor, reject["object"], nil
+	default:
+		h.Logger.Error("Undo Reject activity has invalid reject target type",
+			zap.Any("reject_activity", rejectActivity))
+		return "", nil, services.ErrUndoInvalidObjectType
+	}
+}
+
+func (h *ActivityHandler) resolveUndoRejectFollowState(ctx context.Context, followActivity interface{}) (undoRejectFollowState, error) {
+	switch follow := followActivity.(type) {
+	case string:
+		if err := common.ValidateRequiredParam("followActivityID", follow); err != nil {
+			return undoRejectFollowState{}, services.ErrExtractUsernamesFromReject
+		}
+		resolved, err := h.getActivityByID(ctx, follow)
+		if err != nil {
+			h.Logger.Warn("Failed to resolve follow activity for Undo Reject",
+				zap.String("follow_activity_id", follow),
+				zap.Error(err))
+			return undoRejectFollowState{}, services.ErrExtractUsernamesFromReject
+		}
+		return h.followStateFromActivity(resolved)
+	case *activitypub.Activity:
+		return h.followStateFromActivity(follow)
+	case map[string]interface{}:
+		return h.followStateFromMap(follow)
+	default:
+		h.Logger.Warn("Undo Reject follow activity has unexpected type",
+			zap.Any("follow_activity", follow))
+		return undoRejectFollowState{}, services.ErrExtractUsernamesFromReject
+	}
+}
+
+func (h *ActivityHandler) followStateFromActivity(activity *activitypub.Activity) (undoRejectFollowState, error) {
+	if activity == nil || activity.Type != ActivityTypeFollow {
+		return undoRejectFollowState{}, services.ErrExtractActivityTypeFromUndo
+	}
+	state := undoRejectFollowState{
+		ID:     activity.ID,
+		Actor:  activity.Actor,
+		Target: h.followTargetFromObject(activity.Object),
+	}
+	return validateUndoRejectFollowState(state)
+}
+
+func (h *ActivityHandler) followStateFromMap(activity map[string]interface{}) (undoRejectFollowState, error) {
+	activityType, _ := activity["type"].(string)
+	if activityType != ActivityTypeFollow {
+		return undoRejectFollowState{}, services.ErrExtractActivityTypeFromUndo
+	}
+	state := undoRejectFollowState{}
+	if id, ok := activity["id"].(string); ok {
+		state.ID = id
+	}
+	if actor, ok := activity["actor"].(string); ok {
+		state.Actor = actor
+	}
+	state.Target = h.followTargetFromObject(activity["object"])
+	return validateUndoRejectFollowState(state)
+}
+
+func (h *ActivityHandler) followTargetFromObject(object interface{}) string {
+	switch obj := object.(type) {
+	case string:
+		return obj
+	case map[string]interface{}:
+		if id, ok := obj["id"].(string); ok {
+			return id
+		}
+	}
+	return ""
+}
+
+func validateUndoRejectFollowState(state undoRejectFollowState) (undoRejectFollowState, error) {
+	if err := common.ValidateRequiredParam("followActivityID", state.ID); err != nil {
+		return undoRejectFollowState{}, services.ErrExtractUsernamesFromReject
+	}
+	if err := common.ValidateRequiredParam("followActor", state.Actor); err != nil {
+		return undoRejectFollowState{}, services.ErrExtractUsernamesFromReject
+	}
+	if err := common.ValidateRequiredParam("followTarget", state.Target); err != nil {
+		return undoRejectFollowState{}, services.ErrExtractUsernamesFromReject
+	}
+	return state, nil
 }
 
 // processUndoFlag processes an undo of a Flag activity

--- a/cmd/activity-processor/handler_branch_sweep_additional_test.go
+++ b/cmd/activity-processor/handler_branch_sweep_additional_test.go
@@ -196,7 +196,7 @@ func TestActivityHandler_ProcessUndoReject_AdditionalBranches(t *testing.T) {
 		}
 		undo := &activitypub.Activity{
 			BaseObject: activitypub.BaseObject{ID: "undo-1", Type: ActivityTypeUndo},
-			Actor:      "https://example.com/users/alice",
+			Actor:      "https://example.com/users/",
 		}
 
 		err := handler.processUndoReject(ctx, undo, reject, "alice")
@@ -210,10 +210,13 @@ func TestActivityHandler_ProcessUndoReject_AdditionalBranches(t *testing.T) {
 		handler := &ActivityHandler{Logger: zap.NewNop(), RelationshipRepo: relationshipRepo}
 
 		reject := map[string]any{
+			"type":  ActivityTypeReject,
 			"actor": "https://example.com/users/alice",
 			"object": map[string]any{
-				"actor": "https://remote.example/users/bob",
-				"id":    "follow-1",
+				"type":   ActivityTypeFollow,
+				"actor":  "https://remote.example/users/bob",
+				"id":     "follow-1",
+				"object": "https://example.com/users/alice",
 			},
 		}
 		undo := &activitypub.Activity{
@@ -223,6 +226,23 @@ func TestActivityHandler_ProcessUndoReject_AdditionalBranches(t *testing.T) {
 
 		require.Error(t, handler.processUndoReject(ctx, undo, reject, "alice"))
 		relationshipRepo.AssertExpectations(t)
+	})
+
+	t.Run("forged follow target is rejected", func(t *testing.T) {
+		handler := &ActivityHandler{Logger: zap.NewNop()}
+		reject := map[string]any{
+			"type":  ActivityTypeReject,
+			"actor": "https://example.com/users/alice",
+			"object": map[string]any{
+				"type":   ActivityTypeFollow,
+				"actor":  "https://remote.example/users/bob",
+				"id":     "follow-forged",
+				"object": "https://example.com/users/mallory",
+			},
+		}
+		undo := &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "undo-forged", Type: ActivityTypeUndo}, Actor: "https://example.com/users/alice"}
+
+		require.ErrorIs(t, handler.processUndoReject(ctx, undo, reject, "alice"), services.ErrActorNotAuthorizedUndo)
 	})
 }
 

--- a/cmd/activity-processor/handler_branch_sweep_additional_test.go
+++ b/cmd/activity-processor/handler_branch_sweep_additional_test.go
@@ -128,6 +128,49 @@ func TestActivityHandler_ProcessCreateActivity_NoteExtractionFailed(t *testing.T
 	require.Error(t, handler.processCreateActivity(ctx, create, "alice"))
 }
 
+func TestActivityHandler_NoteMappingBranches(t *testing.T) {
+	handler := &ActivityHandler{Logger: zap.NewNop()}
+
+	note, err := handler.mapToNote(map[string]any{
+		"id":           "https://example.com/objects/1",
+		"type":         "Note",
+		"content":      "hello",
+		"attributedTo": "https://example.com/users/alice",
+		"sensitive":    true,
+		"to":           []any{activitypub.PublicAddress, 123},
+		"cc":           []any{"https://example.com/users/alice/followers"},
+		"bto":          []any{"https://example.com/users/bob"},
+		"bcc":          []any{"https://example.com/users/carol"},
+		"inReplyTo":    "https://example.com/objects/root",
+		"tag": []any{
+			map[string]any{"type": "Hashtag", "href": "https://example.com/tags/test", "name": "#test"},
+			map[string]any{},
+			"not-a-tag",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/objects/1", note.ID)
+	require.Equal(t, "Note", note.Type)
+	require.Equal(t, "hello", note.Content)
+	require.Equal(t, "https://example.com/users/alice", note.AttributedTo)
+	require.True(t, note.Sensitive)
+	require.Equal(t, []string{activitypub.PublicAddress, ""}, note.To)
+	require.Equal(t, []string{"https://example.com/users/alice/followers"}, note.CC)
+	require.Equal(t, []string{"https://example.com/users/bob"}, note.BTo)
+	require.Equal(t, []string{"https://example.com/users/carol"}, note.BCC)
+	require.Equal(t, "https://example.com/objects/root", note.InReplyTo)
+	require.Len(t, note.Tag, 1)
+	require.Equal(t, "#test", note.Tag[0].Name)
+
+	extracted, err := handler.extractNoteFromActivity(&activitypub.Activity{Object: map[string]any{
+		"id":      "https://example.com/objects/2",
+		"type":    "Note",
+		"content": "from map",
+	}})
+	require.NoError(t, err)
+	require.Equal(t, "from map", extracted.Content)
+}
+
 func TestActivityHandler_ProcessUndoActivity_AdditionalErrorBranches(t *testing.T) {
 	ctx := context.Background()
 

--- a/cmd/activity-processor/handler_undo_more_branches_test.go
+++ b/cmd/activity-processor/handler_undo_more_branches_test.go
@@ -251,6 +251,102 @@ func TestActivityHandler_ProcessUndoReject_Branches(t *testing.T) {
 	})
 }
 
+func TestActivityHandler_UndoRejectHelperBranches(t *testing.T) {
+	ctx := context.Background()
+	h := &ActivityHandler{Logger: zap.NewNop()}
+
+	t.Run("extract rejects non reject activity", func(t *testing.T) {
+		_, _, err := h.extractRejectStateForUndoReject(&activitypub.Activity{
+			BaseObject: activitypub.BaseObject{Type: ActivityTypeFollow},
+		})
+		require.ErrorIs(t, err, services.ErrExtractActivityTypeFromUndo)
+	})
+
+	t.Run("extracts valid activity reject state", func(t *testing.T) {
+		actor, follow, err := h.extractRejectStateForUndoReject(&activitypub.Activity{
+			BaseObject: activitypub.BaseObject{Type: ActivityTypeReject},
+			Actor:      "https://example.com/users/alice",
+			Object:     "follow-1",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "https://example.com/users/alice", actor)
+		require.Equal(t, "follow-1", follow)
+	})
+
+	t.Run("extract rejects non reject map", func(t *testing.T) {
+		_, _, err := h.extractRejectStateForUndoReject(map[string]any{
+			"type": ActivityTypeFollow,
+		})
+		require.ErrorIs(t, err, services.ErrExtractActivityTypeFromUndo)
+	})
+
+	t.Run("resolves stored follow state", func(t *testing.T) {
+		activityRepo := testmocks.NewMockActivityRepository()
+		activityRepo.On("GetActivity", mock.Anything, "follow-success").Return(&activitypub.Activity{
+			BaseObject: activitypub.BaseObject{
+				ID:   "follow-success",
+				Type: ActivityTypeFollow,
+			},
+			Actor:  "https://remote.example/users/bob",
+			Object: "https://example.com/users/alice",
+		}, nil).Once()
+
+		h := &ActivityHandler{Logger: zap.NewNop(), ActivityRepo: activityRepo}
+		state, err := h.resolveUndoRejectFollowState(ctx, "follow-success")
+		require.NoError(t, err)
+		require.Equal(t, undoRejectFollowState{
+			ID:     "follow-success",
+			Actor:  "https://remote.example/users/bob",
+			Target: "https://example.com/users/alice",
+		}, state)
+		activityRepo.AssertExpectations(t)
+	})
+
+	t.Run("resolves embedded follow map with object id", func(t *testing.T) {
+		state, err := h.resolveUndoRejectFollowState(ctx, map[string]any{
+			"id":    "follow-embedded",
+			"type":  ActivityTypeFollow,
+			"actor": "https://remote.example/users/bob",
+			"object": map[string]any{
+				"id": "https://example.com/users/alice",
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "https://example.com/users/alice", state.Target)
+	})
+
+	t.Run("empty follow id string is rejected", func(t *testing.T) {
+		_, err := h.resolveUndoRejectFollowState(ctx, "")
+		require.ErrorIs(t, err, services.ErrExtractUsernamesFromReject)
+	})
+
+	t.Run("nil or wrong activity type is rejected", func(t *testing.T) {
+		_, err := h.followStateFromActivity(nil)
+		require.ErrorIs(t, err, services.ErrExtractActivityTypeFromUndo)
+
+		_, err = h.followStateFromActivity(&activitypub.Activity{
+			BaseObject: activitypub.BaseObject{Type: ActivityTypeAccept},
+		})
+		require.ErrorIs(t, err, services.ErrExtractActivityTypeFromUndo)
+	})
+
+	t.Run("missing required follow fields are rejected", func(t *testing.T) {
+		_, err := h.followStateFromMap(map[string]any{
+			"id":     "follow-missing-target",
+			"type":   ActivityTypeFollow,
+			"actor":  "https://remote.example/users/bob",
+			"object": map[string]any{},
+		})
+		require.ErrorIs(t, err, services.ErrExtractUsernamesFromReject)
+
+		_, err = validateUndoRejectFollowState(undoRejectFollowState{
+			ID:     "follow-missing-actor",
+			Target: "https://example.com/users/alice",
+		})
+		require.ErrorIs(t, err, services.ErrExtractUsernamesFromReject)
+	})
+}
+
 func TestActivityHandler_ProcessUndoFlag_Branches(t *testing.T) {
 	t.Setenv("DOMAIN", "example.com")
 	config.ResetForTests()

--- a/cmd/activity-processor/handler_undo_more_branches_test.go
+++ b/cmd/activity-processor/handler_undo_more_branches_test.go
@@ -238,6 +238,28 @@ func TestActivityHandler_ProcessUndoReject_Branches(t *testing.T) {
 		activityRepo.AssertExpectations(t)
 	})
 
+	t.Run("undo actor does not match reject actor", func(t *testing.T) {
+		h := &ActivityHandler{Logger: zap.NewNop()}
+
+		undo := &activitypub.Activity{
+			BaseObject: activitypub.BaseObject{ID: "undo-actor-mismatch", Type: ActivityTypeUndo},
+			Actor:      "https://example.com/users/alice",
+		}
+		reject := map[string]any{
+			"type":  ActivityTypeReject,
+			"actor": "https://example.com/users/bob",
+			"object": map[string]any{
+				"type":   ActivityTypeFollow,
+				"actor":  "https://remote.example/users/carol",
+				"id":     "follow-1",
+				"object": "https://example.com/users/bob",
+			},
+		}
+
+		err := h.processUndoReject(ctx, undo, reject, "alice")
+		require.ErrorIs(t, err, services.ErrActorNotAuthorizedUndo)
+	})
+
 	t.Run("missing follower after fallbacks errors", func(t *testing.T) {
 		relationshipRepo := testmocks.NewMockRelationshipRepository()
 		h := &ActivityHandler{Logger: zap.NewNop(), RelationshipRepo: relationshipRepo}
@@ -332,6 +354,14 @@ func TestActivityHandler_UndoRejectHelperBranches(t *testing.T) {
 
 	t.Run("missing required follow fields are rejected", func(t *testing.T) {
 		_, err := h.followStateFromMap(map[string]any{
+			"id":     "reject-wrong-type",
+			"type":   ActivityTypeReject,
+			"actor":  "https://remote.example/users/bob",
+			"object": "https://example.com/users/alice",
+		})
+		require.ErrorIs(t, err, services.ErrExtractActivityTypeFromUndo)
+
+		_, err = h.followStateFromMap(map[string]any{
 			"id":     "follow-missing-target",
 			"type":   ActivityTypeFollow,
 			"actor":  "https://remote.example/users/bob",

--- a/cmd/activity-processor/handler_undo_more_branches_test.go
+++ b/cmd/activity-processor/handler_undo_more_branches_test.go
@@ -218,27 +218,23 @@ func TestActivityHandler_ProcessUndoReject_Branches(t *testing.T) {
 		require.ErrorIs(t, err, services.ErrUndoInvalidObjectType)
 	})
 
-	t.Run("follow lookup fails and username context used", func(t *testing.T) {
-		relationshipRepo := testmocks.NewMockRelationshipRepository()
-		relationshipRepo.On("CreateRelationship", mock.Anything, "alice", "bob", "follow-1").Return(nil).Once()
-
+	t.Run("follow lookup fails without mutating relationship", func(t *testing.T) {
 		activityRepo := testmocks.NewMockActivityRepository()
 		activityRepo.On("GetActivity", mock.Anything, "follow-1").Return((*activitypub.Activity)(nil), errors.New("not found")).Once()
 
 		h := &ActivityHandler{
-			Logger:           zap.NewNop(),
-			RelationshipRepo: relationshipRepo,
-			ActivityRepo:     activityRepo,
+			Logger:       zap.NewNop(),
+			ActivityRepo: activityRepo,
 		}
 
-		undo := &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "undo-1"}, Actor: "https://example.com/users/alice"}
+		undo := &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "undo-1"}, Actor: "https://remote.example/users/bob"}
 		reject := map[string]any{
+			"type":   ActivityTypeReject,
 			"actor":  "https://remote.example/users/bob",
 			"object": "follow-1",
 		}
-		require.NoError(t, h.processUndoReject(ctx, undo, reject, "alice"))
+		require.Error(t, h.processUndoReject(ctx, undo, reject, "alice"))
 
-		relationshipRepo.AssertExpectations(t)
 		activityRepo.AssertExpectations(t)
 	})
 

--- a/cmd/activity-processor/handler_undo_reject_test.go
+++ b/cmd/activity-processor/handler_undo_reject_test.go
@@ -47,10 +47,8 @@ func TestProcessUndoRejectRecreatesFollowRelationship(t *testing.T) {
 				ID:   followActivityID,
 				Type: "Follow",
 			},
-			Actor: followerActor,
-			Object: map[string]interface{}{
-				"id": followerActor,
-			},
+			Actor:  followerActor,
+			Object: rejectActor,
 		}
 		*dest = append(*dest, &models.Activity{Activity: followActivity})
 	}).Return(nil)

--- a/cmd/activity-processor/main.go
+++ b/cmd/activity-processor/main.go
@@ -790,7 +790,7 @@ func (ap *ActivityProcessor) createAllTimelineEntries(ctx context.Context, activ
 
 // createPublicTimelineEntries creates public timeline entries if applicable
 func (ap *ActivityProcessor) createPublicTimelineEntries(activity *activitypub.Activity, baseEntry models.Timeline, visibility string, now time.Time) []*models.Timeline {
-	if visibility != "public" {
+	if visibility != VisibilityPublic {
 		return nil
 	}
 
@@ -817,7 +817,7 @@ func (ap *ActivityProcessor) createPublicTimelineEntries(activity *activitypub.A
 
 // createFollowerTimelineEntries creates timeline entries for followers
 func (ap *ActivityProcessor) createFollowerTimelineEntries(ctx context.Context, username string, baseEntry models.Timeline, visibility string, now time.Time) []*models.Timeline {
-	if visibility == "direct" {
+	if visibility == VisibilityDirect {
 		return nil
 	}
 
@@ -1013,27 +1013,32 @@ func (ap *ActivityProcessor) createAnnounceTimelineEntries(ctx context.Context, 
 	var entries []*models.Timeline
 	now := time.Now()
 
-	baseEntry := ap.createBaseAnnounceEntry(activity, username, announcedContent, now)
+	visibility := ap.determineAnnounceVisibility(activity)
+	baseEntry := ap.createBaseAnnounceEntry(activity, username, announcedContent, visibility, now)
 
-	// Add to public timelines
-	entries = append(entries, ap.createPublicTimelineEntry(baseEntry, now, activity.ID))
+	if visibility == VisibilityPublic {
+		// Add to public timelines
+		entries = append(entries, ap.createPublicTimelineEntry(baseEntry, now, activity.ID))
 
-	// Add local timeline entry if applicable
-	if ap.isLocalActor(activity.Actor) {
-		entries = append(entries, ap.createLocalTimelineEntry(baseEntry, now, activity.ID))
+		// Add local timeline entry if applicable
+		if ap.isLocalActor(activity.Actor) {
+			entries = append(entries, ap.createLocalTimelineEntry(baseEntry, now, activity.ID))
+		}
 	}
 
 	// Add to author's home timeline
 	entries = append(entries, ap.createHomeTimelineEntry(baseEntry, username, now, activity.ID))
 
-	// Fan out to followers
-	ap.addFollowerEntries(ctx, &entries, baseEntry, username, now, activity.ID)
+	// Fan out to followers unless this boost is direct-only.
+	if visibility != VisibilityDirect {
+		ap.addFollowerEntries(ctx, &entries, baseEntry, username, now, activity.ID)
+	}
 
 	return entries
 }
 
 // createBaseAnnounceEntry creates the base timeline entry for an announce
-func (ap *ActivityProcessor) createBaseAnnounceEntry(activity *activitypub.Activity, username, announcedContent string, now time.Time) models.Timeline {
+func (ap *ActivityProcessor) createBaseAnnounceEntry(activity *activitypub.Activity, username, announcedContent, visibility string, now time.Time) models.Timeline {
 	return models.Timeline{
 		PostID:      activity.ID,
 		ActorID:     activity.Actor,
@@ -1042,7 +1047,7 @@ func (ap *ActivityProcessor) createBaseAnnounceEntry(activity *activitypub.Activ
 		ContentType: "Announce",
 		IsBoost:     true,
 		BoostedBy:   username,
-		Visibility:  "public", // Announces are typically public
+		Visibility:  visibility,
 		CreatedAt:   ap.extractPublishedTime(activity),
 		TimelineAt:  now,
 	}
@@ -1117,15 +1122,35 @@ func (ap *ActivityProcessor) recordAnnounceMetrics(ctx context.Context, activity
 
 // Helper functions
 
+func (ap *ActivityProcessor) determineAnnounceVisibility(activity *activitypub.Activity) string {
+	visibility := ap.determineVisibility(activity.To, activity.CC)
+	if visibility == VisibilityDirect && containsFollowersAddress(activity.To, activity.CC) {
+		return VisibilityPrivate
+	}
+	return visibility
+}
+
+func containsFollowersAddress(groups ...[]string) bool {
+	for _, addresses := range groups {
+		for _, address := range addresses {
+			trimmed := strings.TrimSuffix(strings.TrimSpace(address), "/")
+			if strings.HasSuffix(trimmed, "/followers") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (ap *ActivityProcessor) determineVisibility(to, cc []string) string {
 	// Direct message - no public addressing
 	if !containsPublicAddress(to) && !containsPublicAddress(cc) {
-		return "direct"
+		return VisibilityDirect
 	}
 
 	// Public - addressed to public in 'to'
 	if containsPublicAddress(to) {
-		return "public"
+		return VisibilityPublic
 	}
 
 	// Unlisted - public in 'cc'
@@ -1134,7 +1159,7 @@ func (ap *ActivityProcessor) determineVisibility(to, cc []string) string {
 	}
 
 	// Private - followers only
-	return "private"
+	return VisibilityPrivate
 }
 
 func (ap *ActivityProcessor) extractLanguage(note *activitypub.Note) string {

--- a/cmd/activity-processor/main.go
+++ b/cmd/activity-processor/main.go
@@ -287,10 +287,10 @@ func (ap *ActivityProcessor) processActivityDeleted(ctx context.Context, activit
 		zap.String("direction", activity.Direction),
 	)
 
-	// Parse the deleted activity to understand what was removed
-	var activityData activitypub.Activity
-	if err := json.Unmarshal([]byte(activity.Activity), &activityData); err != nil {
-		ap.logger.Warn("failed to parse deleted activity", zap.Error(err))
+	// Parse the deleted activity to understand what was removed.
+	activityData, err := activitypub.ParseActivity([]byte(activity.Activity))
+	if err != nil {
+		ap.logger.Warn("failed to safely parse deleted activity", zap.Error(err))
 		// Continue with generic cleanup even if we can't parse the activity
 		return ap.cleanupActivityReferences(ctx, activity)
 	}
@@ -299,25 +299,25 @@ func (ap *ActivityProcessor) processActivityDeleted(ctx context.Context, activit
 	switch activityData.Type {
 	case activitypub.CreateType:
 		// Remove from timelines and create tombstone
-		if err := ap.handleCreateActivityDeletion(ctx, &activityData, activity.Username); err != nil {
+		if err := ap.handleCreateActivityDeletion(ctx, activityData, activity.Username); err != nil {
 			ap.logger.Error("failed to handle Create activity deletion", zap.Error(err))
 			return err
 		}
 	case activitypub.AnnounceType:
 		// Remove announce from timelines
-		if err := ap.handleAnnounceActivityDeletion(ctx, &activityData, activity.Username); err != nil {
+		if err := ap.handleAnnounceActivityDeletion(ctx, activityData, activity.Username); err != nil {
 			ap.logger.Error("failed to handle Announce activity deletion", zap.Error(err))
 			return err
 		}
 	case activitypub.FollowType:
 		// Remove follow relationship
-		if err := ap.handleFollowActivityDeletion(ctx, &activityData); err != nil {
+		if err := ap.handleFollowActivityDeletion(ctx, activityData); err != nil {
 			ap.logger.Error("failed to handle Follow activity deletion", zap.Error(err))
 			return err
 		}
 	case activitypub.DeleteType:
 		// Handle nested deletions
-		if err := ap.handleDeleteActivityDeletion(ctx, &activityData); err != nil {
+		if err := ap.handleDeleteActivityDeletion(ctx, activityData); err != nil {
 			ap.logger.Error("failed to handle Delete activity deletion", zap.Error(err))
 			return err
 		}
@@ -391,22 +391,22 @@ func (ap *ActivityProcessor) processOutboxActivity(ctx context.Context, activity
 		zap.String("type", activity.Type),
 	)
 
-	// Parse the activity JSON
-	var activityData activitypub.Activity
-	if err := json.Unmarshal([]byte(activity.Activity), &activityData); err != nil {
-		ap.logger.Error("failed to parse activity", zap.Error(err))
+	// Parse the activity JSON with ActivityPub safety limits.
+	activityData, err := activitypub.ParseActivity([]byte(activity.Activity))
+	if err != nil {
+		ap.logger.Error("failed to safely parse activity", zap.Error(err))
 		return activityParsingFailedDetailed("unknown", err)
 	}
 
 	// Handle timeline fanout based on activity type
 	switch activityData.Type {
 	case activitypub.CreateType:
-		if err := ap.fanOutToTimelines(ctx, &activityData, activity.Username); err != nil {
+		if err := ap.fanOutToTimelines(ctx, activityData, activity.Username); err != nil {
 			ap.logger.Error("failed to fan out Create activity", zap.Error(err))
 			return err
 		}
 	case activitypub.AnnounceType:
-		if err := ap.fanOutAnnounceToTimelines(ctx, &activityData, activity.Username); err != nil {
+		if err := ap.fanOutAnnounceToTimelines(ctx, activityData, activity.Username); err != nil {
 			ap.logger.Error("failed to fan out Announce activity", zap.Error(err))
 			return err
 		}

--- a/cmd/activity-processor/main_announce_test.go
+++ b/cmd/activity-processor/main_announce_test.go
@@ -53,7 +53,7 @@ func TestActivityProcessor_AnnounceFanoutAndObjectReferencePaths(t *testing.T) {
 	}).Return(nil)
 
 	announce := &activitypub.Activity{
-		BaseObject: activitypub.BaseObject{ID: "announce-1", Type: activitypub.AnnounceType},
+		BaseObject: activitypub.BaseObject{ID: "announce-1", Type: activitypub.AnnounceType, To: []string{activitypub.PublicAddress}},
 		Actor:      "https://example.com/users/alice",
 		Object:     "https://example.com/objects/1",
 	}
@@ -105,4 +105,63 @@ func TestActivityProcessor_StoreRemoteObject(t *testing.T) {
 	ap.storeRemoteObject(ctx, note)
 
 	objectRepo.AssertExpectations(t)
+}
+
+func TestActivityProcessor_AnnounceFanoutPreservesPrivateVisibility(t *testing.T) {
+	ctx := context.Background()
+
+	mockDB := new(dynamock.MockDB)
+	mockQuery := new(dynamock.MockQuery)
+	mockDB.On("WithContext", mock.Anything).Return(mockDB)
+	mockDB.On("Model", mock.Anything).Return(mockQuery)
+	mockQuery.On("Create").Return(nil)
+
+	timelineRepo := testmocks.NewMockTimelineRepositoryInterface()
+	objectRepo := testmocks.NewMockObjectRepository()
+	actorRepo := testmocks.NewMockActorRepository()
+	relationshipRepo := testmocks.NewMockRelationshipRepository()
+
+	ap := &ActivityProcessor{
+		db:               mockDB,
+		logger:           zap.NewNop(),
+		timelineRepo:     timelineRepo,
+		objectRepo:       objectRepo,
+		actorRepo:        actorRepo,
+		relationshipRepo: relationshipRepo,
+		baseURL:          "https://example.com",
+	}
+
+	objectRepo.On("GetObject", mock.Anything, "https://example.com/objects/private").Return(&models.Object{Content: "private boost"}, nil).Once()
+	actorRepo.On("GetActor", mock.Anything, "alice").Return(&activitypub.Actor{BaseObject: activitypub.BaseObject{ID: "https://example.com/users/alice"}}, nil).Once()
+	relationshipRepo.On("GetFollowers", mock.Anything, "alice", 1000, "").Return([]string{"bob"}, "", nil).Once()
+
+	var entries []*models.Timeline
+	timelineRepo.On("CreateTimelineEntries", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		entries = args.Get(1).([]*models.Timeline)
+	}).Return(nil).Once()
+
+	announce := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://example.com/activities/private-announce",
+			Type: activitypub.AnnounceType,
+			To:   []string{"https://example.com/users/alice/followers"},
+		},
+		Actor:  "https://example.com/users/alice",
+		Object: "https://example.com/objects/private",
+	}
+
+	require.NoError(t, ap.fanOutAnnounceToTimelines(ctx, announce, "alice"))
+	require.Len(t, entries, 2)
+	require.ElementsMatch(t, []string{"alice", "bob"}, []string{entries[0].TimelineID, entries[1].TimelineID})
+	for _, entry := range entries {
+		require.Equal(t, VisibilityPrivate, entry.Visibility)
+		require.Equal(t, timelineHome, entry.TimelineType)
+	}
+
+	timelineRepo.AssertExpectations(t)
+	objectRepo.AssertExpectations(t)
+	actorRepo.AssertExpectations(t)
+	relationshipRepo.AssertExpectations(t)
+	mockQuery.AssertExpectations(t)
+	mockDB.AssertExpectations(t)
 }

--- a/cmd/activity-processor/main_announced_content_remote_test.go
+++ b/cmd/activity-processor/main_announced_content_remote_test.go
@@ -88,7 +88,7 @@ func TestActivityProcessor_ProcessActivityDeleted_CreateErrorBranch(t *testing.T
 				"direction": events.NewStringAttribute("outbox"),
 				"username":  events.NewStringAttribute("alice"),
 				"type":      events.NewStringAttribute("Create"),
-				"activity":  events.NewStringAttribute(`{"id":"act-1","type":"Create","actor":"https://example.com/users/alice","object":"https://example.com/objects/1"}`),
+				"activity":  events.NewStringAttribute(`{"id":"https://example.com/activities/act-1","type":"Create","actor":"https://example.com/users/alice","object":"https://example.com/objects/1"}`),
 			},
 		},
 	})

--- a/cmd/activity-processor/main_helpers_more_test.go
+++ b/cmd/activity-processor/main_helpers_more_test.go
@@ -86,3 +86,15 @@ func TestActivityProcessor_GetFollowers_Branches(t *testing.T) {
 		relationshipRepo.AssertExpectations(t)
 	})
 }
+
+func TestContainsFollowersAddress_FalseCase(t *testing.T) {
+	// When no address contains /followers, the function returns false.
+	require.False(t, containsFollowersAddress(
+		[]string{"https://example.com/users/alice"},
+		[]string{"https://www.w3.org/ns/activitystreams#Public"},
+	))
+	// Full true path already exercised by fanout tests; this ensures the false return is covered.
+	require.True(t, containsFollowersAddress(
+		[]string{"https://example.com/users/alice/followers"},
+	))
+}

--- a/cmd/activity-processor/main_more_branches_test.go
+++ b/cmd/activity-processor/main_more_branches_test.go
@@ -106,6 +106,129 @@ func TestActivityProcessor_ObjectExtractionHelpers_Branches(t *testing.T) {
 	require.Nil(t, ap.extractAddressingField(map[string]any{"to": "not-a-slice"}, "to"))
 }
 
+func TestActivityProcessor_VisibilityContentAndHostBranches(t *testing.T) {
+	ap := &ActivityProcessor{logger: zap.NewNop()}
+
+	require.Equal(t, VisibilityDirect, ap.determineVisibility(nil, nil))
+	require.Equal(t, VisibilityPublic, ap.determineVisibility([]string{activitypub.PublicAddress}, nil))
+	require.Equal(t, "unlisted", ap.determineVisibility(nil, []string{activitypub.PublicAddress}))
+	require.Equal(t, VisibilityDirect, ap.determineVisibility([]string{"https://example.com/users/alice/followers"}, nil))
+
+	fromDefaultAddressing := ap.createObjectFromContent("object-1", "<p> el mundo de la prueba </p>", &activitypub.Activity{})
+	require.Equal(t, VisibilityPublic, fromDefaultAddressing.Visibility)
+	require.Equal(t, "es", fromDefaultAddressing.Language)
+
+	fromActivityAddressing := ap.createObjectFromContent("object-2", " le monde de une chose ", &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{CC: []string{activitypub.PublicAddress}},
+	})
+	require.Equal(t, "unlisted", fromActivityAddressing.Visibility)
+	require.Equal(t, "fr", fromActivityAddressing.Language)
+
+	note := &activitypub.Note{
+		BaseObject: activitypub.BaseObject{
+			ID:        "https://example.com/objects/note-1",
+			InReplyTo: "https://example.com/objects/root",
+			Sensitive: true,
+			Summary:   "cw",
+		},
+		Content:    "ciao mondo",
+		Attachment: []activitypub.Attachment{{Type: "Document"}},
+	}
+	processed := ap.processNoteObject(&activitypub.Activity{
+		BaseObject: activitypub.BaseObject{To: []string{activitypub.PublicAddress}},
+	}, note)
+	require.True(t, processed.HasMedia)
+	require.True(t, processed.IsReply)
+	require.True(t, processed.Sensitive)
+	require.Equal(t, VisibilityPublic, processed.Visibility)
+	require.Equal(t, "cw", processed.SpoilerText)
+
+	converted, err := ap.convertMapToNote(map[string]any{
+		"id":           "https://remote.example/objects/converted",
+		"type":         "Note",
+		"content":      "converted content",
+		"attributedTo": "https://remote.example/users/bob",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "converted content", converted.Content)
+	_, err = ap.convertMapToNote(map[string]any{"bad": make(chan int)})
+	require.Error(t, err)
+	_, err = ap.convertMapToNote(map[string]any{"to": "not-an-array"})
+	require.Error(t, err)
+
+	require.Equal(t, UnknownValue, ap.extractRemoteHost(""))
+	require.Equal(t, "remote.example", ap.extractRemoteHost("https://remote.example:8443/objects/1"))
+	require.Equal(t, "remote.example", ap.extractRemoteHost("http://remote.example/users/alice"))
+	require.Equal(t, "remote.example", ap.extractRemoteHost("remote.example/path"))
+}
+
+func TestActivityProcessor_BackoffAndHTMLBranches(t *testing.T) {
+	ap := &ActivityProcessor{retryDelay: time.Second}
+
+	oddDelay := ap.calculateBackoffDelay(1)
+	require.Positive(t, oddDelay)
+	require.Less(t, oddDelay, time.Second)
+
+	evenDelay := ap.calculateBackoffDelay(2)
+	require.Greater(t, evenDelay, 2*time.Second)
+
+	cappedDelay := ap.calculateBackoffDelay(10)
+	require.Greater(t, cappedDelay, 30*time.Second)
+	require.Less(t, cappedDelay, 31*time.Second)
+
+	require.Equal(t, " hello  world ", stripHTMLTags("<p>hello</p><b>world</b>"))
+	require.Equal(t, "unterminated <tag", stripHTMLTags("unterminated <tag"))
+}
+
+func TestActivityProcessor_DeletionHandlerAdditionalBranches(t *testing.T) {
+	ctx := context.Background()
+
+	mockDB := new(dynamock.MockDB)
+	mockQuery := new(dynamock.MockQuery)
+	mockDB.On("WithContext", mock.Anything).Return(mockDB)
+	mockDB.On("Model", mock.Anything).Return(mockQuery)
+	mockQuery.On("Create").Return(nil)
+
+	ap := &ActivityProcessor{
+		db:     mockDB,
+		logger: zap.NewNop(),
+	}
+
+	require.NoError(t, ap.handleCreateActivityDeletion(ctx, &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{ID: "act-map", Type: activitypub.CreateType},
+		Actor:      "https://example.com/users/alice",
+		Object: map[string]any{
+			"id": "https://example.com/objects/map",
+		},
+	}, "alice"))
+
+	require.NoError(t, ap.handleCreateActivityDeletion(ctx, &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{ID: "act-note", Type: activitypub.CreateType},
+		Actor:      "https://example.com/users/alice",
+		Object: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{ID: "https://example.com/objects/note"},
+		},
+	}, "alice"))
+
+	require.NoError(t, ap.handleCreateActivityDeletion(ctx, &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{ID: "act-missing-map", Type: activitypub.CreateType},
+		Object:     map[string]any{"name": "missing id"},
+	}, "alice"))
+
+	require.NoError(t, ap.handleCreateActivityDeletion(ctx, &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{ID: "act-invalid-object", Type: activitypub.CreateType},
+		Object:     123,
+	}, "alice"))
+
+	require.NoError(t, ap.handleFollowActivityDeletion(ctx, &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{ID: "act-follow-invalid", Type: activitypub.FollowType},
+		Object:     map[string]any{"id": "https://remote.example/users/bob"},
+	}))
+
+	mockQuery.AssertExpectations(t)
+	mockDB.AssertExpectations(t)
+}
+
 func TestActivityProcessor_ConvertToNote_MarshalError(t *testing.T) {
 	ap := &ActivityProcessor{logger: zap.NewNop()}
 
@@ -309,7 +432,7 @@ func TestActivityProcessor_ProcessRecord_Insert_Outbox_CreateAndAnnounce(t *test
 				"username":  events.NewStringAttribute("alice"),
 				"actor_id":  events.NewStringAttribute("https://example.com/users/alice"),
 				"type":      events.NewStringAttribute("Announce"),
-				"activity":  events.NewStringAttribute(`{"id":"https://example.com/activities/act-announce","type":"Announce","actor":"https://example.com/users/alice","object":"https://example.com/objects/1"}`),
+				"activity":  events.NewStringAttribute(`{"id":"https://example.com/activities/act-announce","type":"Announce","actor":"https://example.com/users/alice","to":["https://www.w3.org/ns/activitystreams#Public"],"object":"https://example.com/objects/1"}`),
 			},
 		},
 	})

--- a/cmd/activity-processor/main_more_branches_test.go
+++ b/cmd/activity-processor/main_more_branches_test.go
@@ -194,11 +194,11 @@ func TestActivityProcessor_ProcessRecord_Remove_DeletionSwitchCases(t *testing.T
 		name         string
 		activityJSON string
 	}{
-		{name: "create", activityJSON: `{"id":"act-1","type":"Create","actor":"https://example.com/users/alice","object":"https://example.com/objects/1"}`},
-		{name: "announce", activityJSON: `{"id":"act-2","type":"Announce","actor":"https://example.com/users/alice","object":"https://example.com/objects/2"}`},
-		{name: "follow", activityJSON: `{"id":"act-3","type":"Follow","actor":"https://example.com/users/alice","object":"https://remote.example/users/bob"}`},
-		{name: "delete", activityJSON: `{"id":"act-4","type":"Delete","actor":"https://example.com/users/alice","object":"https://example.com/objects/3"}`},
-		{name: "default", activityJSON: `{"id":"act-5","type":"Like","actor":"https://example.com/users/alice","object":"https://example.com/objects/4"}`},
+		{name: "create", activityJSON: `{"id":"https://example.com/activities/act-1","type":"Create","actor":"https://example.com/users/alice","object":"https://example.com/objects/1"}`},
+		{name: "announce", activityJSON: `{"id":"https://example.com/activities/act-2","type":"Announce","actor":"https://example.com/users/alice","object":"https://example.com/objects/2"}`},
+		{name: "follow", activityJSON: `{"id":"https://example.com/activities/act-3","type":"Follow","actor":"https://example.com/users/alice","object":"https://remote.example/users/bob"}`},
+		{name: "delete", activityJSON: `{"id":"https://example.com/activities/act-4","type":"Delete","actor":"https://example.com/users/alice","object":"https://example.com/objects/3"}`},
+		{name: "default", activityJSON: `{"id":"https://example.com/activities/act-5","type":"Like","actor":"https://example.com/users/alice","object":"https://example.com/objects/4"}`},
 	}
 
 	for _, tc := range cases {
@@ -262,7 +262,7 @@ func TestActivityProcessor_ProcessRecord_Insert_Outbox_CreateAndAnnounce(t *test
 				"actor_id":  events.NewStringAttribute("https://example.com/users/alice"),
 				"type":      events.NewStringAttribute("Create"),
 				"activity": events.NewStringAttribute(`{
-					"id":"act-create",
+					"id":"https://example.com/activities/act-create",
 					"type":"Create",
 					"actor":"https://example.com/users/alice",
 					"object":{
@@ -309,7 +309,7 @@ func TestActivityProcessor_ProcessRecord_Insert_Outbox_CreateAndAnnounce(t *test
 				"username":  events.NewStringAttribute("alice"),
 				"actor_id":  events.NewStringAttribute("https://example.com/users/alice"),
 				"type":      events.NewStringAttribute("Announce"),
-				"activity":  events.NewStringAttribute(`{"id":"act-announce","type":"Announce","actor":"https://example.com/users/alice","object":"https://example.com/objects/1"}`),
+				"activity":  events.NewStringAttribute(`{"id":"https://example.com/activities/act-announce","type":"Announce","actor":"https://example.com/users/alice","object":"https://example.com/objects/1"}`),
 			},
 		},
 	})

--- a/cmd/activity-processor/main_stream_test.go
+++ b/cmd/activity-processor/main_stream_test.go
@@ -55,7 +55,7 @@ func TestActivityProcessor_StreamProcessingPaths(t *testing.T) {
 				"username":  events.NewStringAttribute("alice"),
 				"actor_id":  events.NewStringAttribute("https://example.com/users/alice"),
 				"type":      events.NewStringAttribute("Like"),
-				"activity":  events.NewStringAttribute(`{"id":"act-1","type":"Like","actor":"https://example.com/users/alice","object":"https://example.com/objects/1"}`),
+				"activity":  events.NewStringAttribute(`{"id":"https://example.com/activities/act-1","type":"Like","actor":"https://example.com/users/alice","object":"https://example.com/objects/1"}`),
 			},
 		},
 	})

--- a/cmd/api/handlers/reputation.go
+++ b/cmd/api/handlers/reputation.go
@@ -47,6 +47,10 @@ func (h *Handler) HandleGetReputationLift(ctx *apptheory.Context) (*apptheory.Re
 		actorID = strings.TrimSpace(actor.ID)
 	}
 
+	if err := reputation.ValidateActorID(actorID); err != nil {
+		return common.RespondBadRequest(ctx, "invalid actor_id")
+	}
+
 	// Initialize reputation service
 	repService, err := h.getReputationService()
 	if err != nil {
@@ -242,6 +246,9 @@ func (h *Handler) HandleGetVouchesLift(ctx *apptheory.Context) (*apptheory.Respo
 	// If it's just a username, convert to full actor URI
 	if !strings.Contains(actorID, "://") {
 		actorID = fmt.Sprintf("https://%s/users/%s", h.cfg.Domain, actorID)
+	}
+	if err := reputation.ValidateActorID(actorID); err != nil {
+		return common.RespondBadRequest(ctx, "invalid actor_id")
 	}
 
 	// Initialize reputation service

--- a/cmd/api/handlers/reputation_round12_test.go
+++ b/cmd/api/handlers/reputation_round12_test.go
@@ -114,6 +114,13 @@ func TestReputationHandlersRound12(t *testing.T) {
 		requireStatus(t, http.StatusOK)(h.HandleGetReputationLift(ctx))
 	})
 
+	t.Run("get reputation rejects crafted actor id", func(t *testing.T) {
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/reputation/crafted", headers, nil, nil)
+		require.NoError(t, err)
+		ctx.Params["actor_id"] = "https://evil.example@real.example/users/alice"
+		requireStatus(t, http.StatusBadRequest)(h.HandleGetReputationLift(ctx))
+	})
+
 	t.Run("get reputation invalid token", func(t *testing.T) {
 		badHeaders := map[string]string{"Authorization": "Bearer bad-token"}
 		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/reputation/alice", badHeaders, nil, nil)

--- a/cmd/inbox/internal/routing/follow_trace_test.go
+++ b/cmd/inbox/internal/routing/follow_trace_test.go
@@ -93,7 +93,7 @@ func TestInboxHandler_VerifyDigestEnhanced_TraceCoverage(t *testing.T) {
 		nil,
 		body,
 	)
-	require.NoError(t, env.handler.verifyDigestEnhanced(missingDigestCtx, req))
+	require.Error(t, env.handler.verifyDigestEnhanced(missingDigestCtx, req))
 
 	validDigestCtx := newAppTheoryContextWithValues(
 		http.MethodPost,

--- a/cmd/inbox/internal/routing/inbox.go
+++ b/cmd/inbox/internal/routing/inbox.go
@@ -895,6 +895,26 @@ func (ih *InboxHandler) verifyAuthentication(ctx *apptheory.Context, req *InboxR
 		ih.logFollowTraceReconstructedRequest(trace, httpReq)
 	}
 
+	if err := ih.validateInboundSignatureHost(httpReq); err != nil {
+		ih.logger.Warn("inbound signature host binding failed",
+			zap.String("actor", req.Activity.Actor),
+			zap.String("request_host", httpReq.Host),
+			zap.String("url_host", httpReq.URL.Host),
+			zap.Error(err))
+		req.CostParams.ProcessingTimeMs = time.Since(start).Milliseconds()
+		ih.recordFailureCost(req, fmt.Sprintf("Signature host binding failed: %v", err), 3)
+		return errors.Unauthorized("signature host binding failed").WithInternalError(err)
+	}
+
+	if err := federation.RequireSignedBodyIntegrity(httpReq); err != nil {
+		ih.logger.Warn("inbound signature integrity headers missing or unsigned",
+			zap.String("actor", req.Activity.Actor),
+			zap.Error(err))
+		req.CostParams.ProcessingTimeMs = time.Since(start).Milliseconds()
+		ih.recordFailureCost(req, fmt.Sprintf("Signature integrity headers failed: %v", err), 3)
+		return errors.Unauthorized("signature integrity headers required").WithInternalError(err)
+	}
+
 	// Enhanced signature verification with caching and retry logic
 	signatureVerifyStart := time.Now()
 	if err := ih.signatureService.VerifySignature(httpReq.Context(), httpReq, req.Activity.Actor); err != nil {
@@ -1005,9 +1025,8 @@ func (ih *InboxHandler) verifyDigestEnhanced(ctx *apptheory.Context, req *InboxR
 	trace := ih.followTraceForRequest(req)
 	if err := common.ValidateRequiredParam("digestHeader", digestHeader); err != nil {
 		ih.logFollowTrace(trace, "receiver.digest.missing")
-		// No digest header is acceptable for some implementations
-		ih.logger.Debug("no digest header present", zap.String("actor", req.Activity.Actor))
-		return nil
+		ih.logger.Warn("missing digest header", zap.String("actor", req.Activity.Actor))
+		return common.AuthenticationError{Message: "missing digest header"}
 	}
 
 	ih.logFollowTrace(trace, "receiver.digest.start",
@@ -1377,6 +1396,24 @@ func (ih *InboxHandler) convertRequest(ctx *apptheory.Context, body []byte) (*ht
 	}
 
 	return req, nil
+}
+
+func (ih *InboxHandler) validateInboundSignatureHost(req *http.Request) error {
+	if req == nil || req.URL == nil {
+		return fmt.Errorf("missing request URL")
+	}
+	requestHost := strings.ToLower(strings.TrimSpace(req.URL.Hostname()))
+	if requestHost == "" {
+		return fmt.Errorf("missing request host")
+	}
+	instanceHost := strings.ToLower(strings.TrimSpace(ih.localDomain()))
+	if instanceHost == "" {
+		return nil
+	}
+	if requestHost != instanceHost {
+		return fmt.Errorf("request host %q does not match instance host %q", requestHost, instanceHost)
+	}
+	return nil
 }
 
 func inboxRequestURL(ctx *apptheory.Context) *url.URL {

--- a/cmd/inbox/internal/routing/shared_inbox_ingress_test.go
+++ b/cmd/inbox/internal/routing/shared_inbox_ingress_test.go
@@ -378,7 +378,7 @@ func TestInboxHandler_InitializeSharedInboxRequest_RejectsInvalidResolvedTargetA
 
 	actorRepo := testingmocks.NewMockActorRepository()
 	env.handler.actorRepository = actorRepo
-	actorRepo.On("GetActorByUsername", mock.Anything, "alice").Return(&activitypub.Actor{PreferredUsername: "alice"}, nil).Once()
+	actorRepo.On("GetActorByUsername", mock.Anything, "alice").Return(&activitypub.Actor{PreferredUsername: "alice"}, nil).Twice()
 
 	activity := map[string]any{
 		"@context": activitypub.Context,
@@ -473,4 +473,109 @@ func newInstanceRepositoryWithState(state *storagemodels.InstanceState, err erro
 	}
 
 	return repositories.NewInstanceRepository(db, "test-table", zap.NewNop())
+}
+
+type sharedInboxResolverActorRepo struct {
+	actors map[string]*activitypub.Actor
+}
+
+func (r sharedInboxResolverActorRepo) GetActorByUsername(_ context.Context, username string) (*activitypub.Actor, error) {
+	actor := r.actors[username]
+	if actor == nil {
+		return nil, stderrors.New(actorNotFoundError)
+	}
+	return actor, nil
+}
+
+type sharedInboxResolverRelationshipRepo struct {
+	followers map[string][]string
+	deleted   [][2]string
+}
+
+func (r *sharedInboxResolverRelationshipRepo) GetFollowers(_ context.Context, username string, _ int, _ string) ([]string, string, error) {
+	return append([]string(nil), r.followers[username]...), "", nil
+}
+
+func (r *sharedInboxResolverRelationshipRepo) DeleteRelationship(_ context.Context, followerUsername, followingUsername string) error {
+	r.deleted = append(r.deleted, [2]string{followerUsername, followingUsername})
+	return nil
+}
+
+func TestSharedInboxTargetResolver_FollowerCollectionsRequireActorOwnership(t *testing.T) {
+	resolver := sharedInboxTargetResolver{
+		actorRepository: sharedInboxResolverActorRepo{actors: map[string]*activitypub.Actor{
+			"alice": {
+				BaseObject:        activitypub.BaseObject{ID: "https://local.example/users/alice", Type: activitypub.PersonType},
+				PreferredUsername: "alice",
+				Inbox:             "https://local.example/users/alice/inbox",
+				Outbox:            "https://local.example/users/alice/outbox",
+			},
+		}},
+		relationshipRepository: &sharedInboxResolverRelationshipRepo{followers: map[string][]string{
+			"bob@remote.example":     {"alice"},
+			"mallory@remote.example": {"alice"},
+		}},
+		localDomain: "local.example",
+	}
+
+	actors, err := resolver.Resolve(context.Background(), &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Type: activitypub.CreateType,
+			ID:   "https://remote.example/activities/1",
+			To:   []string{"https://mallory.remote.example/users/mallory/followers"},
+		},
+		Actor: "https://remote.example/users/bob",
+		Object: map[string]any{
+			"id":           "https://remote.example/objects/1",
+			"type":         activitypub.NoteType,
+			"attributedTo": "https://remote.example/users/bob",
+		},
+	})
+	require.NoError(t, err)
+	require.Empty(t, actors)
+
+	actors, err = resolver.Resolve(context.Background(), &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Type: activitypub.CreateType,
+			ID:   "https://remote.example/activities/2",
+			To:   []string{"https://remote.example/users/bob/followers"},
+		},
+		Actor: "https://remote.example/users/bob",
+		Object: map[string]any{
+			"id":           "https://remote.example/objects/2",
+			"type":         activitypub.NoteType,
+			"attributedTo": "https://remote.example/users/bob",
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, actors, 1)
+	require.Equal(t, "alice", actors[0].PreferredUsername)
+}
+
+func TestSharedInboxTargetResolver_CleansStaleFollowerClaims(t *testing.T) {
+	relationshipRepo := &sharedInboxResolverRelationshipRepo{followers: map[string][]string{
+		"bob@remote.example": {"missing"},
+	}}
+	resolver := sharedInboxTargetResolver{
+		actorRepository:        sharedInboxResolverActorRepo{actors: map[string]*activitypub.Actor{}},
+		relationshipRepository: relationshipRepo,
+		localDomain:            "local.example",
+	}
+
+	actors, err := resolver.Resolve(context.Background(), &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Type: activitypub.CreateType,
+			ID:   "https://remote.example/activities/3",
+			To:   []string{"https://remote.example/users/bob/followers"},
+		},
+		Actor: "https://remote.example/users/bob",
+		Object: map[string]any{
+			"id":           "https://remote.example/objects/3",
+			"type":         activitypub.NoteType,
+			"attributedTo": "https://remote.example/users/bob",
+		},
+	})
+	require.NoError(t, err)
+	require.Empty(t, actors)
+	require.Equal(t, [][2]string{{"missing", "bob@remote.example"}}, relationshipRepo.deleted)
 }

--- a/cmd/inbox/internal/routing/shared_inbox_targets.go
+++ b/cmd/inbox/internal/routing/shared_inbox_targets.go
@@ -16,6 +16,7 @@ type sharedInboxActorRepository interface {
 
 type sharedInboxRelationshipRepository interface {
 	GetFollowers(ctx context.Context, username string, limit int, cursor string) ([]string, string, error)
+	DeleteRelationship(ctx context.Context, followerUsername, followingUsername string) error
 }
 
 type sharedInboxActivityRepository interface {
@@ -38,10 +39,11 @@ func (r sharedInboxTargetResolver) Resolve(ctx context.Context, activity *activi
 	usernames := make(map[string]struct{})
 	followerHandles := make(map[string]struct{})
 
-	r.addAddressTargets(usernames, followerHandles, activity.To...)
-	r.addAddressTargets(usernames, followerHandles, activity.CC...)
-	r.addAddressTargets(usernames, followerHandles, activity.BTo...)
-	r.addAddressTargets(usernames, followerHandles, activity.BCC...)
+	actorOwner := r.localOrRemoteIdentity(activity.Actor)
+	r.addAddressTargets(usernames, followerHandles, actorOwner, activity.To...)
+	r.addAddressTargets(usernames, followerHandles, actorOwner, activity.CC...)
+	r.addAddressTargets(usernames, followerHandles, actorOwner, activity.BTo...)
+	r.addAddressTargets(usernames, followerHandles, actorOwner, activity.BCC...)
 
 	switch activity.Type {
 	case activitypub.FollowType:
@@ -61,7 +63,7 @@ func (r sharedInboxTargetResolver) Resolve(ctx context.Context, activity *activi
 			return nil, err
 		}
 	case activitypub.AddType, activitypub.RemoveType:
-		r.addAddressTargets(usernames, followerHandles, activity.Target)
+		r.addAddressTargets(usernames, followerHandles, actorOwner, activity.Target)
 		if err := r.addObjectOwnerTargets(ctx, usernames, activity.Object); err != nil {
 			return nil, err
 		}
@@ -113,10 +115,10 @@ func (r sharedInboxTargetResolver) addObjectTargets(usernames map[string]struct{
 	switch typed := object.(type) {
 	case map[string]any:
 		if actorID, _ := typed["actor"].(string); actorID != "" {
-			r.addAddressTargets(usernames, followerHandles, actorID)
+			r.addAddressTargets(usernames, followerHandles, r.localOrRemoteIdentity(actorID), actorID)
 		}
 		if attributedTo, _ := typed["attributedTo"].(string); attributedTo != "" {
-			r.addAddressTargets(usernames, followerHandles, attributedTo)
+			r.addAddressTargets(usernames, followerHandles, r.localOrRemoteIdentity(attributedTo), attributedTo)
 		}
 	}
 }
@@ -151,9 +153,18 @@ func (r sharedInboxTargetResolver) expandFollowerHandles(ctx context.Context, us
 				return err
 			}
 			for _, follower := range followers {
-				if username := r.localUsername(follower); username != "" {
-					usernames[username] = struct{}{}
+				username := r.localUsername(follower)
+				if username == "" {
+					continue
 				}
+				if r.actorRepository != nil {
+					actor, err := r.actorRepository.GetActorByUsername(ctx, username)
+					if err != nil || actor == nil {
+						_ = r.relationshipRepository.DeleteRelationship(ctx, username, handle)
+						continue
+					}
+				}
+				usernames[username] = struct{}{}
 			}
 			if nextCursor == "" {
 				break
@@ -182,7 +193,7 @@ func (r sharedInboxTargetResolver) loadActors(ctx context.Context, usernames map
 	return actors, nil
 }
 
-func (r sharedInboxTargetResolver) addAddressTargets(usernames map[string]struct{}, followerHandles map[string]struct{}, addresses ...string) {
+func (r sharedInboxTargetResolver) addAddressTargets(usernames map[string]struct{}, followerHandles map[string]struct{}, authorizedFollowerOwner string, addresses ...string) {
 	for _, address := range addresses {
 		address = strings.TrimSpace(address)
 		if address == "" || address == activitypub.PublicAddress {
@@ -194,11 +205,12 @@ func (r sharedInboxTargetResolver) addAddressTargets(usernames map[string]struct
 			continue
 		}
 
-		if strings.Contains(address, "/followers") {
-			if strings.Contains(normalized, "@") {
-				followerHandles[normalized] = struct{}{}
-				continue
+		if isFollowersCollectionAddress(address) {
+			owner := r.followersCollectionOwner(address)
+			if owner != "" && owner == authorizedFollowerOwner {
+				followerHandles[owner] = struct{}{}
 			}
+			continue
 		}
 
 		if !strings.Contains(normalized, "@") {
@@ -208,11 +220,37 @@ func (r sharedInboxTargetResolver) addAddressTargets(usernames map[string]struct
 }
 
 func (r sharedInboxTargetResolver) localUsername(address string) string {
-	normalized := models.NormalizeRelationshipIdentity(address, r.localDomain)
+	normalized := r.localOrRemoteIdentity(address)
 	if normalized == "" || strings.Contains(normalized, "@") {
 		return ""
 	}
 	return normalized
+}
+
+func (r sharedInboxTargetResolver) localOrRemoteIdentity(address string) string {
+	return models.NormalizeRelationshipIdentity(address, r.localDomain)
+}
+
+func (r sharedInboxTargetResolver) followersCollectionOwner(address string) string {
+	address = strings.TrimSpace(address)
+	if address == "" {
+		return ""
+	}
+	trimmed := strings.TrimSuffix(address, "/")
+	idx := strings.LastIndex(trimmed, "/followers")
+	if idx < 0 || idx+len("/followers") != len(trimmed) {
+		return ""
+	}
+	return r.localOrRemoteIdentity(trimmed[:idx])
+}
+
+func isFollowersCollectionAddress(address string) bool {
+	address = strings.TrimSpace(address)
+	if address == "" {
+		return false
+	}
+	trimmed := strings.TrimSuffix(address, "/")
+	return strings.HasSuffix(trimmed, "/followers")
 }
 
 func explicitLocalRecipients(activity *activitypub.Activity, localDomain string) []string {

--- a/cmd/inbox/internal/routing/shared_inbox_targets_test.go
+++ b/cmd/inbox/internal/routing/shared_inbox_targets_test.go
@@ -313,4 +313,13 @@ func TestSharedInboxTargetResolver_HelperFunctions(t *testing.T) {
 	var nilNote *activitypub.Note
 	require.Empty(t, extractAttributedTo(nilNote))
 	require.Empty(t, extractAttributedTo(struct{}{}))
+
+	// isFollowersCollectionAddress empty and non-followers cases
+	require.False(t, isFollowersCollectionAddress(""))
+	require.False(t, isFollowersCollectionAddress("https://example.com/users/alice"))
+
+	// followersCollectionOwner empty and non-followers cases
+	r := sharedInboxTargetResolver{localDomain: "example.com"}
+	require.Equal(t, "", r.followersCollectionOwner(""))
+	require.Equal(t, "", r.followersCollectionOwner("https://example.com/users/alice"))
 }

--- a/cmd/inbox/internal/routing/shared_inbox_targets_test.go
+++ b/cmd/inbox/internal/routing/shared_inbox_targets_test.go
@@ -39,6 +39,10 @@ func (s *sharedInboxRelationshipRepoStub) GetFollowers(_ context.Context, userna
 	return append([]string(nil), s.followers[username]...), "", nil
 }
 
+func (s *sharedInboxRelationshipRepoStub) DeleteRelationship(_ context.Context, _, _ string) error {
+	return nil
+}
+
 type sharedInboxActivityRepoStub struct {
 	activities map[string]*activitypub.Activity
 }

--- a/cmd/inbox/internal/routing/signature_round12_contract_test.go
+++ b/cmd/inbox/internal/routing/signature_round12_contract_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -97,6 +98,21 @@ func TestInboxRequestURL_OriginMatrix(t *testing.T) {
 			require.Equal(t, tt.want, inboxRequestURL(ctx).String())
 		})
 	}
+}
+
+func TestInboxHandler_validateInboundSignatureHostBindsInstanceDomain(t *testing.T) {
+	env := newInboxTestEnv(t)
+	oldDomain := env.cfg.Domain
+	env.cfg.Domain = "theory.dev.example.com"
+	t.Cleanup(func() { env.cfg.Domain = oldDomain })
+
+	valid := httptest.NewRequest(http.MethodPost, "https://theory.dev.example.com/users/alice/inbox", strings.NewReader(`{}`))
+	valid.Host = "theory.dev.example.com"
+	require.NoError(t, env.handler.validateInboundSignatureHost(valid))
+
+	forged := httptest.NewRequest(http.MethodPost, "https://attacker.example/users/alice/inbox", strings.NewReader(`{}`))
+	forged.Host = "attacker.example"
+	require.Error(t, env.handler.validateInboundSignatureHost(forged))
 }
 
 func TestInboxHandler_convertRequest_VerifiesClassicDeliveryAfterForwardedReconstruction(t *testing.T) {

--- a/cmd/outbox/m3_outbox_safety_test.go
+++ b/cmd/outbox/m3_outbox_safety_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/stretchr/testify/require"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"go.uber.org/zap"
+)
+
+func TestOutboxProcessor_ParseActivityFromRequest_EnforcesSafetyLimits_M3(t *testing.T) {
+	op := &OutboxProcessor{logger: zap.NewNop()}
+
+	t.Run("oversized body rejected before parse", func(t *testing.T) {
+		ctx := &apptheory.Context{Request: apptheory.Request{Body: bytesOf('x', common.MaxActivitySize+1)}}
+		activity, resp := op.parseActivityFromRequest(ctx)
+		require.Nil(t, activity)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusRequestEntityTooLarge, resp.Status)
+	})
+
+	t.Run("json bomb shape rejected", func(t *testing.T) {
+		body := `{"type":"Create","object":` + strings.Repeat(`{"nested":`, common.MaxJSONDepth+2) + `"leaf"` + strings.Repeat(`}`, common.MaxJSONDepth+2) + `}`
+		ctx := &apptheory.Context{Request: apptheory.Request{Body: []byte(body)}}
+		activity, resp := op.parseActivityFromRequest(ctx)
+		require.Nil(t, activity)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusBadRequest, resp.Status)
+	})
+}
+
+func bytesOf(value byte, size int) []byte {
+	out := make([]byte, size)
+	for i := range out {
+		out[i] = value
+	}
+	return out
+}

--- a/cmd/outbox/main.go
+++ b/cmd/outbox/main.go
@@ -962,12 +962,15 @@ func (op *OutboxProcessor) getBearerToken(ctx *apptheory.Context) string {
 func (op *OutboxProcessor) parseActivityFromRequest(ctx *apptheory.Context) (*activitypub.Activity, *apptheory.Response) {
 	var activity activitypub.Activity
 
-	// Parse the request body as JSON
-	if ctx == nil {
+	if ctx == nil || len(ctx.Request.Body) == 0 {
 		return nil, outboxJSONError(http.StatusBadRequest, "invalid JSON activity")
 	}
-	if err := json.Unmarshal(ctx.Request.Body, &activity); err != nil {
-		op.logger.Error("failed to parse activity JSON", zap.Error(err))
+	if len(ctx.Request.Body) > common.MaxActivitySize {
+		op.logger.Warn("outbox activity body too large", zap.Int("size", len(ctx.Request.Body)), zap.Int("max_size", common.MaxActivitySize))
+		return nil, outboxJSONError(http.StatusRequestEntityTooLarge, "activity body too large")
+	}
+	if err := common.ParseActivityPubObject(ctx.Request.Body, &activity); err != nil {
+		op.logger.Error("failed to safely parse activity JSON", zap.Error(err))
 		return nil, outboxJSONError(http.StatusBadRequest, "invalid JSON activity")
 	}
 

--- a/pkg/activitypub/parser.go
+++ b/pkg/activitypub/parser.go
@@ -10,13 +10,12 @@ import (
 
 // ParseActivity parses a JSON byte array into an Activity struct
 func ParseActivity(data []byte) (*Activity, error) {
-	// Validate JSON before parsing
-	if err := common.ValidateJSONField(string(data), "activitypub_activity"); err != nil {
+	if err := validateRawActivityPubJSON(data, "activity"); err != nil {
 		return nil, fmt.Errorf("invalid JSON: %w", err)
 	}
 
 	var activity Activity
-	if err := json.Unmarshal(data, &activity); err != nil {
+	if err := common.ParseActivityPubObject(data, &activity); err != nil {
 		return nil, fmt.Errorf("failed to parse activity: %w", err)
 	}
 
@@ -30,13 +29,12 @@ func ParseActivity(data []byte) (*Activity, error) {
 
 // ParseActor parses a JSON byte array into an Actor struct
 func ParseActor(data []byte) (*Actor, error) {
-	// Validate JSON before parsing
-	if err := common.ValidateJSONField(string(data), "activitypub_actor"); err != nil {
+	if err := validateRawActivityPubJSON(data, "actor"); err != nil {
 		return nil, fmt.Errorf("invalid JSON: %w", err)
 	}
 
 	var actor Actor
-	if err := json.Unmarshal(data, &actor); err != nil {
+	if err := common.ParseActivityPubObject(data, &actor); err != nil {
 		return nil, fmt.Errorf("failed to parse actor: %w", err)
 	}
 
@@ -50,13 +48,12 @@ func ParseActor(data []byte) (*Actor, error) {
 
 // ParseNote parses a JSON byte array into a Note struct
 func ParseNote(data []byte) (*Note, error) {
-	// Validate JSON before parsing
-	if err := common.ValidateJSONField(string(data), "activitypub_note"); err != nil {
+	if err := validateRawActivityPubJSON(data, "note"); err != nil {
 		return nil, fmt.Errorf("invalid JSON: %w", err)
 	}
 
 	var note Note
-	if err := json.Unmarshal(data, &note); err != nil {
+	if err := common.ParseActivityPubObject(data, &note); err != nil {
 		return nil, fmt.Errorf("failed to parse note: %w", err)
 	}
 
@@ -66,4 +63,14 @@ func ParseNote(data []byte) (*Note, error) {
 	}
 
 	return &note, nil
+}
+
+func validateRawActivityPubJSON(data []byte, kind string) error {
+	if len(data) > common.MaxJSONSize {
+		return fmt.Errorf("%s JSON size %d bytes exceeds maximum %d", kind, len(data), common.MaxJSONSize)
+	}
+	if !json.Valid(data) {
+		return fmt.Errorf("malformed %s JSON", kind)
+	}
+	return nil
 }

--- a/pkg/activitypub/parser_test.go
+++ b/pkg/activitypub/parser_test.go
@@ -1,8 +1,10 @@
 package activitypub
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -29,6 +31,13 @@ func TestParseActivity(t *testing.T) {
 
 	t.Run("unmarshal error surfaces as parse failure", func(t *testing.T) {
 		_, err := ParseActivity([]byte(`{"id":123,"type":"Create","actor":"https://example.com/users/alice"}`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse activity")
+	})
+
+	t.Run("json safety limits rejected", func(t *testing.T) {
+		body := `{"id":"https://example.com/a/bomb","type":"Create","actor":"https://example.com/users/alice","object":` + strings.Repeat(`{"nested":`, common.MaxJSONDepth+2) + `"leaf"` + strings.Repeat(`}`, common.MaxJSONDepth+2) + `}`
+		_, err := ParseActivity([]byte(body))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to parse activity")
 	})

--- a/pkg/activitypub/parser_test.go
+++ b/pkg/activitypub/parser_test.go
@@ -84,3 +84,20 @@ func TestParseNote(t *testing.T) {
 		assert.Contains(t, err.Error(), "failed to parse note")
 	})
 }
+
+func TestParseActivityPubSizeLimits(t *testing.T) {
+	oversized := []byte(strings.Repeat(" ", common.MaxJSONSize+1))
+	sizeLimitErr := "exceeds maximum"
+
+	_, err := ParseActivity(oversized)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), sizeLimitErr)
+
+	_, err = ParseActor(oversized)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), sizeLimitErr)
+
+	_, err = ParseNote(oversized)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), sizeLimitErr)
+}

--- a/pkg/common/origin.go
+++ b/pkg/common/origin.go
@@ -1,27 +1,34 @@
 package common // nolint:revive // "common" package name is acceptable for shared utilities
 
 import (
+	"net"
 	"net/url"
+	"strconv"
 	"strings"
-
-	apptheory "github.com/theory-cloud/apptheory/runtime"
 )
 
 // OriginURLFromHeaders reconstructs the public request origin from forwarded headers.
 // Lesser-specific forwarded headers win because CloudFront strips the public Host header
-// before origin verification on API behaviors.
+// before origin verification on API behaviors. Forwarded host values must be plain
+// host[:port] authority values; malformed proxy input is ignored rather than trusted.
 func OriginURLFromHeaders(headers map[string][]string) string {
 	if origin := lesserForwardedOriginURL(headers); origin != "" {
 		return origin
 	}
-	return apptheory.OriginURL(headers)
+	if origin := standardForwardedOriginURL(headers); origin != "" {
+		return origin
+	}
+	if origin := xForwardedOriginURL(headers); origin != "" {
+		return origin
+	}
+	return ""
 }
 
 // RequestURLFromHeaders reconstructs the request URL used for signature verification.
 func RequestURLFromHeaders(headers map[string][]string, path string, query map[string][]string) *url.URL {
 	origin := OriginURLFromHeaders(headers)
 	if origin == "" {
-		if host := headerMapValue(headers, HostHeader); host != "" {
+		if host, ok := normalizeForwardedHost(headerMapValue(headers, HostHeader)); ok {
 			origin = SchemeHTTPS + "://" + host
 		} else {
 			origin = SchemeHTTPS + "://"
@@ -34,6 +41,9 @@ func RequestURLFromHeaders(headers map[string][]string, path string, query map[s
 	}
 	if u.Scheme == "" {
 		u.Scheme = SchemeHTTPS
+	}
+	if _, ok := normalizeForwardedHost(u.Host); !ok {
+		u.Host = ""
 	}
 
 	u.Path = path
@@ -49,9 +59,55 @@ func RequestURLFromHeaders(headers map[string][]string, path string, query map[s
 	return u
 }
 
+func standardForwardedOriginURL(headers map[string][]string) string {
+	forwarded := firstCommaSeparated(headerMapValue(headers, "Forwarded"))
+	if forwarded == "" {
+		return ""
+	}
+	var host string
+	proto := SchemeHTTPS
+	for _, part := range strings.Split(forwarded, ";") {
+		key, value, ok := strings.Cut(strings.TrimSpace(part), "=")
+		if !ok {
+			continue
+		}
+		value = strings.Trim(strings.TrimSpace(value), `"`)
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "host":
+			host = value
+		case "proto":
+			proto = strings.ToLower(value)
+		}
+	}
+	normalizedHost, ok := normalizeForwardedHost(host)
+	if !ok {
+		return ""
+	}
+	switch proto {
+	case SchemeHTTP, SchemeHTTPS:
+	default:
+		proto = SchemeHTTPS
+	}
+	return proto + "://" + normalizedHost
+}
+
+func xForwardedOriginURL(headers map[string][]string) string {
+	host, ok := normalizeForwardedHost(firstCommaSeparated(headerMapValue(headers, "X-Forwarded-Host")))
+	if !ok {
+		return ""
+	}
+	proto := strings.ToLower(firstCommaSeparated(headerMapValue(headers, XForwardedProtoHeader)))
+	switch proto {
+	case SchemeHTTP, SchemeHTTPS:
+	default:
+		proto = SchemeHTTPS
+	}
+	return proto + "://" + host
+}
+
 func lesserForwardedOriginURL(headers map[string][]string) string {
-	host := headerMapValue(headers, XLesserForwardedHost)
-	if host == "" {
+	host, ok := normalizeForwardedHost(headerMapValue(headers, XLesserForwardedHost))
+	if !ok {
 		return ""
 	}
 
@@ -66,6 +122,66 @@ func lesserForwardedOriginURL(headers map[string][]string) string {
 	}
 
 	return proto + "://" + host
+}
+
+func validatedOriginURL(origin string) string {
+	origin = strings.TrimSpace(origin)
+	if origin == "" {
+		return ""
+	}
+	u, err := url.Parse(origin)
+	if err != nil || u == nil {
+		return ""
+	}
+	if u.Scheme != SchemeHTTP && u.Scheme != SchemeHTTPS {
+		return ""
+	}
+	host, ok := normalizeForwardedHost(u.Host)
+	if !ok {
+		return ""
+	}
+	u.Host = host
+	u.User = nil
+	u.Path = ""
+	u.RawPath = ""
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}
+
+func normalizeForwardedHost(raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || strings.ContainsAny(raw, "\r\n\t /\\?#@") {
+		return "", false
+	}
+	u, err := url.Parse(SchemeHTTPS + "://" + raw)
+	if err != nil || u == nil || u.Host == "" || u.User != nil || u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+		return "", false
+	}
+	host := strings.ToLower(strings.TrimSpace(u.Hostname()))
+	if host == "" || strings.ContainsAny(host, "\r\n\t /\\?#@") {
+		return "", false
+	}
+	port := u.Port()
+	if port == "" {
+		if strings.Contains(host, ":") && net.ParseIP(host) != nil {
+			return "[" + host + "]", true
+		}
+		return host, true
+	}
+	portNumber, err := strconv.Atoi(port)
+	if err != nil || portNumber < 1 || portNumber > 65535 {
+		return "", false
+	}
+	return net.JoinHostPort(host, port), true
+}
+
+func firstCommaSeparated(value string) string {
+	value = strings.TrimSpace(value)
+	if idx := strings.Index(value, ","); idx >= 0 {
+		value = value[:idx]
+	}
+	return strings.TrimSpace(value)
 }
 
 func headerMapValue(headers map[string][]string, key string) string {

--- a/pkg/common/origin.go
+++ b/pkg/common/origin.go
@@ -124,31 +124,6 @@ func lesserForwardedOriginURL(headers map[string][]string) string {
 	return proto + "://" + host
 }
 
-func validatedOriginURL(origin string) string {
-	origin = strings.TrimSpace(origin)
-	if origin == "" {
-		return ""
-	}
-	u, err := url.Parse(origin)
-	if err != nil || u == nil {
-		return ""
-	}
-	if u.Scheme != SchemeHTTP && u.Scheme != SchemeHTTPS {
-		return ""
-	}
-	host, ok := normalizeForwardedHost(u.Host)
-	if !ok {
-		return ""
-	}
-	u.Host = host
-	u.User = nil
-	u.Path = ""
-	u.RawPath = ""
-	u.RawQuery = ""
-	u.Fragment = ""
-	return u.String()
-}
-
 func normalizeForwardedHost(raw string) (string, bool) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" || strings.ContainsAny(raw, "\r\n\t /\\?#@") {

--- a/pkg/common/origin_test.go
+++ b/pkg/common/origin_test.go
@@ -74,3 +74,37 @@ func TestHeaderMapValue_UncoveredBranches(t *testing.T) {
 		HostHeader: {},
 	}, HostHeader))
 }
+
+func TestOriginURLFromHeaders_RejectsMalformedForwardedHosts(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string][]string
+	}{
+		{
+			name: "lesser forwarded host with path is ignored",
+			headers: map[string][]string{
+				"x-lesser-forwarded-host": {"theory.dev.example.com/evil"},
+			},
+		},
+		{
+			name: "forwarded host with userinfo is ignored",
+			headers: map[string][]string{
+				"forwarded": {"for=198.51.100.22;proto=https;host=evil.example@theory.dev.example.com"},
+			},
+		},
+		{
+			name: "host fallback with path is ignored",
+			headers: map[string][]string{
+				"host": {"theory.dev.example.com/evil"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := RequestURLFromHeaders(tt.headers, "/inbox", nil)
+			require.Empty(t, u.Host)
+			require.Equal(t, "/inbox", u.Path)
+		})
+	}
+}

--- a/pkg/common/origin_test.go
+++ b/pkg/common/origin_test.go
@@ -108,3 +108,84 @@ func TestOriginURLFromHeaders_RejectsMalformedForwardedHosts(t *testing.T) {
 		})
 	}
 }
+
+func TestOriginURLFromHeaders_UsesNormalizedForwardedAuthorities(t *testing.T) {
+	t.Run("x forwarded host uses first authority and proto", func(t *testing.T) {
+		headers := map[string][]string{
+			"x-forwarded-host":  {"Theory.Dev.Example.Com:8443, stale.example.com"},
+			"x-forwarded-proto": {"http, https"},
+		}
+
+		require.Equal(t, "http://theory.dev.example.com:8443", OriginURLFromHeaders(headers))
+	})
+
+	t.Run("standard forwarded invalid proto defaults to https", func(t *testing.T) {
+		headers := map[string][]string{
+			"forwarded": {"for=198.51.100.22;proto=gopher;host=Theory.Dev.Example.Com:8443"},
+		}
+
+		require.Equal(t, "https://theory.dev.example.com:8443", OriginURLFromHeaders(headers))
+	})
+}
+
+func TestNormalizeForwardedHost(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+		ok   bool
+	}{
+		{
+			name: "hostname lowercased",
+			raw:  "Theory.Dev.Example.Com",
+			want: "theory.dev.example.com",
+			ok:   true,
+		},
+		{
+			name: "hostname with port",
+			raw:  "Theory.Dev.Example.Com:8443",
+			want: "theory.dev.example.com:8443",
+			ok:   true,
+		},
+		{
+			name: "ipv6 literal without port",
+			raw:  "[2001:db8::1]",
+			want: "[2001:db8::1]",
+			ok:   true,
+		},
+		{
+			name: "ipv6 literal with port",
+			raw:  "[2001:db8::1]:8443",
+			want: "[2001:db8::1]:8443",
+			ok:   true,
+		},
+		{
+			name: "invalid port text",
+			raw:  "example.com:notaport",
+		},
+		{
+			name: "invalid port range",
+			raw:  "example.com:70000",
+		},
+		{
+			name: "userinfo is rejected",
+			raw:  "evil@example.com",
+		},
+		{
+			name: "path is rejected",
+			raw:  "example.com/path",
+		},
+		{
+			name: "empty is rejected",
+			raw:  " ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := normalizeForwardedHost(tt.raw)
+			require.Equal(t, tt.ok, ok)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/federation/httpsig.go
+++ b/pkg/federation/httpsig.go
@@ -232,6 +232,85 @@ func ParsePrivateKeyPEM(pemData []byte) (crypto.PrivateKey, error) {
 	}
 }
 
+// RequireSignedBodyIntegrity enforces the minimum signed-header set for
+// body-bearing inbound ActivityPub requests. Digest must be present and signed
+// with host/date/(request-target) so a proxy or attacker cannot alter the body
+// and Digest header without invalidating the HTTP signature.
+func RequireSignedBodyIntegrity(req *http.Request) error {
+	if req == nil {
+		return common.AuthenticationError{Message: "missing request"}
+	}
+
+	sig, err := ParseSignatureHeader(req.Header.Get(SignatureHeader))
+	if err != nil {
+		return errors.Join(ErrSignatureParseFailed, err)
+	}
+
+	signedHeaders := make(map[string]struct{}, len(sig.Headers))
+	for _, header := range sig.Headers {
+		signedHeaders[strings.ToLower(strings.TrimSpace(header))] = struct{}{}
+	}
+	for _, required := range []string{RequestTargetHeader, "host", "date"} {
+		if _, ok := signedHeaders[required]; !ok {
+			return errors.Join(ErrRequiredHeaderNotFound, common.AuthenticationError{Message: "signature must cover " + required})
+		}
+	}
+
+	if err := validateSignedHostBinding(req); err != nil {
+		return err
+	}
+
+	if !requestHasIntegrityBody(req) {
+		return nil
+	}
+	if err := common.ValidateRequiredParam("digest_header", req.Header.Get(DigestHeader)); err != nil {
+		return common.AuthenticationError{Message: "missing digest header"}
+	}
+	if _, ok := signedHeaders["digest"]; !ok {
+		return errors.Join(ErrRequiredHeaderNotFound, common.AuthenticationError{Message: "signature must cover digest"})
+	}
+	return nil
+}
+
+func requestHasIntegrityBody(req *http.Request) bool {
+	if req == nil {
+		return false
+	}
+	if req.ContentLength > 0 || req.Header.Get(DigestHeader) != "" {
+		return true
+	}
+	switch strings.ToUpper(req.Method) {
+	case http.MethodPost, http.MethodPut, http.MethodPatch:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateSignedHostBinding(req *http.Request) error {
+	if req == nil || req.URL == nil {
+		return common.AuthenticationError{Message: "missing request URL"}
+	}
+	urlHost := strings.TrimSpace(req.URL.Host)
+	if err := common.ValidateRequiredParam("url_host", urlHost); err != nil {
+		return common.AuthenticationError{Message: "missing request host"}
+	}
+	signedHost := strings.TrimSpace(req.Host)
+	if signedHost == "" {
+		signedHost = strings.TrimSpace(req.Header.Get(common.HostHeader))
+	}
+	if err := common.ValidateRequiredParam("signed_host", signedHost); err != nil {
+		return common.AuthenticationError{Message: "missing signed host"}
+	}
+	if strings.ContainsAny(signedHost, "\r\n\t /\\?#@") || strings.ContainsAny(urlHost, "\r\n\t /\\?#@") {
+		return common.AuthenticationError{Message: "invalid signed host"}
+	}
+	if !strings.EqualFold(signedHost, urlHost) {
+		return common.AuthenticationError{Message: "signed host does not match request URL host"}
+	}
+	return nil
+}
+
 // VerifyHTTPSignature verifies an incoming HTTP request's signature
 func VerifyHTTPSignature(req *http.Request, publicKey crypto.PublicKey) error {
 	log := common.Logger()

--- a/pkg/federation/httpsig_test.go
+++ b/pkg/federation/httpsig_test.go
@@ -588,3 +588,39 @@ func TestServerInteroperability(t *testing.T) {
 		})
 	}
 }
+
+func TestRequireSignedBodyIntegrity(t *testing.T) {
+	privateKey, err := GenerateRSAKeyPair(2048)
+	require.NoError(t, err)
+
+	t.Run("body requires digest covered by signature", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "https://example.com/inbox", strings.NewReader(`{"type":"Create"}`))
+		req.Host = "example.com"
+		req.Header.Set(DateHeader, time.Now().UTC().Format(time.RFC1123))
+		req.Header.Set("Content-Type", "application/activity+json")
+		require.NoError(t, SignHTTPRequestWithAlgorithm(req, privateKey, "https://example.com/users/alice#main-key", AlgorithmRSASHA256))
+
+		require.Error(t, RequireSignedBodyIntegrity(req))
+	})
+
+	t.Run("signed digest succeeds", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "https://example.com/inbox", strings.NewReader(`{"type":"Create"}`))
+		req.Host = "example.com"
+		req.Header.Set(DateHeader, time.Now().UTC().Format(time.RFC1123))
+		req.Header.Set("Content-Type", "application/activity+json")
+		require.NoError(t, SignHTTPRequest(req, privateKey, "https://example.com/users/alice#main-key"))
+
+		require.NoError(t, RequireSignedBodyIntegrity(req))
+	})
+
+	t.Run("host must match request URL host", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "https://example.com/inbox", strings.NewReader(`{"type":"Create"}`))
+		req.Host = "example.com"
+		req.Header.Set(DateHeader, time.Now().UTC().Format(time.RFC1123))
+		req.Header.Set("Content-Type", "application/activity+json")
+		require.NoError(t, SignHTTPRequest(req, privateKey, "https://example.com/users/alice#main-key"))
+		req.URL.Host = "attacker.example"
+
+		require.Error(t, RequireSignedBodyIntegrity(req))
+	})
+}

--- a/pkg/federation/httpsig_test.go
+++ b/pkg/federation/httpsig_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -620,6 +621,65 @@ func TestRequireSignedBodyIntegrity(t *testing.T) {
 		req.Header.Set("Content-Type", "application/activity+json")
 		require.NoError(t, SignHTTPRequest(req, privateKey, "https://example.com/users/alice#main-key"))
 		req.URL.Host = "attacker.example"
+
+		require.Error(t, RequireSignedBodyIntegrity(req))
+	})
+}
+
+func TestRequireSignedBodyIntegrity_BoundaryBranches(t *testing.T) {
+	dummySignature := func(headers string) string {
+		return `keyId="https://example.com/users/alice#main-key",algorithm="rsa-sha256",headers="` + headers + `",signature="dGVzdA=="`
+	}
+
+	require.Error(t, RequireSignedBodyIntegrity(nil))
+
+	t.Run("missing required signed host header is rejected", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "https://example.com/inbox", nil)
+		req.Host = "example.com"
+		req.Header.Set(SignatureHeader, dummySignature("(request-target) date"))
+
+		require.Error(t, RequireSignedBodyIntegrity(req))
+	})
+
+	t.Run("get without body or digest does not require digest", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "https://example.com/inbox", nil)
+		req.Host = "example.com"
+		req.Header.Set(SignatureHeader, dummySignature("(request-target) host date"))
+
+		require.NoError(t, RequireSignedBodyIntegrity(req))
+	})
+
+	t.Run("get with digest header requires digest to be signed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "https://example.com/inbox", nil)
+		req.Host = "example.com"
+		req.Header.Set(DigestHeader, calculateDigest([]byte("body")))
+		req.Header.Set(SignatureHeader, dummySignature("(request-target) host date"))
+
+		require.Error(t, RequireSignedBodyIntegrity(req))
+	})
+
+	t.Run("host header fallback is accepted", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "https://example.com/inbox", nil)
+		req.Host = ""
+		req.Header.Set(common.HostHeader, "example.com")
+		req.Header.Set(SignatureHeader, dummySignature("(request-target) host date"))
+
+		require.NoError(t, RequireSignedBodyIntegrity(req))
+	})
+
+	t.Run("invalid signed host authority is rejected", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "https://example.com/inbox", nil)
+		req.Host = "example.com/path"
+		req.Header.Set(SignatureHeader, dummySignature("(request-target) host date"))
+
+		require.Error(t, RequireSignedBodyIntegrity(req))
+	})
+
+	t.Run("missing request url host is rejected", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "https://example.com/inbox", nil)
+		req.Host = "example.com"
+		req.URL.Host = ""
+		req.Header.Set(SignatureHeader, dummySignature("(request-target) host date"))
 
 		require.Error(t, RequireSignedBodyIntegrity(req))
 	})

--- a/pkg/reputation/actor_id.go
+++ b/pkg/reputation/actor_id.go
@@ -1,0 +1,59 @@
+package reputation
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/equaltoai/lesser/pkg/common"
+)
+
+// ValidateActorID validates a canonical ActivityPub actor URI used by reputation lookups.
+func ValidateActorID(actorID string) error {
+	actorID = strings.TrimSpace(actorID)
+	if actorID == "" {
+		return fmt.Errorf("actor ID is required")
+	}
+	if containsControlRune(actorID) || strings.ContainsAny(actorID, " \t\r\n") {
+		return fmt.Errorf("actor ID contains invalid characters")
+	}
+	if err := common.ValidateActivityPubURL(actorID, "actor_id"); err != nil {
+		return err
+	}
+
+	parsed, err := url.Parse(actorID)
+	if err != nil || parsed == nil {
+		return fmt.Errorf("actor ID must be a valid URL")
+	}
+	if parsed.User != nil {
+		return fmt.Errorf("actor ID must not contain userinfo")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return fmt.Errorf("actor ID must not contain query or fragment")
+	}
+	if parsed.Opaque != "" || strings.TrimSpace(parsed.Hostname()) == "" || strings.TrimSpace(parsed.Path) == "" || parsed.Path == "/" {
+		return fmt.Errorf("actor ID must include host and path")
+	}
+	for _, segment := range strings.Split(parsed.EscapedPath(), "/") {
+		if segment == "" {
+			continue
+		}
+		unescaped, err := url.PathUnescape(segment)
+		if err != nil {
+			return fmt.Errorf("actor ID path contains invalid escaping")
+		}
+		if unescaped == "." || unescaped == ".." || containsControlRune(unescaped) {
+			return fmt.Errorf("actor ID path contains unsafe segment")
+		}
+	}
+	return nil
+}
+
+func containsControlRune(value string) bool {
+	for _, r := range value {
+		if r < 0x20 || r == 0x7f {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/reputation/actor_id_test.go
+++ b/pkg/reputation/actor_id_test.go
@@ -1,0 +1,30 @@
+package reputation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateActorID(t *testing.T) {
+	require.NoError(t, ValidateActorID("https://example.com/users/alice"))
+	require.NoError(t, ValidateActorID("http://remote.example/@bob"))
+
+	invalid := []string{
+		"",
+		"acct:alice@example.com",
+		"https://evil.example@real.example/users/alice",
+		"https://example.com/users/alice?next=https://evil.example",
+		"https://example.com/users/alice#main-key",
+		"https://example.com/users/../admin",
+		"https://example.com/users/%2e%2e/admin",
+		"https://example.com/users/alice\nHost: evil.example",
+		"https://example.com/" + strings.Repeat("a", 2001),
+	}
+	for _, actorID := range invalid {
+		t.Run(actorID, func(t *testing.T) {
+			require.Error(t, ValidateActorID(actorID))
+		})
+	}
+}

--- a/pkg/reputation/crypto.go
+++ b/pkg/reputation/crypto.go
@@ -83,15 +83,10 @@ func NewSigner(privateKeyPEM string, instanceURL string, logger *zap.Logger) (*S
 		publicKey = pub
 		privateKey = priv
 
-		// Log the generated private key in PEM format for future use
-		privKeyBytes, _ := x509.MarshalPKCS8PrivateKey(privateKey)
-		pemBlock := &pem.Block{
-			Type:  "PRIVATE KEY",
-			Bytes: privKeyBytes,
-		}
-		pemData := pem.EncodeToMemory(pemBlock)
+		publicKeyFingerprint := sha256.Sum256(publicKey)
 		logger.Info("generated new Ed25519 key pair",
-			zap.String("private_key_pem", string(pemData)))
+			zap.String("instance", instanceURL),
+			zap.String("public_key_fingerprint", base64.RawStdEncoding.EncodeToString(publicKeyFingerprint[:])))
 	}
 
 	return &Signer{

--- a/pkg/reputation/crypto_key_logging_test.go
+++ b/pkg/reputation/crypto_key_logging_test.go
@@ -1,0 +1,28 @@
+package reputation
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestNewSigner_DoesNotLogGeneratedPrivateKey(t *testing.T) {
+	core, observed := observer.New(zap.DebugLevel)
+	_, err := NewSigner("", "https://example.com", zap.New(core))
+	require.NoError(t, err)
+
+	var sawFingerprint bool
+	for _, entry := range observed.All() {
+		fields := fmt.Sprint(entry.Context)
+		require.NotContains(t, fields, "private_key_pem")
+		require.NotContains(t, fields, "PRIVATE KEY")
+		if entry.Message == "generated new Ed25519 key pair" && strings.Contains(fields, "public_key_fingerprint") {
+			sawFingerprint = true
+		}
+	}
+	require.True(t, sawFingerprint, "expected generated-key log to include a public fingerprint")
+}

--- a/pkg/reputation/service.go
+++ b/pkg/reputation/service.go
@@ -215,6 +215,10 @@ func NewService(cfg *Config) (*Service, error) {
 
 // GetReputation retrieves the current reputation for an actor
 func (s *Service) GetReputation(ctx context.Context, actorID string) (*Reputation, error) {
+	if err := ValidateActorID(actorID); err != nil {
+		return nil, fmt.Errorf("invalid actor ID: %w", err)
+	}
+
 	// Get reputation from storage
 	storedRep, err := s.userRepo.GetReputation(ctx, actorID)
 	if err != nil {


### PR DESCRIPTION
## Milestone

Codex Security M3 — Federation trust boundaries

Closes #824
Closes #825
Closes #826
Closes #827
Closes #828
Closes #829
Closes #830
Closes #831

## Classification

security / federation-trust / privacy / reliability

## Surfaces affected

- shared inbox follower expansion
- inbound HTTP Signature origin, host, and Digest integrity
- outbox ActivityPub body parsing and safety limits
- ActivityPub parser entry points used by stream processors
- reputation actor ID validation and signing-key logging
- Undo Reject follow restoration semantics
- Announce timeline fanout visibility

## Specialist walks referenced

- Federation trust: completed for all touched inbox/outbox/signature/delivery-adjacent boundaries.
- Contract / API: no Mastodon response-shape changes; only malformed/unsafe inputs are rejected earlier.
- Schema: no PK/SK, GSI, TableTheory tag, or data-model migration changes.
- Framework: idiomatic use; no AppTheory/TableTheory patches or local framework workarounds.

## Consumer impact

Remote ActivityPub peers with valid signed body integrity are unaffected. Malformed/unsafe inputs are rejected earlier. Mastodon-compatible response shapes are unchanged. Operators get safer trust-boundary behavior around shared inbox routing, outbox parsing, reputation endpoints, and timeline fanout.

## Tasks

- [x] #825 — shared inbox follower targeting
- [x] #826 — inbound signature host binding
- [x] #827 — outbox body safety limits
- [x] #828 — safe ActivityPub parser limits
- [x] #829 — reputation actor IDs/key logging
- [x] #830 — forged Undo Reject follows
- [x] #831 — announce audience visibility

## Validation

- `gofmt -l .` — empty
- `go test ./...`
- `go vet ./...`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas` — 38 artifacts
- `./lesser verify ci`

No smoke test instance is available per Aron, so validation is local-only.

## Stage rollout plan (handoff to deploy-instance)

- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination

None required for this milestone.