### PR TITLE
fix(security): complete Codex Security M5

### DIFF
--- a/cmd/api/handlers/agent_access_leases.go
+++ b/cmd/api/handlers/agent_access_leases.go
@@ -345,6 +345,9 @@ func (h *Handler) HandleCreateAgentAccessLeaseSessionKeyChallengeLift(ctx *appth
 	if resp != nil || err != nil {
 		return resp, err
 	}
+	if resp, err := h.ensureActiveAgentLeaseAccount(ctx, username); resp != nil || err != nil {
+		return resp, err
+	}
 	now := time.Now().UTC()
 	if effectiveAgentAccessLeaseStatus(lease, now) != agentAccessLeaseStatusActive {
 		return apptheory.JSON(http.StatusUnauthorized, map[string]any{
@@ -400,6 +403,9 @@ func (h *Handler) HandleAuthorizeAgentAccessLeaseSessionKeyLift(ctx *apptheory.C
 
 	lease, resp, err := h.loadAgentAccessLease(ctx, username, leaseID)
 	if resp != nil || err != nil {
+		return resp, err
+	}
+	if resp, err := h.ensureActiveAgentLeaseAccount(ctx, username); resp != nil || err != nil {
 		return resp, err
 	}
 	now := time.Now().UTC()
@@ -485,6 +491,9 @@ func (h *Handler) HandleCreateAgentAccessLeaseRenewChallengeLift(ctx *apptheory.
 	if resp != nil || err != nil {
 		return resp, err
 	}
+	if resp, err := h.ensureActiveAgentLeaseAccount(ctx, username); resp != nil || err != nil {
+		return resp, err
+	}
 
 	now := time.Now().UTC()
 	if effectiveAgentAccessLeaseStatus(lease, now) != agentAccessLeaseStatusActive {
@@ -553,6 +562,9 @@ func (h *Handler) HandleExchangeAgentAccessLeaseTokenLift(ctx *apptheory.Context
 
 	lease, resp, err := h.loadAgentAccessLease(ctx, username, leaseID)
 	if resp != nil || err != nil {
+		return resp, err
+	}
+	if resp, err := h.ensureActiveAgentLeaseAccount(ctx, username); resp != nil || err != nil {
 		return resp, err
 	}
 	now := time.Now().UTC()
@@ -749,7 +761,7 @@ func (h *Handler) requireOwnedAgentAccount(ctx *apptheory.Context, username stri
 		resp, respErr := common.RespondInternalServerError(ctx)
 		return nil, nil, resp, respErr
 	}
-	if account == nil || account.User == nil || !account.User.IsAgent {
+	if account == nil || account.User == nil || !account.User.IsAgent || account.User.Suspended {
 		resp, respErr := common.RespondNotFound(ctx, "agent")
 		return nil, nil, resp, respErr
 	}
@@ -777,7 +789,7 @@ func (h *Handler) requireManagedAgentAccount(ctx *apptheory.Context, username st
 		resp, respErr := common.RespondInternalServerError(ctx)
 		return nil, nil, resp, respErr
 	}
-	if account == nil || account.User == nil || !account.User.IsAgent {
+	if account == nil || account.User == nil || !account.User.IsAgent || account.User.Suspended {
 		resp, respErr := common.RespondNotFound(ctx, "agent")
 		return nil, nil, resp, respErr
 	}
@@ -786,6 +798,20 @@ func (h *Handler) requireManagedAgentAccount(ctx *apptheory.Context, username st
 		return nil, nil, resp, respErr
 	}
 	return claims, account, nil, nil
+}
+
+func (h *Handler) ensureActiveAgentLeaseAccount(ctx *apptheory.Context, username string) (*apptheory.Response, error) {
+	account, err := h.repos.Account().GetAccount(ctx.Context(), username)
+	if err != nil {
+		if common.IsNotFound(err) {
+			return common.RespondNotFound(ctx, "agent")
+		}
+		return common.RespondInternalServerError(ctx)
+	}
+	if account == nil || account.User == nil || !account.User.IsAgent || account.User.Suspended {
+		return common.RespondNotFound(ctx, "agent")
+	}
+	return nil, nil
 }
 
 func (h *Handler) createAgentAccessLeaseChallenge(ctx *apptheory.Context, opts agentAccessLeaseOptions, action string) (*storageModels.AgentAccessLeaseChallenge, error) {

--- a/cmd/api/handlers/agent_access_leases_error_test.go
+++ b/cmd/api/handlers/agent_access_leases_error_test.go
@@ -730,6 +730,79 @@ func TestAgentAccessLeasesRound20_ErrorPaths(t *testing.T) {
 		requireStatus(t, http.StatusUnauthorized)(h.HandleCreateAgentAccessLeaseRenewChallengeLift(ctx))
 	})
 
+	t.Run("renew challenge rejects suspended agent", func(t *testing.T) {
+		state := baseState()
+		agent := state.usersByUsername["agent1"]
+		agent.Suspended = true
+		state.usersByUsername["agent1"] = agent
+		leaseID := "lease-suspended"
+		state.agentAccessLeasesByKey = map[string]storagemodels.AgentAccessLease{
+			"AGENT_ACCESS_LEASE#agent1#LEASE#" + leaseID: {
+				PK:                "AGENT_ACCESS_LEASE#agent1",
+				SK:                "LEASE#" + leaseID,
+				ID:                leaseID,
+				Username:          "agent1",
+				PrincipalUsername: "owner",
+				PrincipalWallet:   ownerAddr,
+				AgentWallet:       agentAddr,
+				Scopes:            []string{"read"},
+				DeviceLabel:       "local-agent",
+				Status:            "active",
+				IdleTimeoutHours:  24,
+				IdleExpiresAt:     now.Add(24 * time.Hour),
+				AbsoluteExpiresAt: now.Add(48 * time.Hour),
+				LastUsedAt:        now,
+				LeaseVersion:      1,
+				CreatedAt:         now,
+				UpdatedAt:         now,
+			},
+		}
+		h, _, _ := round11NewHandler(t, cfg, state)
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/agents/agent1/access-leases/"+leaseID+"/renew/challenge", nil, nil, nil)
+		require.NoError(t, err)
+		ctx.Params["username"] = "agent1"
+		ctx.Params["leaseID"] = leaseID
+		requireStatus(t, http.StatusNotFound)(h.HandleCreateAgentAccessLeaseRenewChallengeLift(ctx))
+	})
+
+	t.Run("exchange token rejects suspended agent before renewal proof", func(t *testing.T) {
+		state := baseState()
+		agent := state.usersByUsername["agent1"]
+		agent.Suspended = true
+		state.usersByUsername["agent1"] = agent
+		leaseID := "lease-suspended-token"
+		state.agentAccessLeasesByKey = map[string]storagemodels.AgentAccessLease{
+			"AGENT_ACCESS_LEASE#agent1#LEASE#" + leaseID: {
+				PK:                "AGENT_ACCESS_LEASE#agent1",
+				SK:                "LEASE#" + leaseID,
+				ID:                leaseID,
+				Username:          "agent1",
+				PrincipalUsername: "owner",
+				PrincipalWallet:   ownerAddr,
+				AgentWallet:       agentAddr,
+				Scopes:            []string{"read"},
+				DeviceLabel:       "local-agent",
+				Status:            "active",
+				IdleTimeoutHours:  24,
+				IdleExpiresAt:     now.Add(24 * time.Hour),
+				AbsoluteExpiresAt: now.Add(48 * time.Hour),
+				LastUsedAt:        now,
+				LeaseVersion:      1,
+				CreatedAt:         now,
+				UpdatedAt:         now,
+			},
+		}
+		h, _, _ := round11NewHandler(t, cfg, state)
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/agents/agent1/access-leases/"+leaseID+"/token", nil, nil, apimodels.RenewAgentAccessLeaseTokenRequest{
+			ChallengeID: "challenge-suspended",
+			Signature:   "0xdeadbeef",
+		})
+		require.NoError(t, err)
+		ctx.Params["username"] = "agent1"
+		ctx.Params["leaseID"] = leaseID
+		requireStatus(t, http.StatusNotFound)(h.HandleExchangeAgentAccessLeaseTokenLift(ctx))
+	})
+
 	t.Run("exchange token rejects mismatched challenge action", func(t *testing.T) {
 		state := baseState()
 		leaseID := "lease-3"

--- a/cmd/api/handlers/agent_feature_round12_more_coverage_test.go
+++ b/cmd/api/handlers/agent_feature_round12_more_coverage_test.go
@@ -139,7 +139,10 @@ func TestAgentsRound12_DirectoryLifecycleAndActivity(t *testing.T) {
 		require.Equal(t, "alice", out[0].Username)
 		require.Equal(t, 10, out[0].AgentCapabilities.MaxPostsPerHour)
 		require.Equal(t, agents.DroneIdentityStateSouled, out[0].IdentitySemantics.IdentityState)
-		require.Equal(t, "0xalice-soul", out[0].IdentitySemantics.SoulAgentID)
+		require.Empty(t, out[0].AgentOwner)
+		require.Empty(t, out[0].DelegatedScopes)
+		require.Equal(t, "UNBOUND", out[0].IdentitySemantics.SoulBindingState)
+		require.Empty(t, out[0].IdentitySemantics.SoulAgentID)
 	})
 
 	t.Run("gets_agent_by_username", func(t *testing.T) {
@@ -153,6 +156,26 @@ func TestAgentsRound12_DirectoryLifecycleAndActivity(t *testing.T) {
 		require.Equal(t, "alice", out.Username)
 		require.True(t, out.Verified)
 		require.Equal(t, agents.DroneIdentityStateSouled, out.IdentitySemantics.IdentityState)
+		require.Empty(t, out.AgentOwner)
+		require.Empty(t, out.DelegatedScopes)
+		require.Equal(t, "UNBOUND", out.IdentitySemantics.SoulBindingState)
+		require.Empty(t, out.IdentitySemantics.SoulAgentID)
+	})
+
+	t.Run("gets_private_agent_metadata_for_owner", func(t *testing.T) {
+		ownerToken := round11SignAccessToken(t, cfg.JWTSecret, "owner", []string{auth.ScopeRead})
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/agents/alice", map[string]string{
+			"Authorization": "Bearer " + ownerToken,
+		}, nil, nil)
+		require.NoError(t, err)
+		ctx.Params["username"] = "alice"
+
+		resp := requireStatus(t, http.StatusOK)(h.HandleGetAgentLift(ctx))
+		var out apimodels.Agent
+		require.NoError(t, json.Unmarshal(resp.Body, &out))
+		require.Equal(t, "@owner", out.AgentOwner)
+		require.Equal(t, []string{auth.ScopeRead, "write:statuses"}, out.DelegatedScopes)
+		require.Equal(t, "BOUND", out.IdentitySemantics.SoulBindingState)
 		require.Equal(t, "0xalice-soul", out.IdentitySemantics.SoulAgentID)
 	})
 

--- a/cmd/api/handlers/agents.go
+++ b/cmd/api/handlers/agents.go
@@ -397,11 +397,13 @@ func (h *Handler) mintDelegatedAgentTokens(ctx *apptheory.Context, agentUsername
 		deviceLabel = userAgent
 	}
 	bundle, err := auth.IssueAgentRuntimeTokens(ctx.Context(), h.cfg, h.repos, auth.AgentRuntimeTokenIssueParams{
-		Username:    agentUsername,
-		ClientID:    delegatedAgentClientID,
-		Scopes:      requestedScopes,
-		AccessTTL:   accessTTL,
-		DeviceLabel: deviceLabel,
+		Username:           agentUsername,
+		ClientID:           delegatedAgentClientID,
+		Scopes:             requestedScopes,
+		AccessTTL:          accessTTL,
+		RefreshIdleTTL:     accessTTL,
+		RefreshAbsoluteTTL: accessTTL,
+		DeviceLabel:        deviceLabel,
 	})
 	if err != nil {
 		return apimodels.OAuthTokenResponse{}, err

--- a/cmd/api/handlers/agents.go
+++ b/cmd/api/handlers/agents.go
@@ -441,6 +441,7 @@ func (h *Handler) HandleListAgentsLift(ctx *apptheory.Context) (*apptheory.Respo
 		return common.RespondInternalServerError(ctx)
 	}
 	baseURL := handlerBaseURL(h)
+	viewerClaims := h.optionalAuthenticatedClaimsLift(ctx)
 	for _, user := range users {
 		if user == nil || !user.IsAgent {
 			continue
@@ -450,6 +451,9 @@ func (h *Handler) HandleListAgentsLift(ctx *apptheory.Context) (*apptheory.Respo
 		}
 		agentOut := agentFromStorageUserWithBaseURL(user, governanceStates[strings.ToLower(strings.TrimSpace(user.Username))], baseURL)
 		agentOut.IdentitySemantics = apiAgentIdentitySemantics(h.agentIdentitySemantics(ctx.Context(), user))
+		if !h.canViewAgentPrivateFields(viewerClaims, user) {
+			redactAPIAgentPrivateFields(&agentOut)
+		}
 		agentsOut = append(agentsOut, agentOut)
 	}
 
@@ -480,6 +484,9 @@ func (h *Handler) HandleGetAgentLift(ctx *apptheory.Context) (*apptheory.Respons
 
 	agentOut := agentFromStorageUserWithBaseURL(user, governance, handlerBaseURL(h))
 	agentOut.IdentitySemantics = apiAgentIdentitySemantics(h.agentIdentitySemantics(ctx.Context(), user))
+	if !h.canViewAgentPrivateFields(h.optionalAuthenticatedClaimsLift(ctx), user) {
+		redactAPIAgentPrivateFields(&agentOut)
+	}
 	return okJSON(agentOut)
 }
 
@@ -865,12 +872,11 @@ func (h *Handler) isAgentOwnerOrAdmin(claims *auth.Claims, agentUser *storage.Us
 		return true
 	}
 
-	owner := strings.TrimSpace(agentUser.AgentOwner)
-	if owner == "" {
-		return false
-	}
-	owner = strings.TrimPrefix(owner, "@")
-	return strings.EqualFold(owner, claims.Username)
+	return h.agentOwnerMatchesLocalPrincipal(agentUser.AgentOwner, claims.Username)
+}
+
+func (h *Handler) canViewAgentPrivateFields(claims *auth.Claims, agentUser *storage.User) bool {
+	return h.isAgentOwnerOrAdmin(claims, agentUser)
 }
 
 func (h *Handler) validateDelegationScopes(ctx *apptheory.Context, ownerScopes []string, requested []string) ([]string, *apptheory.Response, error) {
@@ -1024,6 +1030,16 @@ func agentFromStorageUserWithBaseURL(user *storage.User, governance *storage.Age
 	out.IdentitySemantics = apiAgentIdentitySemantics(agents.DeriveDroneIdentitySemantics(user.Username, workflowState, false, ""))
 
 	return out
+}
+
+func redactAPIAgentPrivateFields(agent *apimodels.Agent) {
+	if agent == nil {
+		return
+	}
+	agent.AgentOwner = ""
+	agent.DelegatedScopes = nil
+	agent.IdentitySemantics.SoulAgentID = ""
+	agent.IdentitySemantics.SoulBindingState = "UNBOUND"
 }
 
 func applyAPIAgentQuarantineSummary(out *apimodels.Agent, governance *storage.AgentGovernanceState) {

--- a/cmd/api/handlers/agents_round18_scope_helpers_test.go
+++ b/cmd/api/handlers/agents_round18_scope_helpers_test.go
@@ -23,6 +23,7 @@ func TestAgentsRound18_IsAgentOwnerOrAdmin(t *testing.T) {
 	require.False(t, h.isAgentOwnerOrAdmin(&auth.Claims{Username: "alice"}, &storage.User{AgentOwner: ""}))
 	require.True(t, h.isAgentOwnerOrAdmin(&auth.Claims{Username: "alice"}, &storage.User{AgentOwner: "@alice"}))
 	require.False(t, h.isAgentOwnerOrAdmin(&auth.Claims{Username: "alice"}, &storage.User{AgentOwner: "bob"}))
+	require.False(t, h.isAgentOwnerOrAdmin(&auth.Claims{Username: "alice"}, &storage.User{AgentOwner: "https://remote.example/users/alice"}))
 }
 
 func TestAgentsRound18_ValidateDelegationScopes(t *testing.T) {

--- a/cmd/api/handlers/agents_round20_delegation_ci_test.go
+++ b/cmd/api/handlers/agents_round20_delegation_ci_test.go
@@ -233,6 +233,30 @@ func TestAgentsRound20_MintDelegatedAgentTokens_RequiresRefreshTokenPersistence(
 	require.Empty(t, token.RefreshToken)
 }
 
+func TestAgentsRound20_MintDelegatedAgentTokens_BoundsRefreshByRequestedTTL(t *testing.T) {
+	cfg := round10TestConfig()
+	cfg.AllowAgents = true
+
+	state := &round10QueryState{}
+	h, _, _ := round11NewHandler(t, cfg, state)
+	h.repos.Account().SetEncryptor(noopEncryptor{})
+
+	ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/agents/delegate", nil, nil, nil)
+	require.NoError(t, err)
+
+	requestedTTL := 10 * time.Minute
+	token, mintErr := h.mintDelegatedAgentTokens(ctx, "agent1", []string{"read"}, requestedTTL, "test-runtime", "")
+	require.NoError(t, mintErr)
+	require.NotEmpty(t, token.RefreshToken)
+
+	stored, ok := state.refreshTokensByToken[token.RefreshToken]
+	require.True(t, ok)
+	require.Equal(t, delegatedAgentClientID, stored.ClientID)
+	require.WithinDuration(t, stored.CreatedAt.Add(requestedTTL), stored.IdleExpiresAt, 2*time.Second)
+	require.WithinDuration(t, stored.CreatedAt.Add(requestedTTL), stored.AbsoluteExpiresAt, 2*time.Second)
+	require.WithinDuration(t, stored.AbsoluteExpiresAt, stored.ExpiresAt, time.Second)
+}
+
 func TestAgentsRound20_AgentDelegationEnvelope_EmptyMetadataCases(t *testing.T) {
 	scopes, ok := agentDelegationEnvelope(nil)
 	require.False(t, ok)

--- a/cmd/api/handlers/ai.go
+++ b/cmd/api/handlers/ai.go
@@ -1,15 +1,24 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
 
 	originalai "github.com/equaltoai/lesser/pkg/ai"
+	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/common"
 	ai "github.com/equaltoai/lesser/pkg/services/ai"
+	"github.com/equaltoai/lesser/pkg/transformations"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 )
+
+type aiAnalysisLiftRequest struct {
+	ObjectID   string `json:"object_id"`
+	ObjectType string `json:"object_type"`
+	Force      bool   `json:"force"` // Force re-analysis
+}
 
 // Removed global AI storage - now using AIRepository
 
@@ -17,8 +26,12 @@ import (
 // GET /api/v1/ai/analysis/:object_id
 func (h *Handler) HandleGetAIAnalysisLift(ctx *apptheory.Context) (*apptheory.Response, error) {
 	// Auth - require read scope
-	if _, resp, err := h.authenticatedClaimsWithResponder(ctx, common.RespondMissingAuth, common.RespondInvalidToken); resp != nil || err != nil {
+	claims, resp, err := h.authenticatedClaimsWithResponder(ctx, common.RespondMissingAuth, common.RespondInvalidToken)
+	if resp != nil || err != nil {
 		return resp, err
+	}
+	if !claims.HasScope(auth.ScopeRead) && !claims.HasScope(auth.ScopeAdmin) {
+		return common.RespondInsufficientScope(ctx, auth.ScopeRead)
 	}
 
 	// Get object ID from path parameters
@@ -39,6 +52,11 @@ func (h *Handler) HandleGetAIAnalysisLift(ctx *apptheory.Context) (*apptheory.Re
 		})
 	}
 
+	adminViewer, resp, err := h.authorizeAIAnalysisViewer(ctx, claims, objectID)
+	if resp != nil || err != nil {
+		return resp, err
+	}
+
 	// Get analysis using AI service
 	result, err := h.registry.AI().GetAnalysis(ctx.Context(), &ai.GetAnalysisQuery{
 		ObjectID: objectID,
@@ -50,7 +68,67 @@ func (h *Handler) HandleGetAIAnalysisLift(ctx *apptheory.Context) (*apptheory.Re
 	}
 
 	// Return analysis
-	return okJSON(result.Analysis)
+	analysis := result.Analysis
+	if !adminViewer {
+		analysis = originalai.RedactPIIFromAnalysis(analysis)
+	}
+	return okJSON(analysis)
+}
+
+func (h *Handler) authorizeAIAnalysisViewer(ctx *apptheory.Context, claims *auth.Claims, objectID string) (bool, *apptheory.Response, error) {
+	adminViewer, err := h.claimsUserHasAdminRole(ctx.Context(), claims)
+	if err != nil {
+		resp, respErr := common.RespondInternalServerError(ctx)
+		return false, resp, respErr
+	}
+	if adminViewer {
+		return true, nil, nil
+	}
+
+	ownerUsername, err := h.aiAnalysisOwnerUsername(ctx.Context(), objectID)
+	if err != nil {
+		resp, respErr := common.RespondInternalServerError(ctx)
+		return false, resp, respErr
+	}
+	if ownerUsername != "" && strings.EqualFold(ownerUsername, strings.TrimSpace(claims.Username)) {
+		return false, nil, nil
+	}
+	resp, respErr := common.RespondForbidden(ctx, "not authorized to view AI analysis")
+	return false, resp, respErr
+}
+
+func (h *Handler) claimsUserHasAdminRole(ctx context.Context, claims *auth.Claims) (bool, error) {
+	if claims == nil || strings.TrimSpace(claims.Username) == "" {
+		return false, nil
+	}
+	if h == nil || h.repos == nil || h.repos.Account() == nil {
+		return false, nil
+	}
+	user, err := h.repos.Account().GetUser(ctx, claims.Username)
+	if err != nil {
+		return false, err
+	}
+	return user != nil && strings.EqualFold(user.Role, roleAdmin), nil
+}
+
+func (h *Handler) aiAnalysisOwnerUsername(ctx context.Context, objectID string) (string, error) {
+	if h == nil || h.repos == nil || h.repos.Status() == nil {
+		return "", nil
+	}
+	status, err := h.repos.Status().GetStatus(ctx, objectID)
+	if err != nil {
+		if common.IsNotFound(err) || strings.Contains(strings.ToLower(err.Error()), "not found") {
+			return "", nil
+		}
+		return "", err
+	}
+	if status == nil {
+		return "", nil
+	}
+	if owner := strings.TrimSpace(status.AuthorUsername); owner != "" {
+		return owner, nil
+	}
+	return strings.TrimPrefix(strings.TrimSpace(transformations.ExtractUsernameFromActorID(status.AuthorID)), "@"), nil
 }
 
 // HandleRequestAIAnalysisLift triggers AI analysis for an object
@@ -67,6 +145,44 @@ func (h *Handler) HandleRequestAIAnalysisLift(ctx *apptheory.Context) (*apptheor
 		return common.RespondInsufficientScope(ctx, "moderation")
 	}
 
+	if resp, err := h.ensureAIAnalysisEnabled(ctx); resp != nil || err != nil {
+		return resp, err
+	}
+
+	req, resp, err := parseAIAnalysisLiftRequest(ctx)
+	if resp != nil || err != nil {
+		return resp, err
+	}
+
+	// Queue for analysis using AI service
+	queueResult, err := h.registry.AI().QueueForAnalysis(ctx.Context(), &ai.QueueAnalysisCommand{
+		ObjectID:   req.ObjectID,
+		ObjectType: req.ObjectType,
+		Force:      req.Force,
+	})
+	if err != nil {
+		return apptheory.JSON(http.StatusInternalServerError, map[string]string{
+			"error": "failed to queue analysis",
+		})
+	}
+
+	// If not queued (already exists), return existing
+	if !queueResult.Queued {
+		if resp, err := h.existingAIAnalysisResponse(ctx, claims, req.ObjectID); resp != nil || err != nil {
+			return resp, err
+		}
+	}
+
+	response := map[string]any{
+		"message":        "Analysis queued",
+		"object_id":      req.ObjectID,
+		"estimated_time": "10-30 seconds",
+	}
+
+	return apptheory.JSON(http.StatusAccepted, response)
+}
+
+func (h *Handler) ensureAIAnalysisEnabled(ctx *apptheory.Context) (*apptheory.Response, error) {
 	if h.repos != nil && h.repos.Instance() != nil {
 		exists, err := h.repos.Instance().AIConfigExists(ctx.Context())
 		if err != nil {
@@ -88,59 +204,50 @@ func (h *Handler) HandleRequestAIAnalysisLift(ctx *apptheory.Context) (*apptheor
 			}
 		}
 	}
+	return nil, nil
+}
 
-	var req struct {
-		ObjectID   string `json:"object_id"`
-		ObjectType string `json:"object_type"`
-		Force      bool   `json:"force"` // Force re-analysis
-	}
-
+func parseAIAnalysisLiftRequest(ctx *apptheory.Context) (*aiAnalysisLiftRequest, *apptheory.Response, error) {
+	var req aiAnalysisLiftRequest
 	if err := common.ParseRequestWithFallback(ctx, &req); err != nil {
 		// Fallback for test environments / missing content-type
 		if len(ctx.Request.Body) == 0 {
-			return apptheory.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+			resp, respErr := apptheory.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+			return nil, resp, respErr
 		}
 		if err := json.Unmarshal(ctx.Request.Body, &req); err != nil {
-			return apptheory.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+			resp, respErr := apptheory.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+			return nil, resp, respErr
 		}
 	}
 
 	if err := common.ValidateRequiredParam("object_id", req.ObjectID); err != nil {
-		return apptheory.JSON(http.StatusBadRequest, map[string]string{
+		resp, respErr := apptheory.JSON(http.StatusBadRequest, map[string]string{
 			"error": err.Error(),
 		})
+		return nil, resp, respErr
 	}
 
-	// Queue for analysis using AI service
-	queueResult, err := h.registry.AI().QueueForAnalysis(ctx.Context(), &ai.QueueAnalysisCommand{
-		ObjectID:   req.ObjectID,
-		ObjectType: req.ObjectType,
-		Force:      req.Force,
+	return &req, nil, nil
+}
+
+func (h *Handler) existingAIAnalysisResponse(ctx *apptheory.Context, claims *auth.Claims, objectID string) (*apptheory.Response, error) {
+	result, _ := h.registry.AI().GetAnalysis(ctx.Context(), &ai.GetAnalysisQuery{
+		ObjectID: objectID,
 	})
-	if err != nil {
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{
-			"error": "failed to queue analysis",
-		})
+	if result == nil || result.Analysis == nil {
+		return nil, nil
 	}
 
-	// If not queued (already exists), return existing
-	if !queueResult.Queued {
-		// Get the existing analysis
-		result, _ := h.registry.AI().GetAnalysis(ctx.Context(), &ai.GetAnalysisQuery{
-			ObjectID: req.ObjectID,
-		})
-		if result != nil && result.Analysis != nil {
-			return okJSON(result.Analysis)
-		}
+	adminViewer, resp, err := h.authorizeAIAnalysisViewer(ctx, claims, objectID)
+	if resp != nil || err != nil {
+		return resp, err
 	}
-
-	response := map[string]any{
-		"message":        "Analysis queued",
-		"object_id":      req.ObjectID,
-		"estimated_time": "10-30 seconds",
+	analysis := result.Analysis
+	if !adminViewer {
+		analysis = originalai.RedactPIIFromAnalysis(analysis)
 	}
-
-	return apptheory.JSON(http.StatusAccepted, response)
+	return okJSON(analysis)
 }
 
 // HandleGetAIStatsLift returns AI analysis statistics

--- a/cmd/api/handlers/ai_round12_coverage_test.go
+++ b/cmd/api/handlers/ai_round12_coverage_test.go
@@ -10,14 +10,28 @@ import (
 	originalai "github.com/equaltoai/lesser/pkg/ai"
 	"github.com/equaltoai/lesser/pkg/auth"
 	aisvc "github.com/equaltoai/lesser/pkg/services/ai"
+	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/require"
 )
 
 func TestAI_Round12_GetAIAnalysis_Coverage(t *testing.T) {
 	cfg := round11TestConfig()
 	readToken := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{auth.ScopeRead})
+	adminToken := round11SignAccessToken(t, cfg.JWTSecret, "admin", []string{auth.ScopeAdmin})
+	writeToken := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{auth.ScopeWrite})
 
-	handler, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
+	handler, _, _ := round11NewHandler(t, cfg, &round10QueryState{
+		usersByUsername: map[string]storagemodels.User{
+			"alice": {Username: "alice", Role: "user", Approved: true, Version: 1},
+			"admin": {Username: "admin", Role: roleAdmin, Approved: true, Version: 1},
+			"bob":   {Username: "bob", Role: "user", Approved: true, Version: 1},
+		},
+		statusByID: map[string]storagemodels.Status{
+			"abc":             {StatusID: "abc", AuthorUsername: "alice", AuthorID: "https://example.com/users/alice"},
+			"test-object-123": {StatusID: "test-object-123", AuthorUsername: "alice", AuthorID: "https://example.com/users/alice"},
+			"missing":         {StatusID: "missing", AuthorUsername: "alice", AuthorID: "https://example.com/users/alice"},
+		},
+	})
 	handler.registry = &RegistryStub{
 		AISvc: &AIServiceStub{
 			GetAnalysisFunc: func(ctx context.Context, query *aisvc.GetAnalysisQuery) (*aisvc.GetAnalysisResult, error) {
@@ -25,7 +39,20 @@ func TestAI_Round12_GetAIAnalysis_Coverage(t *testing.T) {
 					return nil, stdErrors.New("not found")
 				}
 				return &aisvc.GetAnalysisResult{
-					Analysis: &originalai.AIAnalysis{ObjectID: query.ObjectID, OverallRisk: 0.9},
+					Analysis: &originalai.AIAnalysis{
+						ObjectID:    query.ObjectID,
+						OverallRisk: 0.9,
+						TextAnalysis: &originalai.TextAnalysis{
+							ContainsPII: true,
+							PIIEntities: []originalai.PIIEntity{{
+								Type:        originalai.PiiEmail,
+								Text:        "alice@example.com",
+								Score:       0.99,
+								BeginOffset: 0,
+								EndOffset:   17,
+							}},
+						},
+					},
 				}, nil
 			},
 		},
@@ -48,6 +75,16 @@ func TestAI_Round12_GetAIAnalysis_Coverage(t *testing.T) {
 		var body map[string]any
 		require.NoError(t, json.Unmarshal(resp.Body, &body))
 		require.Equal(t, "invalid_token", body["error"])
+	})
+
+	t.Run("insufficient_scope", func(t *testing.T) {
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/ai/analysis/abc", map[string]string{
+			"Authorization": "Bearer " + writeToken,
+		}, nil, nil)
+		require.NoError(t, err)
+		ctx.Params["object_id"] = "abc"
+
+		requireStatus(t, http.StatusForbidden)(handler.HandleGetAIAnalysisLift(ctx))
 	})
 
 	t.Run("extracts_object_id_from_path_when_param_missing", func(t *testing.T) {
@@ -73,7 +110,35 @@ func TestAI_Round12_GetAIAnalysis_Coverage(t *testing.T) {
 		require.NoError(t, err)
 		ctx.Params["object_id"] = "abc"
 
-		requireStatus(t, http.StatusOK)(handler.HandleGetAIAnalysisLift(ctx))
+		resp := requireStatus(t, http.StatusOK)(handler.HandleGetAIAnalysisLift(ctx))
+		var body originalai.AIAnalysis
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Len(t, body.TextAnalysis.PIIEntities, 1)
+		require.Empty(t, body.TextAnalysis.PIIEntities[0].Text)
+	})
+
+	t.Run("admin sees pii text", func(t *testing.T) {
+		headers := map[string]string{"Authorization": "Bearer " + adminToken}
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/ai/analysis/abc", headers, nil, nil)
+		require.NoError(t, err)
+		ctx.Params["object_id"] = "abc"
+
+		resp := requireStatus(t, http.StatusOK)(handler.HandleGetAIAnalysisLift(ctx))
+		var body originalai.AIAnalysis
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Len(t, body.TextAnalysis.PIIEntities, 1)
+		require.Equal(t, "alice@example.com", body.TextAnalysis.PIIEntities[0].Text)
+	})
+
+	t.Run("non_owner_forbidden", func(t *testing.T) {
+		bobToken := round11SignAccessToken(t, cfg.JWTSecret, "bob", []string{auth.ScopeRead})
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/ai/analysis/abc", map[string]string{
+			"Authorization": "Bearer " + bobToken,
+		}, nil, nil)
+		require.NoError(t, err)
+		ctx.Params["object_id"] = "abc"
+
+		requireStatus(t, http.StatusForbidden)(handler.HandleGetAIAnalysisLift(ctx))
 	})
 }
 
@@ -95,7 +160,21 @@ func TestAI_Round12_RequestAIAnalysis_Coverage(t *testing.T) {
 			},
 			GetAnalysisFunc: func(ctx context.Context, query *aisvc.GetAnalysisQuery) (*aisvc.GetAnalysisResult, error) {
 				if query.ObjectID == "already" {
-					return &aisvc.GetAnalysisResult{Analysis: &originalai.AIAnalysis{ObjectID: "already"}}, nil
+					return &aisvc.GetAnalysisResult{
+						Analysis: &originalai.AIAnalysis{
+							ObjectID: "already",
+							TextAnalysis: &originalai.TextAnalysis{
+								ContainsPII: true,
+								PIIEntities: []originalai.PIIEntity{{
+									Type:        originalai.PiiEmail,
+									Text:        "alice@example.com",
+									Score:       0.99,
+									BeginOffset: 0,
+									EndOffset:   17,
+								}},
+							},
+						},
+					}, nil
 				}
 				return nil, stdErrors.New("not found")
 			},
@@ -166,7 +245,19 @@ func TestAI_Round12_RequestAIAnalysis_Coverage(t *testing.T) {
 		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/ai/analyze", map[string]string{"Authorization": "Bearer " + modToken}, nil, map[string]any{"object_id": "already"})
 		require.NoError(t, err)
 
-		requireStatus(t, http.StatusOK)(handler.HandleRequestAIAnalysisLift(ctx))
+		resp := requireStatus(t, http.StatusOK)(handler.HandleRequestAIAnalysisLift(ctx))
+		var body originalai.AIAnalysis
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Len(t, body.TextAnalysis.PIIEntities, 1)
+		require.Empty(t, body.TextAnalysis.PIIEntities[0].Text)
+	})
+
+	t.Run("already_exists_non_owner_forbidden", func(t *testing.T) {
+		modToken := round11SignAccessToken(t, cfg.JWTSecret, "bob", []string{"moderation"})
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/ai/analyze", map[string]string{"Authorization": "Bearer " + modToken}, nil, map[string]any{"object_id": "already"})
+		require.NoError(t, err)
+
+		requireStatus(t, http.StatusForbidden)(handler.HandleRequestAIAnalysisLift(ctx))
 	})
 
 	t.Run("ok_queued", func(t *testing.T) {
@@ -176,6 +267,93 @@ func TestAI_Round12_RequestAIAnalysis_Coverage(t *testing.T) {
 
 		requireStatus(t, http.StatusAccepted)(handler.HandleRequestAIAnalysisLift(ctx))
 	})
+}
+
+func TestAI_Round12_RequestAIAnalysisHelpers_Coverage(t *testing.T) {
+	cfg := round11TestConfig()
+
+	t.Run("parse_helper_success", func(t *testing.T) {
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/api/v1/ai/analyze", nil, nil, []byte(`{"object_id":"abc","object_type":"status","force":true}`))
+
+		req, resp, err := parseAIAnalysisLiftRequest(ctx)
+		require.NoError(t, err)
+		require.Nil(t, resp)
+		require.Equal(t, "abc", req.ObjectID)
+		require.Equal(t, "status", req.ObjectType)
+		require.True(t, req.Force)
+	})
+
+	t.Run("parse_helper_empty_body", func(t *testing.T) {
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/api/v1/ai/analyze", nil, nil, nil)
+
+		req, resp, err := parseAIAnalysisLiftRequest(ctx)
+		require.Nil(t, req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.Status)
+	})
+
+	t.Run("parse_helper_missing_object_id", func(t *testing.T) {
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/api/v1/ai/analyze", nil, nil, []byte(`{"object_id":""}`))
+
+		req, resp, err := parseAIAnalysisLiftRequest(ctx)
+		require.Nil(t, req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.Status)
+	})
+
+	t.Run("existing_response_absent_returns_nil", func(t *testing.T) {
+		handler, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
+		handler.registry = &RegistryStub{
+			AISvc: &AIServiceStub{
+				GetAnalysisFunc: func(ctx context.Context, query *aisvc.GetAnalysisQuery) (*aisvc.GetAnalysisResult, error) {
+					return nil, nil
+				},
+			},
+		}
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/api/v1/ai/analyze", nil, nil, []byte(`{"object_id":"abc"}`))
+
+		resp, err := handler.existingAIAnalysisResponse(ctx, &auth.Claims{Username: "alice"}, "abc")
+		require.NoError(t, err)
+		require.Nil(t, resp)
+	})
+}
+
+func TestAI_Round12_AuthorizationHelpers_Coverage(t *testing.T) {
+	ctx := context.Background()
+	var nilHandler *Handler
+
+	admin, err := nilHandler.claimsUserHasAdminRole(ctx, nil)
+	require.NoError(t, err)
+	require.False(t, admin)
+
+	admin, err = (&Handler{}).claimsUserHasAdminRole(ctx, &auth.Claims{Username: "alice"})
+	require.NoError(t, err)
+	require.False(t, admin)
+
+	owner, err := (&Handler{}).aiAnalysisOwnerUsername(ctx, "status-1")
+	require.NoError(t, err)
+	require.Empty(t, owner)
+
+	cfg := round11TestConfig()
+	handler, _, _ := round11NewHandler(t, cfg, &round10QueryState{
+		statusByID: map[string]storagemodels.Status{
+			"actor-id-only": {
+				StatusID: "actor-id-only",
+				AuthorID: "https://example.com/users/carol",
+			},
+		},
+	})
+	owner, err = handler.aiAnalysisOwnerUsername(ctx, "actor-id-only")
+	require.NoError(t, err)
+	require.Equal(t, "carol", owner)
+
+	liftCtx, err := round10NewLiftContext(http.MethodGet, "/api/v1/ai/analysis/status-1", nil, nil, nil)
+	require.NoError(t, err)
+	adminViewer, resp, err := (&Handler{}).authorizeAIAnalysisViewer(liftCtx, &auth.Claims{Username: "alice"}, "status-1")
+	require.NoError(t, err)
+	require.False(t, adminViewer)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusForbidden, resp.Status)
 }
 
 func TestAI_Round12_GetAIStatsAndSummary_Coverage(t *testing.T) {

--- a/cmd/api/handlers/lesser_host_trust_proxy.go
+++ b/cmd/api/handlers/lesser_host_trust_proxy.go
@@ -630,7 +630,7 @@ func (h *Handler) HandleTrustGetLinkPreviewLift(ctx *apptheory.Context) (*appthe
 }
 
 // HandleTrustGetLinkPreviewImageLift proxies GET /api/v1/trust/previews/images/{imageId} to lesser-host.
-// This endpoint is public (no user auth) so that image URLs can be loaded by <img> tags.
+// This endpoint requires a user read token; user tokens are never forwarded upstream.
 func (h *Handler) HandleTrustGetLinkPreviewImageLift(ctx *apptheory.Context) (*apptheory.Response, error) {
 	imageID := strings.TrimSpace(ctx.Param("imageId"))
 	if imageID == "" {
@@ -641,7 +641,7 @@ func (h *Handler) HandleTrustGetLinkPreviewImageLift(ctx *apptheory.Context) (*a
 		baseURL:             h.effectiveLesserHostTrustBaseURL(ctx.Context()),
 		path:                "/api/v1/previews/images/" + url.PathEscape(imageID),
 		accept:              "*/*",
-		requiredScope:       "",
+		requiredScope:       auth.ScopeRead,
 		useInstanceAuth:     false,
 		rewriteResponseURLs: false,
 	})
@@ -704,7 +704,7 @@ func (h *Handler) HandleTrustGetRenderLift(ctx *apptheory.Context) (*apptheory.R
 }
 
 // HandleTrustGetRenderThumbnailLift proxies GET /api/v1/trust/renders/{renderId}/thumbnail to lesser-host.
-// This endpoint is public (no user auth) so thumbnail URLs can be loaded by <img> tags.
+// This endpoint requires a user read token; user tokens are never forwarded upstream.
 func (h *Handler) HandleTrustGetRenderThumbnailLift(ctx *apptheory.Context) (*apptheory.Response, error) {
 	renderID := strings.TrimSpace(ctx.Param("renderId"))
 	if renderID == "" {
@@ -715,7 +715,7 @@ func (h *Handler) HandleTrustGetRenderThumbnailLift(ctx *apptheory.Context) (*ap
 		baseURL:             h.effectiveLesserHostTrustBaseURL(ctx.Context()),
 		path:                "/api/v1/renders/" + url.PathEscape(renderID) + "/thumbnail",
 		accept:              "*/*",
-		requiredScope:       "",
+		requiredScope:       auth.ScopeRead,
 		useInstanceAuth:     false,
 		rewriteResponseURLs: false,
 	})
@@ -772,7 +772,7 @@ func (h *Handler) HandleTrustJWKSJSONLift(ctx *apptheory.Context) (*apptheory.Re
 		method:              http.MethodGet,
 		baseURL:             h.effectiveLesserHostAttestationsBaseURL(ctx.Context()),
 		path:                "/.well-known/jwks.json",
-		requiredScope:       "",
+		requiredScope:       auth.ScopeRead,
 		useInstanceAuth:     false,
 		rewriteResponseURLs: false,
 	})
@@ -784,7 +784,7 @@ func (h *Handler) HandleTrustLookupAttestationLift(ctx *apptheory.Context) (*app
 		method:              http.MethodGet,
 		baseURL:             h.effectiveLesserHostAttestationsBaseURL(ctx.Context()),
 		path:                "/attestations",
-		requiredScope:       "",
+		requiredScope:       auth.ScopeRead,
 		useInstanceAuth:     false,
 		rewriteResponseURLs: false,
 	})
@@ -800,7 +800,7 @@ func (h *Handler) HandleTrustGetAttestationLift(ctx *apptheory.Context) (*appthe
 		method:              http.MethodGet,
 		baseURL:             h.effectiveLesserHostAttestationsBaseURL(ctx.Context()),
 		path:                "/attestations/" + url.PathEscape(id),
-		requiredScope:       "",
+		requiredScope:       auth.ScopeRead,
 		useInstanceAuth:     false,
 		rewriteResponseURLs: false,
 	})

--- a/cmd/api/handlers/lesser_host_trust_proxy_round20_test.go
+++ b/cmd/api/handlers/lesser_host_trust_proxy_round20_test.go
@@ -93,7 +93,10 @@ func TestLesserHostTrustProxyRound20(t *testing.T) {
 
 		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
 
-		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/trust/attestations", nil, map[string]string{
+		readToken := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{auth.ScopeRead})
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/trust/attestations", map[string]string{
+			"Authorization": "Bearer " + readToken,
+		}, map[string]string{
 			"actor_uri":      "https://example.com/users/alice",
 			"object_uri":     "https://example.com/objects/1",
 			"content_hash":   "0xdeadbeef",
@@ -204,7 +207,7 @@ func TestLesserHostTrustProxyRound20(t *testing.T) {
 		require.Equal(t, "/api/v1/trust/attestations/"+attestationID, got["attestation_url"])
 	})
 
-	t.Run("public_preview_image_proxies_without_user_auth_or_instance_auth", func(t *testing.T) {
+	t.Run("preview_image_requires_user_auth_and_does_not_forward_it", func(t *testing.T) {
 		const imageID = "img123"
 
 		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -225,6 +228,17 @@ func TestLesserHostTrustProxyRound20(t *testing.T) {
 		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
 
 		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/trust/previews/images/"+imageID, nil, nil, nil)
+		require.NoError(t, err)
+		ctx.Params["imageId"] = imageID
+
+		proxyResp, err := h.HandleTrustGetLinkPreviewImageLift(ctx)
+		require.Nil(t, proxyResp)
+		require.Error(t, err)
+
+		readToken := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{auth.ScopeRead})
+		ctx, err = round10NewLiftContext(http.MethodGet, "/api/v1/trust/previews/images/"+imageID, map[string]string{
+			"Authorization": "Bearer " + readToken,
+		}, nil, nil)
 		require.NoError(t, err)
 		ctx.Params["imageId"] = imageID
 
@@ -329,7 +343,7 @@ func TestLesserHostTrustProxyRound20(t *testing.T) {
 		require.Equal(t, "/api/v1/trust/previews/images/"+imageID, got["image_url"])
 	})
 
-	t.Run("public_thumbnail_and_authenticated_snapshot_proxy_binary_responses", func(t *testing.T) {
+	t.Run("thumbnail_and_snapshot_require_user_auth_for_binary_responses", func(t *testing.T) {
 		const (
 			instanceKey = "instance-key-raw"
 			renderID    = "render123"
@@ -365,11 +379,21 @@ func TestLesserHostTrustProxyRound20(t *testing.T) {
 		require.NoError(t, err)
 		thumbCtx.Params["renderId"] = renderID
 
+		proxyResp, err := h.HandleTrustGetRenderThumbnailLift(thumbCtx)
+		require.Nil(t, proxyResp)
+		require.Error(t, err)
+
+		readToken := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{auth.ScopeRead})
+		thumbCtx, err = round10NewLiftContext(http.MethodGet, "/api/v1/trust/renders/"+renderID+"/thumbnail", map[string]string{
+			"Authorization": "Bearer " + readToken,
+		}, nil, nil)
+		require.NoError(t, err)
+		thumbCtx.Params["renderId"] = renderID
+
 		thumbResp := requireStatus(t, http.StatusOK)(h.HandleTrustGetRenderThumbnailLift(thumbCtx))
 		require.Equal(t, []string{"image/png"}, thumbResp.Headers["content-type"])
 		require.Equal(t, []byte{0x01, 0x02, 0x03}, thumbResp.Body)
 
-		readToken := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{auth.ScopeRead})
 		snapCtx, err := round10NewLiftContext(http.MethodGet, "/api/v1/trust/renders/"+renderID+"/snapshot", map[string]string{
 			"Authorization": "Bearer " + readToken,
 		}, nil, nil)
@@ -464,11 +488,15 @@ func TestLesserHostTrustProxyRound20(t *testing.T) {
 		getAIJobCtx.Params["jobId"] = "j1"
 		requireStatus(t, http.StatusOK)(h.HandleTrustGetAIJobLift(getAIJobCtx))
 
-		jwksCtx, err := round10NewLiftContext(http.MethodGet, "/api/v1/trust/jwks.json", nil, nil, nil)
+		jwksCtx, err := round10NewLiftContext(http.MethodGet, "/api/v1/trust/jwks.json", map[string]string{
+			"Authorization": "Bearer " + readToken,
+		}, nil, nil)
 		require.NoError(t, err)
 		requireStatus(t, http.StatusOK)(h.HandleTrustJWKSJSONLift(jwksCtx))
 
-		attCtx, err := round10NewLiftContext(http.MethodGet, "/api/v1/trust/attestations/"+attestationID, nil, nil, nil)
+		attCtx, err := round10NewLiftContext(http.MethodGet, "/api/v1/trust/attestations/"+attestationID, map[string]string{
+			"Authorization": "Bearer " + readToken,
+		}, nil, nil)
 		require.NoError(t, err)
 		attCtx.Params["id"] = attestationID
 		requireStatus(t, http.StatusOK)(h.HandleTrustGetAttestationLift(attCtx))
@@ -484,6 +512,25 @@ func TestLesserHostTrustProxyRound20(t *testing.T) {
 		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/api/v1/trust/publish/jobs", nil, nil, []byte(`{"object_uri":"https://example.com/objects/1"}`))
 
 		resp, err := h.HandleTrustCreatePublishJobLift(ctx)
+		require.Nil(t, resp)
+		require.Error(t, err)
+
+		ctx2, err := round10NewLiftContext(http.MethodGet, "/api/v1/trust/jwks.json", nil, nil, nil)
+		require.NoError(t, err)
+		resp, err = h.HandleTrustJWKSJSONLift(ctx2)
+		require.Nil(t, resp)
+		require.Error(t, err)
+
+		ctx3, err := round10NewLiftContext(http.MethodGet, "/api/v1/trust/attestations", nil, nil, nil)
+		require.NoError(t, err)
+		resp, err = h.HandleTrustLookupAttestationLift(ctx3)
+		require.Nil(t, resp)
+		require.Error(t, err)
+
+		ctx4, err := round10NewLiftContext(http.MethodGet, "/api/v1/trust/attestations/att-1", nil, nil, nil)
+		require.NoError(t, err)
+		ctx4.Params["id"] = "att-1"
+		resp, err = h.HandleTrustGetAttestationLift(ctx4)
 		require.Nil(t, resp)
 		require.Error(t, err)
 	})
@@ -649,6 +696,19 @@ func TestLesserHostTrustProxyHelpersRound20(t *testing.T) {
 		require.Nil(t, req)
 		require.NotNil(t, resp)
 		require.Equal(t, http.StatusServiceUnavailable, resp.Status)
+	})
+
+	t.Run("empty_scope_and_nil_logger_helpers", func(t *testing.T) {
+		cfg := round11TestConfig()
+		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
+		ctx, err := round10NewLiftContext(http.MethodGet, "/x", nil, nil, nil)
+		require.NoError(t, err)
+
+		require.NoError(t, h.ensureLesserHostProxyScope(ctx, "  "))
+
+		var nilHandler *Handler
+		nilHandler.warnTrustProxyMisconfigured("ignored")
+		(&Handler{}).warnTrustProxyMisconfigured("ignored")
 	})
 
 	t.Run("content_type_normalization", func(t *testing.T) {

--- a/cmd/api/handlers/lesser_host_trust_proxy_round20_test.go
+++ b/cmd/api/handlers/lesser_host_trust_proxy_round20_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/stretchr/testify/require"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
 )
 
 func allowLocalLesserHostProxyForTests(t *testing.T) {
@@ -275,6 +276,33 @@ func TestLesserHostTrustProxyRound20(t *testing.T) {
 		require.NoError(t, err)
 
 		requireStatus(t, http.StatusBadRequest)(h.HandleTrustGetRenderThumbnailLift(ctx))
+	})
+
+	t.Run("missing_asset_ids_return_400_before_proxy", func(t *testing.T) {
+		cfg := round11TestConfig()
+		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
+
+		cases := []struct {
+			name    string
+			path    string
+			handler func(*apptheory.Context) (*apptheory.Response, error)
+		}{
+			{name: "preview", path: "/api/v1/trust/previews/", handler: h.HandleTrustGetLinkPreviewLift},
+			{name: "preview_image", path: "/api/v1/trust/previews/images/", handler: h.HandleTrustGetLinkPreviewImageLift},
+			{name: "publish_job", path: "/api/v1/trust/publish/jobs/", handler: h.HandleTrustGetPublishJobLift},
+			{name: "render", path: "/api/v1/trust/renders/", handler: h.HandleTrustGetRenderLift},
+			{name: "render_snapshot", path: "/api/v1/trust/renders//snapshot", handler: h.HandleTrustGetRenderSnapshotLift},
+			{name: "attestation", path: "/api/v1/trust/attestations/", handler: h.HandleTrustGetAttestationLift},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				ctx, err := round10NewLiftContext(http.MethodGet, tc.path, nil, nil, nil)
+				require.NoError(t, err)
+
+				requireStatus(t, http.StatusBadRequest)(tc.handler(ctx))
+			})
+		}
 	})
 
 	t.Run("missing_job_id_returns_400", func(t *testing.T) {

--- a/cmd/api/handlers/oauth.go
+++ b/cmd/api/handlers/oauth.go
@@ -1296,11 +1296,13 @@ func buildAuthorizationCodeRefreshToken(now time.Time, refreshToken, clientID st
 		return oauthRefreshToken
 	}
 
-	absoluteExpiry := now.Add(auth.AgentRuntimeRefreshAbsoluteTTL)
-	idleExpiry := now.Add(auth.AgentRuntimeRefreshIdleTTL)
-	if idleExpiry.After(absoluteExpiry) {
-		idleExpiry = absoluteExpiry
+	refreshIdleTTL := time.Duration(0)
+	refreshAbsoluteTTL := time.Duration(0)
+	if clientID == delegatedAgentClientID && accessTTL > 0 {
+		refreshIdleTTL = accessTTL
+		refreshAbsoluteTTL = accessTTL
 	}
+	idleExpiry, absoluteExpiry := auth.AgentRuntimeRefreshExpiries(now, refreshIdleTTL, refreshAbsoluteTTL)
 
 	oauthRefreshToken.ExpiresAt = idleExpiry
 	oauthRefreshToken.FamilyID = common.GenerateSessionIDULID()

--- a/cmd/api/handlers/oauth_agent_binding.go
+++ b/cmd/api/handlers/oauth_agent_binding.go
@@ -6,6 +6,25 @@ import (
 	"github.com/equaltoai/lesser/pkg/storage"
 )
 
+func (h *Handler) agentOwnerMatchesLocalPrincipal(owner string, principalUsername string) bool {
+	principalUsername = strings.TrimSpace(principalUsername)
+	owner = strings.TrimSpace(owner)
+	if principalUsername == "" || owner == "" {
+		return false
+	}
+
+	lowerOwner := strings.ToLower(owner)
+	if strings.HasPrefix(lowerOwner, "http://") || strings.HasPrefix(lowerOwner, "https://") {
+		return h != nil && h.cfg != nil && strings.EqualFold(owner, h.cfg.ActorURL(principalUsername))
+	}
+
+	owner = strings.TrimPrefix(owner, "@")
+	if strings.Contains(owner, "/") {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(owner), principalUsername)
+}
+
 func (h *Handler) agentOwnedByPrincipal(agentUser *storage.User, principalUsername string) bool {
 	if agentUser == nil || !agentUser.IsAgent {
 		return false
@@ -21,16 +40,5 @@ func (h *Handler) agentOwnedByPrincipal(agentUser *storage.User, principalUserna
 		return false
 	}
 
-	if h != nil && h.cfg != nil {
-		normalizedOwner := h.normalizeDelegatedByActorURI(owner)
-		if strings.EqualFold(normalizedOwner, h.cfg.ActorURL(principalUsername)) {
-			return true
-		}
-	}
-
-	owner = strings.TrimPrefix(owner, "@")
-	if idx := strings.LastIndex(owner, "/users/"); idx >= 0 {
-		owner = owner[idx+len("/users/"):]
-	}
-	return strings.EqualFold(strings.TrimSpace(owner), principalUsername)
+	return h.agentOwnerMatchesLocalPrincipal(owner, principalUsername)
 }

--- a/cmd/api/handlers/oauth_agent_binding_round14_test.go
+++ b/cmd/api/handlers/oauth_agent_binding_round14_test.go
@@ -25,9 +25,9 @@ func TestAgentOwnedByPrincipalRound14(t *testing.T) {
 		AgentOwner: "@alice",
 	}, "alice"))
 
-	require.True(t, h.agentOwnedByPrincipal(&storage.User{
+	require.False(t, h.agentOwnedByPrincipal(&storage.User{
 		IsAgent:    true,
-		AgentOwner: "https://example.com/users/alice",
+		AgentOwner: "https://remote.example/users/alice",
 	}, "alice"))
 
 	require.False(t, h.agentOwnedByPrincipal(&storage.User{

--- a/cmd/api/handlers/oauth_round13_helper_coverage_test.go
+++ b/cmd/api/handlers/oauth_round13_helper_coverage_test.go
@@ -132,8 +132,9 @@ func TestBuildAuthorizationCodeRefreshToken(t *testing.T) {
 	require.Equal(t, "runtime-app", runtimeToken.DeviceLabel)
 	require.Equal(t, int((45 * time.Minute).Seconds()), runtimeToken.AccessTTLSeconds)
 	require.WithinDuration(t, now, runtimeToken.SessionCreatedAt, time.Second)
-	require.WithinDuration(t, now.Add(auth.AgentRuntimeRefreshAbsoluteTTL), runtimeToken.AbsoluteExpiresAt, time.Second)
-	require.WithinDuration(t, now.Add(auth.AgentRuntimeRefreshIdleTTL), runtimeToken.IdleExpiresAt, time.Second)
+	require.WithinDuration(t, now.Add(45*time.Minute), runtimeToken.AbsoluteExpiresAt, time.Second)
+	require.WithinDuration(t, now.Add(45*time.Minute), runtimeToken.IdleExpiresAt, time.Second)
+	require.WithinDuration(t, runtimeToken.AbsoluteExpiresAt, runtimeToken.ExpiresAt, time.Second)
 }
 
 func TestOAuthDeviceApprovedTokenContext(t *testing.T) {

--- a/cmd/api/handlers/round11_webfinger_mutes_ai_endorsements_test.go
+++ b/cmd/api/handlers/round11_webfinger_mutes_ai_endorsements_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/services/ai"
 	relationshipsvc "github.com/equaltoai/lesser/pkg/services/relationships"
 	"github.com/equaltoai/lesser/pkg/storage"
+	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/require"
 )
 
@@ -170,7 +171,17 @@ func TestAILift_Flows(t *testing.T) {
 		},
 	}
 
-	h := &Handler{cfg: cfg, logger: logger, registry: registry}
+	h, _, _ := round11NewHandler(t, cfg, &round10QueryState{
+		usersByUsername: map[string]storagemodels.User{
+			"alice": {Username: "alice", Role: "user", Approved: true, Version: 1},
+			"admin": {Username: "admin", Role: roleAdmin, Approved: true, Version: 1},
+		},
+		statusByID: map[string]storagemodels.Status{
+			"obj-123": {StatusID: "obj-123", AuthorUsername: "alice", AuthorID: "https://example.com/users/alice"},
+		},
+	})
+	h.logger = logger
+	h.registry = registry
 
 	token := round10SignAccessToken(t, cfg.JWTSecret, "alice")
 	ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/ai/analysis/obj-123", map[string]string{
@@ -180,7 +191,7 @@ func TestAILift_Flows(t *testing.T) {
 	ctx.Params["object_id"] = "obj-123"
 	requireStatus(t, http.StatusOK)(h.HandleGetAIAnalysisLift(ctx))
 
-	moderationToken := round11SignAccessToken(t, cfg.JWTSecret, "mod", []string{"moderation"})
+	moderationToken := round11SignAccessToken(t, cfg.JWTSecret, "admin", []string{"moderation"})
 	ctx2, err := round10NewLiftContext(http.MethodPost, "/api/v1/ai/analyze", map[string]string{
 		"Authorization": "Bearer " + moderationToken,
 	}, nil, map[string]any{"object_id": "obj-123", "object_type": "status"})

--- a/cmd/api/handlers/souls_test.go
+++ b/cmd/api/handlers/souls_test.go
@@ -519,6 +519,42 @@ func TestSoulHandlerHelpers_ServiceResolutionAndErrorMapping(t *testing.T) {
 	requireStatus(t, http.StatusInternalServerError)(h.respondSoulServiceError(ctx, errors.New("boom")))
 }
 
+func TestSoulAvatarConversionIncludesStyles(t *testing.T) {
+	t.Parallel()
+
+	styleID := 7
+	avatar := toAPISoulAvatar(&soulservice.SoulAvatar{
+		TokenURI:               "ipfs://avatar",
+		Image:                  "https://cdn.example/avatar.png",
+		CurrentStyleID:         &styleID,
+		CurrentStyleName:       "classic",
+		CurrentRendererAddress: "0xrenderer",
+		Styles: []soulservice.SoulAvatarStyle{
+			{
+				StyleID:         styleID,
+				StyleName:       "classic",
+				RendererAddress: "0xrenderer",
+				Image:           "https://cdn.example/classic.png",
+				Selected:        true,
+			},
+		},
+	})
+
+	require.NotNil(t, avatar)
+	require.Equal(t, "ipfs://avatar", avatar.TokenURI)
+	require.Equal(t, "https://cdn.example/avatar.png", avatar.Image)
+	require.NotNil(t, avatar.CurrentStyleID)
+	require.Equal(t, styleID, *avatar.CurrentStyleID)
+	require.Equal(t, "classic", avatar.CurrentStyleName)
+	require.Equal(t, "0xrenderer", avatar.CurrentRendererAddress)
+	require.Len(t, avatar.Styles, 1)
+	require.Equal(t, styleID, avatar.Styles[0].StyleID)
+	require.Equal(t, "classic", avatar.Styles[0].StyleName)
+	require.Equal(t, "0xrenderer", avatar.Styles[0].RendererAddress)
+	require.Equal(t, "https://cdn.example/classic.png", avatar.Styles[0].Image)
+	require.True(t, avatar.Styles[0].Selected)
+}
+
 func TestHandleGetMySoulsLift_ReturnsInternalWhenServiceUnavailable(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/inbox/internal/routing/main_round10_coverage_test.go
+++ b/cmd/inbox/internal/routing/main_round10_coverage_test.go
@@ -178,11 +178,11 @@ func TestInboxHandler_Round10_GetAndValidationPaths(t *testing.T) {
 		require.False(t, env.handler.isRequestSuccessful(assertErr{}, 200))
 		require.NotEmpty(t, env.handler.parseRemoteInstance("Mastodon/4.0.0"))
 
-			require.Equal(t, "alice", extractLocalUsernameFromURLPath("/users/alice"))
-			require.Equal(t, "", extractLocalUsernameFromURLPath(""))
-			require.Equal(t, "profile", extractLocalUsernameFromURLPath("/profile"))
-			require.Equal(t, "carol", extractLocalUsernameFromURLPath("/users/carol/inbox"))
-			require.Equal(t, "", headerValue(nil, ""))
+		require.Equal(t, "alice", extractLocalUsernameFromURLPath("/users/alice"))
+		require.Equal(t, "", extractLocalUsernameFromURLPath(""))
+		require.Equal(t, "profile", extractLocalUsernameFromURLPath("/profile"))
+		require.Equal(t, "carol", extractLocalUsernameFromURLPath("/users/carol/inbox"))
+		require.Equal(t, "", headerValue(nil, ""))
 	})
 }
 

--- a/graph/actor_tip_resolvers.go
+++ b/graph/actor_tip_resolvers.go
@@ -106,6 +106,9 @@ func (r *actorResolver) TipAddress(ctx context.Context, obj *activitypub.Actor) 
 	if username == "" {
 		return nil, nil
 	}
+	if !r.canViewActorTipAddress(ctx, obj, username) {
+		return nil, nil
+	}
 
 	wallets, err := r.Storage.Account().GetUserWallets(ctx, username)
 	if err != nil {
@@ -122,6 +125,23 @@ func (r *actorResolver) TipAddress(ctx context.Context, obj *activitypub.Actor) 
 		return nil, nil
 	}
 	return &bestAddress, nil
+}
+
+func (r *actorResolver) canViewActorTipAddress(ctx context.Context, obj *activitypub.Actor, username string) bool {
+	viewerUsername := strings.TrimSpace(r.optionalAuth(ctx))
+	if viewerUsername == "" {
+		return false
+	}
+	if r.isAdmin(ctx, viewerUsername) {
+		return true
+	}
+
+	localUsername := r.localUsernameForLookup(obj.ID)
+	if localUsername == "" && strings.TrimSpace(obj.ID) == "" {
+		localUsername = strings.TrimSpace(username)
+	}
+
+	return localUsername != "" && strings.EqualFold(localUsername, viewerUsername)
 }
 
 func (r *actorResolver) TipChainID(ctx context.Context, _ *activitypub.Actor) (*int, error) {

--- a/graph/actor_tip_resolvers_round32_test.go
+++ b/graph/actor_tip_resolvers_round32_test.go
@@ -1,0 +1,56 @@
+package graph
+
+import (
+	"context"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/stretchr/testify/require"
+)
+
+func TestActorTipAddressRequiresAuthorizedViewer_Round32(t *testing.T) {
+	resolver, _, _, _, state := newRound12GraphResolverWithMocks(t)
+	state.autoPopulateAll = true
+	state.autoPopulateCount = 2
+	resolver.Config.TipEnabled = true
+	resolver.Config.TipChainID = 1
+	resolver.Config.TipContractAddress = "0xfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed"
+
+	actor := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://localhost/users/alice",
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: "alice",
+	}
+	actorResolver := &actorResolver{resolver}
+
+	publicTip, err := actorResolver.TipAddress(context.Background(), actor)
+	require.NoError(t, err)
+	require.Nil(t, publicTip)
+
+	otherTip, err := actorResolver.TipAddress(round12AuthContext("bob"), actor)
+	require.NoError(t, err)
+	require.Nil(t, otherTip)
+
+	ownerTip, err := actorResolver.TipAddress(round12AuthContext("alice"), actor)
+	require.NoError(t, err)
+	require.NotNil(t, ownerTip)
+	require.Equal(t, "0x2222222222222222222222222222222222222222", *ownerTip)
+
+	adminTip, err := actorResolver.TipAddress(round12AuthContext("admin"), actor)
+	require.NoError(t, err)
+	require.NotNil(t, adminTip)
+	require.Equal(t, "0x2222222222222222222222222222222222222222", *adminTip)
+
+	remoteCollisionActor := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://remote.example/users/alice",
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: "alice",
+	}
+	remoteTip, err := actorResolver.TipAddress(round12AuthContext("alice"), remoteCollisionActor)
+	require.NoError(t, err)
+	require.Nil(t, remoteTip)
+}

--- a/graph/agent_access_lease_resolvers.go
+++ b/graph/agent_access_lease_resolvers.go
@@ -578,7 +578,7 @@ func (r *Resolver) requireManagedAgentLeaseAccount(ctx context.Context, username
 	if err != nil || account == nil || account.User == nil || !account.User.IsAgent || account.User.Suspended {
 		return nil, nil, apperrors.NewAppError(apperrors.CodeNotFound, apperrors.CategoryBusiness, "agent not found")
 	}
-	if !isAgentOwnerOrAdmin(claims, account.User) {
+	if !isAgentOwnerOrAdmin(claims, account.User, r.agentOwnerActorURL(claims.Username)) {
 		return nil, nil, apperrors.Forbidden("not authorized to manage agent leases")
 	}
 	return claims, account, nil

--- a/graph/agent_access_lease_resolvers.go
+++ b/graph/agent_access_lease_resolvers.go
@@ -257,6 +257,9 @@ func (r *mutationResolver) CreateAgentAccessLeaseSessionKeyChallenge(ctx context
 	if err != nil {
 		return nil, err
 	}
+	if err := r.ensureActiveAgentLeaseAccount(ctx, username); err != nil {
+		return nil, err
+	}
 	now := time.Now().UTC()
 	if graphEffectiveAgentAccessLeaseStatus(lease, now) != graphAgentAccessLeaseStatusActive {
 		return nil, apperrors.Unauthorized("lease is not active")
@@ -299,6 +302,9 @@ func (r *mutationResolver) AuthorizeAgentAccessLeaseSessionKey(ctx context.Conte
 	}
 	lease, err := r.loadGraphAgentAccessLease(ctx, username, leaseID)
 	if err != nil {
+		return nil, err
+	}
+	if err := r.ensureActiveAgentLeaseAccount(ctx, username); err != nil {
 		return nil, err
 	}
 	now := time.Now().UTC()
@@ -349,6 +355,9 @@ func (r *mutationResolver) CreateAgentAccessLeaseRenewChallenge(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	if err := r.ensureActiveAgentLeaseAccount(ctx, username); err != nil {
+		return nil, err
+	}
 	now := time.Now().UTC()
 	if graphEffectiveAgentAccessLeaseStatus(lease, now) != graphAgentAccessLeaseStatusActive {
 		return nil, apperrors.Unauthorized("lease is not active")
@@ -395,6 +404,9 @@ func (r *mutationResolver) ExchangeAgentAccessLeaseToken(ctx context.Context, us
 	}
 	lease, err := r.loadGraphAgentAccessLease(ctx, username, leaseID)
 	if err != nil {
+		return nil, err
+	}
+	if err := r.ensureActiveAgentLeaseAccount(ctx, username); err != nil {
 		return nil, err
 	}
 	now := time.Now().UTC()
@@ -541,7 +553,7 @@ func (r *Resolver) requireOwnedAgentLeaseAccount(ctx context.Context, username s
 		return nil, nil, ErrStorageUnavailable
 	}
 	account, err := r.Storage.Account().GetAccount(ctx, username)
-	if err != nil || account == nil || account.User == nil || !account.User.IsAgent {
+	if err != nil || account == nil || account.User == nil || !account.User.IsAgent || account.User.Suspended {
 		return nil, nil, apperrors.NewAppError(apperrors.CodeNotFound, apperrors.CategoryBusiness, "agent not found")
 	}
 	owner := strings.TrimPrefix(strings.TrimSpace(account.User.AgentOwner), "@")
@@ -563,13 +575,24 @@ func (r *Resolver) requireManagedAgentLeaseAccount(ctx context.Context, username
 		return nil, nil, ErrStorageUnavailable
 	}
 	account, err := r.Storage.Account().GetAccount(ctx, username)
-	if err != nil || account == nil || account.User == nil || !account.User.IsAgent {
+	if err != nil || account == nil || account.User == nil || !account.User.IsAgent || account.User.Suspended {
 		return nil, nil, apperrors.NewAppError(apperrors.CodeNotFound, apperrors.CategoryBusiness, "agent not found")
 	}
 	if !isAgentOwnerOrAdmin(claims, account.User) {
 		return nil, nil, apperrors.Forbidden("not authorized to manage agent leases")
 	}
 	return claims, account, nil
+}
+
+func (r *Resolver) ensureActiveAgentLeaseAccount(ctx context.Context, username string) error {
+	if r.Storage == nil || r.Storage.Account() == nil {
+		return ErrStorageUnavailable
+	}
+	account, err := r.Storage.Account().GetAccount(ctx, username)
+	if err != nil || account == nil || account.User == nil || !account.User.IsAgent || account.User.Suspended {
+		return apperrors.NewAppError(apperrors.CodeNotFound, apperrors.CategoryBusiness, "agent not found")
+	}
+	return nil
 }
 
 func (r *Resolver) graphUserHasWallet(ctx context.Context, username string, address string) (bool, error) {

--- a/graph/agent_access_lease_round32_test.go
+++ b/graph/agent_access_lease_round32_test.go
@@ -1,9 +1,11 @@
 package graph
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	"github.com/equaltoai/lesser/pkg/auth"
 	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/require"
 )
@@ -89,4 +91,23 @@ func TestGraphAgentAccessLeaseModel_UsesEffectiveTokenTTL(t *testing.T) {
 	model = graphAgentAccessLeaseModel(lease, now)
 	require.NotNil(t, model)
 	require.Equal(t, 12, model.TokenTTLHours)
+}
+
+func TestGraphAgentAccessLeaseAccountGuards_RejectSuspendedAgent(t *testing.T) {
+	state := newDelegationGraphState("agent1", []string{auth.ScopeRead})
+	state.users["agent1"].Suspended = true
+	resolver := newDelegationResolver(t, state, false)
+	ctx := delegatedAgentAuthContext("owner", "write:accounts")
+
+	_, _, err := resolver.requireOwnedAgentLeaseAccount(ctx, "agent1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "agent not found")
+
+	_, _, err = resolver.requireManagedAgentLeaseAccount(ctx, "agent1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "agent not found")
+
+	err = resolver.ensureActiveAgentLeaseAccount(context.Background(), "agent1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "agent not found")
 }

--- a/graph/agent_delegation_round32_test.go
+++ b/graph/agent_delegation_round32_test.go
@@ -449,7 +449,8 @@ func newDelegationResolver(t *testing.T, state *delegationGraphState, allowAgent
 }
 
 func TestDelegateToAgent_AllowsExistingAgentWhenRegistrationDisabled(t *testing.T) {
-	resolver := newDelegationResolver(t, newDelegationGraphState("agent1", []string{"read", "write:statuses"}), false)
+	state := newDelegationGraphState("agent1", []string{"read", "write:statuses"})
+	resolver := newDelegationResolver(t, state, false)
 	ctx := delegatedAgentAuthContext("owner", auth.ScopeRead, auth.ScopeWrite)
 
 	result, err := resolver.Mutation().DelegateToAgent(ctx, model.DelegateToAgentInput{
@@ -467,6 +468,11 @@ func TestDelegateToAgent_AllowsExistingAgentWhenRegistrationDisabled(t *testing.
 	require.Equal(t, "write:statuses", result.Scope)
 	require.NotNil(t, result.Agent)
 	require.Equal(t, "agent1", result.Agent.Username)
+	storedRefresh := state.refreshTokens[result.RefreshToken]
+	require.NotNil(t, storedRefresh)
+	requestedTTL := time.Duration(result.ExpiresIn) * time.Second
+	require.WithinDuration(t, storedRefresh.CreatedAt.Add(requestedTTL), storedRefresh.IdleExpiresAt, 2*time.Second)
+	require.WithinDuration(t, storedRefresh.CreatedAt.Add(requestedTTL), storedRefresh.AbsoluteExpiresAt, 2*time.Second)
 }
 
 func TestDelegateToAgent_CreatesMissingAgentWhenRegistrationEnabled(t *testing.T) {

--- a/graph/agent_governance_helpers.go
+++ b/graph/agent_governance_helpers.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
+	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/common"
 	apperrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/storage"
 )
@@ -73,4 +76,49 @@ func graphAgentGovernanceWriteError(err error, action string) error {
 		)
 	}
 	return apperrors.InternalWithCause(err, fmt.Sprintf("failed to %s agent governance state", action))
+}
+
+func agentOwnerMatchesLocalPrincipal(owner string, principalUsername string, localActorURL string) bool {
+	principalUsername = strings.TrimSpace(principalUsername)
+	owner = strings.TrimSpace(owner)
+	if principalUsername == "" || owner == "" {
+		return false
+	}
+
+	lowerOwner := strings.ToLower(owner)
+	if strings.HasPrefix(lowerOwner, "http://") || strings.HasPrefix(lowerOwner, "https://") {
+		return strings.TrimSpace(localActorURL) != "" && strings.EqualFold(owner, localActorURL)
+	}
+
+	owner = strings.TrimPrefix(owner, "@")
+	if strings.Contains(owner, "/") {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(owner), principalUsername)
+}
+
+func (r *Resolver) agentOwnerActorURL(username string) string {
+	if r == nil || r.Config == nil {
+		return ""
+	}
+	return r.Config.ActorURL(strings.TrimSpace(username))
+}
+
+func optionalGraphAuthClaims(ctx context.Context) *auth.Claims {
+	claims, _ := ctx.Value(common.ContextKeyClaims).(*auth.Claims)
+	if claims == nil || strings.TrimSpace(claims.Username) == "" {
+		return nil
+	}
+	return claims
+}
+
+func (r *Resolver) canViewAgentPrivateFields(claims *auth.Claims, agentUser *storage.User) bool {
+	if claims == nil || agentUser == nil {
+		return false
+	}
+	return isAgentOwnerOrAdmin(claims, agentUser, r.agentOwnerActorURL(claims.Username))
+}
+
+func graphClaimsIsAdmin(claims *auth.Claims) bool {
+	return claims != nil && (claims.HasScope(auth.ScopeAdmin) || claims.HasScope("admin:write") || claims.HasScope("admin:all"))
 }

--- a/graph/agent_model_helpers.go
+++ b/graph/agent_model_helpers.go
@@ -96,6 +96,18 @@ func (r *Resolver) convertStorageUserToAgent(user *storage.User, governance *sto
 	}
 }
 
+func redactGraphAgentPrivateFields(agent *model.Agent) {
+	if agent == nil {
+		return
+	}
+	agent.AgentOwner = nil
+	agent.DelegatedScopes = []string{}
+	if agent.IdentitySemantics != nil {
+		agent.IdentitySemantics.SoulAgentID = nil
+		agent.IdentitySemantics.SoulBindingState = model.SoulBindingStateUnbound
+	}
+}
+
 func graphAgentQuarantineFields(governance *storage.AgentGovernanceState) (*string, *model.Time, *model.Time, *string, *model.Time, bool) {
 	summary := governance.QuarantineSummaryAt(time.Now().UTC())
 	return graphOptionalString(summary.Status),

--- a/graph/agent_model_helpers.go
+++ b/graph/agent_model_helpers.go
@@ -102,10 +102,15 @@ func redactGraphAgentPrivateFields(agent *model.Agent) {
 	}
 	agent.AgentOwner = nil
 	agent.DelegatedScopes = []string{}
-	if agent.IdentitySemantics != nil {
-		agent.IdentitySemantics.SoulAgentID = nil
-		agent.IdentitySemantics.SoulBindingState = model.SoulBindingStateUnbound
+	redactGraphAgentIdentitySemantics(agent.IdentitySemantics)
+}
+
+func redactGraphAgentIdentitySemantics(identity *model.AgentIdentitySemantics) {
+	if identity == nil {
+		return
 	}
+	identity.SoulAgentID = nil
+	identity.SoulBindingState = model.SoulBindingStateUnbound
 }
 
 func graphAgentQuarantineFields(governance *storage.AgentGovernanceState) (*string, *model.Time, *model.Time, *string, *model.Time, bool) {

--- a/graph/agent_model_helpers_test.go
+++ b/graph/agent_model_helpers_test.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -129,6 +130,59 @@ func TestRedactGraphAgentPrivateFields(t *testing.T) {
 	require.Empty(t, agent.DelegatedScopes)
 	require.Equal(t, model.SoulBindingStateUnbound, agent.IdentitySemantics.SoulBindingState)
 	require.Nil(t, agent.IdentitySemantics.SoulAgentID)
+}
+
+func TestAgentIdentitySemanticsResolverRedactsSoulBindingForPublicViewer(t *testing.T) {
+	resolver, graphStorage := newRound12GraphResolver(t)
+	resolver.Config.AllowAgents = true
+	now := time.Now().UTC()
+	metadata, err := agents.SetDroneWorkflowMetadata(nil, &agents.DroneWorkflowState{
+		CurrentPhase: agents.DroneWorkflowPhaseContinuity,
+		CurrentState: agents.DroneWorkflowStateContinuityStable,
+		SoulAgentID:  "soul-agent-1",
+	})
+	require.NoError(t, err)
+
+	user := &storage.User{
+		Username:     "drone1",
+		DisplayName:  "Drone One",
+		IsAgent:      true,
+		AgentType:    "CUSTOM",
+		AgentVersion: "v1",
+		AgentOwner:   "@owner",
+		Metadata:     metadata,
+		Approved:     true,
+		CreatedAt:    now.Add(-time.Hour),
+		UpdatedAt:    now,
+	}
+	graphStorage.SeedAccountUser(user)
+	governance := &storage.AgentGovernanceState{
+		Username:        "drone1",
+		DelegatedScopes: []string{auth.ScopeRead},
+		CreatedAt:       now.Add(-time.Hour),
+		UpdatedAt:       now,
+	}
+	graphStorage.SeedAgentGovernanceState(governance)
+
+	publicAgent := resolver.convertStorageUserToAgent(user, governance)
+	require.NotNil(t, publicAgent)
+	redactGraphAgentPrivateFields(publicAgent)
+	require.Nil(t, publicAgent.AgentOwner)
+	require.Empty(t, publicAgent.DelegatedScopes)
+
+	publicIdentity, err := resolver.Agent().IdentitySemantics(context.Background(), publicAgent)
+	require.NoError(t, err)
+	require.NotNil(t, publicIdentity)
+	require.Equal(t, agents.DroneIdentityStateSouled, publicIdentity.IdentityState)
+	require.Equal(t, model.SoulBindingStateUnbound, publicIdentity.SoulBindingState)
+	require.Nil(t, publicIdentity.SoulAgentID)
+
+	ownerIdentity, err := resolver.Agent().IdentitySemantics(delegatedAgentAuthContext("owner", auth.ScopeRead), publicAgent)
+	require.NoError(t, err)
+	require.NotNil(t, ownerIdentity)
+	require.Equal(t, model.SoulBindingStateBound, ownerIdentity.SoulBindingState)
+	require.NotNil(t, ownerIdentity.SoulAgentID)
+	require.Equal(t, "soul-agent-1", *ownerIdentity.SoulAgentID)
 }
 
 func TestGraphAgentOwnerMatchesLocalPrincipal(t *testing.T) {

--- a/graph/agent_model_helpers_test.go
+++ b/graph/agent_model_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/equaltoai/lesser/graph/model"
 	"github.com/equaltoai/lesser/pkg/agents"
 	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/config"
@@ -109,6 +110,33 @@ func TestConvertStorageUserToAgent_NormalizesExpiredQuarantine(t *testing.T) {
 	require.False(t, agent.QuarantineActive)
 	require.NotNil(t, agent.QuarantineEnd)
 	require.Equal(t, past.UTC(), time.Time(*agent.QuarantineEnd))
+}
+
+func TestRedactGraphAgentPrivateFields(t *testing.T) {
+	owner := "@alice"
+	soulID := "0xsoul"
+	agent := &model.Agent{
+		AgentOwner:      &owner,
+		DelegatedScopes: []string{auth.ScopeRead},
+		IdentitySemantics: &model.AgentIdentitySemantics{
+			SoulBindingState: model.SoulBindingStateBound,
+			SoulAgentID:      &soulID,
+		},
+	}
+
+	redactGraphAgentPrivateFields(agent)
+	require.Nil(t, agent.AgentOwner)
+	require.Empty(t, agent.DelegatedScopes)
+	require.Equal(t, model.SoulBindingStateUnbound, agent.IdentitySemantics.SoulBindingState)
+	require.Nil(t, agent.IdentitySemantics.SoulAgentID)
+}
+
+func TestGraphAgentOwnerMatchesLocalPrincipal(t *testing.T) {
+	require.True(t, agentOwnerMatchesLocalPrincipal("@alice", "alice", ""))
+	require.True(t, agentOwnerMatchesLocalPrincipal("alice", "alice", ""))
+	require.True(t, agentOwnerMatchesLocalPrincipal("https://example.com/users/alice", "alice", "https://example.com/users/alice"))
+	require.False(t, agentOwnerMatchesLocalPrincipal("https://remote.example/users/alice", "alice", "https://example.com/users/alice"))
+	require.False(t, agentOwnerMatchesLocalPrincipal("example.com/users/alice", "alice", ""))
 }
 
 func ptrGraphTime(value time.Time) *time.Time {

--- a/graph/agent_resolvers_stubs.go
+++ b/graph/agent_resolvers_stubs.go
@@ -736,11 +736,13 @@ func (r *mutationResolver) DelegateToAgent(ctx context.Context, input model.Dele
 		return nil, apperrors.Internal("jwt secret not configured")
 	}
 	bundle, err := auth.IssueAgentRuntimeTokens(ctx, r.Config, r.Storage, auth.AgentRuntimeTokenIssueParams{
-		Username:    agentUsername,
-		ClientID:    delegatedAgentClientID,
-		Scopes:      requestedScopes,
-		AccessTTL:   accessTTL,
-		DeviceLabel: auth.DefaultAgentRuntimeDeviceLabel,
+		Username:           agentUsername,
+		ClientID:           delegatedAgentClientID,
+		Scopes:             requestedScopes,
+		AccessTTL:          accessTTL,
+		RefreshIdleTTL:     accessTTL,
+		RefreshAbsoluteTTL: accessTTL,
+		DeviceLabel:        auth.DefaultAgentRuntimeDeviceLabel,
 	})
 	if err != nil {
 		return nil, apperrors.InternalWithCause(err, "failed to mint delegated agent tokens")

--- a/graph/agent_resolvers_stubs.go
+++ b/graph/agent_resolvers_stubs.go
@@ -59,7 +59,11 @@ func (r *queryResolver) Agent(ctx context.Context, username string) (*model.Agen
 		return nil, graphAgentGovernanceLoadError(err)
 	}
 
-	return r.convertStorageUserToAgent(user, governance), nil
+	agent := r.convertStorageUserToAgent(user, governance)
+	if !r.canViewAgentPrivateFields(optionalGraphAuthClaims(ctx), user) {
+		redactGraphAgentPrivateFields(agent)
+	}
+	return agent, nil
 }
 
 type agentListFilters struct {
@@ -169,6 +173,20 @@ func (r *queryResolver) Agents(ctx context.Context, first *int, after *model.Cur
 		return nil, ErrStorageUnavailable
 	}
 
+	ownerFilter := strings.TrimPrefix(strings.TrimSpace(derefString(ownerUsername)), "@")
+	viewerClaims := optionalGraphAuthClaims(ctx)
+	if ownerFilter != "" {
+		if viewerClaims == nil {
+			return nil, ErrAuthenticationRequired
+		}
+		if !viewerClaims.HasScope(auth.ScopeRead) && !graphClaimsIsAdmin(viewerClaims) {
+			return nil, apperrors.InsufficientScope(auth.ScopeRead)
+		}
+		if !graphClaimsIsAdmin(viewerClaims) && !strings.EqualFold(ownerFilter, strings.TrimSpace(viewerClaims.Username)) {
+			return nil, apperrors.Forbidden("not authorized to filter agents by owner")
+		}
+	}
+
 	limit32 := agentListLimit32(first, 100)
 	limit := int(limit32)
 	cursor := agentListCursor(after)
@@ -189,7 +207,7 @@ func (r *queryResolver) Agents(ctx context.Context, first *int, after *model.Cur
 		typeArg:     typeArg,
 		queryValue:  strings.ToLower(strings.TrimSpace(derefString(query))),
 		verified:    verified,
-		ownerFilter: strings.TrimPrefix(strings.TrimSpace(derefString(ownerUsername)), "@"),
+		ownerFilter: ownerFilter,
 	}
 
 	edges := make([]*model.AgentEdge, 0, len(users))
@@ -202,6 +220,9 @@ func (r *queryResolver) Agents(ctx context.Context, first *int, after *model.Cur
 		agent := r.convertStorageUserToAgent(user, governance)
 		if agent == nil {
 			continue
+		}
+		if !r.canViewAgentPrivateFields(viewerClaims, user) {
+			redactGraphAgentPrivateFields(agent)
 		}
 
 		edges = append(edges, &model.AgentEdge{
@@ -326,7 +347,7 @@ func (r *queryResolver) AgentActivity(ctx context.Context, username string, firs
 		return nil, apperrors.NewAppError(apperrors.CodeNotFound, apperrors.CategoryBusiness, "agent not found")
 	}
 
-	if !isAgentOwnerOrAdmin(claims, account.User) && !strings.EqualFold(strings.TrimSpace(claims.Username), username) {
+	if !isAgentOwnerOrAdmin(claims, account.User, r.agentOwnerActorURL(claims.Username)) && !strings.EqualFold(strings.TrimSpace(claims.Username), username) {
 		return nil, apperrors.Forbidden("not authorized to view agent activity")
 	}
 
@@ -545,7 +566,7 @@ func (r *mutationResolver) UpdateAgent(ctx context.Context, username string, inp
 		return nil, apperrors.InternalWithCause(err, "failed to load agent governance state")
 	}
 
-	if !isAgentOwnerOrAdmin(claims, account.User) {
+	if !isAgentOwnerOrAdmin(claims, account.User, r.agentOwnerActorURL(claims.Username)) {
 		return nil, apperrors.Forbidden("not authorized to modify agent")
 	}
 
@@ -674,7 +695,7 @@ func (r *mutationResolver) DeleteAgent(ctx context.Context, username string) (*m
 		return nil, apperrors.InternalWithCause(err, "failed to load agent governance state")
 	}
 
-	if !isAgentOwnerOrAdmin(claims, account.User) {
+	if !isAgentOwnerOrAdmin(claims, account.User, r.agentOwnerActorURL(claims.Username)) {
 		return nil, apperrors.Forbidden("not authorized to delete agent")
 	}
 
@@ -796,7 +817,7 @@ func (r *mutationResolver) resolveDelegatedAgentAccount(ctx context.Context, cla
 	if account == nil || account.User == nil || !account.User.IsAgent || account.User.Suspended {
 		return nil, apperrors.NewAppError(apperrors.CodeNotFound, apperrors.CategoryBusiness, "agent not found")
 	}
-	if !isAgentOwnerOrAdmin(claims, account.User) {
+	if !isAgentOwnerOrAdmin(claims, account.User, r.agentOwnerActorURL(claims.Username)) {
 		return nil, apperrors.Forbidden("not authorized to delegate to agent")
 	}
 	governance, err := r.loadAgentGovernanceState(ctx, agentUsername)
@@ -958,7 +979,7 @@ func (r *mutationResolver) RevokeAgentToken(ctx context.Context, username string
 		return false, apperrors.NewAppError(apperrors.CodeNotFound, apperrors.CategoryBusiness, "agent not found")
 	}
 
-	if !isAgentOwnerOrAdmin(claims, account.User) {
+	if !isAgentOwnerOrAdmin(claims, account.User, r.agentOwnerActorURL(claims.Username)) {
 		return false, apperrors.Forbidden("not authorized to revoke agent tokens")
 	}
 
@@ -1361,7 +1382,7 @@ func scopesAreSubset(ownerScopes, requested []string) bool {
 	return auth.ScopeSetAllows(ownerScopes, requested)
 }
 
-func isAgentOwnerOrAdmin(claims *auth.Claims, agentUser *storage.User) bool {
+func isAgentOwnerOrAdmin(claims *auth.Claims, agentUser *storage.User, localActorURL ...string) bool {
 	if claims == nil || agentUser == nil {
 		return false
 	}
@@ -1370,12 +1391,11 @@ func isAgentOwnerOrAdmin(claims *auth.Claims, agentUser *storage.User) bool {
 		return true
 	}
 
-	owner := strings.TrimSpace(agentUser.AgentOwner)
-	if owner == "" {
-		return false
+	actorURL := ""
+	if len(localActorURL) > 0 {
+		actorURL = localActorURL[0]
 	}
-	owner = strings.TrimPrefix(owner, "@")
-	return strings.EqualFold(owner, strings.TrimSpace(claims.Username))
+	return agentOwnerMatchesLocalPrincipal(agentUser.AgentOwner, claims.Username, actorURL)
 }
 
 //nolint:unused // Retained for follow-up GraphQL delegated-agent creation work.

--- a/graph/drone_workflow_helpers.go
+++ b/graph/drone_workflow_helpers.go
@@ -68,7 +68,7 @@ func (r *Resolver) canViewDroneWorkflow(ctx context.Context, claims *auth.Claims
 	if strings.EqualFold(strings.TrimSpace(claims.Username), strings.TrimSpace(agentUser.Username)) {
 		return true
 	}
-	if isAgentOwnerOrAdmin(claims, agentUser) {
+	if isAgentOwnerOrAdmin(claims, agentUser, r.agentOwnerActorURL(claims.Username)) {
 		return true
 	}
 	role, err := r.normalizedRole(ctx, claims.Username)

--- a/graph/drone_workflow_resolvers.go
+++ b/graph/drone_workflow_resolvers.go
@@ -25,7 +25,13 @@ func (r *agentResolver) IdentitySemantics(ctx context.Context, obj *model.Agent)
 		return nil, err
 	}
 	_, identity, err := r.buildDroneWorkflowSurface(ctx, "", agentUser, governance)
-	return identity, err
+	if err != nil {
+		return nil, err
+	}
+	if !r.canViewAgentPrivateFields(optionalGraphAuthClaims(ctx), agentUser) {
+		redactGraphAgentIdentitySemantics(identity)
+	}
+	return identity, nil
 }
 
 func (r *agentResolver) Workflow(ctx context.Context, obj *model.Agent) (*model.AgentWorkflowSurface, error) {

--- a/graph/query_resolvers_relationships.go
+++ b/graph/query_resolvers_relationships.go
@@ -9,6 +9,7 @@ import (
 	"github.com/equaltoai/lesser/graph/model"
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/common"
+	apperrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/services/relationships"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/models"
@@ -389,7 +390,7 @@ func stringToCursor(value string) *model.Cursor {
 
 // TrustGraph is the resolver for the trustGraph field.
 func (r *queryResolver) TrustGraph(ctx context.Context, actorID string, category *models.TrustCategory) ([]*trust.TrustEdge, error) {
-	_, err := r.requireAuth(ctx)
+	viewerUsername, err := r.requireAuth(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -406,6 +407,9 @@ func (r *queryResolver) TrustGraph(ctx context.Context, actorID string, category
 	// Validate inputs
 	if err := common.ValidateRequiredParam("actorID", actorID); err != nil {
 		return nil, ErrActorIDRequired
+	}
+	if !r.canViewTrustGraph(ctx, viewerUsername, actorID) {
+		return nil, apperrors.Forbidden("not authorized to view trust graph")
 	}
 
 	trustRepo := r.Registry.GetStorage().Trust()
@@ -457,4 +461,16 @@ func (r *queryResolver) TrustGraph(ctx context.Context, actorID string, category
 		zap.Int("edge_count", len(edges)))
 
 	return edges, nil
+}
+
+func (r *Resolver) canViewTrustGraph(ctx context.Context, viewerUsername string, actorID string) bool {
+	viewerUsername = strings.TrimSpace(viewerUsername)
+	if viewerUsername == "" {
+		return false
+	}
+	if r.isAdmin(ctx, viewerUsername) {
+		return true
+	}
+	localUsername := r.localUsernameForLookup(actorID)
+	return localUsername != "" && strings.EqualFold(localUsername, viewerUsername)
 }

--- a/graph/query_resolvers_relationships_round12_test.go
+++ b/graph/query_resolvers_relationships_round12_test.go
@@ -109,4 +109,7 @@ func TestRound12QueryResolvers_Relationships_PagesAndGraph(t *testing.T) {
 	filtered, err := q.TrustGraph(ctx, "alice", &cat)
 	require.NoError(t, err)
 	require.NotNil(t, filtered)
+
+	_, err = q.TrustGraph(ctx, "bob", nil)
+	require.Error(t, err)
 }

--- a/graph/round12_test_harness_test.go
+++ b/graph/round12_test_harness_test.go
@@ -302,6 +302,25 @@ func round12PopulateStruct(dest any, state *round12PermissiveQueryState) {
 		v.CreatedAt = time.Now().Add(-time.Hour)
 		v.UpdatedAt = time.Now().Add(-time.Minute)
 		return
+	case *models.WalletCredential:
+		username := strings.TrimPrefix(state.lastPK, "USER#")
+		if strings.TrimSpace(username) == "" {
+			username = "alice"
+		}
+		addresses := []string{"0x1111111111111111111111111111111111111111", "0x2222222222222222222222222222222222222222"}
+		index := state.autoPopulateIndex
+		if index < 0 || index >= len(addresses) {
+			index = 0
+		}
+		v.PK = fmt.Sprintf("USER#%s", username)
+		v.SK = fmt.Sprintf("WALLET#%s", addresses[index])
+		v.Username = username
+		v.Address = addresses[index]
+		v.ChainID = 1
+		v.Type = "ethereum"
+		v.LinkedAt = time.Now().Add(-2 * time.Hour)
+		v.LastUsed = time.Now().Add(time.Duration(index) * time.Minute)
+		return
 	case *models.RelationshipRecord:
 		follower := strings.TrimPrefix(state.lastPK, "FOLLOW#")
 		if strings.TrimSpace(follower) == "" {

--- a/pkg/ai/service.go
+++ b/pkg/ai/service.go
@@ -77,6 +77,50 @@ type AIService struct {
 	config      *AIConfig
 }
 
+// RedactPIIFromAnalysis returns a response-safe copy of an AI analysis with raw
+// PII text and offsets removed. Storage keeps the full moderation record; this
+// helper is for owner-facing API responses where raw PII is not required.
+func RedactPIIFromAnalysis(analysis *AIAnalysis) *AIAnalysis {
+	if analysis == nil {
+		return nil
+	}
+
+	data, err := json.Marshal(analysis)
+	if err != nil {
+		return &AIAnalysis{
+			ID:               analysis.ID,
+			ObjectID:         analysis.ObjectID,
+			ObjectType:       analysis.ObjectType,
+			OverallRisk:      analysis.OverallRisk,
+			ModerationAction: analysis.ModerationAction,
+			Confidence:       analysis.Confidence,
+			AnalyzedAt:       analysis.AnalyzedAt,
+			Version:          analysis.Version,
+		}
+	}
+	var redacted AIAnalysis
+	if err := json.Unmarshal(data, &redacted); err != nil {
+		return &AIAnalysis{
+			ID:               analysis.ID,
+			ObjectID:         analysis.ObjectID,
+			ObjectType:       analysis.ObjectType,
+			OverallRisk:      analysis.OverallRisk,
+			ModerationAction: analysis.ModerationAction,
+			Confidence:       analysis.Confidence,
+			AnalyzedAt:       analysis.AnalyzedAt,
+			Version:          analysis.Version,
+		}
+	}
+	if redacted.TextAnalysis != nil {
+		for i := range redacted.TextAnalysis.PIIEntities {
+			redacted.TextAnalysis.PIIEntities[i].Text = ""
+			redacted.TextAnalysis.PIIEntities[i].BeginOffset = 0
+			redacted.TextAnalysis.PIIEntities[i].EndOffset = 0
+		}
+	}
+	return &redacted
+}
+
 // AIConfig contains configuration for AI service features and thresholds
 //
 //nolint:revive // AI prefix clarifies this is AI-specific config

--- a/pkg/ai/service_helpers_test.go
+++ b/pkg/ai/service_helpers_test.go
@@ -13,6 +13,31 @@ import (
 // Section 1: Composite scoring helpers
 // =============================================================================
 
+func TestRedactPIIFromAnalysis(t *testing.T) {
+	analysis := &AIAnalysis{
+		ID:       "analysis-1",
+		ObjectID: "status-1",
+		TextAnalysis: &TextAnalysis{
+			ContainsPII: true,
+			PIIEntities: []PIIEntity{{
+				Type:        PiiEmail,
+				Text:        "alice@example.com",
+				Score:       0.99,
+				BeginOffset: 5,
+				EndOffset:   22,
+			}},
+		},
+	}
+
+	redacted := RedactPIIFromAnalysis(analysis)
+	require.NotSame(t, analysis, redacted)
+	require.Len(t, redacted.TextAnalysis.PIIEntities, 1)
+	require.Empty(t, redacted.TextAnalysis.PIIEntities[0].Text)
+	require.Zero(t, redacted.TextAnalysis.PIIEntities[0].BeginOffset)
+	require.Zero(t, redacted.TextAnalysis.PIIEntities[0].EndOffset)
+	require.Equal(t, "alice@example.com", analysis.TextAnalysis.PIIEntities[0].Text)
+}
+
 func TestCalculateOverallRisk(t *testing.T) {
 	// Create a minimal AIService for testing - no AWS clients needed for pure helpers
 	service := &AIService{

--- a/pkg/auth/agent_runtime.go
+++ b/pkg/auth/agent_runtime.go
@@ -48,11 +48,13 @@ type AgentRuntimeAuthDiagnostic struct {
 
 // AgentRuntimeTokenIssueParams describes a first-class bearer + refresh runtime session.
 type AgentRuntimeTokenIssueParams struct {
-	Username    string
-	ClientID    string
-	Scopes      []string
-	AccessTTL   time.Duration
-	DeviceLabel string
+	Username           string
+	ClientID           string
+	Scopes             []string
+	AccessTTL          time.Duration
+	RefreshIdleTTL     time.Duration
+	RefreshAbsoluteTTL time.Duration
+	DeviceLabel        string
 }
 
 // AgentRuntimeTokenBundle contains the issued OAuth tokens and stored refresh-session metadata.
@@ -113,11 +115,7 @@ func IssueAgentRuntimeTokens(ctx context.Context, cfg *config.Config, repos Stor
 		deviceLabel = DefaultAgentRuntimeDeviceLabel
 	}
 
-	idleExpiry := now.Add(AgentRuntimeRefreshIdleTTL)
-	absoluteExpiry := now.Add(AgentRuntimeRefreshAbsoluteTTL)
-	if idleExpiry.After(absoluteExpiry) {
-		idleExpiry = absoluteExpiry
-	}
+	idleExpiry, absoluteExpiry := AgentRuntimeRefreshExpiries(now, params.RefreshIdleTTL, params.RefreshAbsoluteTTL)
 
 	oauthSvc := NewOAuthService(cfg.JWTSecret, cfg, repos, nil)
 	accessToken, refreshToken, err := oauthSvc.GenerateTokensWithAccessTokenTTLAndClientContext(
@@ -163,6 +161,25 @@ func IssueAgentRuntimeTokens(ctx context.Context, cfg *config.Config, repos Stor
 		RefreshToken: refreshToken,
 		Session:      refreshRecord,
 	}, nil
+}
+
+// AgentRuntimeRefreshExpiries returns the idle and absolute refresh-session expiries for
+// an agent runtime token. Zero durations preserve Lesser's default runtime session bounds;
+// positive durations allow delegation flows to cap refresh sessions to the requested TTL.
+func AgentRuntimeRefreshExpiries(now time.Time, idleTTL, absoluteTTL time.Duration) (time.Time, time.Time) {
+	if idleTTL <= 0 {
+		idleTTL = AgentRuntimeRefreshIdleTTL
+	}
+	if absoluteTTL <= 0 {
+		absoluteTTL = AgentRuntimeRefreshAbsoluteTTL
+	}
+
+	idleExpiry := now.Add(idleTTL)
+	absoluteExpiry := now.Add(absoluteTTL)
+	if idleExpiry.After(absoluteExpiry) {
+		idleExpiry = absoluteExpiry
+	}
+	return idleExpiry, absoluteExpiry
 }
 
 // IsAgentRuntimeRefreshToken reports whether a stored refresh token belongs to the dedicated

--- a/pkg/auth/agent_runtime_test.go
+++ b/pkg/auth/agent_runtime_test.go
@@ -204,6 +204,27 @@ func TestIssueAgentRuntimeTokens(t *testing.T) {
 		require.Equal(t, int(customTTL.Seconds()), customBundle.Session.AccessTTLSeconds)
 	})
 
+	t.Run("caps refresh session to delegated absolute ttl", func(t *testing.T) {
+		repoDelegated, _, queryDelegated := newAgentRuntimeAccountRepo()
+		queryDelegated.On("Create").Return(nil).Once()
+
+		delegatedTTL := 90 * time.Minute
+		delegatedBundle, err := IssueAgentRuntimeTokens(context.Background(), cfg, agentRuntimeRepos{account: repoDelegated}, AgentRuntimeTokenIssueParams{
+			Username:           "alice",
+			ClientID:           DelegatedAgentRuntimeClientID,
+			Scopes:             []string{ScopeRead},
+			AccessTTL:          delegatedTTL,
+			RefreshIdleTTL:     delegatedTTL,
+			RefreshAbsoluteTTL: delegatedTTL,
+			DeviceLabel:        "delegated-runtime",
+		})
+		require.NoError(t, err)
+		require.Equal(t, int(delegatedTTL.Seconds()), delegatedBundle.Session.AccessTTLSeconds)
+		require.WithinDuration(t, delegatedBundle.Session.CreatedAt.Add(delegatedTTL), delegatedBundle.Session.IdleExpiresAt, 2*time.Second)
+		require.WithinDuration(t, delegatedBundle.Session.CreatedAt.Add(delegatedTTL), delegatedBundle.Session.AbsoluteExpiresAt, 2*time.Second)
+		require.WithinDuration(t, delegatedBundle.Session.AbsoluteExpiresAt, delegatedBundle.Session.ExpiresAt, time.Second)
+	})
+
 	t.Run("propagates refresh storage failures", func(t *testing.T) {
 		repoErr, _, queryErr := newAgentRuntimeAccountRepo()
 		queryErr.On("Create").Return(errors.New("create failed")).Once()

--- a/pkg/storage/models/round16_zero_coverage_models_test.go
+++ b/pkg/storage/models/round16_zero_coverage_models_test.go
@@ -458,12 +458,13 @@ func TestUserAppConsent_ScopesAndRevocation(t *testing.T) {
 
 func TestWebSocketSubscriptionModels(t *testing.T) {
 	t.Run("WebSocketEventConnection UpdateKeys sets optional GSI", func(t *testing.T) {
-		c := &WebSocketEventConnection{ConnectionID: "c1", UserID: "u1"}
+		c := &WebSocketEventConnection{ConnectionID: "c1", UserID: "u1", Role: "moderator"}
 		require.NoError(t, c.UpdateKeys())
 		assert.Equal(t, "CONNECTION#c1", c.PK)
 		assert.Equal(t, SKMetadata, c.SK)
 		assert.Equal(t, "USER#u1", c.GSI1PK)
 		assert.Equal(t, "CONNECTION#c1", c.GSI1SK)
+		assert.Equal(t, "moderator", c.Role)
 		assert.Equal(t, c.PK, c.GetPK())
 		assert.Equal(t, c.SK, c.GetSK())
 		assert.Equal(t, MainTableName, c.TableName())

--- a/pkg/storage/models/websocket_subscription_manager.go
+++ b/pkg/storage/models/websocket_subscription_manager.go
@@ -20,6 +20,7 @@ type WebSocketEventConnection struct {
 	// Business fields
 	ConnectionID string    `theorydb:"attr:connectionID" json:"connection_id"`
 	UserID       string    `theorydb:"attr:userID" json:"user_id"`
+	Role         string    `theorydb:"attr:role,omitempty" json:"role,omitempty"`
 	ConnectedAt  time.Time `theorydb:"attr:connectedAt" json:"connected_at"`
 	LastSeen     time.Time `theorydb:"attr:lastSeen" json:"last_seen"`
 

--- a/pkg/storage/repositories/websocket_subscription_manager_repository.go
+++ b/pkg/storage/repositories/websocket_subscription_manager_repository.go
@@ -33,11 +33,18 @@ func NewWebSocketSubscriptionManagerRepository(db core.DB, tableName string, log
 	}
 }
 
-// HandleConnect stores a new WebSocket connection
+// HandleConnect stores a new WebSocket connection.
 func (r *WebSocketSubscriptionManagerRepository) HandleConnect(ctx context.Context, connectionID, userID string) error {
+	return r.HandleConnectWithPrincipal(ctx, connectionID, userID, "")
+}
+
+// HandleConnectWithPrincipal stores a new WebSocket connection with the
+// connection's authenticated principal role when available.
+func (r *WebSocketSubscriptionManagerRepository) HandleConnectWithPrincipal(ctx context.Context, connectionID, userID, role string) error {
 	connection := &models.WebSocketEventConnection{
 		ConnectionID: connectionID,
 		UserID:       userID,
+		Role:         role,
 		ConnectedAt:  time.Now(),
 		LastSeen:     time.Now(),
 		TTL:          time.Now().Add(24 * time.Hour).Unix(), // Expire after 24 hours

--- a/pkg/storage/repositories/websocket_subscription_manager_repository_round09_test.go
+++ b/pkg/storage/repositories/websocket_subscription_manager_repository_round09_test.go
@@ -43,6 +43,7 @@ func TestRound09_WebSocketSubscriptionManagerRepository_FlowAndFiltering(t *test
 	ctx := context.Background()
 
 	require.NoError(t, repo.HandleConnect(ctx, "conn-1", "user-1"))
+	require.NoError(t, repo.HandleConnectWithPrincipal(ctx, "conn-2", "user-2", "moderator"))
 
 	require.NoError(t, repo.CreateSubscription(ctx, "conn-1", "notifications", map[string]any{"a": 1}))
 	require.NoError(t, repo.DeleteSubscription(ctx, "conn-1", "notifications"))

--- a/pkg/websocket/subscriptions.go
+++ b/pkg/websocket/subscriptions.go
@@ -4,7 +4,10 @@ package websocket
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -513,6 +516,23 @@ func convertToMap(v any) (map[string]any, error) {
 type WebSocketHandler struct {
 	subscriptionManager SubscriptionManager
 	logger              *zap.Logger
+	principalMu         sync.RWMutex
+	principals          map[string]webSocketPrincipal
+}
+
+type webSocketPrincipal struct {
+	UserID        string
+	Role          string
+	Authenticated bool
+}
+
+type webSocketStatusError struct {
+	statusCode int
+	message    string
+}
+
+func (e *webSocketStatusError) Error() string {
+	return e.message
 }
 
 // NewWebSocketHandler creates a new WebSocket handler
@@ -520,6 +540,7 @@ func NewWebSocketHandler(sm SubscriptionManager, logger *zap.Logger) *WebSocketH
 	return &WebSocketHandler{
 		subscriptionManager: sm,
 		logger:              logger,
+		principals:          make(map[string]webSocketPrincipal),
 	}
 }
 
@@ -544,7 +565,12 @@ func (h *WebSocketHandler) HandleAPIGatewayWebSocketEvent(_ context.Context, eve
 
 // handleConnect handles WebSocket connection events
 func (h *WebSocketHandler) handleConnect(connectionID string, event events.APIGatewayWebsocketProxyRequest) (events.APIGatewayProxyResponse, error) {
-	userID := h.extractUserID(event)
+	principal := h.extractPrincipal(event)
+	userID := principal.UserID
+	if userID == "" {
+		userID = h.extractUserID(event)
+		principal.UserID = userID
+	}
 
 	if err := h.subscriptionManager.HandleConnect(connectionID, userID); err != nil {
 		h.logger.Error("Failed to handle connect",
@@ -554,6 +580,8 @@ func (h *WebSocketHandler) handleConnect(connectionID string, event events.APIGa
 		)
 		return events.APIGatewayProxyResponse{StatusCode: 500}, err
 	}
+
+	h.rememberConnectionPrincipal(connectionID, principal)
 
 	return events.APIGatewayProxyResponse{StatusCode: 200}, nil
 }
@@ -567,8 +595,130 @@ func (h *WebSocketHandler) extractUserID(event events.APIGatewayWebsocketProxyRe
 	return userID
 }
 
+func (h *WebSocketHandler) extractPrincipal(event events.APIGatewayWebsocketProxyRequest) webSocketPrincipal {
+	fields := flattenAuthorizerFields(event.RequestContext.Authorizer)
+	userID := firstAuthorizerField(fields,
+		"username",
+		"user_id",
+		"userid",
+		"user",
+		"sub",
+		"principal_id",
+		"principalid",
+		"cognito_username",
+		"cognitousername",
+	)
+	role := firstAuthorizerField(fields,
+		"role",
+		"roles",
+		"user_role",
+		"userrole",
+		"cognito_groups",
+		"cognitogroups",
+	)
+
+	return webSocketPrincipal{
+		UserID:        userID,
+		Role:          role,
+		Authenticated: userID != "",
+	}
+}
+
+func flattenAuthorizerFields(authorizer any) map[string]string {
+	if authorizer == nil {
+		return nil
+	}
+	data, err := json.Marshal(authorizer)
+	if err != nil {
+		return nil
+	}
+	var decoded any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return nil
+	}
+
+	fields := map[string]string{}
+	collectAuthorizerFields(fields, "", decoded)
+	return fields
+}
+
+func collectAuthorizerFields(fields map[string]string, prefix string, value any) {
+	switch v := value.(type) {
+	case map[string]any:
+		for key, child := range v {
+			collectAuthorizerFields(fields, key, child)
+			if prefix != "" {
+				collectAuthorizerFields(fields, prefix+"_"+key, child)
+			}
+		}
+	case []any:
+		parts := make([]string, 0, len(v))
+		for _, child := range v {
+			if part := strings.TrimSpace(fmt.Sprint(child)); part != "" && part != "<nil>" {
+				parts = append(parts, part)
+			}
+		}
+		if prefix != "" && len(parts) > 0 {
+			fields[normalizeAuthorizerKey(prefix)] = strings.Join(parts, ",")
+		}
+	default:
+		if prefix == "" {
+			return
+		}
+		value := strings.TrimSpace(fmt.Sprint(v))
+		if value == "" || value == "<nil>" {
+			return
+		}
+		fields[normalizeAuthorizerKey(prefix)] = value
+	}
+}
+
+func firstAuthorizerField(fields map[string]string, keys ...string) string {
+	for _, key := range keys {
+		if value := strings.TrimSpace(fields[normalizeAuthorizerKey(key)]); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func normalizeAuthorizerKey(key string) string {
+	key = strings.ToLower(strings.TrimSpace(key))
+	replacer := strings.NewReplacer("_", "", "-", "", ".", "", ":", "", " ", "")
+	return replacer.Replace(key)
+}
+
+func (h *WebSocketHandler) rememberConnectionPrincipal(connectionID string, principal webSocketPrincipal) {
+	h.principalMu.Lock()
+	defer h.principalMu.Unlock()
+
+	if h.principals == nil {
+		h.principals = make(map[string]webSocketPrincipal)
+	}
+	h.principals[connectionID] = principal
+}
+
+func (h *WebSocketHandler) forgetConnectionPrincipal(connectionID string) {
+	h.principalMu.Lock()
+	defer h.principalMu.Unlock()
+
+	delete(h.principals, connectionID)
+}
+
+func (h *WebSocketHandler) connectionPrincipal(connectionID string) (webSocketPrincipal, bool) {
+	h.principalMu.RLock()
+	defer h.principalMu.RUnlock()
+
+	if h.principals == nil {
+		return webSocketPrincipal{}, false
+	}
+	principal, ok := h.principals[connectionID]
+	return principal, ok
+}
+
 // handleDisconnect handles WebSocket disconnection events
 func (h *WebSocketHandler) handleDisconnect(connectionID string) (events.APIGatewayProxyResponse, error) {
+	h.forgetConnectionPrincipal(connectionID)
 	if err := h.subscriptionManager.HandleDisconnect(connectionID); err != nil {
 		h.logger.Error("Failed to handle disconnect",
 			zap.String("connection_id", connectionID),
@@ -591,7 +741,7 @@ func (h *WebSocketHandler) handleSubscribe(connectionID string, body string) (ev
 
 	err := h.processSubscriptionType(connectionID, request.Type, request.Filter)
 	if err != nil {
-		return events.APIGatewayProxyResponse{StatusCode: 500}, err
+		return events.APIGatewayProxyResponse{StatusCode: webSocketErrorStatus(err)}, err
 	}
 
 	return events.APIGatewayProxyResponse{StatusCode: 200}, nil
@@ -599,6 +749,12 @@ func (h *WebSocketHandler) handleSubscribe(connectionID string, body string) (ev
 
 // processSubscriptionType processes different subscription types
 func (h *WebSocketHandler) processSubscriptionType(connectionID string, subType string, filter any) error {
+	if isAdminAlertSubscriptionType(subType) {
+		if err := h.ensureAdminAlertSubscriptionAuthorized(connectionID); err != nil {
+			return err
+		}
+	}
+
 	switch subType {
 	case "moderation":
 		return h.subscribeModerationQueue(connectionID, filter)
@@ -617,6 +773,53 @@ func (h *WebSocketHandler) processSubscriptionType(connectionID string, subType 
 	default:
 		return fmt.Errorf("unknown subscription type: %s", subType)
 	}
+}
+
+func isAdminAlertSubscriptionType(subType string) bool {
+	switch subType {
+	case "moderation", "threat_intel", "performance", "infrastructure":
+		return true
+	default:
+		return false
+	}
+}
+
+func (h *WebSocketHandler) ensureAdminAlertSubscriptionAuthorized(connectionID string) error {
+	principal, ok := h.connectionPrincipal(connectionID)
+	if !ok || !principal.Authenticated {
+		return &webSocketStatusError{
+			statusCode: http.StatusUnauthorized,
+			message:    "admin alert subscriptions require authentication",
+		}
+	}
+	if !webSocketRoleAllowsAdminAlerts(principal.Role) {
+		return &webSocketStatusError{
+			statusCode: http.StatusForbidden,
+			message:    "admin alert subscriptions require admin or moderator role",
+		}
+	}
+	return nil
+}
+
+func webSocketRoleAllowsAdminAlerts(role string) bool {
+	role = strings.ToLower(strings.TrimSpace(role))
+	for _, part := range strings.FieldsFunc(role, func(r rune) bool {
+		return r == ',' || r == ';' || r == ' ' || r == '\t' || r == '\n'
+	}) {
+		switch strings.TrimSpace(part) {
+		case "admin", "moderator", "mod":
+			return true
+		}
+	}
+	return false
+}
+
+func webSocketErrorStatus(err error) int {
+	var statusErr *webSocketStatusError
+	if errors.As(err, &statusErr) {
+		return statusErr.statusCode
+	}
+	return http.StatusInternalServerError
 }
 
 // subscribeModerationQueue handles moderation queue subscriptions

--- a/pkg/websocket/subscriptions.go
+++ b/pkg/websocket/subscriptions.go
@@ -21,7 +21,9 @@ import (
 
 type subscriptionRepository interface {
 	HandleConnect(ctx context.Context, connectionID, userID string) error
+	HandleConnectWithPrincipal(ctx context.Context, connectionID, userID, role string) error
 	HandleDisconnect(ctx context.Context, connectionID string) error
+	GetConnection(ctx context.Context, connectionID string) (*storageModels.WebSocketEventConnection, error)
 	CreateSubscription(ctx context.Context, connectionID, subscriptionType string, filter map[string]any) error
 	DeleteSubscription(ctx context.Context, connectionID, subscriptionType string) error
 	GetSubscriptionsForType(ctx context.Context, subscriptionType string) ([]storageModels.WebSocketEventSubscription, error)
@@ -49,6 +51,7 @@ type SubscriptionManager interface {
 type Connection struct {
 	ConnectionID string    `json:"connection_id" dynamodbav:"ConnectionID"`
 	UserID       string    `json:"user_id" dynamodbav:"UserID"`
+	Role         string    `json:"role,omitempty" dynamodbav:"Role,omitempty"`
 	ConnectedAt  time.Time `json:"connected_at" dynamodbav:"ConnectedAt"`
 	LastSeen     time.Time `json:"last_seen" dynamodbav:"LastSeen"`
 	TTL          int64     `json:"ttl" dynamodbav:"TTL"`
@@ -161,23 +164,35 @@ func NewSubscriptionManager(repo *repositories.WebSocketSubscriptionManagerRepos
 
 // HandleConnect handles a new WebSocket connection
 func (sm *subscriptionManager) HandleConnect(connectionID, userID string) error {
-	sm.mutex.Lock()
-	defer sm.mutex.Unlock()
+	return sm.handleConnect(connectionID, userID, "")
+}
 
+func (sm *subscriptionManager) HandleConnectWithPrincipal(connectionID string, principal webSocketPrincipal) error {
+	return sm.handleConnect(connectionID, principal.UserID, principal.Role)
+}
+
+func (sm *subscriptionManager) handleConnect(connectionID, userID, role string) error {
+	now := time.Now()
+	sm.mutex.Lock()
 	connection := &Connection{
 		ConnectionID: connectionID,
 		UserID:       userID,
-		ConnectedAt:  time.Now(),
-		LastSeen:     time.Now(),
-		TTL:          time.Now().Add(24 * time.Hour).Unix(), // Expire after 24 hours
+		Role:         role,
+		ConnectedAt:  now,
+		LastSeen:     now,
+		TTL:          now.Add(24 * time.Hour).Unix(), // Expire after 24 hours
 	}
 
 	// Store in memory
+	if sm.connections == nil {
+		sm.connections = make(map[string]*Connection)
+	}
 	sm.connections[connectionID] = connection
+	sm.mutex.Unlock()
 
 	// Store in DynamoDB using repository
 	// Use background context for async repository operation
-	err := sm.repo.HandleConnect(context.Background(), connectionID, userID)
+	err := sm.repo.HandleConnectWithPrincipal(context.Background(), connectionID, userID, role)
 	if err != nil {
 		return fmt.Errorf("failed to store connection: %w", err)
 	}
@@ -187,6 +202,23 @@ func (sm *subscriptionManager) HandleConnect(connectionID, userID string) error 
 		zap.String("user_id", userID),
 	)
 	return nil
+}
+
+func (sm *subscriptionManager) ConnectionPrincipal(connectionID string) (webSocketPrincipal, error) {
+	connection, err := sm.loadConnection(context.Background(), connectionID)
+	if err != nil {
+		return webSocketPrincipal{}, err
+	}
+	if connection == nil || strings.TrimSpace(connection.ConnectionID) == "" {
+		return webSocketPrincipal{}, fmt.Errorf("connection not found: %s", connectionID)
+	}
+
+	userID := strings.TrimSpace(connection.UserID)
+	return webSocketPrincipal{
+		UserID:        userID,
+		Role:          connection.Role,
+		Authenticated: userID != "" && userID != "anonymous",
+	}, nil
 }
 
 // HandleDisconnect handles WebSocket disconnection
@@ -254,12 +286,8 @@ func (sm *subscriptionManager) SubscribeNotifications(connectionID string) error
 
 // createSubscription creates a new subscription
 func (sm *subscriptionManager) createSubscription(connectionID string, subscriptionType string, filter any) error {
-	sm.mutex.Lock()
-	defer sm.mutex.Unlock()
-
-	// Check if connection exists
-	if _, exists := sm.connections[connectionID]; !exists {
-		return fmt.Errorf("connection not found: %s", connectionID)
+	if err := sm.ensureConnectionKnown(context.Background(), connectionID); err != nil {
+		return err
 	}
 
 	subscription := &Subscription{
@@ -280,6 +308,11 @@ func (sm *subscriptionManager) createSubscription(connectionID string, subscript
 	}
 
 	// Store in memory
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+	if sm.subscriptions == nil {
+		sm.subscriptions = make(map[string]map[string]*Subscription)
+	}
 	if sm.subscriptions[connectionID] == nil {
 		sm.subscriptions[connectionID] = make(map[string]*Subscription)
 	}
@@ -297,6 +330,59 @@ func (sm *subscriptionManager) createSubscription(connectionID string, subscript
 		zap.String("subscription_type", subscriptionType),
 	)
 	return nil
+}
+
+func (sm *subscriptionManager) ensureConnectionKnown(ctx context.Context, connectionID string) error {
+	connectionID = strings.TrimSpace(connectionID)
+	if connectionID == "" {
+		return fmt.Errorf("connection not found: %s", connectionID)
+	}
+
+	sm.mutex.RLock()
+	_, exists := sm.connections[connectionID]
+	sm.mutex.RUnlock()
+	if exists {
+		return nil
+	}
+
+	connection, err := sm.loadConnection(ctx, connectionID)
+	if err != nil {
+		return fmt.Errorf("failed to load connection %s: %w", connectionID, err)
+	}
+	if connection == nil || strings.TrimSpace(connection.ConnectionID) == "" {
+		return fmt.Errorf("connection not found: %s", connectionID)
+	}
+
+	sm.cacheConnection(connection)
+	return nil
+}
+
+func (sm *subscriptionManager) loadConnection(ctx context.Context, connectionID string) (*storageModels.WebSocketEventConnection, error) {
+	if sm.repo == nil {
+		return nil, fmt.Errorf("connection repository is not configured")
+	}
+	return sm.repo.GetConnection(ctx, connectionID)
+}
+
+func (sm *subscriptionManager) cacheConnection(connection *storageModels.WebSocketEventConnection) {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+
+	if sm.connections == nil {
+		sm.connections = make(map[string]*Connection)
+	}
+	if _, exists := sm.connections[connection.ConnectionID]; exists {
+		return
+	}
+
+	sm.connections[connection.ConnectionID] = &Connection{
+		ConnectionID: connection.ConnectionID,
+		UserID:       connection.UserID,
+		Role:         connection.Role,
+		ConnectedAt:  connection.ConnectedAt,
+		LastSeen:     connection.LastSeen,
+		TTL:          connection.TTL,
+	}
 }
 
 // Unsubscribe removes a subscription
@@ -526,6 +612,11 @@ type webSocketPrincipal struct {
 	Authenticated bool
 }
 
+type principalAwareSubscriptionManager interface {
+	HandleConnectWithPrincipal(connectionID string, principal webSocketPrincipal) error
+	ConnectionPrincipal(connectionID string) (webSocketPrincipal, error)
+}
+
 type webSocketStatusError struct {
 	statusCode int
 	message    string
@@ -555,7 +646,7 @@ func (h *WebSocketHandler) HandleAPIGatewayWebSocketEvent(_ context.Context, eve
 	case "$disconnect":
 		return h.handleDisconnect(connectionID)
 	case "subscribe":
-		return h.handleSubscribe(connectionID, event.Body)
+		return h.handleSubscribe(event)
 	case "unsubscribe":
 		return h.handleUnsubscribe(connectionID, event.Body)
 	default:
@@ -572,7 +663,7 @@ func (h *WebSocketHandler) handleConnect(connectionID string, event events.APIGa
 		principal.UserID = userID
 	}
 
-	if err := h.subscriptionManager.HandleConnect(connectionID, userID); err != nil {
+	if err := h.handleSubscriptionManagerConnect(connectionID, userID, principal); err != nil {
 		h.logger.Error("Failed to handle connect",
 			zap.String("connection_id", connectionID),
 			zap.String("user_id", userID),
@@ -584,6 +675,15 @@ func (h *WebSocketHandler) handleConnect(connectionID string, event events.APIGa
 	h.rememberConnectionPrincipal(connectionID, principal)
 
 	return events.APIGatewayProxyResponse{StatusCode: 200}, nil
+}
+
+func (h *WebSocketHandler) handleSubscriptionManagerConnect(connectionID, userID string, principal webSocketPrincipal) error {
+	if principal.Authenticated {
+		if sm, ok := h.subscriptionManager.(principalAwareSubscriptionManager); ok {
+			return sm.HandleConnectWithPrincipal(connectionID, principal)
+		}
+	}
+	return h.subscriptionManager.HandleConnect(connectionID, userID)
 }
 
 // extractUserID extracts user ID from query parameters or returns anonymous
@@ -729,17 +829,24 @@ func (h *WebSocketHandler) handleDisconnect(connectionID string) (events.APIGate
 }
 
 // handleSubscribe handles subscription requests
-func (h *WebSocketHandler) handleSubscribe(connectionID string, body string) (events.APIGatewayProxyResponse, error) {
+func (h *WebSocketHandler) handleSubscribe(event events.APIGatewayWebsocketProxyRequest) (events.APIGatewayProxyResponse, error) {
 	var request struct {
 		Type   string `json:"type"`
 		Filter any    `json:"filter,omitempty"`
 	}
 
-	if err := json.Unmarshal([]byte(body), &request); err != nil {
+	if err := json.Unmarshal([]byte(event.Body), &request); err != nil {
 		return events.APIGatewayProxyResponse{StatusCode: 400}, fmt.Errorf("invalid request body: %w", err)
 	}
 
-	err := h.processSubscriptionType(connectionID, request.Type, request.Filter)
+	connectionID := event.RequestContext.ConnectionID
+	var principal webSocketPrincipal
+	principalKnown := false
+	if isAdminAlertSubscriptionType(request.Type) {
+		principal, principalKnown = h.principalForEvent(connectionID, event)
+	}
+
+	err := h.processSubscriptionType(connectionID, request.Type, request.Filter, principal, principalKnown)
 	if err != nil {
 		return events.APIGatewayProxyResponse{StatusCode: webSocketErrorStatus(err)}, err
 	}
@@ -748,9 +855,15 @@ func (h *WebSocketHandler) handleSubscribe(connectionID string, body string) (ev
 }
 
 // processSubscriptionType processes different subscription types
-func (h *WebSocketHandler) processSubscriptionType(connectionID string, subType string, filter any) error {
+func (h *WebSocketHandler) processSubscriptionType(
+	connectionID string,
+	subType string,
+	filter any,
+	principal webSocketPrincipal,
+	principalKnown bool,
+) error {
 	if isAdminAlertSubscriptionType(subType) {
-		if err := h.ensureAdminAlertSubscriptionAuthorized(connectionID); err != nil {
+		if err := h.ensureAdminAlertSubscriptionAuthorized(principal, principalKnown); err != nil {
 			return err
 		}
 	}
@@ -784,9 +897,37 @@ func isAdminAlertSubscriptionType(subType string) bool {
 	}
 }
 
-func (h *WebSocketHandler) ensureAdminAlertSubscriptionAuthorized(connectionID string) error {
-	principal, ok := h.connectionPrincipal(connectionID)
-	if !ok || !principal.Authenticated {
+func (h *WebSocketHandler) principalForEvent(connectionID string, event events.APIGatewayWebsocketProxyRequest) (webSocketPrincipal, bool) {
+	principal := h.extractPrincipal(event)
+	if principal.Authenticated {
+		h.rememberConnectionPrincipal(connectionID, principal)
+		return principal, true
+	}
+
+	if stored, ok := h.connectionPrincipal(connectionID); ok {
+		return stored, true
+	}
+
+	if sm, ok := h.subscriptionManager.(principalAwareSubscriptionManager); ok {
+		stored, err := sm.ConnectionPrincipal(connectionID)
+		if err != nil {
+			h.logger.Warn("failed to load WebSocket connection principal",
+				zap.String("connection_id", connectionID),
+				zap.Error(err),
+			)
+			return webSocketPrincipal{}, false
+		}
+		if stored.UserID != "" || stored.Role != "" {
+			h.rememberConnectionPrincipal(connectionID, stored)
+			return stored, true
+		}
+	}
+
+	return webSocketPrincipal{}, false
+}
+
+func (h *WebSocketHandler) ensureAdminAlertSubscriptionAuthorized(principal webSocketPrincipal, known bool) error {
+	if !known || !principal.Authenticated {
 		return &webSocketStatusError{
 			statusCode: http.StatusUnauthorized,
 			message:    "admin alert subscriptions require authentication",

--- a/pkg/websocket/subscriptions_additional_test.go
+++ b/pkg/websocket/subscriptions_additional_test.go
@@ -18,9 +18,11 @@ import (
 type stubSubscriptionRepo struct {
 	handleConnectErr    error
 	handleDisconnectErr error
+	getConnectionErr    error
 	createErr           error
 	deleteErr           error
 	getErr              error
+	connectRole         string
 
 	created []struct {
 		connectionID     string
@@ -32,7 +34,8 @@ type stubSubscriptionRepo struct {
 		subscriptionType string
 	}
 
-	subsByType map[string][]storageModels.WebSocketEventSubscription
+	subsByType      map[string][]storageModels.WebSocketEventSubscription
+	connectionsByID map[string]storageModels.WebSocketEventConnection
 
 	disconnected chan string
 }
@@ -41,11 +44,30 @@ func (s *stubSubscriptionRepo) HandleConnect(_ context.Context, _, _ string) err
 	return s.handleConnectErr
 }
 
+func (s *stubSubscriptionRepo) HandleConnectWithPrincipal(_ context.Context, _, _ string, role string) error {
+	s.connectRole = role
+	return s.handleConnectErr
+}
+
 func (s *stubSubscriptionRepo) HandleDisconnect(_ context.Context, connectionID string) error {
 	if s.disconnected != nil {
 		s.disconnected <- connectionID
 	}
 	return s.handleDisconnectErr
+}
+
+func (s *stubSubscriptionRepo) GetConnection(_ context.Context, connectionID string) (*storageModels.WebSocketEventConnection, error) {
+	if s.getConnectionErr != nil {
+		return nil, s.getConnectionErr
+	}
+	if s.connectionsByID == nil {
+		return nil, nil
+	}
+	connection, ok := s.connectionsByID[connectionID]
+	if !ok {
+		return nil, nil
+	}
+	return &connection, nil
 }
 
 func (s *stubSubscriptionRepo) CreateSubscription(_ context.Context, connectionID, subscriptionType string, filter map[string]any) error {
@@ -131,6 +153,104 @@ func TestSubscriptionManager_SubscribeRejectsUnknownConnection(t *testing.T) {
 	err := sm.SubscribeThreatIntel("missing")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "connection not found")
+}
+
+func TestSubscriptionManager_SubscribeHydratesConnectionFromRepository(t *testing.T) {
+	now := time.Now()
+	repo := &stubSubscriptionRepo{
+		connectionsByID: map[string]storageModels.WebSocketEventConnection{
+			"c1": {
+				ConnectionID: "c1",
+				UserID:       "admin",
+				Role:         "admin",
+				ConnectedAt:  now,
+				LastSeen:     now,
+				TTL:          now.Add(time.Hour).Unix(),
+			},
+		},
+	}
+	sm := &subscriptionManager{
+		repo:          repo,
+		apiGW:         &stubStreamerClient{},
+		connections:   map[string]*Connection{},
+		subscriptions: map[string]map[string]*Subscription{},
+		logger:        zap.NewNop(),
+	}
+
+	err := sm.SubscribeThreatIntel("c1")
+	require.NoError(t, err)
+	require.Len(t, repo.created, 1)
+	assert.Equal(t, "threat_intel", repo.created[0].subscriptionType)
+	require.Contains(t, sm.connections, "c1")
+	assert.Equal(t, "admin", sm.connections["c1"].Role)
+}
+
+func TestSubscriptionManager_ConnectionPrincipalLoadsDurableRole(t *testing.T) {
+	repo := &stubSubscriptionRepo{
+		connectionsByID: map[string]storageModels.WebSocketEventConnection{
+			"c1": {ConnectionID: "c1", UserID: "mod", Role: "moderator"},
+		},
+	}
+	sm := &subscriptionManager{
+		repo:          repo,
+		apiGW:         &stubStreamerClient{},
+		connections:   map[string]*Connection{},
+		subscriptions: map[string]map[string]*Subscription{},
+		logger:        zap.NewNop(),
+	}
+
+	principal, err := sm.ConnectionPrincipal("c1")
+	require.NoError(t, err)
+	assert.True(t, principal.Authenticated)
+	assert.Equal(t, "mod", principal.UserID)
+	assert.Equal(t, "moderator", principal.Role)
+}
+
+func TestSubscriptionManager_SubscribeConvenienceMethodsAndPublishAlerts(t *testing.T) {
+	repo := &stubSubscriptionRepo{
+		subsByType: map[string][]storageModels.WebSocketEventSubscription{
+			"performance": {
+				{
+					ConnectionID:     "c1",
+					SubscriptionType: "performance",
+					Filter:           map[string]any{"severity": "critical"},
+				},
+			},
+			"infrastructure": {
+				{ConnectionID: "c2", SubscriptionType: "infrastructure"},
+			},
+		},
+	}
+	client := &stubStreamerClient{}
+	sm := &subscriptionManager{
+		repo:  repo,
+		apiGW: client,
+		connections: map[string]*Connection{
+			"c1": {ConnectionID: "c1"},
+		},
+		subscriptions: map[string]map[string]*Subscription{},
+		logger:        zap.NewNop(),
+	}
+
+	require.NoError(t, sm.SubscribePerformanceAlerts("c1", "critical"))
+	require.NoError(t, sm.SubscribeInfrastructureEvents("c1"))
+	require.NoError(t, sm.SubscribeCommunityNotes("c1"))
+	require.NoError(t, sm.SubscribeTimeline("c1"))
+	require.NoError(t, sm.SubscribeNotifications("c1"))
+	require.Len(t, repo.created, 5)
+
+	require.NoError(t, sm.PublishPerformanceAlert(&PerformanceAlert{
+		ID:        "p1",
+		Severity:  "critical",
+		Timestamp: time.Now(),
+	}))
+	require.NoError(t, sm.PublishInfrastructureEvent(&InfrastructureEvent{
+		ID:        "i1",
+		Timestamp: time.Now(),
+	}))
+	require.Len(t, client.posts, 2)
+	assert.Equal(t, "c1", client.posts[0].connectionID)
+	assert.Equal(t, "c2", client.posts[1].connectionID)
 }
 
 func TestSubscriptionManager_PublishToSubscribers_MarshalError(t *testing.T) {
@@ -224,6 +344,23 @@ func (s *stubSubscriptionManager) HandleConnect(_ string, userID string) error {
 	return s.connectErr
 }
 func (s *stubSubscriptionManager) HandleDisconnect(_ string) error { return nil }
+
+type principalAwareStubSubscriptionManager struct {
+	stubSubscriptionManager
+	connectPrincipal webSocketPrincipal
+	principal        webSocketPrincipal
+	principalErr     error
+}
+
+func (s *principalAwareStubSubscriptionManager) HandleConnectWithPrincipal(_ string, principal webSocketPrincipal) error {
+	s.connectPrincipal = principal
+	s.connectUserID = principal.UserID
+	return s.connectErr
+}
+
+func (s *principalAwareStubSubscriptionManager) ConnectionPrincipal(_ string) (webSocketPrincipal, error) {
+	return s.principal, s.principalErr
+}
 
 func TestWebSocketHandler_Routes(t *testing.T) {
 	sm := &stubSubscriptionManager{}
@@ -325,4 +462,71 @@ func TestWebSocketHandler_AdminAlertSubscriptionsRequireAuthenticatedRoles(t *te
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
+}
+
+func TestWebSocketHandler_AdminAlertSubscriptionUsesRouteAuthorizer(t *testing.T) {
+	sm := &stubSubscriptionManager{}
+	h := NewWebSocketHandler(sm, zap.NewNop())
+
+	resp, err := h.HandleAPIGatewayWebSocketEvent(context.Background(), events.APIGatewayWebsocketProxyRequest{
+		RequestContext: events.APIGatewayWebsocketProxyRequestContext{
+			ConnectionID: "c1",
+			RouteKey:     "subscribe",
+			Authorizer: map[string]any{
+				"username": "mod",
+				"role":     "moderator",
+			},
+		},
+		Body: `{"type":"threat_intel"}`,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	stored, ok := h.connectionPrincipal("c1")
+	require.True(t, ok)
+	assert.Equal(t, "mod", stored.UserID)
+	assert.Equal(t, "moderator", stored.Role)
+}
+
+func TestWebSocketHandler_AdminAlertSubscriptionLoadsDurablePrincipal(t *testing.T) {
+	sm := &principalAwareStubSubscriptionManager{
+		principal: webSocketPrincipal{
+			UserID:        "admin",
+			Role:          "admin",
+			Authenticated: true,
+		},
+	}
+	h := NewWebSocketHandler(sm, zap.NewNop())
+
+	resp, err := h.HandleAPIGatewayWebSocketEvent(context.Background(), events.APIGatewayWebsocketProxyRequest{
+		RequestContext: events.APIGatewayWebsocketProxyRequestContext{ConnectionID: "c1", RouteKey: "subscribe"},
+		Body:           `{"type":"infrastructure"}`,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	stored, ok := h.connectionPrincipal("c1")
+	require.True(t, ok)
+	assert.Equal(t, "admin", stored.UserID)
+	assert.Equal(t, "admin", stored.Role)
+}
+
+func TestWebSocketHandler_ConnectPersistsDurablePrincipalRole(t *testing.T) {
+	sm := &principalAwareStubSubscriptionManager{}
+	h := NewWebSocketHandler(sm, zap.NewNop())
+
+	resp, err := h.HandleAPIGatewayWebSocketEvent(context.Background(), events.APIGatewayWebsocketProxyRequest{
+		RequestContext: events.APIGatewayWebsocketProxyRequestContext{
+			ConnectionID: "c1",
+			RouteKey:     "$connect",
+			Authorizer: map[string]any{
+				"username": "mod",
+				"role":     "moderator",
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, "mod", sm.connectPrincipal.UserID)
+	assert.Equal(t, "moderator", sm.connectPrincipal.Role)
 }

--- a/pkg/websocket/subscriptions_additional_test.go
+++ b/pkg/websocket/subscriptions_additional_test.go
@@ -230,9 +230,13 @@ func TestWebSocketHandler_Routes(t *testing.T) {
 	h := NewWebSocketHandler(sm, zap.NewNop())
 
 	resp, err := h.HandleAPIGatewayWebSocketEvent(context.Background(), events.APIGatewayWebsocketProxyRequest{
-		RequestContext: events.APIGatewayWebsocketProxyRequestContext{ConnectionID: "c1", RouteKey: "$connect"},
-		QueryStringParameters: map[string]string{
-			"user_id": "u1",
+		RequestContext: events.APIGatewayWebsocketProxyRequestContext{
+			ConnectionID: "c1",
+			RouteKey:     "$connect",
+			Authorizer: map[string]any{
+				"username": "u1",
+				"role":     "admin",
+			},
 		},
 	})
 	require.NoError(t, err)
@@ -278,4 +282,47 @@ func TestWebSocketHandler_Routes(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Equal(t, 404, resp.StatusCode)
+}
+
+func TestWebSocketHandler_AdminAlertSubscriptionsRequireAuthenticatedRoles(t *testing.T) {
+	sm := &stubSubscriptionManager{}
+	h := NewWebSocketHandler(sm, zap.NewNop())
+
+	resp, err := h.HandleAPIGatewayWebSocketEvent(context.Background(), events.APIGatewayWebsocketProxyRequest{
+		RequestContext: events.APIGatewayWebsocketProxyRequestContext{ConnectionID: "c1", RouteKey: "subscribe"},
+		Body:           `{"type":"moderation"}`,
+	})
+	require.Error(t, err)
+	assert.Equal(t, 401, resp.StatusCode)
+
+	h.rememberConnectionPrincipal("c1", webSocketPrincipal{
+		UserID:        "alice",
+		Role:          "user",
+		Authenticated: true,
+	})
+	resp, err = h.HandleAPIGatewayWebSocketEvent(context.Background(), events.APIGatewayWebsocketProxyRequest{
+		RequestContext: events.APIGatewayWebsocketProxyRequestContext{ConnectionID: "c1", RouteKey: "subscribe"},
+		Body:           `{"type":"threat_intel"}`,
+	})
+	require.Error(t, err)
+	assert.Equal(t, 403, resp.StatusCode)
+
+	h.rememberConnectionPrincipal("c1", webSocketPrincipal{
+		UserID:        "mod",
+		Role:          "moderator",
+		Authenticated: true,
+	})
+	resp, err = h.HandleAPIGatewayWebSocketEvent(context.Background(), events.APIGatewayWebsocketProxyRequest{
+		RequestContext: events.APIGatewayWebsocketProxyRequestContext{ConnectionID: "c1", RouteKey: "subscribe"},
+		Body:           `{"type":"infrastructure"}`,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	resp, err = h.HandleAPIGatewayWebSocketEvent(context.Background(), events.APIGatewayWebsocketProxyRequest{
+		RequestContext: events.APIGatewayWebsocketProxyRequestContext{ConnectionID: "c1", RouteKey: "subscribe"},
+		Body:           `{"type":"timeline"}`,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
 }

--- a/pkg/websocket/subscriptions_more_test.go
+++ b/pkg/websocket/subscriptions_more_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-lambda-go/events"
+	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -34,6 +35,27 @@ func TestSubscriptionManager_HandleConnectAndDisconnect_Errors(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestSubscriptionManager_HandleConnectWithPrincipalPersistsRole(t *testing.T) {
+	repo := &stubSubscriptionRepo{}
+	sm := &subscriptionManager{
+		repo:          repo,
+		apiGW:         &stubStreamerClient{},
+		connections:   map[string]*Connection{},
+		subscriptions: map[string]map[string]*Subscription{},
+		logger:        zap.NewNop(),
+	}
+
+	err := sm.HandleConnectWithPrincipal("c1", webSocketPrincipal{
+		UserID:        "mod",
+		Role:          "moderator",
+		Authenticated: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "moderator", repo.connectRole)
+	require.Contains(t, sm.connections, "c1")
+	assert.Equal(t, "moderator", sm.connections["c1"].Role)
+}
+
 func TestSubscriptionManager_createSubscription_ErrorBranches(t *testing.T) {
 	repo := &stubSubscriptionRepo{createErr: errors.New("boom")}
 	sm := &subscriptionManager{
@@ -51,6 +73,77 @@ func TestSubscriptionManager_createSubscription_ErrorBranches(t *testing.T) {
 	err = sm.createSubscription("c1", "moderation", map[string]any{"severity": "high"})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to store subscription")
+}
+
+func TestSubscriptionManager_ConnectionAndFilterBranches(t *testing.T) {
+	smNoRepo := &subscriptionManager{}
+	_, err := smNoRepo.ConnectionPrincipal("c1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "connection repository is not configured")
+
+	smEmptyConnection := &subscriptionManager{
+		repo: &stubSubscriptionRepo{
+			connectionsByID: map[string]storageModels.WebSocketEventConnection{
+				"empty": {},
+			},
+		},
+	}
+	_, err = smEmptyConnection.ConnectionPrincipal("empty")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "connection not found")
+
+	now := time.Now()
+	sm := &subscriptionManager{
+		connections: map[string]*Connection{},
+	}
+	dbConn := &storageModels.WebSocketEventConnection{
+		ConnectionID: "c1",
+		UserID:       "anonymous",
+		ConnectedAt:  now,
+		LastSeen:     now,
+		TTL:          now.Add(time.Hour).Unix(),
+	}
+	sm.cacheConnection(dbConn)
+	sm.cacheConnection(dbConn)
+	require.Contains(t, sm.connections, "c1")
+
+	event := &ModerationEvent{
+		Severity:  "high",
+		Type:      "spam",
+		UserID:    "u1",
+		ContentID: "note1",
+	}
+	require.True(t, sm.matchesModerationFilter(event, nil))
+	require.False(t, sm.matchesModerationFilter(event, map[string]any{"severity": []any{"low"}}))
+	require.False(t, sm.matchesModerationFilter(event, map[string]any{"types": []any{"abuse"}}))
+	require.False(t, sm.matchesModerationFilter(event, map[string]any{"user_id": "u2"}))
+	require.False(t, sm.matchesModerationFilter(event, map[string]any{"content_id": "note2"}))
+
+	alert := &PerformanceAlert{Severity: "critical"}
+	require.True(t, sm.matchesPerformanceFilter(alert, nil))
+	require.False(t, sm.matchesPerformanceFilter(alert, map[string]any{"severity": "warning"}))
+}
+
+func TestNewSubscriptionManagerRejectsEmptyEndpoint(t *testing.T) {
+	manager, err := NewSubscriptionManager(nil, "", zap.NewNop())
+	require.Error(t, err)
+	require.Nil(t, manager)
+}
+
+func TestNewSubscriptionManagerInitializesState(t *testing.T) {
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+
+	manager, err := NewSubscriptionManager(nil, "wss://example.com/dev", zap.NewNop())
+	require.NoError(t, err)
+	require.NotNil(t, manager)
+
+	sm, ok := manager.(*subscriptionManager)
+	require.True(t, ok)
+	require.NotNil(t, sm.apiGW)
+	require.NotNil(t, sm.connections)
+	require.NotNil(t, sm.subscriptions)
+	assert.Equal(t, "wss://example.com/dev", sm.endpoint)
 }
 
 func TestSubscriptionManager_Unsubscribe_RepoError(t *testing.T) {
@@ -236,11 +329,42 @@ func TestWebSocketHandler_PrincipalHelpers(t *testing.T) {
 	anonymous := h.extractPrincipal(events.APIGatewayWebsocketProxyRequest{})
 	require.False(t, anonymous.Authenticated)
 
+	require.Nil(t, flattenAuthorizerFields(make(chan int)))
+	require.Empty(t, flattenAuthorizerFields("plain"))
+	require.Equal(t, "", firstAuthorizerField(nil, "role"))
+
+	h.principals = nil
+	h.rememberConnectionPrincipal("c2", principal)
+	stored, ok = h.connectionPrincipal("c2")
+	require.True(t, ok)
+	require.Equal(t, "mod", stored.UserID)
+
+	h.principals = nil
+	_, ok = h.connectionPrincipal("missing")
+	require.False(t, ok)
+
 	require.Equal(t, http.StatusInternalServerError, webSocketErrorStatus(errors.New("boom")))
+	require.Equal(t, "forbidden", (&webSocketStatusError{message: "forbidden"}).Error())
 	require.Equal(t, http.StatusForbidden, webSocketErrorStatus(&webSocketStatusError{
 		statusCode: http.StatusForbidden,
 		message:    "forbidden",
 	}))
+}
+
+func TestWebSocketHandler_PrincipalForEventDurableMisses(t *testing.T) {
+	h := NewWebSocketHandler(&principalAwareStubSubscriptionManager{principalErr: errors.New("boom")}, zap.NewNop())
+	_, ok := h.principalForEvent("c1", events.APIGatewayWebsocketProxyRequest{
+		RequestContext: events.APIGatewayWebsocketProxyRequestContext{ConnectionID: "c1"},
+	})
+	require.False(t, ok)
+
+	h = NewWebSocketHandler(&principalAwareStubSubscriptionManager{}, zap.NewNop())
+	_, ok = h.principalForEvent("c1", events.APIGatewayWebsocketProxyRequest{
+		RequestContext: events.APIGatewayWebsocketProxyRequestContext{ConnectionID: "c1"},
+	})
+	require.False(t, ok)
+
+	assert.Empty(t, h.parseModerationFilter("not-a-map"))
 }
 
 func TestSubscriptionManager_handleDeadConnection_Async(t *testing.T) {

--- a/pkg/websocket/subscriptions_more_test.go
+++ b/pkg/websocket/subscriptions_more_test.go
@@ -3,6 +3,7 @@ package websocket
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 
@@ -151,6 +152,7 @@ func TestWebSocketHandler_MoreRoutesAndParsing(t *testing.T) {
 	})
 
 	t.Run("subscribe performance uses default severity when missing", func(t *testing.T) {
+		h.rememberConnectionPrincipal("c1", webSocketPrincipal{UserID: "admin", Role: "admin", Authenticated: true})
 		resp, err := h.HandleAPIGatewayWebSocketEvent(context.Background(), events.APIGatewayWebsocketProxyRequest{
 			RequestContext: events.APIGatewayWebsocketProxyRequestContext{ConnectionID: "c1", RouteKey: "subscribe"},
 			Body:           `{"type":"performance","filter":{}}`,
@@ -161,6 +163,7 @@ func TestWebSocketHandler_MoreRoutesAndParsing(t *testing.T) {
 	})
 
 	t.Run("moderation filter unmarshal failure falls back to empty filter", func(t *testing.T) {
+		h.rememberConnectionPrincipal("c1", webSocketPrincipal{UserID: "admin", Role: "admin", Authenticated: true})
 		resp, err := h.HandleAPIGatewayWebSocketEvent(context.Background(), events.APIGatewayWebsocketProxyRequest{
 			RequestContext: events.APIGatewayWebsocketProxyRequestContext{ConnectionID: "c1", RouteKey: "subscribe"},
 			Body:           `{"type":"moderation","filter":{"severity":123}}`,
@@ -198,6 +201,46 @@ func TestWebSocketHandler_MoreRoutesAndParsing(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 200, resp.StatusCode)
 	})
+}
+
+func TestWebSocketHandler_PrincipalHelpers(t *testing.T) {
+	h := NewWebSocketHandler(&stubSubscriptionManager{}, zap.NewNop())
+
+	principal := h.extractPrincipal(events.APIGatewayWebsocketProxyRequest{
+		RequestContext: events.APIGatewayWebsocketProxyRequestContext{
+			Authorizer: map[string]any{
+				"claims": map[string]any{
+					"cognito:username": "mod",
+					"cognito:groups":   []any{"users", "moderator"},
+				},
+			},
+		},
+	})
+	require.True(t, principal.Authenticated)
+	require.Equal(t, "mod", principal.UserID)
+	require.Equal(t, "users,moderator", principal.Role)
+	require.True(t, webSocketRoleAllowsAdminAlerts(principal.Role))
+	require.True(t, webSocketRoleAllowsAdminAlerts("admin"))
+	require.True(t, webSocketRoleAllowsAdminAlerts("mod"))
+	require.False(t, webSocketRoleAllowsAdminAlerts("user"))
+
+	h.rememberConnectionPrincipal("c1", principal)
+	stored, ok := h.connectionPrincipal("c1")
+	require.True(t, ok)
+	require.Equal(t, "mod", stored.UserID)
+
+	h.forgetConnectionPrincipal("c1")
+	_, ok = h.connectionPrincipal("c1")
+	require.False(t, ok)
+
+	anonymous := h.extractPrincipal(events.APIGatewayWebsocketProxyRequest{})
+	require.False(t, anonymous.Authenticated)
+
+	require.Equal(t, http.StatusInternalServerError, webSocketErrorStatus(errors.New("boom")))
+	require.Equal(t, http.StatusForbidden, webSocketErrorStatus(&webSocketStatusError{
+		statusCode: http.StatusForbidden,
+		message:    "forbidden",
+	}))
 }
 
 func TestSubscriptionManager_handleDeadConnection_Async(t *testing.T) {


### PR DESCRIPTION
## Milestone
Codex Security M5 — Agents, trust, wallet, and protected GraphQL data

Closes #841
Closes #842
Closes #843
Closes #844
Closes #845
Closes #846
Closes #847

## Classification
security / federation-trust / contract-stability / privacy / operational-reliability

## Surfaces affected
- Agent access lease renewal, suspension checks, delegated refresh-token expiry caps
- Agent ownership and public agent metadata redaction across REST and GraphQL
- GraphQL trust graph authorization and AI analysis ownership/PII redaction
- GraphQL actor `tipAddress` wallet disclosure rules
- Lesser-host trust proxy auth for read-scoped assets, JWKS, and attestations
- WebSocket admin alert subscription authorization and principal tracking
- Test coverage, including the branch-start gofmt cleanup on inbox routing coverage

## Review follow-up
- Redacts `Agent.identitySemantics.soulBindingState` and `soulAgentId` inside the field resolver for non-owner/admin viewers, so public GraphQL callers cannot recompute soul binding metadata after the parent `Agent` object is redacted.
- Added resolver-level regression coverage for public vs owner identity semantics.
- Added cmd coverage headroom for GitHub's verify coverage gate.

## Specialist walks referenced
- Federation trust: agent delegation, governance, and admin subscription boundaries hardened without weakening HTTP Signature or delivery behavior
- Contract / API: backward-compatible semantic refinements; no response-shape break. Trust proxy auth now matches the already documented bearer/read OpenAPI contract. GraphQL identity semantics keeps the same schema and redacts private fields for unauthorized viewers.
- Schema: no PK/SK, GSI, or TableTheory tag changes
- Framework: idiomatic AppTheory/TableTheory use; no framework patches

## Consumer impact
- Operators get stricter authorization around agents, protected GraphQL data, trust proxy assets, and admin WebSocket feeds.
- Mastodon-compatible REST shape remains backward-compatible; affected protected endpoints now enforce documented auth.
- Remote ActivityPub peers are not impacted by wire-shape changes.
- Sibling repos: no release artifact, JSON-LD namespace, or MCP contract shape changes.

## Tasks
- [x] #842 `fix(agents): enforce lease suspension and refresh expiry`
- [x] #843 `fix(agents): protect identity semantics and ownership checks`
- [x] #844 `fix(graphql): protect trust graph and ai analysis data`
- [x] #845 `fix(graphql): restrict actor tip address disclosure`
- [x] #846 `fix(proxy): require auth for trust proxy assets`
- [x] #847 `fix(websocket): authorize admin alert subscriptions`

## Validation
- `gofmt -l .` (empty)
- `go test ./...`
- `go vet ./...`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas` (38 Lambda artifacts)
- `./lesser verify ci` ✅
  - lint/security/supply-chain/inventory/doc drift/strict GraphQL + OpenAPI contracts
  - coverage gates after review follow-up: pkg 90.007%, cmd 90.023%
- Targeted during implementation/follow-up: `go test ./pkg/auth ./cmd/api/handlers ./graph`, `go test ./pkg/ai ./cmd/api/handlers ./graph`, `go test ./pkg/websocket`, `go test -count=1 -cover ./cmd/api/handlers ./graph`

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live
- [ ] Post-deploy monitoring verified

## Cross-repo coordination
None required for this PR.

## Advisor-brief authorization
Not applicable — Aron directly authorized this milestone work.