### PR TITLE
fix(security): complete Codex Security M6

### DIFF
--- a/cmd/api/handlers/admin.go
+++ b/cmd/api/handlers/admin.go
@@ -52,6 +52,13 @@ func isNotFoundError(err error) bool {
 	return errors.Is(err, storage.ErrNotFound) || apperrors.HasCode(err, apperrors.CodeNotFound)
 }
 
+func (h *Handler) adminInternalServerError(ctx *apptheory.Context, err error) (*apptheory.Response, error) {
+	if h != nil && h.logger != nil {
+		h.logger.Error("admin handler internal error", zap.Error(err))
+	}
+	return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+}
+
 // processUserSessions processes user sessions to extract IP history and most recent IP
 func processUserSessions(sessions []*storage.Session) (lastIP *string, ipHistory []models.AdminIP) {
 	if err := common.ValidateSliceNotEmpty("sessions", sessions); err != nil {
@@ -119,7 +126,7 @@ func (h *Handler) adminAccountAction(ctx *apptheory.Context, action string, acti
 	// Execute the action
 	if err := actionFn(username); err != nil {
 		h.logger.Error("failed to "+action+" account", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	return noContent(), nil
@@ -146,7 +153,7 @@ func (h *Handler) adminAction(ctx *apptheory.Context, action string, updatesFn f
 	updates, err := updatesFn(username)
 	if err != nil {
 		h.logger.Error("failed to execute "+action, zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	// Update user if we have updates
@@ -154,7 +161,7 @@ func (h *Handler) adminAction(ctx *apptheory.Context, action string, updatesFn f
 		updates["updated_at"] = time.Now()
 		if err := h.repos.Account().UpdateUser(ctx.Context(), username, updates); err != nil {
 			h.logger.Error("failed to "+action+" user", zap.Error(err))
-			return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return h.adminInternalServerError(ctx, err)
 		}
 	}
 
@@ -190,7 +197,7 @@ func (h *Handler) HandleAdminGetAccountsLift(ctx *apptheory.Context) (*apptheory
 	users, nextCursor, err := h.repos.User().ListUsers(ctx.Context(), safeLimit32, cursor)
 	if err != nil {
 		h.logger.Error("failed to list users", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	// Convert to admin account format
@@ -277,14 +284,14 @@ func (h *Handler) HandleAdminGetAccountLift(ctx *apptheory.Context) (*apptheory.
 			return apptheory.JSON(http.StatusNotFound, map[string]string{"error": "account not found"})
 		}
 		h.logger.Error("failed to get user", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	// Get actor info
 	actor, err := h.repos.Actor().GetActor(ctx.Context(), username)
 	if err != nil {
 		h.logger.Error("failed to get actor", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	// Get report stats
@@ -411,7 +418,7 @@ func (h *Handler) HandleAdminAccountActionLift(ctx *apptheory.Context) (*apptheo
 		updates["updated_at"] = time.Now()
 		if err := h.repos.Account().UpdateUser(ctx.Context(), username, updates); err != nil {
 			h.logger.Error("failed to update user", zap.Error(err))
-			return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return h.adminInternalServerError(ctx, err)
 		}
 	}
 
@@ -463,7 +470,7 @@ func (h *Handler) HandleAdminEnableAccountLift(ctx *apptheory.Context) (*apptheo
 
 	if err := h.repos.Account().UpdateUser(ctx.Context(), username, updates); err != nil {
 		h.logger.Error("failed to enable user", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	return noContent(), nil
@@ -521,7 +528,7 @@ func (h *Handler) HandleAdminGetReportsLift(ctx *apptheory.Context) (*apptheory.
 	reports, nextCursor, err := h.repos.Moderation().GetReportsByStatus(ctx.Context(), status, limit, cursor)
 	if err != nil {
 		h.logger.Error("failed to get reports", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	// Convert to API format
@@ -705,14 +712,14 @@ func (h *Handler) HandleAdminResolveReportLift(ctx *apptheory.Context) (*apptheo
 			return apptheory.JSON(http.StatusNotFound, map[string]string{"error": "report not found"})
 		}
 		h.logger.Error("failed to resolve report", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	// Get updated report
 	report, err := h.repos.Moderation().GetReport(ctx.Context(), reportID)
 	if err != nil {
 		h.logger.Error("failed to get updated report", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	// Convert to API format (simplified for now)
@@ -743,7 +750,7 @@ func (h *Handler) HandleAdminReopenReportLift(ctx *apptheory.Context) (*apptheor
 			return apptheory.JSON(http.StatusNotFound, map[string]string{"error": "report not found"})
 		}
 		h.logger.Error("failed to reopen report", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	// Log admin action
@@ -780,13 +787,13 @@ func (h *Handler) HandleAdminAssignReportLift(ctx *apptheory.Context) (*apptheor
 			return apptheory.JSON(http.StatusNotFound, map[string]string{"error": "report not found"})
 		}
 		h.logger.Error("failed to get report", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	// Assign report to the admin
 	if err := h.repos.Moderation().AssignReport(ctx.Context(), reportID, adminClaims.Username); err != nil {
 		h.logger.Error("failed to assign report", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	// Log admin action
@@ -823,13 +830,13 @@ func (h *Handler) HandleAdminUnassignReportLift(ctx *apptheory.Context) (*appthe
 			return apptheory.JSON(http.StatusNotFound, map[string]string{"error": "report not found"})
 		}
 		h.logger.Error("failed to get report", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	// Unassign the report
 	if err := h.repos.Moderation().UnassignReport(ctx.Context(), reportID); err != nil {
 		h.logger.Error("failed to unassign report", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	// Log admin action
@@ -935,7 +942,7 @@ func (h *Handler) HandleAdminGetModerationEventsLift(ctx *apptheory.Context) (*a
 	events, nextCursor, err := h.repos.Moderation().GetModerationEvents(ctx.Context(), filter, limit, cursor)
 	if err != nil {
 		h.logger.Error("failed to get moderation events", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	// Convert to response format
@@ -1022,7 +1029,7 @@ func (h *Handler) HandleAdminOverrideModerationEventLift(ctx *apptheory.Context)
 			return apptheory.JSON(http.StatusNotFound, map[string]string{"error": "moderation event not found"})
 		}
 		h.logger.Error("failed to get moderation event", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	// Map decision to action type
@@ -1046,7 +1053,7 @@ func (h *Handler) HandleAdminOverrideModerationEventLift(ctx *apptheory.Context)
 	err = h.repos.Moderation().CreateAdminReview(ctx.Context(), eventID, adminClaims.Username, action, req.Reason)
 	if err != nil {
 		h.logger.Error("failed to create admin review", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	// Log admin action
@@ -1088,7 +1095,7 @@ func (h *Handler) HandleAdminGetTrustGraphLift(ctx *apptheory.Context) (*apptheo
 	trustRelationships, err := h.repos.Trust().GetAllTrustRelationships(ctx.Context(), limit)
 	if err != nil {
 		h.logger.Error("failed to get trust relationships", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	// Build graph structure
@@ -1177,7 +1184,7 @@ func (h *Handler) HandleAdminUpdateTrustLift(ctx *apptheory.Context) (*apptheory
 
 	if err := h.repos.Trust().UpdateTrustRelationship(ctx.Context(), trustRel); err != nil {
 		h.logger.Error("failed to update trust relationship", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	// Log admin action
@@ -1213,14 +1220,14 @@ func (h *Handler) HandleAdminGetReviewersLift(ctx *apptheory.Context) (*apptheor
 	moderatorUsers, err := h.repos.User().ListUsersByRole(ctx.Context(), roleModerator)
 	if err != nil {
 		h.logger.Error("failed to list moderator users", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	// Get users with admin role
 	adminUsers, err := h.repos.User().ListUsersByRole(ctx.Context(), roleAdmin)
 	if err != nil {
 		h.logger.Error("failed to list admin users", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	// Combine both lists
@@ -1277,7 +1284,7 @@ func (h *Handler) HandleAdminPromoteModeratorLift(ctx *apptheory.Context) (*appt
 
 	if err := h.repos.Account().UpdateUser(ctx.Context(), username, updates); err != nil {
 		h.logger.Error("failed to promote user to moderator", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	// Log admin action
@@ -1313,7 +1320,7 @@ func (h *Handler) HandleAdminDemoteModeratorLift(ctx *apptheory.Context) (*appth
 			return apptheory.JSON(http.StatusNotFound, map[string]string{"error": "user not found"})
 		}
 		h.logger.Error("failed to get user", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	if user.Role == roleAdmin {
@@ -1328,7 +1335,7 @@ func (h *Handler) HandleAdminDemoteModeratorLift(ctx *apptheory.Context) (*appth
 
 	if err := h.repos.Account().UpdateUser(ctx.Context(), username, updates); err != nil {
 		h.logger.Error("failed to demote moderator", zap.Error(err))
-		return apptheory.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return h.adminInternalServerError(ctx, err)
 	}
 
 	// Log admin action

--- a/cmd/api/handlers/admin.go
+++ b/cmd/api/handlers/admin.go
@@ -52,7 +52,7 @@ func isNotFoundError(err error) bool {
 	return errors.Is(err, storage.ErrNotFound) || apperrors.HasCode(err, apperrors.CodeNotFound)
 }
 
-func (h *Handler) adminInternalServerError(ctx *apptheory.Context, err error) (*apptheory.Response, error) {
+func (h *Handler) adminInternalServerError(_ *apptheory.Context, err error) (*apptheory.Response, error) {
 	if h != nil && h.logger != nil {
 		h.logger.Error("admin handler internal error", zap.Error(err))
 	}

--- a/cmd/api/handlers/admin_round10_extra_coverage_test.go
+++ b/cmd/api/handlers/admin_round10_extra_coverage_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"reflect"
@@ -498,6 +499,23 @@ func TestAdminLift_Round10Coverage_ExtraPaths(t *testing.T) {
 		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/admin/moderation/reviewers", headers, nil, nil)
 		require.NoError(t, err)
 		requireStatus(t, http.StatusOK)(h.HandleAdminGetReviewersLift(ctx))
+	})
+
+	t.Run("Admin accounts redacts internal error details", func(t *testing.T) {
+		state := cloneState()
+		state.allErrorByType = map[string]error{
+			reflect.TypeOf(&[]storagemodels.User{}).String(): errors.New("secret ddb failure with table internals"),
+		}
+		h := newHandler(t, state)
+
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/admin/accounts", headers, nil, nil)
+		require.NoError(t, err)
+		resp := requireStatus(t, http.StatusInternalServerError)(h.HandleAdminGetAccountsLift(ctx))
+
+		var body map[string]string
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "internal server error", body["error"])
+		require.NotContains(t, string(resp.Body), "secret ddb failure")
 	})
 
 	t.Run("Moderation overview covers empty queue and reports", func(t *testing.T) {

--- a/cmd/api/handlers/helpers_round29_coverage_test.go
+++ b/cmd/api/handlers/helpers_round29_coverage_test.go
@@ -1,0 +1,75 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/config"
+	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHelpers_RecoveredActorAndStatusLinks_Round29(t *testing.T) {
+	h := &Handler{cfg: &config.Config{Domain: "example.com"}}
+
+	t.Run("normalize recovered actor fills local identity when missing", func(t *testing.T) {
+		normalizeRecoveredLocalActor(h, nil, "alice")
+
+		actor := &activitypub.Actor{}
+		normalizeRecoveredLocalActor(h, actor, "alice")
+		require.Equal(t, "alice", actor.PreferredUsername)
+		require.Equal(t, "https://example.com/users/alice", actor.ID)
+
+		actor.ID = "https://remote.example/users/alice"
+		normalizeRecoveredLocalActor(h, actor, "alice-renamed")
+		require.Equal(t, "alice-renamed", actor.PreferredUsername)
+		require.Equal(t, "https://remote.example/users/alice", actor.ID)
+	})
+
+	t.Run("remoteStatusURL prefers note id then first http url", func(t *testing.T) {
+		require.Empty(t, h.remoteStatusURL(nil))
+		require.Equal(t, "https://remote.example/notes/1", h.remoteStatusURL(&storagemodels.Status{
+			Note: &activitypub.Note{BaseObject: activitypub.BaseObject{ID: " https://remote.example/notes/1 "}},
+			URLs: []string{"https://fallback.example/status/1"},
+		}))
+		require.Equal(t, "https://remote.example/status/2", h.remoteStatusURL(&storagemodels.Status{
+			URLs: []string{"not-a-url", " https://remote.example/status/2 "},
+		}))
+		require.Empty(t, h.remoteStatusURL(&storagemodels.Status{URLs: []string{"not-a-url"}}))
+	})
+
+	t.Run("status author profile url separates remote and local authors", func(t *testing.T) {
+		require.Empty(t, h.statusAuthorProfileURL(nil))
+		require.Equal(t, "https://remote.example/users/bob", h.statusAuthorProfileURL(&storagemodels.Status{
+			AuthorUsername: "bob@remote.example",
+			AuthorID:       " https://remote.example/users/bob ",
+		}))
+		require.Equal(t, "https://example.com/@alice", h.statusAuthorProfileURL(&storagemodels.Status{
+			AuthorUsername: "alice",
+			AuthorID:       "https://example.com/users/alice",
+		}))
+	})
+
+	t.Run("status links use remote urls or local actor/status urls", func(t *testing.T) {
+		uri, url := h.statusLinks(nil)
+		require.Empty(t, uri)
+		require.Empty(t, url)
+
+		uri, url = h.statusLinks(&storagemodels.Status{
+			StatusID:       "remote-status-id",
+			AuthorUsername: "bob@remote.example",
+			AuthorID:       "https://remote.example/users/bob",
+			Note:           &activitypub.Note{BaseObject: activitypub.BaseObject{ID: "https://remote.example/notes/1"}},
+		})
+		require.Equal(t, "https://remote.example/notes/1", uri)
+		require.Equal(t, "https://remote.example/notes/1", url)
+
+		uri, url = h.statusLinks(&storagemodels.Status{
+			StatusID:       "status/with slash",
+			AuthorUsername: "alice",
+			AuthorID:       "https://example.com/users/alice",
+		})
+		require.Equal(t, "https://example.com/users/alice/statuses/status%2Fwith%20slash", uri)
+		require.Equal(t, "https://example.com/@alice/status%2Fwith%20slash", url)
+	})
+}

--- a/cmd/api/handlers/misc.go
+++ b/cmd/api/handlers/misc.go
@@ -880,6 +880,14 @@ func (h *Handler) attachStatusToNotification(ctx *apptheory.Context, notif *stor
 		return
 	}
 
+	if !h.notificationObjectVisibleToViewer(ctx.Context(), notif, obj) {
+		h.logger.Debug("skipping notification status expansion due to visibility",
+			zap.String("notification_id", notif.ID),
+			zap.String("status_id", notif.StatusID),
+			zap.String("viewer", notif.Username))
+		return
+	}
+
 	// Get status author
 	statusActor := h.extractStatusAuthor(ctx, obj)
 
@@ -918,6 +926,13 @@ func (h *Handler) statusFromNotificationSnapshot(ctx *apptheory.Context, notif *
 		return nil
 	}
 
+	if !h.notificationSnapshotVisibleToViewer(ctx.Context(), notif, snapshot) {
+		h.logger.Debug("skipping notification snapshot expansion due to visibility",
+			zap.String("notification_id", notif.ID),
+			zap.String("viewer", notif.Username))
+		return nil
+	}
+
 	statusActor := h.notificationSnapshotActor(ctx, snapshot)
 	status := transformations.ObjectToStatusBase(notificationSnapshotObjectMap(snapshot), statusActor, h.cfg.BaseURL())
 	if status.ID == "" {
@@ -932,6 +947,102 @@ func (h *Handler) statusFromNotificationSnapshot(ctx *apptheory.Context, notif *
 	}
 
 	return &status
+}
+
+func (h *Handler) notificationSnapshotVisibleToViewer(ctx context.Context, notif *storage.Notification, snapshot map[string]interface{}) bool {
+	return h.notificationStatusVisibleToViewer(ctx,
+		notif,
+		notificationSnapshotString(snapshot, "visibility"),
+		notificationSnapshotString(snapshot, "attributedTo"),
+		nil,
+		nil,
+	)
+}
+
+func (h *Handler) notificationObjectVisibleToViewer(ctx context.Context, notif *storage.Notification, obj any) bool {
+	visibility, attributedTo, recipients, mentions := notificationObjectVisibilityContext(obj)
+	return h.notificationStatusVisibleToViewer(ctx, notif, visibility, attributedTo, recipients, mentions)
+}
+
+func (h *Handler) notificationStatusVisibleToViewer(
+	ctx context.Context,
+	notif *storage.Notification,
+	visibility string,
+	attributedTo string,
+	recipients []string,
+	mentions []string,
+) bool {
+	visibility = strings.TrimSpace(visibility)
+	if visibility == "" {
+		visibility = storagemodels.VisibilityPublic
+	}
+
+	switch visibility {
+	case storagemodels.VisibilityPublic, storagemodels.VisibilityUnlisted:
+		return true
+	}
+
+	if notif == nil {
+		return false
+	}
+	viewer := strings.TrimSpace(notif.Username)
+	if viewer == "" {
+		return false
+	}
+	author := extractUsernameFromNotificationActorID(attributedTo)
+	if author != "" && strings.EqualFold(viewer, author) {
+		return true
+	}
+
+	switch visibility {
+	case storagemodels.VisibilityPrivate:
+		return h.notificationViewerFollowsAuthor(ctx, viewer, author)
+	case storagemodels.VisibilityDirect:
+		return h.notificationDirectVisibleToViewer(viewer, recipients, mentions)
+	default:
+		h.logger.Warn("unknown notification status visibility",
+			zap.String("notification_id", notif.ID),
+			zap.String("visibility", visibility))
+		return false
+	}
+}
+
+func (h *Handler) notificationViewerFollowsAuthor(ctx context.Context, viewer, author string) bool {
+	if viewer == "" || author == "" || h == nil || h.repos == nil || h.repos.Relationship() == nil {
+		return false
+	}
+	ok, err := h.repos.Relationship().IsFollowing(ctx, viewer, author)
+	if err != nil {
+		h.logger.Warn("failed to check notification status visibility",
+			zap.String("viewer", viewer),
+			zap.String("author", author),
+			zap.Error(err))
+		return false
+	}
+	return ok
+}
+
+func (h *Handler) notificationDirectVisibleToViewer(viewer string, recipients []string, mentions []string) bool {
+	if strings.TrimSpace(viewer) == "" {
+		return false
+	}
+	// Legacy notification snapshots did not persist direct-message recipient
+	// arrays. A notification is already scoped to a single owner, so keep those
+	// owner-visible while enforcing recipient checks whenever recipient evidence
+	// is present.
+	if len(recipients) == 0 && len(mentions) == 0 {
+		return true
+	}
+	viewerActorID := ""
+	if h != nil && h.cfg != nil {
+		viewerActorID = h.cfg.ActorURL(viewer)
+	}
+	for _, value := range append(recipients, mentions...) {
+		if mentionMatchesNotificationViewer(value, viewer, viewerActorID) {
+			return true
+		}
+	}
+	return false
 }
 
 func (h *Handler) notificationSnapshotActor(ctx *apptheory.Context, snapshot map[string]interface{}) *activitypub.Actor {
@@ -997,6 +1108,98 @@ func (h *Handler) cachedRemoteNotificationActor(ctx context.Context, actorID str
 		}
 	}
 	return nil
+}
+
+func notificationObjectVisibilityContext(obj any) (visibility string, attributedTo string, recipients []string, mentions []string) {
+	switch typed := obj.(type) {
+	case *activitypub.Note:
+		return typed.Visibility, typed.AttributedTo, appendNotificationRecipients(nil, typed.To, typed.CC, typed.BTo, typed.BCC), noteMentionTargets(typed.Tag)
+	case *storagemodels.Object:
+		return typed.Visibility, typed.AttributedTo, appendNotificationRecipients(nil, typed.To, typed.CC, typed.BTo, typed.BCC), nil
+	case map[string]interface{}:
+		return notificationSnapshotString(typed, "visibility"),
+			notificationSnapshotString(typed, "attributedTo"),
+			appendNotificationRecipients(nil,
+				notificationStringSliceFromAny(typed["to"]),
+				notificationStringSliceFromAny(typed["cc"]),
+				notificationStringSliceFromAny(typed["bto"]),
+				notificationStringSliceFromAny(typed["bcc"])),
+			notificationMentionTargetsFromAny(typed["tag"])
+	default:
+		return "", "", nil, nil
+	}
+}
+
+func appendNotificationRecipients(dst []string, lists ...[]string) []string {
+	for _, list := range lists {
+		for _, value := range list {
+			if trimmed := strings.TrimSpace(value); trimmed != "" {
+				dst = append(dst, trimmed)
+			}
+		}
+	}
+	return dst
+}
+
+func noteMentionTargets(tags []activitypub.Tag) []string {
+	out := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		if strings.EqualFold(strings.TrimSpace(tag.Type), "Mention") {
+			out = appendNotificationRecipients(out, []string{tag.Href, tag.Name})
+		}
+	}
+	return out
+}
+
+func notificationMentionTargetsFromAny(value interface{}) []string {
+	items, ok := value.([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		tag, ok := item.(map[string]interface{})
+		if !ok || !strings.EqualFold(notificationSnapshotString(tag, "type"), "Mention") {
+			continue
+		}
+		out = appendNotificationRecipients(out, []string{
+			notificationSnapshotString(tag, "href"),
+			notificationSnapshotString(tag, "name"),
+		})
+	}
+	return out
+}
+
+func notificationStringSliceFromAny(value interface{}) []string {
+	switch typed := value.(type) {
+	case []string:
+		return appendNotificationRecipients(nil, typed)
+	case []interface{}:
+		out := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if str, ok := item.(string); ok {
+				out = appendNotificationRecipients(out, []string{str})
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func mentionMatchesNotificationViewer(value, viewer, viewerActorID string) bool {
+	value = strings.TrimSpace(strings.TrimPrefix(value, "@"))
+	viewer = strings.TrimSpace(viewer)
+	if value == "" || viewer == "" {
+		return false
+	}
+	if strings.EqualFold(value, viewer) {
+		return true
+	}
+	if viewerActorID != "" && strings.EqualFold(value, viewerActorID) {
+		return true
+	}
+	return strings.EqualFold(extractUsernameFromNotificationActorID(value), viewer)
 }
 
 func notificationSnapshotObjectMap(snapshot map[string]interface{}) map[string]interface{} {

--- a/cmd/api/handlers/misc_round12_coverage_test.go
+++ b/cmd/api/handlers/misc_round12_coverage_test.go
@@ -263,7 +263,7 @@ func TestMisc_Notifications_AttachStatusAndAuthor_Round12(t *testing.T) {
 					"url":          "https://example.com/@bob/status-snapshot",
 					"content":      "<p>snapshot body</p>",
 					"createdAt":    now.Add(-30 * time.Minute).Format(time.RFC3339),
-					"visibility":   "private",
+					"visibility":   "public",
 					"inReplyToId":  "https://example.com/objects/root",
 					"attributedTo": cfg.BaseURL() + "/users/bob",
 				},
@@ -273,7 +273,7 @@ func TestMisc_Notifications_AttachStatusAndAuthor_Round12(t *testing.T) {
 		require.NotNil(t, apiNotif.Status)
 		require.Equal(t, "<p>snapshot body</p>", apiNotif.Status.Content)
 		require.Equal(t, "https://example.com/@bob/status-snapshot", apiNotif.Status.URL)
-		require.Equal(t, "private", apiNotif.Status.Visibility)
+		require.Equal(t, "public", apiNotif.Status.Visibility)
 	})
 
 	t.Run("object fetch error leaves status unset", func(t *testing.T) {

--- a/cmd/api/handlers/misc_round29_snapshot_helpers_test.go
+++ b/cmd/api/handlers/misc_round29_snapshot_helpers_test.go
@@ -227,3 +227,117 @@ func TestMisc_NotificationVisibilityContextRecipients_Round29(t *testing.T) {
 		require.Nil(t, mentions)
 	})
 }
+
+func TestMisc_NotificationStatusVisibleToViewer_Round29(t *testing.T) {
+	cfg := round11TestConfig()
+	handler, _, _ := round11NewHandler(t, cfg, &round10QueryState{
+		relationshipRecords: []storagemodels.RelationshipRecord{
+			{
+				PK:    "FOLLOW#alice",
+				SK:    "FOLLOWING#bob",
+				State: storagemodels.RelationshipAccepted,
+			},
+		},
+	})
+	ctx, err := round10NewLiftContext("GET", "/test", nil, nil, nil)
+	require.NoError(t, err)
+
+	t.Run("public defaults visible before notification scoping", func(t *testing.T) {
+		require.True(t, handler.notificationStatusVisibleToViewer(ctx.Context(), nil, "", "", nil, nil))
+	})
+
+	t.Run("private requires scoped notification viewer", func(t *testing.T) {
+		require.False(t, handler.notificationStatusVisibleToViewer(
+			ctx.Context(),
+			nil,
+			storagemodels.VisibilityPrivate,
+			"https://example.com/users/bob",
+			nil,
+			nil,
+		))
+		require.False(t, handler.notificationStatusVisibleToViewer(
+			ctx.Context(),
+			&storage.Notification{ID: "n-private-empty-viewer"},
+			storagemodels.VisibilityPrivate,
+			"https://example.com/users/bob",
+			nil,
+			nil,
+		))
+	})
+
+	t.Run("author always sees own private status", func(t *testing.T) {
+		require.True(t, handler.notificationStatusVisibleToViewer(
+			ctx.Context(),
+			&storage.Notification{ID: "n-author", Username: "bob"},
+			storagemodels.VisibilityPrivate,
+			"https://example.com/users/bob",
+			nil,
+			nil,
+		))
+	})
+
+	t.Run("followers see private status from followed author", func(t *testing.T) {
+		require.True(t, handler.notificationStatusVisibleToViewer(
+			ctx.Context(),
+			&storage.Notification{ID: "n-private-follow", Username: "alice"},
+			storagemodels.VisibilityPrivate,
+			"https://example.com/users/bob",
+			nil,
+			nil,
+		))
+		require.False(t, handler.notificationStatusVisibleToViewer(
+			ctx.Context(),
+			&storage.Notification{ID: "n-private-miss", Username: "alice"},
+			storagemodels.VisibilityPrivate,
+			"https://example.com/users/carol",
+			nil,
+			nil,
+		))
+	})
+
+	t.Run("direct visibility accepts legacy snapshots and explicit recipients", func(t *testing.T) {
+		require.True(t, handler.notificationStatusVisibleToViewer(
+			ctx.Context(),
+			&storage.Notification{ID: "n-direct-legacy", Username: "alice"},
+			storagemodels.VisibilityDirect,
+			"https://example.com/users/bob",
+			nil,
+			nil,
+		))
+		require.True(t, handler.notificationStatusVisibleToViewer(
+			ctx.Context(),
+			&storage.Notification{ID: "n-direct-recipient", Username: "alice"},
+			storagemodels.VisibilityDirect,
+			"https://example.com/users/bob",
+			[]string{"https://example.com/users/alice"},
+			nil,
+		))
+		require.True(t, handler.notificationStatusVisibleToViewer(
+			ctx.Context(),
+			&storage.Notification{ID: "n-direct-mention", Username: "alice"},
+			storagemodels.VisibilityDirect,
+			"https://example.com/users/bob",
+			nil,
+			[]string{"@alice"},
+		))
+		require.False(t, handler.notificationStatusVisibleToViewer(
+			ctx.Context(),
+			&storage.Notification{ID: "n-direct-miss", Username: "alice"},
+			storagemodels.VisibilityDirect,
+			"https://example.com/users/bob",
+			[]string{"https://example.com/users/carol"},
+			[]string{"@carol"},
+		))
+	})
+
+	t.Run("unknown visibility fails closed", func(t *testing.T) {
+		require.False(t, handler.notificationStatusVisibleToViewer(
+			ctx.Context(),
+			&storage.Notification{ID: "n-unknown", Username: "alice"},
+			"friends-only",
+			"https://example.com/users/bob",
+			nil,
+			nil,
+		))
+	})
+}

--- a/cmd/api/handlers/misc_round29_snapshot_helpers_test.go
+++ b/cmd/api/handlers/misc_round29_snapshot_helpers_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/equaltoai/lesser/cmd/api/models"
 	"github.com/equaltoai/lesser/pkg/storage"
+	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/require"
 )
 
@@ -64,6 +65,78 @@ func TestMisc_NotificationSnapshotHelpers_Round29(t *testing.T) {
 		require.NotNil(t, actor)
 		require.Equal(t, "missing", actor.PreferredUsername)
 		require.Equal(t, "https://remote.example/users/missing", actor.ID)
+	})
+
+	t.Run("private snapshot is not expanded without viewer access", func(t *testing.T) {
+		ctx, err := round10NewLiftContext("GET", "/test", nil, nil, nil)
+		require.NoError(t, err)
+
+		status := handler.statusFromNotificationSnapshot(ctx, &storage.Notification{
+			ID:       "n-private",
+			Type:     models.NotificationTypeMention,
+			Username: "alice",
+			Data: map[string]interface{}{
+				"postSnapshot": map[string]interface{}{
+					"id":           "https://example.com/objects/private-1",
+					"content":      "private",
+					"visibility":   "private",
+					"attributedTo": "https://example.com/users/bob",
+				},
+			},
+		})
+		require.Nil(t, status)
+	})
+
+	t.Run("private snapshot expands when viewer follows author", func(t *testing.T) {
+		followerHandler, _, _ := round11NewHandler(t, cfg, &round10QueryState{
+			relationshipRecords: []storagemodels.RelationshipRecord{
+				{
+					PK:    "FOLLOW#alice",
+					SK:    "FOLLOWING#bob",
+					State: storagemodels.RelationshipAccepted,
+				},
+			},
+		})
+		ctx, err := round10NewLiftContext("GET", "/test", nil, nil, nil)
+		require.NoError(t, err)
+
+		status := followerHandler.statusFromNotificationSnapshot(ctx, &storage.Notification{
+			ID:       "n-private",
+			Type:     models.NotificationTypeMention,
+			Username: "alice",
+			Data: map[string]interface{}{
+				"postSnapshot": map[string]interface{}{
+					"id":           "https://example.com/objects/private-1",
+					"content":      "private",
+					"visibility":   "private",
+					"attributedTo": "https://example.com/users/bob",
+				},
+			},
+		})
+		require.NotNil(t, status)
+		require.Equal(t, "private", status.Visibility)
+	})
+
+	t.Run("direct object requires recipient evidence when available", func(t *testing.T) {
+		ctx, err := round10NewLiftContext("GET", "/test", nil, nil, nil)
+		require.NoError(t, err)
+
+		require.False(t, handler.notificationStatusVisibleToViewer(
+			ctx.Context(),
+			&storage.Notification{ID: "n-direct", Username: "alice"},
+			"direct",
+			"https://example.com/users/bob",
+			[]string{"https://example.com/users/carol"},
+			nil,
+		))
+		require.True(t, handler.notificationStatusVisibleToViewer(
+			ctx.Context(),
+			&storage.Notification{ID: "n-direct", Username: "alice"},
+			"direct",
+			"https://example.com/users/bob",
+			[]string{"https://example.com/users/alice"},
+			nil,
+		))
 	})
 
 	t.Run("notificationSnapshotString ignores non-string values", func(t *testing.T) {

--- a/cmd/api/handlers/misc_round29_snapshot_helpers_test.go
+++ b/cmd/api/handlers/misc_round29_snapshot_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/equaltoai/lesser/cmd/api/models"
+	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/storage"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/require"
@@ -141,5 +142,88 @@ func TestMisc_NotificationSnapshotHelpers_Round29(t *testing.T) {
 
 	t.Run("notificationSnapshotString ignores non-string values", func(t *testing.T) {
 		require.Equal(t, "", notificationSnapshotString(map[string]interface{}{"createdAt": 123}, "createdAt"))
+	})
+}
+
+func TestMisc_NotificationVisibilityContextRecipients_Round29(t *testing.T) {
+	t.Run("note includes recipients and mention targets", func(t *testing.T) {
+		visibility, attributedTo, recipients, mentions := notificationObjectVisibilityContext(&activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				To:  []string{" https://example.com/users/alice ", ""},
+				CC:  []string{"https://www.w3.org/ns/activitystreams#Public"},
+				BTo: []string{"https://example.com/users/bob"},
+				BCC: []string{"https://example.com/users/carol"},
+			},
+			AttributedTo: "https://example.com/users/author",
+			Visibility:   "private",
+			Tag: []activitypub.Tag{
+				{Type: "Mention", Href: "https://example.com/users/alice", Name: "@alice@example.com"},
+				{Type: "Hashtag", Href: "https://example.com/tags/lesser", Name: "#lesser"},
+			},
+		})
+
+		require.Equal(t, "private", visibility)
+		require.Equal(t, "https://example.com/users/author", attributedTo)
+		require.Equal(t, []string{
+			"https://example.com/users/alice",
+			"https://www.w3.org/ns/activitystreams#Public",
+			"https://example.com/users/bob",
+			"https://example.com/users/carol",
+		}, recipients)
+		require.Equal(t, []string{"https://example.com/users/alice", "@alice@example.com"}, mentions)
+	})
+
+	t.Run("stored object includes recipients without mention targets", func(t *testing.T) {
+		visibility, attributedTo, recipients, mentions := notificationObjectVisibilityContext(&storagemodels.Object{
+			Visibility:   "unlisted",
+			AttributedTo: "https://example.com/users/author",
+			To:           []string{"https://example.com/users/alice"},
+			CC:           []string{"https://www.w3.org/ns/activitystreams#Public"},
+			BTo:          []string{"https://example.com/users/bob"},
+			BCC:          []string{"https://example.com/users/carol"},
+		})
+
+		require.Equal(t, "unlisted", visibility)
+		require.Equal(t, "https://example.com/users/author", attributedTo)
+		require.Equal(t, []string{
+			"https://example.com/users/alice",
+			"https://www.w3.org/ns/activitystreams#Public",
+			"https://example.com/users/bob",
+			"https://example.com/users/carol",
+		}, recipients)
+		require.Nil(t, mentions)
+	})
+
+	t.Run("snapshot maps normalize mixed recipient and tag values", func(t *testing.T) {
+		visibility, attributedTo, recipients, mentions := notificationObjectVisibilityContext(map[string]interface{}{
+			"visibility":   "direct",
+			"attributedTo": "https://example.com/users/author",
+			"to":           []interface{}{" https://example.com/users/alice ", 123, ""},
+			"cc":           []string{"https://www.w3.org/ns/activitystreams#Public"},
+			"bto":          []interface{}{"https://example.com/users/bob"},
+			"bcc":          "not-a-list",
+			"tag": []interface{}{
+				map[string]interface{}{"type": "Mention", "href": "https://example.com/users/alice", "name": "@alice@example.com"},
+				map[string]interface{}{"type": "Hashtag", "href": "https://example.com/tags/lesser", "name": "#lesser"},
+				"bad-tag",
+			},
+		})
+
+		require.Equal(t, "direct", visibility)
+		require.Equal(t, "https://example.com/users/author", attributedTo)
+		require.Equal(t, []string{
+			"https://example.com/users/alice",
+			"https://www.w3.org/ns/activitystreams#Public",
+			"https://example.com/users/bob",
+		}, recipients)
+		require.Equal(t, []string{"https://example.com/users/alice", "@alice@example.com"}, mentions)
+	})
+
+	t.Run("unsupported objects return empty context", func(t *testing.T) {
+		visibility, attributedTo, recipients, mentions := notificationObjectVisibilityContext("bad")
+		require.Empty(t, visibility)
+		require.Empty(t, attributedTo)
+		require.Nil(t, recipients)
+		require.Nil(t, mentions)
 	})
 }

--- a/cmd/api/handlers/notification_actor_fallback.go
+++ b/cmd/api/handlers/notification_actor_fallback.go
@@ -69,7 +69,7 @@ func validNotificationFallbackActorURL(parsed *neturl.URL) bool {
 		return false
 	}
 	scheme := strings.ToLower(strings.TrimSpace(parsed.Scheme))
-	if scheme != "https" && scheme != "http" {
+	if scheme != schemeHTTPS && scheme != schemeHTTP {
 		return false
 	}
 	if strings.TrimSpace(parsed.Hostname()) == "" || parsed.User != nil {

--- a/cmd/api/handlers/notification_actor_fallback.go
+++ b/cmd/api/handlers/notification_actor_fallback.go
@@ -4,19 +4,23 @@ import (
 	"fmt"
 	neturl "net/url"
 	"strings"
+	"unicode"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/common"
 )
+
+const maxNotificationFallbackActorIDLength = 2048
 
 func (h *Handler) fallbackNotificationActor(actorID string) *activitypub.Actor {
 	actorID = strings.TrimSpace(actorID)
-	if actorID == "" {
+	if !validNotificationFallbackActorID(actorID) {
 		return nil
 	}
 
 	username := extractUsernameFromNotificationActorID(actorID)
 	if username == "" {
-		username = actorID
+		return nil
 	}
 
 	baseURL := ""
@@ -29,6 +33,10 @@ func (h *Handler) fallbackNotificationActor(actorID string) *activitypub.Actor {
 	}
 
 	if strings.Contains(actorID, "://") {
+		parsed, err := neturl.Parse(actorID)
+		if err != nil || !validNotificationFallbackActorURL(parsed) {
+			return nil
+		}
 		actor.ID = actorID
 		actor.URL = actorID
 	} else if baseURL != "" && username != "" {
@@ -47,9 +55,32 @@ func (h *Handler) fallbackNotificationActor(actorID string) *activitypub.Actor {
 	return actor
 }
 
+func validNotificationFallbackActorID(actorID string) bool {
+	if actorID == "" || len(actorID) > maxNotificationFallbackActorIDLength {
+		return false
+	}
+	return strings.IndexFunc(actorID, func(r rune) bool {
+		return unicode.IsControl(r) || r == '<' || r == '>' || r == '"' || r == '\''
+	}) == -1
+}
+
+func validNotificationFallbackActorURL(parsed *neturl.URL) bool {
+	if parsed == nil {
+		return false
+	}
+	scheme := strings.ToLower(strings.TrimSpace(parsed.Scheme))
+	if scheme != "https" && scheme != "http" {
+		return false
+	}
+	if strings.TrimSpace(parsed.Hostname()) == "" || parsed.User != nil {
+		return false
+	}
+	return parsed.RawQuery == "" && parsed.Fragment == ""
+}
+
 func extractUsernameFromNotificationActorID(actorID string) string {
 	cleaned := strings.TrimSpace(actorID)
-	if cleaned == "" {
+	if !validNotificationFallbackActorID(cleaned) {
 		return ""
 	}
 
@@ -58,17 +89,17 @@ func extractUsernameFromNotificationActorID(actorID string) string {
 	// URL-style actor identifier
 	if strings.Contains(cleaned, "://") {
 		parsed, err := neturl.Parse(cleaned)
-		if err != nil {
+		if err != nil || !validNotificationFallbackActorURL(parsed) {
 			return ""
 		}
 		segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
 		for i := len(segments) - 1; i >= 0; i-- {
 			if seg := strings.TrimSpace(segments[i]); seg != "" {
-				return strings.TrimPrefix(seg, "@")
+				return sanitizedNotificationActorUsername(strings.TrimPrefix(seg, "@"))
 			}
 		}
 		if host := strings.TrimSpace(parsed.Hostname()); host != "" {
-			return host
+			return sanitizedNotificationActorUsername(host)
 		}
 		return ""
 	}
@@ -77,9 +108,20 @@ func extractUsernameFromNotificationActorID(actorID string) string {
 	if strings.Contains(cleaned, "@") {
 		parts := strings.Split(cleaned, "@")
 		if len(parts) > 0 && strings.TrimSpace(parts[0]) != "" {
-			return strings.TrimSpace(parts[0])
+			return sanitizedNotificationActorUsername(parts[0])
 		}
 	}
 
-	return cleaned
+	return sanitizedNotificationActorUsername(cleaned)
+}
+
+func sanitizedNotificationActorUsername(username string) string {
+	username = strings.TrimSpace(strings.TrimPrefix(username, "@"))
+	if username == "" {
+		return ""
+	}
+	if err := common.ValidateActivityPubUsername(username); err != nil {
+		return ""
+	}
+	return username
 }

--- a/cmd/api/handlers/notification_actor_fallback_test.go
+++ b/cmd/api/handlers/notification_actor_fallback_test.go
@@ -22,6 +22,8 @@ func TestExtractUsernameFromNotificationActorID(t *testing.T) {
 		{name: "url_host_fallback", input: "https://example.com", want: "example.com"},
 		{name: "url_no_host", input: "https:///", want: ""},
 		{name: "url_parse_error", input: "https://%", want: ""},
+		{name: "url_query_rejected", input: "https://example.com/users/alice?token=secret", want: ""},
+		{name: "markup_rejected", input: "<script>", want: ""},
 		{name: "plain", input: "bob", want: "bob"},
 	}
 
@@ -49,15 +51,14 @@ func TestFallbackNotificationActor(t *testing.T) {
 		require.Equal(t, "bob", actor.Name)
 	})
 
-	t.Run("url_parse_error_uses_raw_id_as_username", func(t *testing.T) {
+	t.Run("url_parse_error_is_rejected", func(t *testing.T) {
 		h := &Handler{cfg: &config.Config{Domain: "example.com"}}
-		actorID := "https://%"
-		actor := h.fallbackNotificationActor(actorID)
-		require.NotNil(t, actor)
-		require.Equal(t, actorID, actor.ID)
-		require.Equal(t, actorID, actor.URL)
-		require.Equal(t, actorID, actor.PreferredUsername)
-		require.Equal(t, actorID, actor.Name)
+		require.Nil(t, h.fallbackNotificationActor("https://%"))
+	})
+
+	t.Run("unsafe_identifier_is_rejected", func(t *testing.T) {
+		h := &Handler{cfg: &config.Config{Domain: "example.com"}}
+		require.Nil(t, h.fallbackNotificationActor("alice<script>"))
 	})
 
 	t.Run("local_identifier_builds_urls_when_configured", func(t *testing.T) {

--- a/pkg/services/accounts/service.go
+++ b/pkg/services/accounts/service.go
@@ -991,6 +991,56 @@ func (s *Service) sanitizeAccountForViewer(account *storage.Account, viewerID st
 	return sanitized
 }
 
+func accountStreamingPayload(payload map[string]interface{}, public bool) map[string]interface{} {
+	if len(payload) == 0 {
+		return payload
+	}
+
+	cloned := make(map[string]interface{}, len(payload))
+	for key, value := range payload {
+		if public {
+			switch typed := value.(type) {
+			case *storage.Account:
+				cloned[key] = publicAccountForStreaming(typed)
+				continue
+			case storage.Account:
+				cloned[key] = *publicAccountForStreaming(&typed)
+				continue
+			}
+		}
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func publicAccountForStreaming(account *storage.Account) *storage.Account {
+	if account == nil {
+		return nil
+	}
+
+	sanitized := &storage.Account{PrivateKey: ""}
+	if account.User != nil {
+		userCopy := *account.User
+		userCopy.Email = ""
+		userCopy.PasswordHash = ""
+		userCopy.RecoveryMethods = nil
+		userCopy.Metadata = nil
+		userCopy.Locale = ""
+		userCopy.Role = ""
+		userCopy.AllowNSFW = false
+		userCopy.RequireNSFWWarning = false
+		userCopy.AgentCapabilities = nil
+		userCopy.AgentOwner = ""
+		userCopy.AgentCreatedBy = ""
+		sanitized.User = &userCopy
+	}
+	if account.Actor != nil {
+		actorCopy := *account.Actor
+		sanitized.Actor = &actorCopy
+	}
+	return sanitized
+}
+
 func (s *Service) emitAccountUpdatedEvents(ctx context.Context, account *storage.Account) []*streaming.Event {
 	// Use centralized business logic for event creation
 	businessEvents := common.EmitEntityUpdatedEvents(ctx, "account", account.User.Username, account.User.Username, account, map[string]interface{}{
@@ -1005,7 +1055,7 @@ func (s *Service) emitAccountUpdatedEvents(ctx context.Context, account *storage
 			Type:      businessEvent.Type,
 			Stream:    fmt.Sprintf("user:%s", account.User.Username),
 			Timestamp: businessEvent.Timestamp,
-			Payload:   businessEvent.Metadata,
+			Payload:   accountStreamingPayload(businessEvent.Metadata, false),
 		}
 
 		// Emit to user's stream
@@ -1018,6 +1068,7 @@ func (s *Service) emitAccountUpdatedEvents(ctx context.Context, account *storage
 		// Also emit to followers' streams
 		followersEvent := *streamingEvent
 		followersEvent.Stream = fmt.Sprintf("followers:%s", account.User.Username)
+		followersEvent.Payload = accountStreamingPayload(businessEvent.Metadata, true)
 		if err := s.publisher.PublishToStream(ctx, followersEvent.Stream, &followersEvent); err != nil {
 			s.logger.Error("failed to publish to followers stream", zap.Error(err))
 		} else {

--- a/pkg/services/accounts/service_round12_coverage_test.go
+++ b/pkg/services/accounts/service_round12_coverage_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/streaming"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
@@ -274,6 +275,72 @@ func TestService_emitAccountUpdatedEvents_PublishesToUserAndFollowers(t *testing
 	}
 	assert.True(t, sawUserStream)
 	assert.True(t, sawFollowersStream)
+}
+
+func TestService_emitAccountUpdatedEvents_SanitizesFollowersPayload(t *testing.T) {
+	ctx := context.Background()
+	publisher := new(MockPublisher)
+	svc := NewService(nil, publisher, nil, nil, nil, zap.NewNop(), "example.com")
+
+	account := &storage.Account{
+		User: &storage.User{
+			ID:                 "u1",
+			Username:           "alice",
+			Email:              "alice@example.com",
+			PasswordHash:       "hash",
+			RecoveryMethods:    []string{"wallet"},
+			Metadata:           map[string]interface{}{"auth_hint": "private"},
+			Locale:             "en",
+			Role:               "admin",
+			AllowNSFW:          true,
+			RequireNSFWWarning: true,
+			AgentOwner:         "owner",
+			AgentCreatedBy:     "creator",
+		},
+		Actor: &activitypub.Actor{
+			BaseObject: activitypub.BaseObject{
+				ID:   "https://example.com/users/alice",
+				Type: "Person",
+			},
+			PreferredUsername: "alice",
+		},
+		PrivateKey: "private-key",
+	}
+
+	publisher.On("PublishToUser", ctx, "alice", mock.AnythingOfType("*streaming.Event")).Return(nil).Once()
+	publisher.On("PublishToStream", ctx, "followers:alice", mock.AnythingOfType("*streaming.Event")).Return(nil).Once()
+
+	events := svc.emitAccountUpdatedEvents(ctx, account)
+	assert.Len(t, events, 2)
+
+	var userAccount *storage.Account
+	var followersAccount *storage.Account
+	for _, event := range events {
+		if event.Stream == "user:alice" {
+			userAccount, _ = event.Payload["entity"].(*storage.Account)
+		}
+		if event.Stream == "followers:alice" {
+			followersAccount, _ = event.Payload["entity"].(*storage.Account)
+		}
+	}
+
+	require.NotNil(t, userAccount)
+	require.NotNil(t, followersAccount)
+	assert.Equal(t, "alice@example.com", userAccount.User.Email)
+	assert.Equal(t, "hash", userAccount.User.PasswordHash)
+	assert.Empty(t, followersAccount.PrivateKey)
+	assert.Empty(t, followersAccount.User.Email)
+	assert.Empty(t, followersAccount.User.PasswordHash)
+	assert.Empty(t, followersAccount.User.RecoveryMethods)
+	assert.Empty(t, followersAccount.User.Metadata)
+	assert.Empty(t, followersAccount.User.Locale)
+	assert.Empty(t, followersAccount.User.Role)
+	assert.False(t, followersAccount.User.AllowNSFW)
+	assert.False(t, followersAccount.User.RequireNSFWWarning)
+	assert.Empty(t, followersAccount.User.AgentOwner)
+	assert.Empty(t, followersAccount.User.AgentCreatedBy)
+	assert.Equal(t, "alice", followersAccount.Actor.PreferredUsername)
+	publisher.AssertExpectations(t)
 }
 
 func TestService_emitAccountUpdatedEvents_ToleratesPublishFailures(t *testing.T) {

--- a/pkg/services/notes/service.go
+++ b/pkg/services/notes/service.go
@@ -2308,6 +2308,46 @@ func isAlreadyExistsError(err error) bool {
 	return strings.Contains(lower, "already") || strings.Contains(lower, "condition check failed")
 }
 
+func statusStreamingPayload(payload map[string]interface{}, shared bool) map[string]interface{} {
+	if len(payload) == 0 {
+		return payload
+	}
+
+	cloned := make(map[string]interface{}, len(payload))
+	for key, value := range payload {
+		if shared {
+			switch typed := value.(type) {
+			case *models.Status:
+				cloned[key] = sanitizeStatusForSharedStream(typed)
+				continue
+			case models.Status:
+				cloned[key] = *sanitizeStatusForSharedStream(&typed)
+				continue
+			}
+		}
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func sanitizeStatusForSharedStream(status *models.Status) *models.Status {
+	if status == nil {
+		return nil
+	}
+
+	sanitized := *status
+	sanitized.BtoRecipients = nil
+	sanitized.BccRecipients = nil
+	if status.Note != nil {
+		note := *status.Note
+		note.BTo = nil
+		note.BCC = nil
+		sanitized.Note = &note
+	}
+
+	return &sanitized
+}
+
 func (s *Service) emitStatusCreatedEvents(ctx context.Context, status *models.Status) []*streaming.Event {
 	// Use centralized business logic for event creation
 	businessEvents := common.EmitEntityCreatedEvents(ctx, "status", status.StatusID, status.AuthorID, status)
@@ -2319,7 +2359,7 @@ func (s *Service) emitStatusCreatedEvents(ctx context.Context, status *models.St
 			Type:      businessEvent.Type,
 			Stream:    fmt.Sprintf("user:%s", status.AuthorUsername),
 			Timestamp: businessEvent.Timestamp,
-			Payload:   businessEvent.Metadata,
+			Payload:   statusStreamingPayload(businessEvent.Metadata, false),
 		}
 
 		// Emit to user's stream
@@ -2335,6 +2375,7 @@ func (s *Service) emitStatusCreatedEvents(ctx context.Context, status *models.St
 		if status.IsPublic() {
 			publicEvent := *streamingEvent
 			publicEvent.Stream = "public"
+			publicEvent.Payload = statusStreamingPayload(businessEvent.Metadata, true)
 			if err := s.publisher.PublishToStream(ctx, "public", &publicEvent); err != nil {
 				s.logger.Error("failed to publish to public stream", zap.Error(err))
 			} else {
@@ -2342,16 +2383,21 @@ func (s *Service) emitStatusCreatedEvents(ctx context.Context, status *models.St
 			}
 		}
 
-		// Emit to hashtag streams for this event
-		for _, hashtag := range status.Hashtags {
-			hashtagEvent := *streamingEvent
-			hashtagEvent.Stream = fmt.Sprintf("hashtag:%s", hashtag)
-			if err := s.publisher.PublishToStream(ctx, hashtagEvent.Stream, &hashtagEvent); err != nil {
-				s.logger.Error("failed to publish to hashtag stream",
-					zap.String("hashtag", hashtag),
-					zap.Error(err))
-			} else {
-				streamingEvents = append(streamingEvents, &hashtagEvent)
+		// Emit to hashtag streams only for public posts. Hashtag streams are
+		// shared streams, so private/direct/unlisted content must not appear
+		// there even with sanitized recipient fields.
+		if status.IsPublic() {
+			for _, hashtag := range status.Hashtags {
+				hashtagEvent := *streamingEvent
+				hashtagEvent.Stream = fmt.Sprintf("hashtag:%s", hashtag)
+				hashtagEvent.Payload = statusStreamingPayload(businessEvent.Metadata, true)
+				if err := s.publisher.PublishToStream(ctx, hashtagEvent.Stream, &hashtagEvent); err != nil {
+					s.logger.Error("failed to publish to hashtag stream",
+						zap.String("hashtag", hashtag),
+						zap.Error(err))
+				} else {
+					streamingEvents = append(streamingEvents, &hashtagEvent)
+				}
 			}
 		}
 
@@ -2359,6 +2405,7 @@ func (s *Service) emitStatusCreatedEvents(ctx context.Context, status *models.St
 		if status.IsDirect() && status.ConversationID != "" {
 			conversationEvent := *streamingEvent
 			conversationEvent.Stream = fmt.Sprintf("conversation:%s", status.ConversationID)
+			conversationEvent.Payload = statusStreamingPayload(businessEvent.Metadata, true)
 			if err := s.publisher.PublishToConversation(ctx, status.ConversationID, &conversationEvent); err != nil {
 				s.logger.Error("failed to publish to conversation stream", zap.Error(err))
 			} else {
@@ -2670,6 +2717,7 @@ func (s *Service) emitReblogEvents(ctx context.Context, status *models.Status, r
 	if status.IsPublic() {
 		publicEvent := *event
 		publicEvent.Stream = "public"
+		publicEvent.Payload = statusStreamingPayload(event.Payload, true)
 		if err := s.publisher.PublishToStream(ctx, "public", &publicEvent); err != nil {
 			s.logger.Error("failed to publish reblog to public stream", zap.Error(err))
 		} else {

--- a/pkg/services/notes/service_internal_test.go
+++ b/pkg/services/notes/service_internal_test.go
@@ -299,8 +299,9 @@ func TestMentionHelpersNormalizeURLsAndUsernames(t *testing.T) {
 }
 
 type stubPublisher struct {
-	userEvents   []streamingEventRecord
-	streamEvents []streamingEventRecord
+	userEvents         []streamingEventRecord
+	streamEvents       []streamingEventRecord
+	conversationEvents []streamingEventRecord
 }
 
 type streamingEventRecord struct {
@@ -318,11 +319,109 @@ func (s *stubPublisher) PublishToStream(_ context.Context, streamName string, ev
 	return nil
 }
 
-func (s *stubPublisher) PublishToConversation(_ context.Context, _ string, _ *streaming.Event) error {
+func (s *stubPublisher) PublishToConversation(_ context.Context, conversationID string, event *streaming.Event) error {
+	s.conversationEvents = append(s.conversationEvents, streamingEventRecord{target: conversationID, event: event})
 	return nil
 }
 
 func (s *stubPublisher) Close() error { return nil }
+
+func TestStatusStreamingSharedEventsSanitizeBlindRecipients(t *testing.T) {
+	ctx := context.Background()
+	pub := &stubPublisher{}
+	service := &Service{publisher: pub, logger: zap.NewNop()}
+
+	status := &models.Status{
+		StatusID:       "status-1",
+		AuthorID:       "https://example.com/users/alice",
+		AuthorUsername: "alice",
+		Visibility:     models.VisibilityPublic,
+		Hashtags:       []string{"security"},
+		BtoRecipients:  []string{"https://example.com/users/hidden-to"},
+		BccRecipients:  []string{"https://example.com/users/hidden-bcc"},
+		Note: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:  "https://example.com/objects/status-1",
+				BTo: []string{"https://example.com/users/hidden-to"},
+				BCC: []string{"https://example.com/users/hidden-bcc"},
+			},
+			AttributedTo: "https://example.com/users/alice",
+			Content:      "hello",
+		},
+	}
+
+	service.emitStatusCreatedEvents(ctx, status)
+
+	require.NotEmpty(t, pub.userEvents)
+	userStatus := pub.userEvents[0].event.Payload["entity"].(*models.Status)
+	require.NotEmpty(t, userStatus.BtoRecipients)
+	require.NotEmpty(t, userStatus.BccRecipients)
+
+	require.NotEmpty(t, pub.streamEvents)
+	for _, record := range pub.streamEvents {
+		sharedStatus := record.event.Payload["entity"].(*models.Status)
+		require.Empty(t, sharedStatus.BtoRecipients, "stream %s leaked bto recipients", record.target)
+		require.Empty(t, sharedStatus.BccRecipients, "stream %s leaked bcc recipients", record.target)
+		require.NotNil(t, sharedStatus.Note)
+		require.Empty(t, sharedStatus.Note.BTo, "stream %s leaked note bto", record.target)
+		require.Empty(t, sharedStatus.Note.BCC, "stream %s leaked note bcc", record.target)
+	}
+}
+
+func TestStatusStreamingPrivateHashtagsStayOutOfSharedStreams(t *testing.T) {
+	ctx := context.Background()
+	pub := &stubPublisher{}
+	service := &Service{publisher: pub, logger: zap.NewNop()}
+
+	status := &models.Status{
+		StatusID:       "status-private",
+		AuthorID:       "https://example.com/users/alice",
+		AuthorUsername: "alice",
+		Visibility:     models.VisibilityPrivate,
+		Hashtags:       []string{"private"},
+	}
+
+	service.emitStatusCreatedEvents(ctx, status)
+
+	require.NotEmpty(t, pub.userEvents)
+	require.Empty(t, pub.streamEvents)
+}
+
+func TestStatusStreamingConversationEventsSanitizeBlindRecipients(t *testing.T) {
+	ctx := context.Background()
+	pub := &stubPublisher{}
+	service := &Service{publisher: pub, logger: zap.NewNop()}
+
+	status := &models.Status{
+		StatusID:       "status-direct",
+		AuthorID:       "https://example.com/users/alice",
+		AuthorUsername: "alice",
+		Visibility:     models.VisibilityDirect,
+		ConversationID: "conversation-1",
+		BtoRecipients:  []string{"https://example.com/users/hidden-to"},
+		BccRecipients:  []string{"https://example.com/users/hidden-bcc"},
+		Note: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:  "https://example.com/objects/status-direct",
+				BTo: []string{"https://example.com/users/hidden-to"},
+				BCC: []string{"https://example.com/users/hidden-bcc"},
+			},
+			AttributedTo: "https://example.com/users/alice",
+		},
+	}
+
+	service.emitStatusCreatedEvents(ctx, status)
+
+	require.Len(t, pub.conversationEvents, 2)
+	for _, record := range pub.conversationEvents {
+		sharedStatus := record.event.Payload["entity"].(*models.Status)
+		require.Empty(t, sharedStatus.BtoRecipients)
+		require.Empty(t, sharedStatus.BccRecipients)
+		require.NotNil(t, sharedStatus.Note)
+		require.Empty(t, sharedStatus.Note.BTo)
+		require.Empty(t, sharedStatus.Note.BCC)
+	}
+}
 
 type stubNotificationService struct {
 	cmds []*notifications.CreateNotificationCommand

--- a/pkg/storage/repositories/notification_repository.go
+++ b/pkg/storage/repositories/notification_repository.go
@@ -22,6 +22,8 @@ type NotificationRepository struct {
 	dispatcher interfaces.NotificationDispatcher
 }
 
+const notificationSortKeyPrefix = "notif#"
+
 // NewNotificationRepository creates a new notification repository with enhanced functionality and cost tracking
 func NewNotificationRepository(db core.DB, tableName string, logger *zap.Logger, costService *cost.TrackingService) *NotificationRepository {
 	// Create enhanced repository optimized for notification operations
@@ -44,12 +46,43 @@ func (r *NotificationRepository) SetDispatcher(dispatcher interfaces.Notificatio
 }
 
 func applyNotificationSortKeyScope(query core.Query, cursor string) core.Query {
-	query = query.Where("SK", "begins_with", "notif#")
-	if cursor == "" {
-		return query
+	cursor = strings.TrimSpace(cursor)
+	if notificationCursorInSortKeyRange(cursor) {
+		return query.Where("SK", "between", []any{notificationSortKeyPrefix, cursor})
 	}
 
-	return query.Where("SK", "<", cursor)
+	return query.Where("SK", "begins_with", notificationSortKeyPrefix)
+}
+
+func notificationCursorInSortKeyRange(cursor string) bool {
+	return strings.HasPrefix(cursor, notificationSortKeyPrefix) && cursor > notificationSortKeyPrefix
+}
+
+func notificationQueryFetchLimit(pageLimit int, cursor string) int {
+	extra := 1 // over-fetch one item to detect whether another page exists
+	if notificationCursorInSortKeyRange(strings.TrimSpace(cursor)) {
+		// Cursor-scoped queries use an inclusive BETWEEN condition to keep
+		// DynamoDB's sort-key condition valid while preserving the notif# range.
+		// Over-fetch one more item so dropping the duplicate cursor does not
+		// hide the real has-more sentinel.
+		extra++
+	}
+	return pageLimit + extra
+}
+
+func dropNotificationCursorDuplicate(notifications []models.Notification, cursor string) []models.Notification {
+	cursor = strings.TrimSpace(cursor)
+	if !notificationCursorInSortKeyRange(cursor) || len(notifications) == 0 {
+		return notifications
+	}
+
+	filtered := notifications[:0]
+	for _, notification := range notifications {
+		if notification.SK != cursor {
+			filtered = append(filtered, notification)
+		}
+	}
+	return filtered
 }
 
 // CreateNotification creates a new notification using BaseRepository
@@ -138,7 +171,7 @@ func (r *NotificationRepository) GetUserNotifications(ctx context.Context, userI
 	)
 
 	// Fetch limit+1 to detect if more results exist
-	query = query.Limit(opts.Limit + 1)
+	query = query.Limit(notificationQueryFetchLimit(opts.Limit, opts.Cursor))
 
 	var notifications []models.Notification
 	err := query.All(&notifications)
@@ -148,6 +181,7 @@ func (r *NotificationRepository) GetUserNotifications(ctx context.Context, userI
 			zap.Error(err))
 		return nil, ErrorHandler.HandleQueryError(err, EntityNotification, "user notifications")
 	}
+	notifications = dropNotificationCursorDuplicate(notifications, opts.Cursor)
 
 	result := &interfaces.PaginatedResult[*models.Notification]{
 		Items: make([]*models.Notification, 0, len(notifications)),
@@ -190,13 +224,14 @@ func (r *NotificationRepository) GetUnreadNotifications(ctx context.Context, use
 	).Filter("IsRead", "=", false)
 
 	// Fetch limit+1 to detect if more results exist
-	query = query.Limit(opts.Limit + 1)
+	query = query.Limit(notificationQueryFetchLimit(opts.Limit, opts.Cursor))
 
 	var notifications []models.Notification
 	err := query.All(&notifications)
 	if err != nil {
 		return nil, ErrorHandler.HandleQueryError(err, EntityNotification, "unread notifications")
 	}
+	notifications = dropNotificationCursorDuplicate(notifications, opts.Cursor)
 
 	result := &interfaces.PaginatedResult[*models.Notification]{
 		Items: make([]*models.Notification, 0, len(notifications)),
@@ -481,13 +516,14 @@ func (r *NotificationRepository) GetNotificationGroups(ctx context.Context, user
 	)
 
 	// Fetch extra items to account for grouping expansion and detect more results
-	query = query.Limit((opts.Limit * 3) + 1)
+	query = query.Limit(notificationQueryFetchLimit(opts.Limit*3, opts.Cursor))
 
 	var allNotifications []models.Notification
 	err := query.All(&allNotifications)
 	if err != nil {
 		return nil, ErrorHandler.HandleQueryError(err, EntityNotification, "notification groups")
 	}
+	allNotifications = dropNotificationCursorDuplicate(allNotifications, opts.Cursor)
 
 	// Filter notifications for the specific user and group them
 	userGroups := make(map[string]*models.Notification)
@@ -908,13 +944,14 @@ func (r *NotificationRepository) GetNotificationsAdvanced(ctx context.Context, u
 		query = query.Filter(key, "=", value)
 	}
 
-	query = query.Limit(pagination.Limit + 1)
+	query = query.Limit(notificationQueryFetchLimit(pagination.Limit, pagination.Cursor))
 
 	var notifications []models.Notification
 	err := query.All(&notifications)
 	if err != nil {
 		return nil, ErrorHandler.HandleQueryError(err, EntityNotification, "advanced query")
 	}
+	notifications = dropNotificationCursorDuplicate(notifications, pagination.Cursor)
 
 	result := &interfaces.PaginatedResult[*models.Notification]{
 		Items: make([]*models.Notification, 0, len(notifications)),

--- a/pkg/storage/repositories/notification_repository.go
+++ b/pkg/storage/repositories/notification_repository.go
@@ -44,8 +44,9 @@ func (r *NotificationRepository) SetDispatcher(dispatcher interfaces.Notificatio
 }
 
 func applyNotificationSortKeyScope(query core.Query, cursor string) core.Query {
+	query = query.Where("SK", "begins_with", "notif#")
 	if cursor == "" {
-		return query.Where("SK", "begins_with", "notif#")
+		return query
 	}
 
 	return query.Where("SK", "<", cursor)

--- a/pkg/storage/repositories/notification_repository.go
+++ b/pkg/storage/repositories/notification_repository.go
@@ -662,15 +662,12 @@ func (r *NotificationRepository) GetNotificationCountsByType(ctx context.Context
 	cursor := ""
 
 	for {
-		query := r.db.WithContext(ctx).Model(&models.Notification{}).
-			Where("PK", "=", pk).
-			Where("SK", "begins_with", "notif#").
-			OrderBy("SK", "DESC").
-			Limit(countBatchLimit)
-
-		if cursor != "" {
-			query = query.Where("SK", "<", cursor)
-		}
+		query := applyNotificationSortKeyScope(
+			r.db.WithContext(ctx).Model(&models.Notification{}).
+				Where("PK", "=", pk).
+				OrderBy("SK", "DESC"),
+			cursor,
+		).Limit(notificationQueryFetchLimit(countBatchLimit, cursor))
 
 		var notifications []models.Notification
 		err := query.All(&notifications)
@@ -680,16 +677,22 @@ func (r *NotificationRepository) GetNotificationCountsByType(ctx context.Context
 			}
 			return nil, ErrorHandler.HandleQueryError(err, EntityNotification, "type counting")
 		}
+		notifications = dropNotificationCursorDuplicate(notifications, cursor)
 
 		if len(notifications) == 0 {
 			break
+		}
+
+		hasMore := len(notifications) > countBatchLimit
+		if hasMore {
+			notifications = notifications[:countBatchLimit]
 		}
 
 		for i := range notifications {
 			counts[notifications[i].Type]++
 		}
 
-		if len(notifications) < countBatchLimit {
+		if !hasMore {
 			break
 		}
 

--- a/pkg/storage/repositories/notification_repository_coverage_test.go
+++ b/pkg/storage/repositories/notification_repository_coverage_test.go
@@ -35,6 +35,20 @@ func countMockCalls(q *mocks.MockQuery, method, field, op string) int {
 	return count
 }
 
+func countMockLimitCalls(q *mocks.MockQuery, limit int) int {
+	count := 0
+	for _, call := range q.Calls {
+		if call.Method != "Limit" || len(call.Arguments) < 1 {
+			continue
+		}
+		if got, ok := call.Arguments.Get(0).(int); ok && got == limit {
+			count++
+		}
+	}
+
+	return count
+}
+
 type fakeNotificationDispatcher struct {
 	calls int
 }
@@ -164,8 +178,43 @@ func TestNotificationRepository_PaginationPreservesNotificationSKPrefix(t *testi
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, 1, countMockCalls(mockQuery, "Where", "SK", "begins_with"))
-	require.Equal(t, 1, countMockCalls(mockQuery, "Where", "SK", "<"))
+	require.Equal(t, 1, countMockCalls(mockQuery, "Where", "SK", "between"))
+	require.Equal(t, 0, countMockCalls(mockQuery, "Where", "SK", "begins_with"))
+	require.Equal(t, 0, countMockCalls(mockQuery, "Where", "SK", "<"))
+	require.Equal(t, 1, countMockLimitCalls(mockQuery, 12))
+}
+
+func TestNotificationRepository_PaginationDropsInclusiveCursorDuplicate(t *testing.T) {
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB)
+	mockDB.On("Model", mock.Anything).Return(mockQuery)
+	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery)
+	mockQuery.On("Filter", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery)
+	mockQuery.On("OrderBy", mock.Anything, mock.Anything).Return(mockQuery)
+	mockQuery.On("Limit", mock.Anything).Return(mockQuery)
+	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
+		ptr := args.Get(0).(*[]models.Notification)
+		*ptr = []models.Notification{
+			{ID: "cursor", SK: "notif#20260428120000#cursor"},
+			{ID: "older-2", SK: "notif#20260428115900#older-2"},
+			{ID: "older-1", SK: "notif#20260428115800#older-1"},
+			{ID: "sentinel", SK: "notif#20260428115700#sentinel"},
+		}
+	}).Return(nil)
+
+	repo := NewNotificationRepository(mockDB, "test-table", zap.NewNop(), nil)
+	result, err := repo.GetUserNotifications(context.Background(), "alice", interfaces.PaginationOptions{
+		Limit:  2,
+		Cursor: "notif#20260428120000#cursor",
+	})
+	require.NoError(t, err)
+
+	require.True(t, result.HasMore)
+	require.Equal(t, "notif#20260428115800#older-1", result.NextCursor)
+	require.Equal(t, []string{"older-2", "older-1"}, []string{result.Items[0].ID, result.Items[1].ID})
+	require.Equal(t, 1, countMockLimitCalls(mockQuery, 4))
 }
 
 func TestRound07_NotificationRepository_SetNotificationPreference_UnknownType(t *testing.T) {
@@ -490,7 +539,8 @@ func TestRound07_NotificationRepository_UserNotifications_PaginationBranches(t *
 	require.NoError(t, err)
 	require.True(t, result.HasMore)
 	require.Equal(t, "notif#2", result.NextCursor)
-	require.Equal(t, 1, countMockCalls(mockQuery, "Where", "SK", "<"))
+	require.Equal(t, 1, countMockCalls(mockQuery, "Where", "SK", "between"))
+	require.Zero(t, countMockCalls(mockQuery, "Where", "SK", "<"))
 	require.Zero(t, countMockCalls(mockQuery, "Filter", "SK", "begins_with"))
 
 	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
@@ -504,7 +554,8 @@ func TestRound07_NotificationRepository_UserNotifications_PaginationBranches(t *
 	require.NoError(t, err)
 	require.True(t, result.HasMore)
 	require.Equal(t, "notif#2", result.NextCursor)
-	require.Equal(t, 2, countMockCalls(mockQuery, "Where", "SK", "<"))
+	require.Equal(t, 2, countMockCalls(mockQuery, "Where", "SK", "between"))
+	require.Zero(t, countMockCalls(mockQuery, "Where", "SK", "<"))
 	require.Zero(t, countMockCalls(mockQuery, "Filter", "SK", "begins_with"))
 	require.Equal(t, 1, countMockCalls(mockQuery, "Filter", "IsRead", "="))
 }
@@ -538,7 +589,7 @@ func TestRound07_NotificationRepository_GetUserNotifications_LogsQueryError(t *t
 	require.Equal(t, queryErr.Error(), fields["error"])
 }
 
-func TestRound07_NotificationRepository_NotificationQueries_DropSortKeyPrefixFilterWhenCursorPresent(t *testing.T) {
+func TestRound07_NotificationRepository_NotificationQueries_UsePrefixSafeRangeWhenCursorPresent(t *testing.T) {
 	mockDB := new(mocks.MockDB)
 	mockQuery := new(mocks.MockQuery)
 
@@ -562,7 +613,8 @@ func TestRound07_NotificationRepository_NotificationQueries_DropSortKeyPrefixFil
 	_, err = repo.GetNotificationsAdvanced(context.Background(), "user-1", map[string]interface{}{"Type": "mention"}, interfaces.PaginationOptions{Limit: 1, Cursor: "notif#99"})
 	require.NoError(t, err)
 
-	require.Equal(t, 2, countMockCalls(mockQuery, "Where", "SK", "<"))
+	require.Equal(t, 2, countMockCalls(mockQuery, "Where", "SK", "between"))
+	require.Zero(t, countMockCalls(mockQuery, "Where", "SK", "<"))
 	require.Zero(t, countMockCalls(mockQuery, "Filter", "SK", "begins_with"))
 	require.Equal(t, 1, countMockCalls(mockQuery, "Filter", "Type", "="))
 }

--- a/pkg/storage/repositories/notification_repository_coverage_test.go
+++ b/pkg/storage/repositories/notification_repository_coverage_test.go
@@ -142,6 +142,32 @@ func TestRound07_NotificationRepository_ByTypeFallbackAndPreferencesDefault(t *t
 	require.True(t, prefs.EmailEnabled)
 }
 
+func TestNotificationRepository_PaginationPreservesNotificationSKPrefix(t *testing.T) {
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB)
+	mockDB.On("Model", mock.Anything).Return(mockQuery)
+	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery)
+	mockQuery.On("Filter", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery)
+	mockQuery.On("OrderBy", mock.Anything, mock.Anything).Return(mockQuery)
+	mockQuery.On("Limit", mock.Anything).Return(mockQuery)
+	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
+		ptr := args.Get(0).(*[]models.Notification)
+		*ptr = []models.Notification{}
+	}).Return(nil)
+
+	repo := NewNotificationRepository(mockDB, "test-table", zap.NewNop(), nil)
+	_, err := repo.GetUserNotifications(context.Background(), "alice", interfaces.PaginationOptions{
+		Limit:  10,
+		Cursor: "notif#20260428120000#cursor",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, 1, countMockCalls(mockQuery, "Where", "SK", "begins_with"))
+	require.Equal(t, 1, countMockCalls(mockQuery, "Where", "SK", "<"))
+}
+
 func TestRound07_NotificationRepository_SetNotificationPreference_UnknownType(t *testing.T) {
 	baseTime := time.Unix(1, 0).UTC()
 	mockDB := new(mocks.MockDB)

--- a/pkg/storage/repositories/notification_repository_coverage_test.go
+++ b/pkg/storage/repositories/notification_repository_coverage_test.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -261,26 +262,36 @@ func TestRound07_NotificationRepository_GetNotificationCountsByType_PaginatesAnd
 	mockQuery.On("OrderBy", mock.Anything, mock.Anything).Return(mockQuery)
 	mockQuery.On("Limit", mock.Anything).Return(mockQuery)
 
-	// First call: full batch (forces cursor branch).
+	// First call: full logical batch plus sentinel (forces cursor branch).
 	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
 		ptr := args.Get(0).(*[]models.Notification)
-		batch := make([]models.Notification, 500)
+		batch := make([]models.Notification, 501)
 		for i := range batch {
-			batch[i] = models.Notification{Type: "mention", SK: "notif#cursor"}
+			batch[i] = models.Notification{Type: "mention", SK: fmt.Sprintf("notif#%03d", 999-i)}
 		}
 		*ptr = batch
 	}).Return(nil).Once()
 
-	// Second call: empty slice breaks.
+	// Second call: inclusive cursor duplicate plus two real older notifications.
 	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
 		ptr := args.Get(0).(*[]models.Notification)
-		*ptr = nil
+		*ptr = []models.Notification{
+			{Type: "mention", SK: "notif#500"},
+			{Type: "follow", SK: "notif#498"},
+			{Type: "follow", SK: "notif#497"},
+		}
 	}).Return(nil).Once()
 
 	repo := NewNotificationRepository(mockDB, "test-table", zap.NewNop(), nil)
 	counts, err := repo.GetNotificationCountsByType(context.Background(), "user-1")
 	require.NoError(t, err)
 	require.Equal(t, int64(500), counts["mention"])
+	require.Equal(t, int64(2), counts["follow"])
+	require.Equal(t, 1, countMockCalls(mockQuery, "Where", "SK", "begins_with"))
+	require.Equal(t, 1, countMockCalls(mockQuery, "Where", "SK", "between"))
+	require.Equal(t, 0, countMockCalls(mockQuery, "Where", "SK", "<"))
+	require.Equal(t, 1, countMockLimitCalls(mockQuery, 501))
+	require.Equal(t, 1, countMockLimitCalls(mockQuery, 502))
 
 	// NotFound breaks without error.
 	mockQuery.On("All", mock.Anything).Return(ddbErrors.ErrItemNotFound).Once()

--- a/pkg/storage/repositories/notification_repository_tabletheory_test.go
+++ b/pkg/storage/repositories/notification_repository_tabletheory_test.go
@@ -1,0 +1,107 @@
+package repositories
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	ttquery "github.com/theory-cloud/tabletheory/pkg/query"
+)
+
+type notificationCompileMetadata struct{}
+
+func (notificationCompileMetadata) TableName() string {
+	return models.MainTableName
+}
+
+func (notificationCompileMetadata) PrimaryKey() core.KeySchema {
+	return core.KeySchema{PartitionKey: "PK", SortKey: "SK"}
+}
+
+func (notificationCompileMetadata) Indexes() []core.IndexSchema {
+	return nil
+}
+
+func (notificationCompileMetadata) AttributeMetadata(field string) *core.AttributeMetadata {
+	switch field {
+	case "PK", "SK":
+		return &core.AttributeMetadata{Name: field, DynamoDBName: field, Type: "string"}
+	default:
+		return nil
+	}
+}
+
+func (notificationCompileMetadata) VersionFieldName() string {
+	return "version"
+}
+
+func compileNotificationSortKeyScope(t *testing.T, cursor string) *core.CompiledQuery {
+	t.Helper()
+
+	q := ttquery.New(&models.Notification{}, notificationCompileMetadata{}, nil)
+	scoped := applyNotificationSortKeyScope(
+		q.Where("PK", "=", "USER#alice").OrderBy("SK", "DESC"),
+		cursor,
+	)
+
+	compiled, err := scoped.(*ttquery.Query).Compile()
+	require.NoError(t, err)
+	return compiled
+}
+
+func countCompiledNameValues(compiled *core.CompiledQuery, attr string) int {
+	count := 0
+	for _, value := range compiled.ExpressionAttributeNames {
+		if value == attr {
+			count++
+		}
+	}
+	return count
+}
+
+func compiledStringValues(compiled *core.CompiledQuery) []string {
+	out := make([]string, 0, len(compiled.ExpressionAttributeValues))
+	for _, value := range compiled.ExpressionAttributeValues {
+		if stringValue, ok := value.(*types.AttributeValueMemberS); ok {
+			out = append(out, stringValue.Value)
+		}
+	}
+	return out
+}
+
+func TestNotificationRepository_TableTheoryCompiledSortKeyScope(t *testing.T) {
+	t.Run("no cursor compiles to one begins_with sort key condition", func(t *testing.T) {
+		compiled := compileNotificationSortKeyScope(t, "")
+
+		require.Equal(t, "Query", compiled.Operation)
+		require.Contains(t, compiled.KeyConditionExpression, "begins_with")
+		require.NotContains(t, compiled.KeyConditionExpression, "BETWEEN")
+		require.Equal(t, 1, countCompiledNameValues(compiled, "SK"))
+		require.Contains(t, compiledStringValues(compiled), notificationSortKeyPrefix)
+	})
+
+	t.Run("cursor compiles to one prefix-safe between sort key condition", func(t *testing.T) {
+		cursor := "notif#20260428120000#cursor"
+		compiled := compileNotificationSortKeyScope(t, cursor)
+
+		require.Equal(t, "Query", compiled.Operation)
+		require.Contains(t, compiled.KeyConditionExpression, " BETWEEN ")
+		require.NotContains(t, compiled.KeyConditionExpression, "begins_with")
+		require.NotContains(t, compiled.KeyConditionExpression, " < ")
+		require.Equal(t, 1, countCompiledNameValues(compiled, "SK"))
+		values := compiledStringValues(compiled)
+		require.Contains(t, values, notificationSortKeyPrefix)
+		require.Contains(t, values, cursor)
+	})
+
+	t.Run("malformed cursor falls back to prefix condition", func(t *testing.T) {
+		compiled := compileNotificationSortKeyScope(t, "not-a-notification-sk")
+
+		require.Contains(t, compiled.KeyConditionExpression, "begins_with")
+		require.NotContains(t, compiled.KeyConditionExpression, "BETWEEN")
+		require.NotContains(t, compiled.KeyConditionExpression, " < ")
+		require.Equal(t, 1, countCompiledNameValues(compiled, "SK"))
+	})
+}


### PR DESCRIPTION
## Milestone
Codex Security M6 — sanitize notification/stream payloads and repair notification pagination boundaries.

## Classification
security hardening / privacy / Mastodon API semantic refinement / schema-query integrity

## Surfaces affected
- `/api/v1/notifications` and `/api/v1/notifications/:id` expansion semantics
- Notification repository PK/SK query pagination
- Streaming status/account update payloads
- Admin Lift error responses

## Specialist walks referenced
- Federation trust: no HTTP Signature, inbox/outbox, actor-object shape, or delivery changes.
- Contract / API: backward-compatible semantic refinements; response shapes stay Mastodon-compatible while hidden/private fields are omitted or redacted rather than leaked.
- Schema: #850 preserves the existing `USER#{user}` notification partition and `notif#` SK-prefix query scope; no PK/SK/GSI/tag changes.
- Framework: idiomatic AppTheory/TableTheory use; no framework patch.

## Consumer impact
- Operators: improved privacy guarantees for notification, streaming, and admin responses.
- Mastodon clients: no shape break; status expansions may be absent when the viewer cannot see the status.
- Remote ActivityPub peers: no ActivityPub contract change.
- Sibling repos: no release-artifact, MCP, or namespace contract change.

## Tasks
- [x] #849 `fix(notifications): enforce visibility and sanitize fallback actors`
- [x] #850 `fix(notifications): preserve notification sk prefix pagination`
- [x] #851 `fix(streaming): remove blind recipients from shared events`
- [x] #852 `fix(accounts): sanitize account update streams`
- [x] #853 `fix(admin): redact internal errors`

## Validation
- [x] `gofmt -l .` (empty)
- [x] `go test ./cmd/api/handlers`
- [x] `go test ./pkg/storage/repositories`
- [x] `go test ./pkg/services/notes`
- [x] `go test ./pkg/services/accounts`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build -o lesser ./cmd/lesser`
- [x] `./lesser build lambdas`
- [x] `./lesser verify ci` (cmd 90.036%, pkg 90.039%)

## Review follow-up
- Addressed notification pagination blocker: cursor pages now compile to one prefix-safe `SK BETWEEN "notif#" AND <cursor>` key condition, over-fetch for the inclusive cursor, and drop the cursor duplicate client-side. Added TableTheory compile coverage.
- Addressed follow-up count-summary blocker: `GetNotificationCountsByType` now uses the same prefix-safe cursor scope, drops the inclusive cursor duplicate, and counts only each logical 500-notification batch so the sentinel is not double-counted.

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None expected; this milestone tightens lesser-owned REST, storage-query, streaming, and admin-handler behavior without changing sibling repo contracts.

Closes #849
Closes #850
Closes #851
Closes #852
Closes #853
Closes #848