### PR TITLE
fix(security): complete Codex Security M8

### DIFF
--- a/cmd/api/handlers/filters.go
+++ b/cmd/api/handlers/filters.go
@@ -420,13 +420,12 @@ func (h *Handler) processKeywordUpdate(ctx *apptheory.Context, filterID string, 
 		// Update or delete existing keyword
 		if destroy, ok := kwMap["_destroy"].(bool); ok && destroy {
 			return h.deleteFilterKeyword(ctx, filterID, id)
-		} else {
-			return h.updateFilterKeyword(ctx, filterID, id, kwMap)
 		}
-	} else {
-		// Create new keyword
-		h.createFilterKeyword(ctx, filterID, kwMap)
+		return h.updateFilterKeyword(ctx, filterID, id, kwMap)
 	}
+
+	// Create new keyword
+	h.createFilterKeyword(ctx, filterID, kwMap)
 
 	return nil
 }

--- a/cmd/api/handlers/filters.go
+++ b/cmd/api/handlers/filters.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"time"
 
 	apimodels "github.com/equaltoai/lesser/cmd/api/models"
@@ -12,6 +13,8 @@ import (
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	"go.uber.org/zap"
 )
+
+var errFilterKeywordNotFound = errors.New("filter keyword not found")
 
 // HandleGetFiltersLift handles GET /api/v2/filters
 func (h *Handler) HandleGetFiltersLift(ctx *apptheory.Context) (*apptheory.Response, error) {
@@ -292,6 +295,14 @@ func (h *Handler) HandleUpdateFilterLift(ctx *apptheory.Context) (*apptheory.Res
 		return common.RespondValidationError(ctx, err)
 	}
 
+	if err := h.validateKeywordUpdates(ctx, filterID, params); err != nil {
+		if errors.Is(err, errFilterKeywordNotFound) {
+			return h.respondNotFound(ctx, "filter keyword")
+		}
+		h.logger.Error("failed to verify filter keyword ownership", zap.String("filter_id", filterID), zap.Error(err))
+		return h.respondInternalError(ctx, "internal server error")
+	}
+
 	// Build filter updates
 	updates := h.buildFilterUpdates(params)
 
@@ -302,7 +313,13 @@ func (h *Handler) HandleUpdateFilterLift(ctx *apptheory.Context) (*apptheory.Res
 	}
 
 	// Handle keyword updates
-	h.handleKeywordUpdates(ctx, filterID, params)
+	if err := h.handleKeywordUpdates(ctx, filterID, params); err != nil {
+		if errors.Is(err, errFilterKeywordNotFound) {
+			return h.respondNotFound(ctx, "filter keyword")
+		}
+		h.logger.Error("failed to update filter keywords", zap.String("filter_id", filterID), zap.Error(err))
+		return h.respondInternalError(ctx, "internal server error")
+	}
 
 	// Return updated filter
 	return h.returnUpdatedFilter(ctx, filterID)
@@ -353,11 +370,34 @@ func (h *Handler) buildFilterUpdates(params map[string]any) map[string]any {
 	return updates
 }
 
-// handleKeywordUpdates handles keyword updates for a filter
-func (h *Handler) handleKeywordUpdates(ctx *apptheory.Context, filterID string, params map[string]any) {
+func (h *Handler) validateKeywordUpdates(ctx *apptheory.Context, filterID string, params map[string]any) error {
 	keywordsAttrs, ok := params["keywords_attributes"].([]any)
 	if !ok {
-		return
+		return nil
+	}
+
+	for _, kwAttr := range keywordsAttrs {
+		kwMap, ok := kwAttr.(map[string]any)
+		if !ok {
+			continue
+		}
+		keywordID, hasID := kwMap["id"].(string)
+		if !hasID || keywordID == "" {
+			continue
+		}
+		if err := h.ensureFilterKeywordBelongsToFilter(ctx, filterID, keywordID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// handleKeywordUpdates handles keyword updates for a filter
+func (h *Handler) handleKeywordUpdates(ctx *apptheory.Context, filterID string, params map[string]any) error {
+	keywordsAttrs, ok := params["keywords_attributes"].([]any)
+	if !ok {
+		return nil
 	}
 
 	for _, kwAttr := range keywordsAttrs {
@@ -366,34 +406,48 @@ func (h *Handler) handleKeywordUpdates(ctx *apptheory.Context, filterID string, 
 			continue
 		}
 
-		h.processKeywordUpdate(ctx, filterID, kwMap)
+		if err := h.processKeywordUpdate(ctx, filterID, kwMap); err != nil {
+			return err
+		}
 	}
+
+	return nil
 }
 
 // processKeywordUpdate processes a single keyword update
-func (h *Handler) processKeywordUpdate(ctx *apptheory.Context, filterID string, kwMap map[string]any) {
+func (h *Handler) processKeywordUpdate(ctx *apptheory.Context, filterID string, kwMap map[string]any) error {
 	if id, hasID := kwMap["id"].(string); hasID {
 		// Update or delete existing keyword
 		if destroy, ok := kwMap["_destroy"].(bool); ok && destroy {
-			h.deleteFilterKeyword(ctx, id)
+			return h.deleteFilterKeyword(ctx, filterID, id)
 		} else {
-			h.updateFilterKeyword(ctx, id, kwMap)
+			return h.updateFilterKeyword(ctx, filterID, id, kwMap)
 		}
 	} else {
 		// Create new keyword
 		h.createFilterKeyword(ctx, filterID, kwMap)
 	}
+
+	return nil
 }
 
 // deleteFilterKeyword deletes a filter keyword
-func (h *Handler) deleteFilterKeyword(ctx *apptheory.Context, keywordID string) {
+func (h *Handler) deleteFilterKeyword(ctx *apptheory.Context, filterID string, keywordID string) error {
+	if err := h.ensureFilterKeywordBelongsToFilter(ctx, filterID, keywordID); err != nil {
+		return err
+	}
 	if err := h.repos.Moderation().DeleteFilterKeyword(ctx.Context(), keywordID); err != nil {
 		h.logger.Error("failed to delete filter keyword", zap.String("keyword_id", keywordID), zap.Error(err))
+		return err
 	}
+	return nil
 }
 
 // updateFilterKeyword updates a filter keyword
-func (h *Handler) updateFilterKeyword(ctx *apptheory.Context, keywordID string, kwMap map[string]any) {
+func (h *Handler) updateFilterKeyword(ctx *apptheory.Context, filterID string, keywordID string, kwMap map[string]any) error {
+	if err := h.ensureFilterKeywordBelongsToFilter(ctx, filterID, keywordID); err != nil {
+		return err
+	}
 	kwUpdates := make(map[string]any)
 	if keyword, ok := kwMap["keyword"].(string); ok {
 		kwUpdates["keyword"] = keyword
@@ -403,7 +457,9 @@ func (h *Handler) updateFilterKeyword(ctx *apptheory.Context, keywordID string, 
 	}
 	if err := h.repos.Moderation().UpdateFilterKeyword(ctx.Context(), keywordID, kwUpdates); err != nil {
 		h.logger.Error("failed to update filter keyword", zap.String("keyword_id", keywordID), zap.Error(err))
+		return err
 	}
+	return nil
 }
 
 // createFilterKeyword creates a new filter keyword
@@ -426,6 +482,24 @@ func (h *Handler) createFilterKeyword(ctx *apptheory.Context, filterID string, k
 	if err := h.repos.Moderation().AddFilterKeyword(ctx.Context(), filterID, kw); err != nil {
 		h.logger.Error("failed to add filter keyword", zap.Error(err))
 	}
+}
+
+func (h *Handler) ensureFilterKeywordBelongsToFilter(ctx *apptheory.Context, filterID string, keywordID string) error {
+	keywords, err := h.repos.Moderation().GetFilterKeywords(ctx.Context(), filterID)
+	if err != nil {
+		return err
+	}
+
+	for _, keyword := range keywords {
+		if keyword == nil {
+			continue
+		}
+		if keyword.ID == keywordID && keyword.FilterID == filterID {
+			return nil
+		}
+	}
+
+	return errFilterKeywordNotFound
 }
 
 // returnUpdatedFilter returns the updated filter with keywords and statuses
@@ -659,7 +733,14 @@ func (h *Handler) HandleDeleteFilterKeywordLift(ctx *apptheory.Context) (*appthe
 		return h.respondNotFound(ctx, "filter")
 	}
 
-	// Delete the keyword
+	// Delete the keyword only after proving it belongs to the owned filter.
+	if err := h.ensureFilterKeywordBelongsToFilter(ctx, filterID, keywordID); err != nil {
+		if errors.Is(err, errFilterKeywordNotFound) {
+			return h.respondNotFound(ctx, "filter keyword")
+		}
+		h.logger.Error("failed to verify filter keyword ownership", zap.String("filter_id", filterID), zap.String("keyword_id", keywordID), zap.Error(err))
+		return h.respondInternalError(ctx, "internal server error")
+	}
 	if err := h.repos.Moderation().DeleteFilterKeyword(ctx.Context(), keywordID); err != nil {
 		h.logger.Error("failed to delete filter keyword", zap.Error(err))
 		return h.respondInternalError(ctx, "internal server error")

--- a/cmd/api/handlers/filters_round12_test.go
+++ b/cmd/api/handlers/filters_round12_test.go
@@ -152,6 +152,12 @@ func TestFiltersHandlers_Round12(t *testing.T) {
 			filtersByID: map[string]storagemodels.Filter{
 				"filter-1": {ID: "filter-1", Username: "alice", Title: "x", Context: []string{"home"}, FilterAction: "warn"},
 			},
+			filterKeywords: map[string][]storagemodels.FilterKeyword{
+				"filter-1": {
+					{ID: "kw-1", FilterID: "filter-1", Keyword: "old", WholeWord: false, CreatedAt: time.Now()},
+					{ID: "kw-2", FilterID: "filter-1", Keyword: "eggs", WholeWord: false, CreatedAt: time.Now()},
+				},
+			},
 		}
 		handler, _, _ := round11NewHandler(t, cfg, state)
 
@@ -170,6 +176,28 @@ func TestFiltersHandlers_Round12(t *testing.T) {
 		require.NoError(t, err)
 		ctx.Params["id"] = "filter-1"
 		requireStatus(t, http.StatusOK)(handler.HandleUpdateFilterLift(ctx))
+	})
+
+	t.Run("update filter rejects keyword from another filter", func(t *testing.T) {
+		state := &round10QueryState{
+			filtersByID: map[string]storagemodels.Filter{
+				"filter-1": {ID: "filter-1", Username: "alice", Title: "x", Context: []string{"home"}, FilterAction: "warn"},
+				"filter-2": {ID: "filter-2", Username: "bob", Title: "y", Context: []string{"home"}, FilterAction: "warn"},
+			},
+			filterKeywords: map[string][]storagemodels.FilterKeyword{
+				"filter-2": {{ID: "kw-bob", FilterID: "filter-2", Keyword: "private", WholeWord: true, CreatedAt: time.Now()}},
+			},
+		}
+		handler, _, _ := round11NewHandler(t, cfg, state)
+
+		ctx, err := round10NewLiftContext(http.MethodPut, "/api/v2/filters/filter-1", writeHeaders, nil, map[string]any{
+			"keywords_attributes": []any{
+				map[string]any{"id": "kw-bob", "keyword": "stolen"},
+			},
+		})
+		require.NoError(t, err)
+		ctx.Params["id"] = "filter-1"
+		requireStatus(t, http.StatusNotFound)(handler.HandleUpdateFilterLift(ctx))
 	})
 
 	t.Run("parseFilterUpdateParams supports JSON body bytes", func(t *testing.T) {
@@ -249,6 +277,25 @@ func TestFiltersHandlers_Round12(t *testing.T) {
 		ctxDel.Params["filter_id"] = "filter-1"
 		ctxDel.Params["keyword_id"] = "kw-1"
 		requireStatus(t, http.StatusOK)(handler.HandleDeleteFilterKeywordLift(ctxDel))
+	})
+
+	t.Run("delete filter keyword rejects keyword from another filter", func(t *testing.T) {
+		state := &round10QueryState{
+			filtersByID: map[string]storagemodels.Filter{
+				"filter-1": {ID: "filter-1", Username: "alice", Title: "x", Context: []string{"home"}, FilterAction: "warn"},
+				"filter-2": {ID: "filter-2", Username: "bob", Title: "y", Context: []string{"home"}, FilterAction: "warn"},
+			},
+			filterKeywords: map[string][]storagemodels.FilterKeyword{
+				"filter-2": {{ID: "kw-bob", FilterID: "filter-2", Keyword: "private", WholeWord: true, CreatedAt: time.Now()}},
+			},
+		}
+		handler, _, _ := round11NewHandler(t, cfg, state)
+
+		ctxDel, err := round10NewLiftContext(http.MethodDelete, "/api/v2/filters/filter-1/keywords/kw-bob", writeHeaders, nil, nil)
+		require.NoError(t, err)
+		ctxDel.Params["filter_id"] = "filter-1"
+		ctxDel.Params["keyword_id"] = "kw-bob"
+		requireStatus(t, http.StatusNotFound)(handler.HandleDeleteFilterKeywordLift(ctxDel))
 	})
 
 	t.Run("add and delete filter status", func(t *testing.T) {

--- a/cmd/api/handlers/round11_filters_test.go
+++ b/cmd/api/handlers/round11_filters_test.go
@@ -16,7 +16,10 @@ func TestFiltersHandlers(t *testing.T) {
 			"filter-1": {ID: "filter-1", Username: "alice", Title: "Test", Context: []string{"home"}, FilterAction: "warn", CreatedAt: time.Now(), UpdatedAt: time.Now()},
 		},
 		filterKeywords: map[string][]storagemodels.FilterKeyword{
-			"filter-1": {{ID: "kw-1", FilterID: "filter-1", Keyword: "spam", WholeWord: true, CreatedAt: time.Now()}},
+			"filter-1": {
+				{ID: "kw-1", FilterID: "filter-1", Keyword: "spam", WholeWord: true, CreatedAt: time.Now()},
+				{ID: "kw-2", FilterID: "filter-1", Keyword: "eggs", WholeWord: false, CreatedAt: time.Now()},
+			},
 		},
 		filterStatuses: map[string][]storagemodels.FilterStatus{
 			"filter-1": {{ID: "fs-1", FilterID: "filter-1", StatusID: "status-1", CreatedAt: time.Now()}},

--- a/cmd/moderation-processor/main.go
+++ b/cmd/moderation-processor/main.go
@@ -63,7 +63,9 @@ var (
 
 const (
 	// adminRole is the role string for admin users
-	adminRole = "admin"
+	adminRole         = "admin"
+	streamEventInsert = "INSERT"
+	streamEventModify = "MODIFY"
 )
 
 // ModerationProcessor handles DynamoDB stream events for moderation
@@ -579,7 +581,7 @@ func initAdvancedModerationEngine() {
 // processRecord processes a single DynamoDB stream record
 func (mp *ModerationProcessor) processRecord(ctx context.Context, record events.DynamoDBEventRecord) error {
 	// Only process INSERT and MODIFY events
-	if record.EventName != "INSERT" && record.EventName != "MODIFY" {
+	if record.EventName != streamEventInsert && record.EventName != streamEventModify {
 		return nil
 	}
 
@@ -602,12 +604,12 @@ func (mp *ModerationProcessor) processRecord(ctx context.Context, record events.
 
 	// Handle different types of moderation records
 	switch {
-	case strings.HasPrefix(pk, "REVIEW#") && record.EventName == "INSERT":
+	case strings.HasPrefix(pk, "REVIEW#") && record.EventName == streamEventInsert:
 		// New review added. Review MODIFY events are intentionally ignored to
 		// avoid re-processing rows written by consensus-side effects.
 		return mp.handleNewReview(ctx, record)
 
-	case strings.HasPrefix(pk, "EVENT#") && record.EventName == "INSERT":
+	case strings.HasPrefix(pk, "EVENT#") && record.EventName == streamEventInsert:
 		// New moderation event created
 		return mp.handleNewEvent(ctx, record)
 

--- a/cmd/moderation-processor/main.go
+++ b/cmd/moderation-processor/main.go
@@ -602,8 +602,9 @@ func (mp *ModerationProcessor) processRecord(ctx context.Context, record events.
 
 	// Handle different types of moderation records
 	switch {
-	case strings.HasPrefix(pk, "REVIEW#"):
-		// New review added
+	case strings.HasPrefix(pk, "REVIEW#") && record.EventName == "INSERT":
+		// New review added. Review MODIFY events are intentionally ignored to
+		// avoid re-processing rows written by consensus-side effects.
 		return mp.handleNewReview(ctx, record)
 
 	case strings.HasPrefix(pk, "EVENT#") && record.EventName == "INSERT":
@@ -650,9 +651,14 @@ func (mp *ModerationProcessor) handleNewReview(ctx context.Context, record event
 	if err != nil {
 		return ErrFailedToExtractReview(err)
 	}
+	mp.logger.Debug("validated moderation review stream record",
+		zap.String("review_id", review.ID),
+		zap.String("action", string(review.Action)))
 
-	// Process the review and check for consensus
-	decision, err := mp.consensusEngine.ProcessReview(ctx, eventID, review)
+	// The stream record represents a review that is already persisted. Evaluate
+	// consensus without writing the same review again; otherwise the write can
+	// emit a recursive MODIFY event for this review row.
+	decision, err := mp.consensusEngine.ProcessPersistedReview(ctx, eventID)
 	if err != nil {
 		mp.logger.Warn("Failed to process review",
 			zap.String("event_id", eventID),
@@ -1466,8 +1472,9 @@ func (mp *ModerationProcessor) triggerAutomaticActions(ctx context.Context, even
 			return ErrFailedToAddAutomaticReview(err)
 		}
 
-		// Process immediately to potentially trigger consensus
-		decision, err := mp.consensusEngine.ProcessReview(ctx, event.ID, review)
+		// Process immediately to potentially trigger consensus without writing
+		// the automatic review a second time.
+		decision, err := mp.consensusEngine.ProcessPersistedReview(ctx, event.ID)
 		if err != nil {
 			return ErrFailedToProcessAutomaticReview(err)
 		}

--- a/cmd/moderation-processor/processor_flow_test.go
+++ b/cmd/moderation-processor/processor_flow_test.go
@@ -42,6 +42,7 @@ type fakeConsensusStorage struct {
 	reviewsByEvent  map[string][]*moderation.Review
 	getEventErr     error
 	addReviewErr    error
+	addReviewCalls  int
 	getReviewsErr   error
 	createDecision  error
 	decisions       []*moderation.ModerationDecision
@@ -73,6 +74,7 @@ func (s *fakeConsensusStorage) GetModerationEvent(_ context.Context, eventID str
 }
 
 func (s *fakeConsensusStorage) AddModerationReview(_ context.Context, review *moderation.Review) error {
+	s.addReviewCalls++
 	if s.addReviewErr != nil {
 		return s.addReviewErr
 	}
@@ -188,6 +190,14 @@ func TestModerationProcessor_HandleNewReview_CoversDecisionAndErrorPaths(t *test
 			Category: moderation.CategoryNSFW,
 			Severity: 5,
 		}
+		storageBackend.reviewsByEvent["evt-1"] = []*moderation.Review{{
+			ID:         "rev-1",
+			EventID:    "evt-1",
+			ReviewerID: "mod-1",
+			Action:     moderation.ActionTypeRemove,
+			Weight:     2.5,
+			Created:    time.Now().UTC(),
+		}}
 
 		engine := moderation.NewConsensusEngine(storageBackend, &moderation.ConsensusConfig{
 			MinReviewers:        1,
@@ -215,6 +225,55 @@ func TestModerationProcessor_HandleNewReview_CoversDecisionAndErrorPaths(t *test
 		}
 
 		require.NoError(t, mp.handleNewReview(ctx, record))
+		require.Zero(t, storageBackend.addReviewCalls, "streamed reviews must not be re-written")
+		require.Len(t, storageBackend.reviewsByEvent["evt-1"], 1)
+		require.Len(t, storageBackend.decisions, 1)
+	})
+
+	t.Run("review modify event is ignored", func(t *testing.T) {
+		storageBackend := newFakeConsensusStorage()
+		storageBackend.events["evt-1"] = &moderation.ModerationEvent{
+			ID:       "evt-1",
+			ObjectID: "obj-1",
+			ActorID:  "actor-1",
+			Category: moderation.CategoryNSFW,
+			Severity: 5,
+		}
+		storageBackend.reviewsByEvent["evt-1"] = []*moderation.Review{{
+			ID:         "rev-1",
+			EventID:    "evt-1",
+			ReviewerID: "mod-1",
+			Action:     moderation.ActionTypeRemove,
+			Weight:     2.5,
+			Created:    time.Now().UTC(),
+		}}
+
+		engine := moderation.NewConsensusEngine(storageBackend, &moderation.ConsensusConfig{
+			MinReviewers:        1,
+			MinTrustWeight:      0,
+			ConsensusThreshold:  0,
+			CriticalThreshold:   0,
+			EscalationThreshold: 1.1,
+		})
+
+		mp := &ModerationProcessor{logger: zap.NewNop(), consensusEngine: engine}
+		record := events.DynamoDBEventRecord{
+			EventName: "MODIFY",
+			Change: events.DynamoDBStreamRecord{
+				NewImage: map[string]events.DynamoDBAttributeValue{
+					"Type":   events.NewStringAttribute("REVIEW"),
+					"Action": events.NewStringAttribute("remove"),
+				},
+				Keys: map[string]events.DynamoDBAttributeValue{
+					"PK": events.NewStringAttribute("REVIEW#evt-1"),
+					"SK": events.NewStringAttribute("REVIEWER#mod-1"),
+				},
+			},
+		}
+
+		require.NoError(t, mp.processRecord(ctx, record))
+		require.Zero(t, storageBackend.addReviewCalls)
+		require.Empty(t, storageBackend.decisions)
 	})
 
 	t.Run("invalid PK/SK formats", func(t *testing.T) {

--- a/graph/cms_converters.go
+++ b/graph/cms_converters.go
@@ -404,6 +404,12 @@ func (r *Resolver) ensureAuthorCanWriteCMS(ctx context.Context, username string,
 		return nil
 	}
 
+	if actorHost := cmsHostFromID(attributedTo); actorHost != "" {
+		if !strings.EqualFold(actorHost, r.getDomain()) {
+			return errors.New("insufficient privileges for CMS write")
+		}
+	}
+
 	if strings.EqualFold(cmsNormalizeUsername(attributedTo), username) {
 		return nil
 	}

--- a/graph/cms_helpers.go
+++ b/graph/cms_helpers.go
@@ -80,6 +80,18 @@ func cmsExtractSlugFromURL(id string) string {
 	return id
 }
 
+func cmsHostFromID(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return ""
+	}
+	parsed, err := neturl.Parse(id)
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(parsed.Host))
+}
+
 func cmsNormalizeUsername(value string) string {
 	value = strings.TrimSpace(value)
 	if value == "" {

--- a/graph/cms_permissions_test.go
+++ b/graph/cms_permissions_test.go
@@ -25,11 +25,20 @@ func TestEnsureAuthorCanWriteCMSAllowsLocalActorMatch(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestEnsureAuthorCanWriteCMSAllowsNormalizedUsernameMatch(t *testing.T) {
+func TestEnsureAuthorCanWriteCMSRejectsCrossTenantActorURL(t *testing.T) {
 	t.Parallel()
 
 	resolver := &Resolver{}
 
 	err := resolver.ensureAuthorCanWriteCMS(context.Background(), "alice", "https://example.com/users/alice")
+	require.Error(t, err)
+}
+
+func TestEnsureAuthorCanWriteCMSAllowsLegacyUsernameMatch(t *testing.T) {
+	t.Parallel()
+
+	resolver := &Resolver{}
+
+	err := resolver.ensureAuthorCanWriteCMS(context.Background(), "alice", "alice")
 	require.NoError(t, err)
 }

--- a/graph/cms_resolvers_round12_test.go
+++ b/graph/cms_resolvers_round12_test.go
@@ -380,6 +380,66 @@ func TestRound12CMS_MutationPermissions(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestRound12CMS_SeriesMutationRejectsCrossTenantSeries(t *testing.T) {
+	resolver, _ := newRound12GraphResolver(t)
+	mut := resolver.Mutation()
+	aliceCtx := round12AuthContext("alice")
+
+	cfg := resolver.Registry.GetConfig()
+	require.NotNil(t, cfg)
+
+	cfg.BaseURL = "https://tenant-a.example"
+	seriesSlug := "tenant-series"
+	tenantASeries, err := mut.CreateSeries(aliceCtx, model.CreateSeriesInput{
+		Title: "Tenant A Series",
+		Slug:  &seriesSlug,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, tenantASeries)
+
+	authorID, rawSeriesID, ok := parseSeriesGraphQLID(tenantASeries.ID)
+	require.True(t, ok)
+	storedSeries, err := resolver.Registry.Series().GetSeries(context.Background(), authorID, rawSeriesID)
+	require.NoError(t, err)
+	require.Equal(t, "tenant-a.example", storedSeries.Tenant)
+
+	cfg.BaseURL = "https://tenant-b.example"
+	updatedTitle := "tenant-b takeover"
+	_, err = mut.UpdateSeries(aliceCtx, tenantASeries.ID, model.UpdateSeriesInput{Title: &updatedTitle})
+	require.Error(t, err)
+
+	articleSlug := "tenant-b-article"
+	_, err = mut.CreateArticle(aliceCtx, model.CreateArticleInput{
+		Slug:     &articleSlug,
+		Title:    "Tenant B Article",
+		Content:  "body",
+		SeriesID: &tenantASeries.ID,
+	})
+	require.Error(t, err)
+
+	article, err := mut.CreateArticle(aliceCtx, model.CreateArticleInput{
+		Slug:    &articleSlug,
+		Title:   "Tenant B Article",
+		Content: "body",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, article)
+
+	order := 1
+	_, err = mut.AddArticleToSeries(aliceCtx, tenantASeries.ID, article.ID, &order)
+	require.Error(t, err)
+
+	_, err = mut.RemoveArticleFromSeries(aliceCtx, tenantASeries.ID, article.ID)
+	require.Error(t, err)
+
+	_, err = mut.ReorderSeriesArticles(aliceCtx, tenantASeries.ID, []string{article.ID})
+	require.Error(t, err)
+
+	ok, err = mut.DeleteSeries(aliceCtx, tenantASeries.ID)
+	require.Error(t, err)
+	require.False(t, ok)
+}
+
 func TestRound12CMS_HelperBranches(t *testing.T) {
 	memberGetter := &round12PublicationMemberGetterStub{}
 

--- a/graph/cms_resolvers_round12_test.go
+++ b/graph/cms_resolvers_round12_test.go
@@ -440,6 +440,56 @@ func TestRound12CMS_SeriesMutationRejectsCrossTenantSeries(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestRound12CMS_ArticleWritesRejectCrossTenantArticle(t *testing.T) {
+	resolver, storage := newRound12GraphResolver(t)
+	mut := resolver.Mutation()
+	aliceCtx := round12AuthContext("alice")
+
+	cfg := resolver.Registry.GetConfig()
+	require.NotNil(t, cfg)
+
+	cfg.BaseURL = "https://tenant-a.example"
+	articleSlug := "tenant-a-article"
+	tenantAArticle, err := mut.CreateArticle(aliceCtx, model.CreateArticleInput{
+		Slug:    &articleSlug,
+		Title:   "Tenant A Article",
+		Content: "tenant a body",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, tenantAArticle)
+
+	revision := &models.Revision{
+		ID:           "tenant-a-rev-1",
+		ObjectID:     tenantAArticle.ID,
+		Version:      7,
+		Content:      "restored tenant a body",
+		ChangedBy:    "alice",
+		ChangeType:   "update",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+		MetadataJSON: "{}",
+	}
+	require.NoError(t, revision.UpdateKeys())
+	require.NoError(t, storage.Revision().CreateRevision(aliceCtx, revision))
+
+	cfg.BaseURL = "https://tenant-b.example"
+	updatedTitle := "tenant-b takeover"
+	_, err = mut.UpdateArticle(aliceCtx, tenantAArticle.ID, model.UpdateArticleInput{Title: &updatedTitle})
+	require.Error(t, err)
+
+	restored, err := mut.RestoreRevision(aliceCtx, tenantAArticle.ID, 7)
+	require.Error(t, err)
+	require.Nil(t, restored)
+
+	ok, err := mut.DeleteArticle(aliceCtx, tenantAArticle.ID)
+	require.Error(t, err)
+	require.False(t, ok)
+
+	storedArticle, err := storage.Article().GetArticle(context.Background(), tenantAArticle.ID)
+	require.NoError(t, err)
+	require.Equal(t, "Tenant A Article", storedArticle.Name)
+}
+
 func TestRound12CMS_HelperBranches(t *testing.T) {
 	memberGetter := &round12PublicationMemberGetterStub{}
 

--- a/graph/cms_resolvers_round12_test.go
+++ b/graph/cms_resolvers_round12_test.go
@@ -88,13 +88,14 @@ func TestRound12CMS_DraftLifecycle(t *testing.T) {
 func TestRound12CMS_ArticlesSeriesCategoriesPublications(t *testing.T) {
 	resolver, storage := newRound12GraphResolver(t)
 	ctx := round12AuthContext("alice")
+	adminCtx := round12AuthContext("admin")
 
 	mut := resolver.Mutation()
 	qry := resolver.Query()
 
 	// Categories.
 	categorySlug := "tech"
-	category, err := mut.CreateCategory(ctx, model.CreateCategoryInput{
+	category, err := mut.CreateCategory(adminCtx, model.CreateCategoryInput{
 		Name: "Tech",
 		Slug: &categorySlug,
 	})
@@ -102,7 +103,7 @@ func TestRound12CMS_ArticlesSeriesCategoriesPublications(t *testing.T) {
 	require.NotNil(t, category)
 
 	color := "#ff0"
-	category, err = mut.UpdateCategory(ctx, category.ID, model.UpdateCategoryInput{
+	category, err = mut.UpdateCategory(adminCtx, category.ID, model.UpdateCategoryInput{
 		Color: &color,
 	})
 	require.NoError(t, err)
@@ -334,9 +335,49 @@ func TestRound12CMS_ArticlesSeriesCategoriesPublications(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 
-	ok, err = mut.DeleteCategory(ctx, category.ID)
+	ok, err = mut.DeleteCategory(adminCtx, category.ID)
 	require.NoError(t, err)
 	require.True(t, ok)
+}
+
+func TestRound12CMS_MutationPermissions(t *testing.T) {
+	resolver, _ := newRound12GraphResolver(t)
+	mut := resolver.Mutation()
+
+	aliceCtx := round12AuthContext("alice")
+	adminCtx := round12AuthContext("admin")
+	bobCtx := round12AuthContext("bob")
+
+	categorySlug := "private-taxonomy"
+	_, err := mut.CreateCategory(aliceCtx, model.CreateCategoryInput{
+		Name: "Private Taxonomy",
+		Slug: &categorySlug,
+	})
+	require.Error(t, err)
+
+	category, err := mut.CreateCategory(adminCtx, model.CreateCategoryInput{
+		Name: "Private Taxonomy",
+		Slug: &categorySlug,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, category)
+
+	seriesSlug := "bob-series"
+	bobSeries, err := mut.CreateSeries(bobCtx, model.CreateSeriesInput{
+		Title: "Bob Series",
+		Slug:  &seriesSlug,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, bobSeries)
+
+	articleSlug := "alice-article"
+	_, err = mut.CreateArticle(aliceCtx, model.CreateArticleInput{
+		Slug:     &articleSlug,
+		Title:    "Alice Article",
+		Content:  "body",
+		SeriesID: &bobSeries.ID,
+	})
+	require.Error(t, err)
 }
 
 func TestRound12CMS_HelperBranches(t *testing.T) {

--- a/graph/mutation_resolvers_cms.go
+++ b/graph/mutation_resolvers_cms.go
@@ -492,9 +492,11 @@ func (r *mutationResolver) CreateSeries(ctx context.Context, input model.CreateS
 	}
 
 	now := time.Now()
+	tenant := strings.ToLower(strings.TrimSpace(r.getDomain()))
 	series := &models.Series{
 		ID:          uuid.NewString(),
 		AuthorID:    username,
+		Tenant:      tenant,
 		Title:       input.Title,
 		Description: derefString(input.Description),
 		Slug:        slug,
@@ -511,6 +513,9 @@ func (r *mutationResolver) CreateSeries(ctx context.Context, input model.CreateS
 	}
 	if err := slugIndex.UpdateKeys(); err != nil {
 		return nil, err
+	}
+	if tenant != "" {
+		slugIndex.PK = models.CMSTenantSeriesSlugIndexPK(tenant, slug)
 	}
 	if err := store.GetDB().WithContext(ctx).Model(slugIndex).IfNotExists().Create(); err != nil {
 		if dynamormerrors.IsConditionFailed(err) {
@@ -620,6 +625,9 @@ func (r *mutationResolver) DeleteSeries(ctx context.Context, id string) (bool, e
 		SeriesID: series.ID,
 	}
 	if err := slugIndex.UpdateKeys(); err == nil {
+		if tenant := strings.ToLower(strings.TrimSpace(r.getDomain())); tenant != "" {
+			slugIndex.PK = models.CMSTenantSeriesSlugIndexPK(tenant, series.Slug)
+		}
 		if err := store.GetDB().WithContext(ctx).Model(slugIndex).Delete(); err != nil && !dynamormerrors.IsNotFound(err) {
 			r.Logger.Warn("failed to delete series slug index",
 				zap.String("slug", series.Slug),

--- a/graph/mutation_resolvers_cms.go
+++ b/graph/mutation_resolvers_cms.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -12,6 +13,10 @@ import (
 	dynamormerrors "github.com/theory-cloud/tabletheory/pkg/errors"
 	"go.uber.org/zap"
 )
+
+type cmsSeriesLoader interface {
+	GetSeries(ctx context.Context, authorID, seriesID string) (*models.Series, error)
+}
 
 func (r *mutationResolver) CreateDraft(ctx context.Context, input model.CreateDraftInput) (*model.Draft, error) {
 	if err := r.requireCMSDraftsEnabled(); err != nil {
@@ -554,15 +559,7 @@ func (r *mutationResolver) UpdateSeries(ctx context.Context, id string, input mo
 		return nil, errors.New("series service is not available")
 	}
 
-	authorID, seriesID, ok := parseSeriesGraphQLID(id)
-	if !ok {
-		return nil, errors.New("invalid series id")
-	}
-	if !r.isAdmin(ctx, username) && !strings.EqualFold(authorID, username) {
-		return nil, errors.New("insufficient privileges for series update")
-	}
-
-	series, err := seriesSvc.GetSeries(ctx, authorID, seriesID)
+	series, _, _, err := r.loadAuthorizedCMSSeries(ctx, username, id, "update", seriesSvc)
 	if err != nil {
 		return nil, err
 	}
@@ -608,15 +605,7 @@ func (r *mutationResolver) DeleteSeries(ctx context.Context, id string) (bool, e
 		return false, ErrStorageUnavailable
 	}
 
-	authorID, seriesID, ok := parseSeriesGraphQLID(id)
-	if !ok {
-		return false, errors.New("invalid series id")
-	}
-	if !r.isAdmin(ctx, username) && !strings.EqualFold(authorID, username) {
-		return false, errors.New("insufficient privileges for series delete")
-	}
-
-	series, err := seriesSvc.GetSeries(ctx, authorID, seriesID)
+	series, authorID, seriesID, err := r.loadAuthorizedCMSSeries(ctx, username, id, "delete", seriesSvc)
 	if err != nil {
 		return false, err
 	}
@@ -631,7 +620,7 @@ func (r *mutationResolver) DeleteSeries(ctx context.Context, id string) (bool, e
 		SeriesID: series.ID,
 	}
 	if err := slugIndex.UpdateKeys(); err == nil {
-		if tenant := strings.ToLower(strings.TrimSpace(r.getDomain())); tenant != "" {
+		if tenant := r.seriesTenantForSlugIndex(series); tenant != "" {
 			slugIndex.PK = models.CMSTenantSeriesSlugIndexPK(tenant, series.Slug)
 		}
 		if err := store.GetDB().WithContext(ctx).Model(slugIndex).Delete(); err != nil && !dynamormerrors.IsNotFound(err) {
@@ -673,15 +662,8 @@ func (r *mutationResolver) AddArticleToSeries(ctx context.Context, seriesID stri
 	seriesID = strings.TrimSpace(seriesID)
 	articleID = strings.TrimSpace(articleID)
 
-	authorID, rawID, ok := parseSeriesGraphQLID(seriesID)
-	if !ok {
-		return nil, errors.New("invalid series id")
-	}
-	if !r.isAdmin(ctx, username) && !strings.EqualFold(authorID, username) {
-		return nil, errors.New("insufficient privileges for series update")
-	}
-
-	if _, err := seriesSvc.GetSeries(ctx, authorID, rawID); err != nil {
+	series, _, _, err := r.loadAuthorizedCMSSeries(ctx, username, seriesID, "update", seriesSvc)
+	if err != nil {
 		return nil, err
 	}
 
@@ -701,12 +683,6 @@ func (r *mutationResolver) AddArticleToSeries(ctx context.Context, seriesID stri
 	article.SeriesOrder = &orderVal
 
 	if err := articleSvc.UpdateArticle(ctx, article); err != nil {
-		return nil, err
-	}
-
-	// Return the updated series
-	series, err := seriesSvc.GetSeries(ctx, authorID, rawID)
-	if err != nil {
 		return nil, err
 	}
 
@@ -741,15 +717,8 @@ func (r *mutationResolver) RemoveArticleFromSeries(ctx context.Context, seriesID
 	seriesID = strings.TrimSpace(seriesID)
 	articleID = strings.TrimSpace(articleID)
 
-	authorID, rawID, ok := parseSeriesGraphQLID(seriesID)
-	if !ok {
-		return nil, errors.New("invalid series id")
-	}
-	if !r.isAdmin(ctx, username) && !strings.EqualFold(authorID, username) {
-		return nil, errors.New("insufficient privileges for series update")
-	}
-
-	if _, err := seriesSvc.GetSeries(ctx, authorID, rawID); err != nil {
+	series, _, _, err := r.loadAuthorizedCMSSeries(ctx, username, seriesID, "update", seriesSvc)
+	if err != nil {
 		return nil, err
 	}
 
@@ -773,11 +742,6 @@ func (r *mutationResolver) RemoveArticleFromSeries(ctx context.Context, seriesID
 		if err := articleSvc.UpdateArticle(ctx, article); err != nil {
 			return nil, err
 		}
-	}
-
-	series, err := seriesSvc.GetSeries(ctx, authorID, rawID)
-	if err != nil {
-		return nil, err
 	}
 
 	return r.convertCMSSeries(ctx, series), nil
@@ -810,15 +774,8 @@ func (r *mutationResolver) ReorderSeriesArticles(ctx context.Context, seriesID s
 
 	seriesID = strings.TrimSpace(seriesID)
 
-	authorID, rawID, ok := parseSeriesGraphQLID(seriesID)
-	if !ok {
-		return nil, errors.New("invalid series id")
-	}
-	if !r.isAdmin(ctx, username) && !strings.EqualFold(authorID, username) {
-		return nil, errors.New("insufficient privileges for series update")
-	}
-
-	if _, err := seriesSvc.GetSeries(ctx, authorID, rawID); err != nil {
+	series, _, _, err := r.loadAuthorizedCMSSeries(ctx, username, seriesID, "update", seriesSvc)
+	if err != nil {
 		return nil, err
 	}
 
@@ -846,11 +803,6 @@ func (r *mutationResolver) ReorderSeriesArticles(ctx context.Context, seriesID s
 		}
 	}
 
-	series, err := seriesSvc.GetSeries(ctx, authorID, rawID)
-	if err != nil {
-		return nil, err
-	}
-
 	return r.convertCMSSeries(ctx, series), nil
 }
 
@@ -859,22 +811,61 @@ func (r *mutationResolver) ensureCanUseCMSSeries(ctx context.Context, username s
 		return nil
 	}
 
-	authorID, rawID, ok := parseSeriesGraphQLID(*seriesID)
-	if !ok {
-		return errors.New("invalid series id")
-	}
-	if !r.isAdmin(ctx, username) && !strings.EqualFold(authorID, username) {
-		return errors.New("insufficient privileges for series update")
-	}
-
-	seriesSvc := r.Registry.Series()
+	seriesSvc := r.seriesService()
 	if seriesSvc == nil {
 		return errors.New("series service is not available")
 	}
-	if _, err := seriesSvc.GetSeries(ctx, authorID, rawID); err != nil {
-		return err
+	_, _, _, err := r.loadAuthorizedCMSSeries(ctx, username, *seriesID, "update", seriesSvc)
+	return err
+}
+
+func (r *mutationResolver) seriesService() cmsSeriesLoader {
+	if r == nil || r.Registry == nil {
+		return nil
 	}
-	return nil
+	return r.Registry.Series()
+}
+
+func (r *mutationResolver) loadAuthorizedCMSSeries(
+	ctx context.Context,
+	username string,
+	graphQLID string,
+	action string,
+	loader cmsSeriesLoader,
+) (*models.Series, string, string, error) {
+	authorID, rawID, ok := parseSeriesGraphQLID(graphQLID)
+	if !ok {
+		return nil, "", "", errors.New("invalid series id")
+	}
+	if !r.isAdmin(ctx, username) && !strings.EqualFold(authorID, username) {
+		return nil, "", "", fmt.Errorf("insufficient privileges for series %s", action)
+	}
+	if loader == nil {
+		return nil, "", "", errors.New("series service is not available")
+	}
+
+	series, err := loader.GetSeries(ctx, authorID, rawID)
+	if err != nil {
+		return nil, "", "", err
+	}
+	if !cmsSeriesBelongsToTenant(series, r.currentCMSTenant()) {
+		return nil, "", "", errors.New("series not found")
+	}
+
+	return series, authorID, rawID, nil
+}
+
+func (r *mutationResolver) currentCMSTenant() string {
+	return strings.ToLower(strings.TrimSpace(r.getDomain()))
+}
+
+func (r *mutationResolver) seriesTenantForSlugIndex(series *models.Series) string {
+	if series != nil {
+		if tenant := strings.ToLower(strings.TrimSpace(series.Tenant)); tenant != "" {
+			return tenant
+		}
+	}
+	return r.currentCMSTenant()
 }
 
 func (r *mutationResolver) CreateCategory(ctx context.Context, input model.CreateCategoryInput) (*model.Category, error) {

--- a/graph/mutation_resolvers_cms.go
+++ b/graph/mutation_resolvers_cms.go
@@ -244,6 +244,9 @@ func (r *mutationResolver) CreateArticle(ctx context.Context, input model.Create
 	if err != nil {
 		return nil, err
 	}
+	if err := r.ensureCanUseCMSSeries(ctx, username, input.SeriesID); err != nil {
+		return nil, err
+	}
 
 	articleSvc := r.Registry.Articles()
 	if articleSvc == nil {
@@ -346,6 +349,9 @@ func (r *mutationResolver) UpdateArticle(ctx context.Context, id string, input m
 	}
 
 	if err := r.ensureAuthorCanWriteCMS(ctx, username, article.AttributedTo); err != nil {
+		return nil, err
+	}
+	if err := r.ensureCanUseCMSSeries(ctx, username, input.SeriesID); err != nil {
 		return nil, err
 	}
 
@@ -848,12 +854,35 @@ func (r *mutationResolver) ReorderSeriesArticles(ctx context.Context, seriesID s
 	return r.convertCMSSeries(ctx, series), nil
 }
 
+func (r *mutationResolver) ensureCanUseCMSSeries(ctx context.Context, username string, seriesID *string) error {
+	if seriesID == nil || strings.TrimSpace(*seriesID) == "" {
+		return nil
+	}
+
+	authorID, rawID, ok := parseSeriesGraphQLID(*seriesID)
+	if !ok {
+		return errors.New("invalid series id")
+	}
+	if !r.isAdmin(ctx, username) && !strings.EqualFold(authorID, username) {
+		return errors.New("insufficient privileges for series update")
+	}
+
+	seriesSvc := r.Registry.Series()
+	if seriesSvc == nil {
+		return errors.New("series service is not available")
+	}
+	if _, err := seriesSvc.GetSeries(ctx, authorID, rawID); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (r *mutationResolver) CreateCategory(ctx context.Context, input model.CreateCategoryInput) (*model.Category, error) {
 	if err := r.requireCMSCategoriesEnabled(); err != nil {
 		return nil, err
 	}
 
-	_, err := r.requireAuth(ctx)
+	_, err := r.requireAdmin(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -903,7 +932,7 @@ func (r *mutationResolver) UpdateCategory(ctx context.Context, id string, input 
 		return nil, err
 	}
 
-	_, err := r.requireAuth(ctx)
+	_, err := r.requireAdmin(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -954,7 +983,7 @@ func (r *mutationResolver) DeleteCategory(ctx context.Context, id string) (bool,
 		return false, err
 	}
 
-	_, err := r.requireAuth(ctx)
+	_, err := r.requireAdmin(ctx)
 	if err != nil {
 		return false, err
 	}

--- a/graph/query_resolvers_cms.go
+++ b/graph/query_resolvers_cms.go
@@ -41,29 +41,81 @@ func cmsResolveBySlug[E any](
 	db dynamormcore.DB,
 	slug string,
 	pk string,
+	legacyPK string,
+	tenant string,
 	fetchByID func(string) (E, error),
 	fetchLegacy func() (E, error),
 	extractID func(E) string,
+	belongsToTenant func(E, string) bool,
 ) (E, error) {
 	var zero E
 
-	var idx models.CMSSlugIndex
-	err := db.WithContext(ctx).Model(&models.CMSSlugIndex{}).
-		Where("PK", "=", pk).
-		Where("SK", "=", models.CMSSlugIndexSK()).
-		First(&idx)
-	if err == nil {
-		if targetID := strings.TrimSpace(idx.TargetID); targetID != "" {
-			return fetchByID(targetID)
+	tenant = strings.ToLower(strings.TrimSpace(tenant))
+	fetchFromIndex := func(indexPK string) (E, bool, error) {
+		var idx models.CMSSlugIndex
+		err := db.WithContext(ctx).Model(&models.CMSSlugIndex{}).
+			Where("PK", "=", indexPK).
+			Where("SK", "=", models.CMSSlugIndexSK()).
+			First(&idx)
+		if err != nil {
+			if dynamormerrors.IsNotFound(err) {
+				return zero, false, nil
+			}
+			return zero, false, err
+		}
+
+		targetID := strings.TrimSpace(idx.TargetID)
+		if targetID == "" {
+			return zero, false, nil
+		}
+
+		entity, err := fetchByID(targetID)
+		if err != nil {
+			return zero, false, err
+		}
+		if tenant != "" && belongsToTenant != nil && !belongsToTenant(entity, tenant) {
+			return zero, false, nil
+		}
+		return entity, true, nil
+	}
+
+	if strings.TrimSpace(pk) != "" {
+		entity, ok, err := fetchFromIndex(pk)
+		if err != nil {
+			return zero, err
+		}
+		if ok {
+			return entity, nil
 		}
 	}
-	if err != nil && !dynamormerrors.IsNotFound(err) {
-		return zero, err
+
+	if tenant != "" && strings.TrimSpace(legacyPK) != "" && !strings.EqualFold(pk, legacyPK) {
+		entity, ok, err := fetchFromIndex(legacyPK)
+		if err != nil {
+			return zero, err
+		}
+		if ok {
+			targetID := strings.TrimSpace(extractID(entity))
+			if targetID != "" {
+				backfill := &models.CMSSlugIndex{
+					PK:       pk,
+					Slug:     slug,
+					TargetID: targetID,
+				}
+				if err := backfill.UpdateKeys(); err == nil {
+					_ = db.WithContext(ctx).Model(backfill).IfNotExists().Create()
+				}
+			}
+			return entity, nil
+		}
 	}
 
 	entity, err := fetchLegacy()
 	if err != nil {
 		return zero, err
+	}
+	if tenant != "" && belongsToTenant != nil && !belongsToTenant(entity, tenant) {
+		return zero, nil
 	}
 
 	targetID := strings.TrimSpace(extractID(entity))
@@ -79,6 +131,15 @@ func cmsResolveBySlug[E any](
 	}
 
 	return entity, nil
+}
+
+func cmsStorageIDBelongsToTenant(id string, tenant string) bool {
+	tenant = strings.ToLower(strings.TrimSpace(tenant))
+	if tenant == "" {
+		return true
+	}
+	host := cmsHostFromID(id)
+	return host != "" && strings.EqualFold(host, tenant)
 }
 
 func cmsCategoryGetter(store storagecore.RepositoryStorage) func(context.Context, string) (*models.Category, error) {
@@ -122,7 +183,8 @@ func cmsFetchBySlug[E any](
 	r *queryResolver,
 	rawSlug string,
 	require func(*Resolver) error,
-	pk func(string) string,
+	scopedPK func(string, string) string,
+	legacyPK func(string) string,
 	getter func(storagecore.RepositoryStorage) func(context.Context, string) (E, error),
 	legacyID func(domain, slug string) string,
 	extractID func(E) string,
@@ -151,11 +213,17 @@ func cmsFetchBySlug[E any](
 
 	domain := r.getDomain()
 	legacy := legacyID(domain, slug)
+	tenant := strings.ToLower(strings.TrimSpace(domain))
 
-	entity, err := cmsResolveBySlug(ctx, store.GetDB(), slug, pk(slug),
+	entity, err := cmsResolveBySlug(ctx, store.GetDB(), slug, scopedPK(tenant, slug),
+		legacyPK(slug),
+		tenant,
 		func(id string) (E, error) { return getByID(ctx, id) },
 		func() (E, error) { return getByID(ctx, legacy) },
 		extractID,
+		func(entity E, tenant string) bool {
+			return cmsStorageIDBelongsToTenant(extractID(entity), tenant)
+		},
 	)
 	if err != nil {
 		return zero, err
@@ -426,20 +494,60 @@ func (r *queryResolver) ArticleBySlug(ctx context.Context, slug string) (*model.
 		return nil, errors.New("slug is required")
 	}
 
-	// Preferred path: use a slug index so IDs are stable and slugs are editable.
-	var idx models.CMSSlugIndex
-	err := store.GetDB().WithContext(ctx).Model(&models.CMSSlugIndex{}).
-		Where("PK", "=", models.CMSArticleSlugIndexPK(slug)).
-		Where("SK", "=", models.CMSSlugIndexSK()).
-		First(&idx)
-	if err == nil && strings.TrimSpace(idx.TargetID) != "" {
-		article, err := store.Article().GetArticle(ctx, strings.TrimSpace(idx.TargetID))
-		if err == nil && article != nil {
-			return r.convertCMSArticle(ctx, article, true), nil
+	tenant := strings.ToLower(strings.TrimSpace(domain))
+	fetchIndexedArticle := func(indexPK string) (*models.Article, bool, error) {
+		var idx models.CMSSlugIndex
+		err := store.GetDB().WithContext(ctx).Model(&models.CMSSlugIndex{}).
+			Where("PK", "=", indexPK).
+			Where("SK", "=", models.CMSSlugIndexSK()).
+			First(&idx)
+		if err != nil {
+			if dynamormerrors.IsNotFound(err) {
+				return nil, false, nil
+			}
+			return nil, false, err
 		}
+		targetID := strings.TrimSpace(idx.TargetID)
+		if targetID == "" {
+			return nil, false, nil
+		}
+		article, err := store.Article().GetArticle(ctx, targetID)
+		if err != nil {
+			return nil, false, err
+		}
+		if article == nil {
+			return nil, false, nil
+		}
+		if !cmsStorageIDBelongsToTenant(article.ID, tenant) {
+			return nil, false, nil
+		}
+		return article, true, nil
 	}
-	if err != nil && !dynamormerrors.IsNotFound(err) {
+
+	// Preferred path: use a tenant-scoped slug index so IDs are stable and
+	// slugs are editable without exposing another tenant's same-slug object.
+	if article, ok, err := fetchIndexedArticle(models.CMSTenantArticleSlugIndexPK(tenant, slug)); err != nil {
 		return nil, err
+	} else if ok {
+		return r.convertCMSArticle(ctx, article, true), nil
+	}
+
+	// Back-compat path: read the legacy global index only after verifying that
+	// the resolved target belongs to this resolver's tenant, then backfill.
+	if article, ok, err := fetchIndexedArticle(models.CMSArticleSlugIndexPK(slug)); err != nil {
+		return nil, err
+	} else if ok {
+		backfill := &models.CMSSlugIndex{
+			PK:       models.CMSTenantArticleSlugIndexPK(tenant, slug),
+			Slug:     slug,
+			TargetID: strings.TrimSpace(article.ID),
+		}
+		if backfill.TargetID != "" {
+			if err := backfill.UpdateKeys(); err == nil {
+				_ = store.GetDB().WithContext(ctx).Model(backfill).IfNotExists().Create()
+			}
+		}
+		return r.convertCMSArticle(ctx, article, true), nil
 	}
 
 	legacyID := cmsArticleID(domain, slug)
@@ -450,7 +558,7 @@ func (r *queryResolver) ArticleBySlug(ctx context.Context, slug string) (*model.
 
 	// Best-effort backfill for legacy slug-derived IDs.
 	backfill := &models.CMSSlugIndex{
-		PK:       models.CMSArticleSlugIndexPK(slug),
+		PK:       models.CMSTenantArticleSlugIndexPK(tenant, slug),
 		Slug:     slug,
 		TargetID: strings.TrimSpace(article.ID),
 	}
@@ -555,37 +663,52 @@ func (r *queryResolver) SeriesBySlug(ctx context.Context, slug string) (*model.S
 	if strings.TrimSpace(slug) == "" {
 		return nil, errors.New("slug is required")
 	}
+	tenant := strings.ToLower(strings.TrimSpace(r.getDomain()))
 
-	// Preferred path: use a slug index to avoid scans at scale.
-	var idx models.CMSSeriesSlugIndex
-	err := store.GetDB().WithContext(ctx).Model(&models.CMSSeriesSlugIndex{}).
-		Where("PK", "=", models.CMSSeriesSlugIndexPK(slug)).
-		Where("SK", "=", models.CMSSeriesSlugIndexSK()).
-		First(&idx)
-	if err == nil && strings.TrimSpace(idx.AuthorID) != "" && strings.TrimSpace(idx.SeriesID) != "" {
-		series, err := store.Series().GetSeries(ctx, idx.AuthorID, idx.SeriesID)
-		if err == nil && series != nil {
-			return r.convertCMSSeries(ctx, series), nil
+	fetchSeriesIndex := func(indexPK string) (*models.Series, bool, error) {
+		var idx models.CMSSeriesSlugIndex
+		err := store.GetDB().WithContext(ctx).Model(&models.CMSSeriesSlugIndex{}).
+			Where("PK", "=", indexPK).
+			Where("SK", "=", models.CMSSeriesSlugIndexSK()).
+			First(&idx)
+		if err != nil {
+			if dynamormerrors.IsNotFound(err) {
+				return nil, false, nil
+			}
+			return nil, false, err
 		}
+		if strings.TrimSpace(idx.AuthorID) == "" || strings.TrimSpace(idx.SeriesID) == "" {
+			return nil, false, nil
+		}
+		series, err := store.Series().GetSeries(ctx, idx.AuthorID, idx.SeriesID)
+		if err != nil {
+			return nil, false, err
+		}
+		if series == nil || !cmsSeriesBelongsToTenant(series, tenant) {
+			return nil, false, nil
+		}
+		return series, true, nil
 	}
-	if err != nil && !dynamormerrors.IsNotFound(err) {
+
+	// Preferred path: use a tenant-scoped slug index to avoid scans at scale.
+	if series, ok, err := fetchSeriesIndex(models.CMSTenantSeriesSlugIndexPK(tenant, slug)); err != nil {
 		return nil, err
+	} else if ok {
+		return r.convertCMSSeries(ctx, series), nil
+	}
+
+	// Back-compat path: read the legacy global index, then backfill the scoped
+	// index after the resolved series is accepted for this tenant.
+	if series, ok, err := fetchSeriesIndex(models.CMSSeriesSlugIndexPK(slug)); err != nil {
+		return nil, err
+	} else if ok {
+		backfillSeriesSlugIndex(ctx, store.GetDB(), tenant, series)
+		return r.convertCMSSeries(ctx, series), nil
 	}
 
 	// Backfill helper for instances that have legacy series rows without slug index entries.
 	backfillIndex := func(item *models.Series) {
-		if item == nil {
-			return
-		}
-		idx := &models.CMSSeriesSlugIndex{
-			Slug:     item.Slug,
-			AuthorID: item.AuthorID,
-			SeriesID: item.ID,
-		}
-		if err := idx.UpdateKeys(); err != nil {
-			return
-		}
-		_ = store.GetDB().WithContext(ctx).Model(idx).IfNotExists().Create()
+		backfillSeriesSlugIndex(ctx, store.GetDB(), tenant, item)
 	}
 
 	// Fast fallback: if authenticated, search within the viewer's series (no scan).
@@ -593,7 +716,7 @@ func (r *queryResolver) SeriesBySlug(ctx context.Context, slug string) (*model.S
 		items, err := store.Series().ListSeriesByAuthor(ctx, viewer, 500)
 		if err == nil {
 			for _, item := range items {
-				if item != nil && strings.EqualFold(item.Slug, slug) {
+				if item != nil && strings.EqualFold(item.Slug, slug) && cmsSeriesBelongsToTenant(item, tenant) {
 					backfillIndex(item)
 					return r.convertCMSSeries(ctx, item), nil
 				}
@@ -612,13 +735,44 @@ func (r *queryResolver) SeriesBySlug(ctx context.Context, slug string) (*model.S
 	}
 
 	for i := range seriesModels {
-		if strings.EqualFold(seriesModels[i].Slug, slug) {
+		if strings.EqualFold(seriesModels[i].Slug, slug) && cmsSeriesBelongsToTenant(&seriesModels[i], tenant) {
 			backfillIndex(&seriesModels[i])
 			return r.convertCMSSeries(ctx, &seriesModels[i]), nil
 		}
 	}
 
 	return nil, nil
+}
+
+func cmsSeriesBelongsToTenant(series *models.Series, tenant string) bool {
+	if series == nil {
+		return false
+	}
+	tenant = strings.ToLower(strings.TrimSpace(tenant))
+	if tenant == "" {
+		return true
+	}
+	storedTenant := strings.ToLower(strings.TrimSpace(series.Tenant))
+	return storedTenant == "" || strings.EqualFold(storedTenant, tenant)
+}
+
+func backfillSeriesSlugIndex(ctx context.Context, db dynamormcore.DB, tenant string, item *models.Series) {
+	if item == nil {
+		return
+	}
+	idx := &models.CMSSeriesSlugIndex{
+		Slug:     item.Slug,
+		AuthorID: item.AuthorID,
+		SeriesID: item.ID,
+	}
+	if err := idx.UpdateKeys(); err != nil {
+		return
+	}
+	tenant = strings.ToLower(strings.TrimSpace(tenant))
+	if tenant != "" {
+		idx.PK = models.CMSTenantSeriesSlugIndexPK(tenant, item.Slug)
+	}
+	_ = db.WithContext(ctx).Model(idx).IfNotExists().Create()
 }
 
 func (r *queryResolver) AllSeries(ctx context.Context, authorID *string, first *int, after *model.Cursor) (*model.SeriesConnection, error) {
@@ -724,7 +878,7 @@ func (r *queryResolver) Category(ctx context.Context, id string) (*model.Categor
 }
 
 func (r *queryResolver) CategoryBySlug(ctx context.Context, slug string) (*model.Category, error) {
-	category, err := cmsFetchBySlug(ctx, r, slug, (*Resolver).requireCMSCategoriesEnabled, models.CMSCategorySlugIndexPK, cmsCategoryGetter, cmsCategoryID, cmsCategoryIDFromStorage)
+	category, err := cmsFetchBySlug(ctx, r, slug, (*Resolver).requireCMSCategoriesEnabled, models.CMSTenantCategorySlugIndexPK, models.CMSCategorySlugIndexPK, cmsCategoryGetter, cmsCategoryID, cmsCategoryIDFromStorage)
 	if err != nil {
 		return nil, err
 	}
@@ -798,7 +952,7 @@ func (r *queryResolver) Publication(ctx context.Context, id string) (*model.Publ
 }
 
 func (r *queryResolver) PublicationBySlug(ctx context.Context, slug string) (*model.Publication, error) {
-	pub, err := cmsFetchBySlug(ctx, r, slug, (*Resolver).requireCMSLongFormEnabled, models.CMSPublicationSlugIndexPK, cmsPublicationGetter, cmsPublicationID, cmsPublicationIDFromStorage)
+	pub, err := cmsFetchBySlug(ctx, r, slug, (*Resolver).requireCMSLongFormEnabled, models.CMSTenantPublicationSlugIndexPK, models.CMSPublicationSlugIndexPK, cmsPublicationGetter, cmsPublicationID, cmsPublicationIDFromStorage)
 	if err != nil {
 		return nil, err
 	}

--- a/graph/query_resolvers_cms.go
+++ b/graph/query_resolvers_cms.go
@@ -51,36 +51,8 @@ func cmsResolveBySlug[E any](
 	var zero E
 
 	tenant = strings.ToLower(strings.TrimSpace(tenant))
-	fetchFromIndex := func(indexPK string) (E, bool, error) {
-		var idx models.CMSSlugIndex
-		err := db.WithContext(ctx).Model(&models.CMSSlugIndex{}).
-			Where("PK", "=", indexPK).
-			Where("SK", "=", models.CMSSlugIndexSK()).
-			First(&idx)
-		if err != nil {
-			if dynamormerrors.IsNotFound(err) {
-				return zero, false, nil
-			}
-			return zero, false, err
-		}
-
-		targetID := strings.TrimSpace(idx.TargetID)
-		if targetID == "" {
-			return zero, false, nil
-		}
-
-		entity, err := fetchByID(targetID)
-		if err != nil {
-			return zero, false, err
-		}
-		if tenant != "" && belongsToTenant != nil && !belongsToTenant(entity, tenant) {
-			return zero, false, nil
-		}
-		return entity, true, nil
-	}
-
 	if strings.TrimSpace(pk) != "" {
-		entity, ok, err := fetchFromIndex(pk)
+		entity, ok, err := cmsFetchEntityFromSlugIndex(ctx, db, pk, tenant, fetchByID, belongsToTenant)
 		if err != nil {
 			return zero, err
 		}
@@ -90,22 +62,12 @@ func cmsResolveBySlug[E any](
 	}
 
 	if tenant != "" && strings.TrimSpace(legacyPK) != "" && !strings.EqualFold(pk, legacyPK) {
-		entity, ok, err := fetchFromIndex(legacyPK)
+		entity, ok, err := cmsFetchEntityFromSlugIndex(ctx, db, legacyPK, tenant, fetchByID, belongsToTenant)
 		if err != nil {
 			return zero, err
 		}
 		if ok {
-			targetID := strings.TrimSpace(extractID(entity))
-			if targetID != "" {
-				backfill := &models.CMSSlugIndex{
-					PK:       pk,
-					Slug:     slug,
-					TargetID: targetID,
-				}
-				if err := backfill.UpdateKeys(); err == nil {
-					_ = db.WithContext(ctx).Model(backfill).IfNotExists().Create()
-				}
-			}
+			cmsBackfillSlugIndex(ctx, db, pk, slug, extractID(entity))
 			return entity, nil
 		}
 	}
@@ -118,19 +80,60 @@ func cmsResolveBySlug[E any](
 		return zero, nil
 	}
 
-	targetID := strings.TrimSpace(extractID(entity))
-	if targetID != "" {
-		backfill := &models.CMSSlugIndex{
-			PK:       pk,
-			Slug:     slug,
-			TargetID: targetID,
+	cmsBackfillSlugIndex(ctx, db, pk, slug, extractID(entity))
+	return entity, nil
+}
+
+func cmsFetchEntityFromSlugIndex[E any](
+	ctx context.Context,
+	db dynamormcore.DB,
+	indexPK string,
+	tenant string,
+	fetchByID func(string) (E, error),
+	belongsToTenant func(E, string) bool,
+) (E, bool, error) {
+	var zero E
+
+	var idx models.CMSSlugIndex
+	err := db.WithContext(ctx).Model(&models.CMSSlugIndex{}).
+		Where("PK", "=", indexPK).
+		Where("SK", "=", models.CMSSlugIndexSK()).
+		First(&idx)
+	if err != nil {
+		if dynamormerrors.IsNotFound(err) {
+			return zero, false, nil
 		}
-		if err := backfill.UpdateKeys(); err == nil {
-			_ = db.WithContext(ctx).Model(backfill).IfNotExists().Create()
-		}
+		return zero, false, err
 	}
 
-	return entity, nil
+	targetID := strings.TrimSpace(idx.TargetID)
+	if targetID != "" {
+		entity, err := fetchByID(targetID)
+		if err != nil {
+			return zero, false, err
+		}
+		if tenant != "" && belongsToTenant != nil && !belongsToTenant(entity, tenant) {
+			return zero, false, nil
+		}
+		return entity, true, nil
+	}
+
+	return zero, false, nil
+}
+
+func cmsBackfillSlugIndex(ctx context.Context, db dynamormcore.DB, pk string, slug string, targetID string) {
+	targetID = strings.TrimSpace(targetID)
+	if targetID == "" {
+		return
+	}
+	backfill := &models.CMSSlugIndex{
+		PK:       pk,
+		Slug:     slug,
+		TargetID: targetID,
+	}
+	if err := backfill.UpdateKeys(); err == nil {
+		_ = db.WithContext(ctx).Model(backfill).IfNotExists().Create()
+	}
 }
 
 func cmsStorageIDBelongsToTenant(id string, tenant string) bool {
@@ -665,33 +668,8 @@ func (r *queryResolver) SeriesBySlug(ctx context.Context, slug string) (*model.S
 	}
 	tenant := strings.ToLower(strings.TrimSpace(r.getDomain()))
 
-	fetchSeriesIndex := func(indexPK string) (*models.Series, bool, error) {
-		var idx models.CMSSeriesSlugIndex
-		err := store.GetDB().WithContext(ctx).Model(&models.CMSSeriesSlugIndex{}).
-			Where("PK", "=", indexPK).
-			Where("SK", "=", models.CMSSeriesSlugIndexSK()).
-			First(&idx)
-		if err != nil {
-			if dynamormerrors.IsNotFound(err) {
-				return nil, false, nil
-			}
-			return nil, false, err
-		}
-		if strings.TrimSpace(idx.AuthorID) == "" || strings.TrimSpace(idx.SeriesID) == "" {
-			return nil, false, nil
-		}
-		series, err := store.Series().GetSeries(ctx, idx.AuthorID, idx.SeriesID)
-		if err != nil {
-			return nil, false, err
-		}
-		if series == nil || !cmsSeriesBelongsToTenant(series, tenant) {
-			return nil, false, nil
-		}
-		return series, true, nil
-	}
-
 	// Preferred path: use a tenant-scoped slug index to avoid scans at scale.
-	if series, ok, err := fetchSeriesIndex(models.CMSTenantSeriesSlugIndexPK(tenant, slug)); err != nil {
+	if series, ok, err := cmsFetchSeriesByIndex(ctx, store, models.CMSTenantSeriesSlugIndexPK(tenant, slug), tenant); err != nil {
 		return nil, err
 	} else if ok {
 		return r.convertCMSSeries(ctx, series), nil
@@ -699,49 +677,90 @@ func (r *queryResolver) SeriesBySlug(ctx context.Context, slug string) (*model.S
 
 	// Back-compat path: read the legacy global index, then backfill the scoped
 	// index after the resolved series is accepted for this tenant.
-	if series, ok, err := fetchSeriesIndex(models.CMSSeriesSlugIndexPK(slug)); err != nil {
+	if series, ok, err := cmsFetchSeriesByIndex(ctx, store, models.CMSSeriesSlugIndexPK(slug), tenant); err != nil {
 		return nil, err
 	} else if ok {
 		backfillSeriesSlugIndex(ctx, store.GetDB(), tenant, series)
 		return r.convertCMSSeries(ctx, series), nil
 	}
 
-	// Backfill helper for instances that have legacy series rows without slug index entries.
-	backfillIndex := func(item *models.Series) {
-		backfillSeriesSlugIndex(ctx, store.GetDB(), tenant, item)
-	}
-
 	// Fast fallback: if authenticated, search within the viewer's series (no scan).
 	if viewer := r.optionalAuth(ctx); viewer != "" {
-		items, err := store.Series().ListSeriesByAuthor(ctx, viewer, 500)
-		if err == nil {
-			for _, item := range items {
-				if item != nil && strings.EqualFold(item.Slug, slug) && cmsSeriesBelongsToTenant(item, tenant) {
-					backfillIndex(item)
-					return r.convertCMSSeries(ctx, item), nil
-				}
-			}
+		series, ok, err := cmsFindViewerSeriesBySlug(ctx, store, viewer, slug, tenant)
+		if err == nil && ok {
+			backfillSeriesSlugIndex(ctx, store.GetDB(), tenant, series)
+			return r.convertCMSSeries(ctx, series), nil
 		}
 	}
 
 	// Legacy fallback: scan for the first matching slug across all authors and backfill the index.
+	series, ok, err := cmsScanSeriesBySlug(ctx, store, slug, tenant)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		backfillSeriesSlugIndex(ctx, store.GetDB(), tenant, series)
+		return r.convertCMSSeries(ctx, series), nil
+	}
+
+	return nil, nil
+}
+
+func cmsFetchSeriesByIndex(ctx context.Context, store storagecore.RepositoryStorage, indexPK string, tenant string) (*models.Series, bool, error) {
+	var idx models.CMSSeriesSlugIndex
+	err := store.GetDB().WithContext(ctx).Model(&models.CMSSeriesSlugIndex{}).
+		Where("PK", "=", indexPK).
+		Where("SK", "=", models.CMSSeriesSlugIndexSK()).
+		First(&idx)
+	if err != nil {
+		if dynamormerrors.IsNotFound(err) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	if strings.TrimSpace(idx.AuthorID) == "" || strings.TrimSpace(idx.SeriesID) == "" {
+		return nil, false, nil
+	}
+	series, err := store.Series().GetSeries(ctx, idx.AuthorID, idx.SeriesID)
+	if err != nil {
+		return nil, false, err
+	}
+	if series == nil || !cmsSeriesBelongsToTenant(series, tenant) {
+		return nil, false, nil
+	}
+	return series, true, nil
+}
+
+func cmsFindViewerSeriesBySlug(ctx context.Context, store storagecore.RepositoryStorage, viewer string, slug string, tenant string) (*models.Series, bool, error) {
+	items, err := store.Series().ListSeriesByAuthor(ctx, viewer, 500)
+	if err != nil {
+		return nil, false, err
+	}
+	for _, item := range items {
+		if item != nil && strings.EqualFold(item.Slug, slug) && cmsSeriesBelongsToTenant(item, tenant) {
+			return item, true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+func cmsScanSeriesBySlug(ctx context.Context, store storagecore.RepositoryStorage, slug string, tenant string) (*models.Series, bool, error) {
 	var seriesModels []models.Series
 	scanErr := store.GetDB().WithContext(ctx).Model(&models.Series{}).
 		Where("SK", "BEGINS_WITH", "ID#").
 		Limit(1000).
 		All(&seriesModels)
 	if scanErr != nil {
-		return nil, scanErr
+		return nil, false, scanErr
 	}
 
 	for i := range seriesModels {
 		if strings.EqualFold(seriesModels[i].Slug, slug) && cmsSeriesBelongsToTenant(&seriesModels[i], tenant) {
-			backfillIndex(&seriesModels[i])
-			return r.convertCMSSeries(ctx, &seriesModels[i]), nil
+			return &seriesModels[i], true, nil
 		}
 	}
 
-	return nil, nil
+	return nil, false, nil
 }
 
 func cmsSeriesBelongsToTenant(series *models.Series, tenant string) bool {

--- a/graph/query_resolvers_cms.go
+++ b/graph/query_resolvers_cms.go
@@ -772,6 +772,9 @@ func cmsSeriesBelongsToTenant(series *models.Series, tenant string) bool {
 		return true
 	}
 	storedTenant := strings.ToLower(strings.TrimSpace(series.Tenant))
+	// Legacy series rows created before tenant stamping have no tenant value.
+	// Keep them readable/mutable for compatibility; all new rows are stamped
+	// and must match the current tenant before slug lookup or direct mutation.
 	return storedTenant == "" || strings.EqualFold(storedTenant, tenant)
 }
 

--- a/pkg/moderation/consensus.go
+++ b/pkg/moderation/consensus.go
@@ -147,6 +147,31 @@ func (e *ConsensusEngine) ProcessReview(ctx context.Context, eventID string, rev
 		return nil, fmt.Errorf("%w: %w", ErrModerationReviewsRetrievalFailed, err)
 	}
 
+	return e.processReviews(ctx, event, reviews)
+}
+
+// ProcessPersistedReview processes an already-persisted review stream event.
+//
+// DynamoDB Streams deliver moderation review INSERT records after the review is
+// already stored. Re-writing that same review from the stream handler can emit a
+// MODIFY for the review row and recursively re-enter the stream processor. This
+// path evaluates consensus from the persisted review set without storing the
+// triggering review again.
+func (e *ConsensusEngine) ProcessPersistedReview(ctx context.Context, eventID string) (*ModerationDecision, error) {
+	event, err := e.storage.GetModerationEvent(ctx, eventID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrModerationEventRetrievalFailed, err)
+	}
+
+	reviews, err := e.storage.GetModerationReviews(ctx, eventID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrModerationReviewsRetrievalFailed, err)
+	}
+
+	return e.processReviews(ctx, event, reviews)
+}
+
+func (e *ConsensusEngine) processReviews(ctx context.Context, event *ModerationEvent, reviews []*Review) (*ModerationDecision, error) {
 	// Check if we have enough reviews
 	if len(reviews) < e.config.MinReviewers {
 		return nil, nil // Not enough reviews yet

--- a/pkg/services/cms/article_service.go
+++ b/pkg/services/cms/article_service.go
@@ -102,14 +102,15 @@ func (s *ArticleService) CreateArticle(ctx context.Context, article *models.Arti
 		return err
 	}
 
-	slugCreated, err := cmsEnsureArticleSlugIndex(ctx, s.articleRepo.GetDB(), slug, article.ID)
+	tenant := cmsTenantFromID(article.ID)
+	slugCreated, err := cmsEnsureArticleSlugIndexForTenant(ctx, s.articleRepo.GetDB(), tenant, slug, article.ID)
 	if err != nil {
 		return err
 	}
 
 	if err := s.articleRepo.CreateArticle(ctx, article); err != nil {
 		if slugCreated {
-			cmsDeleteArticleSlugIndex(ctx, s.articleRepo.GetDB(), slug)
+			cmsDeleteArticleSlugIndexForTenant(ctx, s.articleRepo.GetDB(), tenant, slug)
 		}
 		return err
 	}
@@ -119,7 +120,7 @@ func (s *ArticleService) CreateArticle(ctx context.Context, article *models.Arti
 		// Best-effort rollback to avoid creating unreachable content.
 		s.deleteCMSArticleIndexes(ctx, article)
 		if slugCreated {
-			cmsDeleteArticleSlugIndex(ctx, s.articleRepo.GetDB(), slug)
+			cmsDeleteArticleSlugIndexForTenant(ctx, s.articleRepo.GetDB(), tenant, slug)
 		}
 		_ = s.articleRepo.DeleteArticle(ctx, article.ID)
 		return err
@@ -139,10 +140,53 @@ func (s *ArticleService) GetArticleBySlug(ctx context.Context, slug string) (*mo
 	if slug == "" {
 		return nil, apperrors.ValidationFailedWithField("slug")
 	}
+	return s.getArticleBySlugIndex(ctx, slug, models.CMSArticleSlugIndexPK(slug))
+}
+
+// GetArticleByTenantSlug retrieves an article by a tenant-scoped slug index with
+// legacy global-index compatibility. Legacy matches are only returned after the
+// resolved article ID is verified to belong to the requested tenant.
+func (s *ArticleService) GetArticleByTenantSlug(ctx context.Context, tenant string, slug string) (*models.Article, error) {
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		return nil, apperrors.ValidationFailedWithField("slug")
+	}
+	tenant = cmsNormalizeTenant(tenant)
+	if tenant == "" {
+		return s.GetArticleBySlug(ctx, slug)
+	}
+
+	article, err := s.getArticleBySlugIndex(ctx, slug, models.CMSTenantArticleSlugIndexPK(tenant, slug))
+	if err == nil {
+		if articleBelongsToTenant(article, tenant) {
+			return article, nil
+		}
+		return nil, apperrors.ItemNotFoundWithID("article slug", slug)
+	}
+	if err != nil && !apperrors.HasCode(err, apperrors.CodeNotFound) {
+		return nil, err
+	}
+
+	article, err = s.getArticleBySlugIndex(ctx, slug, models.CMSArticleSlugIndexPK(slug))
+	if err != nil {
+		return nil, err
+	}
+	if !articleBelongsToTenant(article, tenant) {
+		return nil, apperrors.ItemNotFoundWithID("article slug", slug)
+	}
+
+	_, _ = cmsEnsureArticleSlugIndexForTenant(ctx, s.articleRepo.GetDB(), tenant, slug, article.ID)
+	return article, nil
+}
+
+func (s *ArticleService) getArticleBySlugIndex(ctx context.Context, slug string, pk string) (*models.Article, error) {
+	if strings.TrimSpace(pk) == "" {
+		return nil, apperrors.ItemNotFoundWithID("article slug", slug)
+	}
 
 	var idx models.CMSSlugIndex
 	err := s.articleRepo.GetDB().WithContext(ctx).Model(&models.CMSSlugIndex{}).
-		Where("PK", "=", models.CMSArticleSlugIndexPK(slug)).
+		Where("PK", "=", pk).
 		Where("SK", "=", models.CMSSlugIndexSK()).
 		First(&idx)
 	if err != nil {
@@ -158,6 +202,13 @@ func (s *ArticleService) GetArticleBySlug(ctx context.Context, slug string) (*mo
 	}
 
 	return s.articleRepo.GetArticle(ctx, articleID)
+}
+
+func articleBelongsToTenant(article *models.Article, tenant string) bool {
+	if article == nil {
+		return false
+	}
+	return strings.EqualFold(cmsTenantFromID(article.ID), tenant)
 }
 
 // GetArticle retrieves an article by ID.
@@ -189,7 +240,8 @@ func (s *ArticleService) UpdateArticle(ctx context.Context, article *models.Arti
 			return err
 		}
 
-		created, err := cmsEnsureArticleSlugIndex(ctx, s.articleRepo.GetDB(), slug, article.ID)
+		tenant := cmsTenantFromID(article.ID)
+		created, err := cmsEnsureArticleSlugIndexForTenant(ctx, s.articleRepo.GetDB(), tenant, slug, article.ID)
 		if err != nil {
 			return err
 		}
@@ -212,7 +264,7 @@ func (s *ArticleService) UpdateArticle(ctx context.Context, article *models.Arti
 
 	if err := s.articleRepo.UpdateArticle(ctx, article); err != nil {
 		if slugCreated {
-			cmsDeleteArticleSlugIndex(ctx, s.articleRepo.GetDB(), slug)
+			cmsDeleteArticleSlugIndexForTenant(ctx, s.articleRepo.GetDB(), cmsTenantFromID(article.ID), slug)
 		}
 		return err
 	}

--- a/pkg/services/cms/article_service_round25_coverage_test.go
+++ b/pkg/services/cms/article_service_round25_coverage_test.go
@@ -241,6 +241,24 @@ func TestArticleService_Round25_CreateUpdateDeleteArticle(t *testing.T) {
 		assert.Equal(t, "a4", got.ID)
 	})
 
+	t.Run("tenant slug lookup rejects legacy index target from other tenant", func(t *testing.T) {
+		db, q := newCMSMockDB(t)
+		repo.db = db
+
+		crossTenantID := "https://other.example/articles/shared"
+		repo.articles[crossTenantID] = &models.Article{Object: models.Object{ID: crossTenantID, Name: "n"}, Slug: "shared"}
+
+		q.On("First", mock.Anything).Return(dynamormerrors.ErrItemNotFound).Once()
+		q.On("First", mock.Anything).Run(func(args mock.Arguments) {
+			dest := args.Get(0).(*models.CMSSlugIndex)
+			dest.TargetID = crossTenantID
+		}).Return(nil).Once()
+
+		_, err := svc.GetArticleByTenantSlug(ctx, "example.com", "shared")
+		require.Error(t, err)
+		assert.True(t, apperrors.HasCode(err, apperrors.CodeNotFound))
+	})
+
 	t.Run("update snapshots revision when configured", func(t *testing.T) {
 		db, q := newCMSMockDB(t)
 		repo.db = db

--- a/pkg/services/cms/category_service.go
+++ b/pkg/services/cms/category_service.go
@@ -63,7 +63,7 @@ func (s *CategoryService) CreateCategory(ctx context.Context, category *models.C
 
 	if err := s.categoryRepo.CreateCategory(ctx, category); err != nil {
 		if slugCreated {
-			cmsDeleteCategorySlugIndex(ctx, s.categoryRepo.GetDB(), slug)
+			cmsDeleteCategorySlugIndexForTenant(ctx, s.categoryRepo.GetDB(), cmsTenantFromID(category.ID), slug)
 		}
 		return err
 	}
@@ -96,7 +96,7 @@ func (s *CategoryService) UpdateCategory(ctx context.Context, category *models.C
 	category.UpdatedAt = time.Now()
 	if err := s.categoryRepo.Update(ctx, category); err != nil {
 		if slugCreated {
-			cmsDeleteCategorySlugIndex(ctx, s.categoryRepo.GetDB(), slug)
+			cmsDeleteCategorySlugIndexForTenant(ctx, s.categoryRepo.GetDB(), cmsTenantFromID(category.ID), slug)
 		}
 		return err
 	}
@@ -134,7 +134,7 @@ func (s *CategoryService) reserveSlugIndex(ctx context.Context, category *models
 		}
 	}
 
-	created, err = cmsEnsureCategorySlugIndex(ctx, s.categoryRepo.GetDB(), slug, categoryID)
+	created, err = cmsEnsureCategorySlugIndexForTenant(ctx, s.categoryRepo.GetDB(), cmsTenantFromID(categoryID), slug, categoryID)
 	return slug, created, err
 }
 

--- a/pkg/services/cms/draft_service.go
+++ b/pkg/services/cms/draft_service.go
@@ -36,6 +36,10 @@ type articleDraftPublisher interface {
 	UpdateArticle(ctx context.Context, article *models.Article) error
 }
 
+type tenantArticleDraftPublisher interface {
+	GetArticleByTenantSlug(ctx context.Context, tenant string, slug string) (*models.Article, error)
+}
+
 // DraftService handles business logic for drafts
 type DraftService struct {
 	draftRepo      draftRepository
@@ -303,7 +307,15 @@ func (s *DraftService) resolveExistingArticleBySlug(ctx context.Context, domain 
 	}
 
 	if s.articleService != nil {
-		article, err := s.articleService.GetArticleBySlug(ctx, slug)
+		var (
+			article *models.Article
+			err     error
+		)
+		if tenantGetter, ok := s.articleService.(tenantArticleDraftPublisher); ok {
+			article, err = tenantGetter.GetArticleByTenantSlug(ctx, domain, slug)
+		} else {
+			article, err = s.articleService.GetArticleBySlug(ctx, slug)
+		}
 		if err == nil {
 			return article, nil
 		}

--- a/pkg/services/cms/publication_service.go
+++ b/pkg/services/cms/publication_service.go
@@ -83,14 +83,15 @@ func (s *PublicationService) CreatePublication(ctx context.Context, publication 
 		}
 	}
 
-	slugCreated, err := cmsEnsurePublicationSlugIndex(ctx, s.pubRepo.GetDB(), slug, publicationID)
+	tenant := cmsTenantFromID(publicationID)
+	slugCreated, err := cmsEnsurePublicationSlugIndexForTenant(ctx, s.pubRepo.GetDB(), tenant, slug, publicationID)
 	if err != nil {
 		return err
 	}
 
 	if err := s.pubRepo.CreatePublication(ctx, publication); err != nil {
 		if slugCreated {
-			cmsDeletePublicationSlugIndex(ctx, s.pubRepo.GetDB(), slug)
+			cmsDeletePublicationSlugIndexForTenant(ctx, s.pubRepo.GetDB(), tenant, slug)
 		}
 		return err
 	}
@@ -136,7 +137,8 @@ func (s *PublicationService) UpdatePublication(ctx context.Context, publication 
 		}
 	}
 
-	slugCreated, err := cmsEnsurePublicationSlugIndex(ctx, s.pubRepo.GetDB(), slug, publicationID)
+	tenant := cmsTenantFromID(publicationID)
+	slugCreated, err := cmsEnsurePublicationSlugIndexForTenant(ctx, s.pubRepo.GetDB(), tenant, slug, publicationID)
 	if err != nil {
 		return err
 	}
@@ -144,7 +146,7 @@ func (s *PublicationService) UpdatePublication(ctx context.Context, publication 
 	publication.UpdatedAt = time.Now()
 	if err := s.pubRepo.Update(ctx, publication); err != nil {
 		if slugCreated {
-			cmsDeletePublicationSlugIndex(ctx, s.pubRepo.GetDB(), slug)
+			cmsDeletePublicationSlugIndexForTenant(ctx, s.pubRepo.GetDB(), tenant, slug)
 		}
 		return err
 	}

--- a/pkg/services/cms/slug_indexes.go
+++ b/pkg/services/cms/slug_indexes.go
@@ -21,7 +21,15 @@ func cmsHostFromURL(value string) string {
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(parsed.Host)
+	return strings.ToLower(strings.TrimSpace(parsed.Host))
+}
+
+func cmsNormalizeTenant(tenant string) string {
+	return strings.ToLower(strings.TrimSpace(tenant))
+}
+
+func cmsTenantFromID(value string) string {
+	return cmsNormalizeTenant(cmsHostFromURL(value))
 }
 
 func cmsEnsureSlugIndex(ctx context.Context, db core.DB, pk string, slug string, targetID string, itemType string) (bool, error) {
@@ -75,22 +83,73 @@ func cmsEnsureArticleSlugIndex(ctx context.Context, db core.DB, slug string, art
 	return cmsEnsureSlugIndex(ctx, db, models.CMSArticleSlugIndexPK(slug), slug, articleID, "article slug")
 }
 
+func cmsEnsureArticleSlugIndexForTenant(ctx context.Context, db core.DB, tenant string, slug string, articleID string) (bool, error) {
+	tenant = cmsNormalizeTenant(tenant)
+	if tenant == "" {
+		return cmsEnsureArticleSlugIndex(ctx, db, slug, articleID)
+	}
+	return cmsEnsureSlugIndex(ctx, db, models.CMSTenantArticleSlugIndexPK(tenant, slug), slug, articleID, "article slug")
+}
+
 func cmsDeleteArticleSlugIndex(ctx context.Context, db core.DB, slug string) {
 	cmsDeleteSlugIndex(ctx, db, models.CMSArticleSlugIndexPK(slug))
+}
+
+func cmsDeleteArticleSlugIndexForTenant(ctx context.Context, db core.DB, tenant string, slug string) {
+	tenant = cmsNormalizeTenant(tenant)
+	if tenant == "" {
+		cmsDeleteArticleSlugIndex(ctx, db, slug)
+		return
+	}
+	cmsDeleteSlugIndex(ctx, db, models.CMSTenantArticleSlugIndexPK(tenant, slug))
 }
 
 func cmsEnsureCategorySlugIndex(ctx context.Context, db core.DB, slug string, categoryID string) (bool, error) {
 	return cmsEnsureSlugIndex(ctx, db, models.CMSCategorySlugIndexPK(slug), slug, categoryID, "category slug")
 }
 
+func cmsEnsureCategorySlugIndexForTenant(ctx context.Context, db core.DB, tenant string, slug string, categoryID string) (bool, error) {
+	tenant = cmsNormalizeTenant(tenant)
+	if tenant == "" {
+		return cmsEnsureCategorySlugIndex(ctx, db, slug, categoryID)
+	}
+	return cmsEnsureSlugIndex(ctx, db, models.CMSTenantCategorySlugIndexPK(tenant, slug), slug, categoryID, "category slug")
+}
+
 func cmsDeleteCategorySlugIndex(ctx context.Context, db core.DB, slug string) {
 	cmsDeleteSlugIndex(ctx, db, models.CMSCategorySlugIndexPK(slug))
+}
+
+func cmsDeleteCategorySlugIndexForTenant(ctx context.Context, db core.DB, tenant string, slug string) {
+	tenant = cmsNormalizeTenant(tenant)
+	if tenant == "" {
+		cmsDeleteCategorySlugIndex(ctx, db, slug)
+		return
+	}
+	cmsDeleteSlugIndex(ctx, db, models.CMSTenantCategorySlugIndexPK(tenant, slug))
 }
 
 func cmsEnsurePublicationSlugIndex(ctx context.Context, db core.DB, slug string, publicationID string) (bool, error) {
 	return cmsEnsureSlugIndex(ctx, db, models.CMSPublicationSlugIndexPK(slug), slug, publicationID, "publication slug")
 }
 
+func cmsEnsurePublicationSlugIndexForTenant(ctx context.Context, db core.DB, tenant string, slug string, publicationID string) (bool, error) {
+	tenant = cmsNormalizeTenant(tenant)
+	if tenant == "" {
+		return cmsEnsurePublicationSlugIndex(ctx, db, slug, publicationID)
+	}
+	return cmsEnsureSlugIndex(ctx, db, models.CMSTenantPublicationSlugIndexPK(tenant, slug), slug, publicationID, "publication slug")
+}
+
 func cmsDeletePublicationSlugIndex(ctx context.Context, db core.DB, slug string) {
 	cmsDeleteSlugIndex(ctx, db, models.CMSPublicationSlugIndexPK(slug))
+}
+
+func cmsDeletePublicationSlugIndexForTenant(ctx context.Context, db core.DB, tenant string, slug string) {
+	tenant = cmsNormalizeTenant(tenant)
+	if tenant == "" {
+		cmsDeletePublicationSlugIndex(ctx, db, slug)
+		return
+	}
+	cmsDeleteSlugIndex(ctx, db, models.CMSTenantPublicationSlugIndexPK(tenant, slug))
 }

--- a/pkg/services/cms/slug_indexes_round25_coverage_test.go
+++ b/pkg/services/cms/slug_indexes_round25_coverage_test.go
@@ -19,6 +19,8 @@ func TestCMS_Round25_cmsHostFromURL(t *testing.T) {
 	assert.Equal(t, "", cmsHostFromURL(""))
 	assert.Equal(t, "", cmsHostFromURL("not a url"))
 	assert.Equal(t, "example.com", cmsHostFromURL("https://example.com/articles/123"))
+	assert.Equal(t, "example.com", cmsHostFromURL("https://Example.COM/articles/123"))
+	assert.Equal(t, "example.com", cmsNormalizeTenant(" Example.COM "))
 }
 
 func TestCMS_Round25_cmsEnsureSlugIndex(t *testing.T) {

--- a/pkg/storage/models/cms_series_slug_index.go
+++ b/pkg/storage/models/cms_series_slug_index.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	cmsSeriesSlugIndexPKPrefix = "CMS#SERIES#SLUG#"
-	cmsSeriesSlugIndexSK       = "REF"
+	cmsSeriesSlugIndexPKPrefix  = "CMS#SERIES#SLUG#"
+	cmsTenantSeriesSlugPKPrefix = "CMS#TENANT#"
+	cmsSeriesSlugIndexSK        = "REF"
 )
 
 // CMSSeriesSlugIndex maps a series slug to its owning author + series ID for efficient lookup.
@@ -70,6 +71,16 @@ func CMSSeriesSlugIndexPK(slug string) string {
 		return ""
 	}
 	return cmsSeriesSlugIndexPKPrefix + slug
+}
+
+// CMSTenantSeriesSlugIndexPK returns the tenant-scoped PK for a series slug.
+func CMSTenantSeriesSlugIndexPK(tenant string, slug string) string {
+	tenant = strings.ToLower(strings.TrimSpace(tenant))
+	slug = strings.TrimSpace(slug)
+	if tenant == "" || slug == "" {
+		return ""
+	}
+	return cmsTenantSeriesSlugPKPrefix + tenant + "#SERIES#SLUG#" + slug
 }
 
 // CMSSeriesSlugIndexSK returns the fixed SK for slug index entries.

--- a/pkg/storage/models/cms_slug_index.go
+++ b/pkg/storage/models/cms_slug_index.go
@@ -12,6 +12,7 @@ const (
 	cmsArticleSlugIndexPKPrefix     = "CMS#ARTICLE#SLUG#"
 	cmsCategorySlugIndexPKPrefix    = "CMS#CATEGORY#SLUG#"
 	cmsPublicationSlugIndexPKPrefix = "CMS#PUBLICATION#SLUG#"
+	cmsTenantSlugIndexPKPrefix      = "CMS#TENANT#"
 )
 
 // CMSSlugIndex maps a slug to a canonical object ID.
@@ -85,6 +86,21 @@ func CMSPublicationSlugIndexPK(slug string) string {
 	return cmsSlugIndexPK(cmsPublicationSlugIndexPKPrefix, slug)
 }
 
+// CMSTenantArticleSlugIndexPK returns the tenant-scoped PK for an article slug.
+func CMSTenantArticleSlugIndexPK(tenant string, slug string) string {
+	return cmsTenantSlugIndexPK(tenant, "ARTICLE", slug)
+}
+
+// CMSTenantCategorySlugIndexPK returns the tenant-scoped PK for a category slug.
+func CMSTenantCategorySlugIndexPK(tenant string, slug string) string {
+	return cmsTenantSlugIndexPK(tenant, "CATEGORY", slug)
+}
+
+// CMSTenantPublicationSlugIndexPK returns the tenant-scoped PK for a publication slug.
+func CMSTenantPublicationSlugIndexPK(tenant string, slug string) string {
+	return cmsTenantSlugIndexPK(tenant, "PUBLICATION", slug)
+}
+
 // CMSArticleSlugIndexSK returns the fixed SK for article slug index entries.
 func CMSArticleSlugIndexSK() string { return cmsSlugIndexSK }
 
@@ -100,4 +116,14 @@ func cmsSlugIndexPK(prefix string, slug string) string {
 		return ""
 	}
 	return prefix + slug
+}
+
+func cmsTenantSlugIndexPK(tenant string, itemType string, slug string) string {
+	tenant = strings.ToLower(strings.TrimSpace(tenant))
+	itemType = strings.ToUpper(strings.TrimSpace(itemType))
+	slug = strings.TrimSpace(slug)
+	if tenant == "" || itemType == "" || slug == "" {
+		return ""
+	}
+	return cmsTenantSlugIndexPKPrefix + tenant + "#" + itemType + "#SLUG#" + slug
 }

--- a/pkg/storage/models/round15_more_zero_coverage_models2_test.go
+++ b/pkg/storage/models/round15_more_zero_coverage_models2_test.go
@@ -413,6 +413,11 @@ func TestCMSSlugIndex(t *testing.T) {
 		assert.Equal(t, "", CMSArticleSlugIndexPK(" "))
 		assert.Equal(t, "", CMSCategorySlugIndexPK(""))
 		assert.Equal(t, "", CMSPublicationSlugIndexPK("\n"))
+		assert.Equal(t, "", CMSTenantArticleSlugIndexPK("", "slug"))
+		assert.Equal(t, "", CMSTenantArticleSlugIndexPK("example.com", " "))
+		assert.Equal(t, "CMS#TENANT#example.com#ARTICLE#SLUG#slug", CMSTenantArticleSlugIndexPK(" Example.COM ", "slug"))
+		assert.Equal(t, "CMS#TENANT#example.com#CATEGORY#SLUG#slug", CMSTenantCategorySlugIndexPK("example.com", "slug"))
+		assert.Equal(t, "CMS#TENANT#example.com#PUBLICATION#SLUG#slug", CMSTenantPublicationSlugIndexPK("example.com", "slug"))
 		assert.Equal(t, cmsSlugIndexSK, CMSSlugIndexSK())
 
 		i := &CMSSlugIndex{}

--- a/pkg/storage/models/round15_more_zero_coverage_models3_test.go
+++ b/pkg/storage/models/round15_more_zero_coverage_models3_test.go
@@ -270,6 +270,9 @@ func TestRoutingMetrics(t *testing.T) {
 func TestCMSSeriesSlugIndex(t *testing.T) {
 	t.Run("PK helpers and UpdateKeys validation", func(t *testing.T) {
 		assert.Equal(t, "", CMSSeriesSlugIndexPK(""))
+		assert.Equal(t, "", CMSTenantSeriesSlugIndexPK("", "series"))
+		assert.Equal(t, "", CMSTenantSeriesSlugIndexPK("example.com", ""))
+		assert.Equal(t, "CMS#TENANT#example.com#SERIES#SLUG#series", CMSTenantSeriesSlugIndexPK(" Example.COM ", "series"))
 		assert.Equal(t, "REF", CMSSeriesSlugIndexSK())
 
 		i := &CMSSeriesSlugIndex{}

--- a/pkg/storage/models/series.go
+++ b/pkg/storage/models/series.go
@@ -12,6 +12,7 @@ type Series struct {
 
 	ID          string `theorydb:"attr:id" json:"id"`
 	AuthorID    string `theorydb:"attr:authorID" json:"author_id"`
+	Tenant      string `theorydb:"attr:tenant,omitempty" json:"tenant,omitempty"`
 	Title       string `theorydb:"attr:title" json:"title"`
 	Description string `theorydb:"attr:description" json:"description,omitempty"`
 	Slug        string `theorydb:"attr:slug" json:"slug"`


### PR DESCRIPTION
## Milestone
[Codex Security M8] CMS, moderation, and filter integrity — close tenant isolation and ownership gaps in CMS/moderation/filter write paths.

Closes #863.

## Classification
security / schema / contract-stability / operational-reliability

## Surfaces affected
- CMS slug index helpers and CMS slug lookup paths for articles, categories, publications, and series
- GraphQL CMS mutations for categories, articles, and series assignments
- Moderation stream processor review handling and consensus evaluation
- Mastodon-compatible filter keyword update/delete handlers under `/api/v2/filters/*`

## Specialist walks referenced
- Federation trust: no ActivityPub signing, verification, actor identity, inbox/outbox, relay, or delivery changes.
- Contract / API: semantic hardening only. GraphQL schema and OpenAPI files remain up to date; filter keyword ownership failures now return not-found instead of mutating cross-filter IDs.
- Schema: additive tenant-scoped CMS slug PK helpers and optional `Series.Tenant`; no TableTheory tag, GSI, or existing PK/SK rewrites. Reads dual-read legacy global indexes, verify tenant ownership before returning, and backfill tenant-scoped indexes.
- Framework: idiomatic AppTheory/TableTheory usage; no framework patches.

## Consumer impact
- Operators keep legacy CMS content readable while new/backfilled slug indexes are tenant-scoped.
- CMS admins now own shared taxonomy mutations; article authors/admins must own referenced series before attaching articles.
- Moderation stream processing avoids recursive review writes from DynamoDB Streams side effects.
- Filter clients see safer 404 behavior for keyword IDs outside the owned filter, with unchanged response schema.

## Tasks
- [x] Tenant-scope CMS slug lookups with dual-read/backfill and no cross-tenant exposure.
- [x] Enforce CMS category/series/article/draft mutation permissions consistently.
- [x] Avoid recursive moderation review writes from stream processing.
- [x] Verify filter keyword ownership before update/delete mutation.

## Validation
- `gofmt -l .` (empty)
- Targeted: `go test ./cmd/moderation-processor ./cmd/api/handlers ./pkg/services/cms ./pkg/moderation ./pkg/storage/models ./graph`
- `go test ./...`
- `go vet ./...`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`
  - overall coverage: 87.568%
  - pkg coverage: 90.024%
  - cmd coverage: 90.016%

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None required. No sibling-repo contract or release-artifact shape changes.

## Notes
Legacy series rows with an empty `tenant` remain accepted during dual-read/backfill for compatibility; newly created series rows are tenant-tagged.
