### PR TITLE
fix(storage): complete security M10 compatibility repairs

### DIFF
--- a/pkg/services/accounts/service.go
+++ b/pkg/services/accounts/service.go
@@ -1172,7 +1172,7 @@ func (s *Service) GetFollowers(ctx context.Context, query *GetFollowersQuery) (*
 
 	// Get followers using relationship repository
 	relationshipRepo := s.storage.Relationship()
-	if relationshipRepo == nil {
+	if isNilInterface(relationshipRepo) {
 		return nil, ErrRelationshipRepositoryNotAvailable
 	}
 
@@ -1238,7 +1238,12 @@ func (s *Service) GetFollowing(ctx context.Context, query *GetFollowingQuery) (*
 	}
 
 	// Get following relationships from storage
-	followingUsernames, nextCursor, err := s.storage.Relationship().GetFollowing(ctx, query.Username, query.Pagination.Limit, query.Pagination.Cursor)
+	relationshipRepo := s.storage.Relationship()
+	if isNilInterface(relationshipRepo) {
+		return nil, ErrRelationshipRepositoryNotAvailable
+	}
+
+	followingUsernames, nextCursor, err := relationshipRepo.GetFollowing(ctx, query.Username, query.Pagination.Limit, query.Pagination.Cursor)
 	if err != nil {
 		return nil, ErrGetFollowingList
 	}
@@ -1280,7 +1285,7 @@ func (s *Service) GetFamiliarFollowers(ctx context.Context, query *GetFamiliarFo
 
 	// Get relationship repository
 	relationshipRepo := s.storage.Relationship()
-	if relationshipRepo == nil {
+	if isNilInterface(relationshipRepo) {
 		return nil, ErrRelationshipRepositoryNotAvailable
 	}
 
@@ -1582,7 +1587,7 @@ func (s *Service) RemoveFollower(ctx context.Context, cmd *RemoveFollowerCommand
 
 	// Get relationship repository
 	relationshipRepo := s.storage.Relationship()
-	if relationshipRepo == nil {
+	if isNilInterface(relationshipRepo) {
 		return nil, ErrRelationshipRepositoryNotAvailable
 	}
 
@@ -1739,12 +1744,22 @@ func (s *Service) buildCollectionMetadata(ctx context.Context, query *GetActivit
 func (s *Service) getCollectionCount(ctx context.Context, query *GetActivityPubCollectionQuery) int {
 	switch query.CollectionType {
 	case collectionFollowers:
-		if count, err := s.storage.Relationship().CountFollowers(ctx, query.Username); err == nil {
+		relationshipRepo := s.storage.Relationship()
+		if isNilInterface(relationshipRepo) {
+			s.logger.Warn("relationship repository unavailable for followers count")
+			return 0
+		}
+		if count, err := relationshipRepo.CountFollowers(ctx, query.Username); err == nil {
 			return count
 		}
 		s.logger.Warn("failed to get followers count")
 	case "following":
-		if count, err := s.storage.Relationship().CountFollowing(ctx, query.Username); err == nil {
+		relationshipRepo := s.storage.Relationship()
+		if isNilInterface(relationshipRepo) {
+			s.logger.Warn("relationship repository unavailable for following count")
+			return 0
+		}
+		if count, err := relationshipRepo.CountFollowing(ctx, query.Username); err == nil {
 			return count
 		}
 		s.logger.Warn("failed to get following count")
@@ -1798,7 +1813,13 @@ func (s *Service) getPageData(ctx context.Context, query *GetActivityPubCollecti
 
 // getFollowersPageData handles followers collection page data
 func (s *Service) getFollowersPageData(ctx context.Context, query *GetActivityPubCollectionQuery, collectionID string) ([]any, string) {
-	usernames, nextCursor, err := s.storage.Relationship().GetFollowers(ctx, query.Username, query.Limit, query.Cursor)
+	relationshipRepo := s.storage.Relationship()
+	if isNilInterface(relationshipRepo) {
+		s.logger.Error("relationship repository unavailable for ActivityPub followers collection")
+		return []any{}, ""
+	}
+
+	usernames, nextCursor, err := relationshipRepo.GetFollowers(ctx, query.Username, query.Limit, query.Cursor)
 	if err != nil {
 		s.logger.Error("failed to get followers for ActivityPub collection", zap.Error(err))
 		return []any{}, ""
@@ -1811,7 +1832,13 @@ func (s *Service) getFollowersPageData(ctx context.Context, query *GetActivityPu
 
 // getFollowingPageData handles following collection page data
 func (s *Service) getFollowingPageData(ctx context.Context, query *GetActivityPubCollectionQuery, collectionID string) ([]any, string) {
-	usernames, nextCursor, err := s.storage.Relationship().GetFollowing(ctx, query.Username, query.Limit, query.Cursor)
+	relationshipRepo := s.storage.Relationship()
+	if isNilInterface(relationshipRepo) {
+		s.logger.Error("relationship repository unavailable for ActivityPub following collection")
+		return []any{}, ""
+	}
+
+	usernames, nextCursor, err := relationshipRepo.GetFollowing(ctx, query.Username, query.Limit, query.Cursor)
 	if err != nil {
 		s.logger.Error("failed to get following for ActivityPub collection", zap.Error(err))
 		return []any{}, ""
@@ -2645,7 +2672,7 @@ func (s *Service) GetFollowRequestState(ctx context.Context, requesterID, target
 	}
 
 	relationshipRepo := s.storage.Relationship()
-	if relationshipRepo == nil {
+	if isNilInterface(relationshipRepo) {
 		return "", ErrRelationshipRepositoryNotAvailable
 	}
 
@@ -2757,7 +2784,7 @@ func (s *Service) GetAccountNote(ctx context.Context, currentUsername, targetAct
 
 // checkBlocking checks if one user has blocked another user
 func (s *Service) checkBlocking(ctx context.Context, relationshipRepo interfaces.ConcreteRelationshipRepository, blockerID, blockedID string) bool {
-	if relationshipRepo == nil {
+	if isNilInterface(relationshipRepo) {
 		return false
 	}
 
@@ -2818,7 +2845,7 @@ func (s *Service) validateRelationshipStorage() error {
 	if s.storage == nil {
 		return ErrStorageNotAvailable
 	}
-	if s.storage.Relationship() == nil {
+	if isNilInterface(s.storage.Relationship()) {
 		return ErrRelationshipRepositoryNotAvailable
 	}
 	return nil
@@ -2829,6 +2856,9 @@ func (s *Service) buildRelationshipData(ctx context.Context, username, targetAcc
 	data := &relationshipData{}
 
 	relationshipRepo := s.storage.Relationship()
+	if isNilInterface(relationshipRepo) {
+		return data
+	}
 
 	// Basic relationship checks
 	data.Following = s.checkFollowingStatus(ctx, relationshipRepo, username, targetAccount)
@@ -2851,6 +2881,10 @@ func (s *Service) buildRelationshipData(ctx context.Context, username, targetAcc
 
 // checkFollowingStatus checks if one user follows another
 func (s *Service) checkFollowingStatus(ctx context.Context, repo interfaces.ConcreteRelationshipRepository, follower, followee string) bool {
+	if isNilInterface(repo) {
+		return false
+	}
+
 	following, err := repo.IsFollowing(ctx, follower, followee)
 	if err != nil {
 		s.logger.Warn("failed to check following status",
@@ -2864,6 +2898,10 @@ func (s *Service) checkFollowingStatus(ctx context.Context, repo interfaces.Conc
 
 // checkMutingStatus checks if one user has muted another
 func (s *Service) checkMutingStatus(ctx context.Context, repo interfaces.ConcreteRelationshipRepository, muter, muted string) bool {
+	if isNilInterface(repo) {
+		return false
+	}
+
 	muting, err := repo.IsMuted(ctx, muter, muted)
 	if err != nil {
 		s.logger.Warn("failed to check muting status",
@@ -2877,7 +2915,7 @@ func (s *Service) checkMutingStatus(ctx context.Context, repo interfaces.Concret
 
 // checkMutingNotifications checks if notifications are muted for a muted user
 func (s *Service) checkMutingNotifications(ctx context.Context, repo interfaces.ConcreteRelationshipRepository, username, targetAccount string, isMuting bool) bool {
-	if !isMuting {
+	if !isMuting || isNilInterface(repo) {
 		return false
 	}
 
@@ -2891,6 +2929,10 @@ func (s *Service) checkMutingNotifications(ctx context.Context, repo interfaces.
 
 // checkFollowRequest checks if there's a pending follow request
 func (s *Service) checkFollowRequest(ctx context.Context, repo interfaces.ConcreteRelationshipRepository, requester, target string) bool {
+	if isNilInterface(repo) {
+		return false
+	}
+
 	requested, err := repo.HasFollowRequest(ctx, requester, target)
 	if err != nil {
 		return false

--- a/pkg/services/accounts/service_relationship_nil_test.go
+++ b/pkg/services/accounts/service_relationship_nil_test.go
@@ -1,0 +1,33 @@
+package accounts
+
+import (
+	"context"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/storage/interfaces"
+	"github.com/equaltoai/lesser/pkg/storage/repositories"
+	"github.com/equaltoai/lesser/pkg/streaming"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type typedNilRelationshipStorage struct {
+	*MockRepositoryStorage
+}
+
+func (s *typedNilRelationshipStorage) Relationship() interfaces.ConcreteRelationshipRepository {
+	var repo *repositories.RelationshipRepository
+	return repo
+}
+
+func TestService_RelationshipRepositoryTypedNilGuards(t *testing.T) {
+	svc := NewService(&typedNilRelationshipStorage{MockRepositoryStorage: NewMockRepositoryStorage()}, streaming.NewMockPublisher(), nil, nil, nil, zap.NewNop(), "example.com")
+
+	require.ErrorIs(t, svc.validateRelationshipStorage(), ErrRelationshipRepositoryNotAvailable)
+
+	require.False(t, svc.checkBlocking(context.Background(), svc.storage.Relationship(), "alice", "bob"))
+	require.False(t, svc.checkFollowingStatus(context.Background(), svc.storage.Relationship(), "alice", "bob"))
+	require.False(t, svc.checkMutingStatus(context.Background(), svc.storage.Relationship(), "alice", "bob"))
+	require.False(t, svc.checkMutingNotifications(context.Background(), svc.storage.Relationship(), "alice", "bob", true))
+	require.False(t, svc.checkFollowRequest(context.Background(), svc.storage.Relationship(), "alice", "bob"))
+}

--- a/pkg/services/notes/service_round15_mainline_test.go
+++ b/pkg/services/notes/service_round15_mainline_test.go
@@ -243,9 +243,12 @@ func populateStructWithTime(target any, state *permissiveQueryState, at time.Tim
 		model.SK = "FOLLOWING#alice"
 		model.State = models.RelationshipAccepted
 	case *models.Bookmark:
+		model.Username = "alice"
 		model.ObjectID = fmt.Sprintf("status-%d", at.Day())
 		model.CreatedAt = at
 		model.Locked = false
+		model.RecordType = models.BookmarkRecordTypeTime
+		_ = model.UpdateKeys()
 	case *models.Like:
 		model.Actor = fmt.Sprintf("https://example.com/users/user-%d", at.Day())
 		if at.Day()%2 == 0 {

--- a/pkg/storage/factory/factory.go
+++ b/pkg/storage/factory/factory.go
@@ -283,7 +283,7 @@ func registerStorageConverters(db dynamormCore.DB) error {
 	if db == nil {
 		return fmt.Errorf("dynamorm DB is nil")
 	}
-	return nil
+	return theorydb.RegisterDefaultTypeConverters(db)
 }
 
 // searchRepositoryDeps implements SearchRepositoryDeps interface

--- a/pkg/storage/factory/factory_round22_coverage_test.go
+++ b/pkg/storage/factory/factory_round22_coverage_test.go
@@ -19,7 +19,8 @@ import (
 )
 
 type extendedMockDB struct {
-	inner *mocks.MockDB
+	inner      *mocks.MockDB
+	registered []reflect.Type
 }
 
 var _ core.ExtendedDB = (*extendedMockDB)(nil)
@@ -34,7 +35,8 @@ func (db *extendedMockDB) Close() error                          { return nil }
 func (db *extendedMockDB) WithContext(_ context.Context) core.DB { return db }
 
 func (db *extendedMockDB) AutoMigrateWithOptions(_ any, _ ...any) error { return nil }
-func (db *extendedMockDB) RegisterTypeConverter(_ reflect.Type, _ pkgtypes.CustomConverter) error {
+func (db *extendedMockDB) RegisterTypeConverter(t reflect.Type, _ pkgtypes.CustomConverter) error {
+	db.registered = append(db.registered, t)
 	return nil
 }
 func (db *extendedMockDB) CreateTable(_ any, _ ...any) error               { return nil }
@@ -51,6 +53,12 @@ func (db *extendedMockDB) TransactWrite(_ context.Context, fn func(core.Transact
 
 func TestRegisterStorageConverters_NonExtendedDB_Round22(t *testing.T) {
 	require.NoError(t, registerStorageConverters(new(mocks.MockDB)))
+}
+
+func TestRegisterStorageConverters_ExtendedDBRegistersDefaults_Round22(t *testing.T) {
+	db := &extendedMockDB{inner: new(mocks.MockDB)}
+	require.NoError(t, registerStorageConverters(db))
+	require.GreaterOrEqual(t, len(db.registered), 5)
 }
 
 func TestNewRepositoryFactory_Success_Round22(t *testing.T) {

--- a/pkg/storage/repositories/account_repository.go
+++ b/pkg/storage/repositories/account_repository.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -2178,6 +2179,20 @@ func (r *AccountRepository) SearchAccounts(ctx context.Context, query string, op
 		searchLimit = 20
 	}
 
+	if len(normalizedQuery) == 1 {
+		users, nextCursor, hasMore, err := r.searchAccountsByShortHandlePrefix(ctx, normalizedQuery, searchLimit, opts.Cursor)
+		if err != nil {
+			return nil, err
+		}
+
+		return &interfaces.PaginatedResult[*storage.Account]{
+			Items:      r.usersToAccounts(users),
+			NextCursor: nextCursor,
+			HasMore:    hasMore,
+			Total:      -1,
+		}, nil
+	}
+
 	prefix := normalizedQuery
 	if len(prefix) > 2 {
 		prefix = prefix[:2]
@@ -2218,14 +2233,6 @@ func (r *AccountRepository) SearchAccounts(ctx context.Context, query string, op
 		users = users[:searchLimit]
 	}
 
-	accounts := make([]*storage.Account, 0, len(users))
-	for _, user := range users {
-		account := &storage.Account{
-			User: r.modelToStorageUser(&user),
-		}
-		accounts = append(accounts, account)
-	}
-
 	var nextCursor string
 	if hasMore && len(users) > 0 {
 		lastUser := users[len(users)-1]
@@ -2233,11 +2240,142 @@ func (r *AccountRepository) SearchAccounts(ctx context.Context, query string, op
 	}
 
 	return &interfaces.PaginatedResult[*storage.Account]{
-		Items:      accounts,
+		Items:      r.usersToAccounts(users),
 		NextCursor: nextCursor,
 		HasMore:    hasMore,
 		Total:      -1,
 	}, nil
+}
+
+const accountHandleSecondChars = "-0123456789_abcdefghijklmnopqrstuvwxyz"
+
+func (r *AccountRepository) searchAccountsByShortHandlePrefix(ctx context.Context, normalizedQuery string, searchLimit int, cursor string) ([]models.User, string, bool, error) {
+	prefixKeys := handlePrefixKeysForShortSearch(normalizedQuery)
+	if len(prefixKeys) == 0 {
+		return nil, "", false, nil
+	}
+
+	var skCursor string
+	if cursor != "" {
+		pkCursor, decodedSK, err := Utils.Pagination.DecodeCursor(cursor)
+		if err != nil {
+			r.logger.Warn("invalid search cursor provided",
+				zap.String("cursor", cursor),
+				zap.Error(err))
+		} else if decodedSK != "" {
+			if pkCursor != "" && !containsString(prefixKeys, pkCursor) {
+				r.logger.Info("search cursor prefix mismatch - resetting to new prefix",
+					zap.String("expected_prefix", prefixKeys[0]),
+					zap.String("cursor_prefix", pkCursor))
+			} else {
+				skCursor = decodedSK
+			}
+		}
+	}
+
+	seen := make(map[string]struct{})
+	users := make([]models.User, 0, searchLimit+1)
+	for _, prefixKey := range prefixKeys {
+		var partitionUsers []models.User
+		queryBuilder := r.db.WithContext(ctx).Model(&models.User{}).
+			Index("gsi5").
+			Where("gsi5PK", "=", prefixKey).
+			Where("gsi5SK", "BEGINS_WITH", normalizedQuery).
+			OrderBy("gsi5SK", "ASC").
+			Limit(searchLimit + 1)
+
+		if skCursor != "" {
+			queryBuilder = queryBuilder.Where("gsi5SK", ">", skCursor)
+		}
+
+		if err := queryBuilder.All(&partitionUsers); err != nil {
+			return nil, "", false, ErrorHandler.HandleQueryError(err, EntityUser, "search")
+		}
+
+		for _, user := range partitionUsers {
+			gsiSK := user.GSI5SK
+			if gsiSK == "" {
+				gsiSK = strings.ToLower(user.Username)
+			}
+			if !strings.HasPrefix(gsiSK, normalizedQuery) {
+				continue
+			}
+			if skCursor != "" && gsiSK <= skCursor {
+				continue
+			}
+
+			identity := user.PK
+			if identity == "" {
+				identity = strings.ToLower(user.Username)
+			}
+			if _, ok := seen[identity]; ok {
+				continue
+			}
+			seen[identity] = struct{}{}
+			users = append(users, user)
+		}
+	}
+
+	sort.SliceStable(users, func(i, j int) bool {
+		left := users[i].GSI5SK
+		if left == "" {
+			left = strings.ToLower(users[i].Username)
+		}
+		right := users[j].GSI5SK
+		if right == "" {
+			right = strings.ToLower(users[j].Username)
+		}
+		if left == right {
+			return users[i].GSI5PK < users[j].GSI5PK
+		}
+		return left < right
+	})
+
+	hasMore := len(users) > searchLimit
+	if hasMore {
+		users = users[:searchLimit]
+	}
+
+	nextCursor := ""
+	if hasMore && len(users) > 0 {
+		lastUser := users[len(users)-1]
+		nextCursor = Utils.Pagination.EncodeCursor(lastUser.GSI5PK, lastUser.GSI5SK)
+	}
+
+	return users, nextCursor, hasMore, nil
+}
+
+func handlePrefixKeysForShortSearch(normalizedQuery string) []string {
+	if len(normalizedQuery) != 1 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(accountHandleSecondChars)+1)
+	keys = append(keys, fmt.Sprintf("USER_HANDLE_PREFIX#%s", normalizedQuery))
+	for _, second := range accountHandleSecondChars {
+		keys = append(keys, fmt.Sprintf("USER_HANDLE_PREFIX#%s%c", normalizedQuery, second))
+	}
+	return keys
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *AccountRepository) usersToAccounts(users []models.User) []*storage.Account {
+	accounts := make([]*storage.Account, 0, len(users))
+	for _, user := range users {
+		account := &storage.Account{
+			User: r.modelToStorageUser(&user),
+		}
+		accounts = append(accounts, account)
+	}
+	return accounts
 }
 
 // GetSuggestedAccounts retrieves suggested accounts to follow

--- a/pkg/storage/repositories/account_repository.go
+++ b/pkg/storage/repositories/account_repository.go
@@ -2255,82 +2255,96 @@ func (r *AccountRepository) searchAccountsByShortHandlePrefix(ctx context.Contex
 		return nil, "", false, nil
 	}
 
-	var skCursor string
-	if cursor != "" {
-		pkCursor, decodedSK, err := Utils.Pagination.DecodeCursor(cursor)
-		if err != nil {
-			r.logger.Warn("invalid search cursor provided",
-				zap.String("cursor", cursor),
-				zap.Error(err))
-		} else if decodedSK != "" {
-			if pkCursor != "" && !containsString(prefixKeys, pkCursor) {
-				r.logger.Info("search cursor prefix mismatch - resetting to new prefix",
-					zap.String("expected_prefix", prefixKeys[0]),
-					zap.String("cursor_prefix", pkCursor))
-			} else {
-				skCursor = decodedSK
-			}
-		}
-	}
-
+	skCursor := r.decodeShortHandleSearchCursor(prefixKeys, cursor)
 	seen := make(map[string]struct{})
 	users := make([]models.User, 0, searchLimit+1)
 	for _, prefixKey := range prefixKeys {
-		var partitionUsers []models.User
-		queryBuilder := r.db.WithContext(ctx).Model(&models.User{}).
-			Index("gsi5").
-			Where("gsi5PK", "=", prefixKey).
-			Where("gsi5SK", "BEGINS_WITH", normalizedQuery).
-			OrderBy("gsi5SK", "ASC").
-			Limit(searchLimit + 1)
-
-		if skCursor != "" {
-			queryBuilder = queryBuilder.Where("gsi5SK", ">", skCursor)
-		}
-
-		if err := queryBuilder.All(&partitionUsers); err != nil {
+		partitionUsers, err := r.queryShortHandlePrefixPartition(ctx, prefixKey, normalizedQuery, searchLimit, skCursor)
+		if err != nil {
 			return nil, "", false, ErrorHandler.HandleQueryError(err, EntityUser, "search")
 		}
-
-		for _, user := range partitionUsers {
-			gsiSK := user.GSI5SK
-			if gsiSK == "" {
-				gsiSK = strings.ToLower(user.Username)
-			}
-			if !strings.HasPrefix(gsiSK, normalizedQuery) {
-				continue
-			}
-			if skCursor != "" && gsiSK <= skCursor {
-				continue
-			}
-
-			identity := user.PK
-			if identity == "" {
-				identity = strings.ToLower(user.Username)
-			}
-			if _, ok := seen[identity]; ok {
-				continue
-			}
-			seen[identity] = struct{}{}
-			users = append(users, user)
-		}
+		users = appendUniqueShortSearchUsers(users, seen, partitionUsers, normalizedQuery, skCursor)
 	}
 
+	sortUsersBySearchKey(users)
+	users, nextCursor, hasMore := paginateSearchUsers(users, searchLimit)
+	return users, nextCursor, hasMore, nil
+}
+
+func (r *AccountRepository) decodeShortHandleSearchCursor(prefixKeys []string, cursor string) string {
+	if cursor == "" {
+		return ""
+	}
+
+	pkCursor, skCursor, err := Utils.Pagination.DecodeCursor(cursor)
+	if err != nil {
+		r.logger.Warn("invalid search cursor provided",
+			zap.String("cursor", cursor),
+			zap.Error(err))
+		return ""
+	}
+	if skCursor == "" {
+		return ""
+	}
+	if pkCursor != "" && !containsString(prefixKeys, pkCursor) {
+		r.logger.Info("search cursor prefix mismatch - resetting to new prefix",
+			zap.String("expected_prefix", prefixKeys[0]),
+			zap.String("cursor_prefix", pkCursor))
+		return ""
+	}
+	return skCursor
+}
+
+func (r *AccountRepository) queryShortHandlePrefixPartition(ctx context.Context, prefixKey, normalizedQuery string, searchLimit int, skCursor string) ([]models.User, error) {
+	var users []models.User
+	queryBuilder := r.db.WithContext(ctx).Model(&models.User{}).
+		Index("gsi5").
+		Where("gsi5PK", "=", prefixKey).
+		Where("gsi5SK", "BEGINS_WITH", normalizedQuery).
+		OrderBy("gsi5SK", "ASC").
+		Limit(searchLimit + 1)
+
+	if skCursor != "" {
+		queryBuilder = queryBuilder.Where("gsi5SK", ">", skCursor)
+	}
+
+	if err := queryBuilder.All(&users); err != nil {
+		return nil, err
+	}
+	return users, nil
+}
+
+func appendUniqueShortSearchUsers(result []models.User, seen map[string]struct{}, users []models.User, normalizedQuery, skCursor string) []models.User {
+	for _, user := range users {
+		gsiSK := userSearchSortKey(user)
+		if !strings.HasPrefix(gsiSK, normalizedQuery) {
+			continue
+		}
+		if skCursor != "" && gsiSK <= skCursor {
+			continue
+		}
+		identity := userSearchIdentity(user)
+		if _, ok := seen[identity]; ok {
+			continue
+		}
+		seen[identity] = struct{}{}
+		result = append(result, user)
+	}
+	return result
+}
+
+func sortUsersBySearchKey(users []models.User) {
 	sort.SliceStable(users, func(i, j int) bool {
-		left := users[i].GSI5SK
-		if left == "" {
-			left = strings.ToLower(users[i].Username)
-		}
-		right := users[j].GSI5SK
-		if right == "" {
-			right = strings.ToLower(users[j].Username)
-		}
+		left := userSearchSortKey(users[i])
+		right := userSearchSortKey(users[j])
 		if left == right {
 			return users[i].GSI5PK < users[j].GSI5PK
 		}
 		return left < right
 	})
+}
 
+func paginateSearchUsers(users []models.User, searchLimit int) ([]models.User, string, bool) {
 	hasMore := len(users) > searchLimit
 	if hasMore {
 		users = users[:searchLimit]
@@ -2342,7 +2356,21 @@ func (r *AccountRepository) searchAccountsByShortHandlePrefix(ctx context.Contex
 		nextCursor = Utils.Pagination.EncodeCursor(lastUser.GSI5PK, lastUser.GSI5SK)
 	}
 
-	return users, nextCursor, hasMore, nil
+	return users, nextCursor, hasMore
+}
+
+func userSearchSortKey(user models.User) string {
+	if user.GSI5SK != "" {
+		return user.GSI5SK
+	}
+	return strings.ToLower(user.Username)
+}
+
+func userSearchIdentity(user models.User) string {
+	if user.PK != "" {
+		return user.PK
+	}
+	return strings.ToLower(user.Username)
 }
 
 func handlePrefixKeysForShortSearch(normalizedQuery string) []string {

--- a/pkg/storage/repositories/account_repository.go
+++ b/pkg/storage/repositories/account_repository.go
@@ -108,6 +108,21 @@ type userMetadataProjection struct {
 	Metadata map[string]interface{} `theorydb:"attr:metadata"`
 }
 
+type userEmailLookupProjection struct {
+	_ struct{} `theorydb:"naming:camelCase"`
+
+	Table string `json:"-"`
+
+	PK string `theorydb:"pk,attr:PK"`
+	SK string `theorydb:"sk,attr:SK"`
+
+	GSI2PK string `theorydb:"index:gsi2,pk,attr:gsi2PK,omitempty"`
+	GSI2SK string `theorydb:"index:gsi2,sk,attr:gsi2SK,omitempty"`
+
+	Username string `theorydb:"attr:username"`
+	Email    string `theorydb:"attr:email"`
+}
+
 func (p userMetadataProjection) TableName() string {
 	if strings.TrimSpace(p.Table) != "" {
 		return p.Table
@@ -116,6 +131,13 @@ func (p userMetadataProjection) TableName() string {
 }
 
 func (p userVersionProjection) TableName() string {
+	if strings.TrimSpace(p.Table) != "" {
+		return p.Table
+	}
+	return models.MainTableName
+}
+
+func (p userEmailLookupProjection) TableName() string {
 	if strings.TrimSpace(p.Table) != "" {
 		return p.Table
 	}
@@ -439,10 +461,38 @@ func (r *AccountRepository) DeleteAgentGovernanceState(ctx context.Context, user
 	return r.getAgentGovernanceRepository().DeleteAgentGovernanceState(ctx, username)
 }
 
-// GetUserByEmail is OBSOLETE - email is forbidden
-// This function exists for backwards compatibility but always returns an error
-func (r *AccountRepository) GetUserByEmail(_ context.Context, email string) (*storage.User, error) {
-	return nil, fmt.Errorf("email-based authentication is not supported for %s - use wallet or passkey authentication", strings.TrimSpace(email))
+// GetUserByEmail retrieves legacy users by their historical email lookup GSI.
+//
+// New email-based authentication remains disabled; this method exists only to
+// preserve reads for deployed data that still carries gsi2PK=EMAIL#{email}.
+func (r *AccountRepository) GetUserByEmail(ctx context.Context, email string) (*storage.User, error) {
+	normalizedEmail := strings.ToLower(strings.TrimSpace(email))
+	if err := common.ValidateRequiredParam("email", normalizedEmail); err != nil {
+		return nil, err
+	}
+	if r.db == nil {
+		return nil, ErrorHandler.HandleGetError(storage.ErrNotFound, EntityUser, normalizedEmail)
+	}
+
+	projection := &userEmailLookupProjection{Table: r.tableName}
+	err := r.db.WithContext(ctx).Model(projection).
+		Index("gsi2").
+		Where("gsi2PK", "=", "EMAIL#"+normalizedEmail).
+		Limit(1).
+		First(projection)
+	if err != nil {
+		return nil, ErrorHandler.HandleGetError(err, EntityUser, normalizedEmail)
+	}
+
+	username := strings.TrimSpace(projection.Username)
+	if username == "" {
+		username = strings.TrimPrefix(strings.TrimSpace(projection.PK), "USER#")
+	}
+	if username == "" {
+		return nil, ErrorHandler.HandleGetError(storage.ErrNotFound, EntityUser, normalizedEmail)
+	}
+
+	return r.GetUser(ctx, username)
 }
 
 // UpdateUser updates user authentication data
@@ -1719,8 +1769,15 @@ func (r *AccountRepository) GetAccountByURL(ctx context.Context, actorURL string
 
 // GetAccountByEmail retrieves an account by email address (updated to match interface)
 func (r *AccountRepository) GetAccountByEmail(ctx context.Context, email string) (*storage.Account, error) {
-	_, err := r.GetUserByEmail(ctx, email)
-	return nil, err
+	user, err := r.GetUserByEmail(ctx, email)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil || strings.TrimSpace(user.Username) == "" {
+		return nil, ErrorHandler.HandleGetError(storage.ErrNotFound, EntityUser, strings.TrimSpace(email))
+	}
+
+	return r.GetAccount(ctx, user.Username)
 }
 
 // UpdateAccount updates account data (updated to match interface)

--- a/pkg/storage/repositories/account_repository_m10_test.go
+++ b/pkg/storage/repositories/account_repository_m10_test.go
@@ -1,0 +1,38 @@
+package repositories
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/theory-cloud/tabletheory/pkg/mocks"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestAccountRepository_GetAccountByEmail_ReturnsAccountAfterUserLookup(t *testing.T) {
+	ctx := context.Background()
+	baseTime := time.Date(2025, 7, 8, 9, 10, 11, 0, time.UTC)
+
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+	mockQuery.On("First", mock.Anything).Run(func(args mock.Arguments) {
+		projection := args.Get(0).(*userEmailLookupProjection)
+		projection.Table = "test-table"
+		projection.PK = "USER#user-1"
+		projection.SK = "METADATA"
+		projection.GSI2PK = "EMAIL#user-1@example.com"
+		projection.GSI2SK = "USER#user-1"
+		projection.Username = "user-1"
+		projection.Email = "user-1@example.com"
+	}).Return(nil).Once()
+	setupPermissiveAccountRepositoryMocks(mockDB, mockQuery, nil, baseTime)
+
+	repo := NewAccountRepository(mockDB, "test-table", "example.com", zaptest.NewLogger(t))
+	account, err := repo.GetAccountByEmail(ctx, " User-1@Example.com ")
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	require.NotNil(t, account.User)
+	require.Equal(t, "user-1", account.User.Username)
+}

--- a/pkg/storage/repositories/account_repository_m10_test.go
+++ b/pkg/storage/repositories/account_repository_m10_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/equaltoai/lesser/pkg/storage/interfaces"
+	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/theory-cloud/tabletheory/pkg/mocks"
@@ -35,4 +37,65 @@ func TestAccountRepository_GetAccountByEmail_ReturnsAccountAfterUserLookup(t *te
 	require.NotNil(t, account)
 	require.NotNil(t, account.User)
 	require.Equal(t, "user-1", account.User.Username)
+}
+
+func TestAccountRepository_SearchAccounts_OneCharacterQueryFansOutHandlePrefixes(t *testing.T) {
+	ctx := context.Background()
+	baseTime := time.Date(2025, 7, 8, 9, 10, 11, 0, time.UTC)
+
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+
+	var currentPrefix string
+	queriedPrefixes := make(map[string]int)
+	mockQuery.On("Where", "gsi5PK", "=", mock.AnythingOfType("string")).Run(func(args mock.Arguments) {
+		currentPrefix = args.String(2)
+		queriedPrefixes[currentPrefix]++
+	}).Return(mockQuery)
+	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
+		dest := args.Get(0).(*[]models.User)
+		switch currentPrefix {
+		case "USER_HANDLE_PREFIX#a":
+			*dest = []models.User{m10SearchUser("a", baseTime)}
+		case "USER_HANDLE_PREFIX#al":
+			*dest = []models.User{m10SearchUser("alice", baseTime.Add(time.Minute))}
+		case "USER_HANDLE_PREFIX#an":
+			*dest = []models.User{m10SearchUser("ann", baseTime.Add(2*time.Minute))}
+		default:
+			*dest = []models.User{}
+		}
+	}).Return(nil)
+	setupPermissiveAccountRepositoryMocks(mockDB, mockQuery, nil, baseTime)
+
+	repo := NewAccountRepository(mockDB, "test-table", "example.com", zaptest.NewLogger(t))
+	firstPage, err := repo.SearchAccounts(ctx, "a", interfaces.PaginationOptions{Limit: 2})
+	require.NoError(t, err)
+	require.True(t, firstPage.HasMore)
+	require.NotEmpty(t, firstPage.NextCursor)
+	require.Len(t, firstPage.Items, 2)
+	require.Equal(t, "a", firstPage.Items[0].User.Username)
+	require.Equal(t, "alice", firstPage.Items[1].User.Username)
+
+	secondPage, err := repo.SearchAccounts(ctx, "a", interfaces.PaginationOptions{Limit: 2, Cursor: firstPage.NextCursor})
+	require.NoError(t, err)
+	require.False(t, secondPage.HasMore)
+	require.Empty(t, secondPage.NextCursor)
+	require.Len(t, secondPage.Items, 1)
+	require.Equal(t, "ann", secondPage.Items[0].User.Username)
+
+	require.GreaterOrEqual(t, queriedPrefixes["USER_HANDLE_PREFIX#a"], 1)
+	require.GreaterOrEqual(t, queriedPrefixes["USER_HANDLE_PREFIX#al"], 1)
+	require.GreaterOrEqual(t, queriedPrefixes["USER_HANDLE_PREFIX#an"], 1)
+}
+
+func m10SearchUser(username string, createdAt time.Time) models.User {
+	user := models.User{
+		Username:  username,
+		Role:      "user",
+		CreatedAt: createdAt,
+		UpdatedAt: createdAt,
+		Approved:  true,
+	}
+	_ = user.UpdateKeys()
+	return user
 }

--- a/pkg/storage/repositories/auth_repository.go
+++ b/pkg/storage/repositories/auth_repository.go
@@ -113,7 +113,7 @@ func (r *AuthRepository) GetWebAuthnCredential(ctx context.Context, credentialID
 	}
 
 	if err := common.ValidateSliceNotEmpty("modelList", modelList); err != nil {
-		return nil, nil
+		return nil, ErrorHandler.HandleGetError(storage.ErrNotFound, EntityWebAuthnCredential, credentialID)
 	}
 
 	model := modelList[0]

--- a/pkg/storage/repositories/auth_repository_round08_coverage_test.go
+++ b/pkg/storage/repositories/auth_repository_round08_coverage_test.go
@@ -82,8 +82,43 @@ func TestRound08_AuthRepository_WebAuthnCredentialOps(t *testing.T) {
 
 			repo := NewAuthRepositoryWithCostTracking(mockDB, "test-table", zaptest.NewLogger(t), costSvc)
 			cred, err := repo.GetWebAuthnCredential(ctx, "cred-1")
-			require.NoError(t, err)
+			require.Error(t, err)
 			require.Nil(t, cred)
+		})
+
+		t.Run("empty results prevent delete and update nil panics", func(t *testing.T) {
+			for _, tc := range []struct {
+				name string
+				call func(*AuthRepository) error
+			}{
+				{
+					name: "delete",
+					call: func(repo *AuthRepository) error {
+						return repo.DeleteWebAuthnCredential(ctx, "missing")
+					},
+				},
+				{
+					name: "update",
+					call: func(repo *AuthRepository) error {
+						return repo.UpdateWebAuthnLastUsed(ctx, "missing", 1)
+					},
+				},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					mockDB := new(mocks.MockDB)
+					mockQuery := new(mocks.MockQuery)
+					mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
+						out := args.Get(0).(*[]models.WebAuthnCredential)
+						*out = nil
+					}).Return(nil).Once()
+					setupPermissiveRound08Mocks(mockDB, mockQuery, nil, baseTime)
+
+					repo := NewAuthRepositoryWithCostTracking(mockDB, "test-table", zaptest.NewLogger(t), costSvc)
+					require.NotPanics(t, func() {
+						require.Error(t, tc.call(repo))
+					})
+				})
+			}
 		})
 
 		t.Run("success", func(t *testing.T) {

--- a/pkg/storage/repositories/bookmark_repository.go
+++ b/pkg/storage/repositories/bookmark_repository.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	stdErrors "errors"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/equaltoai/lesser/pkg/common"
@@ -91,8 +93,11 @@ func (r *BookmarkRepository) CreateBookmark(ctx context.Context, username, objec
 		legacyTimeAttempt bool
 	)
 
-	if legacy, legacyErr := r.findTimeBookmarkFn(ctx, username, objectID); legacyErr == nil && legacy != nil && legacy.Locked {
+	if legacy, legacyErr := r.findTimeBookmarkFn(ctx, username, objectID); legacyErr == nil && legacy != nil {
 		timeRecord = legacy
+		if timeRecord.CreatedAt.IsZero() {
+			timeRecord.CreatedAt = bookmarkCreatedAt(*timeRecord)
+		}
 		createTimeRecord = false
 		legacyTimeAttempt = true
 	} else {
@@ -259,17 +264,22 @@ func (r *BookmarkRepository) IsBookmarked(ctx context.Context, username, objectI
 func (r *BookmarkRepository) CountUserBookmarks(ctx context.Context, username string) (int64, error) {
 	pk := buildBookmarkPK(username)
 
-	query := r.db.WithContext(ctx).Model(&models.Bookmark{}).
+	var bookmarks []models.Bookmark
+	err := r.db.WithContext(ctx).Model(&models.Bookmark{}).
 		Where("PK", "=", pk).
-		Where("SK", "BEGINS_WITH", models.BookmarkSortKeyPrefixTime).
-		Filter("Locked", "=", false)
-
-	count, err := query.Count()
+		All(&bookmarks)
 	if err != nil {
 		r.logger.Error("failed to count user bookmarks",
 			zap.String("username", username),
 			zap.Error(err))
 		return 0, ErrorHandler.HandleQueryError(err, EntityBookmark, "count")
+	}
+
+	var count int64
+	for _, bookmark := range bookmarks {
+		if isReadableTimeBookmark(bookmark) {
+			count++
+		}
 	}
 	return count, nil
 }
@@ -508,17 +518,73 @@ func deduplicate(values []string) []string {
 	return result
 }
 
+func isReadableTimeBookmark(bookmark models.Bookmark) bool {
+	if bookmark.Locked {
+		return false
+	}
+	if bookmark.RecordType == models.BookmarkRecordTypeObject || strings.HasPrefix(bookmark.SK, models.BookmarkSortKeyPrefixObject+"#") {
+		return false
+	}
+	if bookmark.RecordType == models.BookmarkRecordTypeTime || strings.HasPrefix(bookmark.SK, models.BookmarkSortKeyPrefixTime+"#") {
+		return true
+	}
+	return isLegacyBookmarkTimestampSK(bookmark.SK)
+}
+
+func isLegacyBookmarkTimestampSK(sk string) bool {
+	trimmed := strings.TrimSpace(sk)
+	if trimmed == "" || strings.Contains(trimmed, "#") {
+		return false
+	}
+	if _, err := time.Parse(time.RFC3339Nano, trimmed); err == nil {
+		return true
+	}
+	if _, err := time.Parse(time.RFC3339, trimmed); err == nil {
+		return true
+	}
+	return false
+}
+
+func bookmarkCreatedAt(bookmark models.Bookmark) time.Time {
+	if !bookmark.CreatedAt.IsZero() {
+		return bookmark.CreatedAt
+	}
+
+	sk := strings.TrimSpace(bookmark.SK)
+	if strings.HasPrefix(sk, models.BookmarkSortKeyPrefixTime+"#") {
+		remainder := strings.TrimPrefix(sk, models.BookmarkSortKeyPrefixTime+"#")
+		if idx := strings.Index(remainder, "#"); idx >= 0 {
+			sk = remainder[:idx]
+		} else {
+			sk = remainder
+		}
+	}
+
+	if parsed, err := time.Parse(time.RFC3339Nano, sk); err == nil {
+		return parsed
+	}
+	if parsed, err := time.Parse(time.RFC3339, sk); err == nil {
+		return parsed
+	}
+	return time.Time{}
+}
+
 func (r *BookmarkRepository) queryUnlockedTimeBookmarks(ctx context.Context, username string, limit int, cursor string) ([]models.Bookmark, string, error) {
 	pk := buildBookmarkPK(username)
 	limit = sanitizeLimit(limit, 20, 100)
+	readLimit := (limit + 1) * 4
+	if readLimit < 100 {
+		readLimit = 100
+	}
+	if readLimit > 500 {
+		readLimit = 500
+	}
 
 	var bookmarks []models.Bookmark
 	query := r.db.WithContext(ctx).Model(&models.Bookmark{}).
 		Where("PK", "=", pk).
-		Where("SK", "BEGINS_WITH", models.BookmarkSortKeyPrefixTime).
-		Filter("Locked", "=", false).
 		OrderBy("SK", SortOrderDesc).
-		Limit(limit + 1)
+		Limit(readLimit)
 
 	if cursor != "" {
 		query = query.Where("SK", "<", cursor)
@@ -531,17 +597,33 @@ func (r *BookmarkRepository) queryUnlockedTimeBookmarks(ctx context.Context, use
 		return nil, "", ErrorHandler.HandleQueryError(err, EntityBookmark, "user bookmarks")
 	}
 
-	hasMore := len(bookmarks) > limit
+	filtered := make([]models.Bookmark, 0, len(bookmarks))
+	for _, bookmark := range bookmarks {
+		if isReadableTimeBookmark(bookmark) {
+			filtered = append(filtered, bookmark)
+		}
+	}
+
+	sort.SliceStable(filtered, func(i, j int) bool {
+		left := bookmarkCreatedAt(filtered[i])
+		right := bookmarkCreatedAt(filtered[j])
+		if left.Equal(right) {
+			return filtered[i].SK > filtered[j].SK
+		}
+		return left.After(right)
+	})
+
+	hasMore := len(filtered) > limit
 	if hasMore {
-		bookmarks = bookmarks[:limit]
+		filtered = filtered[:limit]
 	}
 
 	nextCursor := ""
-	if hasMore && len(bookmarks) > 0 {
-		nextCursor = bookmarks[len(bookmarks)-1].SK
+	if hasMore && len(filtered) > 0 {
+		nextCursor = filtered[len(filtered)-1].SK
 	}
 
-	return bookmarks, nextCursor, nil
+	return filtered, nextCursor, nil
 }
 
 func (r *BookmarkRepository) repairLegacyBookmark(ctx context.Context, username, objectID string) (*models.Bookmark, error) {
@@ -694,8 +776,31 @@ func (r *BookmarkRepository) dynamoFindTimeBookmarkByObject(ctx context.Context,
 	if err != nil && !errors.IsNotFound(err) {
 		return nil, err
 	}
-	if len(bookmarks) == 0 {
-		return nil, nil
+	for _, bookmark := range bookmarks {
+		if bookmark.ObjectID == objectID && (strings.HasPrefix(bookmark.SK, models.BookmarkSortKeyPrefixTime+"#") || bookmark.RecordType == models.BookmarkRecordTypeTime) {
+			if bookmark.CreatedAt.IsZero() {
+				bookmark.CreatedAt = bookmarkCreatedAt(bookmark)
+			}
+			return &bookmark, nil
+		}
 	}
-	return &bookmarks[0], nil
+
+	bookmarks = nil
+	err = r.db.WithContext(ctx).Model(&models.Bookmark{}).
+		Where("PK", "=", pk).
+		Filter("ObjectID", "=", objectID).
+		Limit(25).
+		All(&bookmarks)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, err
+	}
+	for _, bookmark := range bookmarks {
+		if bookmark.ObjectID == objectID && isReadableTimeBookmark(bookmark) {
+			if bookmark.CreatedAt.IsZero() {
+				bookmark.CreatedAt = bookmarkCreatedAt(bookmark)
+			}
+			return &bookmark, nil
+		}
+	}
+	return nil, nil
 }

--- a/pkg/storage/repositories/bookmark_repository.go
+++ b/pkg/storage/repositories/bookmark_repository.go
@@ -2,6 +2,8 @@ package repositories
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	stdErrors "errors"
 	"fmt"
 	"sort"
@@ -569,40 +571,54 @@ func bookmarkCreatedAt(bookmark models.Bookmark) time.Time {
 	return time.Time{}
 }
 
+const (
+	bookmarkPageCursorPrefix = "bm2:"
+	bookmarkTimeUpperBound   = models.BookmarkSortKeyPrefixTime + "$"
+	bookmarkLegacyUpperBound = "A"
+)
+
+type bookmarkPageCursor struct {
+	Version  int    `json:"v"`
+	TimeSK   string `json:"t,omitempty"`
+	LegacySK string `json:"l,omitempty"`
+}
+
+type bookmarkStreamKind int
+
+const (
+	bookmarkStreamTime bookmarkStreamKind = iota
+	bookmarkStreamLegacy
+)
+
 func (r *BookmarkRepository) queryUnlockedTimeBookmarks(ctx context.Context, username string, limit int, cursor string) ([]models.Bookmark, string, error) {
 	pk := buildBookmarkPK(username)
 	limit = sanitizeLimit(limit, 20, 100)
-	readLimit := (limit + 1) * 4
-	if readLimit < 100 {
-		readLimit = 100
-	}
-	if readLimit > 500 {
-		readLimit = 500
+
+	pageCursor, err := parseBookmarkPageCursor(cursor)
+	if err != nil {
+		return nil, "", err
 	}
 
-	var bookmarks []models.Bookmark
-	query := r.db.WithContext(ctx).Model(&models.Bookmark{}).
-		Where("PK", "=", pk).
-		OrderBy("SK", SortOrderDesc).
-		Limit(readLimit)
-
-	if cursor != "" {
-		query = query.Where("SK", "<", cursor)
-	}
-
-	if err := query.All(&bookmarks); err != nil {
-		r.logger.Error("failed to get user bookmarks",
+	target := limit + 1
+	timeBookmarks, err := r.queryReadableBookmarkStream(ctx, pk, bookmarkStreamTime, pageCursor.TimeSK, target)
+	if err != nil {
+		r.logger.Error("failed to get user time bookmarks",
 			zap.String("username", username),
 			zap.Error(err))
 		return nil, "", ErrorHandler.HandleQueryError(err, EntityBookmark, "user bookmarks")
 	}
 
-	filtered := make([]models.Bookmark, 0, len(bookmarks))
-	for _, bookmark := range bookmarks {
-		if isReadableTimeBookmark(bookmark) {
-			filtered = append(filtered, bookmark)
-		}
+	legacyBookmarks, err := r.queryReadableBookmarkStream(ctx, pk, bookmarkStreamLegacy, pageCursor.LegacySK, target)
+	if err != nil {
+		r.logger.Error("failed to get user legacy bookmarks",
+			zap.String("username", username),
+			zap.Error(err))
+		return nil, "", ErrorHandler.HandleQueryError(err, EntityBookmark, "user bookmarks")
 	}
+
+	filtered := make([]models.Bookmark, 0, len(timeBookmarks)+len(legacyBookmarks))
+	filtered = append(filtered, timeBookmarks...)
+	filtered = append(filtered, legacyBookmarks...)
 
 	sort.SliceStable(filtered, func(i, j int) bool {
 		left := bookmarkCreatedAt(filtered[i])
@@ -620,10 +636,198 @@ func (r *BookmarkRepository) queryUnlockedTimeBookmarks(ctx context.Context, use
 
 	nextCursor := ""
 	if hasMore && len(filtered) > 0 {
-		nextCursor = filtered[len(filtered)-1].SK
+		nextPageCursor := pageCursor
+		for _, bookmark := range filtered {
+			if isTimeBookmarkSK(bookmark.SK) || bookmark.RecordType == models.BookmarkRecordTypeTime {
+				nextPageCursor.TimeSK = bookmark.SK
+				continue
+			}
+			if isLegacyBookmarkTimestampSK(bookmark.SK) {
+				nextPageCursor.LegacySK = bookmark.SK
+			}
+		}
+		nextCursor = encodeBookmarkPageCursor(nextPageCursor)
 	}
 
 	return filtered, nextCursor, nil
+}
+
+func (r *BookmarkRepository) queryReadableBookmarkStream(
+	ctx context.Context,
+	pk string,
+	stream bookmarkStreamKind,
+	cursor string,
+	target int,
+) ([]models.Bookmark, error) {
+	if target <= 0 {
+		return nil, nil
+	}
+
+	upperBound := bookmarkStreamInitialUpperBound(stream)
+	if strings.TrimSpace(cursor) != "" {
+		upperBound = cursor
+	}
+
+	batchLimit := target * 4
+	if batchLimit < 100 {
+		batchLimit = 100
+	}
+	if batchLimit > 500 {
+		batchLimit = 500
+	}
+
+	result := make([]models.Bookmark, 0, target)
+	for len(result) < target {
+		page, err := r.queryBookmarkStreamPage(ctx, pk, upperBound, batchLimit)
+		if err != nil {
+			return nil, err
+		}
+		if len(page) == 0 {
+			break
+		}
+
+		var stop bool
+		result, stop = appendReadableBookmarkStreamPage(result, page, stream, target)
+		if stop {
+			break
+		}
+
+		nextUpperBound, ok := nextBookmarkStreamUpperBound(page, upperBound, batchLimit)
+		if !ok {
+			break
+		}
+		upperBound = nextUpperBound
+	}
+
+	return result, nil
+}
+
+func (r *BookmarkRepository) queryBookmarkStreamPage(ctx context.Context, pk, upperBound string, limit int) ([]models.Bookmark, error) {
+	var page []models.Bookmark
+	err := r.db.WithContext(ctx).Model(&models.Bookmark{}).
+		Where("PK", "=", pk).
+		Where("SK", "<", upperBound).
+		OrderBy("SK", SortOrderDesc).
+		Limit(limit).
+		All(&page)
+	return page, err
+}
+
+func appendReadableBookmarkStreamPage(
+	result []models.Bookmark,
+	page []models.Bookmark,
+	stream bookmarkStreamKind,
+	target int,
+) ([]models.Bookmark, bool) {
+	for _, bookmark := range page {
+		readable, stop := readableBookmarkForStream(bookmark, stream)
+		if stop {
+			return result, true
+		}
+		if !readable {
+			continue
+		}
+		if bookmark.CreatedAt.IsZero() {
+			bookmark.CreatedAt = bookmarkCreatedAt(bookmark)
+		}
+		result = append(result, bookmark)
+		if len(result) >= target {
+			return result, true
+		}
+	}
+	return result, false
+}
+
+func readableBookmarkForStream(bookmark models.Bookmark, stream bookmarkStreamKind) (bool, bool) {
+	switch stream {
+	case bookmarkStreamTime:
+		if !isTimeBookmarkSK(bookmark.SK) && bookmark.RecordType != models.BookmarkRecordTypeTime {
+			return false, true
+		}
+	case bookmarkStreamLegacy:
+		if !isLegacyBookmarkTimestampSK(bookmark.SK) {
+			return false, false
+		}
+	}
+	return isReadableTimeBookmark(bookmark), false
+}
+
+func nextBookmarkStreamUpperBound(page []models.Bookmark, upperBound string, batchLimit int) (string, bool) {
+	lastSK := page[len(page)-1].SK
+	if len(page) < batchLimit || lastSK == upperBound {
+		return "", false
+	}
+	return lastSK, true
+}
+
+func bookmarkStreamInitialUpperBound(stream bookmarkStreamKind) string {
+	if stream == bookmarkStreamTime {
+		return bookmarkTimeUpperBound
+	}
+	return bookmarkLegacyUpperBound
+}
+
+func isTimeBookmarkSK(sk string) bool {
+	return strings.HasPrefix(sk, models.BookmarkSortKeyPrefixTime+"#")
+}
+
+func parseBookmarkPageCursor(cursor string) (bookmarkPageCursor, error) {
+	cursor = strings.TrimSpace(cursor)
+	if cursor == "" {
+		return bookmarkPageCursor{Version: 2}, nil
+	}
+	if !strings.HasPrefix(cursor, bookmarkPageCursorPrefix) {
+		return legacyBookmarkPageCursor(cursor), nil
+	}
+
+	encoded := strings.TrimPrefix(cursor, bookmarkPageCursorPrefix)
+	payload, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return bookmarkPageCursor{}, fmt.Errorf("invalid bookmark cursor: %w", err)
+	}
+
+	var pageCursor bookmarkPageCursor
+	if err := json.Unmarshal(payload, &pageCursor); err != nil {
+		return bookmarkPageCursor{}, fmt.Errorf("invalid bookmark cursor: %w", err)
+	}
+	if pageCursor.Version == 0 {
+		pageCursor.Version = 2
+	}
+	return pageCursor, nil
+}
+
+func legacyBookmarkPageCursor(cursor string) bookmarkPageCursor {
+	pageCursor := bookmarkPageCursor{Version: 2}
+	if isTimeBookmarkSK(cursor) {
+		pageCursor.TimeSK = cursor
+		if createdAt := bookmarkTimestampFromSK(cursor); !createdAt.IsZero() {
+			pageCursor.LegacySK = createdAt.Format(time.RFC3339Nano) + "\xff"
+		}
+		return pageCursor
+	}
+	if isLegacyBookmarkTimestampSK(cursor) {
+		pageCursor.LegacySK = cursor
+		if createdAt := bookmarkTimestampFromSK(cursor); !createdAt.IsZero() {
+			pageCursor.TimeSK = models.BookmarkSortKeyPrefixTime + "#" + createdAt.Format(time.RFC3339Nano)
+		}
+		return pageCursor
+	}
+	pageCursor.TimeSK = cursor
+	pageCursor.LegacySK = cursor
+	return pageCursor
+}
+
+func encodeBookmarkPageCursor(cursor bookmarkPageCursor) string {
+	cursor.Version = 2
+	payload, err := json.Marshal(cursor)
+	if err != nil {
+		return ""
+	}
+	return bookmarkPageCursorPrefix + base64.RawURLEncoding.EncodeToString(payload)
+}
+
+func bookmarkTimestampFromSK(sk string) time.Time {
+	return bookmarkCreatedAt(models.Bookmark{SK: sk})
 }
 
 func (r *BookmarkRepository) repairLegacyBookmark(ctx context.Context, username, objectID string) (*models.Bookmark, error) {

--- a/pkg/storage/repositories/bookmark_repository_m10_test.go
+++ b/pkg/storage/repositories/bookmark_repository_m10_test.go
@@ -64,25 +64,32 @@ func TestBookmarkRepository_M10_QueryUnlockedTimeBookmarksIncludesLegacyTimestam
 	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery)
 	mockQuery.On("OrderBy", mock.Anything, mock.Anything).Return(mockQuery)
 	mockQuery.On("Limit", mock.Anything).Return(mockQuery)
+	allCalls := 0
 	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
+		allCalls++
 		dest := args.Get(0).(*[]models.Bookmark)
+		if allCalls == 1 {
+			*dest = []models.Bookmark{
+				{
+					PK:        pk,
+					SK:        "TIME#" + base.Add(2*time.Minute).Format(time.RFC3339Nano) + "#status-time",
+					Username:  "alice",
+					ObjectID:  "status-time",
+					CreatedAt: base.Add(2 * time.Minute),
+					Locked:    false,
+				},
+				{
+					PK:        pk,
+					SK:        "TIME#" + base.Add(time.Minute).Format(time.RFC3339Nano) + "#status-locked",
+					Username:  "alice",
+					ObjectID:  "status-locked",
+					CreatedAt: base.Add(time.Minute),
+					Locked:    true,
+				},
+			}
+			return
+		}
 		*dest = []models.Bookmark{
-			{
-				PK:         pk,
-				SK:         "OBJECT#status-object",
-				Username:   "alice",
-				ObjectID:   "status-object",
-				CreatedAt:  base.Add(4 * time.Minute),
-				RecordType: models.BookmarkRecordTypeObject,
-			},
-			{
-				PK:        pk,
-				SK:        "TIME#" + base.Add(2*time.Minute).Format(time.RFC3339Nano) + "#status-time",
-				Username:  "alice",
-				ObjectID:  "status-time",
-				CreatedAt: base.Add(2 * time.Minute),
-				Locked:    false,
-			},
 			{
 				PK:       pk,
 				SK:       base.Add(3 * time.Minute).Format(time.RFC3339Nano),
@@ -90,16 +97,8 @@ func TestBookmarkRepository_M10_QueryUnlockedTimeBookmarksIncludesLegacyTimestam
 				ObjectID: "status-legacy",
 				Locked:   false,
 			},
-			{
-				PK:        pk,
-				SK:        "TIME#" + base.Add(time.Minute).Format(time.RFC3339Nano) + "#status-locked",
-				Username:  "alice",
-				ObjectID:  "status-locked",
-				CreatedAt: base.Add(time.Minute),
-				Locked:    true,
-			},
 		}
-	}).Return(nil).Once()
+	}).Return(nil).Twice()
 
 	repo := NewBookmarkRepository(mockDB, "test-table", zap.NewNop())
 	items, nextCursor, err := repo.queryUnlockedTimeBookmarks(ctx, "alice", 10, "")
@@ -109,6 +108,66 @@ func TestBookmarkRepository_M10_QueryUnlockedTimeBookmarksIncludesLegacyTimestam
 	require.Equal(t, "status-legacy", items[0].ObjectID)
 	require.Equal(t, base.Add(3*time.Minute), bookmarkCreatedAt(items[0]))
 	require.Equal(t, "status-time", items[1].ObjectID)
+}
+
+func TestBookmarkRepository_M10_QueryUnlockedTimeBookmarksPaginatesMixedNamespaces(t *testing.T) {
+	ctx := context.Background()
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+	base := time.Date(2025, 12, 28, 12, 0, 0, 0, time.UTC)
+	pk := buildBookmarkPK("alice")
+
+	timeSK4 := "TIME#" + base.Add(4*time.Minute).Format(time.RFC3339Nano) + "#status-time-4"
+	timeSK1 := "TIME#" + base.Add(time.Minute).Format(time.RFC3339Nano) + "#status-time-1"
+	legacySK3 := base.Add(3 * time.Minute).Format(time.RFC3339Nano)
+	legacySK2 := base.Add(2 * time.Minute).Format(time.RFC3339Nano)
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB)
+	mockDB.On("Model", mock.Anything).Return(mockQuery)
+	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery)
+	mockQuery.On("OrderBy", mock.Anything, mock.Anything).Return(mockQuery)
+	mockQuery.On("Limit", mock.Anything).Return(mockQuery)
+
+	allCalls := 0
+	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
+		allCalls++
+		dest := args.Get(0).(*[]models.Bookmark)
+		switch allCalls {
+		case 1:
+			*dest = []models.Bookmark{
+				{PK: pk, SK: timeSK4, Username: "alice", ObjectID: "status-time-4", CreatedAt: base.Add(4 * time.Minute)},
+				{PK: pk, SK: timeSK1, Username: "alice", ObjectID: "status-time-1", CreatedAt: base.Add(time.Minute)},
+			}
+		case 2:
+			*dest = []models.Bookmark{
+				{PK: pk, SK: legacySK3, Username: "alice", ObjectID: "status-legacy-3"},
+				{PK: pk, SK: legacySK2, Username: "alice", ObjectID: "status-legacy-2"},
+			}
+		case 3:
+			*dest = []models.Bookmark{{PK: pk, SK: timeSK1, Username: "alice", ObjectID: "status-time-1", CreatedAt: base.Add(time.Minute)}}
+		case 4:
+			*dest = []models.Bookmark{{PK: pk, SK: legacySK2, Username: "alice", ObjectID: "status-legacy-2"}}
+		default:
+			*dest = nil
+		}
+	}).Return(nil)
+
+	repo := NewBookmarkRepository(mockDB, "test-table", zap.NewNop())
+	firstPage, cursor, err := repo.queryUnlockedTimeBookmarks(ctx, "alice", 2, "")
+	require.NoError(t, err)
+	require.NotEmpty(t, cursor)
+	require.Equal(t, []string{"status-time-4", "status-legacy-3"}, bookmarkObjectIDs(firstPage))
+
+	pageCursor, err := parseBookmarkPageCursor(cursor)
+	require.NoError(t, err)
+	require.Equal(t, timeSK4, pageCursor.TimeSK)
+	require.Equal(t, legacySK3, pageCursor.LegacySK)
+
+	secondPage, nextCursor, err := repo.queryUnlockedTimeBookmarks(ctx, "alice", 2, cursor)
+	require.NoError(t, err)
+	require.Empty(t, nextCursor)
+	require.Equal(t, []string{"status-legacy-2", "status-time-1"}, bookmarkObjectIDs(secondPage))
+	require.Equal(t, 4, allCalls)
 }
 
 func TestBookmarkRepository_M10_CountUserBookmarksCountsLegacyAndTimeRecords(t *testing.T) {
@@ -135,4 +194,38 @@ func TestBookmarkRepository_M10_CountUserBookmarksCountsLegacyAndTimeRecords(t *
 	count, err := repo.CountUserBookmarks(ctx, "alice")
 	require.NoError(t, err)
 	require.Equal(t, int64(2), count)
+}
+
+func TestBookmarkRepository_M10_BookmarkPageCursorCompatibility(t *testing.T) {
+	createdAt := time.Date(2025, 12, 28, 12, 30, 0, 123, time.UTC)
+	timeSK := "TIME#" + createdAt.Format(time.RFC3339Nano) + "#status-time"
+	legacySK := createdAt.Format(time.RFC3339Nano)
+
+	fromTime, err := parseBookmarkPageCursor(timeSK)
+	require.NoError(t, err)
+	require.Equal(t, timeSK, fromTime.TimeSK)
+	require.Equal(t, legacySK+"\xff", fromTime.LegacySK)
+
+	fromLegacy, err := parseBookmarkPageCursor(legacySK)
+	require.NoError(t, err)
+	require.Equal(t, legacySK, fromLegacy.LegacySK)
+	require.Equal(t, "TIME#"+legacySK, fromLegacy.TimeSK)
+
+	encoded := encodeBookmarkPageCursor(bookmarkPageCursor{TimeSK: timeSK, LegacySK: legacySK})
+	decoded, err := parseBookmarkPageCursor(encoded)
+	require.NoError(t, err)
+	require.Equal(t, 2, decoded.Version)
+	require.Equal(t, timeSK, decoded.TimeSK)
+	require.Equal(t, legacySK, decoded.LegacySK)
+
+	_, err = parseBookmarkPageCursor(bookmarkPageCursorPrefix + "not-base64!")
+	require.Error(t, err)
+}
+
+func bookmarkObjectIDs(bookmarks []models.Bookmark) []string {
+	objectIDs := make([]string, len(bookmarks))
+	for i := range bookmarks {
+		objectIDs[i] = bookmarks[i].ObjectID
+	}
+	return objectIDs
 }

--- a/pkg/storage/repositories/bookmark_repository_m10_test.go
+++ b/pkg/storage/repositories/bookmark_repository_m10_test.go
@@ -1,0 +1,138 @@
+package repositories
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/theory-cloud/tabletheory/pkg/mocks"
+	"go.uber.org/zap"
+)
+
+func TestBookmarkRepository_M10_DynamoFindTimeBookmarkByObjectReadsLegacyTimestampSK(t *testing.T) {
+	ctx := context.Background()
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+	createdAt := time.Date(2025, 12, 28, 12, 30, 0, 123, time.UTC)
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB)
+	mockDB.On("Model", mock.Anything).Return(mockQuery)
+	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery)
+	mockQuery.On("Filter", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery)
+	mockQuery.On("Limit", mock.Anything).Return(mockQuery)
+
+	allCalls := 0
+	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
+		allCalls++
+		dest := args.Get(0).(*[]models.Bookmark)
+		if allCalls == 1 {
+			*dest = []models.Bookmark{}
+			return
+		}
+		*dest = []models.Bookmark{
+			{
+				PK:       buildBookmarkPK("alice"),
+				SK:       createdAt.Format(time.RFC3339Nano),
+				Username: "alice",
+				ObjectID: "status-1",
+				Locked:   false,
+			},
+		}
+	}).Return(nil).Twice()
+
+	repo := NewBookmarkRepository(mockDB, "test-table", zap.NewNop())
+	found, err := repo.dynamoFindTimeBookmarkByObject(ctx, "alice", "status-1")
+	require.NoError(t, err)
+	require.NotNil(t, found)
+	require.Equal(t, "status-1", found.ObjectID)
+	require.Equal(t, createdAt, found.CreatedAt)
+	require.Equal(t, 2, allCalls)
+}
+
+func TestBookmarkRepository_M10_QueryUnlockedTimeBookmarksIncludesLegacyTimestampSKs(t *testing.T) {
+	ctx := context.Background()
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+	base := time.Date(2025, 12, 28, 12, 0, 0, 0, time.UTC)
+	pk := buildBookmarkPK("alice")
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB)
+	mockDB.On("Model", mock.Anything).Return(mockQuery)
+	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery)
+	mockQuery.On("OrderBy", mock.Anything, mock.Anything).Return(mockQuery)
+	mockQuery.On("Limit", mock.Anything).Return(mockQuery)
+	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
+		dest := args.Get(0).(*[]models.Bookmark)
+		*dest = []models.Bookmark{
+			{
+				PK:         pk,
+				SK:         "OBJECT#status-object",
+				Username:   "alice",
+				ObjectID:   "status-object",
+				CreatedAt:  base.Add(4 * time.Minute),
+				RecordType: models.BookmarkRecordTypeObject,
+			},
+			{
+				PK:        pk,
+				SK:        "TIME#" + base.Add(2*time.Minute).Format(time.RFC3339Nano) + "#status-time",
+				Username:  "alice",
+				ObjectID:  "status-time",
+				CreatedAt: base.Add(2 * time.Minute),
+				Locked:    false,
+			},
+			{
+				PK:       pk,
+				SK:       base.Add(3 * time.Minute).Format(time.RFC3339Nano),
+				Username: "alice",
+				ObjectID: "status-legacy",
+				Locked:   false,
+			},
+			{
+				PK:        pk,
+				SK:        "TIME#" + base.Add(time.Minute).Format(time.RFC3339Nano) + "#status-locked",
+				Username:  "alice",
+				ObjectID:  "status-locked",
+				CreatedAt: base.Add(time.Minute),
+				Locked:    true,
+			},
+		}
+	}).Return(nil).Once()
+
+	repo := NewBookmarkRepository(mockDB, "test-table", zap.NewNop())
+	items, nextCursor, err := repo.queryUnlockedTimeBookmarks(ctx, "alice", 10, "")
+	require.NoError(t, err)
+	require.Empty(t, nextCursor)
+	require.Len(t, items, 2)
+	require.Equal(t, "status-legacy", items[0].ObjectID)
+	require.Equal(t, base.Add(3*time.Minute), bookmarkCreatedAt(items[0]))
+	require.Equal(t, "status-time", items[1].ObjectID)
+}
+
+func TestBookmarkRepository_M10_CountUserBookmarksCountsLegacyAndTimeRecords(t *testing.T) {
+	ctx := context.Background()
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+	base := time.Date(2025, 12, 28, 12, 0, 0, 0, time.UTC)
+	pk := buildBookmarkPK("alice")
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB)
+	mockDB.On("Model", mock.Anything).Return(mockQuery)
+	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery)
+	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
+		dest := args.Get(0).(*[]models.Bookmark)
+		*dest = []models.Bookmark{
+			{PK: pk, SK: "TIME#" + base.Format(time.RFC3339Nano) + "#status-time", ObjectID: "status-time", Locked: false},
+			{PK: pk, SK: base.Add(-time.Minute).Format(time.RFC3339Nano), ObjectID: "status-legacy", Locked: false},
+			{PK: pk, SK: "OBJECT#status-time", ObjectID: "status-time", RecordType: models.BookmarkRecordTypeObject},
+			{PK: pk, SK: "TIME#" + base.Add(-2*time.Minute).Format(time.RFC3339Nano) + "#status-locked", ObjectID: "status-locked", Locked: true},
+		}
+	}).Return(nil).Once()
+
+	repo := NewBookmarkRepository(mockDB, "test-table", zap.NewNop())
+	count, err := repo.CountUserBookmarks(ctx, "alice")
+	require.NoError(t, err)
+	require.Equal(t, int64(2), count)
+}

--- a/pkg/storage/repositories/bookmark_repository_round08_additional_coverage_test.go
+++ b/pkg/storage/repositories/bookmark_repository_round08_additional_coverage_test.go
@@ -44,12 +44,17 @@ func TestBookmarkRepository_Round08_CountAndQueryUnlockedTimeBookmarks(t *testin
 			}
 			return
 		}
+		if allCalls == 2 {
+			*dest = []models.Bookmark{
+				{PK: pk, SK: "TIME#" + base.Add(2*time.Minute).Format(time.RFC3339Nano) + "#o3", ObjectID: "o3", CreatedAt: base.Add(2 * time.Minute), Locked: false},
+				{PK: pk, SK: "TIME#" + base.Add(time.Minute).Format(time.RFC3339Nano) + "#o2", ObjectID: "o2", CreatedAt: base.Add(time.Minute), Locked: false},
+			}
+			return
+		}
 		*dest = []models.Bookmark{
-			{PK: pk, SK: "TIME#" + base.Add(2*time.Minute).Format(time.RFC3339Nano) + "#o3", ObjectID: "o3", CreatedAt: base.Add(2 * time.Minute), Locked: false},
-			{PK: pk, SK: "TIME#" + base.Add(time.Minute).Format(time.RFC3339Nano) + "#o2", ObjectID: "o2", CreatedAt: base.Add(time.Minute), Locked: false},
 			{PK: pk, SK: base.Add(-time.Minute).Format(time.RFC3339Nano), ObjectID: "legacy", CreatedAt: base.Add(-time.Minute), Locked: false},
 		}
-	}).Return(nil).Twice()
+	}).Return(nil)
 
 	setupPermissiveRound08Mocks(mockDB, mockQuery, nil, time.Date(2025, 12, 28, 0, 0, 0, 0, time.UTC))
 
@@ -64,7 +69,10 @@ func TestBookmarkRepository_Round08_CountAndQueryUnlockedTimeBookmarks(t *testin
 	require.Len(t, items, 2)
 	require.Equal(t, "o3", items[0].ObjectID)
 	require.Equal(t, "o2", items[1].ObjectID)
-	require.Equal(t, items[1].SK, nextCursor)
+	pageCursor, err := parseBookmarkPageCursor(nextCursor)
+	require.NoError(t, err)
+	require.Equal(t, items[1].SK, pageCursor.TimeSK)
+	require.Empty(t, pageCursor.LegacySK)
 }
 
 func TestBookmarkRepository_Round08_CascadeDeleteUserBookmarks_FallbackDeletes(t *testing.T) {

--- a/pkg/storage/repositories/bookmark_repository_round08_additional_coverage_test.go
+++ b/pkg/storage/repositories/bookmark_repository_round08_additional_coverage_test.go
@@ -29,19 +29,27 @@ func TestBookmarkRepository_Round08_CountAndQueryUnlockedTimeBookmarks(t *testin
 	mockDB := new(mocks.MockDB)
 	mockQuery := new(mocks.MockQuery)
 
-	// CountUserBookmarks -> query.Count.
-	mockQuery.On("Count").Return(int64(3), nil).Once()
-
-	// queryUnlockedTimeBookmarks -> query.All.
+	base := time.Date(2025, 12, 28, 12, 0, 0, 0, time.UTC)
+	pk := buildBookmarkPK("alice")
+	allCalls := 0
 	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
+		allCalls++
 		dest := args.Get(0).(*[]models.Bookmark)
-		pk := buildBookmarkPK("alice")
-		*dest = []models.Bookmark{
-			{PK: pk, SK: "TIME#3", ObjectID: "o3", Locked: false},
-			{PK: pk, SK: "TIME#2", ObjectID: "o2", Locked: false},
-			{PK: pk, SK: "TIME#1", ObjectID: "o1", Locked: false},
+		if allCalls == 1 {
+			*dest = []models.Bookmark{
+				{PK: pk, SK: "TIME#" + base.Add(2*time.Minute).Format(time.RFC3339Nano) + "#o3", ObjectID: "o3", CreatedAt: base.Add(2 * time.Minute), Locked: false},
+				{PK: pk, SK: "TIME#" + base.Add(time.Minute).Format(time.RFC3339Nano) + "#o2", ObjectID: "o2", CreatedAt: base.Add(time.Minute), Locked: false},
+				{PK: pk, SK: "OBJECT#o1", ObjectID: "o1", CreatedAt: base, RecordType: models.BookmarkRecordTypeObject},
+				{PK: pk, SK: base.Add(-time.Minute).Format(time.RFC3339Nano), ObjectID: "legacy", CreatedAt: base.Add(-time.Minute), Locked: false},
+			}
+			return
 		}
-	}).Return(nil).Once()
+		*dest = []models.Bookmark{
+			{PK: pk, SK: "TIME#" + base.Add(2*time.Minute).Format(time.RFC3339Nano) + "#o3", ObjectID: "o3", CreatedAt: base.Add(2 * time.Minute), Locked: false},
+			{PK: pk, SK: "TIME#" + base.Add(time.Minute).Format(time.RFC3339Nano) + "#o2", ObjectID: "o2", CreatedAt: base.Add(time.Minute), Locked: false},
+			{PK: pk, SK: base.Add(-time.Minute).Format(time.RFC3339Nano), ObjectID: "legacy", CreatedAt: base.Add(-time.Minute), Locked: false},
+		}
+	}).Return(nil).Twice()
 
 	setupPermissiveRound08Mocks(mockDB, mockQuery, nil, time.Date(2025, 12, 28, 0, 0, 0, 0, time.UTC))
 
@@ -54,7 +62,9 @@ func TestBookmarkRepository_Round08_CountAndQueryUnlockedTimeBookmarks(t *testin
 	items, nextCursor, err := repo.queryUnlockedTimeBookmarks(ctx, "alice", 2, "")
 	require.NoError(t, err)
 	require.Len(t, items, 2)
-	require.Equal(t, "TIME#2", nextCursor)
+	require.Equal(t, "o3", items[0].ObjectID)
+	require.Equal(t, "o2", items[1].ObjectID)
+	require.Equal(t, items[1].SK, nextCursor)
 }
 
 func TestBookmarkRepository_Round08_CascadeDeleteUserBookmarks_FallbackDeletes(t *testing.T) {

--- a/pkg/storage/repositories/bookmark_repository_round08_error_branches_test.go
+++ b/pkg/storage/repositories/bookmark_repository_round08_error_branches_test.go
@@ -266,21 +266,29 @@ func TestBookmarkRepository_Round08_QueryUnlockedTimeBookmarks_HasMore(t *testin
 	mockQuery.On("Filter", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery)
 	mockQuery.On("OrderBy", mock.Anything, mock.Anything).Return(mockQuery)
 	mockQuery.On("Limit", mock.Anything).Return(mockQuery)
+	allCalls := 0
 	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
+		allCalls++
 		dest := args.Get(0).(*[]models.Bookmark)
 		pk := buildBookmarkPK("alice")
-		*dest = []models.Bookmark{
-			{PK: pk, SK: "TIME#3", ObjectID: "o3", Locked: false},
-			{PK: pk, SK: "TIME#2", ObjectID: "o2", Locked: false},
+		if allCalls == 1 {
+			*dest = []models.Bookmark{
+				{PK: pk, SK: "TIME#3", ObjectID: "o3", Locked: false},
+				{PK: pk, SK: "TIME#2", ObjectID: "o2", Locked: false},
+			}
+			return
 		}
-	}).Return(nil).Once()
+		*dest = nil
+	}).Return(nil).Twice()
 
 	repo := NewBookmarkRepository(mockDB, "test-table", zap.NewNop())
 	items, cursor, err := repo.queryUnlockedTimeBookmarks(ctx, "alice", 1, "")
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 	require.Equal(t, "TIME#3", items[0].SK)
-	require.Equal(t, "TIME#3", cursor)
+	pageCursor, err := parseBookmarkPageCursor(cursor)
+	require.NoError(t, err)
+	require.Equal(t, "TIME#3", pageCursor.TimeSK)
 }
 
 func TestBookmarkRepository_Round08_DynamoFindTimeBookmarkByObject_EmptyList(t *testing.T) {

--- a/pkg/storage/repositories/bookmark_repository_round08_error_branches_test.go
+++ b/pkg/storage/repositories/bookmark_repository_round08_error_branches_test.go
@@ -23,8 +23,7 @@ func TestBookmarkRepository_Round08_CountUserBookmarks_ErrorPath(t *testing.T) {
 	mockDB.On("WithContext", mock.Anything).Return(mockDB)
 	mockDB.On("Model", mock.Anything).Return(mockQuery)
 	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery)
-	mockQuery.On("Filter", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery)
-	mockQuery.On("Count").Return(int64(0), errors.New("count failed")).Once()
+	mockQuery.On("All", mock.Anything).Return(errors.New("count failed")).Once()
 
 	repo := NewBookmarkRepository(mockDB, "test-table", zap.NewNop())
 	_, err := repo.CountUserBookmarks(ctx, "alice")
@@ -297,7 +296,7 @@ func TestBookmarkRepository_Round08_DynamoFindTimeBookmarkByObject_EmptyList(t *
 	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
 		dest := args.Get(0).(*[]models.Bookmark)
 		*dest = []models.Bookmark{}
-	}).Return(nil).Once()
+	}).Return(nil).Twice()
 
 	repo := NewBookmarkRepository(mockDB, "test-table", zap.NewNop())
 	found, err := repo.dynamoFindTimeBookmarkByObject(ctx, "alice", "status-1")

--- a/pkg/storage/repositories/bookmark_repository_round08_more_coverage_test.go
+++ b/pkg/storage/repositories/bookmark_repository_round08_more_coverage_test.go
@@ -201,7 +201,7 @@ func TestBookmarkRepository_Round08_DynamoHelpers_TransactWriteBatchGetAndLookup
 	require.NoError(t, err)
 	require.NotNil(t, found)
 
-	mockQuery.On("All", mock.Anything).Return(dynamormerrors.ErrItemNotFound).Once()
+	mockQuery.On("All", mock.Anything).Return(dynamormerrors.ErrItemNotFound).Twice()
 	found, err = repo.dynamoFindTimeBookmarkByObject(ctx, "alice", "missing")
 	require.NoError(t, err)
 	require.Nil(t, found)

--- a/pkg/storage/repositories/user_repository.go
+++ b/pkg/storage/repositories/user_repository.go
@@ -385,24 +385,17 @@ func (r *UserRepository) GetTotalUserCount(ctx context.Context) (int64, error) {
 
 // GetUserByProviderID gets a user by their OAuth provider ID
 func (r *UserRepository) GetUserByProviderID(ctx context.Context, provider, providerID string) (*storage.User, error) {
-	// Query the ProviderAccount by provider and providerID using GSI1
-	var providerAccounts []models.ProviderAccount
-	err := r.GetDB().WithContext(ctx).Model(&models.ProviderAccount{}).
-		Index("gsi1").
-		Where("gsi1PK", "=", "PROVIDER#"+provider).
-		Where("gsi1SK", "=", providerID+"#").
-		Limit(1).
-		All(&providerAccounts)
+	providerAccount, err := r.getProviderAccountByProviderID(ctx, provider, providerID)
 	if err != nil {
-		return nil, ErrorHandler.HandleQueryError(err, "provider account", "query")
+		return nil, err
 	}
 
-	if err := common.ValidateSliceNotEmpty("provider_accounts", providerAccounts); err != nil {
+	if providerAccount == nil {
 		return nil, ErrorHandler.HandleGetError(common.UserNotFoundError{Username: fmt.Sprintf("%s:%s", provider, providerID)}, EntityUser, providerID)
 	}
 
 	// Now get the user by UserID
-	return r.GetUser(ctx, providerAccounts[0].UserID)
+	return r.GetUser(ctx, providerAccount.UserID)
 }
 
 // LinkProviderAccount links an OAuth provider account to a user
@@ -411,6 +404,20 @@ func (r *UserRepository) LinkProviderAccount(ctx context.Context, username, prov
 	_, err := r.GetUser(ctx, username)
 	if err != nil {
 		return err
+	}
+
+	existing, err := r.getProviderAccountByProviderID(ctx, provider, providerID)
+	if err != nil {
+		return err
+	}
+	if existing != nil {
+		if existing.UserID == username {
+			return nil
+		}
+		return ErrorHandler.HandleCreateError(common.ConflictError{
+			Resource: "provider_account",
+			Message:  fmt.Sprintf("provider account %s:%s already linked", provider, providerID),
+		}, "provider account", providerID)
 	}
 
 	// Create the provider account link
@@ -434,6 +441,33 @@ func (r *UserRepository) LinkProviderAccount(ctx context.Context, username, prov
 	}
 
 	return nil
+}
+
+func (r *UserRepository) getProviderAccountByProviderID(ctx context.Context, provider, providerID string) (*models.ProviderAccount, error) {
+	// ProviderAccount.GSI1SK is stored as "{providerID}#{userID}", so provider
+	// lookups must use a prefix match on the stored sort-key shape.
+	var providerAccounts []models.ProviderAccount
+	err := r.GetDB().WithContext(ctx).Model(&models.ProviderAccount{}).
+		Index("gsi1").
+		Where("gsi1PK", "=", "PROVIDER#"+provider).
+		Where("gsi1SK", "BEGINS_WITH", providerID+"#").
+		Limit(2).
+		All(&providerAccounts)
+	if err != nil {
+		return nil, ErrorHandler.HandleQueryError(err, "provider account", "query")
+	}
+
+	for _, providerAccount := range providerAccounts {
+		if providerAccount.ProviderID != "" && providerAccount.ProviderID != providerID {
+			continue
+		}
+		if providerAccount.Provider != "" && providerAccount.Provider != provider {
+			continue
+		}
+		return &providerAccount, nil
+	}
+
+	return nil, nil
 }
 
 // UnlinkProviderAccount unlinks an OAuth provider account from a user

--- a/pkg/storage/repositories/user_repository_m10_test.go
+++ b/pkg/storage/repositories/user_repository_m10_test.go
@@ -1,0 +1,112 @@
+package repositories
+
+import (
+	"context"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/theory-cloud/tabletheory/pkg/mocks"
+	"go.uber.org/zap"
+)
+
+func TestUserRepository_M10_GetUserByProviderIDUsesStoredGSI1Prefix(t *testing.T) {
+	ctx := context.Background()
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB)
+	mockDB.On("Model", &models.ProviderAccount{}).Return(mockQuery)
+	mockDB.On("Model", &models.User{}).Return(mockQuery)
+	mockQuery.On("Index", "gsi1").Return(mockQuery)
+	mockQuery.On("Where", "gsi1PK", "=", "PROVIDER#google").Return(mockQuery)
+	mockQuery.On("Where", "gsi1SK", "BEGINS_WITH", "123#").Return(mockQuery)
+	mockQuery.On("Limit", 2).Return(mockQuery)
+	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
+		dest := args.Get(0).(*[]models.ProviderAccount)
+		*dest = []models.ProviderAccount{{
+			UserID:     "testuser",
+			Provider:   "google",
+			ProviderID: "123",
+			GSI1PK:     "PROVIDER#google",
+			GSI1SK:     "123#testuser",
+		}}
+	}).Return(nil).Once()
+	mockQuery.On("Where", "PK", "=", "USER#testuser").Return(mockQuery)
+	mockQuery.On("Where", "SK", "=", "METADATA").Return(mockQuery)
+	mockQuery.On("First", mock.Anything).Run(func(args mock.Arguments) {
+		dest := args.Get(0).(*models.User)
+		dest.Username = "testuser"
+		dest.Role = "user"
+		dest.Approved = true
+	}).Return(nil).Once()
+
+	repo := NewUserRepository(mockDB, "test-table", zap.NewNop())
+	user, err := repo.GetUserByProviderID(ctx, "google", "123")
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	require.Equal(t, "testuser", user.Username)
+}
+
+func TestUserRepository_M10_LinkProviderAccountExistingSameUserIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB)
+	mockDB.On("Model", &models.User{}).Return(mockQuery)
+	mockDB.On("Model", &models.ProviderAccount{}).Return(mockQuery)
+	mockQuery.On("Where", "PK", "=", "USER#testuser").Return(mockQuery)
+	mockQuery.On("Where", "SK", "=", "METADATA").Return(mockQuery)
+	mockQuery.On("First", mock.Anything).Run(func(args mock.Arguments) {
+		dest := args.Get(0).(*models.User)
+		dest.Username = "testuser"
+		dest.Role = "user"
+		dest.Approved = true
+	}).Return(nil).Once()
+	mockQuery.On("Index", "gsi1").Return(mockQuery)
+	mockQuery.On("Where", "gsi1PK", "=", "PROVIDER#google").Return(mockQuery)
+	mockQuery.On("Where", "gsi1SK", "BEGINS_WITH", "123#").Return(mockQuery)
+	mockQuery.On("Limit", 2).Return(mockQuery)
+	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
+		dest := args.Get(0).(*[]models.ProviderAccount)
+		*dest = []models.ProviderAccount{{UserID: "testuser", Provider: "google", ProviderID: "123"}}
+	}).Return(nil).Once()
+
+	repo := NewUserRepository(mockDB, "test-table", zap.NewNop())
+	require.NoError(t, repo.LinkProviderAccount(ctx, "testuser", "google", "123"))
+	mockQuery.AssertNotCalled(t, "Create")
+}
+
+func TestUserRepository_M10_LinkProviderAccountExistingDifferentUserConflicts(t *testing.T) {
+	ctx := context.Background()
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB)
+	mockDB.On("Model", &models.User{}).Return(mockQuery)
+	mockDB.On("Model", &models.ProviderAccount{}).Return(mockQuery)
+	mockQuery.On("Where", "PK", "=", "USER#testuser").Return(mockQuery)
+	mockQuery.On("Where", "SK", "=", "METADATA").Return(mockQuery)
+	mockQuery.On("First", mock.Anything).Run(func(args mock.Arguments) {
+		dest := args.Get(0).(*models.User)
+		dest.Username = "testuser"
+		dest.Role = "user"
+		dest.Approved = true
+	}).Return(nil).Once()
+	mockQuery.On("Index", "gsi1").Return(mockQuery)
+	mockQuery.On("Where", "gsi1PK", "=", "PROVIDER#google").Return(mockQuery)
+	mockQuery.On("Where", "gsi1SK", "BEGINS_WITH", "123#").Return(mockQuery)
+	mockQuery.On("Limit", 2).Return(mockQuery)
+	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
+		dest := args.Get(0).(*[]models.ProviderAccount)
+		*dest = []models.ProviderAccount{{UserID: "otheruser", Provider: "google", ProviderID: "123"}}
+	}).Return(nil).Once()
+
+	repo := NewUserRepository(mockDB, "test-table", zap.NewNop())
+	err := repo.LinkProviderAccount(ctx, "testuser", "google", "123")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Failed to create provider account")
+	mockQuery.AssertNotCalled(t, "Create")
+}

--- a/pkg/storage/repositories/user_repository_providers_test.go
+++ b/pkg/storage/repositories/user_repository_providers_test.go
@@ -55,6 +55,14 @@ func TestUserRepository_LinkProviderAccount_CreateConflict(t *testing.T) {
 		out.Username = "testuser"
 	}).Return(nil)
 
+	// Setup expectations - duplicate provider lookup finds no existing link
+	mockDB.On("Model", &models.ProviderAccount{}).Return(mockQuery)
+	mockQuery.On("Index", "gsi1").Return(mockQuery)
+	mockQuery.On("Where", "gsi1PK", "=", "PROVIDER#google").Return(mockQuery)
+	mockQuery.On("Where", "gsi1SK", "BEGINS_WITH", "123#").Return(mockQuery)
+	mockQuery.On("Limit", 2).Return(mockQuery)
+	mockQuery.On("All", mock.Anything).Return(nil)
+
 	// Setup expectations - provider creation fails with condition failed (conflict)
 	mockDB.On("Model", mock.AnythingOfType("*models.ProviderAccount")).Return(mockQuery)
 	mockQuery.On("Create").Return(dynamormerrors.ErrConditionFailed)
@@ -83,6 +91,14 @@ func TestUserRepository_LinkProviderAccount_CreateError(t *testing.T) {
 		out := args.Get(0).(*models.User)
 		out.Username = "testuser"
 	}).Return(nil)
+
+	// Setup expectations - duplicate provider lookup finds no existing link
+	mockDB.On("Model", &models.ProviderAccount{}).Return(mockQuery)
+	mockQuery.On("Index", "gsi1").Return(mockQuery)
+	mockQuery.On("Where", "gsi1PK", "=", "PROVIDER#google").Return(mockQuery)
+	mockQuery.On("Where", "gsi1SK", "BEGINS_WITH", "123#").Return(mockQuery)
+	mockQuery.On("Limit", 2).Return(mockQuery)
+	mockQuery.On("All", mock.Anything).Return(nil)
 
 	// Setup expectations - provider creation fails with generic error
 	mockDB.On("Model", mock.AnythingOfType("*models.ProviderAccount")).Return(mockQuery)

--- a/pkg/storage/repositories/user_repository_test.go
+++ b/pkg/storage/repositories/user_repository_test.go
@@ -64,8 +64,8 @@ func TestGetUserByProviderID_Success(t *testing.T) {
 	mockDB.On("Model", &models.ProviderAccount{}).Return(mockQuery)
 	mockQuery.On("Index", "gsi1").Return(mockQuery)
 	mockQuery.On("Where", "gsi1PK", "=", "PROVIDER#google").Return(mockQuery)
-	mockQuery.On("Where", "gsi1SK", "=", "123#").Return(mockQuery)
-	mockQuery.On("Limit", 1).Return(mockQuery)
+	mockQuery.On("Where", "gsi1SK", "BEGINS_WITH", "123#").Return(mockQuery)
+	mockQuery.On("Limit", 2).Return(mockQuery)
 	mockQuery.On("All", mock.Anything).Return(nil) // Return success but empty
 
 	user, err := repo.GetUserByProviderID(context.Background(), "google", "123")
@@ -91,6 +91,14 @@ func TestLinkProviderAccount_Success(t *testing.T) {
 	mockQuery.On("Where", "PK", "=", "USER#testuser").Return(mockQuery)
 	mockQuery.On("Where", "SK", "=", "METADATA").Return(mockQuery)
 	mockQuery.On("First", mock.Anything).Return(nil) // User exists
+
+	// Set up expectations for duplicate provider lookup
+	mockDB.On("Model", &models.ProviderAccount{}).Return(mockQuery)
+	mockQuery.On("Index", "gsi1").Return(mockQuery)
+	mockQuery.On("Where", "gsi1PK", "=", "PROVIDER#google").Return(mockQuery)
+	mockQuery.On("Where", "gsi1SK", "BEGINS_WITH", "123#").Return(mockQuery)
+	mockQuery.On("Limit", 2).Return(mockQuery)
+	mockQuery.On("All", mock.Anything).Return(nil)
 
 	// Set up expectations for the provider account creation
 	mockDB.On("Model", mock.AnythingOfType("*models.ProviderAccount")).Return(mockQuery)

--- a/pkg/storage/theorydb/dynamic_attr_converters.go
+++ b/pkg/storage/theorydb/dynamic_attr_converters.go
@@ -152,6 +152,37 @@ func (activityPubContextValueConverter) FromAttributeValue(av types.AttributeVal
 		return fmt.Errorf("activityPubContextValueConverter: target must be *activitypub.ContextValue, got %T", target)
 	}
 
+	switch v := av.(type) {
+	case nil:
+		*dest = nil
+		return nil
+	case *types.AttributeValueMemberNULL:
+		*dest = nil
+		return nil
+	case *types.AttributeValueMemberS:
+		raw := strings.TrimSpace(v.Value)
+		if raw == "" || strings.EqualFold(raw, "null") {
+			*dest = nil
+			return nil
+		}
+
+		var decoded activitypub.ContextValue
+		if err := json.Unmarshal([]byte(raw), &decoded); err == nil {
+			*dest = decoded
+			return nil
+		}
+
+		*dest = activitypub.ContextValue{v.Value}
+		return nil
+	case *types.AttributeValueMemberM:
+		var out map[string]any
+		if err := (mapStringAnyConverter{}).FromAttributeValue(v, &out); err != nil {
+			return err
+		}
+		*dest = activitypub.ContextValue{out}
+		return nil
+	}
+
 	var out []any
 	if err := (sliceAnyConverter{}).FromAttributeValue(av, &out); err != nil {
 		return err

--- a/pkg/storage/theorydb/dynamic_attr_converters_test.go
+++ b/pkg/storage/theorydb/dynamic_attr_converters_test.go
@@ -125,3 +125,29 @@ func TestActivityPubContextValueConverter_RoundTrip(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "https://spec.lessersoul.ai/ns/agent-attribution/v1#", nested["lessersoul"])
 }
+
+func TestActivityPubContextValueConverter_LegacyAttributeShapes(t *testing.T) {
+	conv := activityPubContextValueConverter{}
+
+	t.Run("raw string context", func(t *testing.T) {
+		var out activitypub.ContextValue
+		require.NoError(t, conv.FromAttributeValue(&types.AttributeValueMemberS{
+			Value: "https://www.w3.org/ns/activitystreams",
+		}, &out))
+		require.Equal(t, activitypub.ContextValue{"https://www.w3.org/ns/activitystreams"}, out)
+	})
+
+	t.Run("json string context", func(t *testing.T) {
+		var out activitypub.ContextValue
+		require.NoError(t, conv.FromAttributeValue(&types.AttributeValueMemberS{
+			Value: `"https://www.w3.org/ns/activitystreams"`,
+		}, &out))
+		require.Equal(t, activitypub.ContextValue{"https://www.w3.org/ns/activitystreams"}, out)
+	})
+
+	t.Run("null context", func(t *testing.T) {
+		var out activitypub.ContextValue
+		require.NoError(t, conv.FromAttributeValue(&types.AttributeValueMemberNULL{Value: true}, &out))
+		require.Nil(t, out)
+	})
+}

--- a/pkg/storage/theorydb/mock_tx.go
+++ b/pkg/storage/theorydb/mock_tx.go
@@ -19,7 +19,7 @@ func (m *MockTx) Put(item any) error {
 		return nil
 	}
 	return runTxOperation(func() error {
-		return m.Tx.Create(item)
+		return m.Create(item)
 	})
 }
 

--- a/pkg/storage/theorydb/mock_tx.go
+++ b/pkg/storage/theorydb/mock_tx.go
@@ -1,40 +1,99 @@
 package theorydb
 
 import (
+	"fmt"
+
 	"github.com/theory-cloud/tabletheory/pkg/core"
 )
 
 // MockTx is a mock implementation of the core.Tx interface for testing
 type MockTx struct {
 	core.Tx
+	Builder core.TransactionBuilder
 }
 
 // Put adds a Put operation to the transaction
-func (m *MockTx) Put(_ any) error {
-	return nil
+func (m *MockTx) Put(item any) error {
+	if m.Builder != nil {
+		m.Builder.Put(item)
+		return nil
+	}
+	return runTxOperation(func() error {
+		return m.Tx.Create(item)
+	})
 }
 
 // Delete adds a Delete operation to the transaction
-func (m *MockTx) Delete(_ any) error {
-	return nil
+func (m *MockTx) Delete(item any) error {
+	if m.Builder != nil {
+		m.Builder.Delete(item)
+		return nil
+	}
+	return runTxOperation(func() error {
+		return m.Tx.Delete(item)
+	})
 }
 
 // Update adds an Update operation to the transaction
-func (m *MockTx) Update(_ any) error {
-	return nil
+func (m *MockTx) Update(item any) error {
+	fields := inferTransactionUpdateFields(item)
+	if len(fields) == 0 {
+		return fmt.Errorf("transaction update requires fields")
+	}
+	if m.Builder != nil {
+		m.Builder.Update(item, fields)
+		return nil
+	}
+	return runTxOperation(func() error {
+		return m.Tx.Update(item, fields...)
+	})
 }
 
 // UpdateWithExpression adds an Update operation with expression to the transaction
-func (m *MockTx) UpdateWithExpression(_ any, _ string, _ ...any) error {
-	return nil
+func (m *MockTx) UpdateWithExpression(item any, _ string, _ ...any) error {
+	if m.Builder == nil && len(inferTransactionUpdateFields(item)) == 0 {
+		return nil
+	}
+	return m.Update(item)
 }
 
 // DeleteByKey adds a Delete operation by key to the transaction
-func (m *MockTx) DeleteByKey(_ string, _ map[string]any) error {
-	return nil
+func (m *MockTx) DeleteByKey(tableName string, key map[string]any) error {
+	item, err := newTransactionKeyItem(tableName, key)
+	if err != nil {
+		return err
+	}
+	if m.Builder == nil {
+		return nil
+	}
+	return m.Delete(item)
 }
 
 // ConditionCheck adds a condition check to the transaction
-func (m *MockTx) ConditionCheck(_ string, _ map[string]any, _ string, _ ...any) error {
+func (m *MockTx) ConditionCheck(tableName string, key map[string]any, condition string, values ...any) error {
+	item, err := newTransactionKeyItem(tableName, key)
+	if err != nil {
+		return err
+	}
+	conditions := transactionConditions(TransactionOperation{
+		Condition: condition,
+		Values:    values,
+	})
+	if len(conditions) == 0 {
+		return fmt.Errorf("condition check requires condition")
+	}
+	if m.Builder != nil {
+		m.Builder.ConditionCheck(item, conditions...)
+		return nil
+	}
 	return nil
+}
+
+func runTxOperation(fn func() error) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("transaction operation failed: %v", recovered)
+		}
+	}()
+	return fn()
 }

--- a/pkg/storage/theorydb/transaction.go
+++ b/pkg/storage/theorydb/transaction.go
@@ -34,7 +34,19 @@ func NewTransaction(client core.DB) *Transaction {
 // Execute runs the provided function within a transaction
 // If the function returns an error, the transaction is aborted
 // Otherwise, the transaction is committed
-func (t *Transaction) Execute(_ context.Context, fn TransactionFunc) error {
+func (t *Transaction) Execute(ctx context.Context, fn TransactionFunc) error {
+	if client, ok := t.client.(interface {
+		TransactWrite(context.Context, func(core.TransactionBuilder) error) error
+	}); ok {
+		return client.TransactWrite(ctx, func(tx core.TransactionBuilder) error {
+			txWrapper := &Transaction{
+				tx:     &MockTx{Builder: tx},
+				client: t.client,
+			}
+			return fn(txWrapper)
+		})
+	}
+
 	// Create a new transaction
 	err := t.client.Transaction(func(tx *core.Tx) error {
 		// Create a transaction wrapper with a mock tx that implements TxOperations

--- a/pkg/storage/theorydb/transaction_example_round23_coverage_test.go
+++ b/pkg/storage/theorydb/transaction_example_round23_coverage_test.go
@@ -22,7 +22,9 @@ func (db *transactionTestDB) Model(_ any) core.Query {
 }
 
 func (db *transactionTestDB) Transaction(fn func(tx *core.Tx) error) error {
-	return fn(&core.Tx{})
+	tx := &core.Tx{}
+	tx.SetDB(db)
+	return fn(tx)
 }
 
 func (db *transactionTestDB) Migrate() error { return nil }
@@ -52,7 +54,10 @@ func TestExampleCreateUserWithPosts_UsesInjectedClient_Round23(t *testing.T) {
 		}
 	})
 
-	db := &transactionTestDB{}
+	q := new(dynamormMocks.MockQuery)
+	q.On("Create").Return(nil).Maybe()
+
+	db := &transactionTestDB{query: q}
 	client = db
 	clientErr = nil
 	clientOnce = sync.Once{}
@@ -111,6 +116,8 @@ func TestExampleTransferBalance_SucceedsAndFailsForInsufficientFunds_Round23(t *
 
 	q := new(dynamormMocks.MockQuery)
 	q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q).Maybe()
+	q.On("Update", mock.Anything).Return(nil).Maybe()
+	q.On("Update").Return(nil).Maybe()
 
 	var firstCalls int
 	q.On("First", mock.Anything).Run(func(args mock.Arguments) {

--- a/pkg/storage/theorydb/transaction_globals_test.go
+++ b/pkg/storage/theorydb/transaction_globals_test.go
@@ -7,20 +7,25 @@ import (
 
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/theory-cloud/tabletheory"
 	"github.com/theory-cloud/tabletheory/pkg/core"
+	dynamormMocks "github.com/theory-cloud/tabletheory/pkg/mocks"
 	"github.com/theory-cloud/tabletheory/pkg/session"
 )
 
 type stubDB struct {
 	transactionCalls int
+	query            core.Query
 }
 
-func (s *stubDB) Model(any) core.Query { return nil }
+func (s *stubDB) Model(any) core.Query { return s.query }
 func (s *stubDB) Transaction(fn func(tx *core.Tx) error) error {
 	s.transactionCalls++
-	return fn(&core.Tx{})
+	tx := &core.Tx{}
+	tx.SetDB(s)
+	return fn(tx)
 }
 func (s *stubDB) Migrate() error                      { return nil }
 func (s *stubDB) AutoMigrate(...any) error            { return nil }
@@ -42,7 +47,11 @@ func TestExecuteTransaction_RunsFnWithClient(t *testing.T) {
 		return &config.Config{Region: "us-east-1"}
 	}
 
-	db := &stubDB{}
+	q := new(dynamormMocks.MockQuery)
+	q.On("Create").Return(nil).Maybe()
+	q.On("Update", mock.Anything).Return(nil).Maybe()
+	q.On("Update").Return(nil).Maybe()
+	db := &stubDB{query: q}
 	newDynamormStandardClient = func(session.Config) (core.DB, error) {
 		return db, nil
 	}

--- a/pkg/storage/theorydb/transaction_key_item.go
+++ b/pkg/storage/theorydb/transaction_key_item.go
@@ -1,0 +1,42 @@
+package theorydb
+
+import "fmt"
+
+type transactionKeyItem struct {
+	tableName string
+
+	PK any `theorydb:"pk,attr:PK"`
+	SK any `theorydb:"sk,attr:SK,omitempty"`
+}
+
+func newTransactionKeyItem(tableName string, key map[string]any) (*transactionKeyItem, error) {
+	if tableName == "" {
+		return nil, fmt.Errorf("key operation requires tableName")
+	}
+	if key == nil {
+		return nil, fmt.Errorf("key operation requires key")
+	}
+
+	pk, ok := key["PK"]
+	if !ok {
+		pk, ok = key["pk"]
+	}
+	if !ok || pk == nil {
+		return nil, fmt.Errorf("key operation requires PK")
+	}
+
+	sk := key["SK"]
+	if sk == nil {
+		sk = key["sk"]
+	}
+
+	return &transactionKeyItem{
+		tableName: tableName,
+		PK:        pk,
+		SK:        sk,
+	}, nil
+}
+
+func (i *transactionKeyItem) TableName() string {
+	return i.tableName
+}

--- a/pkg/storage/theorydb/transaction_manager.go
+++ b/pkg/storage/theorydb/transaction_manager.go
@@ -352,10 +352,6 @@ func inferTransactionUpdateFields(item any) []string {
 		if skipTransactionUpdateField(field) {
 			continue
 		}
-		if name := theoryDBAttrName(field); name != "" {
-			fields = append(fields, name)
-			continue
-		}
 		fields = append(fields, field.Name)
 	}
 	return fields
@@ -374,15 +370,6 @@ func skipTransactionUpdateField(field reflect.StructField) bool {
 		}
 	}
 	return false
-}
-
-func theoryDBAttrName(field reflect.StructField) string {
-	for _, part := range strings.Split(field.Tag.Get("theorydb"), ",") {
-		if strings.HasPrefix(part, "attr:") {
-			return strings.TrimPrefix(part, "attr:")
-		}
-	}
-	return ""
 }
 
 // validateOperations validates the provided operations

--- a/pkg/storage/theorydb/transaction_manager.go
+++ b/pkg/storage/theorydb/transaction_manager.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"reflect"
+	"strings"
 	"time"
 
 	"github.com/equaltoai/lesser/pkg/common"
@@ -24,8 +26,10 @@ type TransactionOperation struct {
 	Type             OperationType
 	Item             any
 	Key              map[string]any
+	Fields           []string
 	UpdateExpression string
 	Condition        string
+	Conditions       []core.TransactCondition
 	Values           []any
 	TableName        string
 }
@@ -196,7 +200,20 @@ func (tm *TransactionManager) ExecuteWithRetry(ctx context.Context, operations .
 }
 
 // executeTransaction executes the actual transaction
-func (tm *TransactionManager) executeTransaction(_ context.Context, operations []TransactionOperation) error {
+func (tm *TransactionManager) executeTransaction(ctx context.Context, operations []TransactionOperation) error {
+	if client, ok := tm.client.(interface {
+		TransactWrite(context.Context, func(core.TransactionBuilder) error) error
+	}); ok {
+		return client.TransactWrite(ctx, func(tx core.TransactionBuilder) error {
+			for i, op := range operations {
+				if err := tm.executeBuilderOperation(tx, op); err != nil {
+					return fmt.Errorf("operation %d (%s) failed: %w", i, op.Type.String(), err)
+				}
+			}
+			return nil
+		})
+	}
+
 	return tm.client.Transaction(func(tx *core.Tx) error {
 		for i, op := range operations {
 			if err := tm.executeOperation(tx, op); err != nil {
@@ -205,6 +222,59 @@ func (tm *TransactionManager) executeTransaction(_ context.Context, operations [
 		}
 		return nil
 	})
+}
+
+func (tm *TransactionManager) executeBuilderOperation(tx core.TransactionBuilder, op TransactionOperation) error {
+	conditions := transactionConditions(op)
+
+	switch op.Type {
+	case OperationPut:
+		if op.Item == nil {
+			return fmt.Errorf("put operation requires item")
+		}
+		tx.Put(op.Item, conditions...)
+		return nil
+	case OperationUpdate:
+		if op.Item == nil {
+			return fmt.Errorf("update operation requires item")
+		}
+		fields := op.Fields
+		if len(fields) == 0 {
+			fields = inferTransactionUpdateFields(op.Item)
+		}
+		if len(fields) == 0 {
+			return fmt.Errorf("update operation requires fields")
+		}
+		tx.Update(op.Item, fields, conditions...)
+		return nil
+	case OperationDelete:
+		if op.Item != nil {
+			tx.Delete(op.Item, conditions...)
+			return nil
+		}
+		keyItem, err := newTransactionKeyItem(op.TableName, op.Key)
+		if err != nil {
+			return err
+		}
+		tx.Delete(keyItem, conditions...)
+		return nil
+	case OperationConditionCheck:
+		if op.Condition == "" && len(op.Conditions) == 0 {
+			return fmt.Errorf("condition check requires condition")
+		}
+		item := op.Item
+		if item == nil {
+			keyItem, err := newTransactionKeyItem(op.TableName, op.Key)
+			if err != nil {
+				return err
+			}
+			item = keyItem
+		}
+		tx.ConditionCheck(item, conditions...)
+		return nil
+	default:
+		return fmt.Errorf("unsupported operation type: %v", op.Type)
+	}
 }
 
 // executeOperation executes a single operation within a transaction
@@ -237,6 +307,82 @@ func (tm *TransactionManager) executeOperation(tx *core.Tx, op TransactionOperat
 	default:
 		return fmt.Errorf("unsupported operation type: %v", op.Type)
 	}
+}
+
+func transactionConditions(op TransactionOperation) []core.TransactCondition {
+	conditions := append([]core.TransactCondition(nil), op.Conditions...)
+	if strings.TrimSpace(op.Condition) != "" {
+		conditions = append(conditions, core.TransactCondition{
+			Kind:       core.TransactConditionKindExpression,
+			Expression: op.Condition,
+			Values:     transactionConditionValues(op.Values),
+		})
+	}
+	return conditions
+}
+
+func transactionConditionValues(values []any) map[string]any {
+	if len(values) == 0 {
+		return nil
+	}
+
+	result := make(map[string]any, len(values))
+	for i, value := range values {
+		result[fmt.Sprintf(":v%d", i)] = value
+	}
+	return result
+}
+
+func inferTransactionUpdateFields(item any) []string {
+	value := reflect.ValueOf(item)
+	if value.Kind() == reflect.Pointer {
+		value = value.Elem()
+	}
+	if !value.IsValid() || value.Kind() != reflect.Struct {
+		return nil
+	}
+
+	itemType := value.Type()
+	fields := make([]string, 0, itemType.NumField())
+	for i := range itemType.NumField() {
+		field := itemType.Field(i)
+		if field.PkgPath != "" || field.Anonymous {
+			continue
+		}
+		if skipTransactionUpdateField(field) {
+			continue
+		}
+		if name := theoryDBAttrName(field); name != "" {
+			fields = append(fields, name)
+			continue
+		}
+		fields = append(fields, field.Name)
+	}
+	return fields
+}
+
+func skipTransactionUpdateField(field reflect.StructField) bool {
+	if field.Name == "PK" || field.Name == "SK" || field.Name == "Version" || strings.HasPrefix(field.Name, "GSI") {
+		return true
+	}
+	for _, part := range strings.Split(field.Tag.Get("theorydb"), ",") {
+		switch {
+		case part == "pk", part == "sk", part == "version", part == "ttl":
+			return true
+		case strings.HasPrefix(part, "index:"):
+			return true
+		}
+	}
+	return false
+}
+
+func theoryDBAttrName(field reflect.StructField) string {
+	for _, part := range strings.Split(field.Tag.Get("theorydb"), ",") {
+		if strings.HasPrefix(part, "attr:") {
+			return strings.TrimPrefix(part, "attr:")
+		}
+	}
+	return ""
 }
 
 // validateOperations validates the provided operations

--- a/pkg/storage/theorydb/transaction_test.go
+++ b/pkg/storage/theorydb/transaction_test.go
@@ -711,6 +711,17 @@ func TestTransactionManager_M10_AdditionalTransactionCoverage(t *testing.T) {
 	mockQuery.AssertExpectations(t)
 }
 
+func TestTransactionManager_M10_BuilderValidationErrors(t *testing.T) {
+	manager := NewTransactionManager(nil, zap.NewNop())
+	builder := new(mocks.MockTransactionBuilder)
+
+	assert.Error(t, manager.executeBuilderOperation(builder, TransactionOperation{Type: OperationPut}))
+	assert.Error(t, manager.executeBuilderOperation(builder, TransactionOperation{Type: OperationUpdate}))
+	assert.Error(t, manager.executeBuilderOperation(builder, TransactionOperation{Type: OperationDelete, TableName: "users"}))
+	assert.Error(t, manager.executeBuilderOperation(builder, TransactionOperation{Type: OperationConditionCheck, TableName: "users", Key: map[string]any{"PK": "user#123"}}))
+	assert.Error(t, manager.executeBuilderOperation(builder, TransactionOperation{Type: OperationType(99)}))
+}
+
 // Tests for convenience functions
 
 func TestExecuteSimpleTransaction(t *testing.T) {

--- a/pkg/storage/theorydb/transaction_test.go
+++ b/pkg/storage/theorydb/transaction_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/equaltoai/lesser/pkg/cost"
+	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/theory-cloud/tabletheory/pkg/core"
@@ -720,6 +721,51 @@ func TestTransactionManager_M10_BuilderValidationErrors(t *testing.T) {
 	assert.Error(t, manager.executeBuilderOperation(builder, TransactionOperation{Type: OperationDelete, TableName: "users"}))
 	assert.Error(t, manager.executeBuilderOperation(builder, TransactionOperation{Type: OperationConditionCheck, TableName: "users", Key: map[string]any{"PK": "user#123"}}))
 	assert.Error(t, manager.executeBuilderOperation(builder, TransactionOperation{Type: OperationType(99)}))
+}
+
+func TestTransactionManager_M10_InferredFieldsUseGoNamesForTaggedModels(t *testing.T) {
+	user := &models.User{
+		PK:          "USER#alice",
+		SK:          models.SKMetadata,
+		Username:    "alice",
+		DisplayName: "Alice",
+	}
+
+	fields := inferTransactionUpdateFields(user)
+	assert.Contains(t, fields, "Username")
+	assert.Contains(t, fields, "DisplayName")
+	assert.NotContains(t, fields, "username")
+	assert.NotContains(t, fields, "displayName")
+	assert.NotContains(t, fields, "PK")
+	assert.NotContains(t, fields, "SK")
+	assert.NotContains(t, fields, "Version")
+	assert.NotContains(t, fields, "GSI1PK")
+
+	mockDB := new(mocks.MockExtendedDB)
+	builder := new(mocks.MockTransactionBuilder)
+	mockDB.TransactWriteBuilder = builder
+	mockDB.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
+	builder.On("Update", user, mock.MatchedBy(func(got []string) bool {
+		return containsString(got, "Username") &&
+			containsString(got, "DisplayName") &&
+			!containsString(got, "username") &&
+			!containsString(got, "displayName")
+	}), mock.Anything).Return(builder).Once()
+
+	manager := NewTransactionManager(mockDB, zap.NewNop())
+	err := manager.ExecuteWrite(context.Background(), TransactionOperation{Type: OperationUpdate, Item: user})
+	assert.NoError(t, err)
+	mockDB.AssertExpectations(t)
+	builder.AssertExpectations(t)
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }
 
 // Tests for convenience functions

--- a/pkg/storage/theorydb/transaction_test.go
+++ b/pkg/storage/theorydb/transaction_test.go
@@ -88,12 +88,41 @@ func TestTransaction_ExecuteWithError(t *testing.T) {
 	mockDB.AssertExpectations(t)
 }
 
+func TestTransaction_M10_ExecuteUsesTableTheoryTransactionBuilder(t *testing.T) {
+	mockDB := new(mocks.MockExtendedDB)
+	builder := new(mocks.MockTransactionBuilder)
+	mockDB.TransactWriteBuilder = builder
+	mockDB.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
+
+	user := &TestUser{
+		StandardModel: StandardModel{
+			PK: "user#123",
+			SK: "user#123",
+		},
+		Name: "John Doe",
+	}
+	builder.On("Put", user, mock.Anything).Return(builder).Once()
+	builder.On("ConditionCheck", mock.Anything, mock.Anything).Return(builder).Once()
+
+	tx := NewTransaction(mockDB)
+	err := tx.Execute(context.Background(), func(tx *Transaction) error {
+		if err := tx.Put(user); err != nil {
+			return err
+		}
+		return tx.ConditionCheck("users", map[string]any{"PK": "user#123"}, "attribute_exists(PK)")
+	})
+
+	assert.NoError(t, err)
+	mockDB.AssertExpectations(t)
+	builder.AssertExpectations(t)
+}
+
 func TestTransaction_Operations(t *testing.T) {
 	// Create mock DB and transaction
 	mockDB := new(mocks.MockDB)
 
-	// Create a mock transaction
-	mockTx := &MockTx{}
+	// Create a mock transaction builder that proves operations are enqueued.
+	builder := new(mocks.MockTransactionBuilder)
 
 	// Test user
 	user := &TestUser{
@@ -104,11 +133,14 @@ func TestTransaction_Operations(t *testing.T) {
 		Name: "John Doe",
 	}
 
-	// No need to set expectations on MockTx since it's not a testify mock
+	builder.On("Put", user, mock.Anything).Return(builder).Once()
+	builder.On("Delete", user, mock.Anything).Return(builder).Once()
+	builder.On("Update", user, []string{"Name"}, mock.Anything).Return(builder).Once()
+	builder.On("ConditionCheck", mock.Anything, mock.Anything).Return(builder).Once()
 
 	// Create transaction wrapper
 	tx := &Transaction{
-		tx:     mockTx,
+		tx:     &MockTx{Builder: builder},
 		client: mockDB,
 	}
 
@@ -132,7 +164,7 @@ func TestTransaction_Operations(t *testing.T) {
 	err = tx.ConditionCheck("users", key, "attribute_exists(PK)")
 	assert.NoError(t, err)
 
-	// No need to verify expectations since MockTx is not a testify mock
+	builder.AssertExpectations(t)
 }
 
 func TestTransaction_OperationsWithoutTransaction(t *testing.T) {
@@ -179,16 +211,13 @@ func TestTransaction_OperationsWithoutTransaction(t *testing.T) {
 
 func TestTransactionManager_ExecuteWrite_Success(t *testing.T) {
 	// Create mock DB
-	mockDB := new(mocks.MockDB)
+	mockDB := new(mocks.MockExtendedDB)
+	builder := new(mocks.MockTransactionBuilder)
+	mockDB.TransactWriteBuilder = builder
 	logger := zap.NewNop()
 
 	// Setup successful transaction
-	mockDB.On("Transaction", mock.AnythingOfType("func(*core.Tx) error")).
-		Run(func(args mock.Arguments) {
-			txFunc := args.Get(0).(func(*core.Tx) error)
-			assert.NoError(t, txFunc(&core.Tx{}))
-		}).
-		Return(nil)
+	mockDB.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
 
 	// Create transaction manager
 	manager := NewTransactionManager(mockDB, logger)
@@ -210,29 +239,31 @@ func TestTransactionManager_ExecuteWrite_Success(t *testing.T) {
 		{Type: OperationConditionCheck, TableName: "users", Key: map[string]any{"PK": "user#123"}, Condition: "attribute_exists(PK)"},
 	}
 
+	builder.On("Put", user, mock.Anything).Return(builder).Once()
+	builder.On("Update", user, []string{"Name"}, mock.Anything).Return(builder).Once()
+	builder.On("Delete", mock.Anything, mock.Anything).Return(builder).Once()
+	builder.On("ConditionCheck", mock.Anything, mock.Anything).Return(builder).Once()
+
 	// Execute transaction
 	err := manager.ExecuteWrite(context.Background(), operations...)
 
 	// Verify results
 	assert.NoError(t, err)
 	mockDB.AssertExpectations(t)
+	builder.AssertExpectations(t)
 }
 
 func TestTransactionManager_ExecuteWrite_WithRetry(t *testing.T) {
 	// Create mock DB
-	mockDB := new(mocks.MockDB)
+	mockDB := new(mocks.MockExtendedDB)
+	builder := new(mocks.MockTransactionBuilder)
+	mockDB.TransactWriteBuilder = builder
 	logger := zap.NewNop()
 
 	// Setup transaction to fail first, then succeed
 	retryableErr := errors.New("transaction conflict")
-	mockDB.On("Transaction", mock.AnythingOfType("func(*core.Tx) error")).
-		Return(retryableErr).Once()
-	mockDB.On("Transaction", mock.AnythingOfType("func(*core.Tx) error")).
-		Run(func(args mock.Arguments) {
-			txFunc := args.Get(0).(func(*core.Tx) error)
-			assert.NoError(t, txFunc(&core.Tx{}))
-		}).
-		Return(nil).Once()
+	mockDB.On("TransactWrite", mock.Anything, mock.Anything).Return(retryableErr).Once()
+	mockDB.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
 
 	// Create transaction manager
 	manager := NewTransactionManager(mockDB, logger)
@@ -251,12 +282,15 @@ func TestTransactionManager_ExecuteWrite_WithRetry(t *testing.T) {
 		{Type: OperationPut, Item: user},
 	}
 
+	builder.On("Put", user, mock.Anything).Return(builder).Once()
+
 	// Execute transaction
 	err := manager.ExecuteWrite(context.Background(), operations...)
 
 	// Verify results
 	assert.NoError(t, err)
 	mockDB.AssertExpectations(t)
+	builder.AssertExpectations(t)
 }
 
 func TestTransactionManager_ExecuteWrite_NonRetryableError(t *testing.T) {
@@ -341,17 +375,14 @@ func TestTransactionManager_ExecuteWrite_MaxRetriesExceeded(t *testing.T) {
 
 func TestTransactionManager_ExecuteWrite_WithCostTracking(t *testing.T) {
 	// Create mock DB
-	mockDB := new(mocks.MockDB)
+	mockDB := new(mocks.MockExtendedDB)
+	builder := new(mocks.MockTransactionBuilder)
+	mockDB.TransactWriteBuilder = builder
 	logger := zap.NewNop()
 	tracker := cost.New()
 
 	// Setup successful transaction
-	mockDB.On("Transaction", mock.AnythingOfType("func(*core.Tx) error")).
-		Run(func(args mock.Arguments) {
-			txFunc := args.Get(0).(func(*core.Tx) error)
-			assert.NoError(t, txFunc(&core.Tx{}))
-		}).
-		Return(nil)
+	mockDB.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
 
 	// Create transaction manager with tracker
 	manager := NewTransactionManagerWithTracker(mockDB, logger, tracker)
@@ -371,12 +402,16 @@ func TestTransactionManager_ExecuteWrite_WithCostTracking(t *testing.T) {
 		{Type: OperationUpdate, Item: user},
 	}
 
+	builder.On("Put", user, mock.Anything).Return(builder).Once()
+	builder.On("Update", user, []string{"Name"}, mock.Anything).Return(builder).Once()
+
 	// Execute transaction
 	err := manager.ExecuteWrite(context.Background(), operations...)
 
 	// Verify results
 	assert.NoError(t, err)
 	mockDB.AssertExpectations(t)
+	builder.AssertExpectations(t)
 
 	// Verify cost tracking (2 operations * 2 = 4 write units for transactions)
 	costs := tracker.CalculateCost()
@@ -570,11 +605,13 @@ func TestTransactionBuilder_FluentInterface(t *testing.T) {
 
 func TestTransactionBuilder_Execute(t *testing.T) {
 	// Create mock DB
-	mockDB := new(mocks.MockDB)
+	mockDB := new(mocks.MockExtendedDB)
+	txBuilder := new(mocks.MockTransactionBuilder)
+	mockDB.TransactWriteBuilder = txBuilder
 	logger := zap.NewNop()
 
 	// Setup successful transaction
-	mockDB.On("Transaction", mock.AnythingOfType("func(*core.Tx) error")).Return(nil)
+	mockDB.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
 
 	// Create transaction manager
 	manager := NewTransactionManager(mockDB, logger)
@@ -586,6 +623,7 @@ func TestTransactionBuilder_Execute(t *testing.T) {
 	}
 
 	builder := NewTransactionBuilder().Put(user)
+	txBuilder.On("Put", user, mock.Anything).Return(txBuilder).Once()
 
 	// Execute using builder
 	err := builder.Execute(context.Background(), manager)
@@ -593,6 +631,7 @@ func TestTransactionBuilder_Execute(t *testing.T) {
 	// Verify results
 	assert.NoError(t, err)
 	mockDB.AssertExpectations(t)
+	txBuilder.AssertExpectations(t)
 }
 
 func TestTransactionBuilder_Clear(t *testing.T) {
@@ -619,10 +658,12 @@ func TestTransactionBuilder_Clear(t *testing.T) {
 
 func TestExecuteSimpleTransaction(t *testing.T) {
 	// Create mock DB
-	mockDB := new(mocks.MockDB)
+	mockDB := new(mocks.MockExtendedDB)
+	builder := new(mocks.MockTransactionBuilder)
+	mockDB.TransactWriteBuilder = builder
 
 	// Setup successful transaction
-	mockDB.On("Transaction", mock.AnythingOfType("func(*core.Tx) error")).Return(nil)
+	mockDB.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
 
 	// Test user
 	user := &TestUser{
@@ -634,6 +675,7 @@ func TestExecuteSimpleTransaction(t *testing.T) {
 	operations := []TransactionOperation{
 		{Type: OperationPut, Item: user},
 	}
+	builder.On("Put", user, mock.Anything).Return(builder).Once()
 
 	// Execute simple transaction
 	err := ExecuteSimpleTransaction(context.Background(), mockDB, operations...)
@@ -641,16 +683,19 @@ func TestExecuteSimpleTransaction(t *testing.T) {
 	// Verify results
 	assert.NoError(t, err)
 	mockDB.AssertExpectations(t)
+	builder.AssertExpectations(t)
 }
 
 func TestExecuteTransactionWithCostTracking(t *testing.T) {
 	// Create mock DB
-	mockDB := new(mocks.MockDB)
+	mockDB := new(mocks.MockExtendedDB)
+	builder := new(mocks.MockTransactionBuilder)
+	mockDB.TransactWriteBuilder = builder
 	logger := zap.NewNop()
 	tracker := cost.New()
 
 	// Setup successful transaction
-	mockDB.On("Transaction", mock.AnythingOfType("func(*core.Tx) error")).Return(nil)
+	mockDB.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
 
 	// Test user
 	user := &TestUser{
@@ -662,6 +707,7 @@ func TestExecuteTransactionWithCostTracking(t *testing.T) {
 	operations := []TransactionOperation{
 		{Type: OperationPut, Item: user},
 	}
+	builder.On("Put", user, mock.Anything).Return(builder).Once()
 
 	// Execute transaction with cost tracking
 	err := ExecuteTransactionWithCostTracking(context.Background(), mockDB, logger, tracker, operations...)
@@ -669,6 +715,7 @@ func TestExecuteTransactionWithCostTracking(t *testing.T) {
 	// Verify results
 	assert.NoError(t, err)
 	mockDB.AssertExpectations(t)
+	builder.AssertExpectations(t)
 
 	// Verify cost tracking
 	costs := tracker.CalculateCost()

--- a/pkg/storage/theorydb/transaction_test.go
+++ b/pkg/storage/theorydb/transaction_test.go
@@ -654,6 +654,63 @@ func TestTransactionBuilder_Clear(t *testing.T) {
 	assert.Equal(t, 0, builder.GetOperationCount())
 }
 
+func TestTransactionManager_M10_AdditionalTransactionCoverage(t *testing.T) {
+	user := &TestUser{
+		StandardModel: StandardModel{PK: "user#123", SK: "user#123"},
+		Name:          "John Doe",
+	}
+
+	assert.Equal(t, "put", OperationPut.String())
+	assert.Equal(t, "update", OperationUpdate.String())
+	assert.Equal(t, "delete", OperationDelete.String())
+	assert.Equal(t, "condition_check", OperationConditionCheck.String())
+	assert.Equal(t, "unknown", OperationType(99).String())
+
+	keyItem, err := newTransactionKeyItem("users", map[string]any{"PK": "user#123", "SK": "user#123"})
+	assert.NoError(t, err)
+	assert.Equal(t, "users", keyItem.TableName())
+	_, err = newTransactionKeyItem("", map[string]any{"PK": "user#123"})
+	assert.Error(t, err)
+	_, err = newTransactionKeyItem("users", nil)
+	assert.Error(t, err)
+	_, err = newTransactionKeyItem("users", map[string]any{"SK": "user#123"})
+	assert.Error(t, err)
+
+	ops, config := NewTransactionBuilder().
+		WithConfig(TransactionConfig{MaxRetries: 1, BaseDelay: time.Millisecond}).
+		UpdateWithExpression(user, "SET #name = :name", "Jane").
+		Delete(user).
+		DeleteByKey("users", map[string]any{"PK": "user#123"}).
+		Build()
+	assert.Len(t, ops, 3)
+	assert.Equal(t, 1, config.MaxRetries)
+	assert.Equal(t, OperationUpdate, ops[0].Type)
+	assert.Equal(t, OperationDelete, ops[1].Type)
+	assert.Equal(t, OperationDelete, ops[2].Type)
+
+	values := transactionConditionValues([]any{"ok", 3})
+	assert.Equal(t, "ok", values[":v0"])
+	assert.Equal(t, 3, values[":v1"])
+
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+	mockDB.On("Model", mock.Anything).Return(mockQuery)
+	mockQuery.On("Create").Return(nil).Once()
+	mockQuery.On("Update", []string{"Name"}).Return(nil).Once()
+	mockQuery.On("Delete").Return(nil).Once()
+	tx := &core.Tx{}
+	tx.SetDB(mockDB)
+
+	manager := NewTransactionManager(mockDB, zap.NewNop())
+	assert.NoError(t, manager.executeOperation(tx, TransactionOperation{Type: OperationPut, Item: user}))
+	assert.NoError(t, manager.executeOperation(tx, TransactionOperation{Type: OperationUpdate, Item: user}))
+	assert.NoError(t, manager.executeOperation(tx, TransactionOperation{Type: OperationDelete, Item: user}))
+	assert.NoError(t, manager.executeOperation(tx, TransactionOperation{Type: OperationDelete, TableName: "users", Key: map[string]any{"PK": "user#123"}}))
+	assert.NoError(t, manager.executeOperation(tx, TransactionOperation{Type: OperationConditionCheck, TableName: "users", Key: map[string]any{"PK": "user#123"}, Condition: "attribute_exists(PK)"}))
+	mockDB.AssertExpectations(t)
+	mockQuery.AssertExpectations(t)
+}
+
 // Tests for convenience functions
 
 func TestExecuteSimpleTransaction(t *testing.T) {
@@ -720,4 +777,25 @@ func TestExecuteTransactionWithCostTracking(t *testing.T) {
 	// Verify cost tracking
 	costs := tracker.CalculateCost()
 	assert.Equal(t, int64(2), costs.DynamoDBWrites) // 1 operation * 2 for transaction
+}
+
+func TestExecuteTransactionWithLoggerAndRetryHelpers(t *testing.T) {
+	mockDB := new(mocks.MockExtendedDB)
+	builder := new(mocks.MockTransactionBuilder)
+	mockDB.TransactWriteBuilder = builder
+	mockDB.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Twice()
+
+	user := &TestUser{
+		StandardModel: StandardModel{PK: "user#123", SK: "user#123"},
+		Name:          "John Doe",
+	}
+	builder.On("Put", user, mock.Anything).Return(builder).Twice()
+
+	logger := zap.NewNop()
+	manager := NewTransactionManager(mockDB, logger)
+	assert.NoError(t, manager.ExecuteWithRetry(context.Background(), TransactionOperation{Type: OperationPut, Item: user}))
+	assert.NoError(t, ExecuteTransactionWithLogger(context.Background(), mockDB, logger, TransactionOperation{Type: OperationPut, Item: user}))
+
+	mockDB.AssertExpectations(t)
+	builder.AssertExpectations(t)
 }

--- a/pkg/testing/mock_repository_storage.go
+++ b/pkg/testing/mock_repository_storage.go
@@ -50,7 +50,7 @@ type MockRepositoryStorage struct {
 	scheduledStatusRepo  *repositories.ScheduledStatusRepository
 	announcementRepo     *repositories.AnnouncementRepository
 	domainBlockRepo      *repositories.DomainBlockRepository
-	relationshipRepo     *repositories.RelationshipRepository
+	relationshipRepo     interfaces.ConcreteRelationshipRepository
 	instanceRepo         *repositories.InstanceRepository
 	federationRepo       *repositories.FederationRepository
 	recoveryRepo         *repositories.RecoveryRepository
@@ -174,6 +174,14 @@ func WithModerationRepository(repo interfaces.ModerationRepository) Option {
 	}
 }
 
+// WithRelationshipRepository sets a custom relationship repository implementation.
+// Use this to inject a mock for testing specific relationship behavior.
+func WithRelationshipRepository(repo interfaces.ConcreteRelationshipRepository) Option {
+	return func(s *MockRepositoryStorage) {
+		s.relationshipRepo = repo
+	}
+}
+
 // WithMediaAnalyticsRepository sets a custom media analytics repository implementation.
 // Use this to inject a mock for testing specific media analytics repository behavior.
 func WithMediaAnalyticsRepository(repo interfaces.MediaAnalyticsRepository) Option {
@@ -284,6 +292,7 @@ func NewMockRepositoryStorage(opts ...Option) *MockRepositoryStorage {
 		timelineRepo:        inmemory.NewTimelineRepository(),
 		objectRepo:          inmemory.NewObjectRepository(),
 		activityRepo:        inmemory.NewActivityRepository(),
+		relationshipRepo:    inmemory.NewRelationshipRepository(),
 		trustRepo:           inmemory.NewTrustRepository(),
 		moderationRepo:      inmemory.NewModerationRepository(),
 		mediaAnalyticsRepo:  inmemory.NewMediaAnalyticsRepository(),

--- a/pkg/testing/mock_repository_storage_test.go
+++ b/pkg/testing/mock_repository_storage_test.go
@@ -198,3 +198,12 @@ func TestMockRepositoryStorage_MultipleOptions(t *testing.T) {
 	assert.Equal(t, logger, s.GetLogger())
 	assert.Equal(t, "multi-option-table", s.GetTableName())
 }
+
+func TestNewMockRepositoryStorage_DefaultRelationshipRepository(t *testing.T) {
+	s := NewMockRepositoryStorage()
+
+	repo := s.Relationship()
+	require.NotNil(t, repo)
+
+	var _ interfaces.ConcreteRelationshipRepository = repo
+}


### PR DESCRIPTION
## Milestone
Codex Security M10 — Storage and schema compatibility repairs (#875)

## Classification
security hardening / schema compatibility / storage reliability

## Surfaces affected
- WebAuthn credential lookup/update/delete storage paths
- ActivityPub persisted `@context` deserialization compatibility
- Account relationship repository guards and testing mocks
- Account lookup/search compatibility paths
- Bookmark legacy read compatibility
- OAuth provider account lookup semantics
- TableTheory transaction wrapper execution

## Specialist walks referenced
- Federation trust: #877 touches ActivityPub context parsing only; no signing, verification, actor identity, inbox/outbox, delivery, relay, moderation, or governance bypass changes.
- Contract / API: backward-compatible storage semantic refinements only; no REST/GraphQL/ActivityPub actor response-shape changes.
- Schema: `validate-schema` discipline applied. PK/SK/GSI contracts and TableTheory tags are preserved; changes add dual-read/fallback compatibility where deployed legacy records exist.
- Framework: idiomatic TableTheory/AppTheory usage; no framework patch or local fork.

## Consumer impact
Operators get safer legacy-read behavior and storage-integrity fixes. Mastodon clients and remote ActivityPub peers should see no response-shape change. Sibling repos should see no contract change.

## Tasks
- [x] #876 `fix(webauthn): avoid nil credential panics`
- [x] #877 `fix(activitypub): restore legacy context unmarshalling`
- [x] #878 `fix(storage): handle nil relationship repositories`
- [x] #879 `fix(accounts): return account by email`
- [x] #880 `fix(bookmarks): preserve legacy bookmark reads`
- [x] #881 `fix(accounts): repair short handle search`
- [x] #882 `fix(oauth): repair provider account lookup`
- [x] #883 `fix(storage): execute real transaction operations`

Closes #875
Closes #876
Closes #877
Closes #878
Closes #879
Closes #880
Closes #881
Closes #882
Closes #883

## Validation
- [x] Baseline on synced `main`: `gofmt -l .` (empty), `go test ./...`, `go vet ./...`
- [x] Targeted package tests for each task family (auth/WebAuthn, storage converters/factory, account relationships, account lookup/search, bookmarks, provider accounts, TableTheory transactions)
- [x] Per-task full checks during implementation: `gofmt -l .`, `go test ./...`, `go vet ./...`
- [x] Final hard gate: `go build -o lesser ./cmd/lesser && ./lesser build lambdas && ./lesser verify ci`
  - overall coverage: 87.577%
  - `pkg` coverage: 90.003%
  - `cmd` coverage: 90.002%

## Review follow-up
- [x] Addressed Tier 1 bookmark pagination blocker: mixed legacy bare timestamp SKs and new `TIME#...` SKs now paginate with an opaque per-stream cursor so neither namespace advances past un-emitted rows; legacy reads use an `SK < "A"` stream to avoid `OBJECT#...` rows hiding legacy records under the read cap.
- [x] Addressed Tier 1 transaction update blocker: inferred transaction update fields now use Go struct field names, with tagged `models.User` coverage proving TableTheory receives `Username` / `DisplayName` rather than `username` / `displayName`.

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None expected; no public contract, sibling-repo contract, or release-artifact shape change.

## Advisor-brief authorization
Not advisor-dispatched.