### PR TITLE
fix(security): complete Codex Security M11

### DIFF
--- a/cmd/api/handlers/admin.go
+++ b/cmd/api/handlers/admin.go
@@ -23,13 +23,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// contextKey is the type for context keys to avoid untyped string context keys
-type contextKey string
-
-const (
-	baseURLContextKey contextKey = "baseURL"
-)
-
 // Admin action constants
 const (
 	actionSuspend = "suspend"

--- a/cmd/api/handlers/coverage_margin_test.go
+++ b/cmd/api/handlers/coverage_margin_test.go
@@ -1,0 +1,98 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestHandlerCoverageMargin_InstanceHelperFallbacks(t *testing.T) {
+	ctx := context.Background()
+
+	var nilHandler *Handler
+	require.False(t, nilHandler.instanceLocked(ctx))
+	require.Empty(t, nilHandler.instanceRules(ctx))
+	require.Empty(t, nilHandler.instanceExtendedDescription(ctx))
+	users, statuses, domains := nilHandler.instanceCounts(ctx)
+	require.Zero(t, users)
+	require.Zero(t, statuses)
+	require.Zero(t, domains)
+	require.Nil(t, nilHandler.instanceContactAccount(ctx))
+	require.Equal(t, map[string]any{"enabled": false}, nilHandler.instanceTipsConfig(ctx))
+	require.False(t, nilHandler.isTranslationEnabled(ctx))
+
+	h := &Handler{cfg: round11TestConfig(), logger: zap.NewNop()}
+	require.Empty(t, h.instanceRules(ctx))
+	require.Empty(t, h.instanceExtendedDescription(ctx))
+	users, statuses, domains = h.instanceCounts(ctx)
+	require.Zero(t, users)
+	require.Zero(t, statuses)
+	require.Zero(t, domains)
+	require.Nil(t, h.instanceContactAccount(ctx))
+}
+
+func TestHandlerCoverageMargin_FeatureConfigFallbacks(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("trust repo error disables", func(t *testing.T) {
+		h, _, _ := round11NewHandler(t, round11TestConfig(), &round10QueryState{firstErrorOnce: errors.New("boom")})
+		h.logger = zap.NewNop()
+		out := h.instanceTrustConfig(ctx)
+		require.Equal(t, false, out["enabled"])
+	})
+
+	t.Run("legacy trust missing key disables", func(t *testing.T) {
+		t.Setenv("LESSER_HOST_URL", "https://lab.lesser.host")
+		cfg := round11TestConfig()
+		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
+		h.logger = zap.NewNop()
+		out := h.instanceTrustConfig(ctx)
+		require.Equal(t, false, out["enabled"])
+	})
+
+	t.Run("tips repo error falls back to legacy config", func(t *testing.T) {
+		cfg := round11TestConfig()
+		cfg.TipEnabled = true
+		cfg.TipChainID = 8453
+		cfg.TipContractAddress = " 0xabc "
+		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{firstErrorOnce: errors.New("boom")})
+		h.logger = zap.NewNop()
+		out := h.instanceTipsConfig(ctx)
+		require.Equal(t, true, out["enabled"])
+		require.Equal(t, 8453, out["chain_id"])
+		require.Equal(t, "0xabc", out["contract_address"])
+	})
+
+	t.Run("translation repo error falls back to legacy config", func(t *testing.T) {
+		cfg := round11TestConfig()
+		cfg.TranslationEnabled = true
+		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{firstErrorOnce: errors.New("boom")})
+		h.logger = zap.NewNop()
+		require.True(t, h.isTranslationEnabled(ctx))
+	})
+}
+
+func TestHandlerCoverageMargin_TranslationAndRelationshipHelpers(t *testing.T) {
+	h := &Handler{cfg: round11TestConfig(), logger: zap.NewNop()}
+
+	content, spoiler, language := h.extractTranslatableContent(&activitypub.Note{
+		BaseObject: activitypub.BaseObject{Summary: "content warning"},
+		Content:    "<p>hello</p>",
+	})
+	require.Equal(t, "<p>hello</p>", content)
+	require.Equal(t, "content warning", spoiler)
+	require.Empty(t, language)
+
+	content, spoiler, language = h.extractTranslatableContent(struct{}{})
+	require.Empty(t, content)
+	require.Empty(t, spoiler)
+	require.Empty(t, language)
+
+	require.False(t, relationshipTargetNotFound(nil))
+	require.True(t, relationshipTargetNotFound(errors.New("actor not found: bob")))
+	require.False(t, relationshipTargetNotFound(errors.New("identity mismatch")))
+}

--- a/cmd/api/handlers/helpers.go
+++ b/cmd/api/handlers/helpers.go
@@ -1073,7 +1073,7 @@ func (h *Handler) transformStatusBase(ctx context.Context, storageStatus *storag
 	}
 
 	transformer := transformations.NewStatusResponseTransformer(h.cfg.BaseURL(), transformations.ObjectToStatusWithContext)
-	transformCtx := context.WithValue(ctx, baseURLContextKey, h.cfg.BaseURL())
+	transformCtx := transformations.ContextWithBaseURL(ctx, h.cfg.BaseURL())
 	baseStatus, err := transformer.Transform(transformCtx, statusMap)
 	if err == nil && baseStatus.ID != "" {
 		return baseStatus

--- a/cmd/api/handlers/instance_streaming_api_url_test.go
+++ b/cmd/api/handlers/instance_streaming_api_url_test.go
@@ -1,8 +1,7 @@
 package handlers
 
 import (
-	"crypto/x509"
-	"encoding/pem"
+	"encoding/base64"
 	"strings"
 	"testing"
 
@@ -76,15 +75,15 @@ func TestIsProductionEnvironment_round28_more_coverage(t *testing.T) {
 func TestGenerateVAPIDKeyPair_round28_more_coverage(t *testing.T) {
 	t.Parallel()
 
-	publicKeyB64, privateKeyPEM, err := generateVAPIDKeyPair()
+	publicKeyB64, privateKeyB64, err := generateVAPIDKeyPair()
 	require.NoError(t, err)
 	require.NotEmpty(t, publicKeyB64)
-	require.NotEmpty(t, privateKeyPEM)
+	require.NotEmpty(t, privateKeyB64)
+	require.NotContains(t, privateKeyB64, "BEGIN EC PRIVATE KEY")
 
-	block, _ := pem.Decode([]byte(privateKeyPEM))
-	require.NotNil(t, block)
-	_, err = x509.ParseECPrivateKey(block.Bytes)
+	privateKeyBytes, err := base64.RawURLEncoding.DecodeString(privateKeyB64)
 	require.NoError(t, err)
+	require.Len(t, privateKeyBytes, 32)
 }
 
 func TestHandler_markdownToHTMLLift_round28_more_coverage(t *testing.T) {

--- a/cmd/api/handlers/instance_trust_config_margin_test.go
+++ b/cmd/api/handlers/instance_trust_config_margin_test.go
@@ -1,0 +1,91 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveExplicitLesserHostTrustBaseURL_CoverageMargin(t *testing.T) {
+	t.Run("no explicit env", func(t *testing.T) {
+		t.Setenv("LESSER_HOST_ATTESTATIONS_URL", "")
+		t.Setenv("LESSER_HOST_URL", "")
+
+		base, ok := resolveExplicitLesserHostTrustBaseURL()
+		require.False(t, ok)
+		require.Empty(t, base)
+	})
+
+	t.Run("attestations url wins and trims", func(t *testing.T) {
+		t.Setenv("LESSER_HOST_ATTESTATIONS_URL", " https://trust.example/attestations/// ")
+		t.Setenv("LESSER_HOST_URL", "https://host.example")
+
+		base, ok := resolveExplicitLesserHostTrustBaseURL()
+		require.True(t, ok)
+		require.Equal(t, "https://trust.example/attestations", base)
+	})
+
+	t.Run("host url fallback trims", func(t *testing.T) {
+		t.Setenv("LESSER_HOST_ATTESTATIONS_URL", "   ")
+		t.Setenv("LESSER_HOST_URL", " https://host.example/// ")
+
+		base, ok := resolveExplicitLesserHostTrustBaseURL()
+		require.True(t, ok)
+		require.Equal(t, "https://host.example", base)
+	})
+}
+
+func TestValidateTrustBaseURL_CoverageMargin(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr string
+	}{
+		{
+			name:    "empty",
+			raw:     "   ",
+			wantErr: "missing base URL",
+		},
+		{
+			name:    "bad scheme",
+			raw:     "ftp://trust.example",
+			wantErr: "base URL must include http(s) scheme",
+		},
+		{
+			name:    "missing host",
+			raw:     "https:///attestations",
+			wantErr: "base URL missing hostname",
+		},
+		{
+			name:    "lambda url host",
+			raw:     "https://abc.lambda-url.us-east-1.on.aws",
+			wantErr: "lambda function URL hosts are not supported",
+		},
+		{
+			name: "https success",
+			raw:  " https://trust.example/attestations ",
+		},
+		{
+			name: "http success",
+			raw:  "http://localhost:8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTrustBaseURL(tt.raw)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestIsLambdaFunctionURLHost_CoverageMargin(t *testing.T) {
+	require.True(t, isLambdaFunctionURLHost(" ABC.lambda-url.us-east-1.on.aws "))
+	require.False(t, isLambdaFunctionURLHost("lambda-url.us-east-1.amazonaws.com"))
+	require.False(t, isLambdaFunctionURLHost(strings.TrimSpace("trust.example")))
+}

--- a/cmd/api/handlers/misc.go
+++ b/cmd/api/handlers/misc.go
@@ -254,7 +254,7 @@ func (h *Handler) convertThinStatusResultToAPI(ctx *apptheory.Context, sr *stora
 
 	// Use centralized transformation framework - ELIMINATES 8+ LINES OF DUPLICATE CODE
 	transformer := transformations.NewStatusResponseTransformer(h.cfg.BaseURL(), transformations.ObjectToStatusWithContext)
-	transformCtx := context.WithValue(ctx.Context(), baseURLContextKey, h.cfg.BaseURL())
+	transformCtx := transformations.ContextWithBaseURL(ctx.Context(), h.cfg.BaseURL())
 
 	status, err := transformer.Transform(transformCtx, statusMap)
 	if err != nil || status.ID == "" {

--- a/cmd/api/handlers/vapid_check.go
+++ b/cmd/api/handlers/vapid_check.go
@@ -5,9 +5,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/x509"
 	"encoding/base64"
-	"encoding/pem"
 	"errors"
 	"time"
 
@@ -80,22 +78,21 @@ func ValidateVAPIDKeysForProduction(ctx context.Context, cfg *config.Config, rep
 	return nil
 }
 
-// generateVAPIDKeyPair generates a new ECDSA P-256 key pair for VAPID
-func generateVAPIDKeyPair() (publicKeyB64 string, privateKeyPEM string, err error) {
+// generateVAPIDKeyPair generates a new ECDSA P-256 key pair for VAPID.
+//
+// The push-delivery processor expects the private key as the raw P-256 scalar
+// encoded with base64url, matching the format produced by the API's runtime
+// /api/v1/instance VAPID bootstrap path.
+func generateVAPIDKeyPair() (publicKeyB64 string, privateKeyB64 string, err error) {
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return "", "", err
 	}
 
-	privateKeyBytes, err := x509.MarshalECPrivateKey(privateKey)
+	privateKeyBytes, err := privateKey.Bytes()
 	if err != nil {
 		return "", "", err
 	}
-
-	privPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "EC PRIVATE KEY",
-		Bytes: privateKeyBytes,
-	})
 
 	ecdhKey, err := privateKey.ECDH()
 	if err != nil {
@@ -103,6 +100,7 @@ func generateVAPIDKeyPair() (publicKeyB64 string, privateKeyPEM string, err erro
 	}
 	publicKeyBytes := ecdhKey.PublicKey().Bytes()
 	publicKeyB64 = base64.RawURLEncoding.EncodeToString(publicKeyBytes)
+	privateKeyB64 = base64.RawURLEncoding.EncodeToString(privateKeyBytes)
 
-	return publicKeyB64, string(privPEM), nil
+	return publicKeyB64, privateKeyB64, nil
 }

--- a/cmd/api/handlers/vapid_check_round28_test.go
+++ b/cmd/api/handlers/vapid_check_round28_test.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"context"
+	"encoding/base64"
+	"strings"
 	"testing"
 
 	"github.com/equaltoai/lesser/pkg/config"
@@ -9,6 +11,25 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
+
+func TestGenerateVAPIDKeyPair_round28_rawScalarPrivateKey(t *testing.T) {
+	t.Parallel()
+
+	publicKey, privateKey, err := generateVAPIDKeyPair()
+	require.NoError(t, err)
+	require.NotEmpty(t, publicKey)
+	require.NotEmpty(t, privateKey)
+	require.False(t, strings.Contains(privateKey, "BEGIN EC PRIVATE KEY"))
+
+	publicKeyBytes, err := base64.RawURLEncoding.DecodeString(publicKey)
+	require.NoError(t, err)
+	require.Len(t, publicKeyBytes, 65)
+	require.Equal(t, byte(4), publicKeyBytes[0])
+
+	privateKeyBytes, err := base64.RawURLEncoding.DecodeString(privateKey)
+	require.NoError(t, err)
+	require.Len(t, privateKeyBytes, 32)
+}
 
 func TestValidateVAPIDKeysForProduction_round28_more_coverage(t *testing.T) {
 	t.Parallel()

--- a/cmd/collections/round12_collections_test.go
+++ b/cmd/collections/round12_collections_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"reflect"
 	"testing"
 	"time"
@@ -761,4 +762,98 @@ func TestReturnCollectionPageReverse_Links_Round12(t *testing.T) {
 	page := mustUnmarshalBody[activitypub.OrderedCollectionPage](t, resp)
 	require.NotEmpty(t, page.Next)
 	require.NotEmpty(t, page.Prev)
+}
+
+func TestCollectionsCoverageMarginHelpers_Round12(t *testing.T) {
+	origCfg := cfg
+	origLogger := logger
+	t.Cleanup(func() {
+		cfg = origCfg
+		logger = origLogger
+	})
+	logger = zap.NewNop()
+
+	cfg = nil
+	require.Equal(t, "", collectionLocalDomain())
+	require.Equal(t, "alice", (&CollectionsHandler{}).localCollectionActorID("alice"))
+
+	cfg = &config.Config{Domain: "https://example.com:8443/path"}
+	require.Equal(t, "example.com", collectionLocalDomain())
+
+	username, domain, ok := parseCollectionHandle("@alice@remote.example ")
+	require.True(t, ok)
+	require.Equal(t, "alice", username)
+	require.Equal(t, "remote.example", domain)
+
+	_, _, ok = parseCollectionHandle("alice")
+	require.False(t, ok)
+	_, _, ok = parseCollectionHandle("@alice@")
+	require.False(t, ok)
+	_, _, ok = parseCollectionHandle("@@remote.example")
+	require.False(t, ok)
+
+	ch := &CollectionsHandler{}
+	cfg = &config.Config{Domain: "example.com"}
+	require.Equal(t, "https://example.com/users/alice", ch.localCollectionActorID("alice"))
+	require.Equal(t, "not-a-handle", ch.remoteCollectionActorURL("not-a-handle"))
+	require.Equal(t, "https://example.com/users/alice", ch.remoteCollectionActorURL("alice@example.com"))
+	require.Equal(t, "https://remote.example/users/bob", ch.remoteCollectionActorURL("@bob@remote.example"))
+
+	require.Equal(t, "", collectionsActorURL(nil))
+	require.Equal(t, "https://example.com/users/alice", collectionsActorURL(&activitypub.Actor{
+		BaseObject: activitypub.BaseObject{ID: "https://example.com/users/alice"},
+		URL:        "https://example.com/@alice",
+	}))
+	require.Equal(t, "https://example.com/@alice", collectionsActorURL(&activitypub.Actor{
+		URL: "https://example.com/@alice",
+	}))
+
+	queryCtx := &apptheory.Context{Request: apptheory.Request{Query: map[string][]string{"limit": {"5"}}}}
+	require.Equal(t, "", collectionsQueryValue(nil, "limit"))
+	require.Equal(t, "", collectionsQueryValue(queryCtx, " "))
+	require.Equal(t, "", collectionsQueryValue(queryCtx, "missing"))
+	require.Equal(t, "5", collectionsQueryValue(queryCtx, " limit "))
+
+	require.Equal(t, "", collectionsContextRequestID(nil))
+	require.Equal(t, " explicit ", collectionsRequestID(&apptheory.Context{RequestID: " explicit "}, "ignored"))
+	generated := collectionsRequestID(&apptheory.Context{}, " ")
+	require.Contains(t, generated, "collections-")
+	ctxWithStoredID := &apptheory.Context{}
+	ctxWithStoredID.Set("requestID", " stored ")
+	require.Equal(t, "stored", collectionsContextRequestID(ctxWithStoredID))
+	require.Equal(t, "request-id", collectionsContextRequestID(&apptheory.Context{RequestID: "request-id"}))
+
+	resp := collectionsJSONError(http.StatusBadRequest, " ")
+	require.Equal(t, http.StatusBadRequest, resp.Status)
+	activityResp, err := collectionsActivityJSON(http.StatusAccepted, map[string]string{"ok": "yes"})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, activityResp.Status)
+	require.Equal(t, []string{contentTypeActivityJSON}, activityResp.Headers["content-type"])
+}
+
+func TestCollectionsMiddlewareCoverageMargin_Round12(t *testing.T) {
+	recovered, err := collectionsPanicRecovery(nil)(func(*apptheory.Context) (*apptheory.Response, error) {
+		panic("boom")
+	})(&apptheory.Context{})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusInternalServerError, recovered.Status)
+
+	okResp, err := collectionsPanicRecovery(zap.NewNop())(func(*apptheory.Context) (*apptheory.Response, error) {
+		return collectionsJSONError(http.StatusTeapot, "short and stout"), nil
+	})(&apptheory.Context{})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusTeapot, okResp.Status)
+
+	nilResp, err := collectionsActivityPubSecurityHeaders()(func(*apptheory.Context) (*apptheory.Response, error) {
+		return nil, nil
+	})(&apptheory.Context{})
+	require.NoError(t, err)
+	require.Nil(t, nilResp)
+
+	secured, err := collectionsActivityPubSecurityHeaders()(func(*apptheory.Context) (*apptheory.Response, error) {
+		return &apptheory.Response{Status: http.StatusOK}, nil
+	})(&apptheory.Context{})
+	require.NoError(t, err)
+	require.Equal(t, []string{"nosniff"}, secured.Headers["x-content-type-options"])
+	require.Equal(t, []string{"cross-origin"}, secured.Headers["cross-origin-resource-policy"])
 }

--- a/cmd/federation-timeseries/main.go
+++ b/cmd/federation-timeseries/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/deploy/naming"
+	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/theorydb"
 	"github.com/equaltoai/lesser/pkg/storage/theorydb/stream"
 )
@@ -210,62 +211,39 @@ func (tp *TimeseriesProcessor) extractInstance(actorID string) string {
 }
 
 func (tp *TimeseriesProcessor) storeMetrics(ctx context.Context, requestID string, window time.Time, metrics *FederationMetrics) error {
+	now := time.Now().UTC()
 	windowStr := window.Format(time.RFC3339)
 
-	// Create timeseries record for federation metrics
-	timeseriesRecord := struct {
-		PK                  string `theorydb:"pk"`
-		SK                  string `theorydb:"sk"`
-		Type                string `json:"type"`
-		Window              string `json:"window"`
-		FollowCount         int    `json:"follow_count"`
-		LikeCount           int    `json:"like_count"`
-		AnnounceCount       int    `json:"announce_count"`
-		ActivityCount       int    `json:"activity_count"`
-		UniqueActorCount    int    `json:"unique_actor_count"`
-		UniqueInstanceCount int    `json:"unique_instance_count"`
-		CreatedAt           string `json:"created_at"`
-		TTL                 int64  `theorydb:"ttl"`
-	}{
-		PK:                  "TIMESERIES#FEDERATION",
-		SK:                  fmt.Sprintf("WINDOW#%s", windowStr),
-		Type:                "FederationTimeseries",
-		Window:              windowStr,
-		FollowCount:         metrics.FollowCount,
-		LikeCount:           metrics.LikeCount,
-		AnnounceCount:       metrics.AnnounceCount,
-		ActivityCount:       metrics.ActivityCount,
-		UniqueActorCount:    len(metrics.UniqueActors),
-		UniqueInstanceCount: len(metrics.UniqueInstances),
-		CreatedAt:           time.Now().Format(time.RFC3339),
-		TTL:                 time.Now().Add(90 * 24 * time.Hour).Unix(), // 90 days retention
-	}
-
-	if err := tp.db.WithContext(ctx).Model(&timeseriesRecord).Create(); err != nil {
+	// Atomically add the current stream batch into the existing window instead
+	// of overwriting previous records from the same 5-minute bucket.
+	timeseriesRecord := models.NewFederationTimeseriesWindow(window, now)
+	if err := tp.db.WithContext(ctx).Model(timeseriesRecord).UpdateBuilder().
+		SetIfNotExists("Type", nil, timeseriesRecord.Type).
+		SetIfNotExists("Window", nil, timeseriesRecord.Window).
+		SetIfNotExists("CreatedAt", nil, timeseriesRecord.CreatedAt).
+		Add("FollowCount", metrics.FollowCount).
+		Add("LikeCount", metrics.LikeCount).
+		Add("AnnounceCount", metrics.AnnounceCount).
+		Add("ActivityCount", metrics.ActivityCount).
+		Add("UniqueActorCount", len(metrics.UniqueActors)).
+		Add("UniqueInstanceCount", len(metrics.UniqueInstances)).
+		Set("UpdatedAt", timeseriesRecord.UpdatedAt).
+		Set("TTL", timeseriesRecord.TTL).
+		Execute(); err != nil {
 		return fmt.Errorf("store timeseries metrics: %w", err)
 	}
 
 	// Also store per-instance metrics for detailed analytics
 	for instance := range metrics.UniqueInstances {
-		instanceRecord := struct {
-			PK        string `theorydb:"pk"`
-			SK        string `theorydb:"sk"`
-			Type      string `json:"type"`
-			Instance  string `json:"instance"`
-			Window    string `json:"window"`
-			CreatedAt string `json:"created_at"`
-			TTL       int64  `theorydb:"ttl"`
-		}{
-			PK:        fmt.Sprintf("TIMESERIES#INSTANCE#%s", instance),
-			SK:        fmt.Sprintf("WINDOW#%s", windowStr),
-			Type:      "InstanceTimeseries",
-			Instance:  instance,
-			Window:    windowStr,
-			CreatedAt: time.Now().Format(time.RFC3339),
-			TTL:       time.Now().Add(30 * 24 * time.Hour).Unix(), // 30 days retention
-		}
-
-		if err := tp.db.WithContext(ctx).Model(&instanceRecord).Create(); err != nil {
+		instanceRecord := models.NewInstanceTimeseriesWindow(instance, window, now)
+		if err := tp.db.WithContext(ctx).Model(instanceRecord).UpdateBuilder().
+			SetIfNotExists("Type", nil, instanceRecord.Type).
+			SetIfNotExists("Instance", nil, instanceRecord.Instance).
+			SetIfNotExists("Window", nil, instanceRecord.Window).
+			SetIfNotExists("CreatedAt", nil, instanceRecord.CreatedAt).
+			Set("UpdatedAt", instanceRecord.UpdatedAt).
+			Set("TTL", instanceRecord.TTL).
+			Execute(); err != nil {
 			tp.logger.Error("failed to store instance metrics",
 				zap.String("request_id", requestID),
 				zap.String("instance", instance),

--- a/cmd/federation-timeseries/main.go
+++ b/cmd/federation-timeseries/main.go
@@ -217,7 +217,10 @@ func (tp *TimeseriesProcessor) storeMetrics(ctx context.Context, requestID strin
 	// Atomically add the current stream batch into the existing window instead
 	// of overwriting previous records from the same 5-minute bucket.
 	timeseriesRecord := models.NewFederationTimeseriesWindow(window, now)
-	if err := tp.db.WithContext(ctx).Model(timeseriesRecord).UpdateBuilder().
+	if err := tp.db.WithContext(ctx).Model(timeseriesRecord).
+		Where("PK", "=", timeseriesRecord.PK).
+		Where("SK", "=", timeseriesRecord.SK).
+		UpdateBuilder().
 		SetIfNotExists("Type", nil, timeseriesRecord.Type).
 		SetIfNotExists("Window", nil, timeseriesRecord.Window).
 		SetIfNotExists("CreatedAt", nil, timeseriesRecord.CreatedAt).
@@ -236,7 +239,10 @@ func (tp *TimeseriesProcessor) storeMetrics(ctx context.Context, requestID strin
 	// Also store per-instance metrics for detailed analytics
 	for instance := range metrics.UniqueInstances {
 		instanceRecord := models.NewInstanceTimeseriesWindow(instance, window, now)
-		if err := tp.db.WithContext(ctx).Model(instanceRecord).UpdateBuilder().
+		if err := tp.db.WithContext(ctx).Model(instanceRecord).
+			Where("PK", "=", instanceRecord.PK).
+			Where("SK", "=", instanceRecord.SK).
+			UpdateBuilder().
 			SetIfNotExists("Type", nil, instanceRecord.Type).
 			SetIfNotExists("Instance", nil, instanceRecord.Instance).
 			SetIfNotExists("Window", nil, instanceRecord.Window).

--- a/cmd/federation-timeseries/round12_additional_test.go
+++ b/cmd/federation-timeseries/round12_additional_test.go
@@ -399,3 +399,12 @@ func TestMain_InvokesLambdaStart(t *testing.T) {
 	main()
 	require.True(t, called)
 }
+
+func TestTimeseriesProcessor_HandleDynamoDBRecord_NilAndNoopBranches(t *testing.T) {
+	var nilProcessor *TimeseriesProcessor
+	require.ErrorContains(t, nilProcessor.HandleDynamoDBRecord(nil, events.DynamoDBEventRecord{}), "timeseries processor is nil")
+
+	tp := &TimeseriesProcessor{db: &fakeDynamoDB{}, tableName: "table"}
+	require.NoError(t, tp.HandleDynamoDBRecord(nil, events.DynamoDBEventRecord{}))
+	require.NotNil(t, tp.logger)
+}

--- a/cmd/federation-timeseries/round12_additional_test.go
+++ b/cmd/federation-timeseries/round12_additional_test.go
@@ -54,7 +54,7 @@ func (f *fakeQuery) Create() error {
 
 func (f *fakeQuery) CreateOrUpdate() error                        { return nil }
 func (f *fakeQuery) Update(...string) error                       { return nil }
-func (f *fakeQuery) UpdateBuilder() dynamormCore.UpdateBuilder    { return nil }
+func (f *fakeQuery) UpdateBuilder() dynamormCore.UpdateBuilder    { return &fakeUpdateBuilder{db: f.db} }
 func (f *fakeQuery) Delete() error                                { return nil }
 func (f *fakeQuery) Scan(any) error                               { return nil }
 func (f *fakeQuery) ParallelScan(int32, int32) dynamormCore.Query { return f }
@@ -76,6 +76,10 @@ type fakeDynamoDB struct {
 	createCalls           int
 	createErr             error
 	failCreatesAfterFirst bool
+	updateCalls           int
+	updateErr             error
+	failUpdatesAfterFirst bool
+	adds                  map[string]int64
 }
 
 func (f *fakeDynamoDB) Model(any) dynamormCore.Query { return &fakeQuery{db: f} }
@@ -86,6 +90,50 @@ func (f *fakeDynamoDB) Migrate() error                              { return nil
 func (f *fakeDynamoDB) AutoMigrate(...any) error                    { return nil }
 func (f *fakeDynamoDB) Close() error                                { return nil }
 func (f *fakeDynamoDB) WithContext(context.Context) dynamormCore.DB { return f }
+
+type fakeUpdateBuilder struct {
+	db *fakeDynamoDB
+}
+
+func (f *fakeUpdateBuilder) Set(string, any) dynamormCore.UpdateBuilder { return f }
+func (f *fakeUpdateBuilder) SetIfNotExists(string, any, any) dynamormCore.UpdateBuilder {
+	return f
+}
+func (f *fakeUpdateBuilder) Add(field string, value any) dynamormCore.UpdateBuilder {
+	if f.db.adds == nil {
+		f.db.adds = make(map[string]int64)
+	}
+	switch v := value.(type) {
+	case int:
+		f.db.adds[field] += int64(v)
+	case int64:
+		f.db.adds[field] += v
+	}
+	return f
+}
+func (f *fakeUpdateBuilder) AddAll(string, any) dynamormCore.UpdateBuilder              { return f }
+func (f *fakeUpdateBuilder) Increment(string) dynamormCore.UpdateBuilder                { return f }
+func (f *fakeUpdateBuilder) Decrement(string) dynamormCore.UpdateBuilder                { return f }
+func (f *fakeUpdateBuilder) Remove(string) dynamormCore.UpdateBuilder                   { return f }
+func (f *fakeUpdateBuilder) Delete(string, any) dynamormCore.UpdateBuilder              { return f }
+func (f *fakeUpdateBuilder) AppendToList(string, any) dynamormCore.UpdateBuilder        { return f }
+func (f *fakeUpdateBuilder) PrependToList(string, any) dynamormCore.UpdateBuilder       { return f }
+func (f *fakeUpdateBuilder) RemoveFromListAt(string, int) dynamormCore.UpdateBuilder    { return f }
+func (f *fakeUpdateBuilder) SetListElement(string, int, any) dynamormCore.UpdateBuilder { return f }
+func (f *fakeUpdateBuilder) Condition(string, string, any) dynamormCore.UpdateBuilder   { return f }
+func (f *fakeUpdateBuilder) OrCondition(string, string, any) dynamormCore.UpdateBuilder { return f }
+func (f *fakeUpdateBuilder) ConditionExists(string) dynamormCore.UpdateBuilder          { return f }
+func (f *fakeUpdateBuilder) ConditionNotExists(string) dynamormCore.UpdateBuilder       { return f }
+func (f *fakeUpdateBuilder) ConditionVersion(int64) dynamormCore.UpdateBuilder          { return f }
+func (f *fakeUpdateBuilder) ReturnValues(string) dynamormCore.UpdateBuilder             { return f }
+func (f *fakeUpdateBuilder) Execute() error {
+	f.db.updateCalls++
+	if f.db.failUpdatesAfterFirst && f.db.updateCalls > 1 {
+		return errors.New("update failed")
+	}
+	return f.db.updateErr
+}
+func (f *fakeUpdateBuilder) ExecuteWithResult(any) error { return f.Execute() }
 
 func TestInitializeFederationTimeseries_WiresGlobals(t *testing.T) {
 	origMustInit := mustInitializeLambdaFn
@@ -147,7 +195,7 @@ func TestTimeseriesProcessor_StoreMetrics(t *testing.T) {
 	requestID := "req"
 
 	t.Run("returns error when base record store fails", func(t *testing.T) {
-		db := &fakeDynamoDB{createErr: errors.New("nope")}
+		db := &fakeDynamoDB{updateErr: errors.New("nope")}
 		tp := &TimeseriesProcessor{db: db, tableName: "table", logger: zap.NewNop()}
 		err := tp.storeMetrics(ctx, requestID, time.Unix(0, 0).UTC(), &FederationMetrics{
 			UniqueActors:    map[string]bool{},
@@ -157,7 +205,7 @@ func TestTimeseriesProcessor_StoreMetrics(t *testing.T) {
 	})
 
 	t.Run("logs and continues on per-instance store failures", func(t *testing.T) {
-		db := &fakeDynamoDB{failCreatesAfterFirst: true}
+		db := &fakeDynamoDB{failUpdatesAfterFirst: true}
 		tp := &TimeseriesProcessor{db: db, tableName: "table", logger: zap.NewNop()}
 
 		metrics := &FederationMetrics{
@@ -170,7 +218,29 @@ func TestTimeseriesProcessor_StoreMetrics(t *testing.T) {
 		}
 
 		require.NoError(t, tp.storeMetrics(ctx, requestID, time.Unix(0, 0).UTC(), metrics))
-		require.GreaterOrEqual(t, db.createCalls, 1)
+		require.GreaterOrEqual(t, db.updateCalls, 1)
+	})
+
+	t.Run("adds counts into the current window instead of overwriting", func(t *testing.T) {
+		db := &fakeDynamoDB{}
+		tp := &TimeseriesProcessor{db: db, tableName: "table", logger: zap.NewNop()}
+
+		metrics := &FederationMetrics{
+			FollowCount:     2,
+			LikeCount:       3,
+			AnnounceCount:   4,
+			ActivityCount:   5,
+			UniqueActors:    map[string]bool{"actor-1": true, "actor-2": true},
+			UniqueInstances: map[string]bool{"example.com": true},
+		}
+
+		require.NoError(t, tp.storeMetrics(ctx, requestID, time.Unix(0, 0).UTC(), metrics))
+		require.Equal(t, int64(2), db.adds["FollowCount"])
+		require.Equal(t, int64(3), db.adds["LikeCount"])
+		require.Equal(t, int64(4), db.adds["AnnounceCount"])
+		require.Equal(t, int64(5), db.adds["ActivityCount"])
+		require.Equal(t, int64(2), db.adds["UniqueActorCount"])
+		require.Equal(t, int64(1), db.adds["UniqueInstanceCount"])
 	})
 }
 
@@ -271,7 +341,7 @@ func TestHandleFederationTimeseriesStreamRecord_DecodeAndDispatch(t *testing.T) 
 	}
 
 	require.NoError(t, handleFederationTimeseriesStreamRecord(&apptheory.EventContext{RequestID: "req"}, record))
-	require.GreaterOrEqual(t, db.createCalls, 1)
+	require.GreaterOrEqual(t, db.updateCalls, 1)
 }
 
 func TestMain_InvokesLambdaStart(t *testing.T) {

--- a/cmd/federation-timeseries/round12_additional_test.go
+++ b/cmd/federation-timeseries/round12_additional_test.go
@@ -21,7 +21,16 @@ type fakeQuery struct {
 	db *fakeDynamoDB
 }
 
-func (f *fakeQuery) Where(string, string, any) dynamormCore.Query                      { return f }
+type fakeWhereCall struct {
+	field string
+	op    string
+	value any
+}
+
+func (f *fakeQuery) Where(field string, op string, value any) dynamormCore.Query {
+	f.db.wheres = append(f.db.wheres, fakeWhereCall{field: field, op: op, value: value})
+	return f
+}
 func (f *fakeQuery) Index(string) dynamormCore.Query                                   { return f }
 func (f *fakeQuery) Filter(string, string, any) dynamormCore.Query                     { return f }
 func (f *fakeQuery) OrFilter(string, string, any) dynamormCore.Query                   { return f }
@@ -80,6 +89,7 @@ type fakeDynamoDB struct {
 	updateErr             error
 	failUpdatesAfterFirst bool
 	adds                  map[string]int64
+	wheres                []fakeWhereCall
 }
 
 func (f *fakeDynamoDB) Model(any) dynamormCore.Query { return &fakeQuery{db: f} }
@@ -241,6 +251,11 @@ func TestTimeseriesProcessor_StoreMetrics(t *testing.T) {
 		require.Equal(t, int64(5), db.adds["ActivityCount"])
 		require.Equal(t, int64(2), db.adds["UniqueActorCount"])
 		require.Equal(t, int64(1), db.adds["UniqueInstanceCount"])
+		require.Len(t, db.wheres, 4)
+		require.Equal(t, fakeWhereCall{field: "PK", op: "=", value: "TIMESERIES#FEDERATION"}, db.wheres[0])
+		require.Equal(t, fakeWhereCall{field: "SK", op: "=", value: "WINDOW#1970-01-01T00:00:00Z"}, db.wheres[1])
+		require.Equal(t, fakeWhereCall{field: "PK", op: "=", value: "TIMESERIES#INSTANCE#example.com"}, db.wheres[2])
+		require.Equal(t, fakeWhereCall{field: "SK", op: "=", value: "WINDOW#1970-01-01T00:00:00Z"}, db.wheres[3])
 	})
 }
 

--- a/cmd/lesser/up_factory_test.go
+++ b/cmd/lesser/up_factory_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBootstrapDBFactoryCreatesConfiguredDB(t *testing.T) {
+	factory := newBootstrapDBFactory(aws.Config{
+		Region:      "us-east-1",
+		Credentials: credentials.NewStaticCredentialsProvider("access", "secret", ""),
+	})
+
+	db, err := factory()
+	require.NoError(t, err)
+	require.NotNil(t, db)
+}

--- a/cmd/stream-router/main.go
+++ b/cmd/stream-router/main.go
@@ -480,8 +480,7 @@ func (h *StreamRouterHandler) HandleDynamoDBRecord(ctx *apptheory.EventContext, 
 			zap.String("event_id", record.EventID),
 			zap.Error(err),
 		)
-		// Match previous Lift behavior: log and continue; do not fail the batch.
-		return nil
+		return err
 	}
 
 	return nil

--- a/cmd/stream-router/round12_stream_router_test.go
+++ b/cmd/stream-router/round12_stream_router_test.go
@@ -394,8 +394,8 @@ func TestStreamRouterHandler_HandleDynamoDBRecord_Round12(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("HandleDynamoDBRecord swallows errors", func(t *testing.T) {
-		require.NoError(t, h.HandleDynamoDBRecord(nil, newUserModifyRecordWithoutID()))
+	t.Run("HandleDynamoDBRecord returns processing errors for retry", func(t *testing.T) {
+		require.Error(t, h.HandleDynamoDBRecord(nil, newUserModifyRecordWithoutID()))
 	})
 }
 

--- a/cmd/websocket-cost-aggregator/round12_websocket_cost_aggregator_test.go
+++ b/cmd/websocket-cost-aggregator/round12_websocket_cost_aggregator_test.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/theory-cloud/tabletheory"
+	"github.com/theory-cloud/tabletheory/pkg/core"
 )
 
 type fakeCostRepo struct {
@@ -729,7 +730,7 @@ func TestInitializeAndMain_RoutesEventBridge(t *testing.T) {
 		DynamoDB: nil,
 	}
 	mustInitializeLambdaFn = func(_ common.LambdaConfig) *common.LambdaContext { return fakeCtx }
-	getLambdaClientFn = func(context.Context) (*tabletheory.LambdaDB, error) { return &tabletheory.LambdaDB{}, nil }
+	getLambdaClientFn = func(context.Context) (core.DB, error) { return &tabletheory.LambdaDB{}, nil }
 	loadAWSConfigFn = func(context.Context, ...func(*awsconfig.LoadOptions) error) (aws.Config, error) {
 		return aws.Config{Region: "us-east-1"}, nil
 	}
@@ -800,7 +801,7 @@ func TestInitializeWebSocketCostAggregator_LoadAWSConfigError(t *testing.T) {
 		DynamoDB: nil,
 	}
 	mustInitializeLambdaFn = func(_ common.LambdaConfig) *common.LambdaContext { return fakeCtx }
-	getLambdaClientFn = func(context.Context) (*tabletheory.LambdaDB, error) { return &tabletheory.LambdaDB{}, nil }
+	getLambdaClientFn = func(context.Context) (core.DB, error) { return &tabletheory.LambdaDB{}, nil }
 	loadAWSConfigFn = func(context.Context, ...func(*awsconfig.LoadOptions) error) (aws.Config, error) {
 		return aws.Config{}, errors.New("load failed")
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -248,6 +248,26 @@ Notes:
 - GraphQL depth is capped for `client_class=cli` tokens even if `GRAPHQL_MAX_DEPTH` is higher.
 - Recommended rollout: enable in `dev`, validate behavior, then `staging`, then `live`.
 
+### Hardened auth + visibility rollout semantics
+
+The generated REST and GraphQL contracts document the same hardened defaults that operators should validate during
+rollout:
+
+- OAuth bearer authentication is required for write APIs and for non-public GraphQL fields. The anonymous GraphQL
+  public-read subset only exposes public/unlisted content.
+- `direct` status creation remains 1:1 in v1: the request content must contain exactly one resolvable local or remote
+  `@mention`. Lesser serializes the resolved actor into ActivityPub addressing (`to`/`cc`/`bto`/`bcc`) and those
+  addressing fields are the authoritative source for repair/backfill tooling.
+- Content mentions alone are not authorization. Operational tools that repair DM conversations must use stored
+  recipient fields and must not infer participants from message text.
+- New deployments remain locked-on-deploy until the operator unlocks the instance. Validate auth, public visibility,
+  direct-message visibility, VAPID push signing, stream retry behavior, and cost/date-range reporting in `dev` before
+  promoting to `staging` or `live`.
+- Lambda-optimized TableTheory clients retain a timeout safety buffer before applying Lambda context deadlines. If you
+  adjust timeout behavior, re-run the full local gate before deploying.
+
+Detailed operator notes live in `docs/security/hardened-auth-visibility-rollout.md`.
+
 ### Crawler protection
 
 ```bash

--- a/docs/contracts/graphql-schema.graphql
+++ b/docs/contracts/graphql-schema.graphql
@@ -1159,6 +1159,8 @@ type CostUpdate {
 #   `actor`, `object`, `timeline(type: PUBLIC|LOCAL|HASHTAG|ACTOR)`, `search`, `instance`,
 #   `instanceActivity`, `instancePeers`, `announcements`, `customEmojis`, `threadContext`
 # - Public note/thread queries only expose `public` and `unlisted` content to anonymous callers.
+# - `private`, `followers`, and `direct` visibility is never part of the anonymous public-read subset;
+#   those reads require an authenticated viewer and the same participant / recipient checks used by REST.
 # - All other Query fields remain auth-only unless explicitly documented otherwise.
 type Query {
   # Mastodon compatibility

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -2312,7 +2312,7 @@ components:
                 status:
                     type: string
                 visibility:
-                    description: Status visibility. `direct` messages must mention exactly one local or remote recipient using an @mention in the status content; group direct messages are not supported in v1.
+                    description: 'Status visibility. `direct` creates are 1:1 only: the content must contain exactly one resolvable local or remote @mention, and Lesser serializes that resolved actor into the ActivityPub addressing fields. Stored DM visibility and repair tooling use the addressing fields as the source of truth; content mentions alone do not authorize or backfill participants.'
                     enum:
                         - public
                         - unlisted

--- a/docs/security.md
+++ b/docs/security.md
@@ -20,6 +20,8 @@ it captures the Lesser-specific “gotchas” and safe defaults.
 - Keep Route53 + ACM validation in the same account as the deployment where possible.
 - Rate limiting is enabled by default; use `DISABLE_RATE_LIMITING` / `DISABLE_FEDERATION_RATE_LIMITING` only for controlled debugging (see `docs/configuration.md`).
 - AWS WAF is not provisioned by default; add it in CDK if you need WAF-level protections.
+- Hardened auth, visibility, and stage-rollout semantics are summarized in
+  `docs/security/hardened-auth-visibility-rollout.md`.
 
 ## Tenant and instance isolation
 

--- a/docs/security/hardened-auth-visibility-rollout.md
+++ b/docs/security/hardened-auth-visibility-rollout.md
@@ -1,0 +1,46 @@
+# Hardened auth, visibility, and rollout semantics
+
+This note summarizes the M11 operator contract for auth, visibility, and rollout validation. It is intentionally aligned
+with the generated REST contract (`docs/contracts/openapi.yaml`) and generated GraphQL schema
+(`docs/contracts/graphql-schema.graphql`).
+
+## Auth contract
+
+- REST write APIs and non-public GraphQL fields require OAuth bearer authentication.
+- GraphQL anonymous reads are limited to the documented public-read subset and only expose public/unlisted content.
+- Device-code authorization is disabled by default. When enabled, `client_class=cli` tokens are governed by the CLI
+  automation rails in `docs/configuration.md` regardless of account type.
+- Browser CORS is fail-closed by default to the instance origin unless the operator configures an explicit trusted origin
+  allowlist.
+
+## Visibility contract
+
+- Public/unlisted objects may be returned by anonymous public-read surfaces.
+- Private/followers/direct content requires an authenticated viewer and the same visibility and participant checks used
+  by REST handlers.
+- Direct messages are 1:1 in v1. `POST /api/v1/statuses` with `visibility=direct` must include exactly one resolvable
+  local or remote `@mention`; group DMs are not accepted.
+- Once a direct message is stored, ActivityPub addressing fields (`to`, `cc`, `bto`, `bcc` and their stored status
+  projections) are the authoritative recipient source. Content mentions are not authorization and are not sufficient for
+  repair/backfill participant recovery.
+- DM conversation backfill must derive participant sets from the stored addressing fields. Local actor URLs normalize to
+  local usernames when they share the author host; remote actor URLs remain actor URIs for typed conversation lookup.
+
+## Operational rollout checks
+
+Before promoting a release beyond `dev`, validate the behaviors that changed in M11:
+
+1. Generated VAPID keys are stored as base64url raw P-256 scalar private keys and push JWT signing succeeds.
+2. Federation strongest-edge reads return concrete edges for all-type queries, and federation timeseries windows
+   aggregate counters instead of overwriting prior samples.
+3. Stream-router record processing returns failed-record errors so Lambda/DynamoDB Streams can retry side effects.
+4. API transformations emit instance-correct URLs from the shared base-url context.
+5. Cost date-range reads honor both start and end dates.
+6. Lambda-optimized TableTheory clients retain the configured timeout safety buffer when a Lambda context deadline is
+   applied.
+7. DM conversation backfill ignores message-text mentions and uses stored recipient fields.
+
+The release path remains `dev -> staging -> live` (with staging where the deployment uses it). Soak is evidence-based:
+check API auth behavior, anonymous public-read visibility, direct-message visibility, federation delivery/receipt,
+stream retry metrics, cost reporting, SQS DLQ depth, CloudWatch error rate, and operator unlock state before promotion.
+Never set timeouts on CDK deploy commands and never delete the bootstrap mnemonic.

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/spruceid/siwe-go v0.2.1
 	github.com/stretchr/testify v1.11.1
 	github.com/theory-cloud/apptheory v1.2.0
-	github.com/theory-cloud/tabletheory v1.7.1
+	github.com/theory-cloud/tabletheory v1.8.0-rc
 	github.com/tyler-smith/go-bip32 v1.0.0
 	github.com/tyler-smith/go-bip39 v1.1.0
 	github.com/vektah/gqlparser/v2 v2.5.32

--- a/go.mod
+++ b/go.mod
@@ -48,8 +48,8 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/spruceid/siwe-go v0.2.1
 	github.com/stretchr/testify v1.11.1
-	github.com/theory-cloud/apptheory v1.2.0
-	github.com/theory-cloud/tabletheory v1.8.0-rc
+	github.com/theory-cloud/apptheory v1.3.0
+	github.com/theory-cloud/tabletheory v1.8.0
 	github.com/tyler-smith/go-bip32 v1.0.0
 	github.com/tyler-smith/go-bip39 v1.1.0
 	github.com/vektah/gqlparser/v2 v2.5.32

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/supranational/blst v0.3.16 h1:bTDadT+3fK497EvLdWRQEjiGnUtzJ7jjIUMF0jq
 github.com/supranational/blst v0.3.16/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/theory-cloud/apptheory v1.2.0 h1:166njRE0GE+FfCVUlfIrPQe6fEoIpY2/slITb6SxknQ=
 github.com/theory-cloud/apptheory v1.2.0/go.mod h1:opIhZD4ipxAKa32+ELwHjfeXaHDRnd17tcVG5+H8134=
-github.com/theory-cloud/tabletheory v1.7.1 h1:pS0RoV6MpXtznL/z5tA4PLQ9vCoVo8Fo60FE1OgUTtY=
-github.com/theory-cloud/tabletheory v1.7.1/go.mod h1:ZbXJkyBD2iTw/Ht3fec3BTECZaOD72D2ufAuTz6ZYrU=
+github.com/theory-cloud/tabletheory v1.8.0-rc h1:+tL1iYIB4CVsDQsHbhbtCaqIoia1l8cN4ydnRTeRKho=
+github.com/theory-cloud/tabletheory v1.8.0-rc/go.mod h1:ZbXJkyBD2iTw/Ht3fec3BTECZaOD72D2ufAuTz6ZYrU=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=

--- a/go.sum
+++ b/go.sum
@@ -255,10 +255,10 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/supranational/blst v0.3.16 h1:bTDadT+3fK497EvLdWRQEjiGnUtzJ7jjIUMF0jqwYhE=
 github.com/supranational/blst v0.3.16/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
-github.com/theory-cloud/apptheory v1.2.0 h1:166njRE0GE+FfCVUlfIrPQe6fEoIpY2/slITb6SxknQ=
-github.com/theory-cloud/apptheory v1.2.0/go.mod h1:opIhZD4ipxAKa32+ELwHjfeXaHDRnd17tcVG5+H8134=
-github.com/theory-cloud/tabletheory v1.8.0-rc h1:+tL1iYIB4CVsDQsHbhbtCaqIoia1l8cN4ydnRTeRKho=
-github.com/theory-cloud/tabletheory v1.8.0-rc/go.mod h1:ZbXJkyBD2iTw/Ht3fec3BTECZaOD72D2ufAuTz6ZYrU=
+github.com/theory-cloud/apptheory v1.3.0 h1:B/7CEv1N3+ymFehaQ7o7PB5XFQGcgD5tnFO4akKESKA=
+github.com/theory-cloud/apptheory v1.3.0/go.mod h1:V0j0LoaaTmRlRfkS8cxh0hWEZMyvniayixg4Hx+sA0g=
+github.com/theory-cloud/tabletheory v1.8.0 h1:IdbEfjjUbyYEj2tCkS/e1rjOHmWUCqZSiPuIcTf7oao=
+github.com/theory-cloud/tabletheory v1.8.0/go.mod h1:ZbXJkyBD2iTw/Ht3fec3BTECZaOD72D2ufAuTz6ZYrU=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=

--- a/graph/core.graphql
+++ b/graph/core.graphql
@@ -1156,6 +1156,8 @@ type CostUpdate {
 #   `actor`, `object`, `timeline(type: PUBLIC|LOCAL|HASHTAG|ACTOR)`, `search`, `instance`,
 #   `instanceActivity`, `instancePeers`, `announcements`, `customEmojis`, `threadContext`
 # - Public note/thread queries only expose `public` and `unlisted` content to anonymous callers.
+# - `private`, `followers`, and `direct` visibility is never part of the anonymous public-read subset;
+#   those reads require an authenticated viewer and the same participant / recipient checks used by REST.
 # - All other Query fields remain auth-only unless explicitly documented otherwise.
 type Query {
   # Mastodon compatibility

--- a/infra/cdk/go.mod
+++ b/infra/cdk/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/constructs-go/constructs/v10 v10.6.0
 	github.com/aws/jsii-runtime-go v1.127.0
 	github.com/equaltoai/lesser v1.1.17
-	github.com/theory-cloud/apptheory v1.2.0
+	github.com/theory-cloud/apptheory v1.3.0
 )
 
 require (

--- a/infra/cdk/go.sum
+++ b/infra/cdk/go.sum
@@ -26,8 +26,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/theory-cloud/apptheory v1.2.0 h1:166njRE0GE+FfCVUlfIrPQe6fEoIpY2/slITb6SxknQ=
-github.com/theory-cloud/apptheory v1.2.0/go.mod h1:opIhZD4ipxAKa32+ELwHjfeXaHDRnd17tcVG5+H8134=
+github.com/theory-cloud/apptheory v1.3.0 h1:B/7CEv1N3+ymFehaQ7o7PB5XFQGcgD5tnFO4akKESKA=
+github.com/theory-cloud/apptheory v1.3.0/go.mod h1:V0j0LoaaTmRlRfkS8cxh0hWEZMyvniayixg4Hx+sA0g=
 github.com/yuin/goldmark v1.7.16 h1:n+CJdUxaFMiDUNnWC3dMWCIQJSkxH4uz3ZwQBkAlVNE=
 github.com/yuin/goldmark v1.7.16/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/pkg/storage/models/coverage_margin_test.go
+++ b/pkg/storage/models/coverage_margin_test.go
@@ -1,0 +1,196 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstanceConfigModelHelpers_CoverageMargin(t *testing.T) {
+	t.Run("translation config", func(t *testing.T) {
+		cfg := NewInstanceTranslationConfig()
+		require.Equal(t, MainTableName, cfg.TableName())
+		require.Equal(t, instanceConfigPK, cfg.GetPK())
+		require.Equal(t, SKTranslationConfig, cfg.GetSK())
+		require.NotNil(t, cfg.Managed)
+		require.False(t, cfg.UpdatedAt.IsZero())
+
+		cfg = &InstanceTranslationConfig{}
+		require.NoError(t, cfg.UpdateKeys())
+		require.Equal(t, instanceConfigPK, cfg.GetPK())
+		require.Equal(t, SKTranslationConfig, cfg.GetSK())
+		require.NotNil(t, cfg.Managed)
+	})
+
+	t.Run("trust config", func(t *testing.T) {
+		cfg := NewInstanceTrustConfig()
+		require.Equal(t, MainTableName, cfg.TableName())
+		require.Equal(t, instanceConfigPK, cfg.GetPK())
+		require.Equal(t, SKTrustConfig, cfg.GetSK())
+		require.NotNil(t, cfg.Managed)
+		require.False(t, cfg.UpdatedAt.IsZero())
+
+		cfg = &InstanceTrustConfig{}
+		require.NoError(t, cfg.UpdateKeys())
+		require.Equal(t, instanceConfigPK, cfg.GetPK())
+		require.Equal(t, SKTrustConfig, cfg.GetSK())
+		require.NotNil(t, cfg.Managed)
+	})
+
+	t.Run("tips config", func(t *testing.T) {
+		cfg := NewInstanceTipsConfig()
+		require.Equal(t, MainTableName, cfg.TableName())
+		require.Equal(t, instanceConfigPK, cfg.GetPK())
+		require.Equal(t, SKTipsConfig, cfg.GetSK())
+		require.NotNil(t, cfg.Managed)
+		require.False(t, cfg.Managed.Enabled)
+		require.False(t, cfg.UpdatedAt.IsZero())
+
+		cfg = &InstanceTipsConfig{}
+		require.NoError(t, cfg.UpdateKeys())
+		require.Equal(t, instanceConfigPK, cfg.GetPK())
+		require.Equal(t, SKTipsConfig, cfg.GetSK())
+		require.NotNil(t, cfg.Managed)
+	})
+
+	t.Run("well-known soul agent", func(t *testing.T) {
+		record := NewInstanceWellKnownLesserSoulAgent()
+		require.Equal(t, MainTableName, record.TableName())
+		require.Equal(t, instanceConfigPK, record.GetPK())
+		require.Equal(t, SKWellKnownLesserSoulAgent, record.GetSK())
+		require.Empty(t, record.ProofValue)
+		require.True(t, record.ExpiresAt.IsZero())
+		require.False(t, record.UpdatedAt.IsZero())
+
+		record = &InstanceWellKnownLesserSoulAgent{}
+		require.NoError(t, record.UpdateKeys())
+		require.Equal(t, instanceConfigPK, record.GetPK())
+		require.Equal(t, SKWellKnownLesserSoulAgent, record.GetSK())
+	})
+}
+
+func TestVisibilityAndModerationModelHelpers_CoverageMargin(t *testing.T) {
+	t.Run("direct message tombstone", func(t *testing.T) {
+		record := &DirectMessageTombstone{}
+		require.Error(t, record.UpdateKeys())
+
+		record.ViewerUsername = "alice"
+		require.Error(t, record.UpdateKeys())
+
+		record.StatusID = "status-1"
+		require.NoError(t, record.UpdateKeys())
+		require.Equal(t, MainTableName, record.TableName())
+		require.Equal(t, "DM_MESSAGE_TOMBSTONE#alice", record.GetPK())
+		require.Equal(t, "STATUS#status-1", record.GetSK())
+		require.False(t, record.CreatedAt.IsZero())
+	})
+
+	t.Run("graphql stream subscription", func(t *testing.T) {
+		required := []GraphQLStreamSubscription{
+			{},
+			{Stream: "public"},
+			{Stream: "public", ConnectionID: "conn-1"},
+			{Stream: "public", ConnectionID: "conn-1", SubscriptionID: "sub-1"},
+			{Stream: "public", ConnectionID: "conn-1", SubscriptionID: "sub-1", Field: "timeline"},
+		}
+		for _, record := range required {
+			require.Error(t, record.UpdateKeys())
+		}
+
+		record := &GraphQLStreamSubscription{
+			Stream:         "public",
+			ConnectionID:   "conn-1",
+			SubscriptionID: "sub-1",
+			Field:          "timeline",
+			UserID:         "alice",
+		}
+		require.NoError(t, record.UpdateKeys())
+		require.Equal(t, MainTableName, record.TableName())
+		require.Equal(t, "GQLSUB#public", record.GetPK())
+		require.Equal(t, "CONN#conn-1#SUB#sub-1", record.GetSK())
+		require.Equal(t, "CONN#conn-1", record.GSI1PK)
+		require.Equal(t, "SUB#sub-1#STREAM#public", record.GSI1SK)
+	})
+
+	t.Run("domain block records", func(t *testing.T) {
+		createdAt := time.Unix(1700000000, 0).UTC()
+
+		userBlock := &UserDomainBlock{Username: "alice", Domain: "bad.example", CreatedAt: createdAt}
+		require.NoError(t, userBlock.UpdateKeys())
+		require.Equal(t, MainTableName, userBlock.TableName())
+		require.Equal(t, "USER#alice", userBlock.GetPK())
+		require.Equal(t, "DOMAIN_BLOCK#bad.example", userBlock.GetSK())
+
+		instanceBlock := &InstanceDomainBlock{Domain: "bad.example", CreatedAt: createdAt}
+		require.NoError(t, instanceBlock.UpdateKeys())
+		require.Equal(t, MainTableName, instanceBlock.TableName())
+		require.Equal(t, "DOMAIN_BLOCK#bad.example", instanceBlock.GetPK())
+		require.Equal(t, "DOMAIN_BLOCK#bad.example", instanceBlock.GetSK())
+		require.Equal(t, "DOMAIN_BLOCKS", instanceBlock.GSI1PK)
+		require.Equal(t, "1700000000#bad.example", instanceBlock.GSI1SK)
+		require.Equal(t, "INSTANCE_DOMAIN_BLOCK", instanceBlock.Type)
+
+		emailBlock := &EmailDomainBlock{ID: "email-1", Domain: "mail.example", CreatedAt: createdAt}
+		require.NoError(t, emailBlock.UpdateKeys())
+		require.Equal(t, MainTableName, emailBlock.TableName())
+		require.Equal(t, "email-1", emailBlock.GetID())
+		require.Equal(t, "EMAIL_DOMAIN_BLOCK#mail.example", emailBlock.GetPK())
+		require.Equal(t, "EMAIL_DOMAIN_BLOCK#mail.example", emailBlock.GetSK())
+		require.Equal(t, "mail.example", emailBlock.GetDomain())
+		require.Equal(t, "EMAIL_DOMAIN_BLOCKS", emailBlock.GSI1PK)
+		require.Equal(t, createdAt.Format(time.RFC3339), emailBlock.GSI1SK)
+
+		allow := &DomainAllow{ID: "allow-1", Domain: "good.example", CreatedAt: createdAt}
+		require.NoError(t, allow.UpdateKeys())
+		require.Equal(t, MainTableName, allow.TableName())
+		require.Equal(t, "allow-1", allow.GetID())
+		require.Equal(t, "DOMAIN_ALLOW#good.example", allow.GetPK())
+		require.Equal(t, "DOMAIN_ALLOW#good.example", allow.GetSK())
+		require.Equal(t, "good.example", allow.GetDomain())
+		require.Equal(t, "DOMAIN_ALLOWS", allow.GSI1PK)
+		require.Equal(t, createdAt.Format(time.RFC3339), allow.GSI1SK)
+	})
+}
+
+func TestDiscoveryFollowModelHelpers_CoverageMargin(t *testing.T) {
+	t.Run("hashtag follow", func(t *testing.T) {
+		follow := &HashtagFollow{}
+		require.EqualError(t, follow.UpdateKeys(), "UserID is required")
+
+		follow.UserID = "alice"
+		require.EqualError(t, follow.UpdateKeys(), "Hashtag is required")
+
+		follow.Hashtag = "lesser"
+		require.NoError(t, follow.UpdateKeys())
+		require.Equal(t, "user#alice", follow.GetPK())
+		require.Equal(t, "hashtag#lesser", follow.GetSK())
+		require.Equal(t, MainTableName, follow.TableName())
+
+		follow.UpdateKeysWithParams("bob", "fediverse")
+		require.Equal(t, "bob", follow.UserID)
+		require.Equal(t, "fediverse", follow.Hashtag)
+		require.Equal(t, "user#bob", follow.GetPK())
+		require.Equal(t, "hashtag#fediverse", follow.GetSK())
+	})
+
+	t.Run("dns cache", func(t *testing.T) {
+		cache := &DNSCache{}
+		require.NoError(t, cache.UpdateKeys())
+		require.Empty(t, cache.GetPK())
+		require.Empty(t, cache.GetSK())
+
+		cache.Hostname = "remote.example"
+		require.NoError(t, cache.UpdateKeys())
+		require.Equal(t, MainTableName, cache.TableName())
+		require.Equal(t, "DNSCACHE#remote.example", cache.GetPK())
+		require.Equal(t, SKEntry, cache.GetSK())
+	})
+
+	t.Run("account note keys", func(t *testing.T) {
+		note := &AccountNote{PK: "ACCOUNT_NOTE#alice", SK: "NOTE#remote"}
+		assert.Equal(t, "ACCOUNT_NOTE#alice", note.GetPK())
+		assert.Equal(t, "NOTE#remote", note.GetSK())
+	})
+}

--- a/pkg/storage/models/federation.go
+++ b/pkg/storage/models/federation.go
@@ -151,6 +151,82 @@ func (FederationHealthReport) TableName() string {
 	return MainTableName
 }
 
+// FederationTimeseriesWindow stores aggregated federation stream metrics for a time window.
+type FederationTimeseriesWindow struct {
+	_ struct{} `theorydb:"naming:camelCase"`
+
+	PK string `theorydb:"pk,attr:PK"`
+	SK string `theorydb:"sk,attr:SK"`
+
+	Type                string `theorydb:"attr:type" json:"type"`
+	Window              string `theorydb:"attr:window" json:"window"`
+	FollowCount         int    `theorydb:"attr:follow_count" json:"follow_count"`
+	LikeCount           int    `theorydb:"attr:like_count" json:"like_count"`
+	AnnounceCount       int    `theorydb:"attr:announce_count" json:"announce_count"`
+	ActivityCount       int    `theorydb:"attr:activity_count" json:"activity_count"`
+	UniqueActorCount    int    `theorydb:"attr:unique_actor_count" json:"unique_actor_count"`
+	UniqueInstanceCount int    `theorydb:"attr:unique_instance_count" json:"unique_instance_count"`
+	CreatedAt           string `theorydb:"attr:created_at" json:"created_at"`
+	UpdatedAt           string `theorydb:"attr:updated_at" json:"updated_at"`
+	TTL                 int64  `theorydb:"ttl,attr:ttl" json:"ttl,omitempty"`
+}
+
+// TableName returns the DynamoDB table backing FederationTimeseriesWindow.
+func (FederationTimeseriesWindow) TableName() string {
+	return MainTableName
+}
+
+// NewFederationTimeseriesWindow builds the key envelope for a federation metrics window.
+func NewFederationTimeseriesWindow(window, now time.Time) *FederationTimeseriesWindow {
+	windowStr := window.Format(time.RFC3339)
+	nowStr := now.Format(time.RFC3339)
+	return &FederationTimeseriesWindow{
+		PK:        "TIMESERIES#FEDERATION",
+		SK:        fmt.Sprintf("WINDOW#%s", windowStr),
+		Type:      "FederationTimeseries",
+		Window:    windowStr,
+		CreatedAt: nowStr,
+		UpdatedAt: nowStr,
+		TTL:       now.Add(90 * 24 * time.Hour).Unix(),
+	}
+}
+
+// InstanceTimeseriesWindow stores per-instance stream observation metadata for a time window.
+type InstanceTimeseriesWindow struct {
+	_ struct{} `theorydb:"naming:camelCase"`
+
+	PK string `theorydb:"pk,attr:PK"`
+	SK string `theorydb:"sk,attr:SK"`
+
+	Type      string `theorydb:"attr:type" json:"type"`
+	Instance  string `theorydb:"attr:instance" json:"instance"`
+	Window    string `theorydb:"attr:window" json:"window"`
+	CreatedAt string `theorydb:"attr:created_at" json:"created_at"`
+	UpdatedAt string `theorydb:"attr:updated_at" json:"updated_at"`
+	TTL       int64  `theorydb:"ttl,attr:ttl" json:"ttl,omitempty"`
+}
+
+// TableName returns the DynamoDB table backing InstanceTimeseriesWindow.
+func (InstanceTimeseriesWindow) TableName() string {
+	return MainTableName
+}
+
+// NewInstanceTimeseriesWindow builds the key envelope for an instance metrics window.
+func NewInstanceTimeseriesWindow(instance string, window, now time.Time) *InstanceTimeseriesWindow {
+	windowStr := window.Format(time.RFC3339)
+	nowStr := now.Format(time.RFC3339)
+	return &InstanceTimeseriesWindow{
+		PK:        fmt.Sprintf("TIMESERIES#INSTANCE#%s", instance),
+		SK:        fmt.Sprintf("WINDOW#%s", windowStr),
+		Type:      "InstanceTimeseries",
+		Instance:  instance,
+		Window:    windowStr,
+		CreatedAt: nowStr,
+		UpdatedAt: nowStr,
+		TTL:       now.Add(30 * 24 * time.Hour).Unix(),
+	}
+}
+
 // FederationNode represents a node in the federation graph
 type FederationNode struct {
 	_ struct{} `theorydb:"naming:camelCase"`

--- a/pkg/storage/models/federation.go
+++ b/pkg/storage/models/federation.go
@@ -160,14 +160,14 @@ type FederationTimeseriesWindow struct {
 
 	Type                string `theorydb:"attr:type" json:"type"`
 	Window              string `theorydb:"attr:window" json:"window"`
-	FollowCount         int    `theorydb:"attr:follow_count" json:"follow_count"`
-	LikeCount           int    `theorydb:"attr:like_count" json:"like_count"`
-	AnnounceCount       int    `theorydb:"attr:announce_count" json:"announce_count"`
-	ActivityCount       int    `theorydb:"attr:activity_count" json:"activity_count"`
-	UniqueActorCount    int    `theorydb:"attr:unique_actor_count" json:"unique_actor_count"`
-	UniqueInstanceCount int    `theorydb:"attr:unique_instance_count" json:"unique_instance_count"`
-	CreatedAt           string `theorydb:"attr:created_at" json:"created_at"`
-	UpdatedAt           string `theorydb:"attr:updated_at" json:"updated_at"`
+	FollowCount         int    `theorydb:"attr:followCount" json:"follow_count"`
+	LikeCount           int    `theorydb:"attr:likeCount" json:"like_count"`
+	AnnounceCount       int    `theorydb:"attr:announceCount" json:"announce_count"`
+	ActivityCount       int    `theorydb:"attr:activityCount" json:"activity_count"`
+	UniqueActorCount    int    `theorydb:"attr:uniqueActorCount" json:"unique_actor_count"`
+	UniqueInstanceCount int    `theorydb:"attr:uniqueInstanceCount" json:"unique_instance_count"`
+	CreatedAt           string `theorydb:"attr:createdAt" json:"created_at"`
+	UpdatedAt           string `theorydb:"attr:updatedAt" json:"updated_at"`
 	TTL                 int64  `theorydb:"ttl,attr:ttl" json:"ttl,omitempty"`
 }
 
@@ -201,8 +201,8 @@ type InstanceTimeseriesWindow struct {
 	Type      string `theorydb:"attr:type" json:"type"`
 	Instance  string `theorydb:"attr:instance" json:"instance"`
 	Window    string `theorydb:"attr:window" json:"window"`
-	CreatedAt string `theorydb:"attr:created_at" json:"created_at"`
-	UpdatedAt string `theorydb:"attr:updated_at" json:"updated_at"`
+	CreatedAt string `theorydb:"attr:createdAt" json:"created_at"`
+	UpdatedAt string `theorydb:"attr:updatedAt" json:"updated_at"`
 	TTL       int64  `theorydb:"ttl,attr:ttl" json:"ttl,omitempty"`
 }
 

--- a/pkg/storage/models/round14_federation_models_test.go
+++ b/pkg/storage/models/round14_federation_models_test.go
@@ -110,6 +110,21 @@ func TestFederationModels_UpdateKeys(t *testing.T) {
 		assert.Equal(t, MainTableName, ic.TableName())
 	})
 
+	t.Run("timeseries window records", func(t *testing.T) {
+		ts := time.Unix(1700000000, 0).UTC()
+		fw := NewFederationTimeseriesWindow(ts, ts)
+		assert.Equal(t, "TIMESERIES#FEDERATION", fw.PK)
+		assert.Equal(t, "WINDOW#2023-11-14T22:13:20Z", fw.SK)
+		assert.Equal(t, "FederationTimeseries", fw.Type)
+		assert.Equal(t, MainTableName, fw.TableName())
+
+		iw := NewInstanceTimeseriesWindow("example.com", ts, ts)
+		assert.Equal(t, "TIMESERIES#INSTANCE#example.com", iw.PK)
+		assert.Equal(t, "WINDOW#2023-11-14T22:13:20Z", iw.SK)
+		assert.Equal(t, "InstanceTimeseries", iw.Type)
+		assert.Equal(t, MainTableName, iw.TableName())
+	})
+
 	t.Run("FederationHealthReport is a computed type", func(t *testing.T) {
 		assert.Equal(t, MainTableName, (FederationHealthReport{}).TableName())
 	})

--- a/pkg/storage/models/round14_federation_models_test.go
+++ b/pkg/storage/models/round14_federation_models_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/theory-cloud/tabletheory"
+	"github.com/theory-cloud/tabletheory/pkg/session"
 )
 
 func TestFederationModels_UpdateKeys(t *testing.T) {
@@ -128,4 +130,23 @@ func TestFederationModels_UpdateKeys(t *testing.T) {
 	t.Run("FederationHealthReport is a computed type", func(t *testing.T) {
 		assert.Equal(t, MainTableName, (FederationHealthReport{}).TableName())
 	})
+}
+
+func TestFederationTimeseriesModelsRegisterWithTableTheory(t *testing.T) {
+	db, err := tabletheory.New(session.Config{Region: "us-east-1"})
+	require.NoError(t, err)
+
+	ts := time.Unix(1700000000, 0).UTC()
+
+	federationWindow := NewFederationTimeseriesWindow(ts, ts)
+	err = db.Model(federationWindow).UpdateBuilder().Set("UpdatedAt", federationWindow.UpdatedAt).Execute()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "partition key PK is required for update")
+	require.NotContains(t, err.Error(), "failed to register model")
+
+	instanceWindow := NewInstanceTimeseriesWindow("example.com", ts, ts)
+	err = db.Model(instanceWindow).UpdateBuilder().Set("UpdatedAt", instanceWindow.UpdatedAt).Execute()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "partition key PK is required for update")
+	require.NotContains(t, err.Error(), "failed to register model")
 }

--- a/pkg/storage/repositories/cost_tracking_repository.go
+++ b/pkg/storage/repositories/cost_tracking_repository.go
@@ -23,6 +23,7 @@ import (
 type TrackingRepository struct {
 	*EnhancedBaseRepository[*models.DynamoDBCostRecord]
 
+	listByOperationTypeFn    func(ctx context.Context, operationType string, startTime, endTime time.Time, limit int) ([]*models.DynamoDBCostRecord, error)
 	listAggregatedByPeriodFn func(ctx context.Context, period, operationType string, startTime, endTime time.Time, limit int, cursor string) ([]*models.DynamoDBCostAggregation, string, error)
 }
 
@@ -37,6 +38,19 @@ const (
 	relayMetricsMaxLimit     = 500
 	aggregatedPageMaxLimit   = 500
 )
+
+var costOperationTypes = []string{
+	"GetItem",
+	"PutItem",
+	"UpdateItem",
+	"DeleteItem",
+	"Query",
+	"Scan",
+	"BatchGetItem",
+	"BatchWriteItem",
+	"TransactGetItems",
+	"TransactWriteItems",
+}
 
 func clampCostTableLimit(limit int) int {
 	if limit <= 0 {
@@ -107,6 +121,10 @@ func (r *TrackingRepository) Get(ctx context.Context, operationType, id string, 
 
 // ListByOperationType lists cost tracking records by operation type within a time range
 func (r *TrackingRepository) ListByOperationType(ctx context.Context, operationType string, startTime, endTime time.Time, limit int) ([]*models.DynamoDBCostRecord, error) {
+	if r.listByOperationTypeFn != nil {
+		return r.listByOperationTypeFn(ctx, operationType, startTime, endTime, limit)
+	}
+
 	// Construct SK range for time-based query
 	pk := fmt.Sprintf("cost#%s", operationType)
 	startSK := fmt.Sprintf("ts#%s", startTime.Format("20060102150405"))
@@ -153,21 +171,21 @@ func (r *TrackingRepository) ListByTable(ctx context.Context, tableName string, 
 
 // GetRecentCosts retrieves recent cost tracking records across all operations
 func (r *TrackingRepository) GetRecentCosts(ctx context.Context, since time.Time, limit int) ([]*models.DynamoDBCostRecord, error) {
+	return r.listCostsAcrossOperationTypes(ctx, since, time.Now(), limit)
+}
+
+func (r *TrackingRepository) listCostsAcrossOperationTypes(ctx context.Context, startTime, endTime time.Time, limit int) ([]*models.DynamoDBCostRecord, error) {
 	var allCosts []*models.DynamoDBCostRecord
 
-	// Query each operation type (we need to iterate through known types)
-	operationTypes := []string{
-		"GetItem", "PutItem", "UpdateItem", "DeleteItem",
-		"Query", "Scan", "BatchGetItem", "BatchWriteItem",
-		"TransactGetItems", "TransactWriteItems",
-	}
-
-	for _, opType := range operationTypes {
-		costs, err := r.ListByOperationType(ctx, opType, since, time.Now(), limit/len(operationTypes))
+	perOperationLimit := perOperationCostLimit(limit)
+	for _, opType := range costOperationTypes {
+		costs, err := r.ListByOperationType(ctx, opType, startTime, endTime, perOperationLimit)
 		if err != nil {
-			r.logger.Warn("failed to get costs for operation type",
-				zap.String("operation_type", opType),
-				zap.Error(err))
+			if r.logger != nil {
+				r.logger.Warn("failed to get costs for operation type",
+					zap.String("operation_type", opType),
+					zap.Error(err))
+			}
 			continue
 		}
 		allCosts = append(allCosts, costs...)
@@ -177,6 +195,17 @@ func (r *TrackingRepository) GetRecentCosts(ctx context.Context, since time.Time
 	// Note: In production, you might want to use a more efficient sorting approach
 
 	return allCosts, nil
+}
+
+func perOperationCostLimit(limit int) int {
+	if limit <= 0 {
+		limit = costTableDefaultLimit
+	}
+	perOperationLimit := limit / len(costOperationTypes)
+	if perOperationLimit <= 0 {
+		return 1
+	}
+	return perOperationLimit
 }
 
 // GetAggregated retrieves aggregated cost tracking
@@ -882,13 +911,9 @@ func finalizeCostMetrics(mergedByWindow map[string]*models.DynamoDBCostAggregati
 
 // GetAggregatedCostsByPeriod retrieves aggregated costs for a specific period
 func (r *TrackingRepository) GetAggregatedCostsByPeriod(ctx context.Context, period string, startDate, endDate time.Time) ([]*models.DynamoDBCostAggregation, error) {
-	// Query all operation types for the period
-	operationTypes := []string{"GetItem", "PutItem", "UpdateItem", "DeleteItem", "Query", "Scan",
-		"BatchGetItem", "BatchWriteItem", "TransactGetItems", "TransactWriteItems"}
-
 	var allAggregates []*models.DynamoDBCostAggregation
 
-	for _, opType := range operationTypes {
+	for _, opType := range costOperationTypes {
 		opAggregates, err := r.fetchAggregatesForOperation(ctx, period, opType, startDate, endDate)
 		if err != nil {
 			// Depending on desired behavior, we could either continue or fail fast.
@@ -912,12 +937,9 @@ func (r *TrackingRepository) GetAggregatedCostsByPeriod(ctx context.Context, per
 
 // GetCostsByOperationType retrieves costs grouped by operation type
 func (r *TrackingRepository) GetCostsByOperationType(ctx context.Context, startDate, endDate time.Time) (map[string]*models.DynamoDBServiceCostStats, error) {
-	operationTypes := []string{"GetItem", "PutItem", "UpdateItem", "DeleteItem", "Query", "Scan",
-		"BatchGetItem", "BatchWriteItem", "TransactGetItems", "TransactWriteItems"}
-
 	result := make(map[string]*models.DynamoDBServiceCostStats)
 
-	for _, opType := range operationTypes {
+	for _, opType := range costOperationTypes {
 		costs, err := r.ListByOperationType(ctx, opType, startDate, endDate, 10000)
 		if err != nil {
 			r.logger.Warn("failed to get costs for operation type",
@@ -995,8 +1017,25 @@ func (r *TrackingRepository) GetCostsByService(ctx context.Context, startDate, e
 }
 
 // GetCostsByDateRange returns individual cost records for the specified date range
-func (r *TrackingRepository) GetCostsByDateRange(ctx context.Context, startDate, _ time.Time) ([]*models.DynamoDBCostRecord, error) {
-	return r.GetRecentCosts(ctx, startDate, 1000) // Use existing method with reasonable limit
+func (r *TrackingRepository) GetCostsByDateRange(ctx context.Context, startDate, endDate time.Time) ([]*models.DynamoDBCostRecord, error) {
+	if endDate.Before(startDate) {
+		return []*models.DynamoDBCostRecord{}, nil
+	}
+
+	costs, err := r.listCostsAcrossOperationTypes(ctx, startDate, endDate, 1000)
+	if err != nil {
+		return nil, err
+	}
+
+	filteredCosts := costs[:0]
+	for _, cost := range costs {
+		if cost.Timestamp.Before(startDate) || cost.Timestamp.After(endDate) {
+			continue
+		}
+		filteredCosts = append(filteredCosts, cost)
+	}
+
+	return filteredCosts, nil
 }
 
 // DailyAggregate represents aggregated costs for a single day

--- a/pkg/storage/repositories/cost_tracking_repository_test.go
+++ b/pkg/storage/repositories/cost_tracking_repository_test.go
@@ -92,6 +92,66 @@ func TestGetAggregatedCostsByPeriod(t *testing.T) {
 	})
 }
 
+func TestTrackingRepository_GetCostsByDateRangeHonorsEndDate(t *testing.T) {
+	ctx := context.Background()
+	startDate := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)
+
+	calls := 0
+	repo := &TrackingRepository{
+		EnhancedBaseRepository: &EnhancedBaseRepository[*models.DynamoDBCostRecord]{
+			BaseRepository: &BaseRepository[*models.DynamoDBCostRecord]{
+				logger: zap.NewNop(),
+			},
+		},
+	}
+	repo.listByOperationTypeFn = func(ctx context.Context, operationType string, startTime, endTime time.Time, limit int) ([]*models.DynamoDBCostRecord, error) {
+		calls++
+		require.Equal(t, startDate, startTime)
+		require.Equal(t, endDate, endTime)
+		require.Positive(t, limit)
+
+		if operationType != "GetItem" {
+			return nil, nil
+		}
+
+		return []*models.DynamoDBCostRecord{
+			{
+				ID:            "inside",
+				OperationType: operationType,
+				Timestamp:     startDate.Add(time.Hour),
+			},
+			{
+				ID:            "after-end",
+				OperationType: operationType,
+				Timestamp:     endDate.Add(time.Nanosecond),
+			},
+		}, nil
+	}
+
+	costs, err := repo.GetCostsByDateRange(ctx, startDate, endDate)
+	require.NoError(t, err)
+	require.Len(t, costs, 1)
+	require.Equal(t, "inside", costs[0].ID)
+	require.Equal(t, len(costOperationTypes), calls)
+}
+
+func TestTrackingRepository_GetCostsByDateRangeSkipsInvertedRange(t *testing.T) {
+	ctx := context.Background()
+	startDate := time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)
+	endDate := startDate.Add(-time.Hour)
+
+	repo := &TrackingRepository{}
+	repo.listByOperationTypeFn = func(ctx context.Context, operationType string, startTime, endTime time.Time, limit int) ([]*models.DynamoDBCostRecord, error) {
+		t.Fatal("inverted date ranges should not query operation type records")
+		return nil, nil
+	}
+
+	costs, err := repo.GetCostsByDateRange(ctx, startDate, endDate)
+	require.NoError(t, err)
+	require.Empty(t, costs)
+}
+
 func TestMergeAggregatesByWindow(t *testing.T) {
 	startDate := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
 	agg1 := &models.DynamoDBCostAggregation{WindowStart: startDate, TotalOperations: 10, TotalCostMicroCents: 100, TableBreakdown: map[string]*models.DynamoDBTableCostStats{"table1": {OperationCount: 10}}}

--- a/pkg/storage/repositories/federation_repository.go
+++ b/pkg/storage/repositories/federation_repository.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -2488,8 +2489,16 @@ func (r *FederationRepository) GetStrongestConnectionsByType(ctx context.Context
 	}
 
 	connectionType = strings.TrimSpace(connectionType)
-	if connectionType == "" {
-		connectionType = ConnectionTypeAll
+	if connectionType == "" || strings.EqualFold(connectionType, ConnectionTypeAll) {
+		edges, err := r.GetAllFederationEdges(ctx, 1000)
+		if err != nil {
+			return nil, err
+		}
+		sortFederationEdgesByStrength(edges)
+		if len(edges) > limit {
+			edges = edges[:limit]
+		}
+		return edges, nil
 	}
 
 	gsi8PK := fmt.Sprintf("FED_EDGES#TYPE#%s", connectionType)
@@ -2524,6 +2533,21 @@ func (r *FederationRepository) GetStrongestConnectionsByType(ctx context.Context
 	}
 
 	return result, nil
+}
+
+func sortFederationEdgesByStrength(edges []*storage.FederationEdge) {
+	sort.SliceStable(edges, func(i, j int) bool {
+		if edges[i].Strength != edges[j].Strength {
+			return edges[i].Strength > edges[j].Strength
+		}
+		if !edges[i].LastActivity.Equal(edges[j].LastActivity) {
+			return edges[i].LastActivity.After(edges[j].LastActivity)
+		}
+		if edges[i].SourceDomain != edges[j].SourceDomain {
+			return edges[i].SourceDomain < edges[j].SourceDomain
+		}
+		return edges[i].TargetDomain < edges[j].TargetDomain
+	})
 }
 
 // StoreDetailedFederationMetrics stores detailed federation time series record with 5-minute aggregation

--- a/pkg/storage/repositories/federation_repository_error_paths_test.go
+++ b/pkg/storage/repositories/federation_repository_error_paths_test.go
@@ -584,6 +584,23 @@ func TestFederationRepository_GetStrongestConnectionsByType_LimitAndTypeBranches
 	require.Len(t, edges, 3)
 }
 
+func TestFederationRepository_GetStrongestConnectionsByType_AllReturnsConcreteEdges(t *testing.T) {
+	ctx := context.Background()
+	baseTime := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+	setupPermissiveFederationRepoMocks(mockDB, mockQuery, baseTime)
+
+	repo := NewFederationRepository(mockDB, "test-table", zap.NewNop(), nil, &appConfig.Config{})
+	edges, err := repo.GetStrongestConnectionsByType(ctx, ConnectionTypeAll, 2)
+	require.NoError(t, err)
+	require.Len(t, edges, 2)
+	require.NotEqual(t, ConnectionTypeAll, edges[0].ConnectionType)
+	require.GreaterOrEqual(t, edges[0].Strength, edges[1].Strength)
+	mockQuery.AssertNotCalled(t, "Where", "gsi8PK", "=", "FED_EDGES#TYPE#all")
+}
+
 func TestFederationRepository_FetchEdgePageWithCursor_CursorAndEmptyResultBranches(t *testing.T) {
 	ctx := context.Background()
 	baseTime := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)

--- a/pkg/storage/theorydb/client.go
+++ b/pkg/storage/theorydb/client.go
@@ -106,10 +106,7 @@ func GetClient(_ context.Context) (core.DB, error) {
 	return client, clientErr
 }
 
-// GetLambdaClient returns a singleton DynamORM Lambda-optimized client instance
-// This ensures that the client is only initialized once per Lambda container
-// and includes Lambda-specific optimizations like timeout handling
-func GetLambdaClient(ctx context.Context) (*tabletheory.LambdaDB, error) {
+func getLambdaOptimizedClient() (*tabletheory.LambdaDB, error) {
 	clientOnce.Do(func() {
 		zap.L().Info("initializing Lambda-optimized DynamORM client")
 		startTime := time.Now()
@@ -134,18 +131,38 @@ func GetLambdaClient(ctx context.Context) (*tabletheory.LambdaDB, error) {
 		zap.L().Info("DynamORM initialized", zap.Duration("duration", time.Since(startTime)))
 	})
 
-	// Apply Lambda context timeout if available
-	if ctx != nil && lambdaDB != nil {
-		return lambdaDB.WithLambdaTimeout(ctx), clientErr
+	return lambdaDB, clientErr
+}
+
+// GetLambdaClient returns a singleton DynamORM Lambda-optimized DB client instance.
+// This ensures that the client is only initialized once per Lambda container
+// and includes Lambda-specific optimizations like timeout handling. The returned
+// core.DB preserves lesser's configured Lambda timeout safety buffer before
+// applying the caller's Lambda context deadline.
+func GetLambdaClient(ctx context.Context) (core.DB, error) {
+	lambdaClient, err := getLambdaOptimizedClient()
+	if err != nil {
+		return nil, err
+	}
+	if client == nil {
+		return lambdaClient, clientErr
 	}
 
-	return lambdaDB, clientErr
+	// Apply Lambda context timeout if available
+	if ctx != nil {
+		if extended, ok := client.(core.ExtendedDB); ok {
+			return extended.WithLambdaTimeout(ctx), clientErr
+		}
+		return client.WithContext(ctx), clientErr
+	}
+
+	return client, clientErr
 }
 
 // InitializeModels pre-registers models with the DynamORM client to reduce cold start time
 // This should be called in the init() function of Lambda handlers
 func InitializeModels(models ...any) error {
-	db, err := GetLambdaClient(context.Background())
+	db, err := getLambdaOptimizedClient()
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/theorydb/client.go
+++ b/pkg/storage/theorydb/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"reflect"
 	"sync"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/theory-cloud/tabletheory"
 	"github.com/theory-cloud/tabletheory/pkg/core"
 	"github.com/theory-cloud/tabletheory/pkg/session"
+	tabletypes "github.com/theory-cloud/tabletheory/pkg/types"
 	"go.uber.org/zap"
 )
 
@@ -31,30 +33,34 @@ var (
 	newDynamormLambdaOptimized = tabletheory.NewLambdaOptimized
 )
 
+type typeConverterRegistrar interface {
+	RegisterTypeConverter(reflect.Type, tabletypes.CustomConverter) error
+}
+
 func registerDefaultTypeConverters(db core.DB) error {
 	if db == nil {
 		return fmt.Errorf("db is nil")
 	}
 
-	extended, ok := db.(core.ExtendedDB)
+	registrar, ok := db.(typeConverterRegistrar)
 	if !ok {
-		// Non-fatal: tests may use mocked core.DB without ExtendedDB support.
+		// Non-fatal: tests may use mocked core.DB without converter support.
 		return nil
 	}
 
-	if err := extended.RegisterTypeConverter(mapStringAnyType, mapStringAnyConverter{}); err != nil {
+	if err := registrar.RegisterTypeConverter(mapStringAnyType, mapStringAnyConverter{}); err != nil {
 		return fmt.Errorf("register map[string]any converter: %w", err)
 	}
-	if err := extended.RegisterTypeConverter(sliceAnyType, sliceAnyConverter{}); err != nil {
+	if err := registrar.RegisterTypeConverter(sliceAnyType, sliceAnyConverter{}); err != nil {
 		return fmt.Errorf("register []any converter: %w", err)
 	}
-	if err := extended.RegisterTypeConverter(activityPubNoteType, activityPubNoteConverter{}); err != nil {
+	if err := registrar.RegisterTypeConverter(activityPubNoteType, activityPubNoteConverter{}); err != nil {
 		return fmt.Errorf("register activitypub.Note converter: %w", err)
 	}
-	if err := extended.RegisterTypeConverter(activityPubContextValueType, activityPubContextValueConverter{}); err != nil {
+	if err := registrar.RegisterTypeConverter(activityPubContextValueType, activityPubContextValueConverter{}); err != nil {
 		return fmt.Errorf("register activitypub.ContextValue converter: %w", err)
 	}
-	if err := extended.RegisterTypeConverter(agentsCapabilitiesType, agentCapabilitiesConverter{}); err != nil {
+	if err := registrar.RegisterTypeConverter(agentsCapabilitiesType, agentCapabilitiesConverter{}); err != nil {
 		return fmt.Errorf("register agents.Capabilities converter: %w", err)
 	}
 
@@ -119,14 +125,22 @@ func getLambdaOptimizedClient() (*tabletheory.LambdaDB, error) {
 			zap.L().Error("failed to initialize DynamORM", zap.Error(err))
 			return
 		}
+		if lambdaDB == nil {
+			clientErr = fmt.Errorf("initialize Lambda-optimized DynamORM: nil client")
+			zap.L().Error("failed to initialize DynamORM", zap.Error(clientErr))
+			return
+		}
 
 		// Store the standard client interface for compatibility
+		lambdaDB = lambdaDB.WithLambdaTimeoutConfig(tabletheory.LambdaTimeoutConfig{
+			Buffer: defaultTimeoutBuffer,
+		})
 		if err := registerDefaultTypeConverters(lambdaDB); err != nil {
 			clientErr = err
 			zap.L().Error("failed to register type converters", zap.Error(err))
 			return
 		}
-		client = lambdaDB.WithLambdaTimeoutBuffer(defaultTimeoutBuffer)
+		client = lambdaDB
 
 		zap.L().Info("DynamORM initialized", zap.Duration("duration", time.Since(startTime)))
 	})
@@ -150,10 +164,7 @@ func GetLambdaClient(ctx context.Context) (core.DB, error) {
 
 	// Apply Lambda context timeout if available
 	if ctx != nil {
-		if extended, ok := client.(core.ExtendedDB); ok {
-			return extended.WithLambdaTimeout(ctx), clientErr
-		}
-		return client.WithContext(ctx), clientErr
+		return lambdaClient.WithLambdaTimeout(ctx), clientErr
 	}
 
 	return client, clientErr
@@ -184,5 +195,7 @@ func WithTimeoutBuffer(db core.DB, buffer time.Duration) core.DB {
 		return db
 	}
 
-	return lambdaDB.WithLambdaTimeoutBuffer(buffer)
+	return lambdaDB.WithLambdaTimeoutConfig(tabletheory.LambdaTimeoutConfig{
+		Buffer: buffer,
+	})
 }

--- a/pkg/storage/theorydb/client_test.go
+++ b/pkg/storage/theorydb/client_test.go
@@ -3,8 +3,11 @@ package theorydb
 import (
 	"context"
 	"os"
+	"reflect"
 	"sync"
 	"testing"
+	"time"
+	"unsafe"
 
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/stretchr/testify/assert"
@@ -97,4 +100,46 @@ func TestWithTimeoutBuffer_NilAndNonLambdaDB(t *testing.T) {
 
 	db := fakeDB{}
 	assert.Equal(t, db, WithTimeoutBuffer(db, 0))
+}
+
+func TestGetLambdaClientPreservesDefaultTimeoutBuffer(t *testing.T) {
+	resetClientState()
+	t.Cleanup(resetClientState)
+
+	deadline := time.Now().Add(30 * time.Second).Round(0)
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+
+	db, err := GetLambdaClient(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, db)
+
+	assert.Equal(t, defaultTimeoutBuffer, lambdaTimeoutBufferOf(t, db))
+	assert.Equal(t, deadline.Add(-defaultTimeoutBuffer), lambdaDeadlineOf(t, db))
+}
+
+func lambdaTimeoutBufferOf(t *testing.T, db core.DB) time.Duration {
+	t.Helper()
+
+	field := tableTheoryDBField(t, db, "lambdaTimeoutBuffer")
+	return time.Duration(field.Int())
+}
+
+func lambdaDeadlineOf(t *testing.T, db core.DB) time.Time {
+	t.Helper()
+
+	field := tableTheoryDBField(t, db, "lambdaDeadline")
+	return reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Interface().(time.Time)
+}
+
+func tableTheoryDBField(t *testing.T, db core.DB, name string) reflect.Value {
+	t.Helper()
+
+	value := reflect.ValueOf(db)
+	require.Equal(t, reflect.Ptr, value.Kind())
+
+	elem := value.Elem()
+	field := elem.FieldByName(name)
+	require.True(t, field.IsValid(), "expected returned Lambda client to expose %s", name)
+	return field
 }

--- a/pkg/storage/theorydb/client_test.go
+++ b/pkg/storage/theorydb/client_test.go
@@ -102,6 +102,19 @@ func TestWithTimeoutBuffer_NilAndNonLambdaDB(t *testing.T) {
 	assert.Equal(t, db, WithTimeoutBuffer(db, 0))
 }
 
+func TestWithTimeoutBuffer_LambdaDB(t *testing.T) {
+	resetClientState()
+	t.Cleanup(resetClientState)
+
+	lambdaClient, err := getLambdaOptimizedClient()
+	require.NoError(t, err)
+	require.NotNil(t, lambdaClient)
+
+	db := WithTimeoutBuffer(lambdaClient, 123*time.Millisecond)
+	require.NotNil(t, db)
+	assert.Equal(t, 123*time.Millisecond, lambdaTimeoutBufferOf(t, db))
+}
+
 func TestGetLambdaClientPreservesDefaultTimeoutBuffer(t *testing.T) {
 	resetClientState()
 	t.Cleanup(resetClientState)
@@ -116,6 +129,18 @@ func TestGetLambdaClientPreservesDefaultTimeoutBuffer(t *testing.T) {
 
 	assert.Equal(t, defaultTimeoutBuffer, lambdaTimeoutBufferOf(t, db))
 	assert.Equal(t, deadline.Add(-defaultTimeoutBuffer), lambdaDeadlineOf(t, db))
+}
+
+func TestGetLambdaClientNilContextReturnsBufferedClient(t *testing.T) {
+	resetClientState()
+	t.Cleanup(resetClientState)
+
+	db, err := GetLambdaClient(nil)
+	require.NoError(t, err)
+	require.NotNil(t, db)
+
+	assert.Equal(t, defaultTimeoutBuffer, lambdaTimeoutBufferOf(t, db))
+	assert.True(t, lambdaDeadlineOf(t, db).IsZero())
 }
 
 func lambdaTimeoutBufferOf(t *testing.T, db core.DB) time.Duration {

--- a/pkg/storage/theorydb/client_test.go
+++ b/pkg/storage/theorydb/client_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/theory-cloud/tabletheory/pkg/core"
 	"github.com/theory-cloud/tabletheory/pkg/session"
+	pkgtypes "github.com/theory-cloud/tabletheory/pkg/types"
 )
 
 func resetClientState() {
@@ -115,6 +116,20 @@ func TestWithTimeoutBuffer_LambdaDB(t *testing.T) {
 	assert.Equal(t, 123*time.Millisecond, lambdaTimeoutBufferOf(t, db))
 }
 
+func TestRegisterDefaultTypeConverters_UsesRegistrarWithoutExtendedDB(t *testing.T) {
+	db := &recordingRegistrarDB{}
+
+	require.NoError(t, registerDefaultTypeConverters(db))
+
+	assert.ElementsMatch(t, []reflect.Type{
+		mapStringAnyType,
+		sliceAnyType,
+		activityPubNoteType,
+		activityPubContextValueType,
+		agentsCapabilitiesType,
+	}, db.registered)
+}
+
 func TestGetLambdaClientPreservesDefaultTimeoutBuffer(t *testing.T) {
 	resetClientState()
 	t.Cleanup(resetClientState)
@@ -128,7 +143,7 @@ func TestGetLambdaClientPreservesDefaultTimeoutBuffer(t *testing.T) {
 	require.NotNil(t, db)
 
 	assert.Equal(t, defaultTimeoutBuffer, lambdaTimeoutBufferOf(t, db))
-	assert.Equal(t, deadline.Add(-defaultTimeoutBuffer), lambdaDeadlineOf(t, db))
+	assert.Equal(t, deadline, lambdaDeadlineOf(t, db))
 }
 
 func TestGetLambdaClientNilContextReturnsBufferedClient(t *testing.T) {
@@ -165,6 +180,27 @@ func tableTheoryDBField(t *testing.T, db core.DB, name string) reflect.Value {
 
 	elem := value.Elem()
 	field := elem.FieldByName(name)
-	require.True(t, field.IsValid(), "expected returned Lambda client to expose %s", name)
+	if field.IsValid() {
+		return field
+	}
+
+	inner := elem.FieldByName("db")
+	require.True(t, inner.IsValid(), "expected returned Lambda client to expose %s", name)
+	require.Equal(t, reflect.Ptr, inner.Kind())
+	require.False(t, inner.IsNil())
+
+	innerValue := reflect.NewAt(inner.Type(), unsafe.Pointer(inner.UnsafeAddr())).Elem()
+	field = innerValue.Elem().FieldByName(name)
+	require.True(t, field.IsValid(), "expected returned Lambda client DB to expose %s", name)
 	return field
+}
+
+type recordingRegistrarDB struct {
+	fakeDB
+	registered []reflect.Type
+}
+
+func (db *recordingRegistrarDB) RegisterTypeConverter(typ reflect.Type, _ pkgtypes.CustomConverter) error {
+	db.registered = append(db.registered, typ)
+	return nil
 }

--- a/pkg/storage/theorydb/lambda_init.go
+++ b/pkg/storage/theorydb/lambda_init.go
@@ -1,7 +1,6 @@
 package theorydb
 
 import (
-	"context"
 	"runtime"
 	"runtime/debug"
 	"sync"
@@ -91,22 +90,19 @@ func LambdaInitWithOptions(opts *LambdaInitOptions) (core.DB, error) {
 
 	zap.L().Info("initializing Lambda-optimized DynamORM client")
 
-	// Get the Lambda-optimized client
-	db, err := GetLambdaClient(context.Background())
-	if err != nil {
-		zap.L().Error("failed to initialize DynamORM", zap.Error(err))
-		return nil, err
-	}
-
 	lambdaDB, err := getLambdaOptimizedClient()
 	if err != nil {
 		zap.L().Error("failed to initialize Lambda DynamORM", zap.Error(err))
 		return nil, err
 	}
+	db := core.DB(lambdaDB)
 
 	// Apply timeout buffer if specified
 	if opts.TimeoutBuffer > 0 {
-		db = lambdaDB.WithLambdaTimeoutBuffer(opts.TimeoutBuffer)
+		lambdaDB = lambdaDB.WithLambdaTimeoutConfig(tabletheory.LambdaTimeoutConfig{
+			Buffer: opts.TimeoutBuffer,
+		})
+		db = lambdaDB
 	}
 
 	// Pre-register models to reduce cold start time

--- a/pkg/storage/theorydb/lambda_init.go
+++ b/pkg/storage/theorydb/lambda_init.go
@@ -92,14 +92,19 @@ func LambdaInitWithOptions(opts *LambdaInitOptions) (core.DB, error) {
 	zap.L().Info("initializing Lambda-optimized DynamORM client")
 
 	// Get the Lambda-optimized client
-	lambdaDB, err := GetLambdaClient(context.Background())
+	db, err := GetLambdaClient(context.Background())
 	if err != nil {
 		zap.L().Error("failed to initialize DynamORM", zap.Error(err))
 		return nil, err
 	}
 
+	lambdaDB, err := getLambdaOptimizedClient()
+	if err != nil {
+		zap.L().Error("failed to initialize Lambda DynamORM", zap.Error(err))
+		return nil, err
+	}
+
 	// Apply timeout buffer if specified
-	var db core.DB = lambdaDB
 	if opts.TimeoutBuffer > 0 {
 		db = lambdaDB.WithLambdaTimeoutBuffer(opts.TimeoutBuffer)
 	}

--- a/pkg/storage/theorydb/lambda_init_test.go
+++ b/pkg/storage/theorydb/lambda_init_test.go
@@ -96,8 +96,7 @@ func TestLambdaInitWithOptions(t *testing.T) {
 
 // TestParallelModelRegistration tests parallel vs sequential registration
 func TestParallelModelRegistration(t *testing.T) {
-	ctx := context.Background()
-	db, err := GetLambdaClient(ctx)
+	db, err := getLambdaOptimizedClient()
 	require.NoError(t, err)
 
 	// Test sequential registration (small number)

--- a/pkg/transformations/converters.go
+++ b/pkg/transformations/converters.go
@@ -582,24 +582,14 @@ func generateNumericID(input string) string {
 
 // ActorToAccountWithContext provides context-aware actor to account conversion
 func ActorToAccountWithContext(ctx context.Context, actor *activitypub.Actor) (models.Account, error) {
-	// Extract baseURL from context or use default
-	baseURL := "https://example.com" // Fallback
-	if url, ok := ctx.Value("baseURL").(string); ok {
-		baseURL = url
-	}
-
+	baseURL := BaseURLFromContext(ctx, defaultBaseURL)
 	account := ActorToAccountBase(actor, baseURL)
 	return account, nil
 }
 
 // ObjectToStatusWithContext provides context-aware object to status conversion
 func ObjectToStatusWithContext(ctx context.Context, obj map[string]interface{}) (models.Status, error) {
-	// Extract baseURL and actor from context
-	baseURL := "https://example.com" // Fallback
-	if url, ok := ctx.Value("baseURL").(string); ok {
-		baseURL = url
-	}
-
+	baseURL := BaseURLFromContext(ctx, defaultBaseURL)
 	var actor *activitypub.Actor
 	if a, ok := ctx.Value("actor").(*activitypub.Actor); ok {
 		actor = a

--- a/pkg/transformations/converters_test.go
+++ b/pkg/transformations/converters_test.go
@@ -368,6 +368,11 @@ func TestConverters_AdditionalBranches(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "bob", account.Username)
 
+	account, err = ActorToAccountWithContext(ContextWithBaseURL(context.Background(), "https://typed.example"), &activitypub.Actor{PreferredUsername: "carol"})
+	require.NoError(t, err)
+	require.Equal(t, "https://typed.example/@carol", account.URL)
+	require.Equal(t, "https://typed.example/avatars/original/missing.png", account.Avatar)
+
 	require.Equal(t, "", ExtractUsernameFromActorID(""))
 
 	status := ObjectToStatusBase(map[string]interface{}{

--- a/pkg/transformations/transformers_activitypub.go
+++ b/pkg/transformations/transformers_activitypub.go
@@ -21,6 +21,32 @@ const (
 	propertyValueType = "PropertyValue"
 )
 
+type contextKey string
+
+const baseURLContextKey contextKey = "baseURL"
+
+// ContextWithBaseURL stores the API base URL using the typed key consumed by
+// response transformers.
+func ContextWithBaseURL(ctx context.Context, baseURL string) context.Context {
+	return context.WithValue(ctx, baseURLContextKey, baseURL)
+}
+
+// BaseURLFromContext retrieves the API base URL from transformer contexts.
+func BaseURLFromContext(ctx context.Context, fallback string) string {
+	if ctx == nil {
+		return fallback
+	}
+	if baseURL, ok := ctx.Value(baseURLContextKey).(string); ok && strings.TrimSpace(baseURL) != "" {
+		return baseURL
+	}
+	// Backward-compatible read for existing tests/callers that used a plain
+	// string key before the Lift handler and transformer key types were aligned.
+	if baseURL, ok := ctx.Value("baseURL").(string); ok && strings.TrimSpace(baseURL) != "" {
+		return baseURL
+	}
+	return fallback
+}
+
 // ActivityPubRegistry is the global transformation registry for ActivityPub transformations
 var ActivityPubRegistry *common.TransformationRegistry
 
@@ -438,10 +464,7 @@ func NewActorToMastodonTransformer() common.Transformer[*activitypub.Actor, *mod
 	return common.NewBaseTransformer(
 		"actor_to_mastodon",
 		func(ctx context.Context, actor *activitypub.Actor) (*models.Account, error) {
-			baseURL := defaultBaseURL // Default fallback
-			if url, ok := ctx.Value("baseURL").(string); ok {
-				baseURL = url
-			}
+			baseURL := BaseURLFromContext(ctx, defaultBaseURL)
 			return ActivityPubActorToMastodon(actor, baseURL)
 		},
 		nil,
@@ -481,10 +504,7 @@ func NewObjectToMastodonTransformer() common.Transformer[*activitypub.Note, *mod
 				return nil, common.ValidationError{Field: "context", Message: "actor not found in context"}
 			}
 
-			baseURL := defaultBaseURL // Default fallback
-			if url, ok := ctx.Value("baseURL").(string); ok {
-				baseURL = url
-			}
+			baseURL := BaseURLFromContext(ctx, defaultBaseURL)
 
 			return ActivityPubObjectToMastodon(obj, actor, baseURL)
 		},
@@ -521,17 +541,11 @@ func NewActorBatchToMastodonTransformer() common.BatchTransformer[*activitypub.A
 	return common.NewBatchTransformer(
 		"actors_to_mastodon_batch",
 		func(ctx context.Context, actor *activitypub.Actor) (*models.Account, error) {
-			baseURL := defaultBaseURL // Default fallback
-			if url, ok := ctx.Value("baseURL").(string); ok {
-				baseURL = url
-			}
+			baseURL := BaseURLFromContext(ctx, defaultBaseURL)
 			return ActivityPubActorToMastodon(actor, baseURL)
 		},
 		func(ctx context.Context, actors []*activitypub.Actor) ([]*models.Account, error) {
-			baseURL := defaultBaseURL // Default fallback
-			if url, ok := ctx.Value("baseURL").(string); ok {
-				baseURL = url
-			}
+			baseURL := BaseURLFromContext(ctx, defaultBaseURL)
 
 			accounts := make([]*models.Account, 0, len(actors))
 			for _, actor := range actors {
@@ -558,10 +572,7 @@ func NewObjectBatchToMastodonTransformer() common.BatchTransformer[*activitypub.
 				return nil, common.ValidationError{Field: "context", Message: "actor not found in context"}
 			}
 
-			baseURL := defaultBaseURL // Default fallback
-			if url, ok := ctx.Value("baseURL").(string); ok {
-				baseURL = url
-			}
+			baseURL := BaseURLFromContext(ctx, defaultBaseURL)
 
 			return ActivityPubObjectToMastodon(obj, actor, baseURL)
 		},

--- a/tools/dm_conversation_backfill/main.go
+++ b/tools/dm_conversation_backfill/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
 	"sort"
 	"strings"
@@ -13,8 +14,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/deploy/naming"
-	"github.com/equaltoai/lesser/pkg/services/conversations"
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
@@ -668,7 +669,7 @@ func participantsForStatus(status *models.Status) ([]string, bool) {
 	}
 
 	participants := []string{sender}
-	participants = append(participants, mentionRecipients(status, sender)...)
+	participants = append(participants, recipientParticipants(status, sender)...)
 	participants = canonicalizeParticipants(participants)
 	if len(participants) < 2 {
 		return nil, false
@@ -676,14 +677,14 @@ func participantsForStatus(status *models.Status) ([]string, bool) {
 	return participants, true
 }
 
-func mentionRecipients(status *models.Status, sender string) []string {
+func recipientParticipants(status *models.Status, sender string) []string {
 	seen := map[string]struct{}{
 		sender: {},
 	}
 
 	recipients := make([]string, 0)
 	appendRecipient := func(candidate string) {
-		normalized := strings.TrimSpace(strings.TrimPrefix(candidate, "@"))
+		normalized := participantIDForRecipient(status, candidate)
 		if normalized == "" {
 			return
 		}
@@ -694,19 +695,66 @@ func mentionRecipients(status *models.Status, sender string) []string {
 		recipients = append(recipients, normalized)
 	}
 
-	for _, mention := range conversations.ExtractMentionHandles(status.Content) {
-		appendRecipient(mention)
-	}
-
-	if len(recipients) > 0 {
-		return recipients
-	}
-
-	for _, recipientURL := range status.ToRecipients {
-		appendRecipient(extractUsernameFromActorID(recipientURL))
+	for _, recipient := range authoritativeRecipients(status) {
+		appendRecipient(recipient)
 	}
 
 	return recipients
+}
+
+func authoritativeRecipients(status *models.Status) []string {
+	if status == nil {
+		return nil
+	}
+
+	recipients := make([]string, 0, len(status.ToRecipients)+len(status.CcRecipients)+len(status.BtoRecipients)+len(status.BccRecipients))
+	recipients = append(recipients, status.ToRecipients...)
+	recipients = append(recipients, status.CcRecipients...)
+	recipients = append(recipients, status.BtoRecipients...)
+	recipients = append(recipients, status.BccRecipients...)
+	if len(recipients) > 0 || status.Note == nil {
+		return recipients
+	}
+
+	recipients = append(recipients, status.Note.To...)
+	recipients = append(recipients, status.Note.CC...)
+	recipients = append(recipients, status.Note.BTo...)
+	recipients = append(recipients, status.Note.BCC...)
+	return recipients
+}
+
+func participantIDForRecipient(status *models.Status, recipient string) string {
+	recipient = strings.TrimSpace(recipient)
+	if !isSpecificActorRecipient(recipient) {
+		return ""
+	}
+
+	recipientHost := actorHost(recipient)
+	authorID := ""
+	if status != nil {
+		authorID = status.AuthorID
+	}
+	authorHost := actorHost(authorID)
+	if recipientHost != "" {
+		if authorHost == "" || !strings.EqualFold(recipientHost, authorHost) {
+			return recipient
+		}
+	}
+
+	return extractUsernameFromActorID(recipient)
+}
+
+func isSpecificActorRecipient(recipient string) bool {
+	if recipient == "" || strings.EqualFold(recipient, activitypub.PublicAddress) {
+		return false
+	}
+
+	lowerRecipient := strings.ToLower(recipient)
+	if strings.Contains(lowerRecipient, "/followers") || strings.Contains(lowerRecipient, "/following") {
+		return false
+	}
+
+	return true
 }
 
 func canonicalizeParticipants(participants []string) []string {
@@ -780,6 +828,27 @@ func extractUsernameFromActorID(actorID string) string {
 		return ""
 	}
 	return strings.TrimPrefix(last, "@")
+}
+
+func actorHost(actorID string) string {
+	value := strings.TrimSpace(actorID)
+	if value == "" {
+		return ""
+	}
+	if strings.Contains(value, "://") {
+		parsed, err := url.Parse(value)
+		if err != nil {
+			return ""
+		}
+		return strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+	}
+
+	handle := strings.TrimPrefix(value, "@")
+	if parts := strings.SplitN(handle, "@", 2); len(parts) == 2 {
+		return strings.ToLower(strings.TrimSpace(parts[1]))
+	}
+
+	return ""
 }
 
 func timePtr(ts time.Time) *time.Time {

--- a/tools/dm_conversation_backfill/main_test.go
+++ b/tools/dm_conversation_backfill/main_test.go
@@ -9,35 +9,66 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParticipantsForStatus_PrefersMentionHandlesFromContent(t *testing.T) {
+func TestParticipantsForStatus_UsesRecipientFieldsAndIgnoresContentMentions(t *testing.T) {
 	status := &models.Status{
 		AuthorUsername: "medic",
+		AuthorID:       "https://sim.example.com/users/medic",
 		Content:        "hello @arch and @pilot, looping back to @arch",
-		ToRecipients:   []string{"https://sim.example.com/users/ignored"},
+		ToRecipients:   []string{"https://sim.example.com/users/arch"},
+		CcRecipients:   []string{"https://sim.example.com/users/scout"},
 	}
 
 	participants, ok := participantsForStatus(status)
 	require.True(t, ok)
-	require.Equal(t, []string{"arch", "medic", "pilot"}, participants)
+	require.Equal(t, []string{"arch", "medic", "scout"}, participants)
 }
 
-func TestParticipantsForStatus_FallsBackToAudienceWhenContentHasNoMention(t *testing.T) {
+func TestParticipantsForStatus_PreservesRemoteRecipientActorIDs(t *testing.T) {
 	status := &models.Status{
 		AuthorUsername: "medic",
+		AuthorID:       "https://sim.example.com/users/medic",
 		ToRecipients: []string{
-			"https://sim.example.com/users/arch",
+			"https://remote.example/users/arch",
 		},
 	}
 
 	participants, ok := participantsForStatus(status)
 	require.True(t, ok)
-	require.Equal(t, []string{"arch", "medic"}, participants)
+	require.Equal(t, []string{"https://remote.example/users/arch", "medic"}, participants)
+}
+
+func TestParticipantsForStatus_FallsBackToNoteAudience(t *testing.T) {
+	status := &models.Status{
+		AuthorUsername: "medic",
+		AuthorID:       "https://sim.example.com/users/medic",
+		Note: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				To:  []string{"https://sim.example.com/users/arch"},
+				BCC: []string{"https://sim.example.com/users/scout"},
+			},
+		},
+	}
+
+	participants, ok := participantsForStatus(status)
+	require.True(t, ok)
+	require.Equal(t, []string{"arch", "medic", "scout"}, participants)
 }
 
 func TestParticipantsForStatus_RejectsMissingRecipient(t *testing.T) {
 	status := &models.Status{
 		AuthorUsername: "medic",
 		Content:        "hello there",
+	}
+
+	participants, ok := participantsForStatus(status)
+	require.False(t, ok)
+	require.Nil(t, participants)
+}
+
+func TestParticipantsForStatus_RejectsContentOnlyMentions(t *testing.T) {
+	status := &models.Status{
+		AuthorUsername: "medic",
+		Content:        "hello @arch",
 	}
 
 	participants, ok := participantsForStatus(status)

--- a/tools/openapi/schema_overrides.go
+++ b/tools/openapi/schema_overrides.go
@@ -40,7 +40,7 @@ func overrideCreateStatusRequest(schemas map[string]any) {
 	}
 
 	visibility["enum"] = []string{"public", "unlisted", "private", "direct"}
-	visibility["description"] = "Status visibility. `direct` messages must mention exactly one local or remote recipient using an @mention in the status content; group direct messages are not supported in v1."
+	visibility["description"] = "Status visibility. `direct` creates are 1:1 only: the content must contain exactly one resolvable local or remote @mention, and Lesser serializes that resolved actor into the ActivityPub addressing fields. Stored DM visibility and repair tooling use the addressing fields as the source of truth; content mentions alone do not authorize or backfill participants."
 }
 
 func overrideOAuthClientSchemas(schemas map[string]any) {


### PR DESCRIPTION
## Milestone
Codex Security M11 — operational availability, tooling, and contracts (#884)

## Classification
security / federation-trust / contract-stability / schema / operational-reliability / tooling / docs

## Surfaces affected
- Push notification VAPID key generation and push-delivery JWT signing compatibility
- Federation edge queries and federation timeseries aggregation
- DynamoDB stream router failure/retry handling
- API Lift base URL propagation into ActivityPub transformations
- Cost tracking date-range queries
- TableTheory/DynamORM Lambda timeout safety buffer construction
- DM conversation backfill tooling participant derivation
- Security/operator docs and generated contract alignment

## Specialist walks referenced
- Federation trust: M11 only preserves or restores delivery/federation aggregation behavior; no HTTP Signature bypass or actor key-shape relaxation.
- Contract / API: base URL propagation and documentation updates are compatibility-preserving; generated OpenAPI/GraphQL contracts ride with the doc task.
- Schema: storage work preserves PK/SK/GSI patterns and TableTheory tags; query bounds and timeout-client construction only.
- Framework: TableTheory v1.8.0 addresses the Lambda timeout-buffer gap with `LambdaDB.WithLambdaTimeoutConfig`; lesser now keeps a configured `*tabletheory.LambdaDB` for both pre-registration and per-invocation `WithLambdaTimeout(ctx)`. AppTheory is bumped to v1.3.0 in both the root module and CDK module; no local framework patch.

## Consumer impact
- Operators: improved push, aggregation, stream retry, cost-window correctness, and docs clarity.
- Mastodon clients: no intended breaking REST/streaming shape changes.
- Remote ActivityPub peers: no actor-object or signature semantics changes; aggregation correctness only.
- Sibling repos: no release artifact or JSON-LD namespace contract changes expected.

## Tasks
- [x] #885 fix(push): align vapid private key format
- [x] #886 fix(federation): restore edge and timeseries aggregation
- [x] #887 fix(streams): retry failed routed records
- [x] #888 fix(api): propagate base url consistently
- [x] #889 fix(costs): respect date range end
- [x] #890 fix(storage): preserve lambda timeout buffer
- [x] #891 fix(tools): avoid inferred dm backfill participants
- [x] #892 docs(security): document hardened auth and visibility semantics

## Validation
- [x] Baseline on synced `main`: `gofmt -l . && go test ./... && go vet ./...`
- [x] #885 targeted: `go test ./cmd/api/handlers ./cmd/push-delivery`
- [x] #885 full: `gofmt -l . && go test ./... && go vet ./...`
- [x] #886 targeted: `go test ./pkg/storage/models ./pkg/storage/repositories ./cmd/federation-timeseries`
- [x] #886 full: `gofmt -l . && go test ./... && go vet ./...`
- [x] #887 targeted: `go test ./cmd/stream-router`
- [x] #887 full: `gofmt -l . && go test ./... && go vet ./...`
- [x] #888 targeted: `go test ./pkg/transformations ./cmd/api/handlers`
- [x] #888 full: `gofmt -l . && go test ./... && go vet ./...`
- [x] #889 targeted: `go test ./pkg/storage/repositories`
- [x] #889 full: `gofmt -l . && go test ./... && go vet ./...`
- [x] #890 targeted: `go test ./pkg/storage/theorydb ./cmd/websocket-cost-aggregator`
- [x] #890 full: `gofmt -l . && go test ./... && go vet ./...`
- [x] #891 targeted: `go test ./tools/dm_conversation_backfill`
- [x] #891 full: `gofmt -l . && go test ./... && go vet ./...`
- [x] #892 targeted: `go run ./tools/openapi --check --strict && bash ./scripts/verify_schema.sh && ./lesser verify docs`
- [x] #892 full: `gofmt -l . && go test ./... && go vet ./...`
- [x] Coverage gate remediation: `go test ./pkg/storage/theorydb`
- [x] Coverage gate remediation: `go test ./cmd/lesser -run TestNewBootstrapDBFactoryCreatesConfiguredDB -count=1`
- [x] Final: `go build -o lesser ./cmd/lesser`
- [x] Final: `./lesser build lambdas`
- [x] Final: `./lesser verify ci`

Final local hard-gate coverage from `./lesser verify ci`: overall 87.655%, pkg 90.078%, cmd 90.108%.

Note: baseline `./lesser verify --smoke` was attempted on synced `main` and reached the smoke phase, which requires `--base-url`/`SMOKE_BASE_URL`; no deployed smoke URL is configured in this local session.


## Tier 1 review follow-up
- [x] Addressed blocker: federation timeseries models now use camelCase TableTheory attrs (`followCount`, `createdAt`, etc.) matching `naming:camelCase`.
- [x] Addressed blocker: federation-timeseries UpdateBuilder writes now include explicit `Where("PK", "=", ...)` and `Where("SK", "=", ...)` key conditions.
- [x] Follow-up targeted: `go test ./pkg/storage/models ./cmd/federation-timeseries`
- [x] Follow-up full: `gofmt -l . && go test ./... && go vet ./...`
- [x] Follow-up hard gate: `go build -o lesser ./cmd/lesser && ./lesser build lambdas && ./lesser verify ci`

## CI coverage-margin follow-up
- [x] GitHub verify failure root cause: pkg coverage was 89.994% on CI at head `d42baed3`, below the strict 90.000% package gate.
- [x] Added coverage-only tests for storage model key helpers, API instance/trust fallback helpers, collections helper/middleware branches, and federation-timeseries nil/no-op handling.
- [x] Targeted checks: `go test ./pkg/storage/models`, `go test ./cmd/federation-timeseries -cover`, `go test ./cmd/api/handlers`, `go test ./cmd/collections`.
- [x] Follow-up hard gate: `go build -o lesser ./cmd/lesser && ./lesser build lambdas && ./lesser verify ci`.
- [x] Follow-up hard-gate coverage: overall 87.652%, pkg 90.077%, cmd 90.099%.

## Theory framework version follow-up
- [x] Bumped `github.com/theory-cloud/tabletheory` from v1.7.1 to v1.8.0-rc, then to stable v1.8.0.
- [x] Confirmed TableTheory v1.8.0 preserves the M11 Lambda timeout-buffer fix via `LambdaDB.WithLambdaTimeoutConfig`.
- [x] Removed lesser's split raw-`*LambdaDB` / buffered-`core.DB` workaround: the singleton Lambda client is now a configured `*tabletheory.LambdaDB`, preserving model pre-registration and custom timeout buffers through `WithLambdaTimeout(ctx)`.
- [x] Updated converter registration to depend on the narrow `RegisterTypeConverter` capability so TableTheory's v1.8 LambdaDB API remains registered correctly even though it no longer needs to satisfy `core.ExtendedDB` for timeout configuration.
- [x] Bumped `github.com/theory-cloud/apptheory` from v1.2.0 to v1.3.0 in both `go.mod` and `infra/cdk/go.mod`.
- [x] Targeted checks: `go test ./cmd/api ./cmd/api/handlers ./pkg/apptheory ./pkg/storage/theorydb ./cmd/websocket-cost-aggregator ./cmd/federation-timeseries && (cd infra/cdk && go test ./...)`.
- [x] Follow-up hard gate: `go build -o lesser ./cmd/lesser && ./lesser build lambdas && ./lesser verify ci`.
- [x] Follow-up hard-gate coverage: overall 87.655%, pkg 90.078%, cmd 90.108%.

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
No sibling-repo change is required. The prior TableTheory framework-feedback signal is resolved by v1.8.0 for this PR path; no local framework patch was introduced. AppTheory v1.3.0 was consumed as a normal framework bump in the root and CDK modules.

## Advisor-brief authorization (if applicable)
Not applicable; user requested the Project 24 milestone directly.




