### PR TITLE
feat(migrate): add Codex Security M12 dev repair tooling

### DIFF
--- a/cmd/lesser/main.go
+++ b/cmd/lesser/main.go
@@ -47,6 +47,7 @@ var (
 	runMigrateNumericIDsFn                       = runMigrateNumericIDs
 	runMigrateMCPAuthCutoverFn                   = runMigrateMCPAuthCutover
 	runMigrateRemoteNoteStatusesFn               = runMigrateRemoteNoteStatuses
+	runMigrateFn                                 = runMigrate
 )
 
 func runCLI(args []string, stderr io.Writer) int {
@@ -106,6 +107,7 @@ func commandRunner(cmd string) (func([]string) error, bool) {
 		"auth":                  func(argv []string) error { return runAuthFn(argv) },
 		"api":                   func(argv []string) error { return runAPIFn(argv) },
 		"soul":                  func(argv []string) error { return runSoulFn(argv) },
+		"migrate":               func(argv []string) error { return runMigrateFn(argv) },
 		"migrate-user-keys":     func(argv []string) error { return runMigrateUserKeysFn(argv) },
 		"migrate-conversations": func(argv []string) error { return runMigrateConversationsFn(argv) },
 		"migrate-conversation-metadata": func(argv []string) error {
@@ -177,6 +179,7 @@ func printUsageTo(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  lesser auth login|logout|status|whoami|device [flags...]")
 	_, _ = fmt.Fprintln(w, "  lesser api request --method GET --path /api/v1/accounts/verify_credentials [flags...]")
 	_, _ = fmt.Fprintln(w, "  lesser soul ens set|preview|publish [flags...]")
+	_, _ = fmt.Fprintln(w, "  lesser migrate security-findings [--app <slug>] [--base-domain <domain>] [--stage dev|staging|live] [--aws-profile <profile>] [--table <name>] [--limit <n>] [--operation all|numeric-ids|hashtag-indexes|cms-publication-members] [--dry-run|--apply]")
 	_, _ = fmt.Fprintln(w, "  lesser migrate-user-keys [--app <slug>] [--env dev|staging|live] [--aws-profile <profile>] [--table <name>] [--limit <n>] [--apply]")
 	_, _ = fmt.Fprintln(w, "  lesser migrate-conversations [--app <slug>] [--env dev|staging|live] [--aws-profile <profile>] [--table <name>] [--limit <n>] [--apply]")
 	_, _ = fmt.Fprintln(w, "  lesser migrate-conversation-metadata [--app <slug>] [--env dev|staging|live] [--aws-profile <profile>] [--table <name>] [--limit <n>] [--apply]")

--- a/cmd/lesser/migrate_security_findings.go
+++ b/cmd/lesser/migrate_security_findings.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+)
+
+const securityFindingsMigrationName = "security-findings"
+
+type securityFindingsMigrationClient interface {
+	userKeyMigrationClient
+	UpdateItem(context.Context, *dynamodb.UpdateItemInput, ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error)
+}
+
+type securityFindingsMigrationOptions struct {
+	App        string
+	BaseDomain string
+	Stage      string
+	AWSProfile string
+	TableName  string
+	Limit      int
+	Apply      bool
+	DryRunFlag bool
+	AllowLive  bool
+	Only       string
+}
+
+type securityFindingsMigrationContext struct {
+	AWSConfig       aws.Config
+	Client          securityFindingsMigrationClient
+	TableName       string
+	ResolvedProfile string
+	AccountID       string
+	Options         securityFindingsMigrationOptions
+}
+
+type securityFindingsMigrationSummary struct {
+	OperationSummaries []securityFindingsOperationSummary
+}
+
+type securityFindingsOperationSummary struct {
+	Name          string
+	Scanned       int
+	Candidates    int
+	PlannedWrites int
+	AppliedWrites int
+	Skipped       int
+	Samples       []string
+}
+
+type securityFindingsMigrationOperation struct {
+	Name    string
+	Execute func(context.Context, securityFindingsMigrationClient, string, bool, int) (securityFindingsOperationSummary, error)
+}
+
+var newSecurityFindingsMigrationClientFn = func(cfg aws.Config) securityFindingsMigrationClient {
+	return dynamodb.NewFromConfig(cfg)
+}
+
+var runMigrateSecurityFindingsFn = runMigrateSecurityFindings
+
+var securityFindingsMigrationOperations = []securityFindingsMigrationOperation{}
+
+func runMigrate(argv []string) error {
+	if len(argv) == 0 {
+		return fmt.Errorf("usage: lesser migrate security-findings [flags]")
+	}
+
+	switch argv[0] {
+	case securityFindingsMigrationName:
+		return runMigrateSecurityFindingsFn(argv[1:])
+	case helpFlagShort, helpFlagLong, helpCommand:
+		fmt.Fprintln(os.Stderr, "Usage: lesser migrate security-findings [--app <slug>] [--base-domain <domain>] [--stage dev|staging|live] [--aws-profile <profile>] [--table <name>] [--limit <n>] [--operation all|numeric-ids|hashtag-indexes|cms-publication-members] [--apply]")
+		return nil
+	default:
+		return fmt.Errorf("unknown migrate command %q", argv[0])
+	}
+}
+
+func runMigrateSecurityFindings(argv []string) error {
+	options, err := parseSecurityFindingsMigrationOptions(argv)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	migrationCtx, err := resolveSecurityFindingsMigrationContext(ctx, options)
+	if err != nil {
+		return err
+	}
+
+	summary, err := executeSecurityFindingsMigration(ctx, migrationCtx)
+	if err != nil {
+		return err
+	}
+
+	printSecurityFindingsMigrationSummary(migrationCtx, summary)
+	return nil
+}
+
+func parseSecurityFindingsMigrationOptions(argv []string) (securityFindingsMigrationOptions, error) {
+	fs := flag.NewFlagSet("lesser migrate security-findings", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	options := securityFindingsMigrationOptions{Stage: valueDev, Only: "all"}
+	fs.StringVar(&options.App, "app", envOrDefault("LESSER_APP", ""), "app slug (default: lesser)")
+	fs.StringVar(&options.BaseDomain, "base-domain", os.Getenv("LESSER_BASE_DOMAIN"), "base domain for operator confirmation output")
+	fs.StringVar(&options.Stage, "stage", valueDev, "deployment stage (dev|staging|live)")
+	fs.StringVar(&options.Stage, "env", valueDev, "deployment stage alias (dev|staging|live)")
+	fs.StringVar(&options.AWSProfile, "aws-profile", os.Getenv("AWS_PROFILE"), "AWS profile name (optional; sets AWS_PROFILE)")
+	fs.StringVar(&options.TableName, "table", "", "explicit DynamoDB table name override")
+	fs.IntVar(&options.Limit, "limit", 0, "maximum candidates per operation to process (0 = all)")
+	fs.StringVar(&options.Only, "operation", "all", "operation to run: all|numeric-ids|hashtag-indexes|cms-publication-members")
+	fs.BoolVar(&options.Apply, "apply", false, "apply planned security-finding data repairs")
+	fs.BoolVar(&options.DryRunFlag, "dry-run", false, "force dry-run mode; this is the default when --apply is omitted")
+	fs.BoolVar(&options.AllowLive, "allow-live", false, "permit --apply against live stage after explicit operator authorization")
+
+	if err := fs.Parse(argv); err != nil {
+		return securityFindingsMigrationOptions{}, err
+	}
+	if fs.NArg() > 0 {
+		return securityFindingsMigrationOptions{}, fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	if options.Apply && options.DryRunFlag {
+		return securityFindingsMigrationOptions{}, fmt.Errorf("--apply and --dry-run are mutually exclusive")
+	}
+	options.Stage = strings.TrimSpace(options.Stage)
+	if options.Stage == "" {
+		options.Stage = valueDev
+	}
+	if options.Apply && strings.EqualFold(options.Stage, "live") && !options.AllowLive {
+		return securityFindingsMigrationOptions{}, fmt.Errorf("refusing to apply security findings migration to live without --allow-live")
+	}
+	options.Only = strings.ToLower(strings.TrimSpace(options.Only))
+	if options.Only == "" {
+		options.Only = "all"
+	}
+	if !validSecurityFindingsOperationName(options.Only) {
+		return securityFindingsMigrationOptions{}, fmt.Errorf("unknown security findings migration operation %q", options.Only)
+	}
+
+	return options, nil
+}
+
+func validSecurityFindingsOperationName(name string) bool {
+	switch name {
+	case "all", "numeric-ids", "hashtag-indexes", "cms-publication-members":
+		return true
+	default:
+		return false
+	}
+}
+
+func resolveSecurityFindingsMigrationContext(ctx context.Context, options securityFindingsMigrationOptions) (securityFindingsMigrationContext, error) {
+	resolvedTableName, err := resolveUserKeyMigrationTableName(options.App, options.Stage, options.TableName)
+	if err != nil {
+		return securityFindingsMigrationContext{}, err
+	}
+
+	awsCfg, resolvedProfile, err := loadAWSConfigForCLIFn(ctx, options.AWSProfile)
+	if err != nil {
+		return securityFindingsMigrationContext{}, err
+	}
+
+	accountID, err := resolveAWSAccountIDFn(ctx, awsCfg)
+	if err != nil {
+		return securityFindingsMigrationContext{}, err
+	}
+
+	return securityFindingsMigrationContext{
+		AWSConfig:       awsCfg,
+		Client:          newSecurityFindingsMigrationClientFn(awsCfg),
+		TableName:       resolvedTableName,
+		ResolvedProfile: resolvedProfile,
+		AccountID:       accountID,
+		Options:         options,
+	}, nil
+}
+
+func executeSecurityFindingsMigration(ctx context.Context, migrationCtx securityFindingsMigrationContext) (securityFindingsMigrationSummary, error) {
+	if migrationCtx.Client == nil {
+		return securityFindingsMigrationSummary{}, fmt.Errorf("migration client is required")
+	}
+	if strings.TrimSpace(migrationCtx.TableName) == "" {
+		return securityFindingsMigrationSummary{}, fmt.Errorf("table name is required")
+	}
+
+	operations := selectedSecurityFindingsMigrationOperations(migrationCtx.Options.Only)
+	summary := securityFindingsMigrationSummary{OperationSummaries: make([]securityFindingsOperationSummary, 0, len(operations))}
+	for _, operation := range operations {
+		operationSummary, err := operation.Execute(ctx, migrationCtx.Client, migrationCtx.TableName, migrationCtx.Options.Apply, migrationCtx.Options.Limit)
+		if err != nil {
+			return summary, fmt.Errorf("%s: %w", operation.Name, err)
+		}
+		if operationSummary.Name == "" {
+			operationSummary.Name = operation.Name
+		}
+		summary.OperationSummaries = append(summary.OperationSummaries, operationSummary)
+	}
+	return summary, nil
+}
+
+func selectedSecurityFindingsMigrationOperations(only string) []securityFindingsMigrationOperation {
+	if only == "all" {
+		return append([]securityFindingsMigrationOperation(nil), securityFindingsMigrationOperations...)
+	}
+	selected := make([]securityFindingsMigrationOperation, 0, 1)
+	for _, operation := range securityFindingsMigrationOperations {
+		if operation.Name == only {
+			selected = append(selected, operation)
+		}
+	}
+	return selected
+}
+
+func printSecurityFindingsMigrationSummary(migrationCtx securityFindingsMigrationContext, summary securityFindingsMigrationSummary) {
+	mode := selectedMigrationMode(migrationCtx.Options.Apply)
+	fmt.Printf("migrate security-findings %s complete\n", mode)
+	fmt.Printf("app: %s\n", printableMigrationValue(migrationCtx.Options.App, "lesser"))
+	fmt.Printf("base_domain: %s\n", printableMigrationValue(migrationCtx.Options.BaseDomain, "(not provided)"))
+	fmt.Printf("stage: %s\n", printableMigrationValue(migrationCtx.Options.Stage, valueDev))
+	fmt.Printf("table: %s\n", migrationCtx.TableName)
+	if migrationCtx.ResolvedProfile != "" {
+		fmt.Printf("aws_profile: %s\n", migrationCtx.ResolvedProfile)
+	}
+	fmt.Printf("aws_account_id: %s\n", printableMigrationValue(migrationCtx.AccountID, "(unknown)"))
+	fmt.Printf("aws_region: %s\n", printableMigrationValue(migrationCtx.AWSConfig.Region, "(unknown)"))
+	fmt.Printf("operation_filter: %s\n", migrationCtx.Options.Only)
+
+	totals := totalSecurityFindingsOperationSummary(summary.OperationSummaries)
+	fmt.Printf("operations: %d\n", len(summary.OperationSummaries))
+	fmt.Printf("scanned_items: %d\n", totals.Scanned)
+	fmt.Printf("candidates: %d\n", totals.Candidates)
+	fmt.Printf("planned_writes: %d\n", totals.PlannedWrites)
+	fmt.Printf("applied_writes: %d\n", totals.AppliedWrites)
+	fmt.Printf("skipped: %d\n", totals.Skipped)
+
+	for _, operationSummary := range sortedSecurityFindingsOperationSummaries(summary.OperationSummaries) {
+		fmt.Printf("operation.%s.scanned: %d\n", operationSummary.Name, operationSummary.Scanned)
+		fmt.Printf("operation.%s.candidates: %d\n", operationSummary.Name, operationSummary.Candidates)
+		fmt.Printf("operation.%s.planned_writes: %d\n", operationSummary.Name, operationSummary.PlannedWrites)
+		fmt.Printf("operation.%s.applied_writes: %d\n", operationSummary.Name, operationSummary.AppliedWrites)
+		fmt.Printf("operation.%s.skipped: %d\n", operationSummary.Name, operationSummary.Skipped)
+		printMigrationSamples("operation."+operationSummary.Name+".samples", operationSummary.Samples)
+	}
+
+	if !migrationCtx.Options.Apply {
+		fmt.Println("no writes performed; re-run with --apply only after reviewing this dry-run output for the intended dev instance")
+	}
+}
+
+func printableMigrationValue(value string, fallback string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return fallback
+	}
+	return trimmed
+}
+
+func totalSecurityFindingsOperationSummary(summaries []securityFindingsOperationSummary) securityFindingsOperationSummary {
+	total := securityFindingsOperationSummary{Name: "total"}
+	for _, summary := range summaries {
+		total.Scanned += summary.Scanned
+		total.Candidates += summary.Candidates
+		total.PlannedWrites += summary.PlannedWrites
+		total.AppliedWrites += summary.AppliedWrites
+		total.Skipped += summary.Skipped
+	}
+	return total
+}
+
+func sortedSecurityFindingsOperationSummaries(summaries []securityFindingsOperationSummary) []securityFindingsOperationSummary {
+	sorted := append([]securityFindingsOperationSummary(nil), summaries...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+	return sorted
+}

--- a/cmd/lesser/migrate_security_findings.go
+++ b/cmd/lesser/migrate_security_findings.go
@@ -66,7 +66,9 @@ var newSecurityFindingsMigrationClientFn = func(cfg aws.Config) securityFindings
 
 var runMigrateSecurityFindingsFn = runMigrateSecurityFindings
 
-var securityFindingsMigrationOperations = []securityFindingsMigrationOperation{}
+var securityFindingsMigrationOperations = []securityFindingsMigrationOperation{
+	{Name: "numeric-ids", Execute: executeSecurityFindingsNumericIDBackfill},
+}
 
 func runMigrate(argv []string) error {
 	if len(argv) == 0 {

--- a/cmd/lesser/migrate_security_findings.go
+++ b/cmd/lesser/migrate_security_findings.go
@@ -68,6 +68,7 @@ var runMigrateSecurityFindingsFn = runMigrateSecurityFindings
 
 var securityFindingsMigrationOperations = []securityFindingsMigrationOperation{
 	{Name: "numeric-ids", Execute: executeSecurityFindingsNumericIDBackfill},
+	{Name: "hashtag-indexes", Execute: executeSecurityFindingsHashtagIndexCleanup},
 }
 
 func runMigrate(argv []string) error {

--- a/cmd/lesser/migrate_security_findings.go
+++ b/cmd/lesser/migrate_security_findings.go
@@ -81,7 +81,7 @@ func runMigrate(argv []string) error {
 	case securityFindingsMigrationName:
 		return runMigrateSecurityFindingsFn(argv[1:])
 	case helpFlagShort, helpFlagLong, helpCommand:
-		fmt.Fprintln(os.Stderr, "Usage: lesser migrate security-findings [--app <slug>] [--base-domain <domain>] [--stage dev|staging|live] [--aws-profile <profile>] [--table <name>] [--limit <n>] [--operation all|numeric-ids|hashtag-indexes|cms-publication-members] [--apply]")
+		fmt.Fprintln(os.Stderr, "Usage: lesser migrate security-findings [--app <slug>] [--base-domain <domain>] [--stage dev|staging|live] [--aws-profile <profile>] [--table <name>] [--limit <n>] [--operation all|numeric-ids|hashtag-indexes|cms-publication-members] [--dry-run|--apply]")
 		return nil
 	default:
 		return fmt.Errorf("unknown migrate command %q", argv[0])
@@ -113,7 +113,7 @@ func parseSecurityFindingsMigrationOptions(argv []string) (securityFindingsMigra
 	fs := flag.NewFlagSet("lesser migrate security-findings", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 
-	options := securityFindingsMigrationOptions{Stage: valueDev, Only: "all"}
+	options := securityFindingsMigrationOptions{Stage: valueDev, Only: valueAll}
 	fs.StringVar(&options.App, "app", envOrDefault("LESSER_APP", ""), "app slug (default: lesser)")
 	fs.StringVar(&options.BaseDomain, "base-domain", os.Getenv("LESSER_BASE_DOMAIN"), "base domain for operator confirmation output")
 	fs.StringVar(&options.Stage, "stage", valueDev, "deployment stage (dev|staging|live)")
@@ -144,7 +144,7 @@ func parseSecurityFindingsMigrationOptions(argv []string) (securityFindingsMigra
 	}
 	options.Only = strings.ToLower(strings.TrimSpace(options.Only))
 	if options.Only == "" {
-		options.Only = "all"
+		options.Only = valueAll
 	}
 	if !validSecurityFindingsOperationName(options.Only) {
 		return securityFindingsMigrationOptions{}, fmt.Errorf("unknown security findings migration operation %q", options.Only)
@@ -155,7 +155,7 @@ func parseSecurityFindingsMigrationOptions(argv []string) (securityFindingsMigra
 
 func validSecurityFindingsOperationName(name string) bool {
 	switch name {
-	case "all", "numeric-ids", "hashtag-indexes", "cms-publication-members":
+	case valueAll, "numeric-ids", "hashtag-indexes", "cms-publication-members":
 		return true
 	default:
 		return false
@@ -212,7 +212,7 @@ func executeSecurityFindingsMigration(ctx context.Context, migrationCtx security
 }
 
 func selectedSecurityFindingsMigrationOperations(only string) []securityFindingsMigrationOperation {
-	if only == "all" {
+	if only == valueAll {
 		return append([]securityFindingsMigrationOperation(nil), securityFindingsMigrationOperations...)
 	}
 	selected := make([]securityFindingsMigrationOperation, 0, 1)

--- a/cmd/lesser/migrate_security_findings.go
+++ b/cmd/lesser/migrate_security_findings.go
@@ -69,6 +69,7 @@ var runMigrateSecurityFindingsFn = runMigrateSecurityFindings
 var securityFindingsMigrationOperations = []securityFindingsMigrationOperation{
 	{Name: "numeric-ids", Execute: executeSecurityFindingsNumericIDBackfill},
 	{Name: "hashtag-indexes", Execute: executeSecurityFindingsHashtagIndexCleanup},
+	{Name: "cms-publication-members", Execute: executeSecurityFindingsCMSPublicationMemberRepair},
 }
 
 func runMigrate(argv []string) error {

--- a/cmd/lesser/migrate_security_findings_cms.go
+++ b/cmd/lesser/migrate_security_findings_cms.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+const (
+	securityPublicationPrefix       = "PUBLICATION#"
+	securityPublicationMemberSuffix = "#MEMBER"
+	securityPublicationUserPrefix   = "USER#"
+)
+
+func executeSecurityFindingsCMSPublicationMemberRepair(
+	ctx context.Context,
+	client securityFindingsMigrationClient,
+	tableName string,
+	apply bool,
+	limit int,
+) (securityFindingsOperationSummary, error) {
+	summary := securityFindingsOperationSummary{Name: "cms-publication-members"}
+
+	items, err := scanSecurityFindingsItems(ctx, client, tableName,
+		"begins_with(PK, :pkPrefix) AND begins_with(SK, :skPrefix)",
+		map[string]types.AttributeValue{
+			":pkPrefix": &types.AttributeValueMemberS{Value: securityPublicationPrefix},
+			":skPrefix": &types.AttributeValueMemberS{Value: securityPublicationUserPrefix},
+		},
+	)
+	if err != nil {
+		return summary, fmt.Errorf("scan publication member rows: %w", err)
+	}
+
+	for _, item := range items {
+		summary.Scanned++
+		candidate, sample, ok, skipped := buildCMSPublicationMemberRepair(item)
+		if skipped {
+			summary.Skipped++
+			appendSecurityFindingsSample(&summary, sample)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if securityFindingsCandidateLimitReached(&summary, limit) {
+			break
+		}
+
+		summary.Candidates++
+		summary.PlannedWrites++
+		appendSecurityFindingsSample(&summary, sample)
+		if apply {
+			_, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+				TableName: aws.String(tableName),
+				Key:       migrationDynamoKey(candidate.PK, candidate.SK),
+				UpdateExpression: aws.String(
+					"SET gsi1PK = :gsi1pk, gsi1SK = :gsi1sk, publicationID = :publicationID, userID = :userID",
+				),
+				ConditionExpression: aws.String("attribute_exists(PK) AND attribute_exists(SK)"),
+				ExpressionAttributeValues: map[string]types.AttributeValue{
+					":gsi1pk":        &types.AttributeValueMemberS{Value: candidate.GSI1PK},
+					":gsi1sk":        &types.AttributeValueMemberS{Value: candidate.GSI1SK},
+					":publicationID": &types.AttributeValueMemberS{Value: candidate.PublicationID},
+					":userID":        &types.AttributeValueMemberS{Value: candidate.UserID},
+				},
+			})
+			if err != nil {
+				return summary, fmt.Errorf("repair publication member %s %s: %w", candidate.PK, candidate.SK, err)
+			}
+			summary.AppliedWrites++
+		}
+	}
+
+	return summary, nil
+}
+
+type cmsPublicationMemberRepairCandidate struct {
+	PK            string
+	SK            string
+	PublicationID string
+	UserID        string
+	GSI1PK        string
+	GSI1SK        string
+}
+
+func buildCMSPublicationMemberRepair(item map[string]types.AttributeValue) (cmsPublicationMemberRepairCandidate, string, bool, bool) {
+	pk, sk, ok := migrationItemKey(item)
+	if !ok {
+		return cmsPublicationMemberRepairCandidate{}, "publication member row missing PK/SK", false, true
+	}
+	publicationID, userID, ok := parseCMSPublicationMemberKey(pk, sk)
+	if !ok {
+		return cmsPublicationMemberRepairCandidate{}, fmt.Sprintf("publication member row has unexpected key %s %s", pk, sk), false, true
+	}
+
+	desired := cmsPublicationMemberRepairCandidate{
+		PK:            pk,
+		SK:            sk,
+		PublicationID: publicationID,
+		UserID:        userID,
+		GSI1PK:        fmt.Sprintf("USER#%s#PUBLICATION", userID),
+		GSI1SK:        fmt.Sprintf("PUBLICATION#%s", publicationID),
+	}
+
+	currentPublicationID, _ := attributeString(item["publicationID"])
+	currentUserID, _ := attributeString(item["userID"])
+	currentGSI1PK, _ := attributeString(item["gsi1PK"])
+	currentGSI1SK, _ := attributeString(item["gsi1SK"])
+	if currentPublicationID == desired.PublicationID &&
+		currentUserID == desired.UserID &&
+		currentGSI1PK == desired.GSI1PK &&
+		currentGSI1SK == desired.GSI1SK {
+		return cmsPublicationMemberRepairCandidate{}, "", false, false
+	}
+
+	return desired, fmt.Sprintf("repair %s %s -> %s/%s", pk, sk, desired.GSI1PK, desired.GSI1SK), true, false
+}
+
+func parseCMSPublicationMemberKey(pk string, sk string) (string, string, bool) {
+	if !strings.HasPrefix(pk, securityPublicationPrefix) || !strings.HasSuffix(pk, securityPublicationMemberSuffix) {
+		return "", "", false
+	}
+	publicationID := strings.TrimSuffix(strings.TrimPrefix(pk, securityPublicationPrefix), securityPublicationMemberSuffix)
+	if publicationID == "" || strings.Contains(publicationID, "#") {
+		return "", "", false
+	}
+	if !strings.HasPrefix(sk, securityPublicationUserPrefix) {
+		return "", "", false
+	}
+	userID := strings.TrimPrefix(sk, securityPublicationUserPrefix)
+	if strings.TrimSpace(userID) == "" {
+		return "", "", false
+	}
+	return publicationID, userID, true
+}

--- a/cmd/lesser/migrate_security_findings_cms_test.go
+++ b/cmd/lesser/migrate_security_findings_cms_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteSecurityFindingsCMSPublicationMemberRepair_DryRunPlansOnlyBrokenRows(t *testing.T) {
+	client := &fakeSecurityFindingsMigrationClient{
+		fakeUserKeyMigrationClient: fakeUserKeyMigrationClient{
+			scanOutputs: []*dynamodb.ScanOutput{{Items: []map[string]types.AttributeValue{
+				publicationMemberItem("PUBLICATION#pub1#MEMBER", "USER#alice", "", "", "", ""),
+				publicationMemberItem("PUBLICATION#pub2#MEMBER", "USER#bob", "pub2", "bob", "USER#bob#PUBLICATION", "PUBLICATION#pub2"),
+				publicationMemberItem("PUBLICATION#bad#extra#MEMBER", "USER#carol", "", "", "", ""),
+			}}},
+		},
+	}
+
+	summary, err := executeSecurityFindingsCMSPublicationMemberRepair(context.Background(), client, "theory-dev-main-table", false, 0)
+	require.NoError(t, err)
+	require.Equal(t, "cms-publication-members", summary.Name)
+	require.Equal(t, 3, summary.Scanned)
+	require.Equal(t, 1, summary.Candidates)
+	require.Equal(t, 1, summary.PlannedWrites)
+	require.Equal(t, 0, summary.AppliedWrites)
+	require.Equal(t, 1, summary.Skipped)
+	require.Empty(t, client.updateInputs)
+	require.Contains(t, summary.Samples[0], "repair PUBLICATION#pub1#MEMBER USER#alice")
+	require.Contains(t, summary.Samples[1], "unexpected key")
+}
+
+func TestExecuteSecurityFindingsCMSPublicationMemberRepair_ApplyUpdatesGSIKeys(t *testing.T) {
+	client := &fakeSecurityFindingsMigrationClient{
+		fakeUserKeyMigrationClient: fakeUserKeyMigrationClient{
+			scanOutputs: []*dynamodb.ScanOutput{{Items: []map[string]types.AttributeValue{
+				publicationMemberItem("PUBLICATION#pub1#MEMBER", "USER#alice", "", "", "", ""),
+			}}},
+		},
+	}
+
+	summary, err := executeSecurityFindingsCMSPublicationMemberRepair(context.Background(), client, "theory-dev-main-table", true, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, summary.Candidates)
+	require.Equal(t, 1, summary.AppliedWrites)
+	require.Len(t, client.updateInputs, 1)
+	update := client.updateInputs[0]
+	require.Equal(t, "PUBLICATION#pub1#MEMBER", strAttr(t, update.Key["PK"]))
+	require.Equal(t, "USER#alice", strAttr(t, update.Key["SK"]))
+	require.Contains(t, *update.UpdateExpression, "gsi1PK")
+	require.Equal(t, "USER#alice#PUBLICATION", strAttr(t, update.ExpressionAttributeValues[":gsi1pk"]))
+	require.Equal(t, "PUBLICATION#pub1", strAttr(t, update.ExpressionAttributeValues[":gsi1sk"]))
+	require.Equal(t, "pub1", strAttr(t, update.ExpressionAttributeValues[":publicationID"]))
+	require.Equal(t, "alice", strAttr(t, update.ExpressionAttributeValues[":userID"]))
+}
+
+func TestParseCMSPublicationMemberKey(t *testing.T) {
+	pub, user, ok := parseCMSPublicationMemberKey("PUBLICATION#news#MEMBER", "USER#alice")
+	require.True(t, ok)
+	require.Equal(t, "news", pub)
+	require.Equal(t, "alice", user)
+
+	_, _, ok = parseCMSPublicationMemberKey("PUBLICATION#news", "USER#alice")
+	require.False(t, ok)
+	_, _, ok = parseCMSPublicationMemberKey("PUBLICATION#news#extra#MEMBER", "USER#alice")
+	require.False(t, ok)
+	_, _, ok = parseCMSPublicationMemberKey("PUBLICATION#news#MEMBER", "TEAM#alice")
+	require.False(t, ok)
+}
+
+func publicationMemberItem(pk, sk, publicationID, userID, gsi1PK, gsi1SK string) map[string]types.AttributeValue {
+	item := map[string]types.AttributeValue{
+		"PK": sAttr(pk),
+		"SK": sAttr(sk),
+	}
+	if publicationID != "" {
+		item["publicationID"] = sAttr(publicationID)
+	}
+	if userID != "" {
+		item["userID"] = sAttr(userID)
+	}
+	if gsi1PK != "" {
+		item["gsi1PK"] = sAttr(gsi1PK)
+	}
+	if gsi1SK != "" {
+		item["gsi1SK"] = sAttr(gsi1SK)
+	}
+	return item
+}

--- a/cmd/lesser/migrate_security_findings_hashtags.go
+++ b/cmd/lesser/migrate_security_findings_hashtags.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+)
+
+const (
+	securityHashtagGSIPrimaryPrefix  = "HASHTAG#"
+	securityStatusHashtagIndexPrefix = "HASHTAG_INDEX#"
+	securityHashtagTimelinePrefix    = "HASHTAG_TIMELINE#"
+)
+
+func executeSecurityFindingsHashtagIndexCleanup(
+	ctx context.Context,
+	client securityFindingsMigrationClient,
+	tableName string,
+	apply bool,
+	limit int,
+) (securityFindingsOperationSummary, error) {
+	summary := securityFindingsOperationSummary{Name: "hashtag-indexes"}
+
+	statusItems, err := scanSecurityFindingsItems(ctx, client, tableName,
+		"attribute_exists(gsi5PK) AND begins_with(gsi5PK, :prefix)",
+		map[string]types.AttributeValue{":prefix": &types.AttributeValueMemberS{Value: securityHashtagGSIPrimaryPrefix}},
+	)
+	if err != nil {
+		return summary, fmt.Errorf("scan status hashtag GSI rows: %w", err)
+	}
+	if err := planAndApplyPrimaryHashtagGSIRepairs(ctx, client, tableName, statusItems, apply, limit, &summary); err != nil {
+		return summary, err
+	}
+
+	legacyIndexItems, err := scanSecurityFindingsItems(ctx, client, tableName,
+		"begins_with(PK, :prefix)",
+		map[string]types.AttributeValue{":prefix": &types.AttributeValueMemberS{Value: securityStatusHashtagIndexPrefix}},
+	)
+	if err != nil {
+		return summary, fmt.Errorf("scan legacy hashtag index rows: %w", err)
+	}
+	if err := planAndApplyHashtagIndexDeletes(ctx, client, tableName, legacyIndexItems, apply, limit, &summary); err != nil {
+		return summary, err
+	}
+
+	timelineIndexItems, err := scanSecurityFindingsItems(ctx, client, tableName,
+		"begins_with(PK, :prefix)",
+		map[string]types.AttributeValue{":prefix": &types.AttributeValueMemberS{Value: securityHashtagTimelinePrefix}},
+	)
+	if err != nil {
+		return summary, fmt.Errorf("scan hashtag timeline index rows: %w", err)
+	}
+	if err := planAndApplyHashtagIndexDeletes(ctx, client, tableName, timelineIndexItems, apply, limit, &summary); err != nil {
+		return summary, err
+	}
+
+	return summary, nil
+}
+
+func scanSecurityFindingsItems(
+	ctx context.Context,
+	client securityFindingsMigrationClient,
+	tableName string,
+	filterExpression string,
+	values map[string]types.AttributeValue,
+) ([]map[string]types.AttributeValue, error) {
+	input := &dynamodb.ScanInput{
+		TableName:                 aws.String(tableName),
+		FilterExpression:          aws.String(filterExpression),
+		ExpressionAttributeValues: values,
+	}
+
+	var items []map[string]types.AttributeValue
+	for {
+		out, err := client.Scan(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, out.Items...)
+		if len(out.LastEvaluatedKey) == 0 {
+			return items, nil
+		}
+		input.ExclusiveStartKey = out.LastEvaluatedKey
+	}
+}
+
+func planAndApplyPrimaryHashtagGSIRepairs(
+	ctx context.Context,
+	client securityFindingsMigrationClient,
+	tableName string,
+	items []map[string]types.AttributeValue,
+	apply bool,
+	limit int,
+	summary *securityFindingsOperationSummary,
+) error {
+	for _, item := range items {
+		summary.Scanned++
+		if isPublicVisibilityAttribute(item["visibility"]) {
+			continue
+		}
+		if securityFindingsCandidateLimitReached(summary, limit) {
+			return nil
+		}
+		pk, sk, ok := migrationItemKey(item)
+		if !ok {
+			summary.Skipped++
+			appendSecurityFindingsSample(summary, "primary hashtag row missing PK/SK")
+			continue
+		}
+
+		summary.Candidates++
+		summary.PlannedWrites++
+		appendSecurityFindingsSample(summary, fmt.Sprintf("remove gsi5 from %s %s", pk, sk))
+		if apply {
+			_, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+				TableName:        aws.String(tableName),
+				Key:              migrationDynamoKey(pk, sk),
+				UpdateExpression: aws.String("REMOVE gsi5PK, gsi5SK"),
+				ConditionExpression: aws.String(
+					"attribute_exists(PK) AND attribute_exists(SK)",
+				),
+			})
+			if err != nil {
+				return fmt.Errorf("remove hashtag GSI keys from %s %s: %w", pk, sk, err)
+			}
+			summary.AppliedWrites++
+		}
+	}
+	return nil
+}
+
+func planAndApplyHashtagIndexDeletes(
+	ctx context.Context,
+	client securityFindingsMigrationClient,
+	tableName string,
+	items []map[string]types.AttributeValue,
+	apply bool,
+	limit int,
+	summary *securityFindingsOperationSummary,
+) error {
+	for _, item := range items {
+		summary.Scanned++
+		if isPublicVisibilityAttribute(item["visibility"]) {
+			continue
+		}
+		if securityFindingsCandidateLimitReached(summary, limit) {
+			return nil
+		}
+		pk, sk, ok := migrationItemKey(item)
+		if !ok {
+			summary.Skipped++
+			appendSecurityFindingsSample(summary, "hashtag index row missing PK/SK")
+			continue
+		}
+
+		summary.Candidates++
+		summary.PlannedWrites++
+		appendSecurityFindingsSample(summary, fmt.Sprintf("delete stale hashtag index %s %s", pk, sk))
+		if apply {
+			if _, err := client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+				TableName: aws.String(tableName),
+				Key:       migrationDynamoKey(pk, sk),
+			}); err != nil {
+				return fmt.Errorf("delete stale hashtag index %s %s: %w", pk, sk, err)
+			}
+			summary.AppliedWrites++
+		}
+	}
+	return nil
+}
+
+func isPublicVisibilityAttribute(value types.AttributeValue) bool {
+	visibility, ok := attributeString(value)
+	return ok && strings.EqualFold(strings.TrimSpace(visibility), models.VisibilityPublic)
+}
+
+func securityFindingsCandidateLimitReached(summary *securityFindingsOperationSummary, limit int) bool {
+	return limit > 0 && summary != nil && summary.Candidates >= limit
+}
+
+func migrationItemKey(item map[string]types.AttributeValue) (string, string, bool) {
+	pk, pkOK := attributeString(item["PK"])
+	sk, skOK := attributeString(item["SK"])
+	return pk, sk, pkOK && skOK && strings.TrimSpace(pk) != "" && strings.TrimSpace(sk) != ""
+}
+
+func migrationDynamoKey(pk string, sk string) map[string]types.AttributeValue {
+	return map[string]types.AttributeValue{
+		"PK": &types.AttributeValueMemberS{Value: pk},
+		"SK": &types.AttributeValueMemberS{Value: sk},
+	}
+}

--- a/cmd/lesser/migrate_security_findings_hashtags_test.go
+++ b/cmd/lesser/migrate_security_findings_hashtags_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteSecurityFindingsHashtagIndexCleanup_DryRunPlansNonPublicRepairs(t *testing.T) {
+	client := &fakeSecurityFindingsMigrationClient{
+		fakeUserKeyMigrationClient: fakeUserKeyMigrationClient{
+			scanOutputs: []*dynamodb.ScanOutput{
+				{Items: []map[string]types.AttributeValue{
+					statusHashtagPrimaryItem("status#public", "status#public", "public"),
+					statusHashtagPrimaryItem("status#private", "status#private", "private"),
+				}},
+				{Items: []map[string]types.AttributeValue{
+					hashtagIndexItem("HASHTAG_INDEX#go", "2026#public", "public"),
+					hashtagIndexItem("HASHTAG_INDEX#go", "2026#direct", "direct"),
+				}},
+				{Items: []map[string]types.AttributeValue{
+					hashtagIndexItem("HASHTAG_TIMELINE#go", "STATUS#1#public", "public"),
+					hashtagIndexItem("HASHTAG_TIMELINE#go", "STATUS#2#private", "private"),
+				}},
+			},
+		},
+	}
+
+	summary, err := executeSecurityFindingsHashtagIndexCleanup(context.Background(), client, "theory-dev-main-table", false, 0)
+	require.NoError(t, err)
+	require.Equal(t, "hashtag-indexes", summary.Name)
+	require.Equal(t, 6, summary.Scanned)
+	require.Equal(t, 3, summary.Candidates)
+	require.Equal(t, 3, summary.PlannedWrites)
+	require.Equal(t, 0, summary.AppliedWrites)
+	require.Empty(t, client.updateInputs)
+	require.Empty(t, client.deleteInputs)
+	require.Len(t, summary.Samples, 3)
+	require.Contains(t, summary.Samples[0], "remove gsi5")
+	require.Contains(t, summary.Samples[1], "delete stale hashtag index")
+}
+
+func TestExecuteSecurityFindingsHashtagIndexCleanup_ApplyUpdatesAndDeletes(t *testing.T) {
+	client := &fakeSecurityFindingsMigrationClient{
+		fakeUserKeyMigrationClient: fakeUserKeyMigrationClient{
+			scanOutputs: []*dynamodb.ScanOutput{
+				{Items: []map[string]types.AttributeValue{
+					statusHashtagPrimaryItem("status#private", "status#private", "private"),
+				}},
+				{Items: []map[string]types.AttributeValue{
+					hashtagIndexItem("HASHTAG_INDEX#go", "2026#private", "private"),
+				}},
+				{Items: []map[string]types.AttributeValue{
+					hashtagIndexItem("HASHTAG_TIMELINE#go", "STATUS#2#direct", "direct"),
+				}},
+			},
+		},
+	}
+
+	summary, err := executeSecurityFindingsHashtagIndexCleanup(context.Background(), client, "theory-dev-main-table", true, 0)
+	require.NoError(t, err)
+	require.Equal(t, 3, summary.Candidates)
+	require.Equal(t, 3, summary.AppliedWrites)
+	require.Len(t, client.updateInputs, 1)
+	require.Equal(t, "REMOVE gsi5PK, gsi5SK", *client.updateInputs[0].UpdateExpression)
+	require.Equal(t, "status#private", strAttr(t, client.updateInputs[0].Key["PK"]))
+	require.Len(t, client.deleteInputs, 2)
+	require.Equal(t, "HASHTAG_INDEX#go", strAttr(t, client.deleteInputs[0].Key["PK"]))
+	require.Equal(t, "HASHTAG_TIMELINE#go", strAttr(t, client.deleteInputs[1].Key["PK"]))
+}
+
+func TestExecuteSecurityFindingsHashtagIndexCleanup_RespectsLimitAcrossActions(t *testing.T) {
+	client := &fakeSecurityFindingsMigrationClient{
+		fakeUserKeyMigrationClient: fakeUserKeyMigrationClient{
+			scanOutputs: []*dynamodb.ScanOutput{
+				{Items: []map[string]types.AttributeValue{
+					statusHashtagPrimaryItem("status#one", "status#one", "private"),
+					statusHashtagPrimaryItem("status#two", "status#two", "private"),
+				}},
+				{Items: []map[string]types.AttributeValue{
+					hashtagIndexItem("HASHTAG_INDEX#go", "2026#private", "private"),
+				}},
+				{Items: nil},
+			},
+		},
+	}
+
+	summary, err := executeSecurityFindingsHashtagIndexCleanup(context.Background(), client, "theory-dev-main-table", true, 1)
+	require.NoError(t, err)
+	require.Equal(t, 1, summary.Candidates)
+	require.Equal(t, 1, summary.AppliedWrites)
+	require.Len(t, client.updateInputs, 1)
+	require.Empty(t, client.deleteInputs)
+}
+
+func statusHashtagPrimaryItem(pk, sk, visibility string) map[string]types.AttributeValue {
+	return map[string]types.AttributeValue{
+		"PK":         sAttr(pk),
+		"SK":         sAttr(sk),
+		"gsi5PK":     sAttr("HASHTAG#go"),
+		"gsi5SK":     sAttr("2026#status"),
+		"visibility": sAttr(visibility),
+	}
+}
+
+func hashtagIndexItem(pk, sk, visibility string) map[string]types.AttributeValue {
+	return map[string]types.AttributeValue{
+		"PK":         sAttr(pk),
+		"SK":         sAttr(sk),
+		"visibility": sAttr(visibility),
+	}
+}

--- a/cmd/lesser/migrate_security_findings_numeric.go
+++ b/cmd/lesser/migrate_security_findings_numeric.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/equaltoai/lesser/pkg/common"
+)
+
+func executeSecurityFindingsNumericIDBackfill(
+	ctx context.Context,
+	client securityFindingsMigrationClient,
+	tableName string,
+	apply bool,
+	limit int,
+) (securityFindingsOperationSummary, error) {
+	summary := securityFindingsOperationSummary{Name: "numeric-ids"}
+
+	actors, err := scanMigrationItems(ctx, client, tableName, actorPartitionPrefix, actorProfileSortKey)
+	if err != nil {
+		return summary, fmt.Errorf("scan actor profiles: %w", err)
+	}
+	mappings, err := scanMigrationItems(ctx, client, tableName, numericMappingPartition, numericMetadataSortKey)
+	if err != nil {
+		return summary, fmt.Errorf("scan numeric ID mappings: %w", err)
+	}
+
+	mappingsByPK := make(map[string]map[string]types.AttributeValue, len(mappings))
+	for _, mapping := range mappings {
+		if pk, ok := attributeString(mapping["PK"]); ok {
+			mappingsByPK[pk] = mapping
+		}
+	}
+
+	for _, actorItem := range actors {
+		summary.Scanned++
+		mappingItem, sample, ok, skipped, err := buildSecurityFindingsNumericIDBackfill(actorItem, mappingsByPK)
+		if err != nil {
+			return summary, err
+		}
+		if skipped {
+			summary.Skipped++
+			appendSecurityFindingsSample(&summary, sample)
+			continue
+		}
+		if !ok {
+			continue
+		}
+
+		summary.Candidates++
+		summary.PlannedWrites++
+		appendSecurityFindingsSample(&summary, sample)
+		if apply {
+			if _, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+				TableName:           aws.String(tableName),
+				Item:                mappingItem,
+				ConditionExpression: aws.String("attribute_not_exists(PK)"),
+			}); err != nil {
+				pk, _ := attributeString(mappingItem["PK"])
+				return summary, fmt.Errorf("put numeric ID mapping %s: %w", pk, err)
+			}
+			summary.AppliedWrites++
+		}
+
+		if limit > 0 && summary.Candidates >= limit {
+			break
+		}
+	}
+
+	return summary, nil
+}
+
+func buildSecurityFindingsNumericIDBackfill(
+	actorItem map[string]types.AttributeValue,
+	mappingsByPK map[string]map[string]types.AttributeValue,
+) (map[string]types.AttributeValue, string, bool, bool, error) {
+	actorPK, ok := attributeString(actorItem["PK"])
+	if !ok || !strings.HasPrefix(actorPK, actorPartitionPrefix) {
+		return nil, "", false, false, nil
+	}
+	actorSK, ok := attributeString(actorItem["SK"])
+	if !ok || actorSK != actorProfileSortKey {
+		return nil, "", false, false, nil
+	}
+
+	canonicalUsername := canonicalMigrationUsername(actorItem, actorPK)
+	if canonicalUsername == "" {
+		return nil, "", false, false, fmt.Errorf("actor profile %q is missing username", actorPK)
+	}
+
+	numericID := common.GenerateNumericID(canonicalUsername)
+	mappingPK := numericMappingPartition + numericID
+	if existing := mappingsByPK[mappingPK]; existing != nil {
+		existingUsername, _ := attributeString(existing["username"])
+		if strings.EqualFold(strings.TrimSpace(existingUsername), canonicalUsername) {
+			return nil, "", false, false, nil
+		}
+		return nil, fmt.Sprintf("%s conflicts with existing username %q for actor %s", mappingPK, existingUsername, canonicalUsername), false, true, nil
+	}
+
+	actorID := desiredActorIDForMapping(actorItem, nil, nil, canonicalUsername)
+	mapping := buildNumericIDMappingItem(
+		numericID,
+		canonicalUsername,
+		actorID,
+		&types.AttributeValueMemberS{Value: time.Now().UTC().Format(time.RFC3339Nano)},
+	)
+	return mapping, fmt.Sprintf("%s -> %s", mappingPK, canonicalUsername), true, false, nil
+}
+
+func appendSecurityFindingsSample(summary *securityFindingsOperationSummary, sample string) {
+	if summary == nil || strings.TrimSpace(sample) == "" || len(summary.Samples) >= 10 {
+		return
+	}
+	summary.Samples = append(summary.Samples, sample)
+}

--- a/cmd/lesser/migrate_security_findings_numeric_test.go
+++ b/cmd/lesser/migrate_security_findings_numeric_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteSecurityFindingsNumericIDBackfill_DryRunReportsMissingOnly(t *testing.T) {
+	mappedID := common.GenerateNumericID("mapped")
+	missingID := common.GenerateNumericID("missing")
+	conflictID := common.GenerateNumericID("conflict")
+	client := &fakeSecurityFindingsMigrationClient{
+		fakeUserKeyMigrationClient: fakeUserKeyMigrationClient{
+			scanOutputs: []*dynamodb.ScanOutput{
+				{Items: []map[string]types.AttributeValue{
+					legacyActorMigrationItem("mapped", mappedID, "mapped"),
+					legacyActorMigrationItem("missing", missingID, "missing"),
+					legacyActorMigrationItem("conflict", conflictID, "conflict"),
+				}},
+				{Items: []map[string]types.AttributeValue{
+					legacyNumericMappingItem(mappedID, "mapped", "https://example.com/users/mapped"),
+					legacyNumericMappingItem(conflictID, "other", "https://example.com/users/other"),
+				}},
+			},
+		},
+	}
+
+	summary, err := executeSecurityFindingsNumericIDBackfill(context.Background(), client, "simulacrum-dev-main-table", false, 0)
+	require.NoError(t, err)
+	require.Equal(t, "numeric-ids", summary.Name)
+	require.Equal(t, 3, summary.Scanned)
+	require.Equal(t, 1, summary.Candidates)
+	require.Equal(t, 1, summary.PlannedWrites)
+	require.Equal(t, 0, summary.AppliedWrites)
+	require.Equal(t, 1, summary.Skipped)
+	require.Empty(t, client.putInputs)
+	require.Contains(t, summary.Samples[0], "NUMERIC_ID#"+missingID)
+	require.Contains(t, summary.Samples[1], "conflicts with existing username")
+}
+
+func TestExecuteSecurityFindingsNumericIDBackfill_ApplyCreatesAbsentMappingConditionally(t *testing.T) {
+	numericID := common.GenerateNumericID("agent-0")
+	client := &fakeSecurityFindingsMigrationClient{
+		fakeUserKeyMigrationClient: fakeUserKeyMigrationClient{
+			scanOutputs: []*dynamodb.ScanOutput{
+				{Items: []map[string]types.AttributeValue{
+					legacyActorMigrationItem("agent-0", numericID, "agent-0"),
+				}},
+				{Items: nil},
+			},
+		},
+	}
+
+	summary, err := executeSecurityFindingsNumericIDBackfill(context.Background(), client, "theory-dev-main-table", true, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, summary.Candidates)
+	require.Equal(t, 1, summary.PlannedWrites)
+	require.Equal(t, 1, summary.AppliedWrites)
+	require.Len(t, client.putInputs, 1)
+	put := client.putInputs[0]
+	require.Equal(t, "attribute_not_exists(PK)", *put.ConditionExpression)
+	require.Equal(t, "NUMERIC_ID#"+numericID, strAttr(t, put.Item["PK"]))
+	require.Equal(t, numericMetadataSortKey, strAttr(t, put.Item["SK"]))
+	require.Equal(t, "agent-0", strAttr(t, put.Item["username"]))
+	require.Equal(t, numericMappingTypeName, strAttr(t, put.Item["type"]))
+}
+
+func TestExecuteSecurityFindingsNumericIDBackfill_RespectsCandidateLimit(t *testing.T) {
+	client := &fakeSecurityFindingsMigrationClient{
+		fakeUserKeyMigrationClient: fakeUserKeyMigrationClient{
+			scanOutputs: []*dynamodb.ScanOutput{
+				{Items: []map[string]types.AttributeValue{
+					legacyActorMigrationItem("one", common.GenerateNumericID("one"), "one"),
+					legacyActorMigrationItem("two", common.GenerateNumericID("two"), "two"),
+				}},
+				{Items: nil},
+			},
+		},
+	}
+
+	summary, err := executeSecurityFindingsNumericIDBackfill(context.Background(), client, "theory-dev-main-table", true, 1)
+	require.NoError(t, err)
+	require.Equal(t, 1, summary.Candidates)
+	require.Equal(t, 1, summary.AppliedWrites)
+	require.Len(t, client.putInputs, 1)
+}

--- a/cmd/lesser/migrate_security_findings_test.go
+++ b/cmd/lesser/migrate_security_findings_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeSecurityFindingsMigrationClient struct {
+	fakeUserKeyMigrationClient
+	updateInputs []*dynamodb.UpdateItemInput
+	updateErr    error
+}
+
+func (f *fakeSecurityFindingsMigrationClient) UpdateItem(_ context.Context, input *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	f.updateInputs = append(f.updateInputs, input)
+	if f.updateErr != nil {
+		return nil, f.updateErr
+	}
+	return &dynamodb.UpdateItemOutput{}, nil
+}
+
+func TestRunMigrateSecurityFindings_PrintsDryRunContext(t *testing.T) {
+	previousLoadAWSConfig := loadAWSConfigForCLIFn
+	previousResolveAccountID := resolveAWSAccountIDFn
+	previousClientFactory := newSecurityFindingsMigrationClientFn
+	previousOperations := securityFindingsMigrationOperations
+	t.Cleanup(func() {
+		loadAWSConfigForCLIFn = previousLoadAWSConfig
+		resolveAWSAccountIDFn = previousResolveAccountID
+		newSecurityFindingsMigrationClientFn = previousClientFactory
+		securityFindingsMigrationOperations = previousOperations
+	})
+
+	securityFindingsMigrationOperations = []securityFindingsMigrationOperation{
+		{
+			Name: "numeric-ids",
+			Execute: func(context.Context, securityFindingsMigrationClient, string, bool, int) (securityFindingsOperationSummary, error) {
+				return securityFindingsOperationSummary{Name: "numeric-ids", Scanned: 2, Candidates: 1, PlannedWrites: 1}, nil
+			},
+		},
+	}
+	loadAWSConfigForCLIFn = func(_ context.Context, awsProfile string) (aws.Config, string, error) {
+		require.Equal(t, "Sim", awsProfile)
+		return aws.Config{Region: "us-west-2"}, "Sim", nil
+	}
+	resolveAWSAccountIDFn = func(context.Context, aws.Config) (string, error) {
+		return "123456789012", nil
+	}
+	newSecurityFindingsMigrationClientFn = func(aws.Config) securityFindingsMigrationClient {
+		return &fakeSecurityFindingsMigrationClient{}
+	}
+
+	output := captureStdout(t, func() {
+		require.NoError(t, runMigrateSecurityFindings([]string{
+			"--app", "simulacrum",
+			"--base-domain", "sim.example",
+			"--stage", "dev",
+			"--aws-profile", "Sim",
+			"--operation", "numeric-ids",
+		}))
+	})
+
+	require.Contains(t, output, "migrate security-findings dry-run complete")
+	require.Contains(t, output, "app: simulacrum")
+	require.Contains(t, output, "base_domain: sim.example")
+	require.Contains(t, output, "stage: dev")
+	require.Contains(t, output, "table: simulacrum-dev-main-table")
+	require.Contains(t, output, "aws_profile: Sim")
+	require.Contains(t, output, "aws_account_id: 123456789012")
+	require.Contains(t, output, "aws_region: us-west-2")
+	require.Contains(t, output, "planned_writes: 1")
+	require.Contains(t, output, "no writes performed")
+}
+
+func TestRunMigrateSecurityFindings_RejectsUnsafeFlags(t *testing.T) {
+	_, err := parseSecurityFindingsMigrationOptions([]string{"--apply", "--dry-run"})
+	require.EqualError(t, err, "--apply and --dry-run are mutually exclusive")
+
+	_, err = parseSecurityFindingsMigrationOptions([]string{"--stage", "live", "--apply"})
+	require.EqualError(t, err, "refusing to apply security findings migration to live without --allow-live")
+
+	_, err = parseSecurityFindingsMigrationOptions([]string{"--operation", "unknown"})
+	require.EqualError(t, err, "unknown security findings migration operation \"unknown\"")
+}
+
+func TestRunMigrate_DispatchesSecurityFindings(t *testing.T) {
+	previousRunner := runMigrateSecurityFindingsFn
+	t.Cleanup(func() { runMigrateSecurityFindingsFn = previousRunner })
+
+	var seen []string
+	runMigrateSecurityFindingsFn = func(argv []string) error {
+		seen = append([]string(nil), argv...)
+		return nil
+	}
+
+	require.NoError(t, runMigrate([]string{"security-findings", "--dry-run"}))
+	require.Equal(t, []string{"--dry-run"}, seen)
+}
+
+func TestResolveSecurityFindingsMigrationContext_PropagatesAccountError(t *testing.T) {
+	previousLoadAWSConfig := loadAWSConfigForCLIFn
+	previousResolveAccountID := resolveAWSAccountIDFn
+	t.Cleanup(func() {
+		loadAWSConfigForCLIFn = previousLoadAWSConfig
+		resolveAWSAccountIDFn = previousResolveAccountID
+	})
+
+	loadAWSConfigForCLIFn = func(context.Context, string) (aws.Config, string, error) {
+		return aws.Config{Region: "us-east-1"}, "Theory", nil
+	}
+	resolveAWSAccountIDFn = func(context.Context, aws.Config) (string, error) {
+		return "", errors.New("sts down")
+	}
+
+	_, err := resolveSecurityFindingsMigrationContext(context.Background(), securityFindingsMigrationOptions{App: "theory", Stage: valueDev})
+	require.EqualError(t, err, "sts down")
+}

--- a/tools/audit_gates/baseline.yml
+++ b/tools/audit_gates/baseline.yml
@@ -31,6 +31,7 @@ goDynamoDBQueryScan:
   cmd/lesser/migrate_conversations.go: 1
   cmd/lesser/migrate_mcp_auth_cutover.go: 1
   cmd/lesser/migrate_numeric_ids.go: 1
+  cmd/lesser/migrate_security_findings_hashtags.go: 1
   cmd/lesser/migrate_user_keys.go: 1
   pkg/cost/dynamorm_tracker.go: 1
   pkg/federation/relationship_tracker.go: 4


### PR DESCRIPTION
## Milestone
Codex Security M12 — Dev migration and data repair

Closes #904
Closes #905
Closes #906
Closes #907
Closes #908

## Classification
security / schema-adjacent data repair / operational-reliability / CLI tooling

## Surfaces affected
- `cmd/lesser` migration CLI
- DynamoDB operator-only migration scans and targeted writes
- Audit gate baseline for intentional migration scan usage

## Specialist walks referenced
- Federation trust: none directly; M12 only prepares data repair tooling for later trust/API hardening milestones
- Contract / API: none
- Schema: schema-adjacent data repair only; no PK/SK/TableTheory tag changes, no GSI structure changes
- Framework: idiomatic AWS SDK/CLI usage; no AppTheory/TableTheory patch

## Consumer impact
Operators get a new dry-run-first command:

```bash
./lesser migrate security-findings \
  --app <slug> \
  --base-domain <domain> \
  --stage dev \
  --aws-profile <profile> \
  --dry-run
```

Apply remains explicit:

```bash
./lesser migrate security-findings ... --apply
```

The command prints app, base domain, stage, table, AWS profile, AWS account ID, AWS region, selected operation, scanned counts, candidate counts, planned writes, applied writes, skipped rows, and samples.

## Tasks
- [x] #905 — `feat(migrate): add security findings migration runner`
- [x] #906 — `fix(migrate): backfill local actor numeric id mappings`
- [x] #907 — `fix(migrate): clean stale private hashtag indexes`
- [x] #908 — `fix(migrate): repair cms publication member rows`

## Safety posture
- Dry-run is the default when `--apply` is omitted.
- `--apply` and `--dry-run` are mutually exclusive.
- `--apply --stage live` is refused unless `--allow-live` is explicitly supplied.
- Numeric-ID repair uses conditional put and does not overwrite conflicting mappings.
- Hashtag cleanup removes only hashtag GSI participation / derived hashtag index rows for non-public statuses; it does not delete status records.
- CMS publication member repair updates only membership lookup attributes derived from existing PK/SK.
- No broad deletes, truncation, stack operations, or data-destroying shortcuts.

## Validation
- [x] `gofmt -l .` clean
- [x] `go test ./cmd/lesser`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build -o lesser ./cmd/lesser`
- [x] `./lesser build lambdas`
- [x] `./lesser verify ci`

Hard-gate coverage from `./lesser verify ci`:
- overall: 87.646%
- pkg: 90.078%
- cmd: 90.061%

## Stage rollout plan / migration handoff
No deploy was run from this PR.

After merge:
- [ ] Run dry-run against `theory` dev with AWS SSO profile `Theory`.
- [ ] Run dry-run against `simulacrum` dev with AWS SSO profile `Sim`.
- [ ] Review counts/samples before any mutation.
- [ ] Apply only with explicit operator authorization.
- [ ] Deploy dev instances through `deploy-instance` / `./lesser up` discipline.
- [ ] Live rollout is intentionally N/A until live instances exist.

## Cross-repo coordination
None required. Release-note awareness only for future managed consumers.
