### PR TITLE
fix(security): complete Codex Security M13

### DIFF
--- a/.codex/skills/create-github-project/SKILL.md
+++ b/.codex/skills/create-github-project/SKILL.md
@@ -143,7 +143,7 @@ Issue body template:
 <one sentence>
 
 ## Validation commands
-<go test ./..., ./lesser verify --smoke, cdk synth>
+<go test ./..., ./lesser verify ci or targeted contract verify modes, cdk synth>
 
 ## Stage rollout checkpoints
 - [ ] Merged to main

--- a/.codex/skills/deploy-instance/SKILL.md
+++ b/.codex/skills/deploy-instance/SKILL.md
@@ -74,7 +74,7 @@ After `./lesser up --stage dev` completes:
 - **Watch SQS DLQ depth** for federation-delivery, ai-processor, moderation-processor.
 - **Confirm DynamoDB Streams processors are healthy** — iterator age flat, invocations occurring on writes.
 - **For federation-trust changes**: exercise signing and verification with test fixtures; monitor HTTP Signature verification failure rate.
-- **For contract changes**: run `./lesser verify --smoke` or equivalent against the deployed endpoint.
+- **For contract changes**: do not run smoke tests. Use targeted API/manual verification against the deployed endpoint plus static contract verification from the release commit.
 - **For schema changes**: verify read and write paths against the new shape; confirm async processors see expected stream events.
 - **Soak duration** per roadmap. Non-trivial: hours to a day. Federation / schema / contract changes: longer.
 

--- a/.codex/skills/enumerate-changes/SKILL.md
+++ b/.codex/skills/enumerate-changes/SKILL.md
@@ -101,7 +101,7 @@ Each enumerated item fits in one commit:
 - `go test ./...` passes at the end of the commit
 - `go vet ./...` passes
 - `gofmt` / `goimports` leave the tree clean
-- `./lesser verify --smoke` (or equivalent) passes for contract-adjacent changes
+- Contract-adjacent changes use static contract verification (`./lesser verify ci` or targeted contract verify modes) plus targeted handler/resolver tests; do not run smoke tests
 - For CDK changes: `cdk synth` succeeds for at least one representative `(<app>, <stage>)`
 - No commit depends on a later item to compile or pass tests
 
@@ -118,7 +118,7 @@ Each enumerated item fits in one commit:
 - **Schema impact**: <none / walk complete via validate-schema>
 - **Framework consumption**: <idiomatic / reported upstream via coordinate-framework-feedback>
 - **Acceptance**: <one sentence: what makes this commit done>
-- **Validation**: <`go test ./<package>/...`, `go vet ./...`, `gofmt -l .`, `./lesser verify --smoke`, `cdk synth` for representative stage>
+- **Validation**: <`go test ./<package>/...`, `go vet ./...`, `gofmt -l .`, `./lesser verify ci` or targeted contract verify modes, `cdk synth` for representative stage>
 - **Conventional Commit subject**: `<type(scope): subject>` (lowercase present-tense also acceptable: "feat: milestone M2 federation delivery retry")
 ```
 
@@ -136,7 +136,7 @@ Each enumerated item fits in one commit:
 - [ ] GraphQL schema changes include `docs/contracts/graphql-schema.graphql` regeneration
 - [ ] OpenAPI changes ride with handler changes
 - [ ] Dependency bumps isolated
-- [ ] Every item has a test or verify-smoke validation
+- [ ] Every item has targeted tests or static verification validation; smoke tests are not used
 - [ ] No item requires a future item to compile
 - [ ] No hardcoded secrets or signing keys
 - [ ] No full-JWT / full-actor-private-key / raw-password / raw-credential logging

--- a/.codex/skills/implement-milestone/SKILL.md
+++ b/.codex/skills/implement-milestone/SKILL.md
@@ -17,7 +17,7 @@ Do not start without all of the following:
 - **`go test ./...` passes** on `main` as of your checkout.
 - **`go vet ./...` passes.**
 - **`gofmt -l .`** returns empty.
-- **`./lesser verify --smoke`** passes if the milestone touches contract-adjacent surfaces.
+- **Smoke tests are never run.** Contract-adjacent milestones use static contract verification (`./lesser verify ci` or targeted `./lesser verify schema`, `./lesser verify openapi`, `./lesser verify graphql-coverage`) plus targeted tests instead.
 - **The enumerated tasks are in-mission work** — not scope growth that slipped through.
 - **Specialist walks are complete** for tasks that touch federation trust, API contract, schema, framework consumption, or deploy.
 - **Advisor-dispatched milestones** have Aron's authorization from `review-advisor-brief` recorded.
@@ -63,7 +63,7 @@ PR description template:
 - `go test ./...`
 - `go vet ./...`
 - `gofmt -l .` (empty)
-- `./lesser verify --smoke`
+- `./lesser verify ci` or targeted contract verify modes when contract-adjacent
 - Targeted: <specific go test ./path>
 - `cdk synth` for representative stage (if CDK changed)
 
@@ -91,7 +91,7 @@ For each issue in the milestone, in enumerated order:
 3. **For bug fixes: add the regression test first.** The test should fail against current code.
 4. **Make the change.** Only files in the enumerated paths. Scope creep becomes a new task; it doesn't silently grow the current commit.
 5. **Run validation.** `go test ./...` minimum. Focused work: `go test ./pkg/<package>/...`. `go vet ./...`. `gofmt -l .` returns empty.
-6. **For contract-adjacent changes**: `./lesser verify --smoke` (or equivalent) passes. Regenerate `docs/contracts/graphql-schema.graphql` with `./lesser schema` if GraphQL changed. Update `docs/contracts/openapi.yaml` alongside REST handler changes.
+6. **For contract-adjacent changes**: do not run smoke tests. Use static contract verification (`./lesser verify ci` or targeted `./lesser verify schema`, `./lesser verify openapi`, `./lesser verify graphql-coverage`) plus targeted handler/resolver tests. Regenerate `docs/contracts/graphql-schema.graphql` with `./lesser schema` if GraphQL changed. Update `docs/contracts/openapi.yaml` alongside REST handler changes.
 7. **For schema-touching changes**: validate that TableTheory model tags match intended PK/SK/GSI semantics. Run storage-layer tests.
 8. **For federation-trust changes**: exercise signing and verification paths with test fixtures. If possible, test against a known Mastodon test server.
 9. **For CDK changes**: `cdk synth --context app=<name> --context stage=dev --context baseDomain=<domain>` succeeds. Never set timeouts on synth.
@@ -133,7 +133,7 @@ When all tasks are committed, pushed, and linked project items closed (if applic
 
 1. Run `go test ./...` one more time on the tip.
 2. Run `go vet ./...`, `gofmt -l .`.
-3. Run `./lesser verify --smoke` if contract-adjacent.
+3. For contract-adjacent changes, run static contract verification (`./lesser verify ci` or targeted `./lesser verify schema`, `./lesser verify openapi`, `./lesser verify graphql-coverage`) plus targeted tests. Do not run smoke tests.
 4. Run `./lesser schema` if GraphQL changed; commit regenerated contract if not already present.
 5. Run `cdk synth` if CDK changed.
 6. Promote the PR out of draft.
@@ -164,6 +164,7 @@ Once the milestone is merged to `main`, `deploy-instance` owns:
 - Will not merge PRs — required review is the process.
 - Will not skip required review for "small" changes.
 - Will not run deploy commands — that's `deploy-instance`.
+- Will not run smoke tests; they are not part of the lesser steward workflow.
 - Will not skip specialist walks for federation, contract, schema, framework, or advisor-brief work.
 - Will not delete published Lambda function versions.
 - Will not force-push, amend pushed commits, or rewrite history.

--- a/cmd/api/handlers/accounts.go
+++ b/cmd/api/handlers/accounts.go
@@ -226,27 +226,14 @@ func (h *Handler) isRemoteURL(accountID string) bool {
 func (h *Handler) lookupStorageAccountByID(ctx context.Context, accountID string) (*storage.Account, error) {
 	skipLocalLookup := h.isRemoteURL(accountID)
 
-	if h != nil && h.registry != nil && h.registry.Accounts() != nil && !skipLocalLookup {
-		account, err := h.registry.Accounts().GetAccount(ctx, accountID)
-		if err == nil && account != nil && h.accountLookupMatchesRequestedID(account, accountID) {
-			return account, nil
-		}
-		if !shouldFallbackAccountResolution(accountID) {
-			if err != nil {
-				return nil, err
-			}
-			return nil, fmt.Errorf("account not found")
-		}
+	account, shouldFallback, err := h.lookupRegistryStorageAccount(ctx, accountID, skipLocalLookup)
+	if err != nil || account != nil || !shouldFallback {
+		return account, err
 	}
 
-	if h != nil && (h.registry == nil || h.registry.Accounts() == nil) && h.repos != nil && h.repos.Account() != nil {
-		normalizedID := strings.TrimSpace(accountID)
-		if normalizedID != "" {
-			account, err := h.repos.Account().GetAccount(ctx, normalizedID)
-			if err == nil && account != nil && h.accountLookupMatchesRequestedID(account, accountID) {
-				return account, nil
-			}
-		}
+	account, err = h.lookupRepositoryStorageAccount(ctx, accountID)
+	if err != nil || account != nil {
+		return account, err
 	}
 
 	if h == nil || h.repos == nil {
@@ -266,6 +253,52 @@ func (h *Handler) lookupStorageAccountByID(ctx context.Context, accountID string
 	}
 
 	return storageAccountFromActor(actor, h.cfg.Domain), nil
+}
+
+func (h *Handler) lookupRegistryStorageAccount(ctx context.Context, accountID string, skipLocalLookup bool) (*storage.Account, bool, error) {
+	if h == nil || h.registry == nil || h.registry.Accounts() == nil || skipLocalLookup {
+		return nil, true, nil
+	}
+
+	account, err := h.registry.Accounts().GetAccount(ctx, accountID)
+	if err == nil && account != nil {
+		visibleAccount, visibleErr := h.visibleRequestedStorageAccount(account, accountID)
+		return visibleAccount, visibleAccount == nil && visibleErr == nil, visibleErr
+	}
+	if !shouldFallbackAccountResolution(accountID) {
+		if err != nil {
+			return nil, false, err
+		}
+		return nil, false, fmt.Errorf("account not found")
+	}
+	return nil, true, nil
+}
+
+func (h *Handler) lookupRepositoryStorageAccount(ctx context.Context, accountID string) (*storage.Account, error) {
+	if h == nil || h.repos == nil || h.repos.Account() == nil || (h.registry != nil && h.registry.Accounts() != nil) {
+		return nil, nil
+	}
+
+	normalizedID := strings.TrimSpace(accountID)
+	if normalizedID == "" {
+		return nil, nil
+	}
+
+	account, err := h.repos.Account().GetAccount(ctx, normalizedID)
+	if err != nil || account == nil {
+		return nil, nil
+	}
+	return h.visibleRequestedStorageAccount(account, accountID)
+}
+
+func (h *Handler) visibleRequestedStorageAccount(account *storage.Account, accountID string) (*storage.Account, error) {
+	if storageAccountIsSuspended(account) {
+		return nil, fmt.Errorf("account not found")
+	}
+	if h.accountLookupMatchesRequestedID(account, accountID) {
+		return account, nil
+	}
+	return nil, nil
 }
 
 func (h *Handler) accountLookupMatchesRequestedID(account *storage.Account, accountID string) bool {
@@ -309,6 +342,9 @@ func (h *Handler) localStorageAccountForActor(ctx context.Context, actor *activi
 	if h != nil && h.registry != nil && h.registry.Accounts() != nil {
 		account, err := h.registry.Accounts().GetAccount(ctx, username)
 		if err == nil && account != nil {
+			if storageAccountIsSuspended(account) {
+				return nil, fmt.Errorf("account not found")
+			}
 			if account.Actor == nil {
 				account.Actor = actor
 			}
@@ -320,6 +356,9 @@ func (h *Handler) localStorageAccountForActor(ctx context.Context, actor *activi
 	if h != nil && h.repos != nil && h.repos.Account() != nil {
 		account, err := h.repos.Account().GetAccount(ctx, username)
 		if err == nil && account != nil {
+			if storageAccountIsSuspended(account) {
+				return nil, fmt.Errorf("account not found")
+			}
 			if account.Actor == nil {
 				account.Actor = actor
 			}
@@ -329,6 +368,69 @@ func (h *Handler) localStorageAccountForActor(ctx context.Context, actor *activi
 	}
 
 	return storageAccountFromActor(actor, h.cfg.Domain), nil
+}
+
+func (h *Handler) rejectSuspendedLocalActor(ctx context.Context, actor *activitypub.Actor) (*activitypub.Actor, error) {
+	if h.localActorSuspended(ctx, actor) {
+		return nil, fmt.Errorf("account not found")
+	}
+	return actor, nil
+}
+
+func (h *Handler) localActorSuspended(ctx context.Context, actor *activitypub.Actor) bool {
+	if actor == nil || !h.actorAppearsLocal(actor) {
+		return false
+	}
+
+	username := strings.TrimSpace(actor.PreferredUsername)
+	if username == "" {
+		username = localActorPathUsername(actor)
+	}
+	return h.localAccountSuspended(ctx, username)
+}
+
+func (h *Handler) localAccountSuspended(ctx context.Context, username string) bool {
+	username = strings.TrimSpace(username)
+	if username == "" || h == nil {
+		return false
+	}
+
+	if h.registry != nil && h.registry.Accounts() != nil {
+		if account, err := h.registry.Accounts().GetAccount(ctx, username); err == nil && storageAccountIsSuspended(account) {
+			return true
+		}
+	}
+
+	if h.repos != nil && h.repos.Account() != nil {
+		if account, err := h.repos.Account().GetAccount(ctx, username); err == nil && storageAccountIsSuspended(account) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func storageAccountIsSuspended(account *storage.Account) bool {
+	return account != nil && account.User != nil && account.User.Suspended
+}
+
+func localActorPathUsername(actor *activitypub.Actor) string {
+	if actor == nil {
+		return ""
+	}
+
+	actorID := strings.Trim(strings.TrimSpace(actor.ID), "/")
+	if actorID == "" {
+		return ""
+	}
+	parts := strings.Split(actorID, "/")
+	if len(parts) < 2 {
+		return ""
+	}
+	if parts[len(parts)-2] != actorUsersPathSegment {
+		return ""
+	}
+	return strings.TrimSpace(parts[len(parts)-1])
 }
 
 func (h *Handler) actorAppearsLocal(actor *activitypub.Actor) bool {

--- a/cmd/api/handlers/accounts_round21_numeric_recovery_test.go
+++ b/cmd/api/handlers/accounts_round21_numeric_recovery_test.go
@@ -50,7 +50,7 @@ func round21LocalActor(baseURL, username string) storagemodels.Actor {
 	return actor
 }
 
-func TestAccountsRound21_RelationshipListsRecoverMissingNumericIDMapping(t *testing.T) {
+func TestAccountsRound21_RelationshipListsRejectMissingNumericIDMapping(t *testing.T) {
 	cfg := round10TestConfig()
 	username := "Agent-0"
 	numericID := common.GenerateNumericID(username)
@@ -86,23 +86,22 @@ func TestAccountsRound21_RelationshipListsRecoverMissingNumericIDMapping(t *test
 	ctxFollowers, err := round10NewLiftContext(http.MethodGet, "/api/v1/accounts/"+numericID+"/followers", nil, nil, nil)
 	require.NoError(t, err)
 	ctxFollowers.Params["id"] = numericID
-	requireStatus(t, http.StatusOK)(h.HandleGetAccountFollowersLift(ctxFollowers))
+	requireStatus(t, http.StatusNotFound)(h.HandleGetAccountFollowersLift(ctxFollowers))
 
 	ctxFollowing, err := round10NewLiftContext(http.MethodGet, "/api/v1/accounts/"+numericID+"/following", nil, nil, nil)
 	require.NoError(t, err)
 	ctxFollowing.Params["id"] = numericID
-	requireStatus(t, http.StatusOK)(h.HandleGetAccountFollowingLift(ctxFollowing))
+	requireStatus(t, http.StatusNotFound)(h.HandleGetAccountFollowingLift(ctxFollowing))
 
-	require.Equal(t, username, followersUsername)
-	require.Equal(t, username, followingUsername)
+	require.Empty(t, followersUsername)
+	require.Empty(t, followingUsername)
 }
 
-func TestInteractionsRound21_FollowRecoversMissingNumericIDMapping(t *testing.T) {
+func TestInteractionsRound21_FollowRejectsMissingNumericIDMapping(t *testing.T) {
 	cfg := round10TestConfig()
 	followerUsername := "Agent-0"
 	targetUsername := "simulacrum"
 	targetNumericID := common.GenerateNumericID(targetUsername)
-	targetActorID := cfg.BaseURL() + "/users/" + targetUsername
 
 	state := &round10QueryState{
 		usersByUsername: map[string]storagemodels.User{
@@ -143,12 +142,12 @@ func TestInteractionsRound21_FollowRecoversMissingNumericIDMapping(t *testing.T)
 	require.NoError(t, err)
 	ctx.Params["id"] = targetNumericID
 
-	requireStatus(t, http.StatusOK)(h.HandleFollowLift(ctx))
-	require.Equal(t, followerUsername, gotFollowerID)
-	require.Equal(t, targetActorID, gotFollowingID)
+	requireStatus(t, http.StatusNotFound)(h.HandleFollowLift(ctx))
+	require.Empty(t, gotFollowerID)
+	require.Empty(t, gotFollowingID)
 }
 
-func TestAccountsFullRound21_ResolveAccountIDFull_RecoversMissingNumericIDMapping(t *testing.T) {
+func TestAccountsFullRound21_ResolveAccountIDFull_RejectsMissingNumericIDMapping(t *testing.T) {
 	cfg := round10TestConfig()
 	username := "simulacrum"
 	numericID := common.GenerateNumericID(username)
@@ -167,9 +166,9 @@ func TestAccountsFullRound21_ResolveAccountIDFull_RecoversMissingNumericIDMappin
 
 	h, _, _ := round11NewHandler(t, cfg, state)
 	actor, err := h.resolveAccountIDFull(context.Background(), numericID)
-	require.NoError(t, err)
-	require.NotNil(t, actor)
-	require.Equal(t, username, actor.PreferredUsername)
+	require.Error(t, err)
+	require.Nil(t, actor)
+	require.True(t, isMissingAccountLookup(err), "expected missing-account lookup error, got %v", err)
 }
 
 func TestAccountsRound21_VerifyCredentialsEnsuresOwnNumericIDStillWorks(t *testing.T) {
@@ -206,7 +205,7 @@ func TestAccountsRound21_VerifyCredentialsEnsuresOwnNumericIDStillWorks(t *testi
 	requireStatus(t, http.StatusOK)(h.HandleVerifyCredentialsLift(ctx))
 }
 
-func TestAccountsFullRound21_ResolveAccountIDFull_RecoversLegacyMixedCaseNumericIDRows(t *testing.T) {
+func TestAccountsFullRound21_ResolveAccountIDFull_RejectsLegacyMixedCaseNumericIDRowsWithoutMapping(t *testing.T) {
 	cfg := round10TestConfig()
 	username := "agent-0"
 	requestedNumericID := common.GenerateNumericID(username)
@@ -230,7 +229,7 @@ func TestAccountsFullRound21_ResolveAccountIDFull_RecoversLegacyMixedCaseNumeric
 
 	h, _, _ := round11NewHandler(t, cfg, state)
 	actor, err := h.resolveAccountIDFull(context.Background(), requestedNumericID)
-	require.NoError(t, err)
-	require.NotNil(t, actor)
-	require.Equal(t, username, actor.PreferredUsername)
+	require.Error(t, err)
+	require.Nil(t, actor)
+	require.True(t, isMissingAccountLookup(err), "expected missing-account lookup error, got %v", err)
 }

--- a/cmd/api/handlers/accounts_round21_numeric_recovery_test.go
+++ b/cmd/api/handlers/accounts_round21_numeric_recovery_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -168,7 +169,7 @@ func TestAccountsFullRound21_ResolveAccountIDFull_RejectsMissingNumericIDMapping
 	actor, err := h.resolveAccountIDFull(context.Background(), numericID)
 	require.Error(t, err)
 	require.Nil(t, actor)
-	require.True(t, isMissingAccountLookup(err), "expected missing-account lookup error, got %v", err)
+	require.Contains(t, strings.ToLower(err.Error()), "not found")
 }
 
 func TestAccountsRound21_VerifyCredentialsEnsuresOwnNumericIDStillWorks(t *testing.T) {
@@ -231,5 +232,5 @@ func TestAccountsFullRound21_ResolveAccountIDFull_RejectsLegacyMixedCaseNumericI
 	actor, err := h.resolveAccountIDFull(context.Background(), requestedNumericID)
 	require.Error(t, err)
 	require.Nil(t, actor)
-	require.True(t, isMissingAccountLookup(err), "expected missing-account lookup error, got %v", err)
+	require.Contains(t, strings.ToLower(err.Error()), "not found")
 }

--- a/cmd/api/handlers/accounts_round21_suspended_fallback_test.go
+++ b/cmd/api/handlers/accounts_round21_suspended_fallback_test.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/storage"
+	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountsRound21_RelationshipListsSuppressSuspendedLocalURLFallback(t *testing.T) {
+	cfg := round10TestConfig()
+	username := "suspended"
+
+	suspendedUser := round21LocalUser(username)
+	suspendedUser.Suspended = true
+
+	state := &round10QueryState{
+		usersByUsername: map[string]storagemodels.User{
+			username: suspendedUser,
+		},
+		actorsByUser: map[string]storagemodels.Actor{
+			username: round21LocalActor(cfg.BaseURL(), username),
+		},
+	}
+
+	var followersCalled bool
+	var followingCalled bool
+
+	h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{
+		AccountsSvc: &AccountsServiceStub{
+			GetAccountFunc: func(context.Context, string) (*storage.Account, error) {
+				return nil, errors.New("account not found")
+			},
+		},
+		RelationshipsSvc: &RelationshipsServiceStub{
+			GetFollowersFunc: func(context.Context, string, int, string) ([]*storage.Account, string, error) {
+				followersCalled = true
+				return []*storage.Account{}, "", nil
+			},
+			GetFollowingFunc: func(context.Context, string, int, string) ([]*storage.Account, string, error) {
+				followingCalled = true
+				return []*storage.Account{}, "", nil
+			},
+		},
+	})
+
+	localActorURL := cfg.BaseURL() + "/users/" + username
+
+	ctxFollowers, err := round10NewLiftContext(http.MethodGet, "/api/v1/accounts/"+localActorURL+"/followers", nil, nil, nil)
+	require.NoError(t, err)
+	ctxFollowers.Params["id"] = localActorURL
+	requireStatus(t, http.StatusNotFound)(h.HandleGetAccountFollowersLift(ctxFollowers))
+
+	ctxFollowing, err := round10NewLiftContext(http.MethodGet, "/api/v1/accounts/"+localActorURL+"/following", nil, nil, nil)
+	require.NoError(t, err)
+	ctxFollowing.Params["id"] = localActorURL
+	requireStatus(t, http.StatusNotFound)(h.HandleGetAccountFollowingLift(ctxFollowing))
+
+	require.False(t, followersCalled)
+	require.False(t, followingCalled)
+}

--- a/cmd/api/handlers/helpers.go
+++ b/cmd/api/handlers/helpers.go
@@ -139,18 +139,7 @@ func normalizeReadableStatusID(statusID string) (string, error) {
 
 func (h *Handler) resolveNumericAccountID(ctx context.Context, accountID string) (*activitypub.Actor, error) {
 	actor, err := h.repos.Actor().GetActorByNumericID(ctx, accountID)
-	if err == nil || !isMissingAccountLookup(err) {
-		return actor, err
-	}
-
-	recovered, recoverErr := h.recoverLocalActorByNumericID(ctx, accountID)
-	if recoverErr == nil {
-		return recovered, nil
-	}
-	if !isMissingAccountLookup(recoverErr) {
-		return nil, recoverErr
-	}
-	return nil, err
+	return actor, err
 }
 
 func isMissingAccountLookup(err error) bool {
@@ -161,94 +150,6 @@ func isMissingAccountLookup(err error) bool {
 		return true
 	}
 	return strings.Contains(strings.ToLower(err.Error()), "not found")
-}
-
-func (h *Handler) recoverLocalActorByNumericID(ctx context.Context, numericID string) (*activitypub.Actor, error) {
-	if h == nil || h.repos == nil || h.repos.GetDB() == nil || h.cfg == nil {
-		return nil, common.ActorNotFoundError{Username: numericID}
-	}
-
-	domain := normalizeLocalActorDomain(h.cfg.Domain)
-	if domain == "" {
-		return nil, common.ActorNotFoundError{Username: numericID}
-	}
-
-	var actorModels []storageModels.Actor
-	err := h.repos.GetDB().WithContext(ctx).
-		Model(&storageModels.Actor{}).
-		Index("gsi3").
-		Where("gsi3PK", "=", fmt.Sprintf("DOMAIN#%s", domain)).
-		All(&actorModels)
-	if err != nil {
-		return nil, err
-	}
-
-	trimmedNumericID := strings.TrimSpace(numericID)
-	for _, actorModel := range actorModels {
-		canonicalUsername, ok := recoveredActorCanonicalUsername(actorModel, trimmedNumericID)
-		if !ok {
-			continue
-		}
-		actor, err := h.loadRecoveredLocalActor(ctx, canonicalUsername, actorModel.Actor)
-		if err == nil && actor != nil {
-			return actor, nil
-		}
-		if err != nil && !isMissingAccountLookup(err) {
-			return nil, err
-		}
-	}
-
-	return nil, common.ActorNotFoundError{Username: numericID}
-}
-
-func recoveredActorCanonicalUsername(actorModel storageModels.Actor, numericID string) (string, bool) {
-	username := strings.TrimSpace(actorModel.Username)
-	if username == "" && actorModel.Actor != nil {
-		username = strings.TrimSpace(actorModel.Actor.PreferredUsername)
-	}
-	if username == "" {
-		return "", false
-	}
-
-	canonicalUsername := strings.ToLower(username)
-	if strings.TrimSpace(actorModel.NumericID) != numericID && common.GenerateNumericID(canonicalUsername) != numericID {
-		return "", false
-	}
-
-	return canonicalUsername, true
-}
-
-func (h *Handler) loadRecoveredLocalActor(ctx context.Context, canonicalUsername string, fallback *activitypub.Actor) (*activitypub.Actor, error) {
-	h.ensureLocalNumericIDMapping(ctx, canonicalUsername)
-
-	actor, err := h.repos.Actor().GetActor(ctx, canonicalUsername)
-	if err == nil && actor != nil {
-		normalizeRecoveredLocalActor(h, actor, canonicalUsername)
-		return actor, nil
-	}
-	if err != nil && !isMissingAccountLookup(err) {
-		return nil, err
-	}
-	if fallback == nil {
-		return nil, nil
-	}
-
-	normalizeRecoveredLocalActor(h, fallback, canonicalUsername)
-	return fallback, nil
-}
-
-func normalizeRecoveredLocalActor(h *Handler, actor *activitypub.Actor, canonicalUsername string) {
-	if actor == nil {
-		return
-	}
-
-	actor.PreferredUsername = canonicalUsername
-	if strings.TrimSpace(actor.ID) == "" {
-		baseURL := handlerBaseURL(h)
-		if baseURL != "" {
-			actor.ID = baseURL + "/users/" + canonicalUsername
-		}
-	}
 }
 
 func normalizeLocalActorDomain(domain string) string {

--- a/cmd/api/handlers/helpers.go
+++ b/cmd/api/handlers/helpers.go
@@ -80,8 +80,12 @@ func (h *Handler) resolveAccountID(ctx context.Context, accountID string) (*acti
 		if strings.EqualFold(host, h.cfg.Domain) {
 			path := strings.Trim(parsed.Path, "/")
 			parts := strings.Split(path, "/")
-			if len(parts) >= 2 && parts[0] == "users" && strings.TrimSpace(parts[1]) != "" {
-				return h.repos.Actor().GetActor(ctx, parts[1])
+			if len(parts) >= 2 && parts[0] == actorUsersPathSegment && strings.TrimSpace(parts[1]) != "" {
+				actor, err := h.repos.Actor().GetActor(ctx, parts[1])
+				if err != nil {
+					return nil, err
+				}
+				return h.rejectSuspendedLocalActor(ctx, actor)
 			}
 			return nil, invalidAccountURL()
 		}
@@ -97,8 +101,8 @@ func (h *Handler) resolveAccountID(ctx context.Context, accountID string) (*acti
 		return nil, err
 	}
 	// If the resolved actor appears to be local, verify it is not suspended.
-	if resolution.Actor != nil && common.IsLocalActorID(resolution.Actor.ID, h.cfg.Domain) && h.repos != nil && h.repos.Account() != nil {
-		if account, acctErr := h.repos.Account().GetAccount(ctx, resolution.Actor.PreferredUsername); acctErr == nil && account != nil && account.User != nil && account.User.Suspended {
+	if resolution.Actor != nil {
+		if h.localActorSuspended(ctx, resolution.Actor) {
 			return nil, fmt.Errorf("account not found")
 		}
 	}
@@ -139,17 +143,10 @@ func normalizeReadableStatusID(statusID string) (string, error) {
 
 func (h *Handler) resolveNumericAccountID(ctx context.Context, accountID string) (*activitypub.Actor, error) {
 	actor, err := h.repos.Actor().GetActorByNumericID(ctx, accountID)
-	return actor, err
-}
-
-func isMissingAccountLookup(err error) bool {
-	if err == nil {
-		return false
+	if err != nil {
+		return nil, err
 	}
-	if common.IsNotFound(err) {
-		return true
-	}
-	return strings.Contains(strings.ToLower(err.Error()), "not found")
+	return h.rejectSuspendedLocalActor(ctx, actor)
 }
 
 func normalizeLocalActorDomain(domain string) string {

--- a/cmd/api/handlers/helpers_round29_coverage_test.go
+++ b/cmd/api/handlers/helpers_round29_coverage_test.go
@@ -12,20 +12,6 @@ import (
 func TestHelpers_RecoveredActorAndStatusLinks_Round29(t *testing.T) {
 	h := &Handler{cfg: &config.Config{Domain: "example.com"}}
 
-	t.Run("normalize recovered actor fills local identity when missing", func(t *testing.T) {
-		normalizeRecoveredLocalActor(h, nil, "alice")
-
-		actor := &activitypub.Actor{}
-		normalizeRecoveredLocalActor(h, actor, "alice")
-		require.Equal(t, "alice", actor.PreferredUsername)
-		require.Equal(t, "https://example.com/users/alice", actor.ID)
-
-		actor.ID = "https://remote.example/users/alice"
-		normalizeRecoveredLocalActor(h, actor, "alice-renamed")
-		require.Equal(t, "alice-renamed", actor.PreferredUsername)
-		require.Equal(t, "https://remote.example/users/alice", actor.ID)
-	})
-
 	t.Run("remoteStatusURL prefers note id then first http url", func(t *testing.T) {
 		require.Empty(t, h.remoteStatusURL(nil))
 		require.Equal(t, "https://remote.example/notes/1", h.remoteStatusURL(&storagemodels.Status{

--- a/cmd/outbox/main.go
+++ b/cmd/outbox/main.go
@@ -682,16 +682,6 @@ func (op *OutboxProcessor) HandleOutboxGet(ctx *apptheory.Context) (*apptheory.R
 
 	// Collection response (metadata) when `page=true` is not set.
 	if page != "true" && page != "1" {
-		totalItems, countErr := op.countOutboxActivities(runCtx, username)
-		if countErr != nil {
-			op.logger.Warn("failed to count outbox activities",
-				zap.String("request_id", requestID),
-				zap.String("username", username),
-				zap.Error(countErr),
-			)
-			totalItems = 0
-		}
-
 		collection := &activitypub.OrderedCollection{
 			Collection: activitypub.Collection{
 				BaseObject: activitypub.BaseObject{
@@ -699,7 +689,12 @@ func (op *OutboxProcessor) HandleOutboxGet(ctx *apptheory.Context) (*apptheory.R
 					ID:      outboxID,
 					Type:    activitypub.OrderedCollectionType,
 				},
-				TotalItems: totalItems,
+				// Avoid counting the actor activity partition here. Without a
+				// public-only count/index, an exact total requires scanning every
+				// outbox activity and filtering private/followers-only records in
+				// memory. Return a conservative placeholder and expose the bounded
+				// page endpoint as the public read path.
+				TotalItems: 0,
 				First:      fmt.Sprintf("%s?page=true", outboxID),
 			},
 		}
@@ -745,29 +740,6 @@ func (op *OutboxProcessor) HandleOutboxGet(ctx *apptheory.Context) (*apptheory.R
 	}
 
 	return outboxActivityJSON(http.StatusOK, collectionPage)
-}
-
-func (op *OutboxProcessor) countOutboxActivities(ctx context.Context, username string) (int, error) {
-	pk := "ACTOR#" + username
-	const skPrefix = "ACTIVITY#"
-
-	var activities []*models.Activity
-	err := op.db.WithContext(ctx).Model(&models.Activity{}).
-		Where("PK", "=", pk).
-		Where("SK", "BEGINS_WITH", skPrefix).
-		OrderBy("SK", "DESC").
-		All(&activities)
-	if err != nil {
-		return 0, err
-	}
-
-	count := 0
-	for _, record := range activities {
-		if record != nil && activitypub.IsPublicAddressedActivity(record.Activity) {
-			count++
-		}
-	}
-	return count, nil
 }
 
 func filterPublicOutboxActivities(activities []*activitypub.Activity) []*activitypub.Activity {

--- a/cmd/outbox/round12_outbox_test.go
+++ b/cmd/outbox/round12_outbox_test.go
@@ -772,10 +772,11 @@ func TestOutboxApp_HTTPHandlers_Round12(t *testing.T) {
 
 	app := buildOutboxApp(processor)
 
-	// GET collection metadata (counts via DB)
+	// GET collection metadata does not count via DB.
 	resp := serveOutbox(app, "GET", "/users/alice/outbox", nil, nil, "")
 	require.Equal(t, 200, resp.Status)
 	require.Equal(t, contentTypeActivityJSON, resp.Headers["content-type"][0])
+	mockQuery.AssertNotCalled(t, "All", mock.Anything)
 
 	// GET page=true (activities via repository)
 	resp = serveOutbox(app, "GET", "/users/alice/outbox", map[string]string{
@@ -945,7 +946,7 @@ func TestOutboxProcessor_HandleOutboxGet_DirectErrorBranches_Round12(t *testing.
 	_ = mustUnmarshalBody[activitypub.OrderedCollectionPage](t, resp)
 }
 
-func TestOutboxProcessor_HandleOutboxGet_CountAndActivitiesErrors_Round12(t *testing.T) {
+func TestOutboxProcessor_HandleOutboxGet_MetadataAndActivitiesErrors_Round12(t *testing.T) {
 	mockDB := new(dynamock.MockDB)
 	mockQuery := new(dynamock.MockQuery)
 	mockDB.On("WithContext", mock.Anything).Return(mockDB).Maybe()
@@ -984,6 +985,7 @@ func TestOutboxProcessor_HandleOutboxGet_CountAndActivitiesErrors_Round12(t *tes
 
 	body := mustUnmarshalBody[activitypub.OrderedCollection](t, resp)
 	require.Equal(t, 0, body.TotalItems)
+	mockQuery.AssertNotCalled(t, "All", mock.Anything)
 
 	actorRepo.On("GetActorByUsername", mock.Anything, "bob").Return(&activitypub.Actor{
 		BaseObject: activitypub.BaseObject{

--- a/pkg/storage/repositories/activity_repository.go
+++ b/pkg/storage/repositories/activity_repository.go
@@ -147,8 +147,9 @@ func (r *ActivityRepository) DeleteActivity(ctx context.Context, id string) erro
 
 // GetInboxActivities retrieves inbox activities for a user - matches legacy implementation
 const (
-	activityDefaultLimit = 20
-	activityMaxLimit     = 100
+	activityDefaultLimit      = 20
+	activityMaxLimit          = 100
+	maxOutboxPublicQueryPages = 4
 )
 
 func clampActivityLimit(limit int) int {
@@ -263,7 +264,7 @@ func (r *ActivityRepository) GetOutboxActivities(ctx context.Context, username s
 
 	result := make([]*activitypub.Activity, 0, safeLimit)
 	var nextCursor string
-	for {
+	for pagesQueried := 0; pagesQueried < maxOutboxPublicQueryPages; pagesQueried++ {
 		activities, hasMore, batchCursor, err := r.queryOutboxActivityRecords(ctx, username, safeLimit, cursorData)
 		if err != nil {
 			r.logger.Error("failed to query outbox activities",
@@ -303,6 +304,17 @@ func (r *ActivityRepository) GetOutboxActivities(ctx context.Context, username s
 				zap.String("username", username))
 			break
 		}
+
+		if pagesQueried == maxOutboxPublicQueryPages-1 {
+			nextCursor = activityEncodeQueryCursor(batchCursor)
+			r.logger.Warn("stopping public outbox pagination after bounded query budget",
+				zap.String("username", username),
+				zap.Int("pages_queried", pagesQueried+1),
+				zap.Int("returned_public_activities", len(result)),
+				zap.Bool("has_more_private_or_filtered_activities", nextCursor != ""))
+			break
+		}
+
 		cursorData = batchCursor
 	}
 
@@ -687,6 +699,17 @@ func activityQueryCursor(data map[string]string) string {
 		return ""
 	}
 	return string(jsonData)
+}
+
+func activityEncodeQueryCursor(cursorData string) string {
+	if strings.TrimSpace(cursorData) == "" {
+		return ""
+	}
+	var data map[string]string
+	if err := json.Unmarshal([]byte(cursorData), &data); err != nil {
+		return ""
+	}
+	return activityEncodeCursor(data)
 }
 
 // activityDecodeCursor decodes a string cursor to a map

--- a/pkg/storage/repositories/activity_repository.go
+++ b/pkg/storage/repositories/activity_repository.go
@@ -306,12 +306,11 @@ func (r *ActivityRepository) GetOutboxActivities(ctx context.Context, username s
 		}
 
 		if pagesQueried == maxOutboxPublicQueryPages-1 {
-			nextCursor = activityEncodeQueryCursor(batchCursor)
 			r.logger.Warn("stopping public outbox pagination after bounded query budget",
 				zap.String("username", username),
 				zap.Int("pages_queried", pagesQueried+1),
 				zap.Int("returned_public_activities", len(result)),
-				zap.Bool("has_more_private_or_filtered_activities", nextCursor != ""))
+				zap.Bool("has_more_private_or_filtered_activities", true))
 			break
 		}
 
@@ -699,17 +698,6 @@ func activityQueryCursor(data map[string]string) string {
 		return ""
 	}
 	return string(jsonData)
-}
-
-func activityEncodeQueryCursor(cursorData string) string {
-	if strings.TrimSpace(cursorData) == "" {
-		return ""
-	}
-	var data map[string]string
-	if err := json.Unmarshal([]byte(cursorData), &data); err != nil {
-		return ""
-	}
-	return activityEncodeCursor(data)
 }
 
 // activityDecodeCursor decodes a string cursor to a map

--- a/pkg/storage/repositories/activity_repository_round09_coverage_test.go
+++ b/pkg/storage/repositories/activity_repository_round09_coverage_test.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"testing"
 	"time"
 
@@ -342,6 +343,30 @@ func TestActivityRepository_Round09_Coverage(t *testing.T) {
 		require.Equal(t, "public", outbox[0].ID)
 		require.Equal(t, "unlisted", outbox[1].ID)
 		require.Equal(t, "object", outbox[2].ID)
+	})
+
+	t.Run("GetOutboxActivities stops after bounded non-public pages", func(t *testing.T) {
+		mockDB := new(mocks.MockDB)
+		mockQuery := new(mocks.MockQuery)
+		allCalls := 0
+		mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
+			allCalls++
+			out := args.Get(0).(*[]*models.Activity)
+			if allCalls <= 6 {
+				*out = []*models.Activity{
+					{PK: "ACTOR#alice", SK: fmt.Sprintf("ACTIVITY#z%d#private", allCalls), Activity: &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: fmt.Sprintf("private-%d-a", allCalls), To: []string{"https://example.com/users/bob"}}}},
+					{PK: "ACTOR#alice", SK: fmt.Sprintf("ACTIVITY#y%d#private", allCalls), Activity: &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: fmt.Sprintf("private-%d-b", allCalls), To: []string{"https://example.com/users/bob"}}}},
+				}
+			}
+		}).Return(nil)
+		setupPermissiveRound08Mocks(mockDB, mockQuery, nil, baseTime)
+		repo := NewActivityRepository(mockDB, "test-table", zap.NewNop(), nil)
+
+		outbox, cursor, err := repo.GetOutboxActivities(ctx, "alice", 1, "")
+		require.NoError(t, err)
+		require.Empty(t, outbox)
+		require.NotEmpty(t, cursor)
+		require.Equal(t, 4, allCalls)
 	})
 
 	t.Run("GetOutboxActivities decodes valid cursor and handles query error", func(t *testing.T) {

--- a/pkg/storage/repositories/activity_repository_round09_coverage_test.go
+++ b/pkg/storage/repositories/activity_repository_round09_coverage_test.go
@@ -365,7 +365,7 @@ func TestActivityRepository_Round09_Coverage(t *testing.T) {
 		outbox, cursor, err := repo.GetOutboxActivities(ctx, "alice", 1, "")
 		require.NoError(t, err)
 		require.Empty(t, outbox)
-		require.NotEmpty(t, cursor)
+		require.Empty(t, cursor)
 		require.Equal(t, 4, allCalls)
 	})
 

--- a/pkg/storage/repositories/bookmark_repository.go
+++ b/pkg/storage/repositories/bookmark_repository.go
@@ -793,6 +793,9 @@ func parseBookmarkPageCursor(cursor string) (bookmarkPageCursor, error) {
 	if pageCursor.Version == 0 {
 		pageCursor.Version = 2
 	}
+	if err := validateBookmarkPageCursor(pageCursor); err != nil {
+		return bookmarkPageCursor{}, err
+	}
 	return pageCursor, nil
 }
 
@@ -812,9 +815,22 @@ func legacyBookmarkPageCursor(cursor string) bookmarkPageCursor {
 		}
 		return pageCursor
 	}
-	pageCursor.TimeSK = cursor
-	pageCursor.LegacySK = cursor
 	return pageCursor
+}
+
+func validateBookmarkPageCursor(cursor bookmarkPageCursor) error {
+	if cursor.TimeSK != "" && !isTimeBookmarkSK(cursor.TimeSK) {
+		return fmt.Errorf("invalid bookmark cursor: time key out of range")
+	}
+	if cursor.LegacySK != "" && !isLegacyBookmarkCursorSK(cursor.LegacySK) {
+		return fmt.Errorf("invalid bookmark cursor: legacy key out of range")
+	}
+	return nil
+}
+
+func isLegacyBookmarkCursorSK(sk string) bool {
+	trimmed := strings.TrimSuffix(sk, "\xff")
+	return isLegacyBookmarkTimestampSK(trimmed)
 }
 
 func encodeBookmarkPageCursor(cursor bookmarkPageCursor) string {

--- a/pkg/storage/repositories/bookmark_repository_m10_test.go
+++ b/pkg/storage/repositories/bookmark_repository_m10_test.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	"context"
+	"encoding/base64"
 	"testing"
 	"time"
 
@@ -219,6 +220,16 @@ func TestBookmarkRepository_M10_BookmarkPageCursorCompatibility(t *testing.T) {
 	require.Equal(t, legacySK, decoded.LegacySK)
 
 	_, err = parseBookmarkPageCursor(bookmarkPageCursorPrefix + "not-base64!")
+	require.Error(t, err)
+
+	invalidLegacy, err := parseBookmarkPageCursor("zzzz-attacker-cursor")
+	require.NoError(t, err)
+	require.Equal(t, 2, invalidLegacy.Version)
+	require.Empty(t, invalidLegacy.TimeSK)
+	require.Empty(t, invalidLegacy.LegacySK)
+
+	malicious := bookmarkPageCursorPrefix + base64.RawURLEncoding.EncodeToString([]byte(`{"v":2,"t":"zzzz-attacker-cursor","l":"zzzz-attacker-cursor"}`))
+	_, err = parseBookmarkPageCursor(malicious)
 	require.Error(t, err)
 }
 


### PR DESCRIPTION
## Milestone
M13 — bounded public read paths for Codex Security project 24 (#909)

## Classification
security hardening / Mastodon API compatibility / privacy / reliability

## Surfaces affected
- Bookmark pagination cursor decoding and repository bounds
- Public outbox collection reads
- Mastodon account numeric-ID resolution
- Account follower/following relationship lookup fallbacks
- Repo-local Codex steward guidance for smoke-free validation

## Specialist walks referenced
- Federation trust: preserves moderation enforcement by suppressing suspended local-account rediscovery
- Contract / API: backward-compatible security hardening; legacy missing numeric-ID mappings now return not found after M12 backfill/migration path
- Schema: no schema changes
- Framework: idiomatic AppTheory/TableTheory consumption; no framework patches

## Consumer impact
- Operators get bounded unauthenticated/public read paths.
- Mastodon clients retain response shapes; missing legacy numeric mappings now fail closed with account-not-found.
- Remote AP peers are unaffected; no ActivityPub actor shape changes.
- Sibling repos: no required changes.

## Tasks
- [x] #910 fix(bookmarks): bound pagination cursor reads
- [x] #911 fix(outbox): bound public collection scans
- [x] #912 fix(accounts): remove numeric id scan fallback
- [x] #913 fix(accounts): suppress suspended fallback lookups
- [x] Update repo-local steward guidance: smoke tests are never run

## Validation
- `gofmt -l .` (empty)
- `go test ./...`
- `go vet ./...`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`
- Targeted during implementation:
  - `go test ./pkg/storage/repositories -run TestBookmarkRepository_M10_BookmarkPageCursorCompatibility`
  - `go test ./pkg/storage/repositories ./cmd/api/handlers`
  - `go test ./pkg/storage/repositories -run 'TestActivityRepository_Round09_Coverage/GetOutboxActivities_stops_after_bounded_non-public_pages'`
  - `go test ./pkg/storage/repositories ./cmd/outbox`
  - `go test ./cmd/api/handlers -run 'Round21.*NumericID|VerifyCredentialsEnsuresOwnNumericIDStillWorks|TestAccountsRound21_RelationshipListsSuppressSuspendedLocalURLFallback'`

No smoke tests were run; per Aron's guidance, smoke tests are not part of the lesser steward workflow.

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to `theory` dev
- [ ] Deployed to `simulacrum` dev
- [ ] Dev soak complete
- [ ] Live rollout intentionally N/A until live instances exist
- [ ] Post-deploy monitoring verified

## Cross-repo coordination
None required.

## Advisor-brief authorization
N/A — direct Aron request.
