### PR TITLE
fix(security): complete Codex Security M14

### DIFF
--- a/cmd/activity-processor/handler.go
+++ b/cmd/activity-processor/handler.go
@@ -1930,15 +1930,12 @@ func validateUndoRejectFollowState(state undoRejectFollowState) (undoRejectFollo
 
 //nolint:unused // Used by follow response and Undo Reject handlers.
 func (h *ActivityHandler) followTargetMatchesActor(followTarget, actorID string) bool {
-	followTarget = strings.TrimSpace(followTarget)
-	actorID = strings.TrimSpace(actorID)
+	followTarget = normalizeFollowTrustID(followTarget)
+	actorID = normalizeFollowTrustID(actorID)
 	if followTarget == "" || actorID == "" {
 		return false
 	}
-	if followTarget == actorID {
-		return true
-	}
-	return h.extractUsernameFromActorURI(followTarget) == h.extractUsernameFromActorURI(actorID)
+	return followTarget == actorID
 }
 
 //nolint:unused // Used by follow response and Undo Reject handlers.
@@ -1994,29 +1991,17 @@ func (h *ActivityHandler) requirePersistedFollowRelationshipState(
 
 //nolint:unused // Used by follow response and Undo Reject state validation.
 func followActivityIDMatches(storedActivityID, referencedActivityID string) bool {
-	storedActivityID = strings.TrimSpace(storedActivityID)
-	referencedActivityID = strings.TrimSpace(referencedActivityID)
+	storedActivityID = normalizeFollowTrustID(storedActivityID)
+	referencedActivityID = normalizeFollowTrustID(referencedActivityID)
 	if storedActivityID == "" || referencedActivityID == "" {
 		return false
 	}
-	if storedActivityID == referencedActivityID {
-		return true
-	}
-
-	return activityIDLastSegment(storedActivityID) == activityIDLastSegment(referencedActivityID)
+	return storedActivityID == referencedActivityID
 }
 
-//nolint:unused // Used by follow response and Undo Reject state validation.
-func activityIDLastSegment(activityID string) string {
-	activityID = strings.TrimRight(strings.TrimSpace(activityID), "/")
-	if activityID == "" {
-		return ""
-	}
-	idx := strings.LastIndex(activityID, "/")
-	if idx < 0 {
-		return activityID
-	}
-	return activityID[idx+1:]
+//nolint:unused // Used by follow response and Undo Reject trust matching helpers.
+func normalizeFollowTrustID(id string) string {
+	return strings.TrimRight(strings.TrimSpace(id), "/")
 }
 
 // processUndoFlag processes an undo of a Flag activity

--- a/cmd/activity-processor/handler.go
+++ b/cmd/activity-processor/handler.go
@@ -410,97 +410,159 @@ func (h *ActivityHandler) processFollowActivity(ctx context.Context, activity *a
 //
 //nolint:unused // False positive - called from processInboxActivity
 func (h *ActivityHandler) processAcceptActivity(ctx context.Context, activity *activitypub.Activity, username string) error {
-	h.Logger.Info("Processing Accept activity",
+	return h.processFollowResponseActivity(ctx, activity, username, followResponseProcessingConfig{
+		responseName:     "Accept",
+		invalidObjectErr: services.ErrAcceptInvalidObjectType,
+		extractErr:       services.ErrExtractUsernamesFromAccept,
+		mutate: func(ctx context.Context, follower, responder string) error {
+			return h.RelationshipRepo.AcceptFollowRequest(ctx, follower, responder)
+		},
+		mutationFailureLog:      "Failed to accept persisted follow relationship",
+		mutationErr:             func(err error) error { return relationshipStatusUpdateFailed(err) },
+		notificationTitleFormat: "%s accepted your follow request",
+		notificationBodyFormat:  "You are now following %s",
+		notificationFailureLog:  "Failed to create accept notification",
+		successLog:              "Successfully processed Accept activity",
+		notificationSuccessNote: "relationship was updated successfully",
+	})
+}
+
+//nolint:unused // Called from stream-dispatched follow response handlers.
+type followResponseProcessingConfig struct {
+	responseName            string
+	invalidObjectErr        error
+	extractErr              error
+	mutate                  func(context.Context, string, string) error
+	mutationFailureLog      string
+	mutationErr             func(error) error
+	notificationTitleFormat string
+	notificationBodyFormat  string
+	notificationFailureLog  string
+	successLog              string
+	notificationSuccessNote string
+}
+
+//nolint:unused // Called from stream-dispatched follow response handlers.
+func (h *ActivityHandler) processFollowResponseActivity(
+	ctx context.Context,
+	activity *activitypub.Activity,
+	username string,
+	cfg followResponseProcessingConfig,
+) error {
+	follower, responder, err := h.resolvePersistedFollowResponse(ctx, activity, username, cfg.responseName, cfg.invalidObjectErr, cfg.extractErr)
+	if err != nil {
+		return err
+	}
+
+	responderField := strings.ToLower(cfg.responseName) + "er"
+	if err := cfg.mutate(ctx, follower, responder); err != nil {
+		h.Logger.Error(cfg.mutationFailureLog,
+			zap.String("follower", follower),
+			zap.String(responderField, responder),
+			zap.String("activity_id", activity.ID),
+			zap.Error(err))
+		return cfg.mutationErr(err)
+	}
+
+	notification := models.NewNotificationBuilder().
+		ForUser(follower).
+		OfType("follow_request").
+		FromActor(responder, "remote_actor").
+		WithContent(
+			fmt.Sprintf(cfg.notificationTitleFormat, responder),
+			fmt.Sprintf(cfg.notificationBodyFormat, responder)).
+		Build()
+
+	if err := h.createNotificationRepo().CreateNotification(ctx, notification); err != nil {
+		h.Logger.Error(cfg.notificationFailureLog,
+			zap.String("follower", follower),
+			zap.String(responderField, responder),
+			zap.Error(err))
+		h.Logger.Debug("follow response notification skipped after successful state change",
+			zap.String("reason", cfg.notificationSuccessNote))
+	}
+
+	h.Logger.Info(cfg.successLog,
+		zap.String("follower", follower),
+		zap.String(responderField, responder),
+		zap.String("activity_id", activity.ID))
+
+	return nil
+}
+
+//nolint:unused // Called from stream-dispatched follow response handlers.
+func (h *ActivityHandler) resolvePersistedFollowResponse(
+	ctx context.Context,
+	activity *activitypub.Activity,
+	username string,
+	responseName string,
+	invalidObjectErr error,
+	extractErr error,
+) (string, string, error) {
+	h.Logger.Info("Processing "+responseName+" activity",
 		zap.String("username", username),
 		zap.String("activity_id", activity.ID),
 		zap.String("actor", activity.Actor),
 		zap.Any("object", activity.Object),
 	)
 
-	// Extract the activity being accepted (typically a Follow activity)
-	var followActivity interface{}
-	switch obj := activity.Object.(type) {
-	case string:
-		// Object is just an ID - we'll need to find the original activity
-		h.Logger.Debug("Accept activity references activity by ID",
-			zap.String("follow_activity_id", obj))
-		// For now, we'll extract info from the Accept activity itself
-		followActivity = obj
-	case map[string]interface{}:
-		followActivity = obj
-	default:
-		h.Logger.Error("Accept activity has invalid object type",
-			zap.String("activity_id", activity.ID),
-			zap.Any("object", activity.Object))
-		return services.ErrAcceptInvalidObjectType
+	followActivity, err := h.extractFollowResponseObject(activity, responseName, invalidObjectErr)
+	if err != nil {
+		return "", "", err
 	}
 
-	accepter := h.extractUsernameFromActorURI(activity.Actor)
-	if err := common.ValidateRequiredParam("accepter", accepter); err != nil {
-		h.Logger.Error("Failed to extract usernames from Accept activity",
-			zap.String("accepter", accepter),
+	responderField := strings.ToLower(responseName) + "er"
+	responder := h.extractUsernameFromActorURI(activity.Actor)
+	if err := common.ValidateRequiredParam(responderField, responder); err != nil {
+		h.Logger.Error("Failed to extract usernames from "+responseName+" activity",
+			zap.String(responderField, responder),
 			zap.String("activity_id", activity.ID))
-		return services.ErrExtractUsernamesFromAccept
+		return "", "", extractErr
 	}
 
 	followState, err := h.resolveFollowResponseState(ctx, followActivity)
 	if err != nil {
-		h.Logger.Warn("Accept activity did not reference a valid persisted Follow",
+		h.Logger.Warn(responseName+" activity did not reference a valid persisted Follow",
 			zap.String("activity_id", activity.ID),
 			zap.Error(err))
-		return services.ErrExtractUsernamesFromAccept
+		return "", "", extractErr
 	}
 	if !h.followTargetMatchesActor(followState.Target, activity.Actor) {
-		h.Logger.Warn("Accept activity follow target does not match accepting actor",
+		h.Logger.Warn(responseName+" activity follow target does not match responding actor",
 			zap.String("activity_id", activity.ID),
-			zap.String("accept_actor", activity.Actor),
+			zap.String(strings.ToLower(responseName)+"_actor", activity.Actor),
 			zap.String("follow_target", followState.Target),
 			zap.String("follow_activity_id", followState.ID))
-		return services.ErrActorNotAuthorizedUndo
+		return "", "", services.ErrActorNotAuthorizedUndo
 	}
 
 	follower := h.extractUsernameFromActorURI(followState.Actor)
 	if err := common.ValidateRequiredParam("follower", follower); err != nil {
-		return services.ErrExtractUsernamesFromAccept
+		return "", "", extractErr
 	}
 
-	if err := h.requirePersistedFollowRelationshipState(ctx, follower, accepter, followState.ID, models.RelationshipPending); err != nil {
-		return err
+	if err := h.requirePersistedFollowRelationshipState(ctx, follower, responder, followState.ID, models.RelationshipPending); err != nil {
+		return "", "", err
 	}
 
-	if err := h.RelationshipRepo.AcceptFollowRequest(ctx, follower, accepter); err != nil {
-		h.Logger.Error("Failed to accept persisted follow relationship",
-			zap.String("follower", follower),
-			zap.String("accepter", accepter),
+	return follower, responder, nil
+}
+
+//nolint:unused // Called from stream-dispatched follow response handlers.
+func (h *ActivityHandler) extractFollowResponseObject(activity *activitypub.Activity, responseName string, invalidObjectErr error) (interface{}, error) {
+	switch obj := activity.Object.(type) {
+	case string:
+		h.Logger.Debug(responseName+" activity references activity by ID",
+			zap.String("follow_activity_id", obj))
+		return obj, nil
+	case map[string]interface{}:
+		return obj, nil
+	default:
+		h.Logger.Error(responseName+" activity has invalid object type",
 			zap.String("activity_id", activity.ID),
-			zap.Error(err))
-		return relationshipStatusUpdateFailed(err)
+			zap.Any("object", activity.Object))
+		return nil, invalidObjectErr
 	}
-
-	// Create notification for the follower that their follow request was accepted
-	notification := models.NewNotificationBuilder().
-		ForUser(follower).
-		OfType("follow_request").
-		FromActor(accepter, "remote_actor").
-		WithContent(
-			fmt.Sprintf("%s accepted your follow request", accepter),
-			fmt.Sprintf("You are now following %s", accepter)).
-		Build()
-
-	if err := h.createNotificationRepo().CreateNotification(ctx, notification); err != nil {
-		h.Logger.Error("Failed to create accept notification",
-			zap.String("follower", follower),
-			zap.String("accepter", accepter),
-			zap.Error(err))
-		// Don't return error - the relationship was updated successfully
-	}
-
-	h.Logger.Info("Successfully processed Accept activity",
-		zap.String("follower", follower),
-		zap.String("accepter", accepter),
-		zap.String("activity_id", activity.ID))
-
-	return nil
 }
 
 // processCreateActivity processes a Create activity with visibility controls
@@ -886,96 +948,21 @@ func (h *ActivityHandler) extractStatusID(noteID string) string {
 //
 //nolint:unused // False positive - called from processInboxActivity
 func (h *ActivityHandler) processRejectActivity(ctx context.Context, activity *activitypub.Activity, username string) error {
-	h.Logger.Info("Processing Reject activity",
-		zap.String("username", username),
-		zap.String("activity_id", activity.ID),
-		zap.String("actor", activity.Actor),
-		zap.Any("object", activity.Object),
-	)
-
-	// Extract the activity being rejected (typically a Follow activity)
-	var followActivity interface{}
-	switch obj := activity.Object.(type) {
-	case string:
-		h.Logger.Debug("Reject activity references activity by ID",
-			zap.String("follow_activity_id", obj))
-		followActivity = obj
-	case map[string]interface{}:
-		followActivity = obj
-	default:
-		h.Logger.Error("Reject activity has invalid object type",
-			zap.String("activity_id", activity.ID),
-			zap.Any("object", activity.Object))
-		return services.ErrRejectInvalidObjectType
-	}
-
-	rejecter := h.extractUsernameFromActorURI(activity.Actor)
-	if err := common.ValidateRequiredParam("rejecter", rejecter); err != nil {
-		h.Logger.Error("Failed to extract usernames from Reject activity",
-			zap.String("rejecter", rejecter),
-			zap.String("activity_id", activity.ID))
-		return services.ErrExtractUsernamesFromReject
-	}
-
-	followState, err := h.resolveFollowResponseState(ctx, followActivity)
-	if err != nil {
-		h.Logger.Warn("Reject activity did not reference a valid persisted Follow",
-			zap.String("activity_id", activity.ID),
-			zap.Error(err))
-		return services.ErrExtractUsernamesFromReject
-	}
-	if !h.followTargetMatchesActor(followState.Target, activity.Actor) {
-		h.Logger.Warn("Reject activity follow target does not match rejecting actor",
-			zap.String("activity_id", activity.ID),
-			zap.String("reject_actor", activity.Actor),
-			zap.String("follow_target", followState.Target),
-			zap.String("follow_activity_id", followState.ID))
-		return services.ErrActorNotAuthorizedUndo
-	}
-
-	follower := h.extractUsernameFromActorURI(followState.Actor)
-	if err := common.ValidateRequiredParam("follower", follower); err != nil {
-		return services.ErrExtractUsernamesFromReject
-	}
-
-	if err := h.requirePersistedFollowRelationshipState(ctx, follower, rejecter, followState.ID, models.RelationshipPending); err != nil {
-		return err
-	}
-
-	if err := h.RelationshipRepo.RejectFollowRequest(ctx, follower, rejecter); err != nil {
-		h.Logger.Error("Failed to reject persisted follow relationship",
-			zap.String("follower", follower),
-			zap.String("rejecter", rejecter),
-			zap.String("activity_id", activity.ID),
-			zap.Error(err))
-		return rejectedRelationshipDeletionFailed(err)
-	}
-
-	// Optional: Create notification for the follower that their follow request was rejected
-	// Some implementations might choose not to notify on rejection to avoid spam
-	notification := models.NewNotificationBuilder().
-		ForUser(follower).
-		OfType("follow_request").
-		FromActor(rejecter, "remote_actor").
-		WithContent(
-			fmt.Sprintf("%s declined your follow request", rejecter),
-			fmt.Sprintf("Your follow request to %s was declined", rejecter)).
-		Build()
-
-	if err := h.createNotificationRepo().CreateNotification(ctx, notification); err != nil {
-		h.Logger.Error("Failed to create reject notification",
-			zap.String("follower", follower),
-			zap.String("rejecter", rejecter),
-			zap.Error(err))
-		// Don't return error - the relationship was deleted successfully
-	}
-
-	h.Logger.Info("Successfully processed Reject activity",
-		zap.String("follower", follower),
-		zap.String("rejecter", rejecter),
-		zap.String("activity_id", activity.ID))
-
-	return nil
+	return h.processFollowResponseActivity(ctx, activity, username, followResponseProcessingConfig{
+		responseName:     "Reject",
+		invalidObjectErr: services.ErrRejectInvalidObjectType,
+		extractErr:       services.ErrExtractUsernamesFromReject,
+		mutate: func(ctx context.Context, follower, responder string) error {
+			return h.RelationshipRepo.RejectFollowRequest(ctx, follower, responder)
+		},
+		mutationFailureLog:      "Failed to reject persisted follow relationship",
+		mutationErr:             func(err error) error { return rejectedRelationshipDeletionFailed(err) },
+		notificationTitleFormat: "%s declined your follow request",
+		notificationBodyFormat:  "Your follow request to %s was declined",
+		notificationFailureLog:  "Failed to create reject notification",
+		successLog:              "Successfully processed Reject activity",
+		notificationSuccessNote: "relationship was rejected successfully",
+	})
 }
 
 // processUpdateActivity processes an Update activity
@@ -2005,6 +1992,7 @@ func (h *ActivityHandler) requirePersistedFollowRelationshipState(
 	return nil
 }
 
+//nolint:unused // Used by follow response and Undo Reject state validation.
 func followActivityIDMatches(storedActivityID, referencedActivityID string) bool {
 	storedActivityID = strings.TrimSpace(storedActivityID)
 	referencedActivityID = strings.TrimSpace(referencedActivityID)
@@ -2018,6 +2006,7 @@ func followActivityIDMatches(storedActivityID, referencedActivityID string) bool
 	return activityIDLastSegment(storedActivityID) == activityIDLastSegment(referencedActivityID)
 }
 
+//nolint:unused // Used by follow response and Undo Reject state validation.
 func activityIDLastSegment(activityID string) string {
 	activityID = strings.TrimRight(strings.TrimSpace(activityID), "/")
 	if activityID == "" {

--- a/cmd/activity-processor/handler.go
+++ b/cmd/activity-processor/handler.go
@@ -1771,7 +1771,7 @@ func (h *ActivityHandler) processUndoReject(ctx context.Context, undoActivity *a
 	if err != nil {
 		return err
 	}
-	if followState.Target != rejectActor && h.extractUsernameFromActorURI(followState.Target) != rejecter {
+	if !h.followTargetMatchesActor(followState.Target, rejectActor) {
 		h.Logger.Warn("Undo Reject referenced Follow target does not match Reject actor",
 			zap.String("reject_actor", rejectActor),
 			zap.String("follow_target", followState.Target),

--- a/cmd/activity-processor/handler.go
+++ b/cmd/activity-processor/handler.go
@@ -435,43 +435,41 @@ func (h *ActivityHandler) processAcceptActivity(ctx context.Context, activity *a
 		return services.ErrAcceptInvalidObjectType
 	}
 
-	// Extract the actors involved
-	// The actor of the Accept is who is accepting (followee)
-	// We need to find who initiated the follow (follower)
 	accepter := h.extractUsernameFromActorURI(activity.Actor)
-
-	var follower string
-	switch followObj := followActivity.(type) {
-	case string:
-		// If it's just an ID, we can't easily extract the follower
-		// We'd need to look up the original activity or infer from context
-		h.Logger.Debug("Cannot extract follower from activity ID, using context username",
-			zap.String("activity_id", followObj),
-			zap.String("context_username", username))
-		follower = username // The user context might be the follower
-	case map[string]interface{}:
-		if actor, ok := followObj["actor"].(string); ok {
-			follower = h.extractUsernameFromActorURI(actor)
-		}
-	}
-
-	if err := common.ValidateRequiredParam("follower", follower); err != nil {
-		return err
-	}
 	if err := common.ValidateRequiredParam("accepter", accepter); err != nil {
 		h.Logger.Error("Failed to extract usernames from Accept activity",
 			zap.String("accepter", accepter),
-			zap.String("follower", follower))
+			zap.String("activity_id", activity.ID))
 		return services.ErrExtractUsernamesFromAccept
 	}
 
-	// Update the relationship status to accepted
-	updates := map[string]interface{}{
-		"State": "accepted",
+	followState, err := h.resolveFollowResponseState(ctx, followActivity)
+	if err != nil {
+		h.Logger.Warn("Accept activity did not reference a valid persisted Follow",
+			zap.String("activity_id", activity.ID),
+			zap.Error(err))
+		return services.ErrExtractUsernamesFromAccept
+	}
+	if !h.followTargetMatchesActor(followState.Target, activity.Actor) {
+		h.Logger.Warn("Accept activity follow target does not match accepting actor",
+			zap.String("activity_id", activity.ID),
+			zap.String("accept_actor", activity.Actor),
+			zap.String("follow_target", followState.Target),
+			zap.String("follow_activity_id", followState.ID))
+		return services.ErrActorNotAuthorizedUndo
 	}
 
-	if err := h.RelationshipRepo.UpdateRelationship(ctx, follower, accepter, updates); err != nil {
-		h.Logger.Error("Failed to update relationship status to accepted",
+	follower := h.extractUsernameFromActorURI(followState.Actor)
+	if err := common.ValidateRequiredParam("follower", follower); err != nil {
+		return services.ErrExtractUsernamesFromAccept
+	}
+
+	if err := h.requirePersistedFollowRelationshipState(ctx, follower, accepter, followState.ID, models.RelationshipPending); err != nil {
+		return err
+	}
+
+	if err := h.RelationshipRepo.AcceptFollowRequest(ctx, follower, accepter); err != nil {
+		h.Logger.Error("Failed to accept persisted follow relationship",
 			zap.String("follower", follower),
 			zap.String("accepter", accepter),
 			zap.String("activity_id", activity.ID),
@@ -911,38 +909,41 @@ func (h *ActivityHandler) processRejectActivity(ctx context.Context, activity *a
 		return services.ErrRejectInvalidObjectType
 	}
 
-	// Extract the actors involved
-	// The actor of the Reject is who is rejecting (followee)
-	// We need to find who initiated the follow (follower)
 	rejecter := h.extractUsernameFromActorURI(activity.Actor)
-
-	var follower string
-	switch followObj := followActivity.(type) {
-	case string:
-		// If it's just an ID, infer follower from context
-		h.Logger.Debug("Cannot extract follower from activity ID, using context username",
-			zap.String("activity_id", followObj),
-			zap.String("context_username", username))
-		follower = username
-	case map[string]interface{}:
-		if actor, ok := followObj["actor"].(string); ok {
-			follower = h.extractUsernameFromActorURI(actor)
-		}
-	}
-
-	if err := common.ValidateRequiredParam("follower", follower); err != nil {
-		return err
-	}
 	if err := common.ValidateRequiredParam("rejecter", rejecter); err != nil {
 		h.Logger.Error("Failed to extract usernames from Reject activity",
 			zap.String("rejecter", rejecter),
-			zap.String("follower", follower))
+			zap.String("activity_id", activity.ID))
 		return services.ErrExtractUsernamesFromReject
 	}
 
-	// Delete the follow relationship entirely (rejected follow requests should be removed)
-	if err := h.RelationshipRepo.DeleteRelationship(ctx, follower, rejecter); err != nil {
-		h.Logger.Error("Failed to delete rejected follow relationship",
+	followState, err := h.resolveFollowResponseState(ctx, followActivity)
+	if err != nil {
+		h.Logger.Warn("Reject activity did not reference a valid persisted Follow",
+			zap.String("activity_id", activity.ID),
+			zap.Error(err))
+		return services.ErrExtractUsernamesFromReject
+	}
+	if !h.followTargetMatchesActor(followState.Target, activity.Actor) {
+		h.Logger.Warn("Reject activity follow target does not match rejecting actor",
+			zap.String("activity_id", activity.ID),
+			zap.String("reject_actor", activity.Actor),
+			zap.String("follow_target", followState.Target),
+			zap.String("follow_activity_id", followState.ID))
+		return services.ErrActorNotAuthorizedUndo
+	}
+
+	follower := h.extractUsernameFromActorURI(followState.Actor)
+	if err := common.ValidateRequiredParam("follower", follower); err != nil {
+		return services.ErrExtractUsernamesFromReject
+	}
+
+	if err := h.requirePersistedFollowRelationshipState(ctx, follower, rejecter, followState.ID, models.RelationshipPending); err != nil {
+		return err
+	}
+
+	if err := h.RelationshipRepo.RejectFollowRequest(ctx, follower, rejecter); err != nil {
+		h.Logger.Error("Failed to reject persisted follow relationship",
 			zap.String("follower", follower),
 			zap.String("rejecter", rejecter),
 			zap.String("activity_id", activity.ID),
@@ -1802,6 +1803,10 @@ func (h *ActivityHandler) processUndoReject(ctx context.Context, undoActivity *a
 		return services.ErrExtractUsernamesFromReject
 	}
 
+	if err := h.requirePersistedFollowRelationshipState(ctx, follower, rejecter, followState.ID, models.RelationshipRejected); err != nil {
+		return err
+	}
+
 	if err := h.RelationshipRepo.CreateRelationship(ctx, follower, rejecter, followState.ID); err != nil {
 		h.Logger.Error("Failed to recreate follow relationship after Undo Reject",
 			zap.String("follower", follower),
@@ -1817,6 +1822,11 @@ func (h *ActivityHandler) processUndoReject(ctx context.Context, undoActivity *a
 		zap.String("follow_activity_id", followState.ID))
 
 	return nil
+}
+
+//nolint:unused // Used by follow response and Undo Reject handlers.
+func (h *ActivityHandler) resolveFollowResponseState(ctx context.Context, followActivity interface{}) (undoRejectFollowState, error) {
+	return h.resolveUndoRejectFollowState(ctx, followActivity)
 }
 
 //nolint:unused // Used by processUndoReject; production reachability is through stream dispatch.
@@ -1929,6 +1939,95 @@ func validateUndoRejectFollowState(state undoRejectFollowState) (undoRejectFollo
 		return undoRejectFollowState{}, services.ErrExtractUsernamesFromReject
 	}
 	return state, nil
+}
+
+//nolint:unused // Used by follow response and Undo Reject handlers.
+func (h *ActivityHandler) followTargetMatchesActor(followTarget, actorID string) bool {
+	followTarget = strings.TrimSpace(followTarget)
+	actorID = strings.TrimSpace(actorID)
+	if followTarget == "" || actorID == "" {
+		return false
+	}
+	if followTarget == actorID {
+		return true
+	}
+	return h.extractUsernameFromActorURI(followTarget) == h.extractUsernameFromActorURI(actorID)
+}
+
+//nolint:unused // Used by follow response and Undo Reject handlers.
+func (h *ActivityHandler) requirePersistedFollowRelationshipState(
+	ctx context.Context,
+	follower string,
+	following string,
+	followActivityID string,
+	requiredState string,
+) error {
+	if h.RelationshipRepo == nil {
+		h.Logger.Warn("relationship repository unavailable for follow state validation",
+			zap.String("follower", follower),
+			zap.String("following", following),
+			zap.String("follow_activity_id", followActivityID),
+			zap.String("required_state", requiredState))
+		return services.ErrRelationshipRepositoryNotAvailable
+	}
+
+	relationship, err := h.RelationshipRepo.GetRelationship(ctx, follower, following)
+	if err != nil {
+		h.Logger.Warn("failed to load follow relationship for state validation",
+			zap.String("follower", follower),
+			zap.String("following", following),
+			zap.String("follow_activity_id", followActivityID),
+			zap.String("required_state", requiredState),
+			zap.Error(err))
+		return services.ErrActorNotAuthorizedUndo
+	}
+	if relationship == nil || relationship.State != requiredState {
+		state := ""
+		if relationship != nil {
+			state = relationship.State
+		}
+		h.Logger.Warn("follow relationship state mismatch",
+			zap.String("follower", follower),
+			zap.String("following", following),
+			zap.String("follow_activity_id", followActivityID),
+			zap.String("required_state", requiredState),
+			zap.String("actual_state", state))
+		return services.ErrActorNotAuthorizedUndo
+	}
+	if !followActivityIDMatches(relationship.ActivityID, followActivityID) {
+		h.Logger.Warn("follow relationship activity id mismatch",
+			zap.String("follower", follower),
+			zap.String("following", following),
+			zap.String("stored_activity_id", relationship.ActivityID),
+			zap.String("referenced_activity_id", followActivityID))
+		return services.ErrActorNotAuthorizedUndo
+	}
+	return nil
+}
+
+func followActivityIDMatches(storedActivityID, referencedActivityID string) bool {
+	storedActivityID = strings.TrimSpace(storedActivityID)
+	referencedActivityID = strings.TrimSpace(referencedActivityID)
+	if storedActivityID == "" || referencedActivityID == "" {
+		return false
+	}
+	if storedActivityID == referencedActivityID {
+		return true
+	}
+
+	return activityIDLastSegment(storedActivityID) == activityIDLastSegment(referencedActivityID)
+}
+
+func activityIDLastSegment(activityID string) string {
+	activityID = strings.TrimRight(strings.TrimSpace(activityID), "/")
+	if activityID == "" {
+		return ""
+	}
+	idx := strings.LastIndex(activityID, "/")
+	if idx < 0 {
+		return activityID
+	}
+	return activityID[idx+1:]
 }
 
 // processUndoFlag processes an undo of a Flag activity

--- a/cmd/activity-processor/handler.go
+++ b/cmd/activity-processor/handler.go
@@ -1863,7 +1863,18 @@ func (h *ActivityHandler) resolveUndoRejectFollowState(ctx context.Context, foll
 	case *activitypub.Activity:
 		return h.followStateFromActivity(follow)
 	case map[string]interface{}:
-		return h.followStateFromMap(follow)
+		inlineState, err := h.followStateFromMap(follow)
+		if err != nil {
+			return undoRejectFollowState{}, err
+		}
+		resolved, err := h.getActivityByID(ctx, inlineState.ID)
+		if err != nil {
+			h.Logger.Warn("Failed to resolve inline follow activity by ID",
+				zap.String("follow_activity_id", inlineState.ID),
+				zap.Error(err))
+			return undoRejectFollowState{}, services.ErrExtractUsernamesFromReject
+		}
+		return h.followStateFromActivity(resolved)
 	default:
 		h.Logger.Warn("Undo Reject follow activity has unexpected type",
 			zap.Any("follow_activity", follow))

--- a/cmd/activity-processor/handler_branch_sweep_additional_test.go
+++ b/cmd/activity-processor/handler_branch_sweep_additional_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/services"
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
+	"github.com/equaltoai/lesser/pkg/storage/models"
 	testmocks "github.com/equaltoai/lesser/pkg/testing/mocks"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -248,6 +249,10 @@ func TestActivityHandler_ProcessUndoReject_AdditionalBranches(t *testing.T) {
 
 	t.Run("relationship creation fails", func(t *testing.T) {
 		relationshipRepo := testmocks.NewMockRelationshipRepository()
+		relationshipRepo.On("GetRelationship", mock.Anything, "bob", "alice").Return(&models.RelationshipRecord{
+			State:      models.RelationshipRejected,
+			ActivityID: "follow-1",
+		}, nil).Once()
 		relationshipRepo.On("CreateRelationship", mock.Anything, "bob", "alice", "follow-1").Return(errors.New("boom")).Once()
 
 		handler := &ActivityHandler{Logger: zap.NewNop(), RelationshipRepo: relationshipRepo}

--- a/cmd/activity-processor/handler_branch_sweep_additional_test.go
+++ b/cmd/activity-processor/handler_branch_sweep_additional_test.go
@@ -248,6 +248,12 @@ func TestActivityHandler_ProcessUndoReject_AdditionalBranches(t *testing.T) {
 	})
 
 	t.Run("relationship creation fails", func(t *testing.T) {
+		activityRepo := testmocks.NewMockActivityRepository()
+		activityRepo.On("GetActivity", mock.Anything, "follow-1").Return(&activitypub.Activity{
+			BaseObject: activitypub.BaseObject{ID: "follow-1", Type: ActivityTypeFollow},
+			Actor:      "https://remote.example/users/bob",
+			Object:     "https://example.com/users/alice",
+		}, nil).Once()
 		relationshipRepo := testmocks.NewMockRelationshipRepository()
 		relationshipRepo.On("GetRelationship", mock.Anything, "bob", "alice").Return(&models.RelationshipRecord{
 			State:      models.RelationshipRejected,
@@ -255,7 +261,7 @@ func TestActivityHandler_ProcessUndoReject_AdditionalBranches(t *testing.T) {
 		}, nil).Once()
 		relationshipRepo.On("CreateRelationship", mock.Anything, "bob", "alice", "follow-1").Return(errors.New("boom")).Once()
 
-		handler := &ActivityHandler{Logger: zap.NewNop(), RelationshipRepo: relationshipRepo}
+		handler := &ActivityHandler{Logger: zap.NewNop(), ActivityRepo: activityRepo, RelationshipRepo: relationshipRepo}
 
 		reject := map[string]any{
 			"type":  ActivityTypeReject,
@@ -273,11 +279,18 @@ func TestActivityHandler_ProcessUndoReject_AdditionalBranches(t *testing.T) {
 		}
 
 		require.Error(t, handler.processUndoReject(ctx, undo, reject, "alice"))
+		activityRepo.AssertExpectations(t)
 		relationshipRepo.AssertExpectations(t)
 	})
 
 	t.Run("forged follow target is rejected", func(t *testing.T) {
-		handler := &ActivityHandler{Logger: zap.NewNop()}
+		activityRepo := testmocks.NewMockActivityRepository()
+		activityRepo.On("GetActivity", mock.Anything, "follow-forged").Return(&activitypub.Activity{
+			BaseObject: activitypub.BaseObject{ID: "follow-forged", Type: ActivityTypeFollow},
+			Actor:      "https://remote.example/users/bob",
+			Object:     "https://example.com/users/mallory",
+		}, nil).Once()
+		handler := &ActivityHandler{Logger: zap.NewNop(), ActivityRepo: activityRepo}
 		reject := map[string]any{
 			"type":  ActivityTypeReject,
 			"actor": "https://example.com/users/alice",
@@ -291,6 +304,7 @@ func TestActivityHandler_ProcessUndoReject_AdditionalBranches(t *testing.T) {
 		undo := &activitypub.Activity{BaseObject: activitypub.BaseObject{ID: "undo-forged", Type: ActivityTypeUndo}, Actor: "https://example.com/users/alice"}
 
 		require.ErrorIs(t, handler.processUndoReject(ctx, undo, reject, "alice"), services.ErrActorNotAuthorizedUndo)
+		activityRepo.AssertExpectations(t)
 	})
 }
 

--- a/cmd/activity-processor/handler_error_branches_test.go
+++ b/cmd/activity-processor/handler_error_branches_test.go
@@ -38,6 +38,12 @@ func TestActivityHandler_ErrorBranches(t *testing.T) {
 	})
 
 	t.Run("accept relationship update fails", func(t *testing.T) {
+		activityRepo := testmocks.NewMockActivityRepository()
+		activityRepo.On("GetActivity", mock.Anything, "follow-err").Return(&activitypub.Activity{
+			BaseObject: activitypub.BaseObject{ID: "follow-err", Type: ActivityTypeFollow},
+			Actor:      "https://remote.example/users/bob",
+			Object:     "https://example.com/users/alice",
+		}, nil).Once()
 		relationshipRepo := testmocks.NewMockRelationshipRepository()
 		relationshipRepo.On("GetRelationship", mock.Anything, "bob", "alice").Return(&models.RelationshipRecord{
 			State:      models.RelationshipPending,
@@ -45,7 +51,7 @@ func TestActivityHandler_ErrorBranches(t *testing.T) {
 		}, nil).Once()
 		relationshipRepo.On("AcceptFollowRequest", mock.Anything, "bob", "alice").Return(errors.New("boom")).Once()
 
-		handler := &ActivityHandler{Logger: zap.NewNop(), RelationshipRepo: relationshipRepo}
+		handler := &ActivityHandler{Logger: zap.NewNop(), ActivityRepo: activityRepo, RelationshipRepo: relationshipRepo}
 
 		accept := &activitypub.Activity{
 			BaseObject: activitypub.BaseObject{ID: "accept-err", Type: ActivityTypeAccept},
@@ -58,10 +64,17 @@ func TestActivityHandler_ErrorBranches(t *testing.T) {
 			},
 		}
 		require.Error(t, handler.processAcceptActivity(ctx, accept, "ignored"))
+		activityRepo.AssertExpectations(t)
 		relationshipRepo.AssertExpectations(t)
 	})
 
 	t.Run("reject relationship delete fails", func(t *testing.T) {
+		activityRepo := testmocks.NewMockActivityRepository()
+		activityRepo.On("GetActivity", mock.Anything, "follow-reject-err").Return(&activitypub.Activity{
+			BaseObject: activitypub.BaseObject{ID: "follow-reject-err", Type: ActivityTypeFollow},
+			Actor:      "https://remote.example/users/bob",
+			Object:     "https://example.com/users/alice",
+		}, nil).Once()
 		relationshipRepo := testmocks.NewMockRelationshipRepository()
 		relationshipRepo.On("GetRelationship", mock.Anything, "bob", "alice").Return(&models.RelationshipRecord{
 			State:      models.RelationshipPending,
@@ -69,7 +82,7 @@ func TestActivityHandler_ErrorBranches(t *testing.T) {
 		}, nil).Once()
 		relationshipRepo.On("RejectFollowRequest", mock.Anything, "bob", "alice").Return(errors.New("boom")).Once()
 
-		handler := &ActivityHandler{Logger: zap.NewNop(), RelationshipRepo: relationshipRepo}
+		handler := &ActivityHandler{Logger: zap.NewNop(), ActivityRepo: activityRepo, RelationshipRepo: relationshipRepo}
 
 		reject := &activitypub.Activity{
 			BaseObject: activitypub.BaseObject{ID: "reject-err", Type: ActivityTypeReject},
@@ -82,6 +95,7 @@ func TestActivityHandler_ErrorBranches(t *testing.T) {
 			},
 		}
 		require.Error(t, handler.processRejectActivity(ctx, reject, "ignored"))
+		activityRepo.AssertExpectations(t)
 		relationshipRepo.AssertExpectations(t)
 	})
 

--- a/cmd/activity-processor/handler_error_branches_test.go
+++ b/cmd/activity-processor/handler_error_branches_test.go
@@ -39,14 +39,23 @@ func TestActivityHandler_ErrorBranches(t *testing.T) {
 
 	t.Run("accept relationship update fails", func(t *testing.T) {
 		relationshipRepo := testmocks.NewMockRelationshipRepository()
-		relationshipRepo.On("UpdateRelationship", mock.Anything, "bob", "alice", mock.Anything).Return(errors.New("boom"))
+		relationshipRepo.On("GetRelationship", mock.Anything, "bob", "alice").Return(&models.RelationshipRecord{
+			State:      models.RelationshipPending,
+			ActivityID: "follow-err",
+		}, nil).Once()
+		relationshipRepo.On("AcceptFollowRequest", mock.Anything, "bob", "alice").Return(errors.New("boom")).Once()
 
 		handler := &ActivityHandler{Logger: zap.NewNop(), RelationshipRepo: relationshipRepo}
 
 		accept := &activitypub.Activity{
 			BaseObject: activitypub.BaseObject{ID: "accept-err", Type: ActivityTypeAccept},
 			Actor:      "https://example.com/users/alice",
-			Object:     map[string]any{"actor": "https://remote.example/users/bob"},
+			Object: map[string]any{
+				"id":     "follow-err",
+				"type":   ActivityTypeFollow,
+				"actor":  "https://remote.example/users/bob",
+				"object": "https://example.com/users/alice",
+			},
 		}
 		require.Error(t, handler.processAcceptActivity(ctx, accept, "ignored"))
 		relationshipRepo.AssertExpectations(t)
@@ -54,14 +63,23 @@ func TestActivityHandler_ErrorBranches(t *testing.T) {
 
 	t.Run("reject relationship delete fails", func(t *testing.T) {
 		relationshipRepo := testmocks.NewMockRelationshipRepository()
-		relationshipRepo.On("DeleteRelationship", mock.Anything, "bob", "alice").Return(errors.New("boom"))
+		relationshipRepo.On("GetRelationship", mock.Anything, "bob", "alice").Return(&models.RelationshipRecord{
+			State:      models.RelationshipPending,
+			ActivityID: "follow-reject-err",
+		}, nil).Once()
+		relationshipRepo.On("RejectFollowRequest", mock.Anything, "bob", "alice").Return(errors.New("boom")).Once()
 
 		handler := &ActivityHandler{Logger: zap.NewNop(), RelationshipRepo: relationshipRepo}
 
 		reject := &activitypub.Activity{
 			BaseObject: activitypub.BaseObject{ID: "reject-err", Type: ActivityTypeReject},
 			Actor:      "https://example.com/users/alice",
-			Object:     map[string]any{"actor": "https://remote.example/users/bob"},
+			Object: map[string]any{
+				"id":     "follow-reject-err",
+				"type":   ActivityTypeFollow,
+				"actor":  "https://remote.example/users/bob",
+				"object": "https://example.com/users/alice",
+			},
 		}
 		require.Error(t, handler.processRejectActivity(ctx, reject, "ignored"))
 		relationshipRepo.AssertExpectations(t)

--- a/cmd/activity-processor/handler_m14_follow_state_test.go
+++ b/cmd/activity-processor/handler_m14_follow_state_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/services"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	testmocks "github.com/equaltoai/lesser/pkg/testing/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestActivityHandler_M14_InlineFollowResponsesRequirePersistedPendingState(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("accept rejects forged inline follow id", func(t *testing.T) {
+		relationshipRepo := testmocks.NewMockRelationshipRepository()
+		relationshipRepo.On("GetRelationship", mock.Anything, "bob", "alice").Return(&models.RelationshipRecord{
+			State:      models.RelationshipPending,
+			ActivityID: "stored-follow",
+		}, nil).Once()
+
+		handler := &ActivityHandler{Logger: zap.NewNop(), RelationshipRepo: relationshipRepo}
+		accept := &activitypub.Activity{
+			BaseObject: activitypub.BaseObject{ID: "accept-forged-inline", Type: ActivityTypeAccept},
+			Actor:      "https://example.com/users/alice",
+			Object: map[string]any{
+				"id":     "forged-follow",
+				"type":   ActivityTypeFollow,
+				"actor":  "https://remote.example/users/bob",
+				"object": "https://example.com/users/alice",
+			},
+		}
+
+		require.ErrorIs(t, handler.processAcceptActivity(ctx, accept, "ignored"), services.ErrActorNotAuthorizedUndo)
+		relationshipRepo.AssertNotCalled(t, "AcceptFollowRequest", mock.Anything, "bob", "alice")
+		relationshipRepo.AssertExpectations(t)
+	})
+
+	t.Run("reject rejects forged inline follow id", func(t *testing.T) {
+		relationshipRepo := testmocks.NewMockRelationshipRepository()
+		relationshipRepo.On("GetRelationship", mock.Anything, "bob", "alice").Return(&models.RelationshipRecord{
+			State:      models.RelationshipPending,
+			ActivityID: "stored-follow",
+		}, nil).Once()
+
+		handler := &ActivityHandler{Logger: zap.NewNop(), RelationshipRepo: relationshipRepo}
+		reject := &activitypub.Activity{
+			BaseObject: activitypub.BaseObject{ID: "reject-forged-inline", Type: ActivityTypeReject},
+			Actor:      "https://example.com/users/alice",
+			Object: map[string]any{
+				"id":     "forged-follow",
+				"type":   ActivityTypeFollow,
+				"actor":  "https://remote.example/users/bob",
+				"object": "https://example.com/users/alice",
+			},
+		}
+
+		require.ErrorIs(t, handler.processRejectActivity(ctx, reject, "ignored"), services.ErrActorNotAuthorizedUndo)
+		relationshipRepo.AssertNotCalled(t, "RejectFollowRequest", mock.Anything, "bob", "alice")
+		relationshipRepo.AssertExpectations(t)
+	})
+}
+
+func TestActivityHandler_M14_UndoRejectRequiresPersistedRejectedState(t *testing.T) {
+	ctx := context.Background()
+	relationshipRepo := testmocks.NewMockRelationshipRepository()
+	relationshipRepo.On("GetRelationship", mock.Anything, "bob", "alice").Return(&models.RelationshipRecord{
+		State:      models.RelationshipPending,
+		ActivityID: "follow-1",
+	}, nil).Once()
+
+	handler := &ActivityHandler{Logger: zap.NewNop(), RelationshipRepo: relationshipRepo}
+	reject := map[string]any{
+		"type":  ActivityTypeReject,
+		"actor": "https://example.com/users/alice",
+		"object": map[string]any{
+			"id":     "follow-1",
+			"type":   ActivityTypeFollow,
+			"actor":  "https://remote.example/users/bob",
+			"object": "https://example.com/users/alice",
+		},
+	}
+	undo := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{ID: "undo-reject-pending", Type: ActivityTypeUndo},
+		Actor:      "https://example.com/users/alice",
+	}
+
+	require.ErrorIs(t, handler.processUndoReject(ctx, undo, reject, "alice"), services.ErrActorNotAuthorizedUndo)
+	relationshipRepo.AssertNotCalled(t, "CreateRelationship", mock.Anything, "bob", "alice", "follow-1")
+	relationshipRepo.AssertExpectations(t)
+}

--- a/cmd/activity-processor/handler_m14_follow_state_test.go
+++ b/cmd/activity-processor/handler_m14_follow_state_test.go
@@ -17,13 +17,19 @@ func TestActivityHandler_M14_InlineFollowResponsesRequirePersistedPendingState(t
 	ctx := context.Background()
 
 	t.Run("accept rejects forged inline follow id", func(t *testing.T) {
+		activityRepo := testmocks.NewMockActivityRepository()
+		activityRepo.On("GetActivity", mock.Anything, "forged-follow").Return(&activitypub.Activity{
+			BaseObject: activitypub.BaseObject{ID: "forged-follow", Type: ActivityTypeFollow},
+			Actor:      "https://remote.example/users/bob",
+			Object:     "https://example.com/users/alice",
+		}, nil).Once()
 		relationshipRepo := testmocks.NewMockRelationshipRepository()
 		relationshipRepo.On("GetRelationship", mock.Anything, "bob", "alice").Return(&models.RelationshipRecord{
 			State:      models.RelationshipPending,
 			ActivityID: "stored-follow",
 		}, nil).Once()
 
-		handler := &ActivityHandler{Logger: zap.NewNop(), RelationshipRepo: relationshipRepo}
+		handler := &ActivityHandler{Logger: zap.NewNop(), ActivityRepo: activityRepo, RelationshipRepo: relationshipRepo}
 		accept := &activitypub.Activity{
 			BaseObject: activitypub.BaseObject{ID: "accept-forged-inline", Type: ActivityTypeAccept},
 			Actor:      "https://example.com/users/alice",
@@ -37,17 +43,24 @@ func TestActivityHandler_M14_InlineFollowResponsesRequirePersistedPendingState(t
 
 		require.ErrorIs(t, handler.processAcceptActivity(ctx, accept, "ignored"), services.ErrActorNotAuthorizedUndo)
 		relationshipRepo.AssertNotCalled(t, "AcceptFollowRequest", mock.Anything, "bob", "alice")
+		activityRepo.AssertExpectations(t)
 		relationshipRepo.AssertExpectations(t)
 	})
 
 	t.Run("reject rejects forged inline follow id", func(t *testing.T) {
+		activityRepo := testmocks.NewMockActivityRepository()
+		activityRepo.On("GetActivity", mock.Anything, "forged-follow").Return(&activitypub.Activity{
+			BaseObject: activitypub.BaseObject{ID: "forged-follow", Type: ActivityTypeFollow},
+			Actor:      "https://remote.example/users/bob",
+			Object:     "https://example.com/users/alice",
+		}, nil).Once()
 		relationshipRepo := testmocks.NewMockRelationshipRepository()
 		relationshipRepo.On("GetRelationship", mock.Anything, "bob", "alice").Return(&models.RelationshipRecord{
 			State:      models.RelationshipPending,
 			ActivityID: "stored-follow",
 		}, nil).Once()
 
-		handler := &ActivityHandler{Logger: zap.NewNop(), RelationshipRepo: relationshipRepo}
+		handler := &ActivityHandler{Logger: zap.NewNop(), ActivityRepo: activityRepo, RelationshipRepo: relationshipRepo}
 		reject := &activitypub.Activity{
 			BaseObject: activitypub.BaseObject{ID: "reject-forged-inline", Type: ActivityTypeReject},
 			Actor:      "https://example.com/users/alice",
@@ -61,18 +74,26 @@ func TestActivityHandler_M14_InlineFollowResponsesRequirePersistedPendingState(t
 
 		require.ErrorIs(t, handler.processRejectActivity(ctx, reject, "ignored"), services.ErrActorNotAuthorizedUndo)
 		relationshipRepo.AssertNotCalled(t, "RejectFollowRequest", mock.Anything, "bob", "alice")
+		activityRepo.AssertExpectations(t)
 		relationshipRepo.AssertExpectations(t)
 	})
 
-	t.Run("accept rejects inline follow target with same username on another domain", func(t *testing.T) {
+	t.Run("accept rejects inline follow actor and target forged around exact persisted id", func(t *testing.T) {
+		followID := "https://remote.example/activities/follow-1"
+		activityRepo := testmocks.NewMockActivityRepository()
+		activityRepo.On("GetActivity", mock.Anything, followID).Return(&activitypub.Activity{
+			BaseObject: activitypub.BaseObject{ID: followID, Type: ActivityTypeFollow},
+			Actor:      "https://remote.example/users/bob",
+			Object:     "https://example.com/users/alice",
+		}, nil).Once()
 		relationshipRepo := testmocks.NewMockRelationshipRepository()
 
-		handler := &ActivityHandler{Logger: zap.NewNop(), RelationshipRepo: relationshipRepo}
+		handler := &ActivityHandler{Logger: zap.NewNop(), ActivityRepo: activityRepo, RelationshipRepo: relationshipRepo}
 		accept := &activitypub.Activity{
 			BaseObject: activitypub.BaseObject{ID: "accept-forged-target", Type: ActivityTypeAccept},
-			Actor:      "https://example.com/users/alice",
+			Actor:      "https://evil.example/users/alice",
 			Object: map[string]any{
-				"id":     "https://remote.example/activities/follow-1",
+				"id":     followID,
 				"type":   ActivityTypeFollow,
 				"actor":  "https://remote.example/users/bob",
 				"object": "https://evil.example/users/alice",
@@ -82,17 +103,24 @@ func TestActivityHandler_M14_InlineFollowResponsesRequirePersistedPendingState(t
 		require.ErrorIs(t, handler.processAcceptActivity(ctx, accept, "ignored"), services.ErrActorNotAuthorizedUndo)
 		relationshipRepo.AssertNotCalled(t, "GetRelationship", mock.Anything, "bob", "alice")
 		relationshipRepo.AssertNotCalled(t, "AcceptFollowRequest", mock.Anything, "bob", "alice")
+		activityRepo.AssertExpectations(t)
 		relationshipRepo.AssertExpectations(t)
 	})
 
 	t.Run("accept rejects inline follow id matching only the last path segment", func(t *testing.T) {
+		activityRepo := testmocks.NewMockActivityRepository()
+		activityRepo.On("GetActivity", mock.Anything, "https://evil.example/activities/follow-1").Return(&activitypub.Activity{
+			BaseObject: activitypub.BaseObject{ID: "https://evil.example/activities/follow-1", Type: ActivityTypeFollow},
+			Actor:      "https://remote.example/users/bob",
+			Object:     "https://example.com/users/alice",
+		}, nil).Once()
 		relationshipRepo := testmocks.NewMockRelationshipRepository()
 		relationshipRepo.On("GetRelationship", mock.Anything, "bob", "alice").Return(&models.RelationshipRecord{
 			State:      models.RelationshipPending,
 			ActivityID: "https://remote.example/activities/follow-1",
 		}, nil).Once()
 
-		handler := &ActivityHandler{Logger: zap.NewNop(), RelationshipRepo: relationshipRepo}
+		handler := &ActivityHandler{Logger: zap.NewNop(), ActivityRepo: activityRepo, RelationshipRepo: relationshipRepo}
 		accept := &activitypub.Activity{
 			BaseObject: activitypub.BaseObject{ID: "accept-forged-id-segment", Type: ActivityTypeAccept},
 			Actor:      "https://example.com/users/alice",
@@ -106,6 +134,7 @@ func TestActivityHandler_M14_InlineFollowResponsesRequirePersistedPendingState(t
 
 		require.ErrorIs(t, handler.processAcceptActivity(ctx, accept, "ignored"), services.ErrActorNotAuthorizedUndo)
 		relationshipRepo.AssertNotCalled(t, "AcceptFollowRequest", mock.Anything, "bob", "alice")
+		activityRepo.AssertExpectations(t)
 		relationshipRepo.AssertExpectations(t)
 	})
 }
@@ -122,13 +151,19 @@ func TestActivityHandler_M14_FollowResponseTrustMatchingIsStrict(t *testing.T) {
 
 func TestActivityHandler_M14_UndoRejectRequiresPersistedRejectedState(t *testing.T) {
 	ctx := context.Background()
+	activityRepo := testmocks.NewMockActivityRepository()
+	activityRepo.On("GetActivity", mock.Anything, "follow-1").Return(&activitypub.Activity{
+		BaseObject: activitypub.BaseObject{ID: "follow-1", Type: ActivityTypeFollow},
+		Actor:      "https://remote.example/users/bob",
+		Object:     "https://example.com/users/alice",
+	}, nil).Once()
 	relationshipRepo := testmocks.NewMockRelationshipRepository()
 	relationshipRepo.On("GetRelationship", mock.Anything, "bob", "alice").Return(&models.RelationshipRecord{
 		State:      models.RelationshipPending,
 		ActivityID: "follow-1",
 	}, nil).Once()
 
-	handler := &ActivityHandler{Logger: zap.NewNop(), RelationshipRepo: relationshipRepo}
+	handler := &ActivityHandler{Logger: zap.NewNop(), ActivityRepo: activityRepo, RelationshipRepo: relationshipRepo}
 	reject := map[string]any{
 		"type":  ActivityTypeReject,
 		"actor": "https://example.com/users/alice",
@@ -146,19 +181,27 @@ func TestActivityHandler_M14_UndoRejectRequiresPersistedRejectedState(t *testing
 
 	require.ErrorIs(t, handler.processUndoReject(ctx, undo, reject, "alice"), services.ErrActorNotAuthorizedUndo)
 	relationshipRepo.AssertNotCalled(t, "CreateRelationship", mock.Anything, "bob", "alice", "follow-1")
+	activityRepo.AssertExpectations(t)
 	relationshipRepo.AssertExpectations(t)
 }
 
 func TestActivityHandler_M14_UndoRejectRequiresExactFollowTarget(t *testing.T) {
 	ctx := context.Background()
+	followID := "https://remote.example/activities/follow-1"
+	activityRepo := testmocks.NewMockActivityRepository()
+	activityRepo.On("GetActivity", mock.Anything, followID).Return(&activitypub.Activity{
+		BaseObject: activitypub.BaseObject{ID: followID, Type: ActivityTypeFollow},
+		Actor:      "https://remote.example/users/bob",
+		Object:     "https://example.com/users/alice",
+	}, nil).Once()
 	relationshipRepo := testmocks.NewMockRelationshipRepository()
 
-	handler := &ActivityHandler{Logger: zap.NewNop(), RelationshipRepo: relationshipRepo}
+	handler := &ActivityHandler{Logger: zap.NewNop(), ActivityRepo: activityRepo, RelationshipRepo: relationshipRepo}
 	reject := map[string]any{
 		"type":  ActivityTypeReject,
-		"actor": "https://example.com/users/alice",
+		"actor": "https://evil.example/users/alice",
 		"object": map[string]any{
-			"id":     "https://remote.example/activities/follow-1",
+			"id":     followID,
 			"type":   ActivityTypeFollow,
 			"actor":  "https://remote.example/users/bob",
 			"object": "https://evil.example/users/alice",
@@ -166,11 +209,12 @@ func TestActivityHandler_M14_UndoRejectRequiresExactFollowTarget(t *testing.T) {
 	}
 	undo := &activitypub.Activity{
 		BaseObject: activitypub.BaseObject{ID: "undo-reject-forged-target", Type: ActivityTypeUndo},
-		Actor:      "https://example.com/users/alice",
+		Actor:      "https://evil.example/users/alice",
 	}
 
 	require.ErrorIs(t, handler.processUndoReject(ctx, undo, reject, "alice"), services.ErrActorNotAuthorizedUndo)
 	relationshipRepo.AssertNotCalled(t, "GetRelationship", mock.Anything, "bob", "alice")
-	relationshipRepo.AssertNotCalled(t, "CreateRelationship", mock.Anything, "bob", "alice", "https://remote.example/activities/follow-1")
+	relationshipRepo.AssertNotCalled(t, "CreateRelationship", mock.Anything, "bob", "alice", followID)
+	activityRepo.AssertExpectations(t)
 	relationshipRepo.AssertExpectations(t)
 }

--- a/cmd/activity-processor/handler_m14_follow_state_test.go
+++ b/cmd/activity-processor/handler_m14_follow_state_test.go
@@ -148,3 +148,29 @@ func TestActivityHandler_M14_UndoRejectRequiresPersistedRejectedState(t *testing
 	relationshipRepo.AssertNotCalled(t, "CreateRelationship", mock.Anything, "bob", "alice", "follow-1")
 	relationshipRepo.AssertExpectations(t)
 }
+
+func TestActivityHandler_M14_UndoRejectRequiresExactFollowTarget(t *testing.T) {
+	ctx := context.Background()
+	relationshipRepo := testmocks.NewMockRelationshipRepository()
+
+	handler := &ActivityHandler{Logger: zap.NewNop(), RelationshipRepo: relationshipRepo}
+	reject := map[string]any{
+		"type":  ActivityTypeReject,
+		"actor": "https://example.com/users/alice",
+		"object": map[string]any{
+			"id":     "https://remote.example/activities/follow-1",
+			"type":   ActivityTypeFollow,
+			"actor":  "https://remote.example/users/bob",
+			"object": "https://evil.example/users/alice",
+		},
+	}
+	undo := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{ID: "undo-reject-forged-target", Type: ActivityTypeUndo},
+		Actor:      "https://example.com/users/alice",
+	}
+
+	require.ErrorIs(t, handler.processUndoReject(ctx, undo, reject, "alice"), services.ErrActorNotAuthorizedUndo)
+	relationshipRepo.AssertNotCalled(t, "GetRelationship", mock.Anything, "bob", "alice")
+	relationshipRepo.AssertNotCalled(t, "CreateRelationship", mock.Anything, "bob", "alice", "https://remote.example/activities/follow-1")
+	relationshipRepo.AssertExpectations(t)
+}

--- a/cmd/activity-processor/handler_m14_follow_state_test.go
+++ b/cmd/activity-processor/handler_m14_follow_state_test.go
@@ -63,6 +63,61 @@ func TestActivityHandler_M14_InlineFollowResponsesRequirePersistedPendingState(t
 		relationshipRepo.AssertNotCalled(t, "RejectFollowRequest", mock.Anything, "bob", "alice")
 		relationshipRepo.AssertExpectations(t)
 	})
+
+	t.Run("accept rejects inline follow target with same username on another domain", func(t *testing.T) {
+		relationshipRepo := testmocks.NewMockRelationshipRepository()
+
+		handler := &ActivityHandler{Logger: zap.NewNop(), RelationshipRepo: relationshipRepo}
+		accept := &activitypub.Activity{
+			BaseObject: activitypub.BaseObject{ID: "accept-forged-target", Type: ActivityTypeAccept},
+			Actor:      "https://example.com/users/alice",
+			Object: map[string]any{
+				"id":     "https://remote.example/activities/follow-1",
+				"type":   ActivityTypeFollow,
+				"actor":  "https://remote.example/users/bob",
+				"object": "https://evil.example/users/alice",
+			},
+		}
+
+		require.ErrorIs(t, handler.processAcceptActivity(ctx, accept, "ignored"), services.ErrActorNotAuthorizedUndo)
+		relationshipRepo.AssertNotCalled(t, "GetRelationship", mock.Anything, "bob", "alice")
+		relationshipRepo.AssertNotCalled(t, "AcceptFollowRequest", mock.Anything, "bob", "alice")
+		relationshipRepo.AssertExpectations(t)
+	})
+
+	t.Run("accept rejects inline follow id matching only the last path segment", func(t *testing.T) {
+		relationshipRepo := testmocks.NewMockRelationshipRepository()
+		relationshipRepo.On("GetRelationship", mock.Anything, "bob", "alice").Return(&models.RelationshipRecord{
+			State:      models.RelationshipPending,
+			ActivityID: "https://remote.example/activities/follow-1",
+		}, nil).Once()
+
+		handler := &ActivityHandler{Logger: zap.NewNop(), RelationshipRepo: relationshipRepo}
+		accept := &activitypub.Activity{
+			BaseObject: activitypub.BaseObject{ID: "accept-forged-id-segment", Type: ActivityTypeAccept},
+			Actor:      "https://example.com/users/alice",
+			Object: map[string]any{
+				"id":     "https://evil.example/activities/follow-1",
+				"type":   ActivityTypeFollow,
+				"actor":  "https://remote.example/users/bob",
+				"object": "https://example.com/users/alice",
+			},
+		}
+
+		require.ErrorIs(t, handler.processAcceptActivity(ctx, accept, "ignored"), services.ErrActorNotAuthorizedUndo)
+		relationshipRepo.AssertNotCalled(t, "AcceptFollowRequest", mock.Anything, "bob", "alice")
+		relationshipRepo.AssertExpectations(t)
+	})
+}
+
+func TestActivityHandler_M14_FollowResponseTrustMatchingIsStrict(t *testing.T) {
+	handler := &ActivityHandler{Logger: zap.NewNop()}
+
+	require.True(t, handler.followTargetMatchesActor("https://example.com/users/alice/", "https://example.com/users/alice"))
+	require.False(t, handler.followTargetMatchesActor("https://evil.example/users/alice", "https://example.com/users/alice"))
+
+	require.True(t, followActivityIDMatches("https://remote.example/activities/follow-1/", "https://remote.example/activities/follow-1"))
+	require.False(t, followActivityIDMatches("https://remote.example/activities/follow-1", "https://evil.example/activities/follow-1"))
 }
 
 func TestActivityHandler_M14_UndoRejectRequiresPersistedRejectedState(t *testing.T) {

--- a/cmd/activity-processor/handler_more_test.go
+++ b/cmd/activity-processor/handler_more_test.go
@@ -93,8 +93,13 @@ func TestActivityHandler_ProcessFollowAcceptCreateLikeAnnounceDeleteBlockFlagMov
 	}
 	require.NoError(t, h.processFollowActivity(ctx, follow, "alice"))
 
-	// Accept (string object path uses context username as follower)
-	relationshipRepo.On("UpdateRelationship", mock.Anything, "bob", "alice", mock.Anything).Return(nil)
+	// Accept resolves the referenced persisted Follow before mutating relationship state.
+	activityRepo.On("GetActivity", mock.Anything, "follow-1").Return(follow, nil).Once()
+	relationshipRepo.On("GetRelationship", mock.Anything, "bob", "alice").Return(&models.RelationshipRecord{
+		State:      models.RelationshipPending,
+		ActivityID: "follow-1",
+	}, nil).Once()
+	relationshipRepo.On("AcceptFollowRequest", mock.Anything, "bob", "alice").Return(nil).Once()
 	notificationRepo.On("CreateNotification", mock.Anything, mock.Anything).Return(nil)
 
 	accept := &activitypub.Activity{

--- a/cmd/activity-processor/handler_remaining_test.go
+++ b/cmd/activity-processor/handler_remaining_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/config"
+	"github.com/equaltoai/lesser/pkg/storage/models"
 	testmocks "github.com/equaltoai/lesser/pkg/testing/mocks"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -65,12 +66,24 @@ func TestActivityHandler_ProcessRejectUpdateAndStreamRecordNoop(t *testing.T) {
 	ctx := context.Background()
 
 	relationshipRepo := testmocks.NewMockRelationshipRepository()
+	activityRepo := testmocks.NewMockActivityRepository()
 	notificationRepo := testmocks.NewMockNotificationRepository()
 
-	relationshipRepo.On("DeleteRelationship", mock.Anything, "bob", "alice").Return(nil)
+	follow := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{ID: "follow-1", Type: ActivityTypeFollow},
+		Actor:      "https://remote.example/users/bob",
+		Object:     "https://example.com/users/alice",
+	}
+	activityRepo.On("GetActivity", mock.Anything, "follow-1").Return(follow, nil).Once()
+	relationshipRepo.On("GetRelationship", mock.Anything, "bob", "alice").Return(&models.RelationshipRecord{
+		State:      models.RelationshipPending,
+		ActivityID: "follow-1",
+	}, nil).Once()
+	relationshipRepo.On("RejectFollowRequest", mock.Anything, "bob", "alice").Return(nil).Once()
 	notificationRepo.On("CreateNotification", mock.Anything, mock.Anything).Return(nil)
 
 	handler := &ActivityHandler{
+		ActivityRepo:     activityRepo,
 		Logger:           zap.NewNop(),
 		RelationshipRepo: relationshipRepo,
 		NotificationRepo: notificationRepo,
@@ -89,5 +102,6 @@ func TestActivityHandler_ProcessRejectUpdateAndStreamRecordNoop(t *testing.T) {
 	require.NoError(t, handler.processRecord(ctx, events.DynamoDBEventRecord{EventName: "MODIFY"}))
 
 	relationshipRepo.AssertExpectations(t)
+	activityRepo.AssertExpectations(t)
 	notificationRepo.AssertExpectations(t)
 }

--- a/cmd/activity-processor/handler_undo_more_branches_test.go
+++ b/cmd/activity-processor/handler_undo_more_branches_test.go
@@ -325,7 +325,15 @@ func TestActivityHandler_UndoRejectHelperBranches(t *testing.T) {
 	})
 
 	t.Run("resolves embedded follow map with object id", func(t *testing.T) {
-		state, err := h.resolveUndoRejectFollowState(ctx, map[string]any{
+		activityRepo := testmocks.NewMockActivityRepository()
+		activityRepo.On("GetActivity", mock.Anything, "follow-embedded").Return(&activitypub.Activity{
+			BaseObject: activitypub.BaseObject{ID: "follow-embedded", Type: ActivityTypeFollow},
+			Actor:      "https://remote.example/users/bob",
+			Object:     "https://example.com/users/alice",
+		}, nil).Once()
+
+		withActivityRepo := &ActivityHandler{Logger: zap.NewNop(), ActivityRepo: activityRepo}
+		state, err := withActivityRepo.resolveUndoRejectFollowState(ctx, map[string]any{
 			"id":    "follow-embedded",
 			"type":  ActivityTypeFollow,
 			"actor": "https://remote.example/users/bob",
@@ -335,6 +343,7 @@ func TestActivityHandler_UndoRejectHelperBranches(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, "https://example.com/users/alice", state.Target)
+		activityRepo.AssertExpectations(t)
 	})
 
 	t.Run("empty follow id string is rejected", func(t *testing.T) {

--- a/cmd/activity-processor/handler_undo_reject_test.go
+++ b/cmd/activity-processor/handler_undo_reject_test.go
@@ -21,7 +21,7 @@ func TestProcessUndoRejectRecreatesFollowRelationship(t *testing.T) {
 
 	mockDB := new(dynamock.MockDB)
 	mockQueryFetch := new(dynamock.MockQuery)
-	mockQueryCreate := new(dynamock.MockQuery)
+	mockQueryRelationship := new(dynamock.MockQuery)
 
 	followActivityID := "https://remote.example/activities/follow123"
 	rejectActor := "https://example.com/users/alice"
@@ -64,8 +64,17 @@ func TestProcessUndoRejectRecreatesFollowRelationship(t *testing.T) {
 		if rel, ok := args.Get(0).(*models.RelationshipRecord); ok {
 			createdRelationship = rel
 		}
-	}).Return(mockQueryCreate)
-	mockQueryCreate.On("Create").Return(nil)
+	}).Return(mockQueryRelationship)
+	mockQueryRelationship.On("Where", "PK", "=", "FOLLOW#bob").Return(mockQueryRelationship).Maybe()
+	mockQueryRelationship.On("Where", "SK", "=", "FOLLOWING#alice").Return(mockQueryRelationship).Maybe()
+	mockQueryRelationship.On("First", mock.AnythingOfType("*models.RelationshipRecord")).Run(func(args mock.Arguments) {
+		relationship := args.Get(0).(*models.RelationshipRecord)
+		relationship.PK = "FOLLOW#bob"
+		relationship.SK = "FOLLOWING#alice"
+		relationship.ActivityID = followActivityID
+		relationship.State = models.RelationshipRejected
+	}).Return(nil).Once()
+	mockQueryRelationship.On("Create").Return(nil).Once()
 
 	handler := &ActivityHandler{
 		DB:               mockDB,
@@ -97,7 +106,7 @@ func TestProcessUndoRejectRecreatesFollowRelationship(t *testing.T) {
 	assert.Equal(t, followActivityID, createdRelationship.ActivityID)
 	assert.Equal(t, models.RelationshipPending, createdRelationship.State)
 
-	mockQueryCreate.AssertExpectations(t)
+	mockQueryRelationship.AssertExpectations(t)
 	mockQueryFetch.AssertExpectations(t)
 	mockDB.AssertExpectations(t)
 }

--- a/cmd/inbox/internal/routing/error_branches_round10_coverage_test.go
+++ b/cmd/inbox/internal/routing/error_branches_round10_coverage_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/observability"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
+	testmocks "github.com/equaltoai/lesser/pkg/testing/mocks"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
@@ -306,6 +307,63 @@ func TestInboxHandler_Round10_StoreAndProcessActivity_ErrorBranches(t *testing.T
 		}
 		require.Error(t, badHandler.storeAndProcessActivity(ctx, req))
 	})
+}
+
+func TestInboxHandler_M14_ReleasesUnprocessedTargetClaimsOnProcessingFailure(t *testing.T) {
+	env := newInboxTestEnv(t)
+	recorder := newRecordingInboxProcessingRecorder()
+	relationshipRepo := testmocks.NewMockRelationshipRepository()
+
+	failingHandler := *env.handler
+	failingHandler.inboxProcessingRepository = recorder
+	failingHandler.relationshipRepository = relationshipRepo
+
+	carol := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   env.cfg.ActorURL("carol"),
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: "carol",
+	}
+
+	activity := &activitypub.Activity{
+		BaseObject: activitypub.BaseObject{
+			Context: activitypub.Context,
+			Type:    activitypub.FollowType,
+			ID:      "https://remote.example/activities/follow-multi-target-fail",
+			To:      []string{env.local.ID, carol.ID},
+		},
+		Actor:  env.remoteActorID,
+		Object: env.local.ID,
+	}
+
+	relationshipRepo.On("IsBlockedBidirectional", mock.Anything, env.remoteActorID, env.local.ID).Return(false, nil).Once()
+	relationshipRepo.On("CreateRelationship", mock.Anything, mock.Anything, env.local.PreferredUsername, activity.ID).Return(errors.New("relationship unavailable")).Once()
+
+	now := time.Now()
+	req := &InboxRequest{
+		Activity:     activity,
+		Actor:        env.local,
+		TargetActors: []*activitypub.Actor{env.local, carol},
+		ActorDomain:  "remote.example",
+		StartTime:    now,
+		CostParams: &federation.CostCalculationParams{
+			ActivityID:    activity.ID,
+			Domain:        "remote.example",
+			ActivityType:  activity.Type,
+			Direction:     "inbound",
+			OperationType: "inbox_processing",
+			Timestamp:     now,
+		},
+	}
+	ctx := newAppTheoryContext("POST", "/inbox", map[string]string{"Host": env.cfg.Domain}, nil, nil)
+
+	require.Error(t, failingHandler.storeAndProcessActivity(ctx, req))
+	require.ElementsMatch(t, []string{
+		activity.ID + "\x00" + env.local.ID,
+		activity.ID + "\x00" + carol.ID,
+	}, recorder.released)
+	relationshipRepo.AssertExpectations(t)
 }
 
 func TestInboxHandler_Round10_CheckDomainBlock_Branches(t *testing.T) {

--- a/cmd/inbox/internal/routing/federated_conversations_inbound_test.go
+++ b/cmd/inbox/internal/routing/federated_conversations_inbound_test.go
@@ -296,6 +296,91 @@ func TestInboxHandler_FederatedConversation_PrepareAndPersistUpdateBranch(t *tes
 	require.Equal(t, env.remoteActorID, stateResult.Items[0].CounterpartID)
 }
 
+func TestInboxHandler_M14_ReplayedRemoteDirectDoesNotOverwriteConversationMetadata(t *testing.T) {
+	env := newInboxTestEnv(t)
+	ctx := context.Background()
+	notifications := inmemory.NewNotificationRepository()
+	conversations := inmemory.NewConversationRepository()
+	statuses := inmemory.NewStatusRepository()
+	objects := inmemory.NewObjectRepository()
+	publisher := &inboundDirectCapturePublisher{}
+	env.handler.notificationRepository = notifications
+	env.handler.conversationRepository = conversations
+	env.handler.statusRepository = statuses
+	env.handler.objectRepository = objects
+	env.handler.publisher = publisher
+
+	originalPublished := time.Date(2026, 4, 27, 18, 0, 0, 0, time.UTC)
+	replayPublished := originalPublished.Add(-2 * time.Hour)
+	noteID := "https://remote.example/users/bob/statuses/direct-replay"
+	statusID := models.CanonicalStatusIDForDomain(noteID, env.handler.localDomain())
+	conversationID := "conv-replay-protected"
+	participantRefs := models.NormalizeConversationParticipantRefs([]models.ConversationParticipantRef{
+		{
+			ParticipantType: models.ConversationParticipantTypeLocalUser,
+			ParticipantID:   "alice",
+		},
+		{
+			ParticipantType: models.ConversationParticipantTypeRemoteActor,
+			ParticipantID:   env.remoteActorID,
+			Acct:            "bob@remote.example",
+			Domain:          "remote.example",
+			ResolvedAt:      &originalPublished,
+		},
+	})
+	participants := models.ConversationParticipantIDsFromRefs(participantRefs)
+	existingConversation := &models.Conversation{
+		ID:                conversationID,
+		Participants:      participants,
+		ParticipantRefs:   participantRefs,
+		LastStatusID:      "newer-direct-status",
+		LastMessageTime:   originalPublished.Add(time.Hour),
+		TotalMessageCount: 7,
+		CreatedAt:         originalPublished,
+		UpdatedAt:         originalPublished.Add(time.Hour),
+	}
+	require.NoError(t, conversations.CreateConversationWithParticipantStates(ctx, existingConversation, participants, nil))
+	require.NoError(t, statuses.CreateStatus(ctx, &models.Status{
+		StatusID:       statusID,
+		AuthorID:       env.remoteActorID,
+		Content:        "<p>original direct</p>",
+		Visibility:     models.VisibilityDirect,
+		ConversationID: conversationID,
+		PublishedAt:    originalPublished,
+		CreatedAt:      originalPublished,
+		UpdatedAt:      originalPublished,
+	}))
+
+	forgedActor := "https://evil.example/users/eve"
+	replayedNote := &activitypub.Note{
+		BaseObject: activitypub.BaseObject{
+			Context:   activitypub.Context,
+			ID:        noteID,
+			Type:      activitypub.NoteType,
+			Published: &replayPublished,
+			To:        []string{env.local.ID},
+		},
+		AttributedTo: forgedActor,
+		Content:      "<p>replayed direct attempting metadata overwrite</p>",
+	}
+	activity := remoteCreateActivityForNote(t, forgedActor, replayedNote, "https://evil.example/activities/replay-direct")
+
+	require.NoError(t, env.handler.processRemoteCreateActivity(ctx, activity, env.local))
+
+	stored, err := conversations.GetConversation(ctx, conversationID)
+	require.NoError(t, err)
+	require.Equal(t, "newer-direct-status", stored.LastStatusID)
+	require.Equal(t, int64(7), stored.TotalMessageCount)
+	require.Equal(t, originalPublished.Add(time.Hour), stored.LastMessageTime)
+	require.ElementsMatch(t, participants, stored.Participants)
+	require.Equal(t, participantRefs, stored.ParticipantRefs)
+
+	result, err := notifications.GetUserNotifications(ctx, "alice", interfaces.PaginationOptions{Limit: 10})
+	require.NoError(t, err)
+	require.Empty(t, result.Items)
+	require.Empty(t, publisher.events)
+}
+
 func TestInboxHandler_FederatedConversation_HelperFallbackBranches(t *testing.T) {
 	env := newInboxTestEnv(t)
 	ctx := context.Background()

--- a/cmd/inbox/internal/routing/inbox.go
+++ b/cmd/inbox/internal/routing/inbox.go
@@ -1082,6 +1082,9 @@ func (ih *InboxHandler) storeAndProcessActivity(ctx *apptheory.Context, req *Inb
 		}
 		shouldProcess, err := ih.shouldProcessInboundActivityTarget(ctx.Context(), req.Activity, targetActor)
 		if err != nil {
+			for _, claimedTargetActor := range targetsToProcess {
+				ih.releaseInboundActivityTargetClaim(ctx.Context(), req.Activity, claimedTargetActor)
+			}
 			processingDuration := time.Since(processingStart)
 			req.CostParams.ProcessingTimeMs += processingDuration.Milliseconds()
 			ih.recordFailureCost(req, fmt.Sprintf("Failed to claim %s activity for idempotent processing: %v", req.Activity.Type, err), 0)
@@ -1114,9 +1117,11 @@ func (ih *InboxHandler) storeAndProcessActivity(ctx *apptheory.Context, req *Inb
 
 	req.CostParams.DynamoDBWriteCount = 1 // Activity storage
 
-	for _, targetActor := range targetsToProcess {
+	for i, targetActor := range targetsToProcess {
 		if err := ih.processActivityByTypeForTarget(ctx.Context(), req.Activity, targetActor, req.CostParams); err != nil {
-			ih.releaseInboundActivityTargetClaim(ctx.Context(), req.Activity, targetActor)
+			for _, unprocessedTargetActor := range targetsToProcess[i:] {
+				ih.releaseInboundActivityTargetClaim(ctx.Context(), req.Activity, unprocessedTargetActor)
+			}
 			processingDuration := time.Since(processingStart)
 			req.CostParams.ProcessingTimeMs += processingDuration.Milliseconds()
 			ih.recordFailureCost(req, fmt.Sprintf("Failed to process %s activity: %v", req.Activity.Type, err), 0)

--- a/cmd/inbox/internal/routing/inbox.go
+++ b/cmd/inbox/internal/routing/inbox.go
@@ -2437,6 +2437,23 @@ func (ih *InboxHandler) processRemoteCreateActivity(ctx context.Context, activit
 		var directConversation *models.Conversation
 		var createDirectConversation bool
 		if directInfo.isDirect {
+			existingStatus, err := ih.existingInboundDirectStatus(ctx, &note)
+			if err != nil {
+				log.Error("failed to check existing inbound direct status",
+					zap.String("activity_id", activity.ID),
+					zap.String("note_id", note.ID),
+					zap.Error(err))
+				return err
+			}
+			if existingStatus != nil {
+				log.Info("skipping replayed inbound direct status",
+					zap.String("activity_id", activity.ID),
+					zap.String("note_id", note.ID),
+					zap.String("status_id", existingStatus.StatusID),
+					zap.String("conversation_id", existingStatus.ConversationID))
+				return nil
+			}
+
 			directConversation, createDirectConversation, err = ih.prepareInboundDirectConversation(ctx, activity, &note, targetActor, directInfo)
 			if err != nil {
 				log.Error("failed to prepare inbound direct conversation",
@@ -2480,6 +2497,26 @@ func (ih *InboxHandler) processRemoteCreateActivity(ctx context.Context, activit
 	}
 
 	return nil
+}
+
+func (ih *InboxHandler) existingInboundDirectStatus(ctx context.Context, note *activitypub.Note) (*models.Status, error) {
+	if ih.statusRepository == nil || note == nil {
+		return nil, nil
+	}
+
+	statusID := models.CanonicalStatusIDForDomain(note.ID, ih.localDomain())
+	if statusID == "" {
+		return nil, nil
+	}
+
+	existing, err := ih.statusRepository.GetStatus(ctx, statusID)
+	if err == nil && existing != nil {
+		return existing, nil
+	}
+	if isRemoteStatusNotFound(err) {
+		return nil, nil
+	}
+	return nil, err
 }
 
 type inboundDirectCreateInfo struct {

--- a/cmd/inbox/internal/routing/inbox.go
+++ b/cmd/inbox/internal/routing/inbox.go
@@ -2416,91 +2416,136 @@ func (ih *InboxHandler) processRemoteCreateActivity(ctx context.Context, activit
 
 	// Store the object if it's a Note
 	if objType, _ := objMap["type"].(string); objType == activitypub.NoteType {
-		// Validate ActivityPub Note object
-		if err := common.ValidateActivityPubNote(objMap); err != nil {
-			log.Warn("invalid note object in create activity", zap.Error(err))
-			return invalidNoteError()
-		}
+		return ih.processRemoteCreateNote(ctx, activity, targetActor, objMap)
+	}
 
-		// Convert to Note object
-		objJSON, err := json.Marshal(objMap)
-		if err != nil {
+	return nil
+}
+
+func (ih *InboxHandler) processRemoteCreateNote(ctx context.Context, activity *activitypub.Activity, targetActor *activitypub.Actor, objMap map[string]any) error {
+	log := common.WithContext(ctx)
+
+	// Validate ActivityPub Note object
+	if err := common.ValidateActivityPubNote(objMap); err != nil {
+		log.Warn("invalid note object in create activity", zap.Error(err))
+		return invalidNoteError()
+	}
+
+	// Convert to Note object
+	objJSON, err := json.Marshal(objMap)
+	if err != nil {
+		return err
+	}
+
+	var note activitypub.Note
+	if err := common.ParseActivityPubObject(objJSON, &note); err != nil {
+		return err
+	}
+
+	directInfo := ih.classifyInboundDirectCreate(activity, &note, targetActor)
+	if directInfo.unsupportedGroup {
+		ih.logUnsupportedInboundDirectGroup(activity, &note, targetActor, directInfo)
+		return nil
+	}
+
+	directConversation, createDirectConversation, skipCreate, err := ih.prepareDirectCreateState(ctx, activity, targetActor, &note, directInfo)
+	if err != nil {
+		return err
+	}
+	if skipCreate {
+		return nil
+	}
+
+	// Store the note (it will be marked as remote)
+	if err := ih.objectRepository.CreateObject(ctx, &note); err != nil {
+		if !dynamormerrors.IsConditionFailed(err) && !stdErrors.Is(err, storage.ErrAlreadyExists) {
+			log.Error("failed to store remote note", zap.Error(err))
 			return err
-		}
-
-		var note activitypub.Note
-		if err := common.ParseActivityPubObject(objJSON, &note); err != nil {
-			return err
-		}
-
-		directInfo := ih.classifyInboundDirectCreate(activity, &note, targetActor)
-		if directInfo.unsupportedGroup {
-			ih.logUnsupportedInboundDirectGroup(activity, &note, targetActor, directInfo)
-			return nil
-		}
-
-		var directConversation *models.Conversation
-		var createDirectConversation bool
-		if directInfo.isDirect {
-			existingStatus, err := ih.existingInboundDirectStatus(ctx, &note)
-			if err != nil {
-				log.Error("failed to check existing inbound direct status",
-					zap.String("activity_id", activity.ID),
-					zap.String("note_id", note.ID),
-					zap.Error(err))
-				return err
-			}
-			if existingStatus != nil {
-				log.Info("skipping replayed inbound direct status",
-					zap.String("activity_id", activity.ID),
-					zap.String("note_id", note.ID),
-					zap.String("status_id", existingStatus.StatusID),
-					zap.String("conversation_id", existingStatus.ConversationID))
-				return nil
-			}
-
-			directConversation, createDirectConversation, err = ih.prepareInboundDirectConversation(ctx, activity, &note, targetActor, directInfo)
-			if err != nil {
-				log.Error("failed to prepare inbound direct conversation",
-					zap.String("activity_id", activity.ID),
-					zap.String("target_actor", targetActor.ID),
-					zap.Error(err))
-				return err
-			}
-			note.ConversationID = directConversation.ID
-			note.Visibility = models.VisibilityDirect
-		}
-
-		// Store the note (it will be marked as remote)
-		if err := ih.objectRepository.CreateObject(ctx, &note); err != nil {
-			if !dynamormerrors.IsConditionFailed(err) && !stdErrors.Is(err, storage.ErrAlreadyExists) {
-				log.Error("failed to store remote note", zap.Error(err))
-				return err
-			}
-		}
-
-		status, err := ih.materializeRemoteNoteStatus(ctx, &note)
-		if err != nil {
-			log.Error("failed to materialize remote note status",
-				zap.String("note_id", note.ID),
-				zap.Error(err))
-			return err
-		}
-		if directInfo.isDirect {
-			if err := ih.persistInboundDirectConversation(ctx, directConversation, createDirectConversation, status, directInfo); err != nil {
-				log.Error("failed to persist inbound direct conversation",
-					zap.String("activity_id", activity.ID),
-					zap.String("conversation_id", directConversation.ID),
-					zap.Error(err))
-				return err
-			}
-			ih.createRemoteDirectNotification(ctx, activity, targetActor, &note, status, directConversation, directInfo)
-			ih.emitInboundDirectConversationEvent(ctx, directConversation, status, directInfo.localParticipantID)
-		} else {
-			ih.createRemoteCreateNotifications(ctx, activity, targetActor, &note, status)
 		}
 	}
 
+	status, err := ih.materializeRemoteNoteStatus(ctx, &note)
+	if err != nil {
+		log.Error("failed to materialize remote note status",
+			zap.String("note_id", note.ID),
+			zap.Error(err))
+		return err
+	}
+
+	return ih.finishRemoteCreateDeliverySideEffects(ctx, activity, targetActor, &note, status, directConversation, createDirectConversation, directInfo)
+}
+
+func (ih *InboxHandler) prepareDirectCreateState(
+	ctx context.Context,
+	activity *activitypub.Activity,
+	targetActor *activitypub.Actor,
+	note *activitypub.Note,
+	directInfo inboundDirectCreateInfo,
+) (*models.Conversation, bool, bool, error) {
+	if !directInfo.isDirect {
+		return nil, false, false, nil
+	}
+
+	log := common.WithContext(ctx)
+	existingStatus, err := ih.existingInboundDirectStatus(ctx, note)
+	if err != nil {
+		log.Error("failed to check existing inbound direct status",
+			zap.String("activity_id", activity.ID),
+			zap.String("note_id", note.ID),
+			zap.Error(err))
+		return nil, false, false, err
+	}
+	if existingStatus != nil {
+		log.Info("skipping replayed inbound direct status",
+			zap.String("activity_id", activity.ID),
+			zap.String("note_id", note.ID),
+			zap.String("status_id", existingStatus.StatusID),
+			zap.String("conversation_id", existingStatus.ConversationID))
+		return nil, false, true, nil
+	}
+
+	directConversation, createDirectConversation, err := ih.prepareInboundDirectConversation(ctx, activity, note, targetActor, directInfo)
+	if err != nil {
+		log.Error("failed to prepare inbound direct conversation",
+			zap.String("activity_id", activity.ID),
+			zap.String("target_actor", targetActor.ID),
+			zap.Error(err))
+		return nil, false, false, err
+	}
+
+	note.ConversationID = directConversation.ID
+	note.Visibility = models.VisibilityDirect
+	return directConversation, createDirectConversation, false, nil
+}
+
+func (ih *InboxHandler) finishRemoteCreateDeliverySideEffects(
+	ctx context.Context,
+	activity *activitypub.Activity,
+	targetActor *activitypub.Actor,
+	note *activitypub.Note,
+	status *models.Status,
+	directConversation *models.Conversation,
+	createDirectConversation bool,
+	directInfo inboundDirectCreateInfo,
+) error {
+	if !directInfo.isDirect {
+		ih.createRemoteCreateNotifications(ctx, activity, targetActor, note, status)
+		return nil
+	}
+	if directConversation == nil {
+		return nil
+	}
+
+	log := common.WithContext(ctx)
+	if err := ih.persistInboundDirectConversation(ctx, directConversation, createDirectConversation, status, directInfo); err != nil {
+		log.Error("failed to persist inbound direct conversation",
+			zap.String("activity_id", activity.ID),
+			zap.String("conversation_id", directConversation.ID),
+			zap.Error(err))
+		return err
+	}
+	ih.createRemoteDirectNotification(ctx, activity, targetActor, note, status, directConversation, directInfo)
+	ih.emitInboundDirectConversationEvent(ctx, directConversation, status, directInfo.localParticipantID)
 	return nil
 }
 

--- a/pkg/federation/httpsig.go
+++ b/pkg/federation/httpsig.go
@@ -232,11 +232,12 @@ func ParsePrivateKeyPEM(pemData []byte) (crypto.PrivateKey, error) {
 	}
 }
 
-// RequireSignedBodyIntegrity enforces the minimum signed-header set for
-// body-bearing inbound ActivityPub requests. Digest must be present and signed
-// with host/date/(request-target) so a proxy or attacker cannot alter the body
-// and Digest header without invalidating the HTTP signature.
-func RequireSignedBodyIntegrity(req *http.Request) error {
+// RequireSignedRequestIntegrity enforces the minimum signed-header set for
+// inbound ActivityPub requests. All requests must sign host/date/(request-target)
+// so replays and host/path rewrites fail verification. Body-bearing requests
+// must also include and sign Digest so a proxy or attacker cannot alter the
+// body and Digest header without invalidating the HTTP signature.
+func RequireSignedRequestIntegrity(req *http.Request) error {
 	if req == nil {
 		return common.AuthenticationError{Message: "missing request"}
 	}
@@ -244,6 +245,23 @@ func RequireSignedBodyIntegrity(req *http.Request) error {
 	sig, err := ParseSignatureHeader(req.Header.Get(SignatureHeader))
 	if err != nil {
 		return errors.Join(ErrSignatureParseFailed, err)
+	}
+
+	return requireSignedRequestIntegrity(req, sig)
+}
+
+// RequireSignedBodyIntegrity is kept for callers that adopted the earlier
+// body-oriented name; the invariant is now request-wide.
+func RequireSignedBodyIntegrity(req *http.Request) error {
+	return RequireSignedRequestIntegrity(req)
+}
+
+func requireSignedRequestIntegrity(req *http.Request, sig *HTTPSignature) error {
+	if req == nil {
+		return common.AuthenticationError{Message: "missing request"}
+	}
+	if sig == nil {
+		return common.AuthenticationError{Message: "missing signature"}
 	}
 
 	signedHeaders := make(map[string]struct{}, len(sig.Headers))
@@ -257,6 +275,9 @@ func RequireSignedBodyIntegrity(req *http.Request) error {
 	}
 
 	if err := validateSignedHostBinding(req); err != nil {
+		return err
+	}
+	if err := verifyTimestamp(req.Header.Get(DateHeader)); err != nil {
 		return err
 	}
 
@@ -355,27 +376,30 @@ func SignHTTPRequest(req *http.Request, privateKey crypto.PrivateKey, keyID stri
 		req.Header.Set(DateHeader, time.Now().UTC().Format(http.TimeFormat))
 	}
 
-	// Calculate and set digest header if there's a body
-	if req.Body != nil && req.ContentLength != 0 {
-		// Read body
-		bodyBytes, err := io.ReadAll(req.Body)
-		if err != nil {
-			common.Logger().Error("failed to read request body", zap.Error(err))
-			return errors.Join(ErrReadRequestBodyFailed, err)
-		}
-
-		// Reset body for future reads
-		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-
-		// Calculate and set digest
-		digest := calculateDigest(bodyBytes)
-		req.Header.Set(DigestHeader, digest)
+	if err := ensureDigestHeaderForBody(req); err != nil {
+		return err
 	}
 
 	// Use enhanced signing for better algorithm support
 	algorithm := DetermineSigningAlgorithm(privateKey, true) // Use legacy for max compatibility
 
 	return SignHTTPRequestWithAlgorithm(req, privateKey, keyID, algorithm)
+}
+
+func ensureDigestHeaderForBody(req *http.Request) error {
+	if req == nil || req.Body == nil || req.ContentLength == 0 || req.Header.Get(DigestHeader) != "" {
+		return nil
+	}
+
+	bodyBytes, err := io.ReadAll(req.Body)
+	if err != nil {
+		common.Logger().Error("failed to read request body", zap.Error(err))
+		return errors.Join(ErrReadRequestBodyFailed, err)
+	}
+
+	req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	req.Header.Set(DigestHeader, calculateDigest(bodyBytes))
+	return nil
 }
 
 // GenerateRSAKeyPair generates a new RSA key pair

--- a/pkg/federation/httpsig_enhanced.go
+++ b/pkg/federation/httpsig_enhanced.go
@@ -66,6 +66,15 @@ func VerifyHTTPSignatureV2(req *http.Request, publicKey crypto.PublicKey) error 
 // VerifyHTTPSignatureEnhanced verifies signatures with support for multiple algorithms
 func VerifyHTTPSignatureEnhanced(req *http.Request, publicKey crypto.PublicKey, sig *HTTPSignature) error {
 	log := common.Logger()
+	if req == nil {
+		return common.AuthenticationError{Message: "missing request"}
+	}
+	if sig == nil {
+		return ErrMissingSignatureValue
+	}
+	if err := requireSignedRequestIntegrity(req, sig); err != nil {
+		return err
+	}
 	trace, _ := FollowTraceFromContext(req.Context())
 
 	// Build signature string
@@ -237,6 +246,9 @@ func SignHTTPRequestWithAlgorithm(req *http.Request, privateKey crypto.PrivateKe
 	// Set date header if not present
 	if err := common.ValidateRequiredParam("req.Header.Get(DateHeader)", req.Header.Get(DateHeader)); err != nil {
 		req.Header.Set(DateHeader, time.Now().UTC().Format(http.TimeFormat))
+	}
+	if err := ensureDigestHeaderForBody(req); err != nil {
+		return err
 	}
 
 	// Determine headers to sign

--- a/pkg/federation/httpsig_enhanced_additional_test.go
+++ b/pkg/federation/httpsig_enhanced_additional_test.go
@@ -91,7 +91,7 @@ func TestVerifyHTTPSignatureV2_StructuredSignature_Success(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "https://example.com/inbox?x=1", nil)
 	req.Host = "example.com"
-	req.Header.Set(DateHeader, "Mon, 01 Jan 2024 12:00:00 GMT")
+	req.Header.Set(DateHeader, time.Now().UTC().Format(http.TimeFormat))
 
 	signatureInput := `sig=("@method" "@path" "host" "date");keyid="https://example.com/users/alice#main-key";alg="rsa-sha256"`
 	headers := []string{RequestTargetHeader, RequestTargetHeader, "host", "date"}

--- a/pkg/federation/httpsig_test.go
+++ b/pkg/federation/httpsig_test.go
@@ -2,8 +2,12 @@ package federation
 
 import (
 	"bytes"
+	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -252,6 +256,70 @@ func TestVerifyHTTPSignature(t *testing.T) {
 	req.Header.Del("Signature")
 	err = VerifyHTTPSignature(req, publicKey)
 	assert.Error(t, err)
+}
+
+func TestVerifyHTTPSignatureRequiresSignedRequestIntegrity(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	publicKey := &privateKey.PublicKey
+	keyID := "https://example.com/users/alice#main-key"
+
+	signWithHeaders := func(t *testing.T, req *http.Request, headers []string) {
+		t.Helper()
+
+		sigString, err := buildSignatureString(req, headers)
+		require.NoError(t, err)
+
+		hash := sha256.Sum256([]byte(sigString))
+		signature, err := rsa.SignPKCS1v15(rand.Reader, privateKey, crypto.SHA256, hash[:])
+		require.NoError(t, err)
+
+		req.Header.Set(SignatureHeader, fmt.Sprintf(
+			`keyId="%s",algorithm="%s",headers="%s",signature="%s"`,
+			keyID,
+			AlgorithmRSASHA256,
+			strings.Join(headers, " "),
+			base64.StdEncoding.EncodeToString(signature),
+		))
+	}
+
+	t.Run("get succeeds with signed freshness host and request target", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "https://example.com/inbox", nil)
+		req.Host = "example.com"
+
+		require.NoError(t, SignHTTPRequest(req, privateKey, keyID))
+		require.NoError(t, VerifyHTTPSignature(req, publicKey))
+	})
+
+	t.Run("get rejects signature missing request target coverage", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "https://example.com/inbox", nil)
+		req.Host = "example.com"
+		req.Header.Set(DateHeader, time.Now().UTC().Format(http.TimeFormat))
+		signWithHeaders(t, req, []string{"host", "date"})
+
+		require.Error(t, VerifyHTTPSignature(req, publicKey))
+	})
+
+	t.Run("get rejects stale signed freshness", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "https://example.com/inbox", nil)
+		req.Host = "example.com"
+		req.Header.Set(DateHeader, "Mon, 01 Jan 2024 12:00:00 GMT")
+		signWithHeaders(t, req, []string{RequestTargetHeader, "host", "date"})
+
+		require.Error(t, VerifyHTTPSignature(req, publicKey))
+	})
+
+	t.Run("post rejects unsigned digest coverage", func(t *testing.T) {
+		body := []byte(`{"type":"Create"}`)
+		req := httptest.NewRequest(http.MethodPost, "https://example.com/inbox", bytes.NewReader(body))
+		req.Host = "example.com"
+		req.Header.Set(DateHeader, time.Now().UTC().Format(http.TimeFormat))
+		req.Header.Set(DigestHeader, calculateDigest(body))
+		req.Header.Set("Content-Type", "application/activity+json")
+		signWithHeaders(t, req, []string{RequestTargetHeader, "host", "date"})
+
+		require.Error(t, VerifyHTTPSignature(req, publicKey))
+	})
 }
 
 func TestSignHTTPRequest(t *testing.T) {
@@ -599,7 +667,7 @@ func TestRequireSignedBodyIntegrity(t *testing.T) {
 		req.Host = "example.com"
 		req.Header.Set(DateHeader, time.Now().UTC().Format(time.RFC1123))
 		req.Header.Set("Content-Type", "application/activity+json")
-		require.NoError(t, SignHTTPRequestWithAlgorithm(req, privateKey, "https://example.com/users/alice#main-key", AlgorithmRSASHA256))
+		req.Header.Set(SignatureHeader, `keyId="https://example.com/users/alice#main-key",algorithm="rsa-sha256",headers="(request-target) host date",signature="dGVzdA=="`)
 
 		require.Error(t, RequireSignedBodyIntegrity(req))
 	})
@@ -630,12 +698,16 @@ func TestRequireSignedBodyIntegrity_BoundaryBranches(t *testing.T) {
 	dummySignature := func(headers string) string {
 		return `keyId="https://example.com/users/alice#main-key",algorithm="rsa-sha256",headers="` + headers + `",signature="dGVzdA=="`
 	}
+	setFreshDate := func(req *http.Request) {
+		req.Header.Set(DateHeader, time.Now().UTC().Format(time.RFC1123))
+	}
 
 	require.Error(t, RequireSignedBodyIntegrity(nil))
 
 	t.Run("missing required signed host header is rejected", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "https://example.com/inbox", nil)
 		req.Host = "example.com"
+		setFreshDate(req)
 		req.Header.Set(SignatureHeader, dummySignature("(request-target) date"))
 
 		require.Error(t, RequireSignedBodyIntegrity(req))
@@ -644,6 +716,7 @@ func TestRequireSignedBodyIntegrity_BoundaryBranches(t *testing.T) {
 	t.Run("get without body or digest does not require digest", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "https://example.com/inbox", nil)
 		req.Host = "example.com"
+		setFreshDate(req)
 		req.Header.Set(SignatureHeader, dummySignature("(request-target) host date"))
 
 		require.NoError(t, RequireSignedBodyIntegrity(req))
@@ -652,6 +725,7 @@ func TestRequireSignedBodyIntegrity_BoundaryBranches(t *testing.T) {
 	t.Run("get with digest header requires digest to be signed", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "https://example.com/inbox", nil)
 		req.Host = "example.com"
+		setFreshDate(req)
 		req.Header.Set(DigestHeader, calculateDigest([]byte("body")))
 		req.Header.Set(SignatureHeader, dummySignature("(request-target) host date"))
 
@@ -661,6 +735,7 @@ func TestRequireSignedBodyIntegrity_BoundaryBranches(t *testing.T) {
 	t.Run("host header fallback is accepted", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "https://example.com/inbox", nil)
 		req.Host = ""
+		setFreshDate(req)
 		req.Header.Set(common.HostHeader, "example.com")
 		req.Header.Set(SignatureHeader, dummySignature("(request-target) host date"))
 
@@ -670,6 +745,7 @@ func TestRequireSignedBodyIntegrity_BoundaryBranches(t *testing.T) {
 	t.Run("invalid signed host authority is rejected", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "https://example.com/inbox", nil)
 		req.Host = "example.com/path"
+		setFreshDate(req)
 		req.Header.Set(SignatureHeader, dummySignature("(request-target) host date"))
 
 		require.Error(t, RequireSignedBodyIntegrity(req))
@@ -679,6 +755,7 @@ func TestRequireSignedBodyIntegrity_BoundaryBranches(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "https://example.com/inbox", nil)
 		req.Host = "example.com"
 		req.URL.Host = ""
+		setFreshDate(req)
 		req.Header.Set(SignatureHeader, dummySignature("(request-target) host date"))
 
 		require.Error(t, RequireSignedBodyIntegrity(req))

--- a/pkg/federation/remote_search.go
+++ b/pkg/federation/remote_search.go
@@ -189,6 +189,14 @@ func (s *RemoteSearchService) ResolveActor(ctx context.Context, handle string) (
 			zap.Error(err))
 		return nil, errors.Join(ErrFetchRemoteActorFailed, err)
 	}
+	if err := validateResolvedActorDomainForHandle(actor, domain); err != nil {
+		s.logger.Error("actor domain mismatch for resolved handle — possible spoofing",
+			zap.String("handle", cacheKey),
+			zap.String("actor_url", actorURL),
+			zap.String("actor_id", strings.TrimSpace(actor.ID)),
+			zap.Error(err))
+		return nil, errors.Join(ErrActorDomainMismatch, err)
+	}
 
 	// Cache the remote actor with 24 hour TTL
 	if err := s.cacheRemoteActor(ctx, cacheKey, actor, 24*time.Hour); err != nil {
@@ -737,6 +745,22 @@ func cachedRemoteActorMatchesHandle(actor *activitypub.Actor, handle string) boo
 
 	identity := DescribeActorIdentity(actor, "")
 	return strings.EqualFold(exactHandle(identity.Username, identity.Domain), exactHandle(username, domain))
+}
+
+func validateResolvedActorDomainForHandle(actor *activitypub.Actor, expectedDomain string) error {
+	expectedDomain = normalizeActorDomain(expectedDomain)
+	if actor == nil || expectedDomain == "" {
+		return ErrActorDomainMismatch
+	}
+
+	actorDomain := normalizeActorDomain(common.ExtractDomainFromActorID(actor.ID))
+	if actorDomain == "" {
+		return ErrActorDomainMismatch
+	}
+	if !strings.EqualFold(actorDomain, expectedDomain) {
+		return fmt.Errorf("resolved actor ID domain %q does not match requested handle domain %q", actorDomain, expectedDomain)
+	}
+	return nil
 }
 
 func cachedRemoteActorUsername(handle string) string {

--- a/pkg/federation/remote_search_test.go
+++ b/pkg/federation/remote_search_test.go
@@ -222,6 +222,51 @@ func TestRemoteSearchService_ResolveActor_WebFingerAndFetch(t *testing.T) {
 	assert.True(t, cached)
 }
 
+func TestRemoteSearchService_ResolveActor_RejectsHandleDomainMismatch(t *testing.T) {
+	actorRepo := &fakeRemoteSearchActorRepo{
+		localByUsername: map[string]*activitypub.Actor{},
+		cachedByHandle:  map[string]*activitypub.Actor{},
+	}
+	userRepo := &fakeRemoteSearchUserRepo{}
+
+	const actorURL = "https://evil.example/users/bob"
+	httpClient := &fakeHTTPMux{}
+	httpClient.do = func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Hostname() + req.URL.Path {
+		case "remote.example/.well-known/webfinger":
+			return jsonResponse(http.StatusOK, activitypub.WebFingerResource{
+				Links: []activitypub.WebFingerLink{
+					{Rel: "self", Type: "application/activity+json", Href: actorURL},
+				},
+			}), nil
+		case "evil.example/users/bob":
+			return jsonResponse(http.StatusOK, &activitypub.Actor{
+				BaseObject:        activitypub.BaseObject{ID: actorURL, Type: activitypub.PersonType},
+				Inbox:             actorURL + "/inbox",
+				Outbox:            actorURL + "/outbox",
+				PreferredUsername: "bob",
+			}), nil
+		default:
+			return nil, errors.New("unexpected url: " + req.URL.String())
+		}
+	}
+
+	svc := &RemoteSearchService{
+		actorRepo:  actorRepo,
+		userRepo:   userRepo,
+		httpClient: httpClient,
+		logger:     common.Logger(),
+	}
+
+	_, err := svc.ResolveActor(context.Background(), "bob@remote.example")
+	require.ErrorIs(t, err, ErrActorDomainMismatch)
+
+	userRepo.mu.Lock()
+	_, cached := userRepo.cached["bob@remote.example"]
+	userRepo.mu.Unlock()
+	assert.False(t, cached)
+}
+
 func TestRemoteSearchService_ResolveActor_WebFingerErrors(t *testing.T) {
 	svc := &RemoteSearchService{
 		actorRepo: &fakeRemoteSearchActorRepo{},


### PR DESCRIPTION
## Milestone
M14 — federation-trust hardening for remaining Codex Security follow-up findings.

## Classification
security / federation-trust / ActivityPub hardening

## Surfaces affected
- Inbound inbox direct Create replay handling and idempotency claims
- Activity processor Follow Accept/Reject/Undo Reject state transitions
- Remote actor WebFinger/actor-domain binding
- HTTP Signature verification and outbound signing helpers

## Specialist walks referenced
- Federation trust: protect-federation-trust walk applied for inbox, actor identity, Follow state, and HTTP Signature paths
- Contract / API: federation semantic tightening only; no Mastodon REST/OpenAPI shape change
- Schema: none
- Framework: idiomatic lesser usage; no AppTheory/TableTheory patch

## Consumer impact
- Operators: stricter federation verification may reject malformed or stale signed requests earlier
- Remote AP peers: valid signed ActivityPub delivery remains compatible; body-bearing requests must include signed Digest
- Mastodon clients / GraphQL consumers: no client-facing contract change
- Sibling repos: no release artifact, MCP, or JSON-LD contract change

## Tasks
- [x] Closes #915 — prevent replayed remote direct activities from overwriting conversation metadata
- [x] Closes #916 — validate Undo Reject Follow state and harden inline forged Follow handling
- [x] Closes #917 — bind resolved remote actor IDs to requested handle domains
- [x] Closes #918 — require signed freshness, host, request-target, and body digest integrity
- [x] Closes #919 — release inbox idempotency claims on partial failure

## Validation
- `gofmt -l .` (empty)
- `go test ./cmd/inbox/internal/routing ./cmd/activity-processor ./pkg/federation`
- `go test ./...`
- `go vet ./...`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`

Smoke tests were not run, per lesser steward workflow.

## Migration / data handling
No schema or data migration is required for M14. The M12 dev repair tooling remains the direct-migration path for earlier numeric ID/domain-map findings; M14 is code-only hardening.

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to `theory` dev
- [ ] Deployed to `simulacrum` dev
- [ ] Dev soak complete
- [ ] Live rollout intentionally N/A until live instances exist
- [ ] Post-deploy monitoring verified

## Cross-repo coordination
None required.
