### PR TITLE
fix(security): complete Codex Security M15

### DIFF
--- a/cmd/api/handlers/interactions_round11_test.go
+++ b/cmd/api/handlers/interactions_round11_test.go
@@ -122,12 +122,12 @@ func TestInteractionsHandlers_Round11(t *testing.T) {
 	ctxUnreblog.Params["id"] = "1"
 	requireStatus(t, http.StatusOK)(handler.HandleUnreblogLift(ctxUnreblog))
 
-	ctxFavBy, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/1/favourited_by", nil, map[string]string{"limit": "2"}, nil)
+	ctxFavBy, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/1/favourited_by", readHeaders, map[string]string{"limit": "2"}, nil)
 	require.NoError(t, err)
 	ctxFavBy.Params["id"] = "1"
 	requireStatus(t, http.StatusOK)(handler.HandleGetStatusFavouritedByLift(ctxFavBy))
 
-	ctxReblogBy, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/1/reblogged_by", nil, map[string]string{"limit": "2"}, nil)
+	ctxReblogBy, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/1/reblogged_by", readHeaders, map[string]string{"limit": "2"}, nil)
 	require.NoError(t, err)
 	ctxReblogBy.Params["id"] = "1"
 	requireStatus(t, http.StatusOK)(handler.HandleGetStatusRebloggedByLift(ctxReblogBy))

--- a/cmd/api/handlers/status_interactions.go
+++ b/cmd/api/handlers/status_interactions.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/equaltoai/lesser/cmd/api/models"
+	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/services/notes"
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
@@ -51,6 +52,14 @@ func (h *Handler) handleStatusInteractions(ctx *apptheory.Context, interactionTy
 		return common.RespondValidationError(ctx, err)
 	}
 
+	claims, err := h.authenticateWithScope(ctx, auth.ScopeRead)
+	if err != nil {
+		if isInsufficientScopeError(err) {
+			return common.RespondForbidden(ctx, err.Error())
+		}
+		return common.RespondUnauthorized(ctx)
+	}
+
 	// Parse pagination parameters
 	limitStr := queryValue(ctx, "limit")
 	limit, err := common.ParseFollowLimit(limitStr)
@@ -69,6 +78,7 @@ func (h *Handler) handleStatusInteractions(ctx *apptheory.Context, interactionTy
 	case statusFavourites:
 		result, err := h.registry.Notes().GetLikers(ctx.Context(), &notes.GetLikersQuery{
 			StatusID: statusID,
+			ViewerID: claims.Username,
 			Pagination: interfaces.PaginationOptions{
 				Limit:  limit,
 				Cursor: cursor,
@@ -94,6 +104,7 @@ func (h *Handler) handleStatusInteractions(ctx *apptheory.Context, interactionTy
 	case statusReblogs:
 		result, err := h.registry.Notes().GetRebloggers(ctx.Context(), &notes.GetRebloggersQuery{
 			StatusID: statusID,
+			ViewerID: claims.Username,
 			Pagination: interfaces.PaginationOptions{
 				Limit:  limit,
 				Cursor: cursor,

--- a/cmd/api/handlers/status_interactions_round12_test.go
+++ b/cmd/api/handlers/status_interactions_round12_test.go
@@ -16,6 +16,7 @@ import (
 func TestStatusInteractions_Round12(t *testing.T) {
 	cfg := round11TestConfig()
 	handler, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
+	readHeaders := map[string]string{"Authorization": "Bearer " + round10SignAccessToken(t, cfg.JWTSecret, "alice")}
 
 	t.Run("getStatusInteractionConfig default", func(t *testing.T) {
 		cfg := getStatusInteractionConfig(statusInteractionType(99))
@@ -44,7 +45,7 @@ func TestStatusInteractions_Round12(t *testing.T) {
 			},
 		}
 
-		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/1/favourited_by", nil, map[string]string{"limit": "nope"}, nil)
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/1/favourited_by", readHeaders, map[string]string{"limit": "nope"}, nil)
 		require.NoError(t, err)
 		ctx.Params["id"] = "1"
 		resp := requireStatus(t, http.StatusOK)(handler.HandleGetStatusFavouritedByLift(ctx))
@@ -60,7 +61,7 @@ func TestStatusInteractions_Round12(t *testing.T) {
 			},
 		}
 
-		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/1/reblogged_by", nil, nil, nil)
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/1/reblogged_by", readHeaders, nil, nil)
 		require.NoError(t, err)
 		ctx.Params["id"] = "1"
 		requireStatus(t, http.StatusNotFound)(handler.HandleGetStatusRebloggedByLift(ctx))
@@ -75,9 +76,36 @@ func TestStatusInteractions_Round12(t *testing.T) {
 			},
 		}
 
-		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/1/favourited_by", nil, nil, nil)
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/1/favourited_by", readHeaders, nil, nil)
 		require.NoError(t, err)
 		ctx.Params["id"] = "1"
 		requireStatus(t, http.StatusInternalServerError)(handler.HandleGetStatusFavouritedByLift(ctx))
+	})
+
+	t.Run("missing auth is rejected", func(t *testing.T) {
+		handler.registry = &RegistryStub{NotesSvc: &NotesServiceStub{}}
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/1/favourited_by", nil, nil, nil)
+		require.NoError(t, err)
+		ctx.Params["id"] = "1"
+		requireStatus(t, http.StatusUnauthorized)(handler.HandleGetStatusFavouritedByLift(ctx))
+	})
+
+	t.Run("passes authenticated viewer to service", func(t *testing.T) {
+		handler.registry = &RegistryStub{
+			NotesSvc: &NotesServiceStub{
+				GetRebloggersFunc: func(_ context.Context, query *notes.GetRebloggersQuery) (*notes.UsersResult, error) {
+					require.Equal(t, "alice", query.ViewerID)
+					return &notes.UsersResult{
+						Users:      []*storage.Account{},
+						Pagination: &interfaces.PaginatedResult[*storage.Account]{},
+					}, nil
+				},
+			},
+		}
+
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/1/reblogged_by", readHeaders, nil, nil)
+		require.NoError(t, err)
+		ctx.Params["id"] = "1"
+		requireStatus(t, http.StatusOK)(handler.HandleGetStatusRebloggedByLift(ctx))
 	})
 }

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -15670,6 +15670,8 @@ paths:
             operationId: get_api_v1_statuses_by_id_favourited_by
             tags:
                 - statuses
+            security:
+                - bearerAuth: []
             parameters:
                 - $ref: '#/components/parameters/Limit'
                 - $ref: '#/components/parameters/MaxID'
@@ -15692,6 +15694,10 @@ paths:
                                 type: string
                 "400":
                     $ref: '#/components/responses/BadRequest'
+                "401":
+                    $ref: '#/components/responses/Unauthorized'
+                "403":
+                    $ref: '#/components/responses/Forbidden'
                 "404":
                     $ref: '#/components/responses/NotFound'
                 "500":
@@ -15700,6 +15706,8 @@ paths:
             x-lesser-lambda: api
             x-lesser-routeSources:
                 - cmd/api/routes.go
+            x-oauth-scopes:
+                - read
     /api/v1/statuses/{id}/history:
         get:
             operationId: get_api_v1_statuses_by_id_history
@@ -16042,6 +16050,8 @@ paths:
             operationId: get_api_v1_statuses_by_id_reblogged_by
             tags:
                 - statuses
+            security:
+                - bearerAuth: []
             parameters:
                 - $ref: '#/components/parameters/Limit'
                 - $ref: '#/components/parameters/MaxID'
@@ -16064,6 +16074,10 @@ paths:
                                 type: string
                 "400":
                     $ref: '#/components/responses/BadRequest'
+                "401":
+                    $ref: '#/components/responses/Unauthorized'
+                "403":
+                    $ref: '#/components/responses/Forbidden'
                 "404":
                     $ref: '#/components/responses/NotFound'
                 "500":
@@ -16072,6 +16086,8 @@ paths:
             x-lesser-lambda: api
             x-lesser-routeSources:
                 - cmd/api/routes.go
+            x-oauth-scopes:
+                - read
     /api/v1/statuses/{id}/source:
         get:
             operationId: get_api_v1_statuses_by_id_source

--- a/pkg/services/notes/service.go
+++ b/pkg/services/notes/service.go
@@ -3086,6 +3086,7 @@ type UnlikeNoteCommand struct {
 // GetLikersQuery represents a request to get users who liked a status
 type GetLikersQuery struct {
 	StatusID   string                       `json:"status_id" validate:"required"`
+	ViewerID   string                       `json:"viewer_id,omitempty"`
 	Pagination interfaces.PaginationOptions `json:"pagination"`
 }
 
@@ -3191,8 +3192,18 @@ func (s *Service) UnlikeNote(ctx context.Context, cmd *UnlikeNoteCommand) (*Like
 // GetLikers retrieves users who liked a status
 func (s *Service) GetLikers(ctx context.Context, query *GetLikersQuery) (*UsersResult, error) {
 	// Get the status first to validate it exists
-	_, err := s.noteRepo.GetStatus(ctx, query.StatusID)
+	status, err := s.noteRepo.GetStatus(ctx, query.StatusID)
 	if err != nil {
+		return nil, ErrStatusNotFound
+	}
+	if status.Deleted {
+		return nil, ErrStatusNotFound
+	}
+	canView, err := s.checkViewPermissions(ctx, status, query.ViewerID)
+	if err != nil {
+		return nil, ErrCheckViewPermissions
+	}
+	if !canView {
 		return nil, ErrStatusNotFound
 	}
 
@@ -3369,6 +3380,7 @@ type UnreblogNoteCommand struct {
 // GetRebloggersQuery represents a request to get users who reblogged a status
 type GetRebloggersQuery struct {
 	StatusID   string                       `json:"status_id" validate:"required"`
+	ViewerID   string                       `json:"viewer_id,omitempty"`
 	Pagination interfaces.PaginationOptions `json:"pagination"`
 }
 
@@ -3458,8 +3470,18 @@ func (s *Service) UnreblogNote(ctx context.Context, cmd *UnreblogNoteCommand) (*
 // GetRebloggers retrieves users who reblogged a status
 func (s *Service) GetRebloggers(ctx context.Context, query *GetRebloggersQuery) (*UsersResult, error) {
 	// Get the status first to validate it exists
-	_, err := s.noteRepo.GetStatus(ctx, query.StatusID)
+	status, err := s.noteRepo.GetStatus(ctx, query.StatusID)
 	if err != nil {
+		return nil, ErrStatusNotFound
+	}
+	if status.Deleted {
+		return nil, ErrStatusNotFound
+	}
+	canView, err := s.checkViewPermissions(ctx, status, query.ViewerID)
+	if err != nil {
+		return nil, ErrCheckViewPermissions
+	}
+	if !canView {
 		return nil, ErrStatusNotFound
 	}
 

--- a/pkg/services/notes/service_round15_mainline_test.go
+++ b/pkg/services/notes/service_round15_mainline_test.go
@@ -2317,6 +2317,43 @@ func TestService_round15_additional_branch_coverage(t *testing.T) {
 	})
 }
 
+func TestService_M15_GetInteractionListsRequireVisibleStatus(t *testing.T) {
+	ctx := context.Background()
+	statusRepo := testingmocks.NewMockStatusRepositoryInterface()
+	relationshipRepo := testingmocks.NewMockRelationshipRepository()
+	service := &Service{
+		noteRepo:         statusRepo,
+		relationshipRepo: relationshipRepo,
+		logger:           zap.NewNop(),
+		domainName:       "example.com",
+	}
+
+	privateStatus := &models.Status{
+		StatusID:       "private-1",
+		Visibility:     models.VisibilityPrivate,
+		AuthorUsername: "alice",
+	}
+	statusRepo.On("GetStatus", mock.Anything, "private-1").Return(privateStatus, nil).Twice()
+	relationshipRepo.On("IsFollowing", mock.Anything, "bob", "alice").Return(false, nil).Twice()
+
+	_, err := service.GetLikers(ctx, &GetLikersQuery{
+		StatusID:   "private-1",
+		ViewerID:   "bob",
+		Pagination: interfaces.PaginationOptions{Limit: 2},
+	})
+	require.ErrorIs(t, err, ErrStatusNotFound)
+
+	_, err = service.GetRebloggers(ctx, &GetRebloggersQuery{
+		StatusID:   "private-1",
+		ViewerID:   "bob",
+		Pagination: interfaces.PaginationOptions{Limit: 2},
+	})
+	require.ErrorIs(t, err, ErrStatusNotFound)
+
+	statusRepo.AssertExpectations(t)
+	relationshipRepo.AssertExpectations(t)
+}
+
 func TestService_round15_createReblog_and_boost_idempotency(t *testing.T) {
 	ctx := context.Background()
 	actorURL := "https://example.com/users/bob"

--- a/pkg/storage/models/status.go
+++ b/pkg/storage/models/status.go
@@ -318,9 +318,9 @@ func (s *Status) setupGSIKeys() {
 		s.GSI4SK = ""
 	}
 
-	// GSI5 - Primary hashtag index (use the first hashtag for primary record)
-	// Additional hashtag records will be created separately via CreateHashtagIndexRecords
-	if len(s.Hashtags) > 0 {
+	// GSI5 - Primary public hashtag index (use the first hashtag for primary record).
+	// Additional public hashtag records will be created separately via CreateHashtagIndexRecords.
+	if s.Visibility == VisibilityPublic && len(s.Hashtags) > 0 {
 		s.GSI5PK = "HASHTAG#" + s.Hashtags[0]
 		s.GSI5SK = fmt.Sprintf("%s#%s", timestampStr, statusID)
 	} else {

--- a/pkg/storage/models/status_test.go
+++ b/pkg/storage/models/status_test.go
@@ -269,10 +269,14 @@ func (suite *StatusModelTestSuite) TestSetupGSIKeys_HashtagIndex() {
 	testCases := []struct {
 		name       string
 		hashtags   []string
+		visibility string
 		expectGSI5 bool
 	}{
-		{"with hashtags", []string{"test", "golang"}, true},
-		{"without hashtags", []string{}, false},
+		{"public with hashtags", []string{"test", "golang"}, VisibilityPublic, true},
+		{"unlisted with hashtags", []string{"test", "golang"}, VisibilityUnlisted, false},
+		{"private with hashtags", []string{"test", "golang"}, VisibilityPrivate, false},
+		{"direct with hashtags", []string{"test", "golang"}, VisibilityDirect, false},
+		{"without hashtags", []string{}, VisibilityPublic, false},
 	}
 
 	for _, tc := range testCases {
@@ -280,6 +284,7 @@ func (suite *StatusModelTestSuite) TestSetupGSIKeys_HashtagIndex() {
 			status := &Status{
 				StatusID:    "123",
 				Hashtags:    tc.hashtags,
+				Visibility:  tc.visibility,
 				PublishedAt: time.Unix(1609459200, 0), // 2021-01-01 00:00:00 UTC
 			}
 

--- a/pkg/storage/repositories/analytics_repository.go
+++ b/pkg/storage/repositories/analytics_repository.go
@@ -1113,12 +1113,15 @@ func (r *TrendingRepository) GetStatusesByLink(ctx context.Context, linkURL stri
 		return nil, fmt.Errorf("failed to get statuses by link: %w", err)
 	}
 
-	// Filter results to only include statuses that actually contain the exact link
-	var matchingStatuses []*models.Status
+	// Filter results to publicly visible statuses that actually contain the exact link.
+	// The link timeline is unauthenticated, so private/direct/unlisted/deleted statuses
+	// must not be exposed even when legacy status search rows still match the URL.
+	matchingStatuses := make([]*storage.TrendingStatus, 0, len(statuses.Items))
 	for _, status := range statuses.Items {
-		if status != nil && strings.Contains(status.Content, linkURL) {
-			matchingStatuses = append(matchingStatuses, status)
+		if !publicStatusContainsLink(status, linkURL) {
+			continue
 		}
+		matchingStatuses = append(matchingStatuses, trendingStatusFromStatus(status))
 	}
 
 	// Convert status objects to any slice for interface compatibility
@@ -1133,6 +1136,54 @@ func (r *TrendingRepository) GetStatusesByLink(ctx context.Context, linkURL stri
 		zap.Int("count", len(results)))
 
 	return results, nil
+}
+
+func publicStatusContainsLink(status *models.Status, linkURL string) bool {
+	if status == nil || status.Deleted || status.Visibility != models.VisibilityPublic {
+		return false
+	}
+
+	normalizedLink := strings.TrimSpace(linkURL)
+	if normalizedLink == "" {
+		return false
+	}
+
+	for _, candidate := range status.URLs {
+		if strings.EqualFold(strings.TrimSpace(candidate), normalizedLink) {
+			return true
+		}
+	}
+
+	return strings.Contains(status.Content, normalizedLink)
+}
+
+func trendingStatusFromStatus(status *models.Status) *storage.TrendingStatus {
+	if status == nil {
+		return nil
+	}
+
+	statusURL := ""
+	if status.Note != nil {
+		statusURL = strings.TrimSpace(status.Note.ID)
+	}
+
+	return &storage.TrendingStatus{
+		ID:              status.StatusID,
+		StatusID:        status.StatusID,
+		AuthorID:        status.AuthorID,
+		Content:         status.Content,
+		URL:             statusURL,
+		ReblogsCount:    status.ReblogCount,
+		FavouritesCount: status.LikeCount,
+		RepliesCount:    status.ReplyCount,
+		Engagements:     int64(status.LikeCount + status.ReblogCount + status.ReplyCount),
+		PublishedAt:     status.PublishedAt,
+		UpdatedAt:       status.UpdatedAt,
+		CreatedAt:       status.CreatedAt,
+		Likes:           status.LikeCount,
+		Boosts:          status.ReblogCount,
+		Replies:         status.ReplyCount,
+	}
 }
 
 // IndexByEngagement creates an index entry for engagement-based discovery

--- a/pkg/storage/repositories/analytics_repository_additional_coverage_test.go
+++ b/pkg/storage/repositories/analytics_repository_additional_coverage_test.go
@@ -330,8 +330,8 @@ func TestTrendingRepository_AnalyticsAdditionalCoverage(t *testing.T) {
 			searchFn: func(ctx context.Context, query string, opts interfaces.PaginationOptions) (*interfaces.PaginatedResult[*models.Status], error) {
 				return &interfaces.PaginatedResult[*models.Status]{
 					Items: []*models.Status{
-						{Content: "check this out https://example.com"},
-						{Content: "no link here"},
+						{StatusID: "public-1", Visibility: models.VisibilityPublic, Content: "check this out https://example.com"},
+						{StatusID: "public-2", Visibility: models.VisibilityPublic, Content: "no link here"},
 					},
 				}, nil
 			},
@@ -341,6 +341,30 @@ func TestTrendingRepository_AnalyticsAdditionalCoverage(t *testing.T) {
 		results, err := repo.GetStatusesByLink(ctx, "https://example.com", 0)
 		require.NoError(t, err)
 		require.Len(t, results, 1)
+	})
+
+	t.Run("statuses by link filters non-public matches", func(t *testing.T) {
+		statusRepo := &stubStatusRepository{
+			searchFn: func(ctx context.Context, query string, opts interfaces.PaginationOptions) (*interfaces.PaginatedResult[*models.Status], error) {
+				return &interfaces.PaginatedResult[*models.Status]{
+					Items: []*models.Status{
+						{StatusID: "public-1", Visibility: models.VisibilityPublic, Content: "see https://example.com/private-topic"},
+						{StatusID: "private-1", Visibility: models.VisibilityPrivate, Content: "see https://example.com/private-topic"},
+						{StatusID: "direct-1", Visibility: models.VisibilityDirect, Content: "see https://example.com/private-topic"},
+						{StatusID: "unlisted-1", Visibility: models.VisibilityUnlisted, Content: "see https://example.com/private-topic"},
+						{StatusID: "deleted-1", Visibility: models.VisibilityPublic, Deleted: true, Content: "see https://example.com/private-topic"},
+					},
+				}, nil
+			},
+		}
+		repo.SetStatusRepository(statusRepo)
+
+		results, err := repo.GetStatusesByLink(ctx, "https://example.com/private-topic", 20)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		result, ok := results[0].(*storage.TrendingStatus)
+		require.True(t, ok)
+		require.Equal(t, "public-1", result.StatusID)
 	})
 
 	t.Run("engagement ranking and aggregation", func(t *testing.T) {

--- a/pkg/storage/repositories/status_repository.go
+++ b/pkg/storage/repositories/status_repository.go
@@ -256,6 +256,13 @@ func (r *StatusRepository) createHashtagTimelineIndexes(ctx context.Context, sta
 	if status == nil || len(status.Hashtags) == 0 {
 		return nil
 	}
+	if !isPublicHashtagVisibility(status.Visibility) {
+		r.logger.Debug("skipping non-public supplemental hashtag timeline indexes",
+			zap.String("status_id", status.StatusID),
+			zap.String("visibility", status.Visibility),
+			zap.Int("hashtag_count", len(status.Hashtags)))
+		return nil
+	}
 
 	now := time.Now()
 	records := make([]*models.HashtagStatusIndex, 0, len(status.Hashtags))
@@ -1377,10 +1384,13 @@ func (r *StatusRepository) GetStatusesByHashtag(ctx context.Context, hashtag str
 		zap.Int("result_count", len(statuses)),
 		zap.Int("limit", limit))
 
-	// Convert to pointer slice
-	result := make([]*models.Status, len(statuses))
+	// Convert to pointer slice and suppress legacy non-public hashtag rows.
+	result := make([]*models.Status, 0, len(statuses))
 	for i := range statuses {
-		result[i] = &statuses[i]
+		if statuses[i].Visibility != models.VisibilityPublic || statuses[i].Deleted {
+			continue
+		}
+		result = append(result, &statuses[i])
 	}
 
 	return &interfaces.PaginatedResult[*models.Status]{

--- a/pkg/storage/repositories/status_repository_additional_coverage_test.go
+++ b/pkg/storage/repositories/status_repository_additional_coverage_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/theory-cloud/tabletheory/pkg/core"
 	dynamormErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 	"github.com/theory-cloud/tabletheory/pkg/mocks"
@@ -717,6 +718,27 @@ func TestStatusRepository_hashtag_queries(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotEmpty(t, page.Items)
 	})
+
+	t.Run("legacy_non_public_rows_are_filtered", func(t *testing.T) {
+		mockDB := new(mocks.MockDB)
+		mockQuery := new(mocks.MockQuery)
+		mockQuery.On("All", mock.AnythingOfType("*[]models.Status")).Run(func(args mock.Arguments) {
+			dest := args.Get(0).(*[]models.Status)
+			*dest = []models.Status{
+				{StatusID: "public-1", Visibility: models.VisibilityPublic},
+				{StatusID: "private-1", Visibility: models.VisibilityPrivate},
+				{StatusID: "direct-1", Visibility: models.VisibilityDirect},
+				{StatusID: "unlisted-1", Visibility: models.VisibilityUnlisted},
+			}
+		}).Return(nil).Once()
+		setupPermissiveStatusRepoMocks(mockDB, mockQuery, nil)
+
+		repo := NewStatusRepository(mockDB, "test-table", zap.NewNop(), nil)
+		page, err := repo.GetStatusesByHashtag(ctx, "go", interfaces.PaginationOptions{Limit: 10})
+		require.NoError(t, err)
+		require.Len(t, page.Items, 1)
+		assert.Equal(t, "public-1", page.Items[0].StatusID)
+	})
 }
 
 func TestStatusRepository_engagement_edge_cases(t *testing.T) {
@@ -771,6 +793,23 @@ func TestStatusRepository_canonicalize_and_hashtag_index_branches(t *testing.T) 
 
 	status.Visibility = models.VisibilityPrivate
 	assert.NoError(t, repo.canonicalizeStatusIndexes(ctx, status))
+}
+
+func TestStatusRepository_M15_SkipsNonPublicSupplementalHashtagIndexes(t *testing.T) {
+	ctx := context.Background()
+	mockDB := new(mocks.MockDB)
+	repo := NewStatusRepository(mockDB, "test-table", zap.NewNop(), nil)
+
+	err := repo.createHashtagTimelineIndexes(ctx, &models.Status{
+		StatusID:       "private-1",
+		AuthorID:       "https://localhost/users/alice",
+		AuthorUsername: "alice",
+		Visibility:     models.VisibilityPrivate,
+		PublishedAt:    time.Now(),
+		Hashtags:       []string{"secret"},
+	})
+	require.NoError(t, err)
+	mockDB.AssertNotCalled(t, "WithContext", mock.Anything)
 }
 
 func TestStatusRepository_home_timeline_relationship_repo_interface(t *testing.T) {


### PR DESCRIPTION
## Milestone
M15 — public status privacy and discovery hardening.

## Classification
security / privacy / Mastodon-compatible semantic refinement / schema-adjacent discovery hardening

## Surfaces affected
- `/api/v1/statuses/:id/favourited_by`
- `/api/v1/statuses/:id/reblogged_by`
- Status hashtag GSI/index population and hashtag timeline reads
- Public `/api/v1/timelines/link` link timeline reads
- `docs/contracts/openapi.yaml` authentication metadata for interaction lists

## Specialist walks referenced
- Federation trust: none; no ActivityPub signing, delivery, actor shape, or inbox/outbox trust change
- Contract / API: preserve-mastodon-api-compat walk applied; response shapes unchanged, semantics tightened to hide non-viewable status data; OpenAPI regenerated for interaction-list auth metadata
- Schema: validate-schema walk applied for hashtag GSI/index population-rule change; no PK/SK/tag restructuring or new GSI
- Framework: idiomatic lesser usage; no AppTheory/TableTheory patch

## Consumer impact
- Operators: public discovery leaks are closed for private/direct/unlisted statuses
- Mastodon clients / API consumers: same endpoint shapes; unauthenticated interaction-list calls now fail auth and inaccessible statuses resolve as not found
- Remote AP peers: no ActivityPub contract impact
- Sibling repos: no release artifact, MCP, or JSON-LD contract change

## Tasks
- [x] Closes #921 — enforce visibility on interaction lists
- [x] Closes #922 — keep private posts out of hashtag indexes
- [x] Closes #923 — filter link timelines to public statuses

## Validation
- `git diff --check origin/main...HEAD`
- `gofmt -l .` (empty)
- Targeted: `go test ./pkg/services/notes ./cmd/api/handlers`
- Targeted: `go test ./pkg/storage/models ./pkg/storage/repositories`
- Targeted: `go test ./pkg/storage/repositories -run 'TestTrendingRepository_AnalyticsAdditionalCoverage/statuses_by_link'`
- Targeted: `go test ./pkg/storage/repositories ./cmd/api/handlers ./pkg/trends`
- `go test ./...`
- `go vet ./...`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`

Smoke tests are not run, per lesser steward workflow.

## Migration / data handling
M15 changes are code-side hardening only. The hashtag visibility change filters legacy index rows at read time and prevents new non-public index rows; no dev data mutation is planned unless a later review explicitly requests repair tooling.

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to `theory` dev
- [ ] Deployed to `simulacrum` dev
- [ ] Dev soak complete
- [ ] Live rollout intentionally N/A until live instances exist
- [ ] Post-deploy monitoring verified

## Cross-repo coordination
None required.