### PR TITLE
fix(security): complete Codex Security M16

### DIFF
--- a/cmd/api/handlers/oauth.go
+++ b/cmd/api/handlers/oauth.go
@@ -1366,9 +1366,39 @@ func refreshGrantClientClass(client *storage.OAuthClient, storedToken *storage.R
 	return ""
 }
 
-func agentRefreshGrantLifetimes(now time.Time, cfg *config.Config, storedToken *storage.RefreshToken) (time.Duration, time.Time, error) {
+func refreshTokenCarriesRuntimeDecisionState(token *storage.RefreshToken) bool {
+	if token == nil {
+		return false
+	}
+	return strings.TrimSpace(token.FamilyID) != "" ||
+		token.Generation > 0 ||
+		token.Current ||
+		strings.TrimSpace(token.DeviceLabel) != "" ||
+		!token.LastUsedAt.IsZero() ||
+		!token.IdleExpiresAt.IsZero() ||
+		!token.AbsoluteExpiresAt.IsZero() ||
+		!token.SessionCreatedAt.IsZero() ||
+		!token.ReuseDetectedAt.IsZero() ||
+		strings.TrimSpace(token.ReuseDetectedFromIP) != "" ||
+		strings.TrimSpace(token.ReuseDetectedFromUA) != ""
+}
+
+func validateAgentRefreshGrantState(storedToken *storage.RefreshToken) error {
 	if storedToken == nil {
-		return 0, time.Time{}, auth.ErrInvalidToken
+		return auth.ErrInvalidToken
+	}
+	if storedToken.Revoked || !storedToken.RevokedAt.IsZero() {
+		return auth.ErrInvalidToken
+	}
+	if refreshTokenCarriesRuntimeDecisionState(storedToken) && !storedToken.Current {
+		return auth.ErrInvalidToken
+	}
+	return nil
+}
+
+func agentRefreshGrantLifetimes(now time.Time, cfg *config.Config, storedToken *storage.RefreshToken) (time.Duration, time.Time, error) {
+	if err := validateAgentRefreshGrantState(storedToken); err != nil {
+		return 0, time.Time{}, err
 	}
 
 	refreshExpiry := storedToken.ExpiresAt
@@ -1487,6 +1517,9 @@ func (h *Handler) exchangeRefreshToken(ctx context.Context, oauthSvc *auth.OAuth
 		LastAuthFailureAt:   storedToken.LastAuthFailureAt,
 		LastAuthFailureMsg:  storedToken.LastAuthFailureMsg,
 		LastAuthSuccessAt:   now,
+	}
+	if clientClass == auth.ClientClassAgent && storedToken.AccessTTLSeconds > 0 {
+		newOAuthRefreshToken.AccessTTLSeconds = storedToken.AccessTTLSeconds
 	}
 
 	// Store new refresh token

--- a/cmd/api/handlers/oauth.go
+++ b/cmd/api/handlers/oauth.go
@@ -1354,6 +1354,72 @@ func validateRefreshGrantClientSecret(ctx context.Context, oauthSvc *auth.OAuthS
 	return oauthSvc.ValidateClient(ctx, clientID, clientSecret)
 }
 
+func refreshGrantClientClass(client *storage.OAuthClient, storedToken *storage.RefreshToken) string {
+	if storedToken != nil {
+		if clientClass := strings.TrimSpace(storedToken.ClientClass); clientClass != "" {
+			return strings.ToLower(clientClass)
+		}
+	}
+	if client != nil {
+		return strings.ToLower(strings.TrimSpace(client.ClientClass))
+	}
+	return ""
+}
+
+func agentRefreshGrantLifetimes(now time.Time, cfg *config.Config, storedToken *storage.RefreshToken) (time.Duration, time.Time, error) {
+	if storedToken == nil {
+		return 0, time.Time{}, auth.ErrInvalidToken
+	}
+
+	refreshExpiry := storedToken.ExpiresAt
+	if refreshExpiry.IsZero() || !refreshExpiry.After(now) {
+		return 0, time.Time{}, auth.ErrInvalidToken
+	}
+
+	accessTTL := auth.AgentAccessTokenTTL(cfg)
+	if storedToken.AccessTTLSeconds > 0 {
+		storedAccessTTL := time.Duration(storedToken.AccessTTLSeconds) * time.Second
+		if storedAccessTTL > 0 && storedAccessTTL < accessTTL {
+			accessTTL = storedAccessTTL
+		}
+	}
+
+	for _, expiry := range []time.Time{storedToken.IdleExpiresAt, storedToken.AbsoluteExpiresAt} {
+		if expiry.IsZero() {
+			continue
+		}
+		remaining := expiry.Sub(now)
+		if remaining <= 0 {
+			return 0, time.Time{}, auth.ErrInvalidToken
+		}
+		if expiry.Before(refreshExpiry) {
+			refreshExpiry = expiry
+		}
+		if remaining < accessTTL {
+			accessTTL = remaining
+		}
+	}
+
+	if remaining := refreshExpiry.Sub(now); remaining < accessTTL {
+		accessTTL = remaining
+	}
+	if accessTTL <= 0 {
+		return 0, time.Time{}, auth.ErrInvalidToken
+	}
+
+	return accessTTL, refreshExpiry, nil
+}
+
+func standardRefreshGrantLifetimes(now time.Time, cfg *config.Config, client *storage.OAuthClient, storedToken *storage.RefreshToken) (time.Duration, time.Time, string, error) {
+	clientClass := refreshGrantClientClass(client, storedToken)
+	if clientClass == auth.ClientClassAgent {
+		accessTTL, refreshExpiry, err := agentRefreshGrantLifetimes(now, cfg, storedToken)
+		return accessTTL, refreshExpiry, clientClass, err
+	}
+
+	return auth.AccessTokenDuration, now.Add(auth.RefreshTokenDuration), clientClass, nil
+}
+
 // exchangeRefreshToken exchanges a refresh token for new access and refresh tokens
 func (h *Handler) exchangeRefreshToken(ctx context.Context, oauthSvc *auth.OAuthService, refreshToken, clientID, clientSecret, ipAddress, userAgent string) (string, string, []string, error) {
 	refreshToken = strings.TrimSpace(refreshToken)
@@ -1364,7 +1430,7 @@ func (h *Handler) exchangeRefreshToken(ctx context.Context, oauthSvc *auth.OAuth
 		return h.exchangeAgentRuntimeRefreshToken(ctx, oauthSvc, refreshToken, clientID, ipAddress, userAgent)
 	}
 
-	_, err := h.validateRefreshGrantClient(ctx, oauthSvc, refreshToken, clientID, clientSecret)
+	client, err := h.validateRefreshGrantClient(ctx, oauthSvc, refreshToken, clientID, clientSecret)
 	if err != nil {
 		return "", "", nil, err
 	}
@@ -1386,30 +1452,22 @@ func (h *Handler) exchangeRefreshToken(ctx context.Context, oauthSvc *auth.OAuth
 		return "", "", nil, auth.ErrInvalidToken
 	}
 
+	now := time.Now().UTC()
+
 	// Check expiration
-	if time.Now().After(storedToken.ExpiresAt) {
+	if now.After(storedToken.ExpiresAt) {
 		// Clean up expired token
 		_ = h.repos.Account().DeleteRefreshToken(ctx, refreshToken)
 		return "", "", nil, auth.ErrInvalidToken
 	}
 
-	accessTTL := auth.AccessTokenDuration
-	refreshExpiry := time.Now().Add(auth.RefreshTokenDuration)
-
-	// Delegated agent tokens are bounded by the stored refresh token expiry.
-	if storedToken.ClientID == delegatedAgentClientID {
-		remaining := time.Until(storedToken.ExpiresAt)
-		if remaining <= 0 {
-			_ = h.repos.Account().DeleteRefreshToken(ctx, refreshToken)
-			return "", "", nil, auth.ErrInvalidToken
-		}
-		if remaining < accessTTL {
-			accessTTL = remaining
-		}
-		refreshExpiry = storedToken.ExpiresAt
+	accessTTL, refreshExpiry, clientClass, err := standardRefreshGrantLifetimes(now, h.cfg, client, storedToken)
+	if err != nil {
+		_ = h.repos.Account().DeleteRefreshToken(ctx, refreshToken)
+		return "", "", nil, err
 	}
 
-	accessToken, newRefreshToken, err := oauthSvc.GenerateTokensWithAccessTokenTTLAndClientContextAndAudience(ctx, storedToken.Username, clientID, "", storedToken.Scopes, accessTTL, storedToken.ClientClass, storedToken.SessionID, storedToken.Resource)
+	accessToken, newRefreshToken, err := oauthSvc.GenerateTokensWithAccessTokenTTLAndClientContextAndAudience(ctx, storedToken.Username, clientID, "", storedToken.Scopes, accessTTL, clientClass, storedToken.SessionID, storedToken.Resource)
 	if err != nil {
 		return "", "", nil, errors.Join(failedToGenerateNewTokens(), err)
 	}
@@ -1421,14 +1479,14 @@ func (h *Handler) exchangeRefreshToken(ctx context.Context, oauthSvc *auth.OAuth
 		ClientID:            clientID,
 		Resource:            storedToken.Resource,
 		Scopes:              storedToken.Scopes,
-		CreatedAt:           time.Now(),
+		CreatedAt:           now,
 		ExpiresAt:           refreshExpiry,
-		ClientClass:         storedToken.ClientClass,
+		ClientClass:         clientClass,
 		SessionID:           storedToken.SessionID,
 		LastAuthFailureCode: storedToken.LastAuthFailureCode,
 		LastAuthFailureAt:   storedToken.LastAuthFailureAt,
 		LastAuthFailureMsg:  storedToken.LastAuthFailureMsg,
-		LastAuthSuccessAt:   time.Now().UTC(),
+		LastAuthSuccessAt:   now,
 	}
 
 	// Store new refresh token

--- a/cmd/api/handlers/oauth_round12_test.go
+++ b/cmd/api/handlers/oauth_round12_test.go
@@ -1123,14 +1123,75 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		require.Equal(t, token.SessionID, newToken.SessionID)
 		require.Equal(t, agent1Resource, newToken.Resource)
 		require.Empty(t, newToken.FamilyID)
-		require.Zero(t, newToken.Generation)
-		require.False(t, newToken.Current)
+		require.Equal(t, 1, newToken.Generation)
+		require.True(t, newToken.Current)
 		require.Empty(t, newToken.DeviceLabel)
-		require.Zero(t, newToken.AccessTTLSeconds)
-		require.True(t, newToken.SessionCreatedAt.IsZero())
-		require.True(t, newToken.IdleExpiresAt.IsZero())
-		require.True(t, newToken.AbsoluteExpiresAt.IsZero())
+		require.Equal(t, token.AccessTTLSeconds, newToken.AccessTTLSeconds)
+		require.WithinDuration(t, newToken.CreatedAt, newToken.SessionCreatedAt, 2*time.Second)
+		require.WithinDuration(t, newToken.ExpiresAt, newToken.IdleExpiresAt, 2*time.Second)
+		require.WithinDuration(t, newToken.ExpiresAt, newToken.AbsoluteExpiresAt, 2*time.Second)
 		require.WithinDuration(t, token.ExpiresAt, newToken.ExpiresAt, 2*time.Second)
+	})
+
+	t.Run("refresh_token public agent client preserves access ttl cap across rotations", func(t *testing.T) {
+		now := time.Now().UTC()
+		accessTTLSeconds := int((10 * time.Minute).Seconds())
+		token := storagemodels.RefreshToken{
+			Token:            "rt-agent-capped",
+			ClientID:         "client-agent",
+			Username:         "agent1",
+			Resource:         agent1Resource,
+			Scopes:           []string{auth.ScopeRead},
+			CreatedAt:        now.Add(-1 * time.Hour),
+			ExpiresAt:        now.Add(2 * time.Hour),
+			ClientClass:      auth.ClientClassAgent,
+			SessionID:        "sid-agent-capped",
+			AccessTTLSeconds: accessTTLSeconds,
+		}
+		state := &round10QueryState{
+			oauthClientsByID: map[string]storagemodels.OAuthClient{
+				"client-agent": {
+					ClientID:      "client-agent",
+					ClientSecret:  "secret",
+					Name:          "Connector App",
+					RedirectURIs:  []string{"https://example.com/callback"},
+					Scopes:        []string{auth.ScopeRead},
+					ClientClass:   auth.ClientClassAgent,
+					AgentUsername: "agent1",
+					CreatedAt:     now.Add(-24 * time.Hour),
+				},
+			},
+			refreshTokensByToken: map[string]storagemodels.RefreshToken{
+				token.Token: token,
+			},
+			usersByUsername: map[string]storagemodels.User{
+				"agent1": {Username: "agent1", IsAgent: true, AgentOwner: "@owner"},
+			},
+		}
+		h, _, _ := round11NewHandler(t, cfg, state)
+
+		refreshToken := token.Token
+		for i := 0; i < 2; i++ {
+			ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type=refresh_token&refresh_token="+url.QueryEscape(refreshToken)+"&client_id=client-agent"))
+			resp := requireStatus(t, http.StatusOK)(h.HandleOAuthTokenLift(ctx))
+			var body apimodels.OAuthTokenResponse
+			require.NoError(t, json.Unmarshal(resp.Body, &body))
+			require.NotEmpty(t, body.AccessToken)
+			require.NotEmpty(t, body.RefreshToken)
+			require.NotEqual(t, refreshToken, body.RefreshToken)
+
+			claims := round12DecodeJWTClaims(t, body.AccessToken)
+			require.NotNil(t, claims.IssuedAt)
+			require.NotNil(t, claims.ExpiresAt)
+			require.InDelta(t, float64(accessTTLSeconds), claims.ExpiresAt.Time.Sub(claims.IssuedAt.Time).Seconds(), 5)
+
+			newToken, ok := state.refreshTokensByToken[body.RefreshToken]
+			require.True(t, ok)
+			require.Equal(t, accessTTLSeconds, newToken.AccessTTLSeconds)
+			require.Equal(t, auth.ClientClassAgent, newToken.ClientClass)
+			require.Equal(t, token.SessionID, newToken.SessionID)
+			refreshToken = body.RefreshToken
+		}
 	})
 
 	t.Run("refresh_token public agent client preserves legacy runtime session bounds", func(t *testing.T) {
@@ -1189,13 +1250,73 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		require.Equal(t, token.SessionID, newToken.SessionID)
 		require.Equal(t, token.Resource, newToken.Resource)
 		require.Empty(t, newToken.FamilyID)
-		require.Zero(t, newToken.Generation)
-		require.False(t, newToken.Current)
+		require.Equal(t, 1, newToken.Generation)
+		require.True(t, newToken.Current)
 		require.Empty(t, newToken.DeviceLabel)
-		require.Zero(t, newToken.AccessTTLSeconds)
+		require.Equal(t, token.AccessTTLSeconds, newToken.AccessTTLSeconds)
+		require.WithinDuration(t, newToken.CreatedAt, newToken.SessionCreatedAt, 2*time.Second)
+		require.WithinDuration(t, newToken.ExpiresAt, newToken.IdleExpiresAt, 2*time.Second)
+		require.WithinDuration(t, newToken.ExpiresAt, newToken.AbsoluteExpiresAt, 2*time.Second)
 		require.WithinDuration(t, token.ExpiresAt, newToken.ExpiresAt, 2*time.Second)
 		require.False(t, newToken.ExpiresAt.After(token.IdleExpiresAt))
 		require.False(t, newToken.ExpiresAt.After(token.AbsoluteExpiresAt))
+	})
+
+	t.Run("refresh_token public agent client rejects revoked or non-current runtime compatibility state", func(t *testing.T) {
+		now := time.Now().UTC()
+		cases := []struct {
+			name    string
+			current bool
+			revoked bool
+		}{
+			{name: "revoked", current: true, revoked: true},
+			{name: "non_current", current: false, revoked: false},
+			{name: "revoked_non_current", current: false, revoked: true},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				token := buildRuntimeRefreshToken(t, "rt-agent-compat-"+tc.name, "agent1", "client-agent", "sid-agent-compat-"+tc.name, "family-agent-compat-"+tc.name, "Connector App", 1, true, false, now)
+				token.Resource = agent1Resource
+				token.Current = tc.current
+				token.Revoked = tc.revoked
+				if tc.revoked {
+					token.RevokedAt = now.Add(-2 * time.Minute)
+					token.RevokedReason = "rotated"
+				} else {
+					token.RevokedAt = time.Time{}
+					token.RevokedReason = ""
+				}
+
+				state := &round10QueryState{
+					oauthClientsByID: map[string]storagemodels.OAuthClient{
+						"client-agent": {
+							ClientID:      "client-agent",
+							ClientSecret:  "secret",
+							Name:          "Connector App",
+							RedirectURIs:  []string{"https://example.com/callback"},
+							Scopes:        []string{auth.ScopeRead},
+							ClientClass:   auth.ClientClassAgent,
+							AgentUsername: "agent1",
+							CreatedAt:     now.Add(-96 * time.Hour),
+						},
+					},
+					refreshTokensByToken: map[string]storagemodels.RefreshToken{
+						token.Token: token,
+					},
+					usersByUsername: map[string]storagemodels.User{
+						"agent1": {Username: "agent1", IsAgent: true, AgentOwner: "@owner"},
+					},
+				}
+				h, _, _ := round11NewHandler(t, cfg, state)
+
+				ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type=refresh_token&refresh_token="+url.QueryEscape(token.Token)+"&client_id=client-agent"))
+				resp := requireStatus(t, http.StatusBadRequest)(h.HandleOAuthTokenLift(ctx))
+				var body map[string]string
+				require.NoError(t, json.Unmarshal(resp.Body, &body))
+				require.Equal(t, "invalid_grant", body["error"])
+			})
+		}
 	})
 
 	t.Run("refresh_token legacy agent client class is bounded by current client metadata", func(t *testing.T) {

--- a/cmd/api/handlers/oauth_round12_test.go
+++ b/cmd/api/handlers/oauth_round12_test.go
@@ -1076,7 +1076,7 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		require.True(t, storedRefresh.AbsoluteExpiresAt.IsZero())
 	})
 
-	t.Run("refresh_token public agent client rotates legacy runtime state into standard refresh state", func(t *testing.T) {
+	t.Run("refresh_token public agent client preserves legacy refresh expiry", func(t *testing.T) {
 		now := time.Now().UTC()
 		token := buildRuntimeRefreshToken(t, "rt-agent-connector", "agent1", "client-agent", "sid-agent-connector", "family-agent-connector", "Connector App", 1, true, false, now)
 		token.Resource = agent1Resource
@@ -1130,9 +1130,10 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		require.True(t, newToken.SessionCreatedAt.IsZero())
 		require.True(t, newToken.IdleExpiresAt.IsZero())
 		require.True(t, newToken.AbsoluteExpiresAt.IsZero())
+		require.WithinDuration(t, token.ExpiresAt, newToken.ExpiresAt, 2*time.Second)
 	})
 
-	t.Run("refresh_token public agent client ignores legacy runtime session bounds", func(t *testing.T) {
+	t.Run("refresh_token public agent client preserves legacy runtime session bounds", func(t *testing.T) {
 		now := time.Now().UTC()
 		token := buildRuntimeRefreshToken(t, "rt-agent-aged", "agent1", "client-agent", "sid-agent-aged", "family-agent-aged", "Connector App", 1, true, false, now)
 		token.Resource = agent1Resource
@@ -1192,6 +1193,56 @@ func TestOAuthTokenLiftRound12(t *testing.T) {
 		require.False(t, newToken.Current)
 		require.Empty(t, newToken.DeviceLabel)
 		require.Zero(t, newToken.AccessTTLSeconds)
+		require.WithinDuration(t, token.ExpiresAt, newToken.ExpiresAt, 2*time.Second)
+		require.False(t, newToken.ExpiresAt.After(token.IdleExpiresAt))
+		require.False(t, newToken.ExpiresAt.After(token.AbsoluteExpiresAt))
+	})
+
+	t.Run("refresh_token legacy agent client class is bounded by current client metadata", func(t *testing.T) {
+		now := time.Now().UTC()
+		token := storagemodels.RefreshToken{
+			Token:     "rt-agent-legacy-class",
+			ClientID:  "client-agent",
+			Username:  "agent1",
+			Resource:  agent1Resource,
+			Scopes:    []string{auth.ScopeRead},
+			CreatedAt: now.Add(-1 * time.Hour),
+			ExpiresAt: now.Add(2 * time.Hour),
+		}
+
+		state := &round10QueryState{
+			oauthClientsByID: map[string]storagemodels.OAuthClient{
+				"client-agent": {
+					ClientID:      "client-agent",
+					ClientSecret:  "secret",
+					Name:          "Connector App",
+					RedirectURIs:  []string{"https://example.com/callback"},
+					Scopes:        []string{auth.ScopeRead},
+					ClientClass:   auth.ClientClassAgent,
+					AgentUsername: "agent1",
+					CreatedAt:     now.Add(-96 * time.Hour),
+				},
+			},
+			refreshTokensByToken: map[string]storagemodels.RefreshToken{
+				token.Token: token,
+			},
+			usersByUsername: map[string]storagemodels.User{
+				"agent1": {Username: "agent1", IsAgent: true, AgentOwner: "@owner"},
+			},
+		}
+		h, _, _ := round11NewHandler(t, cfg, state)
+
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte("grant_type=refresh_token&refresh_token=rt-agent-legacy-class&client_id=client-agent"))
+		resp := requireStatus(t, http.StatusOK)(h.HandleOAuthTokenLift(ctx))
+		var body apimodels.OAuthTokenResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.NotEmpty(t, body.RefreshToken)
+
+		newToken, ok := state.refreshTokensByToken[body.RefreshToken]
+		require.True(t, ok)
+		require.Equal(t, auth.ClientClassAgent, newToken.ClientClass)
+		require.Equal(t, token.Resource, newToken.Resource)
+		require.WithinDuration(t, token.ExpiresAt, newToken.ExpiresAt, 2*time.Second)
 	})
 
 	t.Run("authorization_code invalid_grant when code consumption fails", func(t *testing.T) {

--- a/graph/agent_delegation_round32_test.go
+++ b/graph/agent_delegation_round32_test.go
@@ -605,6 +605,24 @@ func TestDelegateToAgent_MissingGovernanceFailsClosed(t *testing.T) {
 	require.ErrorIs(t, err, ErrAgentGovernanceUnavailable)
 }
 
+func TestUpdateAgent_MissingGovernanceFailsClosed(t *testing.T) {
+	state := newDelegationGraphState("agent1", []string{"read"})
+	delete(state.governance, "agent1")
+
+	resolver := newDelegationResolver(t, state, true)
+	ctx := delegatedAgentAuthContext("owner", auth.ScopeWrite)
+	displayName := "Updated Agent"
+
+	var err error
+	require.NotPanics(t, func() {
+		_, err = resolver.Mutation().UpdateAgent(ctx, "agent1", model.UpdateAgentInput{
+			DisplayName: &displayName,
+		})
+	})
+	require.ErrorIs(t, err, ErrAgentGovernanceUnavailable)
+	require.Equal(t, "Agent One", state.user("agent1").DisplayName)
+}
+
 func TestAdminUnverifyAgent_ClearsStaleVerificationFields(t *testing.T) {
 	state := newDelegationGraphState("agent1", []string{"read"})
 	verifiedAt := time.Now().UTC().Add(-time.Hour)

--- a/graph/agent_resolvers_stubs.go
+++ b/graph/agent_resolvers_stubs.go
@@ -561,9 +561,9 @@ func (r *mutationResolver) UpdateAgent(ctx context.Context, username string, inp
 	if err != nil || account == nil || account.User == nil || !account.User.IsAgent {
 		return nil, apperrors.NewAppError(apperrors.CodeNotFound, apperrors.CategoryBusiness, "agent not found")
 	}
-	governance, err := r.loadAgentGovernanceState(ctx, username)
+	governance, err := r.requireAgentGovernanceState(ctx, username)
 	if err != nil {
-		return nil, apperrors.InternalWithCause(err, "failed to load agent governance state")
+		return nil, graphAgentGovernanceLoadError(err)
 	}
 
 	if !isAgentOwnerOrAdmin(claims, account.User, r.agentOwnerActorURL(claims.Username)) {

--- a/pkg/auth/auth_round13_buffer_test.go
+++ b/pkg/auth/auth_round13_buffer_test.go
@@ -6,8 +6,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/equaltoai/lesser/pkg/storage/repositories"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	dynamormmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
+	"go.uber.org/zap"
 )
 
 type rateLimitSelectiveErrRepo struct {
@@ -91,6 +96,35 @@ func TestOAuthService_HelperEarlyReturns(t *testing.T) {
 	require.NoError(t, svc.validateAccessTokenNotRevoked(&Claims{
 		RegisteredClaims: jwt.RegisteredClaims{ID: "jti"},
 	}))
+}
+
+func TestOAuthService_RevocationLookupErrorFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	jti := "jti-read-error"
+	mockDB := new(dynamormmocks.MockDB)
+	mockQuery := new(dynamormmocks.MockQuery)
+	accountRepo := repositories.NewAccountRepository(mockDB, "test-table", "example.com", zap.NewNop())
+	svc := &OAuthService{repos: reposWithAccount{account: accountRepo}}
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB)
+	mockDB.On("Model", mock.MatchedBy(func(model *models.RevokedAccessToken) bool {
+		return model != nil
+	})).Return(mockQuery)
+	mockQuery.On("Where", "PK", "=", "REVOKEDTOKEN#"+jti).Return(mockQuery)
+	mockQuery.On("Where", "SK", "=", repositories.SKToken).Return(mockQuery)
+	mockQuery.On("ConsistentRead").Return(mockQuery)
+	mockQuery.On("First", mock.MatchedBy(func(dest *models.RevokedAccessToken) bool {
+		return dest != nil
+	})).Return(errors.New("read failed"))
+
+	err := svc.validateAccessTokenNotRevoked(&Claims{
+		RegisteredClaims: jwt.RegisteredClaims{ID: jti},
+	})
+	require.ErrorIs(t, err, ErrInvalidToken)
+
+	mockDB.AssertExpectations(t)
+	mockQuery.AssertExpectations(t)
 }
 
 func TestRateLimiter_ErrorBranches(t *testing.T) {

--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -550,7 +550,7 @@ func (s *OAuthService) validateAccessTokenNotRevoked(claims *Claims) error {
 		if s.auditLogger != nil && s.auditLogger.logger != nil {
 			s.auditLogger.logger.Warn("access token revocation check failed", zap.Error(err))
 		}
-		return nil
+		return ErrInvalidToken
 	}
 
 	if revoked {
@@ -607,9 +607,9 @@ func (s *OAuthService) ValidateAccessTokenWithContext(tokenString, expectedSessi
 		return nil, err
 	}
 
-	// Best-effort access token revocation check (RFC 7009).
-	// This is a read-after-parse DynamoDB lookup keyed by token JTI; if storage is unavailable,
-	// we accept the token to avoid turning storage blips into auth outages.
+	// Access-token revocation check (RFC 7009). This is a read-after-parse
+	// DynamoDB lookup keyed by token JTI; if storage is unavailable, fail closed
+	// rather than accepting a potentially revoked token.
 	if err := s.validateAccessTokenNotRevoked(claims); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Milestone
M16 — auth and agent governance safety.

## Classification
security / auth / OAuth / GraphQL governance / federation-trust-adjacent governance hardening

## Surfaces affected
- `/oauth/token` refresh-token grant for agent-class clients
- OAuth access-token revocation validation
- GraphQL `updateAgent` mutation governance-state loading

## Specialist walks referenced
- Federation trust: AgentGovernanceState handling is tightened; no HTTP Signature, actor object, inbox/outbox, delivery, or WebFinger changes
- Contract / API: backward-compatible semantic refinements; response shapes unchanged; invalid/unsafe states now fail closed or return controlled errors
- Schema: none; no PK/SK/GSI/tag changes
- Framework: idiomatic lesser usage; no AppTheory/TableTheory patch

## Consumer impact
- Operators: credential lifetime and revocation behavior fail safe; missing governance state no longer panics GraphQL mutation paths
- Mastodon clients / API consumers: OAuth shape unchanged; stricter failure semantics for unsafe refresh/revocation states
- Remote AP peers: no ActivityPub contract impact
- Sibling repos: no release artifact, MCP, or JSON-LD contract change

## Tasks
- [x] Closes #925 — enforce agent refresh expiry limits
- [x] Closes #926 — fail closed on revocation lookup errors
- [x] Closes #927 — guard update agent governance lookup

## Validation
- `git diff --check origin/main...HEAD`
- `gofmt -l .` (empty)
- Targeted #925: `go test ./cmd/api/handlers -run 'TestOAuthTokenLiftRound12/refresh_token_public_agent_client_preserves_legacy_refresh_expiry|TestOAuthTokenLiftRound12/refresh_token_public_agent_client_preserves_legacy_runtime_session_bounds|TestOAuthTokenLiftRound12/refresh_token_legacy_agent_client_class_is_bounded_by_current_client_metadata|TestOAuthRuntimeRefreshGrant'`
- Targeted #925 package: `go test ./cmd/api/handlers`
- Targeted #926: `go test ./pkg/auth -run 'TestOAuthService_RevocationLookupErrorFailsClosed|TestOAuthService_HelperEarlyReturns'`
- Targeted #926 package: `go test ./pkg/auth`
- Targeted #927: `go test ./graph -run 'TestUpdateAgent_MissingGovernanceFailsClosed|TestDelegateToAgent_MissingGovernanceFailsClosed|TestAdminUnverifyAgent_MissingGovernanceFailsClosed'`
- Targeted #927 package: `go test ./graph`
- `go test ./...`
- `go vet ./...`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`

Smoke tests are not run, per lesser steward workflow.

## Migration / data handling
M16 is code-side auth/governance hardening only. No dev data mutation is planned unless review discovers a concrete repair need.

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to `theory` dev
- [ ] Deployed to `simulacrum` dev
- [ ] Dev soak complete
- [ ] Live rollout intentionally N/A until live instances exist
- [ ] Post-deploy monitoring verified

## Cross-repo coordination
None required.