### PR TITLE
fix(security): complete Codex Security M17

### DIFF
--- a/cmd/api/handlers/misc.go
+++ b/cmd/api/handlers/misc.go
@@ -939,8 +939,15 @@ func (h *Handler) statusFromNotificationSnapshot(ctx *apptheory.Context, notif *
 		return nil
 	}
 
+	if safeURL, ok := common.SafeHTTPURL(status.URL); ok {
+		status.URL = safeURL
+	} else {
+		status.URL = ""
+	}
 	if url := strings.TrimSpace(notificationSnapshotString(snapshot, "url")); url != "" {
-		status.URL = url
+		if safeURL, ok := common.SafeHTTPURL(url); ok {
+			status.URL = safeURL
+		}
 	}
 	if visibility := strings.TrimSpace(notificationSnapshotString(snapshot, "visibility")); visibility != "" {
 		status.Visibility = visibility

--- a/cmd/api/handlers/notifications_comm_list_round28_test.go
+++ b/cmd/api/handlers/notifications_comm_list_round28_test.go
@@ -263,6 +263,25 @@ func TestNotifications_ListHandlesSnapshotAndLegacyStatuses_Round28(t *testing.T
 							},
 						},
 						{
+							ID:         "notif-snapshot-unsafe",
+							Type:       apiModels.NotificationTypeReply,
+							ActorID:    "bob",
+							UserID:     "alice",
+							TargetID:   "status-snapshot-unsafe",
+							TargetType: "status",
+							CreatedAt:  now.Add(-2 * time.Minute),
+							Data: map[string]interface{}{
+								"postSnapshot": map[string]interface{}{
+									"id":           "https://example.com/objects/status-snapshot-unsafe",
+									"url":          "javascript:alert(1)",
+									"content":      "unsafe snapshot body",
+									"createdAt":    now.Add(-90 * time.Second).Format(time.RFC3339),
+									"visibility":   "unlisted",
+									"attributedTo": cfg.BaseURL() + "/users/bob",
+								},
+							},
+						},
+						{
 							ID:         "notif-legacy-1",
 							Type:       apiModels.NotificationTypeReply,
 							ActorID:    "bob",
@@ -290,10 +309,13 @@ func TestNotifications_ListHandlesSnapshotAndLegacyStatuses_Round28(t *testing.T
 
 	var out []apiModels.Notification
 	require.NoError(t, json.Unmarshal(resp.Body, &out))
-	require.Len(t, out, 2)
+	require.Len(t, out, 3)
 	require.NotNil(t, out[0].Status)
 	require.Equal(t, "snapshot body", out[0].Status.Content)
 	require.Equal(t, "https://example.com/@bob/status-snapshot", out[0].Status.URL)
 	require.NotNil(t, out[1].Status)
-	require.Equal(t, "legacy body", out[1].Status.Content)
+	require.Equal(t, "unsafe snapshot body", out[1].Status.Content)
+	require.Equal(t, "https://example.com/objects/status-snapshot-unsafe", out[1].Status.URL)
+	require.NotNil(t, out[2].Status)
+	require.Equal(t, "legacy body", out[2].Status.Content)
 }

--- a/cmd/cms-scheduler/main.go
+++ b/cmd/cms-scheduler/main.go
@@ -297,7 +297,7 @@ func (p *CMSSchedulerProcessor) markScheduledDraftFailed(ctx context.Context, dr
 	draft.Status = "failed"
 	draft.ScheduledAt = nil
 	draft.UpdatedAt = now
-	if updateErr := draftRepo.UpdateDraft(ctx, draft); updateErr != nil {
+	if updateErr := draftRepo.UpdateDraft(ctx, authorID, draft); updateErr != nil {
 		p.logger.Warn("failed to mark scheduled draft as failed",
 			zap.String("draft_id", draftID),
 			zap.String("author_id", authorID),

--- a/cmd/cms-scheduler/round12_cms_scheduler_test.go
+++ b/cmd/cms-scheduler/round12_cms_scheduler_test.go
@@ -44,7 +44,7 @@ func (f *fakeInstanceStateRepo) GetInstanceState(context.Context) (*models.Insta
 type fakeDraftRepo struct {
 	listFn   func(context.Context, time.Time, int, string) ([]*models.Draft, string, error)
 	getFn    func(context.Context, string, string) (*models.Draft, error)
-	updateFn func(context.Context, *models.Draft) error
+	updateFn func(context.Context, string, *models.Draft) error
 
 	listCalls   int
 	getCalls    int
@@ -62,11 +62,11 @@ func (f *fakeDraftRepo) GetDraft(ctx context.Context, authorID, draftID string) 
 	return nil, errors.New("not implemented")
 }
 
-func (f *fakeDraftRepo) UpdateDraft(ctx context.Context, draft *models.Draft) error {
+func (f *fakeDraftRepo) UpdateDraft(ctx context.Context, authorID string, draft *models.Draft) error {
 	f.updateCalls++
 	f.lastUpdated = draft
 	if f.updateFn != nil {
-		return f.updateFn(ctx, draft)
+		return f.updateFn(ctx, authorID, draft)
 	}
 	return nil
 }
@@ -239,7 +239,7 @@ func TestCMSSchedulerProcessor_markScheduledDraftFailed_Round12(t *testing.T) {
 			getFn: func(context.Context, string, string) (*models.Draft, error) {
 				return &models.Draft{ID: "draft", AuthorID: "author", Status: "scheduled"}, nil
 			},
-			updateFn: func(context.Context, *models.Draft) error { return errors.New("boom") },
+			updateFn: func(context.Context, string, *models.Draft) error { return errors.New("boom") },
 		}
 		p.markScheduledDraftFailed(context.Background(), repo, "author", "draft", errors.New("cause"))
 		require.Equal(t, 1, repo.updateCalls)

--- a/graph/cms_resolvers_round12_test.go
+++ b/graph/cms_resolvers_round12_test.go
@@ -6,8 +6,17 @@ import (
 	"time"
 
 	"github.com/equaltoai/lesser/graph/model"
+	"github.com/equaltoai/lesser/pkg/config"
+	"github.com/equaltoai/lesser/pkg/storage/core"
+	"github.com/equaltoai/lesser/pkg/storage/interfaces"
 	"github.com/equaltoai/lesser/pkg/storage/models"
+	pkgtesting "github.com/equaltoai/lesser/pkg/testing"
+	"github.com/equaltoai/lesser/pkg/testing/inmemory"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	dynamormcore "github.com/theory-cloud/tabletheory/pkg/core"
+	dynamormmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
+	"go.uber.org/zap"
 )
 
 func TestRound12CMS_DraftLifecycle(t *testing.T) {
@@ -338,6 +347,122 @@ func TestRound12CMS_ArticlesSeriesCategoriesPublications(t *testing.T) {
 	ok, err = mut.DeleteCategory(adminCtx, category.ID)
 	require.NoError(t, err)
 	require.True(t, ok)
+}
+
+func TestRound12CMS_MyPublicationsDoesNotSelfHealFallbackRows(t *testing.T) {
+	mockDB := new(dynamormmocks.MockDB)
+	mockQuery := new(dynamormmocks.MockQuery)
+
+	fallbackMember := models.PublicationMember{
+		PublicationID: "pub-1",
+		UserID:        "alice",
+		Role:          "owner",
+		// Deliberately blank GSI keys model pre-M12 rows that need repair outside
+		// of read resolvers.
+		GSI1PK: "",
+		GSI1SK: "",
+	}
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB).Maybe()
+	mockDB.On("Model", mock.Anything).Return(mockQuery).Maybe()
+	mockQuery.On("Where", "SK", "=", "USER#alice").Return(mockQuery).Once()
+	mockQuery.On("Limit", 1000).Return(mockQuery).Once()
+	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
+		members, ok := args.Get(0).(*[]models.PublicationMember)
+		require.True(t, ok)
+		*members = []models.PublicationMember{fallbackMember}
+	}).Return(nil).Once()
+
+	pubRepo := inmemory.NewPublicationRepository()
+	now := time.Now().UTC()
+	require.NoError(t, pubRepo.CreatePublication(context.Background(), &models.Publication{
+		ID:        "pub-1",
+		Name:      "Publication",
+		Slug:      "publication",
+		ActorID:   "https://localhost/users/publication",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}))
+	memberRepo := &round12NoHealPublicationMemberRepo{}
+	baseStorage := pkgtesting.NewMockRepositoryStorage(
+		pkgtesting.WithPublicationRepository(pubRepo),
+		pkgtesting.WithPublicationMemberRepository(memberRepo),
+	)
+	storage := &round12NoHealCMSStorage{
+		RepositoryStorage: baseStorage,
+		db:                mockDB,
+		publication:       pubRepo,
+		member:            memberRepo,
+	}
+	resolver := &Resolver{
+		Config: &config.Config{
+			Domain:                       "localhost",
+			CMSLongFormPublishingEnabled: true,
+		},
+		Storage: storage,
+		Logger:  zap.NewNop(),
+	}
+
+	publications, err := resolver.Query().MyPublications(round12AuthContext("alice"))
+	require.NoError(t, err)
+	require.Len(t, publications, 1)
+	require.Equal(t, "pub-1", publications[0].ID)
+	require.Zero(t, memberRepo.updates, "read resolvers must not self-heal publication member rows")
+}
+
+type round12NoHealCMSStorage struct {
+	core.RepositoryStorage
+	db          dynamormcore.DB
+	publication interfaces.PublicationRepository
+	member      interfaces.PublicationMemberRepository
+}
+
+func (s *round12NoHealCMSStorage) GetDB() dynamormcore.DB { return s.db }
+func (s *round12NoHealCMSStorage) Publication() interfaces.PublicationRepository {
+	return s.publication
+}
+func (s *round12NoHealCMSStorage) PublicationMember() interfaces.PublicationMemberRepository {
+	return s.member
+}
+
+type round12NoHealPublicationMemberRepo struct {
+	*inmemory.PublicationMemberRepository
+	updates int
+}
+
+func (r *round12NoHealPublicationMemberRepo) ensure() {
+	if r.PublicationMemberRepository == nil {
+		r.PublicationMemberRepository = inmemory.NewPublicationMemberRepository()
+	}
+}
+
+func (r *round12NoHealPublicationMemberRepo) CreateMember(ctx context.Context, member *models.PublicationMember) error {
+	r.ensure()
+	return r.PublicationMemberRepository.CreateMember(ctx, member)
+}
+
+func (r *round12NoHealPublicationMemberRepo) GetMember(ctx context.Context, publicationID, userID string) (*models.PublicationMember, error) {
+	r.ensure()
+	return r.PublicationMemberRepository.GetMember(ctx, publicationID, userID)
+}
+
+func (r *round12NoHealPublicationMemberRepo) DeleteMember(ctx context.Context, publicationID, userID string) error {
+	r.ensure()
+	return r.PublicationMemberRepository.DeleteMember(ctx, publicationID, userID)
+}
+
+func (r *round12NoHealPublicationMemberRepo) ListMembers(ctx context.Context, publicationID string) ([]*models.PublicationMember, error) {
+	r.ensure()
+	return r.PublicationMemberRepository.ListMembers(ctx, publicationID)
+}
+
+func (r *round12NoHealPublicationMemberRepo) ListMembershipsForUserPaginated(context.Context, string, int, string) ([]*models.PublicationMember, string, error) {
+	return nil, "", nil
+}
+
+func (r *round12NoHealPublicationMemberRepo) Update(context.Context, *models.PublicationMember) error {
+	r.updates++
+	return nil
 }
 
 func TestRound12CMS_MutationPermissions(t *testing.T) {

--- a/graph/cms_resolvers_round12_test.go
+++ b/graph/cms_resolvers_round12_test.go
@@ -76,6 +76,12 @@ func TestRound12CMS_DraftLifecycle(t *testing.T) {
 	require.NotNil(t, fetched)
 	require.Equal(t, draft.ID, fetched.ID)
 
+	crossUserTitle := "Cross User Update"
+	_, err = mut.UpdateDraft(round12AuthContext("bob"), draft.ID, model.UpdateDraftInput{
+		Title: &crossUserTitle,
+	})
+	require.Error(t, err)
+
 	toDeleteTitle := "Delete Me"
 	toDelete, err := mut.CreateDraft(ctx, model.CreateDraftInput{
 		ContentType:   model.ObjectTypeArticle,
@@ -84,7 +90,11 @@ func TestRound12CMS_DraftLifecycle(t *testing.T) {
 		ContentFormat: model.ContentFormatMarkdown,
 	})
 	require.NoError(t, err)
-	ok, err := mut.DeleteDraft(ctx, toDelete.ID)
+	ok, err := mut.DeleteDraft(round12AuthContext("bob"), toDelete.ID)
+	require.Error(t, err)
+	require.False(t, ok)
+
+	ok, err = mut.DeleteDraft(ctx, toDelete.ID)
 	require.NoError(t, err)
 	require.True(t, ok)
 

--- a/graph/mutation_resolvers_cms.go
+++ b/graph/mutation_resolvers_cms.go
@@ -99,7 +99,7 @@ func (r *mutationResolver) UpdateDraft(ctx context.Context, id string, input mod
 		draft.ContentFormat = cmsContentFormatToStorage(*input.ContentFormat)
 	}
 
-	if err := draftSvc.UpdateDraft(ctx, draft); err != nil {
+	if err := draftSvc.UpdateDraft(ctx, username, draft); err != nil {
 		return nil, err
 	}
 
@@ -127,7 +127,7 @@ func (r *mutationResolver) AutosaveDraft(ctx context.Context, id string, content
 	}
 
 	draft.Content = content
-	if err := draftSvc.Autosave(ctx, draft); err != nil {
+	if err := draftSvc.Autosave(ctx, username, draft); err != nil {
 		return nil, err
 	}
 

--- a/graph/query_resolvers_cms.go
+++ b/graph/query_resolvers_cms.go
@@ -1016,15 +1016,7 @@ func (r *queryResolver) MyPublications(ctx context.Context) ([]*model.Publicatio
 		}
 
 		for i := range members {
-			member := &members[i]
-			membershipItems = append(membershipItems, member)
-
-			// Best-effort self-heal: ensure GSI keys exist so future lookups use the index.
-			if member.GSI1PK == "" || member.GSI1SK == "" {
-				if err := member.UpdateKeys(); err == nil {
-					_ = store.PublicationMember().Update(ctx, member)
-				}
-			}
+			membershipItems = append(membershipItems, &members[i])
 		}
 	}
 

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -4863,17 +4863,36 @@ func (r *queryResolver) estimateFederationCostCount(ctx context.Context, usernam
 
 // Actor implements ActivityResolver
 func (r *activityResolver) Actor(ctx context.Context, obj *activitypub.Activity) (*activitypub.Actor, error) {
-	// If we have an actor ID, fetch the account
-	if obj.Actor != "" {
-		account, err := r.Registry.Accounts().GetAccount(ctx, obj.Actor)
-		if err != nil {
-			return nil, errors.Join(errors.New("failed to get activity actor"), err)
-		}
-
-		return r.convertAccountToActor(account), nil
+	if obj == nil {
+		return nil, nil
 	}
 
-	return nil, nil
+	actorID := strings.TrimSpace(obj.Actor)
+	if actorID == "" {
+		return nil, nil
+	}
+
+	if resolution, err := r.resolveStoredActorLookup(ctx, actorID); err == nil && resolution != nil {
+		return r.materializeActorResolution(ctx, resolution), nil
+	} else if err != nil && !graphActorLookupNotFound(err) {
+		return nil, errors.Join(errors.New("failed to get activity actor"), err)
+	}
+
+	if actorIdentifierLooksRemote(actorID, r.localActorDomain()) {
+		return r.buildPlaceholderActor(actorID, ""), nil
+	}
+
+	username := r.localUsernameForLookup(actorID)
+	if username == "" || r.Registry == nil || r.Registry.Accounts() == nil {
+		return nil, nil
+	}
+
+	account, err := r.Registry.Accounts().GetAccount(ctx, username)
+	if err != nil {
+		return nil, errors.Join(errors.New("failed to get activity actor"), err)
+	}
+
+	return r.convertAccountToActor(account), nil
 }
 
 // Cost implements ActivityResolver - returns cost in microcents

--- a/graph/schema_remote_actor_round32_test.go
+++ b/graph/schema_remote_actor_round32_test.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"context"
 	"testing"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
@@ -31,4 +32,30 @@ func TestRound32Resolver_ConvertAccountToActor_PreservesRemoteIdentity(t *testin
 	require.Equal(t, remoteActor.ID, actor.ID)
 	require.Equal(t, remoteActor.PreferredUsername, actor.PreferredUsername)
 	require.Equal(t, remoteActor.URL, actor.URL)
+}
+
+func TestRound32ActivityResolver_ActorPreservesRemoteIdentifiers(t *testing.T) {
+	resolver, graphStorage := newRound12GraphResolver(t)
+	graphStorage.SeedAccountUser(&storage.User{
+		Username:    "alice",
+		DisplayName: "Local Alice",
+		Approved:    true,
+	})
+
+	activityResolver := resolver.Activity()
+	ctx := context.Background()
+
+	remoteActorURL := "https://remote.example/users/alice"
+	urlActor, err := activityResolver.Actor(ctx, &activitypub.Activity{Actor: remoteActorURL})
+	require.NoError(t, err)
+	require.NotNil(t, urlActor)
+	require.Equal(t, remoteActorURL, urlActor.ID)
+	require.Equal(t, "alice", urlActor.PreferredUsername)
+
+	remoteActorHandle := "alice@remote.example"
+	handleActor, err := activityResolver.Actor(ctx, &activitypub.Activity{Actor: remoteActorHandle})
+	require.NoError(t, err)
+	require.NotNil(t, handleActor)
+	require.Equal(t, remoteActorHandle, handleActor.ID)
+	require.Equal(t, "alice", handleActor.PreferredUsername)
 }

--- a/pkg/common/safe_url.go
+++ b/pkg/common/safe_url.go
@@ -1,0 +1,31 @@
+package common // nolint:revive // "common" package name is acceptable for shared utilities
+
+import (
+	"net/url"
+	"strings"
+	"unicode"
+)
+
+// SafeHTTPURL returns a canonical HTTP(S) URL only when the input has no raw
+// control characters, uses an allowed scheme, and includes a host.
+func SafeHTTPURL(raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || strings.ContainsFunc(raw, unicode.IsControl) {
+		return "", false
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", false
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != SchemeHTTP && scheme != SchemeHTTPS {
+		return "", false
+	}
+	if strings.TrimSpace(parsed.Host) == "" {
+		return "", false
+	}
+
+	return parsed.String(), true
+}

--- a/pkg/services/cms/draft_service.go
+++ b/pkg/services/cms/draft_service.go
@@ -24,7 +24,7 @@ const (
 
 type draftRepository interface {
 	CreateDraft(ctx context.Context, draft *models.Draft) error
-	UpdateDraft(ctx context.Context, draft *models.Draft) error
+	UpdateDraft(ctx context.Context, authorID string, draft *models.Draft) error
 	GetDraft(ctx context.Context, authorID, draftID string) (*models.Draft, error)
 	DeleteDraft(ctx context.Context, authorID, draftID string) error
 }
@@ -73,22 +73,47 @@ func (s *DraftService) CreateDraft(ctx context.Context, draft *models.Draft) err
 	return s.draftRepo.CreateDraft(ctx, draft)
 }
 
+func validateDraftWriteAuthor(authorID string, draft *models.Draft) error {
+	authorID = strings.TrimSpace(authorID)
+	if authorID == "" {
+		return stdErrors.New("authorID is required")
+	}
+	if draft == nil {
+		return stdErrors.New("draft is required")
+	}
+	draftAuthor := strings.TrimSpace(draft.AuthorID)
+	if draftAuthor == "" {
+		return stdErrors.New("draft author is required")
+	}
+	if draftAuthor != authorID {
+		return stdErrors.New("draft does not belong to author")
+	}
+	draft.AuthorID = draftAuthor
+	return nil
+}
+
 // UpdateDraft updates an existing draft
-func (s *DraftService) UpdateDraft(ctx context.Context, draft *models.Draft) error {
+func (s *DraftService) UpdateDraft(ctx context.Context, authorID string, draft *models.Draft) error {
+	if err := validateDraftWriteAuthor(authorID, draft); err != nil {
+		return err
+	}
 	now := time.Now()
 	draft.UpdatedAt = now
 	draft.LastSavedAt = now
-	return s.draftRepo.UpdateDraft(ctx, draft)
+	return s.draftRepo.UpdateDraft(ctx, authorID, draft)
 }
 
 // Autosave updates the draft content without changing its primary status
-func (s *DraftService) Autosave(ctx context.Context, draft *models.Draft) error {
+func (s *DraftService) Autosave(ctx context.Context, authorID string, draft *models.Draft) error {
+	if err := validateDraftWriteAuthor(authorID, draft); err != nil {
+		return err
+	}
 	s.logger.Debug("autosaving draft", zap.String("id", draft.ID))
 	now := time.Now()
 	draft.LastSavedAt = now
 	draft.UpdatedAt = now
 	draft.AutosaveVersion++
-	return s.draftRepo.UpdateDraft(ctx, draft)
+	return s.draftRepo.UpdateDraft(ctx, authorID, draft)
 }
 
 // GetDraft retrieves a draft
@@ -98,6 +123,14 @@ func (s *DraftService) GetDraft(ctx context.Context, authorID, draftID string) (
 
 // DeleteDraft deletes a draft
 func (s *DraftService) DeleteDraft(ctx context.Context, authorID, draftID string) error {
+	authorID = strings.TrimSpace(authorID)
+	draftID = strings.TrimSpace(draftID)
+	if authorID == "" {
+		return stdErrors.New("authorID is required")
+	}
+	if draftID == "" {
+		return stdErrors.New("draftID is required")
+	}
 	return s.draftRepo.DeleteDraft(ctx, authorID, draftID)
 }
 
@@ -115,7 +148,7 @@ func (s *DraftService) ScheduleDraft(ctx context.Context, authorID, draftID stri
 	draft.ScheduledAt = &scheduledAt
 	draft.Status = draftStatusScheduled
 	draft.UpdatedAt = time.Now()
-	return s.draftRepo.UpdateDraft(ctx, draft)
+	return s.draftRepo.UpdateDraft(ctx, authorID, draft)
 }
 
 // PublishDraft converts a draft into an article
@@ -146,7 +179,7 @@ func (s *DraftService) PublishDraft(ctx context.Context, authorID, draftID strin
 	}
 
 	now := time.Now()
-	if err := s.transitionDraftToPublishing(ctx, draft, now); err != nil {
+	if err := s.transitionDraftToPublishing(ctx, authorID, draft, now); err != nil {
 		return nil, err
 	}
 
@@ -218,23 +251,26 @@ func (s *DraftService) cleanupPublishedDraft(ctx context.Context, authorID, draf
 	return article, nil
 }
 
-func (s *DraftService) transitionDraftToPublishing(ctx context.Context, draft *models.Draft, now time.Time) error {
+func (s *DraftService) transitionDraftToPublishing(ctx context.Context, authorID string, draft *models.Draft, now time.Time) error {
+	if err := validateDraftWriteAuthor(authorID, draft); err != nil {
+		return err
+	}
 	draft.Status = draftStatusPublishing
 	draft.ScheduledAt = nil
 	draft.UpdatedAt = now
-	return s.draftRepo.UpdateDraft(ctx, draft)
+	return s.draftRepo.UpdateDraft(ctx, authorID, draft)
 }
 
 func (s *DraftService) publishDraftUpdateExistingArticle(ctx context.Context, authorID, draftID, domain, objectID, slug string, draft *models.Draft, now time.Time) (*models.Article, error) {
 	article, err := s.articleService.GetArticle(ctx, objectID)
 	if err != nil {
-		s.markDraftFailed(ctx, draft, draftID, err)
+		s.markDraftFailed(ctx, authorID, draft, draftID, err)
 		return nil, err
 	}
 
 	if strings.TrimSpace(article.AttributedTo) != common.GenerateActorID(domain, authorID) {
 		err := stdErrors.New("draft does not have permission to update this article")
-		s.markDraftFailed(ctx, draft, draftID, err)
+		s.markDraftFailed(ctx, authorID, draft, draftID, err)
 		return nil, err
 	}
 
@@ -252,7 +288,7 @@ func (s *DraftService) publishDraftUpdateExistingArticle(ctx context.Context, au
 	article.Updated = now
 
 	if err := s.articleService.UpdateArticle(ctx, article); err != nil {
-		s.markDraftFailed(ctx, draft, draftID, err)
+		s.markDraftFailed(ctx, authorID, draft, draftID, err)
 		return nil, err
 	}
 
@@ -283,7 +319,7 @@ func (s *DraftService) publishDraftCreateNewArticle(ctx context.Context, authorI
 			existing, getErr := s.resolveExistingArticleBySlug(ctx, domain, slug)
 			if getErr == nil && existing != nil {
 				if strings.TrimSpace(existing.AttributedTo) != common.GenerateActorID(domain, authorID) {
-					s.markDraftFailed(ctx, draft, draftID, err)
+					s.markDraftFailed(ctx, authorID, draft, draftID, err)
 					return nil, err
 				}
 
@@ -292,7 +328,7 @@ func (s *DraftService) publishDraftCreateNewArticle(ctx context.Context, authorI
 			}
 		}
 
-		s.markDraftFailed(ctx, draft, draftID, err)
+		s.markDraftFailed(ctx, authorID, draft, draftID, err)
 		return nil, err
 	}
 
@@ -337,15 +373,15 @@ func (s *DraftService) deleteDraftAfterPublish(ctx context.Context, draft *model
 		draft.Status = draftStatusPublished
 		draft.ObjectID = &objectID
 		draft.UpdatedAt = time.Now()
-		_ = s.draftRepo.UpdateDraft(ctx, draft)
+		_ = s.draftRepo.UpdateDraft(ctx, authorID, draft)
 	}
 }
 
-func (s *DraftService) markDraftFailed(ctx context.Context, draft *models.Draft, draftID string, err error) {
+func (s *DraftService) markDraftFailed(ctx context.Context, authorID string, draft *models.Draft, draftID string, err error) {
 	s.logger.Warn("draft publish failed", zap.String("draft_id", draftID), zap.Error(err))
 	draft.Status = draftStatusFailed
 	draft.UpdatedAt = time.Now()
-	_ = s.draftRepo.UpdateDraft(ctx, draft)
+	_ = s.draftRepo.UpdateDraft(ctx, authorID, draft)
 }
 
 // CancelScheduledDraft cancels a scheduled draft publish.
@@ -359,5 +395,5 @@ func (s *DraftService) CancelScheduledDraft(ctx context.Context, authorID, draft
 	draft.Status = draftStatusDraft
 	draft.UpdatedAt = time.Now()
 
-	return s.draftRepo.UpdateDraft(ctx, draft)
+	return s.draftRepo.UpdateDraft(ctx, authorID, draft)
 }

--- a/pkg/services/cms/draft_service_test.go
+++ b/pkg/services/cms/draft_service_test.go
@@ -39,14 +39,17 @@ func (r *memDraftRepo) CreateDraft(ctx context.Context, draft *models.Draft) err
 	return nil
 }
 
-func (r *memDraftRepo) UpdateDraft(ctx context.Context, draft *models.Draft) error {
-	if draft == nil {
+func (r *memDraftRepo) UpdateDraft(ctx context.Context, authorID string, draft *models.Draft) error {
+	if draft == nil || strings.TrimSpace(authorID) == "" {
 		return apperrors.ValidationFailedWithField("draft")
 	}
 	if err := draft.UpdateKeys(); err != nil {
 		return err
 	}
-	r.items[r.key(draft.AuthorID, draft.ID)] = cloneDraft(draft)
+	if strings.TrimSpace(draft.AuthorID) != strings.TrimSpace(authorID) {
+		return apperrors.NotFound("draft")
+	}
+	r.items[r.key(authorID, draft.ID)] = cloneDraft(draft)
 	return nil
 }
 

--- a/pkg/services/cms/round32_more_coverage_test.go
+++ b/pkg/services/cms/round32_more_coverage_test.go
@@ -38,15 +38,18 @@ func TestDraftService_SimpleCRUDWrappers(t *testing.T) {
 	require.False(t, draft.UpdatedAt.IsZero())
 	require.False(t, draft.LastSavedAt.IsZero())
 
+	require.Error(t, svc.UpdateDraft(ctx, "bob", draft))
+
 	beforeUpdated := draft.UpdatedAt
 	time.Sleep(1 * time.Millisecond)
-	require.NoError(t, svc.UpdateDraft(ctx, draft))
+	require.NoError(t, svc.UpdateDraft(ctx, "alice", draft))
 	require.True(t, draft.UpdatedAt.After(beforeUpdated))
 	require.True(t, draft.LastSavedAt.After(beforeUpdated))
 
+	require.Error(t, svc.Autosave(ctx, "bob", draft))
 	autosaveBefore := draft.AutosaveVersion
 	time.Sleep(1 * time.Millisecond)
-	require.NoError(t, svc.Autosave(ctx, draft))
+	require.NoError(t, svc.Autosave(ctx, "alice", draft))
 	require.Equal(t, autosaveBefore+1, draft.AutosaveVersion)
 
 	got, err := svc.GetDraft(ctx, "alice", "draft-1")

--- a/pkg/services/notifications.go
+++ b/pkg/services/notifications.go
@@ -356,10 +356,12 @@ func buildNotificationPostSnapshot(id, url, content, createdAt, visibility, inRe
 
 	snapshot := map[string]interface{}{
 		"id":         id,
-		"url":        firstNonEmptyString(url, id),
 		"content":    content,
 		"createdAt":  createdAt,
 		"visibility": firstNonEmptyString(visibility, models.VisibilityPublic),
+	}
+	if safeURL := firstSafeHTTPURL(url, id); safeURL != "" {
+		snapshot["url"] = safeURL
 	}
 
 	if trimmed := strings.TrimSpace(inReplyToID); trimmed != "" {
@@ -370,6 +372,15 @@ func buildNotificationPostSnapshot(id, url, content, createdAt, visibility, inRe
 	}
 
 	return snapshot
+}
+
+func firstSafeHTTPURL(candidates ...string) string {
+	for _, candidate := range candidates {
+		if safeURL, ok := common.SafeHTTPURL(candidate); ok {
+			return safeURL
+		}
+	}
+	return ""
 }
 
 func cloneNotificationPostSnapshot(snapshot map[string]interface{}) map[string]interface{} {

--- a/pkg/services/notifications_round32_snapshot_test.go
+++ b/pkg/services/notifications_round32_snapshot_test.go
@@ -52,6 +52,34 @@ func TestNotificationService_PostSnapshotHelpers_Round32(t *testing.T) {
 		assert.Equal(t, parentID, snapshot["inReplyToId"])
 	})
 
+	t.Run("snapshot status urls fall back when unsafe", func(t *testing.T) {
+		svc := &notificationService{logger: zap.NewNop()}
+
+		snapshot := svc.buildPostSnapshotFromObject(&models.Object{
+			ID:           "https://local.example/objects/safe-id",
+			URL:          "javascript:alert(1)",
+			Content:      "<p>body</p>",
+			Published:    publishedAt,
+			Visibility:   models.VisibilityPublic,
+			AttributedTo: "https://local.example/users/alice",
+		}, "", "")
+
+		require.NotNil(t, snapshot)
+		assert.Equal(t, "https://local.example/objects/safe-id", snapshot["url"])
+
+		controlSnapshot := svc.buildPostSnapshotFromObject(map[string]interface{}{
+			"id":           "https://local.example/objects/control-safe-id",
+			"url":          "https://local.example/@alice/control\nlocation:https://evil.example/",
+			"content":      "<p>body</p>",
+			"published":    publishedAt.Format(time.RFC3339),
+			"visibility":   models.VisibilityPublic,
+			"attributedTo": "https://local.example/users/alice",
+		}, "", "")
+
+		require.NotNil(t, controlSnapshot)
+		assert.Equal(t, "https://local.example/objects/control-safe-id", controlSnapshot["url"])
+	})
+
 	t.Run("postSnapshotForActivity returns nil when lookup fails", func(t *testing.T) {
 		svc := &notificationService{
 			storage: &repositoryStorageAdapter{repos: fakeStorageAdapterRepos{

--- a/pkg/storage/interfaces/draft.go
+++ b/pkg/storage/interfaces/draft.go
@@ -19,8 +19,8 @@ type DraftRepository interface {
 	// GetDraft retrieves a draft by author ID and draft ID
 	GetDraft(ctx context.Context, authorID, draftID string) (*models.Draft, error)
 
-	// UpdateDraft updates an existing draft
-	UpdateDraft(ctx context.Context, draft *models.Draft) error
+	// UpdateDraft updates an existing draft owned by authorID
+	UpdateDraft(ctx context.Context, authorID string, draft *models.Draft) error
 
 	// DeleteDraft deletes a draft
 	DeleteDraft(ctx context.Context, authorID, draftID string) error

--- a/pkg/storage/repositories/draft_repository.go
+++ b/pkg/storage/repositories/draft_repository.go
@@ -32,6 +32,25 @@ func NewDraftRepository(db core.DB, tableName string, logger *zap.Logger, costSe
 	}
 }
 
+func validateDraftWriteOwner(authorID string, draft *models.Draft) error {
+	authorID = strings.TrimSpace(authorID)
+	if err := common.ValidateRequiredParam("authorID", authorID); err != nil {
+		return err
+	}
+	if draft == nil {
+		return common.ValidationError{Field: "draft", Message: "is required"}
+	}
+	draftAuthor := strings.TrimSpace(draft.AuthorID)
+	if err := common.ValidateRequiredParam("draft.AuthorID", draftAuthor); err != nil {
+		return err
+	}
+	if draftAuthor != authorID {
+		return common.ValidationError{Field: "authorID", Message: "does not match draft author"}
+	}
+	draft.AuthorID = draftAuthor
+	return nil
+}
+
 // CreateDraft creates a new draft
 func (r *DraftRepository) CreateDraft(ctx context.Context, draft *models.Draft) error {
 	return r.ValidateAndCreate(ctx, draft)
@@ -51,7 +70,10 @@ func (r *DraftRepository) GetDraft(ctx context.Context, authorID, draftID string
 }
 
 // UpdateDraft updates an existing draft
-func (r *DraftRepository) UpdateDraft(ctx context.Context, draft *models.Draft) error {
+func (r *DraftRepository) UpdateDraft(ctx context.Context, authorID string, draft *models.Draft) error {
+	if err := validateDraftWriteOwner(authorID, draft); err != nil {
+		return err
+	}
 	if err := draft.UpdateKeys(); err != nil {
 		return err
 	}
@@ -61,6 +83,14 @@ func (r *DraftRepository) UpdateDraft(ctx context.Context, draft *models.Draft) 
 
 // DeleteDraft deletes a draft
 func (r *DraftRepository) DeleteDraft(ctx context.Context, authorID, draftID string) error {
+	authorID = strings.TrimSpace(authorID)
+	draftID = strings.TrimSpace(draftID)
+	if err := common.ValidateRequiredParam("authorID", authorID); err != nil {
+		return err
+	}
+	if err := common.ValidateRequiredParam("draftID", draftID); err != nil {
+		return err
+	}
 	pk := fmt.Sprintf("USER#%s#DRAFT", authorID)
 	sk := fmt.Sprintf("ID#%s", draftID)
 	return r.Delete(ctx, pk, sk)

--- a/pkg/storage/repositories/draft_repository_round10_test.go
+++ b/pkg/storage/repositories/draft_repository_round10_test.go
@@ -42,8 +42,9 @@ func TestRound10_DraftRepository_CRUDAndPagination(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, got)
 
-	require.Error(t, repo.UpdateDraft(ctx, &models.Draft{ID: "draft-1"})) // missing AuthorID
-	require.NoError(t, repo.UpdateDraft(ctx, draft))
+	require.Error(t, repo.UpdateDraft(ctx, "user-1", &models.Draft{ID: "draft-1"})) // missing AuthorID
+	require.Error(t, repo.UpdateDraft(ctx, "other-user", draft))
+	require.NoError(t, repo.UpdateDraft(ctx, "user-1", draft))
 
 	require.NoError(t, repo.DeleteDraft(ctx, "user-1", "draft-1"))
 

--- a/pkg/testing/inmemory/draft_repository.go
+++ b/pkg/testing/inmemory/draft_repository.go
@@ -89,15 +89,18 @@ func (r *DraftRepository) GetDraft(_ context.Context, authorID, draftID string) 
 }
 
 // UpdateDraft updates an existing draft
-func (r *DraftRepository) UpdateDraft(_ context.Context, draft *models.Draft) error {
+func (r *DraftRepository) UpdateDraft(_ context.Context, authorID string, draft *models.Draft) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if draft == nil || draft.AuthorID == "" || draft.ID == "" {
+	if draft == nil || strings.TrimSpace(authorID) == "" || draft.AuthorID == "" || draft.ID == "" {
 		return storage.ErrInvalidInput
 	}
+	if strings.TrimSpace(draft.AuthorID) != strings.TrimSpace(authorID) {
+		return storage.ErrNotFound
+	}
 
-	key := draftKey(draft.AuthorID, draft.ID)
+	key := draftKey(authorID, draft.ID)
 	oldDraft, exists := r.drafts[key]
 	if !exists {
 		return storage.ErrNotFound
@@ -126,6 +129,12 @@ func (r *DraftRepository) UpdateDraft(_ context.Context, draft *models.Draft) er
 func (r *DraftRepository) DeleteDraft(_ context.Context, authorID, draftID string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	authorID = strings.TrimSpace(authorID)
+	draftID = strings.TrimSpace(draftID)
+	if authorID == "" || draftID == "" {
+		return storage.ErrInvalidInput
+	}
 
 	key := draftKey(authorID, draftID)
 	draft, exists := r.drafts[key]

--- a/pkg/testing/mocks/draft_repository_mock.go
+++ b/pkg/testing/mocks/draft_repository_mock.go
@@ -39,8 +39,8 @@ func (m *MockDraftRepository) GetDraft(ctx context.Context, authorID, draftID st
 }
 
 // UpdateDraft mocks the UpdateDraft method
-func (m *MockDraftRepository) UpdateDraft(ctx context.Context, draft *models.Draft) error {
-	args := m.Called(ctx, draft)
+func (m *MockDraftRepository) UpdateDraft(ctx context.Context, authorID string, draft *models.Draft) error {
+	args := m.Called(ctx, authorID, draft)
 	return args.Error(0)
 }
 


### PR DESCRIPTION
## Milestone
M17 — CMS, GraphQL identity, and notifications hardening for Project 24.

Closes #928.
Children implemented/closed: #929, #930, #931, #932.

## Classification
security hardening / contract-stability / federation-trust / CMS correctness

## Surfaces affected
- Notifications: status snapshot URL serialization and API projection
- CMS GraphQL: publication member reads and draft mutation ownership
- CMS storage/service: draft write authorization seam
- GraphQL activity resolution: remote actor URL/handle identity preservation

## Specialist walks referenced
- Federation trust: #932 preserves actor identity integrity by preventing remote actor identifiers from flowing through local account normalization.
- Contract / API: M17 changes are backward-compatible semantic refinements; GraphQL schema shape is unchanged and `./lesser verify ci` confirmed the generated GraphQL/OpenAPI contracts are current.
- Schema: no PK/SK/GSI/TableTheory tag changes; no data migration required for this milestone.
- Framework: idiomatic lesser usage; no AppTheory/TableTheory patch.

## Consumer impact
- Operators: safer defaults; no migration/apply step required.
- Mastodon clients: no response-shape changes; notification URL values are sanitized/omitted when unsafe.
- Remote AP peers: GraphQL activity actor resolution now preserves remote identity instead of normalizing same-named remote actors to local accounts.
- Sibling repos: no release-artifact, MCP, namespace, or UI contract changes required.

## Tasks
- [x] #929 `fix(notifications): sanitize snapshot status urls`
- [x] #930 `fix(cms): remove publication member query self-heal`
- [x] #931 `fix(cms): enforce draft ownership on writes`
- [x] #932 `fix(graphql): preserve remote actor domains in activity resolution`

## Validation
- `git diff --check origin/main...HEAD`
- `gofmt -l .` (empty)
- Targeted M17 tests:
  - `go test ./pkg/services -run 'TestNotificationService_PostSnapshotHelpers_Round32/snapshot_status_urls_fall_back_when_unsafe'`
  - `go test ./cmd/api/handlers -run 'TestNotifications_ListHandlesSnapshotAndLegacyStatuses_Round28'`
  - `go test ./pkg/common ./pkg/services ./cmd/api/handlers`
  - `go test ./graph -run TestRound12CMS_MyPublicationsDoesNotSelfHealFallbackRows`
  - `go test ./graph -run TestRound12CMS`
  - `go test ./pkg/services/cms ./pkg/storage/repositories ./pkg/testing/inmemory ./cmd/cms-scheduler ./graph`
  - `go test ./graph -run 'TestRound32ActivityResolver_ActorPreservesRemoteIdentifiers|TestRound32Resolver_ConvertAccountToActor_PreservesRemoteIdentity|TestRound34ConvertStatusToGraphQLObject'`
  - `go test ./graph`
- `go test ./...`
- `go vet ./...`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`

Smoke tests were not run, per current lesser workflow guidance.

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Migration dry-run intentionally N/A for `Theory` / `theory` dev: no data migration needed
- [ ] Migration dry-run intentionally N/A for `Sim` / `simulacrum` dev: no data migration needed
- [ ] Deployed to `theory` dev
- [ ] Deployed to `simulacrum` dev
- [ ] Dev soak complete
- [ ] Live rollout intentionally N/A until live instances exist
- [ ] Post-deploy monitoring verified

## Cross-repo coordination
None required.

## Advisor-brief authorization
N/A — Aron directly authorized Project 24 M17 implementation.
