### PR TITLE
feat(souls): add bound self endpoint

### DIFF
--- a/cmd/api/handlers/souls.go
+++ b/cmd/api/handlers/souls.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 	"strings"
 
 	apimodels "github.com/equaltoai/lesser/cmd/api/models"
@@ -46,6 +47,44 @@ func (h *Handler) HandleGetMySoulsLift(ctx *apptheory.Context) (*apptheory.Respo
 	return okJSON(apimodels.SoulsMineResponse{
 		Souls: items,
 		Count: len(items),
+	})
+}
+
+// HandleGetBoundSoulMeLift returns the active soul bound to the authenticated local runtime-agent principal.
+func (h *Handler) HandleGetBoundSoulMeLift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	claims, err := h.authenticateWithAnyScope(ctx, auth.ScopeRead, auth.ScopeWrite)
+	if err != nil {
+		if isInsufficientScopeError(err) {
+			return common.RespondForbidden(ctx, err.Error())
+		}
+		return common.RespondUnauthorized(ctx)
+	}
+
+	svc := h.getSoulService()
+	if svc == nil {
+		return common.RespondInternalServerError(ctx)
+	}
+
+	soul, err := svc.ResolveBoundAgent(ctx.Context(), claims.Username)
+	if err != nil {
+		if errors.Is(err, soulservice.ErrSoulNotAvailable) {
+			return respondBoundSoulNotFound("soul_not_available", "bound soul is not available")
+		}
+		return h.respondSoulServiceError(ctx, err)
+	}
+	if soul == nil || !soul.Bound {
+		return respondBoundSoulNotFound("soul_not_bound", "no bound soul for authenticated principal")
+	}
+
+	item := toAPISoulInventoryItem(*soul)
+	if item.Binding == nil || item.BindingState != "bound" {
+		return respondBoundSoulNotFound("soul_not_bound", "no bound soul for authenticated principal")
+	}
+
+	return okJSON(apimodels.BoundSoulResponse{
+		Agent:        item.Agent,
+		BindingState: item.BindingState,
+		Binding:      *item.Binding,
 	})
 }
 
@@ -99,6 +138,14 @@ func (h *Handler) getSoulService() soulHandlerService {
 		return nil
 	}
 	return soulservice.NewService(h.repos.Account(), h.repos.Instance(), h.cfg, h.logger)
+}
+
+func respondBoundSoulNotFound(code string, message string) (*apptheory.Response, error) {
+	return apptheory.JSON(http.StatusNotFound, common.StandardErrorResponse{
+		Error:       message,
+		Description: message,
+		Code:        code,
+	})
 }
 
 func (h *Handler) respondSoulServiceError(ctx *apptheory.Context, err error) (*apptheory.Response, error) {

--- a/cmd/api/handlers/souls_test.go
+++ b/cmd/api/handlers/souls_test.go
@@ -10,6 +10,7 @@ import (
 
 	apimodels "github.com/equaltoai/lesser/cmd/api/models"
 	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/common"
 	soulservice "github.com/equaltoai/lesser/pkg/services/souls"
 	"github.com/stretchr/testify/require"
 )
@@ -217,6 +218,189 @@ func TestHandleGetMySoulsLift_AuthFailures(t *testing.T) {
 
 		requireStatus(t, http.StatusForbidden)(h.HandleGetMySoulsLift(ctx))
 	})
+}
+
+func TestHandleGetBoundSoulMeLift_ReturnsActiveBoundSoul(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 1, 14, 30, 0, 0, time.UTC)
+	cfg := round10TestConfig()
+	service := &stubSoulHandlerService{
+		resolveBoundOut: &soulservice.Soul{
+			AgentID:               "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			Domain:                "example.com",
+			LocalID:               "ops",
+			Wallet:                "0x1111111111111111111111111111111111111111",
+			PrincipalAddress:      "0x2222222222222222222222222222222222222222",
+			Status:                "active",
+			LifecycleStatus:       "active",
+			Bound:                 true,
+			BoundAgentUsername:    "ops",
+			BoundPrincipalAddress: "0x2222222222222222222222222222222222222222",
+			BoundAt:               now,
+			BoundUpdatedAt:        now,
+		},
+	}
+	h := &Handler{cfg: cfg, logger: round10TestLogger(t), soulsService: service}
+	token := round11SignToken(t, cfg.JWTSecret, "ops", []string{auth.ScopeRead}, "sess-bound")
+
+	ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/souls/bound/me", map[string]string{
+		"Authorization": "Bearer " + token,
+	}, nil, nil)
+	require.NoError(t, err)
+
+	resp := requireStatus(t, http.StatusOK)(h.HandleGetBoundSoulMeLift(ctx))
+
+	var body apimodels.BoundSoulResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Equal(t, "ops", service.lastTargetAgent)
+	require.Equal(t, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", body.Agent.AgentID)
+	require.Equal(t, "ops", body.Agent.LocalID)
+	require.Equal(t, "bound", body.BindingState)
+	require.Equal(t, "ops", body.Binding.AgentUsername)
+	require.Equal(t, "0x2222222222222222222222222222222222222222", body.Binding.PrincipalAddress)
+	require.NotContains(t, string(resp.Body), "available_for_incorporation")
+}
+
+func TestHandleGetBoundSoulMeLift_AuthGuards(t *testing.T) {
+	t.Parallel()
+
+	cfg := round10TestConfig()
+	readToken := round11SignToken(t, cfg.JWTSecret, "ops", []string{auth.ScopeRead}, "sess-bound-read")
+	writeToken := round11SignToken(t, cfg.JWTSecret, "ops", []string{auth.ScopeWrite}, "sess-bound-write")
+	adminToken := round11SignToken(t, cfg.JWTSecret, "ops", []string{auth.ScopeAdmin}, "sess-bound-admin")
+	h := &Handler{
+		cfg:    cfg,
+		logger: round10TestLogger(t),
+		soulsService: &stubSoulHandlerService{
+			resolveBoundOut: &soulservice.Soul{
+				AgentID:            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				Domain:             "example.com",
+				LocalID:            "ops",
+				Wallet:             "0x1111111111111111111111111111111111111111",
+				Status:             "active",
+				Bound:              true,
+				BoundAgentUsername: "ops",
+				BoundAt:            time.Date(2026, 5, 1, 14, 30, 0, 0, time.UTC),
+				BoundUpdatedAt:     time.Date(2026, 5, 1, 14, 30, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	testCases := []struct {
+		name       string
+		headers    map[string]string
+		wantStatus int
+	}{
+		{
+			name:       "missing token",
+			headers:    nil,
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "insufficient scope",
+			headers: map[string]string{
+				"Authorization": "Bearer " + adminToken,
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name: "read scope works",
+			headers: map[string]string{
+				"Authorization": "Bearer " + readToken,
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "write scope works",
+			headers: map[string]string{
+				"Authorization": "Bearer " + writeToken,
+			},
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/souls/bound/me", tc.headers, nil, nil)
+			require.NoError(t, err)
+
+			requireStatus(t, tc.wantStatus)(h.HandleGetBoundSoulMeLift(ctx))
+		})
+	}
+}
+
+func TestHandleGetBoundSoulMeLift_MapsServiceFailures(t *testing.T) {
+	t.Parallel()
+
+	cfg := round10TestConfig()
+	token := round11SignToken(t, cfg.JWTSecret, "ops", []string{auth.ScopeRead}, "sess-bound-errors")
+
+	testCases := []struct {
+		name       string
+		service    *stubSoulHandlerService
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "unbound",
+			service:    &stubSoulHandlerService{},
+			wantStatus: http.StatusNotFound,
+			wantCode:   "soul_not_bound",
+		},
+		{
+			name:       "unavailable",
+			service:    &stubSoulHandlerService{resolveBoundErr: soulservice.ErrSoulNotAvailable},
+			wantStatus: http.StatusNotFound,
+			wantCode:   "soul_not_available",
+		},
+		{
+			name:       "trust not configured",
+			service:    &stubSoulHandlerService{resolveBoundErr: soulservice.ErrTrustNotConfigured},
+			wantStatus: http.StatusUnprocessableEntity,
+		},
+		{
+			name:       "unexpected",
+			service:    &stubSoulHandlerService{resolveBoundErr: errors.New("boom")},
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := &Handler{cfg: cfg, logger: round10TestLogger(t), soulsService: tc.service}
+			ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/souls/bound/me", map[string]string{
+				"Authorization": "Bearer " + token,
+			}, nil, nil)
+			require.NoError(t, err)
+
+			resp := requireStatus(t, tc.wantStatus)(h.HandleGetBoundSoulMeLift(ctx))
+			if tc.wantCode != "" {
+				var body common.StandardErrorResponse
+				require.NoError(t, json.Unmarshal(resp.Body, &body))
+				require.Equal(t, tc.wantCode, body.Code)
+			}
+		})
+	}
+}
+
+func TestHandleGetBoundSoulMeLift_ReturnsInternalWhenServiceUnavailable(t *testing.T) {
+	t.Parallel()
+
+	cfg := round10TestConfig()
+	h := &Handler{cfg: cfg, logger: round10TestLogger(t)}
+	token := round11SignToken(t, cfg.JWTSecret, "ops", []string{auth.ScopeRead}, "sess-bound-service")
+
+	ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/souls/bound/me", map[string]string{
+		"Authorization": "Bearer " + token,
+	}, nil, nil)
+	require.NoError(t, err)
+
+	requireStatus(t, http.StatusInternalServerError)(h.HandleGetBoundSoulMeLift(ctx))
 }
 
 func TestHandleIncorporateSoulLift_MapsServiceResponses(t *testing.T) {

--- a/cmd/api/models/souls.go
+++ b/cmd/api/models/souls.go
@@ -69,6 +69,13 @@ type SoulsMineResponse struct {
 	Count int                 `json:"count"`
 }
 
+// BoundSoulResponse represents GET /api/v1/souls/bound/me.
+type BoundSoulResponse struct {
+	Agent        SoulAgentIdentity `json:"agent"`
+	BindingState string            `json:"binding_state"`
+	Binding      SoulAgentBinding  `json:"binding"`
+}
+
 // SoulIncorporateRequest represents POST /api/v1/souls/{agentId}/incorporate.
 type SoulIncorporateRequest struct {
 	TargetAgentUsername string `json:"target_agent_username"`

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -380,6 +380,7 @@ func configureRoutes(app *apptheory.App) {
 	app.Delete("/api/v1/vouches/{vouch_id}", apiHandler.HandleRevokeVouchLift, requireAuth)
 
 	// Souls
+	app.Get("/api/v1/souls/bound/me", apiHandler.HandleGetBoundSoulMeLift, requireReadOrWrite)
 	app.Get("/api/v1/souls/mine", apiHandler.HandleGetMySoulsLift, requireReadOrWrite)
 	app.Post("/api/v1/souls/{agentId}/incorporate", apiHandler.HandleIncorporateSoulLift, requireWrite)
 

--- a/cmd/api/testdata/routes_manifest.txt
+++ b/cmd/api/testdata/routes_manifest.txt
@@ -101,6 +101,7 @@ GET /api/v1/reputation/{actor_id}
 GET /api/v1/scheduled_statuses
 GET /api/v1/scheduled_statuses/{id}
 GET /api/v1/search/statuses
+GET /api/v1/souls/bound/me
 GET /api/v1/souls/mine
 GET /api/v1/statuses/{id}
 GET /api/v1/statuses/{id}/context

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -1816,6 +1816,20 @@ components:
                 - challenge_id
                 - signature
             type: object
+        BoundSoulResponse:
+            additionalProperties: false
+            properties:
+                agent:
+                    $ref: '#/components/schemas/SoulAgentIdentity'
+                binding:
+                    $ref: '#/components/schemas/SoulAgentBinding'
+                binding_state:
+                    type: string
+            required:
+                - agent
+                - binding
+                - binding_state
+            type: object
         ClearNotificationsRequest:
             additionalProperties: false
             properties: {}
@@ -15292,11 +15306,47 @@ paths:
                 - cmd/api/routes.go
             x-oauth-scopes:
                 - write
+    /api/v1/souls/bound/me:
+        get:
+            operationId: get_api_v1_souls_bound_me
+            description: 'Return the active soul identity bound to the authenticated local runtime-agent principal. The endpoint is fail-closed: unbound, inactive, missing host identity, or wrong-domain identities return 404.'
+            tags:
+                - souls
+            security:
+                - bearerAuth: []
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/BoundSoulResponse'
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "401":
+                    $ref: '#/components/responses/Unauthorized'
+                "403":
+                    $ref: '#/components/responses/Forbidden'
+                "404":
+                    $ref: '#/components/responses/NotFound'
+                "422":
+                    $ref: '#/components/responses/UnprocessableEntity'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+            x-lesser-handler: HandleGetBoundSoulMeLift
+            x-lesser-lambda: api
+            x-lesser-routeSources:
+                - cmd/api/routes.go
+            x-oauth-scopes:
+                - read
+                - write
     /api/v1/souls/mine:
         get:
             operationId: get_api_v1_souls_mine
             tags:
                 - souls
+            security:
+                - bearerAuth: []
             responses:
                 "200":
                     description: OK
@@ -15316,6 +15366,9 @@ paths:
             x-lesser-lambda: api
             x-lesser-routeSources:
                 - cmd/api/routes.go
+            x-oauth-scopes:
+                - read
+                - write
     /api/v1/statuses:
         post:
             operationId: post_api_v1_statuses

--- a/docs/specs/graphql_coverage.yaml
+++ b/docs/specs/graphql_coverage.yaml
@@ -61,6 +61,11 @@ exemptions:
         exact:
             - /api/v1/admin/soul/well-known
             - /api/v1/notifications/deliver
+    - id: lesser_body_mcp
+      reason: lesser-body MCP runtime-agent self-verification endpoints are REST-only support APIs.
+      match:
+        exact:
+            - /api/v1/souls/bound/me
     - id: admin_agent_unlock
       reason: Agent operator unlock is currently exposed as a REST-only admin operation.
       match:
@@ -1161,6 +1166,10 @@ routes:
       status: covered
       graphql:
         - Query.search
+    - method: GET
+      path: /api/v1/souls/bound/me
+      policy: rest_only
+      exemptedBy: lesser_body_mcp
     - method: GET
       path: /api/v1/souls/mine
       policy: graphql_required

--- a/pkg/services/souls/service_test.go
+++ b/pkg/services/souls/service_test.go
@@ -1322,6 +1322,113 @@ func TestService_ResolveBoundAgent_ReturnsNilWhenUnbound(t *testing.T) {
 	require.Nil(t, soul)
 }
 
+func TestService_ResolveBoundAgent_FailsClosedForUnavailableHostIdentity(t *testing.T) {
+	t.Parallel()
+
+	const agentAlpha = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	testCases := []struct {
+		name     string
+		response map[string]any
+	}{
+		{
+			name: "wrong domain",
+			response: map[string]any{
+				"agent_id":         agentAlpha,
+				"domain":           "other.example",
+				"local_id":         "alpha",
+				"wallet":           "0x1111111111111111111111111111111111111111",
+				"status":           "active",
+				"lifecycle_status": "active",
+			},
+		},
+		{
+			name: "inactive lifecycle",
+			response: map[string]any{
+				"agent_id":         agentAlpha,
+				"domain":           "example.com",
+				"local_id":         "alpha",
+				"wallet":           "0x1111111111111111111111111111111111111111",
+				"status":           "active",
+				"lifecycle_status": "retired",
+			},
+		},
+		{
+			name: "inactive status",
+			response: map[string]any{
+				"agent_id": agentAlpha,
+				"domain":   "example.com",
+				"local_id": "alpha",
+				"wallet":   "0x1111111111111111111111111111111111111111",
+				"status":   "inactive",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, "/api/v1/soul/agents/"+agentAlpha, r.URL.Path)
+				require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+					"version": "1",
+					"agent":   tc.response,
+				}))
+			}))
+			defer host.Close()
+
+			service := NewService(
+				nil,
+				&fakeInstanceRepo{
+					trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL},
+					bindingsByUser: map[string]*storageModels.InstanceSoulBodyBinding{
+						"agent-alpha": {
+							AgentID:  agentAlpha,
+							Username: "agent-alpha",
+						},
+					},
+				},
+				&config.Config{Domain: "example.com"},
+				zap.NewNop(),
+			).WithHTTPClient(host.Client())
+
+			soul, err := service.ResolveBoundAgent(context.Background(), "agent-alpha")
+			require.ErrorIs(t, err, ErrSoulNotAvailable)
+			require.Nil(t, soul)
+		})
+	}
+}
+
+func TestService_ResolveBoundAgent_FailsClosedWhenHostIdentityMissing(t *testing.T) {
+	t.Parallel()
+
+	const agentAlpha = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	host := httptest.NewServer(http.NotFoundHandler())
+	defer host.Close()
+
+	service := NewService(
+		nil,
+		&fakeInstanceRepo{
+			trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL},
+			bindingsByUser: map[string]*storageModels.InstanceSoulBodyBinding{
+				"agent-alpha": {
+					AgentID:  agentAlpha,
+					Username: "agent-alpha",
+				},
+			},
+		},
+		&config.Config{Domain: "example.com"},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	soul, err := service.ResolveBoundAgent(context.Background(), "agent-alpha")
+	require.ErrorIs(t, err, ErrSoulNotAvailable)
+	require.Nil(t, soul)
+}
+
 type erroringInstanceRepo struct {
 	instanceRepository
 	getBindingErr error

--- a/tools/openapi/main.go
+++ b/tools/openapi/main.go
@@ -1806,7 +1806,7 @@ func (a *handlerAuthAnalyzer) handleCall(call *ast.CallExpr) {
 
 	a.callees[sel.Sel.Name] = struct{}{}
 	switch sel.Sel.Name {
-	case "authenticateUser", "authenticateUserWithWriteScope", "authenticateAdminRequest", "authenticateWithScope":
+	case "authenticateUser", "authenticateUserWithWriteScope", "authenticateAdminRequest", "authenticateWithScope", "authenticateWithAnyScope":
 		a.hasRequiredAuth = true
 	case "authenticateUserOptional", "getOptionalAuthenticatedUser", "getAuthenticatedUserLift":
 		a.hasOptionalAuth = true

--- a/tools/openapi/operation_overrides.go
+++ b/tools/openapi/operation_overrides.go
@@ -12,7 +12,25 @@ func applyOperationOverrides(op *operation, route routeDef) {
 	applyOAuthOverrides(op, route)
 	applyAppRegistrationOverrides(op, route)
 	applyMediaOverrides(op, route)
+	applySoulOverrides(op, route)
 	applyStatusOverrides(op, route)
+}
+
+func applySoulOverrides(op *operation, route routeDef) {
+	if op == nil {
+		return
+	}
+
+	if route.Method != methodGET || route.Path != "/api/v1/souls/bound/me" {
+		return
+	}
+
+	op.Description = "Return the active soul identity bound to the authenticated local runtime-agent principal. The endpoint is fail-closed: unbound, inactive, missing host identity, or wrong-domain identities return 404."
+	if op.Responses == nil {
+		op.Responses = map[string]response{}
+	}
+	ensureResponseRef(op.Responses, "404", "NotFound")
+	ensureResponseRef(op.Responses, "422", "UnprocessableEntity")
 }
 
 func applyGraphQLOverrides(op *operation, route routeDef) {

--- a/tools/openapi/scope_defaults.go
+++ b/tools/openapi/scope_defaults.go
@@ -37,6 +37,8 @@ func defaultScopesForRoute(route routeDef) []string {
 
 func scopesForKnownPrefixes(method, path string) []string {
 	switch {
+	case method == methodGET && (path == "/api/v1/souls/mine" || path == "/api/v1/souls/bound/me"):
+		return []string{"read", "write"}
 	case strings.HasPrefix(path, "/api/v1/admin/"):
 		return scopesByMethod(method, "admin:read", "admin:write")
 	case strings.HasPrefix(path, "/api/v1/follow_requests"):


### PR DESCRIPTION
## Milestone
issue #939 — add authenticated bound-self soul endpoint for runtime-agent self identity.

## Classification
contract-stability / operational-reliability / cross-repo support for `lesser-body`.

## Surfaces affected
- REST API: `GET /api/v1/souls/bound/me`
- API Lambda handler/model/route wiring
- OpenAPI contract: `docs/contracts/openapi.yaml`
- GraphQL coverage inventory: REST-only MCP support exemption
- Route manifest snapshot

## Specialist walks referenced
- Federation trust: not directly touched; endpoint preserves fail-closed identity behavior and does not affect HTTP Signatures or federation delivery.
- Contract / API: additive `/api/v1/*` endpoint; `/api/v1/souls/mine` and GraphQL `mySouls` semantics remain unchanged.
- Schema: not touched.
- Framework: AppTheory route/middleware shape remains idiomatic; OpenAPI generator updated to recognize `authenticateWithAnyScope`.

## Consumer impact
- `lesser-body`: can switch self-verification from wallet inventory to this endpoint after this deploy (see equaltoai/lesser-body#155).
- Greater / Simulacrum: no semantic change to owner inventory surfaces.
- Mastodon clients and remote ActivityPub peers: no impact.

## Tasks
- [x] Add `BoundSoulResponse` and `HandleGetBoundSoulMeLift` backed by `ResolveBoundAgent(ctx, claims.Username)`.
- [x] Register `GET /api/v1/souls/bound/me` with read-or-write OAuth scope.
- [x] Fail closed for unbound, unavailable, wrong-domain, inactive, missing host identity, and trust-not-configured states.
- [x] Preserve `/api/v1/souls/mine` wallet-owner inventory semantics.
- [x] Update OpenAPI, route manifest, and GraphQL coverage artifacts.
- [x] Add handler and service regressions.

## Validation
- `git diff --check`
- `gofmt -l .` (empty)
- `go test ./cmd/api/handlers -run TestHandleGetBoundSoulMeLift`
- `go test ./cmd/api/handlers ./pkg/services/souls ./tools/openapi`
- `./lesser verify openapi --strict`
- `./lesser verify graphql-coverage`
- `go test ./...`
- `go vet ./...`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete: probe `GET /api/v1/souls/bound/me` for a bound walletless runtime agent such as `ops`; confirm `/api/v1/souls/mine` remains wallet inventory.
- [ ] Deploy dependent `lesser-body` caller change (equaltoai/lesser-body#155) after Lesser endpoint is live.
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
- Required: `lesser-body` must consume the new endpoint after this Lesser change is deployed.
- Not required: `soul`, `host`, `greater`, `sim` code changes for this PR.

Closes #939.
