### PR TITLE
fix(conversations): apply sender preview projection before remote-recipient early return

### DIFF
--- a/pkg/services/conversations/service.go
+++ b/pkg/services/conversations/service.go
@@ -938,6 +938,21 @@ func applyConversationCounterpartRef(state *models.UserConversationState, ref *m
 	state.CounterpartResolvedAt = ref.ResolvedAt
 }
 
+// applyDirectMessageStatusPreview applies the status projection fields to a
+// UserConversationState for a newly created direct message. This is a narrow
+// private helper that keeps sender/recipient status-projection branches from
+// drifting — the same four-field assignment is used for both local and remote
+// recipient paths.
+func applyDirectMessageStatusPreview(state *models.UserConversationState, statusID string, publishedAt time.Time) {
+	if state == nil {
+		return
+	}
+	state.PreviewStatusID = statusID
+	state.PreviewStatusPublishedAt = publishedAt
+	state.SortAt = publishedAt
+	state.UpdatedAt = publishedAt
+}
+
 func isRemoteConversationParticipant(conversation *models.Conversation, participantID string) bool {
 	if ref := conversationParticipantRefByID(conversation, participantID); ref != nil {
 		return ref.ParticipantType == models.ConversationParticipantTypeRemoteActor
@@ -1008,6 +1023,9 @@ func buildDirectMessageParticipantStatesForSend(
 		senderState.AcceptedAt = &t
 	}
 
+	if status != nil {
+		applyDirectMessageStatusPreview(senderState, status.StatusID, now)
+	}
 	if isRemoteConversationParticipant(conversation, recipientID) {
 		return []*models.UserConversationState{senderState}
 	}
@@ -1056,15 +1074,7 @@ func buildDirectMessageParticipantStatesForSend(
 	}
 
 	if status != nil {
-		senderState.PreviewStatusID = status.StatusID
-		senderState.PreviewStatusPublishedAt = now
-		senderState.SortAt = now
-		senderState.UpdatedAt = now
-
-		recipientState.PreviewStatusID = status.StatusID
-		recipientState.PreviewStatusPublishedAt = now
-		recipientState.SortAt = now
-		recipientState.UpdatedAt = now
+		applyDirectMessageStatusPreview(recipientState, status.StatusID, now)
 	}
 
 	return []*models.UserConversationState{senderState, recipientState}

--- a/pkg/services/conversations/service_round52_stale_preview_regression_test.go
+++ b/pkg/services/conversations/service_round52_stale_preview_regression_test.go
@@ -1,0 +1,93 @@
+package conversations
+
+import (
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildDirectMessageParticipantStatesForSend_RemoteRecipientAppliesPreviewProjection
+// verifies that when sending a direct message to a remote recipient, the sender's
+// UserConversationState receives PreviewStatusID, PreviewStatusPublishedAt, SortAt,
+// and UpdatedAt before the remote-recipient early return. This catches the regression
+// where local→remote sends left the sender preview stale (Track B).
+func TestBuildDirectMessageParticipantStatesForSend_RemoteRecipientAppliesPreviewProjection(t *testing.T) {
+	publishedAt := time.Date(2026, 5, 3, 17, 0, 0, 0, time.UTC)
+	remoteActorID := "https://remote.com/users/steward"
+
+	// Existing sender state with OLD stale preview fields — simulates an existing
+	// remote conversation where a prior message set the preview and a new message
+	// should overwrite it.
+	oldTime := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	senderState := &models.UserConversationState{
+		PreviewStatusID:          "old-status-id",
+		PreviewStatusPublishedAt: oldTime,
+		SortAt:                   oldTime,
+		UpdatedAt:                oldTime,
+		Unread:                   false,
+		LastReadAt:               &oldTime,
+	}
+
+	conversation := createTestConversation("conv-remote", []string{"alice", remoteActorID})
+
+	states := buildDirectMessageParticipantStatesForSend(
+		conversation,
+		&models.Status{StatusID: "new-status-id", PublishedAt: publishedAt},
+		"alice",
+		remoteActorID,
+		senderState,
+		nil,   // recipientState is nil for remote recipients (no local state row)
+		false, // deliversToInbox — not used for remote path
+	)
+
+	// Remote path returns only the sender state.
+	require.Len(t, states, 1)
+
+	s := states[0]
+
+	// Preview projection must use the NEW status, overwriting the old stale values.
+	require.Equal(t, "new-status-id", s.PreviewStatusID,
+		"PreviewStatusID must be updated to the new status for remote-recipient sends")
+	require.Equal(t, publishedAt, s.PreviewStatusPublishedAt,
+		"PreviewStatusPublishedAt must be updated to the new status time")
+	require.Equal(t, publishedAt, s.SortAt,
+		"SortAt must be updated so conversation list ordering reflects the new message")
+	require.Equal(t, publishedAt, s.UpdatedAt,
+		"UpdatedAt must be updated to the new status time")
+
+	// Read-state invariants must be preserved.
+	require.False(t, s.Unread, "Sender must remain read for their own message")
+	require.NotNil(t, s.LastReadAt, "Sender must have LastReadAt set")
+}
+
+// TestBuildDirectMessageParticipantStatesForSend_LocalRecipientStillAppliesPreview
+// confirms the local-recipient path is unaffected by the remote-path fix: both sender
+// and recipient states receive the preview projection, and the recipient-specific
+// request-state / folder / unread logic is intact.
+func TestBuildDirectMessageParticipantStatesForSend_LocalRecipientStillAppliesPreview(t *testing.T) {
+	publishedAt := time.Date(2026, 5, 3, 17, 5, 0, 0, time.UTC)
+
+	states := buildDirectMessageParticipantStatesForSend(
+		createTestConversation("conv-local", []string{"alice", "bob"}),
+		&models.Status{StatusID: "status-local", PublishedAt: publishedAt},
+		"alice",
+		"bob",
+		&models.UserConversationState{},
+		&models.UserConversationState{},
+		false,
+	)
+
+	require.Len(t, states, 2)
+
+	senderState := states[0]
+	require.Equal(t, "status-local", senderState.PreviewStatusID)
+	require.Equal(t, publishedAt, senderState.SortAt)
+	require.False(t, senderState.Unread)
+
+	recipientState := states[1]
+	require.Equal(t, "status-local", recipientState.PreviewStatusID)
+	require.Equal(t, publishedAt, recipientState.SortAt)
+	require.True(t, recipientState.Unread)
+}

--- a/pkg/services/conversations/service_test.go
+++ b/pkg/services/conversations/service_test.go
@@ -988,7 +988,7 @@ func TestService_SendDirectMessage_WithResolvedRemoteRecipient(t *testing.T) {
 			state.CounterpartDomain == "remote.com" &&
 			state.RequestState == models.DmRequestStateAccepted &&
 			state.Folder == models.UserConversationFolderInbox &&
-			!state.Unread
+			!state.Unread && state.PreviewStatusID == transition.Status.StatusID && !state.PreviewStatusPublishedAt.IsZero() && !state.SortAt.IsZero() && !state.UpdatedAt.IsZero()
 	}), mock.Anything).Return(nil).Once()
 
 	result, err := service.SendDirectMessage(ctx, cmd)


### PR DESCRIPTION
## Milestone
Track B — stale direct conversation preview fix

## Classification
bug-fix

## Surfaces affected
- `pkg/services/conversations/service.go` — fix + `applyDirectMessageStatusPreview` helper
- `pkg/services/conversations/service_test.go` — strengthened `WithResolvedRemoteRecipient` matcher
- `pkg/services/conversations/service_round52_stale_preview_regression_test.go` — new regression tests

## Specialist walks referenced
- Federation trust: none (projection-only fix, no signature/verification/delivery change)
- Contract / API: none (same REST/GraphQL shape, consumers receive corrected data)
- Schema: none (no PK/SK/GSI/TableTheory tag changes)
- Framework: idiomatic (standard Go helper, no AppTheory/TableTheory workaround)

## Consumer impact
- Operators: stale preview corrected; no config or migration needed
- Mastodon clients: none
- Remote AP peers: none
- Sibling repos (body/sim): none (consume same API, receive corrected preview)

## Root cause
`buildDirectMessageParticipantStatesForSend` returned early for remote recipients before applying `PreviewStatusID`, `PreviewStatusPublishedAt`, `SortAt`, and `UpdatedAt` to the sender state. For existing remote conversations with non-empty stale preview fields, repository normalization preserved old values.

## Fix
1. Added `applyDirectMessageStatusPreview` private helper
2. Called for sender state before `isRemoteConversationParticipant` check
3. Replaced duplicated sender lines with recipient-only helper call in local path

## Validation
- `go test ./pkg/services/conversations/...` — PASS (0.020s)
- `go vet ./...` — clean
- `gofmt -l .` — clean

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
none

## Advisor-brief authorization
Authorized via arch@lessersoul.ai — Aron's direct channel. Treat as in-session directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)