### PR TITLE
[codex] pin auth ui pnpm version

### DIFF
--- a/auth-ui/package.json
+++ b/auth-ui/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "description": "STATELESS passwordless OAuth UI for Lesser - NO SESSIONS OR COOKIES - JWT-only authentication",
   "type": "module",
+  "packageManager": "pnpm@10.33.0",
   "engines": {
     "node": ">=20.0.0"
   },


### PR DESCRIPTION
## Summary

- Pin `auth-ui` to `pnpm@10.33.0` via `packageManager` so Corepack does not float to pnpm 11 during release asset builds.
- Keeps the existing pnpm 10-generated `auth-ui/pnpm-lock.yaml` valid under `--frozen-lockfile` without changing resolved frontend dependencies.

## Root cause

The release workflow runs `corepack pnpm install --frozen-lockfile` inside `auth-ui`. Without a `packageManager` pin, Corepack can select a newer pnpm. I reproduced the release failure with `pnpm@11.0.9`, which reports `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` against the current lockfile override metadata. Pinning the package manager makes the release workflow use the pnpm version that matches the committed lockfile.

## Validation

- `cd auth-ui && corepack pnpm --version` → `10.33.0`
- `cd auth-ui && CI=true corepack pnpm install --frozen-lockfile`
- `cd auth-ui && corepack pnpm build`
- `go build -o lesser ./cmd/lesser && ./lesser build lambdas && ./lesser verify ci`
