### PR TITLE
use canonical notification renderer

### DIFF
--- a/cmd/api/handlers/misc.go
+++ b/cmd/api/handlers/misc.go
@@ -17,7 +17,6 @@ import (
 	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
-	"github.com/equaltoai/lesser/pkg/services/notes"
 	"github.com/equaltoai/lesser/pkg/services/notifications"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
@@ -43,6 +42,10 @@ const (
 	pathComponentStatuses = "statuses"
 
 	notificationPostSnapshotKey = "postSnapshot"
+
+	notificationActorTypeUser        = "user"
+	notificationActorTypeRemoteActor = "remote_actor"
+	notificationActorTypeExternal    = "external"
 )
 
 // SearchParams holds search request parameters
@@ -707,41 +710,10 @@ func (h *Handler) HandleGetNotificationsLift(ctx *apptheory.Context) (*apptheory
 		cursor = listResult.Pagination.NextCursor
 	}
 
-	// Convert notifications to storage format for API converter
-	storageNotifications := make([]*storage.Notification, 0, len(notificationsList))
-	for _, notification := range notificationsList {
-		var data map[string]interface{}
-		if len(notification.Data) > 0 || notification.Title != "" || notification.Body != "" {
-			data = make(map[string]interface{}, len(notification.Data)+2)
-			for key, value := range notification.Data {
-				data[key] = value
-			}
-			if notification.Title != "" {
-				data["subject"] = notification.Title
-			}
-			if notification.Body != "" {
-				data["body"] = notification.Body
-			}
-		}
-
-		storageNotif := &storage.Notification{
-			ID:        notification.ID,
-			Type:      notification.Type,
-			AccountID: notification.ActorID,
-			TargetID:  notification.TargetID,
-			Read:      notification.IsRead,
-			CreatedAt: notification.CreatedAt,
-			Username:  notification.UserID,
-			Data:      data,
-		}
-		if notification.TargetType == notificationTargetTypeStatus {
-			storageNotif.StatusID = notification.TargetID
-		}
-		storageNotifications = append(storageNotifications, storageNotif)
-	}
-
-	// Convert notifications to API format
-	apiNotifications := h.convertNotificationsToAPI(ctx, storageNotifications)
+	// Convert canonical notifications to API format without passing through the
+	// legacy storage.Notification DTO. The JSON boundary stays Mastodon-compatible;
+	// the internal renderer keeps actor/target semantics intact.
+	apiNotifications := h.convertNotificationsToAPI(ctx, notificationsList)
 
 	// Set pagination header if needed
 	if cursor != "" {
@@ -806,8 +778,96 @@ func (h *Handler) parseNotificationExcludeTypes(ctx *apptheory.Context, filter *
 	}
 }
 
-// convertNotificationsToAPI converts storage notifications to API format
-func (h *Handler) convertNotificationsToAPI(ctx *apptheory.Context, notifications []*storage.Notification) []*models.Notification {
+type notificationView struct {
+	ID         string
+	Type       string
+	ActorID    string
+	ActorType  string
+	TargetID   string
+	TargetType string
+	UserID     string
+	IsRead     bool
+	ReadAt     *time.Time
+	CreatedAt  time.Time
+	Title      string
+	Body       string
+	Data       map[string]interface{}
+}
+
+func notificationViewFromModel(notification *storagemodels.Notification) *notificationView {
+	if notification == nil {
+		return nil
+	}
+
+	return &notificationView{
+		ID:         notification.ID,
+		Type:       notification.Type,
+		ActorID:    notification.ActorID,
+		ActorType:  notification.ActorType,
+		TargetID:   notification.TargetID,
+		TargetType: notification.TargetType,
+		UserID:     notification.UserID,
+		IsRead:     notification.IsRead,
+		ReadAt:     notification.ReadAt,
+		CreatedAt:  notification.CreatedAt,
+		Title:      notification.Title,
+		Body:       notification.Body,
+		Data:       notification.Data,
+	}
+}
+
+func (view *notificationView) communicationData() map[string]interface{} {
+	if view == nil {
+		return nil
+	}
+	return notificationDataWithCommunicationFields(view.Data, view.Title, view.Body)
+}
+
+func notificationDataWithCommunicationFields(data map[string]interface{}, title, body string) map[string]interface{} {
+	if len(data) == 0 && strings.TrimSpace(title) == "" && strings.TrimSpace(body) == "" {
+		return nil
+	}
+
+	merged := make(map[string]interface{}, len(data)+2)
+	for key, value := range data {
+		merged[key] = value
+	}
+	if strings.TrimSpace(title) != "" {
+		merged["subject"] = title
+	}
+	if strings.TrimSpace(body) != "" {
+		merged["body"] = body
+	}
+	return merged
+}
+
+func (view *notificationView) statusID() string {
+	if view == nil {
+		return ""
+	}
+	if strings.EqualFold(strings.TrimSpace(view.TargetType), notificationTargetTypeStatus) {
+		return strings.TrimSpace(view.TargetID)
+	}
+	if strings.TrimSpace(view.TargetType) == "" && common.ValidateMastodonStatusID(view.TargetID) == nil {
+		return strings.TrimSpace(view.TargetID)
+	}
+	return ""
+}
+
+func notificationTypeSupportsStatus(notifType string) bool {
+	switch notifType {
+	case models.NotificationTypeMention,
+		models.NotificationTypeReply,
+		models.NotificationTypeFavourite,
+		models.NotificationTypeReblog:
+		return true
+	default:
+		return false
+	}
+}
+
+// convertNotificationsToAPI converts canonical storage-model notifications to API format.
+func (h *Handler) convertNotificationsToAPI(ctx *apptheory.Context, notifications []*storagemodels.Notification) []*models.Notification {
 	apiNotifications := make([]*models.Notification, 0, len(notifications))
 
 	for _, notif := range notifications {
@@ -820,97 +880,96 @@ func (h *Handler) convertNotificationsToAPI(ctx *apptheory.Context, notification
 	return apiNotifications
 }
 
-// convertSingleNotification converts a single notification to API format
-func (h *Handler) convertSingleNotification(ctx *apptheory.Context, notif *storage.Notification) *models.Notification {
-	// Get the account that triggered the notification
-	actor := h.notificationActor(ctx.Context(), notif.AccountID)
+// convertSingleNotification converts a single canonical notification to API format.
+func (h *Handler) convertSingleNotification(ctx *apptheory.Context, notif *storagemodels.Notification) *models.Notification {
+	return h.convertNotificationViewToAPI(ctx, notificationViewFromModel(notif))
+}
+
+func (h *Handler) convertNotificationViewToAPI(ctx *apptheory.Context, view *notificationView) *models.Notification {
+	if view == nil {
+		return nil
+	}
+
+	actor := h.notificationActorForView(ctx.Context(), view)
 	if actor == nil {
 		return nil
 	}
 
 	account := transformations.ActorToAccountBase(actor, h.cfg.BaseURL())
 	apiNotif := &models.Notification{
-		ID:        notif.ID,
-		Type:      notif.Type,
-		CreatedAt: notif.CreatedAt,
+		ID:        view.ID,
+		Type:      view.Type,
+		CreatedAt: view.CreatedAt,
 		Account:   account,
-		Read:      notif.Read,
+		Read:      view.IsRead,
 	}
-	apiNotif.Communication = communicationNotificationFromData(notif.Type, notif.CreatedAt, notif.Data)
+	apiNotif.Communication = communicationNotificationFromData(view.Type, view.CreatedAt, view.communicationData())
 
-	// Add status if applicable
-	if h.shouldIncludeStatus(notif) {
-		h.attachStatusToNotification(ctx, notif, apiNotif)
+	if h.shouldIncludeStatus(view) {
+		h.attachStatusToNotification(ctx, view, apiNotif)
 	}
 
 	return apiNotif
 }
 
-// shouldIncludeStatus checks if a status should be included in the notification
-func (h *Handler) shouldIncludeStatus(notif *storage.Notification) bool {
-	if notif == nil {
+// shouldIncludeStatus checks if a status should be included in the notification.
+func (h *Handler) shouldIncludeStatus(view *notificationView) bool {
+	if view == nil || !notificationTypeSupportsStatus(view.Type) {
 		return false
 	}
 
-	if notif.Type != models.NotificationTypeMention &&
-		notif.Type != models.NotificationTypeReply &&
-		notif.Type != models.NotificationTypeFavourite &&
-		notif.Type != models.NotificationTypeReblog {
-		return false
-	}
-
-	if _, ok := h.notificationPostSnapshot(notif); ok {
+	if _, ok := h.notificationPostSnapshot(view); ok {
 		return true
 	}
 
-	return common.ValidateMastodonStatusID(notif.StatusID) == nil
+	return view.statusID() != ""
 }
 
-// attachStatusToNotification attaches status information to a notification
-func (h *Handler) attachStatusToNotification(ctx *apptheory.Context, notif *storage.Notification, apiNotif *models.Notification) {
-	if snapshotStatus := h.statusFromNotificationSnapshot(ctx, notif); snapshotStatus != nil {
+// attachStatusToNotification attaches status information to a notification.
+func (h *Handler) attachStatusToNotification(ctx *apptheory.Context, view *notificationView, apiNotif *models.Notification) {
+	if snapshotStatus := h.statusFromNotificationSnapshot(ctx, view); snapshotStatus != nil {
 		apiNotif.Status = snapshotStatus
 		return
 	}
 
-	// Get the status
-	obj, err := h.repos.Object().GetObject(ctx.Context(), notif.StatusID)
+	statusID := view.statusID()
+	if statusID == "" {
+		return
+	}
+
+	obj, err := h.repos.Object().GetObject(ctx.Context(), statusID)
 	if err != nil {
 		h.logger.Warn("failed to get status for notification",
-			zap.String("notification_id", notif.ID),
-			zap.String("status_id", notif.StatusID),
+			zap.String("notification_id", view.ID),
+			zap.String("status_id", statusID),
 			zap.Error(err))
 		return
 	}
 
-	if !h.notificationObjectVisibleToViewer(ctx.Context(), notif, obj) {
+	if !h.notificationObjectVisibleToViewer(ctx.Context(), view, obj) {
 		h.logger.Debug("skipping notification status expansion due to visibility",
-			zap.String("notification_id", notif.ID),
-			zap.String("status_id", notif.StatusID),
-			zap.String("viewer", notif.Username))
+			zap.String("notification_id", view.ID),
+			zap.String("status_id", statusID),
+			zap.String("viewer", view.UserID))
 		return
 	}
 
-	// Get status author
 	statusActor := h.extractStatusAuthor(ctx, obj)
-
-	// Convert obj to map for transformation
 	if objMap, ok := obj.(map[string]interface{}); ok {
 		status := transformations.ObjectToStatusBase(objMap, statusActor, h.cfg.BaseURL())
 		apiNotif.Status = &status
 	} else {
-		// Fallback for non-map objects
 		status := transformations.ObjectToStatusAny(obj, statusActor, h.cfg.BaseURL())
 		apiNotif.Status = &status
 	}
 }
 
-func (h *Handler) notificationPostSnapshot(notif *storage.Notification) (map[string]interface{}, bool) {
-	if notif == nil || len(notif.Data) == 0 {
+func (h *Handler) notificationPostSnapshot(view *notificationView) (map[string]interface{}, bool) {
+	if view == nil || len(view.Data) == 0 {
 		return nil, false
 	}
 
-	rawSnapshot, ok := notif.Data[notificationPostSnapshotKey]
+	rawSnapshot, ok := view.Data[notificationPostSnapshotKey]
 	if !ok {
 		return nil, false
 	}
@@ -923,16 +982,16 @@ func (h *Handler) notificationPostSnapshot(notif *storage.Notification) (map[str
 	return snapshot, true
 }
 
-func (h *Handler) statusFromNotificationSnapshot(ctx *apptheory.Context, notif *storage.Notification) *models.Status {
-	snapshot, ok := h.notificationPostSnapshot(notif)
+func (h *Handler) statusFromNotificationSnapshot(ctx *apptheory.Context, view *notificationView) *models.Status {
+	snapshot, ok := h.notificationPostSnapshot(view)
 	if !ok {
 		return nil
 	}
 
-	if !h.notificationSnapshotVisibleToViewer(ctx.Context(), notif, snapshot) {
+	if !h.notificationSnapshotVisibleToViewer(ctx.Context(), view, snapshot) {
 		h.logger.Debug("skipping notification snapshot expansion due to visibility",
-			zap.String("notification_id", notif.ID),
-			zap.String("viewer", notif.Username))
+			zap.String("notification_id", view.ID),
+			zap.String("viewer", view.UserID))
 		return nil
 	}
 
@@ -959,9 +1018,9 @@ func (h *Handler) statusFromNotificationSnapshot(ctx *apptheory.Context, notif *
 	return &status
 }
 
-func (h *Handler) notificationSnapshotVisibleToViewer(ctx context.Context, notif *storage.Notification, snapshot map[string]interface{}) bool {
+func (h *Handler) notificationSnapshotVisibleToViewer(ctx context.Context, view *notificationView, snapshot map[string]interface{}) bool {
 	return h.notificationStatusVisibleToViewer(ctx,
-		notif,
+		view,
 		notificationSnapshotString(snapshot, "visibility"),
 		notificationSnapshotString(snapshot, "attributedTo"),
 		nil,
@@ -969,14 +1028,14 @@ func (h *Handler) notificationSnapshotVisibleToViewer(ctx context.Context, notif
 	)
 }
 
-func (h *Handler) notificationObjectVisibleToViewer(ctx context.Context, notif *storage.Notification, obj any) bool {
+func (h *Handler) notificationObjectVisibleToViewer(ctx context.Context, view *notificationView, obj any) bool {
 	visibility, attributedTo, recipients, mentions := notificationObjectVisibilityContext(obj)
-	return h.notificationStatusVisibleToViewer(ctx, notif, visibility, attributedTo, recipients, mentions)
+	return h.notificationStatusVisibleToViewer(ctx, view, visibility, attributedTo, recipients, mentions)
 }
 
 func (h *Handler) notificationStatusVisibleToViewer(
 	ctx context.Context,
-	notif *storage.Notification,
+	view *notificationView,
 	visibility string,
 	attributedTo string,
 	recipients []string,
@@ -992,10 +1051,10 @@ func (h *Handler) notificationStatusVisibleToViewer(
 		return true
 	}
 
-	if notif == nil {
+	if view == nil {
 		return false
 	}
-	viewer := strings.TrimSpace(notif.Username)
+	viewer := strings.TrimSpace(view.UserID)
 	if viewer == "" {
 		return false
 	}
@@ -1011,7 +1070,7 @@ func (h *Handler) notificationStatusVisibleToViewer(
 		return h.notificationDirectVisibleToViewer(viewer, recipients, mentions)
 	default:
 		h.logger.Warn("unknown notification status visibility",
-			zap.String("notification_id", notif.ID),
+			zap.String("notification_id", view.ID),
 			zap.String("visibility", visibility))
 		return false
 	}
@@ -1078,12 +1137,40 @@ func (h *Handler) notificationSnapshotActor(ctx *apptheory.Context, snapshot map
 	return statusActor
 }
 
-func (h *Handler) notificationActor(ctx context.Context, actorID string) *activitypub.Actor {
-	actorID = strings.TrimSpace(actorID)
+func (h *Handler) notificationActorForView(ctx context.Context, view *notificationView) *activitypub.Actor {
+	if view == nil {
+		return nil
+	}
+	actorID := strings.TrimSpace(view.ActorID)
 	if actorID == "" {
 		return nil
 	}
 
+	actorType := strings.ToLower(strings.TrimSpace(view.ActorType))
+	switch {
+	case actorType == notificationActorTypeExternal || isCommunicationNotificationType(view.Type):
+		if actor := h.externalNotificationActor(view); actor != nil {
+			return actor
+		}
+		return h.fallbackNotificationActor(actorID)
+	case actorType == notificationActorTypeRemoteActor || notificationActorIDLooksURL(actorID):
+		return h.remoteNotificationActor(ctx, actorID)
+	case actorType == notificationActorTypeUser:
+		return h.localNotificationActor(ctx, actorID)
+	case actorType == "" && notificationActorIDLooksEmailLike(actorID):
+		if actor := h.cachedRemoteNotificationActor(ctx, actorID); actor != nil {
+			return actor
+		}
+		if actor := h.externalNotificationActor(view); actor != nil {
+			return actor
+		}
+		return h.fallbackNotificationActor(actorID)
+	default:
+		return h.localNotificationActor(ctx, actorID)
+	}
+}
+
+func (h *Handler) localNotificationActor(ctx context.Context, actorID string) *activitypub.Actor {
 	if h != nil && h.repos != nil && h.repos.Actor() != nil {
 		if actor, err := h.repos.Actor().GetActor(ctx, actorID); err == nil && actor != nil {
 			return actor
@@ -1097,6 +1184,60 @@ func (h *Handler) notificationActor(ctx context.Context, actorID string) *activi
 		}
 	}
 	return h.fallbackNotificationActor(actorID)
+}
+
+func (h *Handler) remoteNotificationActor(ctx context.Context, actorID string) *activitypub.Actor {
+	if actor := h.cachedRemoteNotificationActor(ctx, actorID); actor != nil {
+		return actor
+	}
+	return h.fallbackNotificationActor(actorID)
+}
+
+func (h *Handler) externalNotificationActor(view *notificationView) *activitypub.Actor {
+	if view == nil {
+		return nil
+	}
+
+	data := view.communicationData()
+	from, _ := data["from"].(map[string]interface{})
+	address := extractStringFromNotificationData(from, "address")
+	displayName := extractStringFromNotificationData(from, "displayName", "display_name")
+	soulAgentID := extractStringFromNotificationData(from, "soulAgentId", "soul_agent_id")
+
+	actorID := strings.TrimSpace(view.ActorID)
+	fallbackID := address
+	if fallbackID == "" {
+		fallbackID = actorID
+	}
+	if fallbackID == "" {
+		fallbackID = soulAgentID
+	}
+
+	actor := h.fallbackNotificationActor(fallbackID)
+	if actor == nil && soulAgentID != "" {
+		actor = h.fallbackNotificationActor(soulAgentID)
+	}
+	if actor == nil {
+		return nil
+	}
+	if displayName != "" {
+		actor.Name = displayName
+	}
+	return actor
+}
+
+func notificationActorIDLooksURL(actorID string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(actorID))
+	if err != nil || parsed == nil {
+		return false
+	}
+	scheme := strings.ToLower(strings.TrimSpace(parsed.Scheme))
+	return (scheme == schemeHTTPS || scheme == schemeHTTP) && strings.TrimSpace(parsed.Host) != ""
+}
+
+func notificationActorIDLooksEmailLike(actorID string) bool {
+	actorID = strings.TrimSpace(actorID)
+	return actorID != "" && !strings.Contains(actorID, "://") && strings.Contains(actorID, "@")
 }
 
 func (h *Handler) cachedRemoteNotificationActor(ctx context.Context, actorID string) *activitypub.Actor {
@@ -1431,58 +1572,9 @@ func (h *Handler) HandleGetNotificationLift(ctx *apptheory.Context) (*apptheory.
 		return common.RespondNotFound(ctx, "notification")
 	}
 
-	// Get the account that triggered the notification
-	actor := h.notificationActor(ctx.Context(), notification.ActorID)
-	if actor == nil {
+	apiNotif := h.convertSingleNotification(ctx, notification)
+	if apiNotif == nil {
 		return common.RespondFailedToGet(ctx, "notification details")
-	}
-
-	account := transformations.ActorToAccountBase(actor, h.cfg.BaseURL())
-	apiNotif := &models.Notification{
-		ID:        notification.ID,
-		Type:      notification.Type,
-		CreatedAt: notification.CreatedAt,
-		Account:   account,
-		Read:      notification.IsRead,
-	}
-	{
-		var data map[string]interface{}
-		if len(notification.Data) > 0 || notification.Title != "" || notification.Body != "" {
-			data = make(map[string]interface{}, len(notification.Data)+2)
-			for key, value := range notification.Data {
-				data[key] = value
-			}
-			if notification.Title != "" {
-				data["subject"] = notification.Title
-			}
-			if notification.Body != "" {
-				data["body"] = notification.Body
-			}
-		}
-		apiNotif.Communication = communicationNotificationFromData(notification.Type, notification.CreatedAt, data)
-	}
-
-	// Add status if applicable
-	if notification.TargetID != "" && notification.TargetType == notificationTargetTypeStatus && (notification.Type == models.NotificationTypeMention ||
-		notification.Type == models.NotificationTypeFavourite ||
-		notification.Type == models.NotificationTypeReblog) {
-		statusModel, err := h.registry.Notes().GetNoteWithViewer(ctx.Context(), &notes.GetNoteQuery{
-			StatusID: notification.TargetID,
-			ViewerID: username,
-		})
-		if err == nil && statusModel != nil && statusModel.Note != nil {
-			// Convert note to status format
-			var statusActor *activitypub.Actor
-			if statusModel.AuthorUsername != "" {
-				account, _ := h.registry.Accounts().GetAccount(ctx.Context(), statusModel.AuthorUsername)
-				if account != nil {
-					statusActor = account.Actor
-				}
-			}
-			// Use the embedded Note from the status model
-			status := transformations.ObjectToStatusAny(statusModel.Note, statusActor, h.cfg.BaseURL())
-			apiNotif.Status = &status
-		}
 	}
 
 	return okJSON(apiNotif)
@@ -2007,6 +2099,9 @@ func (h *Handler) convertGroupedNotificationsToAPI(
 	apiResponse := make([]models.GroupedNotificationGroup, 0, len(groupedNotifications))
 
 	for _, group := range groupedNotifications {
+		resolvedSampleAccounts := h.resolveGroupedNotificationSampleAccounts(ctx.Context(), group)
+		group.SampleAccounts = resolvedSampleAccounts
+
 		groupResponse := models.GroupedNotificationGroup{
 			ID:                group.ID,
 			Type:              group.Type,
@@ -2015,7 +2110,7 @@ func (h *Handler) convertGroupedNotificationsToAPI(
 			LatestCreatedAt:   group.LatestCreatedAt.Format(time.RFC3339),
 			EarliestCreatedAt: group.EarliestCreatedAt.Format(time.RFC3339),
 			Read:              group.IsRead,
-			SampleAccounts:    h.convertNotificationAccountsToAPI(group.SampleAccounts),
+			SampleAccounts:    h.convertNotificationAccountsToAPI(resolvedSampleAccounts),
 			Summary:           h.generateGroupSummary(group),
 		}
 
@@ -2061,6 +2156,83 @@ func (h *Handler) convertGroupedNotificationsToAPI(
 	}
 
 	return apiResponse
+}
+
+func (h *Handler) resolveGroupedNotificationSampleAccounts(
+	ctx context.Context,
+	group *notifications.GroupedNotification,
+) []notifications.NotificationAccount {
+	if group == nil || len(group.SampleAccounts) == 0 {
+		return nil
+	}
+
+	notificationsByActorID := make(map[string]*storagemodels.Notification, len(group.AllNotifications))
+	for _, notif := range group.AllNotifications {
+		if notif == nil {
+			continue
+		}
+		actorID := strings.TrimSpace(notif.ActorID)
+		if actorID == "" {
+			continue
+		}
+		if _, exists := notificationsByActorID[actorID]; !exists {
+			notificationsByActorID[actorID] = notif
+		}
+	}
+
+	resolved := make([]notifications.NotificationAccount, 0, len(group.SampleAccounts))
+	for _, sample := range group.SampleAccounts {
+		account := sample
+		if notif := notificationsByActorID[strings.TrimSpace(sample.ID)]; notif != nil {
+			account = h.resolveGroupedNotificationAccount(ctx, sample, notif)
+		}
+		account.DisplayName = notificationAccountDisplayName(account)
+		resolved = append(resolved, account)
+	}
+
+	return resolved
+}
+
+func (h *Handler) resolveGroupedNotificationAccount(
+	ctx context.Context,
+	sample notifications.NotificationAccount,
+	notif *storagemodels.Notification,
+) notifications.NotificationAccount {
+	view := notificationViewFromModel(notif)
+	actor := h.notificationActorForView(ctx, view)
+	if actor == nil {
+		return sample
+	}
+
+	apiAccount := transformations.ActorToAccountBase(actor, h.cfg.BaseURL())
+	accountID := strings.TrimSpace(sample.ID)
+	if accountID == "" {
+		accountID = apiAccount.ID
+	}
+
+	createdAt := sample.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = notif.CreatedAt
+	}
+
+	return notifications.NotificationAccount{
+		ID:          accountID,
+		Username:    apiAccount.Username,
+		DisplayName: apiAccount.DisplayName,
+		Avatar:      apiAccount.Avatar,
+		IsBot:       apiAccount.Bot,
+		CreatedAt:   createdAt,
+	}
+}
+
+func notificationAccountDisplayName(account notifications.NotificationAccount) string {
+	if strings.TrimSpace(account.DisplayName) != "" {
+		return account.DisplayName
+	}
+	if strings.TrimSpace(account.Username) != "" {
+		return account.Username
+	}
+	return strings.TrimSpace(account.ID)
 }
 
 // convertNotificationAccountsToAPI converts notification accounts to API format

--- a/cmd/api/handlers/misc_round12_coverage_test.go
+++ b/cmd/api/handlers/misc_round12_coverage_test.go
@@ -190,11 +190,11 @@ func TestMisc_Notifications_AttachStatusAndAuthor_Round12(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("note object attaches status and author", func(t *testing.T) {
-		notif := &storage.Notification{
+		notif := &storagemodels.Notification{
 			ID:        "n1",
 			Type:      models.NotificationTypeMention,
-			AccountID: "alice",
-			StatusID:  "status-1",
+			ActorID:   "alice",
+			TargetID:  "status-1",
 			CreatedAt: now,
 		}
 		apiNotif := handler.convertSingleNotification(ctx, notif)
@@ -203,11 +203,11 @@ func TestMisc_Notifications_AttachStatusAndAuthor_Round12(t *testing.T) {
 	})
 
 	t.Run("non-note object uses map branch", func(t *testing.T) {
-		notif := &storage.Notification{
+		notif := &storagemodels.Notification{
 			ID:        "n2",
 			Type:      models.NotificationTypeMention,
-			AccountID: "alice",
-			StatusID:  "obj-1",
+			ActorID:   "alice",
+			TargetID:  "obj-1",
 			CreatedAt: now,
 		}
 		apiNotif := handler.convertSingleNotification(ctx, notif)
@@ -219,11 +219,11 @@ func TestMisc_Notifications_AttachStatusAndAuthor_Round12(t *testing.T) {
 		errState := &round10QueryState{firstErrorOnce: errors.New("boom")}
 		errHandler, _, _ := round11NewHandler(t, cfg, errState)
 
-		apiNotif := errHandler.convertSingleNotification(ctx, &storage.Notification{
+		apiNotif := errHandler.convertSingleNotification(ctx, &storagemodels.Notification{
 			ID:        "n3",
 			Type:      models.NotificationTypeMention,
-			AccountID: "alice",
-			StatusID:  "status-1",
+			ActorID:   "alice",
+			TargetID:  "status-1",
 			CreatedAt: now,
 		})
 		require.NotNil(t, apiNotif)
@@ -231,11 +231,11 @@ func TestMisc_Notifications_AttachStatusAndAuthor_Round12(t *testing.T) {
 	})
 
 	t.Run("invalid status id is excluded", func(t *testing.T) {
-		apiNotif := handler.convertSingleNotification(ctx, &storage.Notification{
+		apiNotif := handler.convertSingleNotification(ctx, &storagemodels.Notification{
 			ID:        "n4",
 			Type:      models.NotificationTypeMention,
-			AccountID: "alice",
-			StatusID:  "",
+			ActorID:   "alice",
+			TargetID:  "",
 			CreatedAt: now,
 		})
 		require.NotNil(t, apiNotif)
@@ -251,11 +251,11 @@ func TestMisc_Notifications_AttachStatusAndAuthor_Round12(t *testing.T) {
 		}
 		snapshotHandler, _, _ := round11NewHandler(t, cfg, errState)
 
-		apiNotif := snapshotHandler.convertSingleNotification(ctx, &storage.Notification{
+		apiNotif := snapshotHandler.convertSingleNotification(ctx, &storagemodels.Notification{
 			ID:        "n-snapshot",
 			Type:      models.NotificationTypeMention,
-			AccountID: "alice",
-			StatusID:  "status-snapshot",
+			ActorID:   "alice",
+			TargetID:  "status-snapshot",
 			CreatedAt: now,
 			Data: map[string]interface{}{
 				"postSnapshot": map[string]interface{}{
@@ -294,11 +294,11 @@ func TestMisc_Notifications_AttachStatusAndAuthor_Round12(t *testing.T) {
 		}
 		errHandler, _, _ := round11NewHandler(t, cfg, errState)
 
-		apiNotif := errHandler.convertSingleNotification(ctx, &storage.Notification{
+		apiNotif := errHandler.convertSingleNotification(ctx, &storagemodels.Notification{
 			ID:        "n5",
 			Type:      models.NotificationTypeMention,
-			AccountID: "alice",
-			StatusID:  "status-1",
+			ActorID:   "alice",
+			TargetID:  "status-1",
 			CreatedAt: now,
 		})
 		require.NotNil(t, apiNotif)

--- a/cmd/api/handlers/misc_round29_snapshot_helpers_test.go
+++ b/cmd/api/handlers/misc_round29_snapshot_helpers_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/equaltoai/lesser/cmd/api/models"
 	"github.com/equaltoai/lesser/pkg/activitypub"
-	"github.com/equaltoai/lesser/pkg/storage"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/require"
 )
@@ -22,9 +21,9 @@ func TestMisc_NotificationSnapshotHelpers_Round29(t *testing.T) {
 
 	t.Run("shouldIncludeStatus handles snapshot and unsupported types", func(t *testing.T) {
 		require.False(t, handler.shouldIncludeStatus(nil))
-		require.False(t, handler.shouldIncludeStatus(&storage.Notification{Type: models.NotificationTypeFollow, StatusID: "123"}))
-		require.False(t, handler.shouldIncludeStatus(&storage.Notification{Type: models.NotificationTypeMention, StatusID: "not valid"}))
-		require.True(t, handler.shouldIncludeStatus(&storage.Notification{
+		require.False(t, handler.shouldIncludeStatus(&notificationView{Type: models.NotificationTypeFollow, TargetID: "123"}))
+		require.False(t, handler.shouldIncludeStatus(&notificationView{Type: models.NotificationTypeMention, TargetID: "not valid"}))
+		require.True(t, handler.shouldIncludeStatus(&notificationView{
 			Type: models.NotificationTypeMention,
 			Data: map[string]interface{}{
 				"postSnapshot": map[string]interface{}{"id": "https://example.com/objects/s1"},
@@ -33,10 +32,10 @@ func TestMisc_NotificationSnapshotHelpers_Round29(t *testing.T) {
 	})
 
 	t.Run("notificationPostSnapshot rejects invalid payloads", func(t *testing.T) {
-		_, ok := handler.notificationPostSnapshot(&storage.Notification{})
+		_, ok := handler.notificationPostSnapshot(&notificationView{})
 		require.False(t, ok)
 
-		_, ok = handler.notificationPostSnapshot(&storage.Notification{
+		_, ok = handler.notificationPostSnapshot(&notificationView{
 			Data: map[string]interface{}{"postSnapshot": "bad"},
 		})
 		require.False(t, ok)
@@ -46,7 +45,7 @@ func TestMisc_NotificationSnapshotHelpers_Round29(t *testing.T) {
 		ctx, err := round10NewLiftContext("GET", "/test", nil, nil, nil)
 		require.NoError(t, err)
 
-		status := handler.statusFromNotificationSnapshot(ctx, &storage.Notification{
+		status := handler.statusFromNotificationSnapshot(ctx, &notificationView{
 			Data: map[string]interface{}{
 				"postSnapshot": map[string]interface{}{
 					"id": 123,
@@ -72,10 +71,10 @@ func TestMisc_NotificationSnapshotHelpers_Round29(t *testing.T) {
 		ctx, err := round10NewLiftContext("GET", "/test", nil, nil, nil)
 		require.NoError(t, err)
 
-		status := handler.statusFromNotificationSnapshot(ctx, &storage.Notification{
-			ID:       "n-private",
-			Type:     models.NotificationTypeMention,
-			Username: "alice",
+		status := handler.statusFromNotificationSnapshot(ctx, &notificationView{
+			ID:     "n-private",
+			Type:   models.NotificationTypeMention,
+			UserID: "alice",
 			Data: map[string]interface{}{
 				"postSnapshot": map[string]interface{}{
 					"id":           "https://example.com/objects/private-1",
@@ -101,10 +100,10 @@ func TestMisc_NotificationSnapshotHelpers_Round29(t *testing.T) {
 		ctx, err := round10NewLiftContext("GET", "/test", nil, nil, nil)
 		require.NoError(t, err)
 
-		status := followerHandler.statusFromNotificationSnapshot(ctx, &storage.Notification{
-			ID:       "n-private",
-			Type:     models.NotificationTypeMention,
-			Username: "alice",
+		status := followerHandler.statusFromNotificationSnapshot(ctx, &notificationView{
+			ID:     "n-private",
+			Type:   models.NotificationTypeMention,
+			UserID: "alice",
 			Data: map[string]interface{}{
 				"postSnapshot": map[string]interface{}{
 					"id":           "https://example.com/objects/private-1",
@@ -124,7 +123,7 @@ func TestMisc_NotificationSnapshotHelpers_Round29(t *testing.T) {
 
 		require.False(t, handler.notificationStatusVisibleToViewer(
 			ctx.Context(),
-			&storage.Notification{ID: "n-direct", Username: "alice"},
+			&notificationView{ID: "n-direct", UserID: "alice"},
 			"direct",
 			"https://example.com/users/bob",
 			[]string{"https://example.com/users/carol"},
@@ -132,7 +131,7 @@ func TestMisc_NotificationSnapshotHelpers_Round29(t *testing.T) {
 		))
 		require.True(t, handler.notificationStatusVisibleToViewer(
 			ctx.Context(),
-			&storage.Notification{ID: "n-direct", Username: "alice"},
+			&notificationView{ID: "n-direct", UserID: "alice"},
 			"direct",
 			"https://example.com/users/bob",
 			[]string{"https://example.com/users/alice"},
@@ -257,7 +256,7 @@ func TestMisc_NotificationStatusVisibleToViewer_Round29(t *testing.T) {
 		))
 		require.False(t, handler.notificationStatusVisibleToViewer(
 			ctx.Context(),
-			&storage.Notification{ID: "n-private-empty-viewer"},
+			&notificationView{ID: "n-private-empty-viewer"},
 			storagemodels.VisibilityPrivate,
 			"https://example.com/users/bob",
 			nil,
@@ -268,7 +267,7 @@ func TestMisc_NotificationStatusVisibleToViewer_Round29(t *testing.T) {
 	t.Run("author always sees own private status", func(t *testing.T) {
 		require.True(t, handler.notificationStatusVisibleToViewer(
 			ctx.Context(),
-			&storage.Notification{ID: "n-author", Username: "bob"},
+			&notificationView{ID: "n-author", UserID: "bob"},
 			storagemodels.VisibilityPrivate,
 			"https://example.com/users/bob",
 			nil,
@@ -279,7 +278,7 @@ func TestMisc_NotificationStatusVisibleToViewer_Round29(t *testing.T) {
 	t.Run("followers see private status from followed author", func(t *testing.T) {
 		require.True(t, handler.notificationStatusVisibleToViewer(
 			ctx.Context(),
-			&storage.Notification{ID: "n-private-follow", Username: "alice"},
+			&notificationView{ID: "n-private-follow", UserID: "alice"},
 			storagemodels.VisibilityPrivate,
 			"https://example.com/users/bob",
 			nil,
@@ -287,7 +286,7 @@ func TestMisc_NotificationStatusVisibleToViewer_Round29(t *testing.T) {
 		))
 		require.False(t, handler.notificationStatusVisibleToViewer(
 			ctx.Context(),
-			&storage.Notification{ID: "n-private-miss", Username: "alice"},
+			&notificationView{ID: "n-private-miss", UserID: "alice"},
 			storagemodels.VisibilityPrivate,
 			"https://example.com/users/carol",
 			nil,
@@ -298,7 +297,7 @@ func TestMisc_NotificationStatusVisibleToViewer_Round29(t *testing.T) {
 	t.Run("direct visibility accepts legacy snapshots and explicit recipients", func(t *testing.T) {
 		require.True(t, handler.notificationStatusVisibleToViewer(
 			ctx.Context(),
-			&storage.Notification{ID: "n-direct-legacy", Username: "alice"},
+			&notificationView{ID: "n-direct-legacy", UserID: "alice"},
 			storagemodels.VisibilityDirect,
 			"https://example.com/users/bob",
 			nil,
@@ -306,7 +305,7 @@ func TestMisc_NotificationStatusVisibleToViewer_Round29(t *testing.T) {
 		))
 		require.True(t, handler.notificationStatusVisibleToViewer(
 			ctx.Context(),
-			&storage.Notification{ID: "n-direct-recipient", Username: "alice"},
+			&notificationView{ID: "n-direct-recipient", UserID: "alice"},
 			storagemodels.VisibilityDirect,
 			"https://example.com/users/bob",
 			[]string{"https://example.com/users/alice"},
@@ -314,7 +313,7 @@ func TestMisc_NotificationStatusVisibleToViewer_Round29(t *testing.T) {
 		))
 		require.True(t, handler.notificationStatusVisibleToViewer(
 			ctx.Context(),
-			&storage.Notification{ID: "n-direct-mention", Username: "alice"},
+			&notificationView{ID: "n-direct-mention", UserID: "alice"},
 			storagemodels.VisibilityDirect,
 			"https://example.com/users/bob",
 			nil,
@@ -322,7 +321,7 @@ func TestMisc_NotificationStatusVisibleToViewer_Round29(t *testing.T) {
 		))
 		require.False(t, handler.notificationStatusVisibleToViewer(
 			ctx.Context(),
-			&storage.Notification{ID: "n-direct-miss", Username: "alice"},
+			&notificationView{ID: "n-direct-miss", UserID: "alice"},
 			storagemodels.VisibilityDirect,
 			"https://example.com/users/bob",
 			[]string{"https://example.com/users/carol"},
@@ -333,7 +332,7 @@ func TestMisc_NotificationStatusVisibleToViewer_Round29(t *testing.T) {
 	t.Run("unknown visibility fails closed", func(t *testing.T) {
 		require.False(t, handler.notificationStatusVisibleToViewer(
 			ctx.Context(),
-			&storage.Notification{ID: "n-unknown", Username: "alice"},
+			&notificationView{ID: "n-unknown", UserID: "alice"},
 			"friends-only",
 			"https://example.com/users/bob",
 			nil,

--- a/cmd/api/handlers/notifications_canonical_renderer_round30_test.go
+++ b/cmd/api/handlers/notifications_canonical_renderer_round30_test.go
@@ -1,0 +1,280 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	apiModels "github.com/equaltoai/lesser/cmd/api/models"
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/services/notifications"
+	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestNotifications_CanonicalRendererListSingleAndSemanticActors_Round30(t *testing.T) {
+	cfg := round11TestConfig()
+	now := time.Date(2026, time.May, 11, 10, 30, 0, 0, time.UTC)
+	comm := &storageModels.Notification{
+		ID:        "notif-comm",
+		Type:      commNotificationTypeInbound,
+		ActorID:   "alice@example.net",
+		ActorType: notificationActorTypeExternal,
+		UserID:    "admin",
+		IsRead:    true,
+		Title:     "Subject from title",
+		Body:      "Body from canonical field",
+		CreatedAt: now,
+		Data: map[string]interface{}{
+			"channel":   "email",
+			"messageId": "message-1",
+			"from": map[string]interface{}{
+				"address":     "alice@example.net",
+				"displayName": "Alice External",
+				"soulAgentId": "soul-agent-1",
+			},
+		},
+	}
+
+	state := &round10QueryState{
+		firstErrorPK: map[string]error{
+			"ACTOR#alice@example.net": context.DeadlineExceeded,
+		},
+	}
+	h, _, _ := round11NewHandler(t, cfg, state)
+	core, observed := observer.New(zap.WarnLevel)
+	h.logger = zap.New(core)
+	h.registry = &RegistryStub{
+		NotificationsSvc: &NotificationsServiceStub{
+			ListNotificationsFunc: func(_ context.Context, query *notifications.ListNotificationsQuery) (*notifications.NotificationListResult, error) {
+				require.Equal(t, "admin", query.UserID)
+				return &notifications.NotificationListResult{Notifications: []*storageModels.Notification{comm}}, nil
+			},
+			GetNotificationFunc: func(_ context.Context, query *notifications.GetNotificationQuery) (*storageModels.Notification, error) {
+				require.Equal(t, "admin", query.UserID)
+				require.Equal(t, "notif-comm", query.NotificationID)
+				return comm, nil
+			},
+		},
+	}
+
+	readToken := round11SignAccessToken(t, cfg.JWTSecret, "admin", []string{"read:notifications", auth.ScopeRead})
+	headers := map[string]string{"Authorization": "Bearer " + readToken, "Host": "example.com"}
+
+	ctxList, err := round10NewLiftContext(http.MethodGet, "/api/v1/notifications", headers, nil, nil)
+	require.NoError(t, err)
+	listResp := requireStatus(t, http.StatusOK)(h.HandleGetNotificationsLift(ctxList))
+
+	var listOut []apiModels.Notification
+	require.NoError(t, json.Unmarshal(listResp.Body, &listOut))
+	require.Len(t, listOut, 1)
+
+	ctxSingle, err := round10NewLiftContext(http.MethodGet, "/api/v1/notifications/notif-comm", headers, nil, nil)
+	require.NoError(t, err)
+	ctxSingle.Params["id"] = "notif-comm"
+	singleResp := requireStatus(t, http.StatusOK)(h.HandleGetNotificationLift(ctxSingle))
+
+	var singleOut apiModels.Notification
+	require.NoError(t, json.Unmarshal(singleResp.Body, &singleOut))
+
+	require.Equal(t, listOut[0].ID, singleOut.ID)
+	require.Equal(t, listOut[0].Type, singleOut.Type)
+	require.Equal(t, listOut[0].Read, singleOut.Read)
+	require.Equal(t, listOut[0].Account.Username, singleOut.Account.Username)
+	require.Equal(t, "alice", singleOut.Account.Username)
+	require.Equal(t, "Alice External", singleOut.Account.DisplayName)
+	require.NotNil(t, singleOut.Communication)
+	require.Equal(t, "Subject from title", singleOut.Communication.Subject)
+	require.Equal(t, "Body from canonical field", singleOut.Communication.Body)
+	require.Equal(t, "soul-agent-1", singleOut.Communication.From.SoulAgentID)
+	require.Equal(t, 0, observed.FilterMessage("failed to get local actor for notification; trying remote cache/fallback").Len())
+}
+
+func TestNotifications_RemoteActorRendererSkipsLocalLookup_Round30(t *testing.T) {
+	cfg := round11TestConfig()
+	now := time.Date(2026, time.May, 11, 11, 0, 0, 0, time.UTC)
+	remoteActorID := "https://remote.example/users/riley"
+	state := &round10QueryState{
+		firstErrorPK: map[string]error{
+			"ACTOR#riley": context.DeadlineExceeded,
+		},
+		remoteActorsByPK: map[string]storageModels.RemoteActor{
+			"REMOTE_ACTOR#riley@remote.example": {
+				PK:        "REMOTE_ACTOR#riley@remote.example",
+				SK:        storageModels.SKProfile,
+				Handle:    "riley@remote.example",
+				ExpiresAt: time.Now().Add(time.Hour),
+				Actor: &activitypub.Actor{
+					BaseObject:        activitypub.BaseObject{ID: remoteActorID, Type: activitypub.PersonType},
+					PreferredUsername: "riley",
+					Name:              "Riley Remote",
+					URL:               "https://remote.example/@riley",
+					Inbox:             "https://remote.example/users/riley/inbox",
+				},
+			},
+		},
+	}
+	h, _, _ := round11NewHandler(t, cfg, state)
+	core, observed := observer.New(zap.WarnLevel)
+	h.logger = zap.New(core)
+
+	ctx, err := round10NewLiftContext(http.MethodGet, "/test", nil, nil, nil)
+	require.NoError(t, err)
+	out := h.convertSingleNotification(ctx, &storageModels.Notification{
+		ID:        "notif-remote",
+		Type:      apiModels.NotificationTypeMention,
+		ActorID:   remoteActorID,
+		ActorType: notificationActorTypeRemoteActor,
+		UserID:    "admin",
+		CreatedAt: now,
+	})
+
+	require.NotNil(t, out)
+	require.Equal(t, remoteActorID, out.Account.ID)
+	require.Equal(t, "riley", out.Account.Username)
+	require.Equal(t, "riley@remote.example", out.Account.Acct)
+	require.Equal(t, "Riley Remote", out.Account.DisplayName)
+	require.Equal(t, 0, observed.FilterMessage("failed to get local actor for notification; trying remote cache/fallback").Len())
+}
+
+func TestNotifications_GroupedSampleAccountsUseSemanticResolver_Round30(t *testing.T) {
+	cfg := round11TestConfig()
+	now := time.Date(2026, time.May, 11, 11, 30, 0, 0, time.UTC)
+	remoteActorID := "https://remote.example/users/riley"
+	state := &round10QueryState{
+		firstErrorPK: map[string]error{
+			"ACTOR#riley":             context.DeadlineExceeded,
+			"ACTOR#alice@example.net": context.DeadlineExceeded,
+		},
+		remoteActorsByPK: map[string]storageModels.RemoteActor{
+			"REMOTE_ACTOR#riley@remote.example": {
+				PK:        "REMOTE_ACTOR#riley@remote.example",
+				SK:        storageModels.SKProfile,
+				Handle:    "riley@remote.example",
+				ExpiresAt: time.Now().Add(time.Hour),
+				Actor: &activitypub.Actor{
+					BaseObject:        activitypub.BaseObject{ID: remoteActorID, Type: activitypub.PersonType},
+					PreferredUsername: "riley",
+					Name:              "Riley Remote",
+					URL:               "https://remote.example/@riley",
+					Inbox:             "https://remote.example/users/riley/inbox",
+				},
+			},
+		},
+	}
+	h, _, _ := round11NewHandler(t, cfg, state)
+	core, observed := observer.New(zap.WarnLevel)
+	h.logger = zap.New(core)
+
+	remote := &storageModels.Notification{
+		ID:        "notif-remote",
+		Type:      apiModels.NotificationTypeFollow,
+		ActorID:   remoteActorID,
+		ActorType: notificationActorTypeRemoteActor,
+		UserID:    "admin",
+		CreatedAt: now,
+	}
+	external := &storageModels.Notification{
+		ID:        "notif-external",
+		Type:      commNotificationTypeInbound,
+		ActorID:   "alice@example.net",
+		ActorType: notificationActorTypeExternal,
+		UserID:    "admin",
+		CreatedAt: now.Add(-time.Minute),
+		Data: map[string]interface{}{
+			"messageId": "message-2",
+			"from": map[string]interface{}{
+				"address":     "alice@example.net",
+				"displayName": "Alice External",
+			},
+		},
+	}
+
+	ctx, err := round10NewLiftContext(http.MethodGet, "/api/v2/notifications/grouped", nil, nil, nil)
+	require.NoError(t, err)
+	out := h.convertGroupedNotificationsToAPI(ctx, []*notifications.GroupedNotification{
+		{
+			ID:                "group-1",
+			Type:              apiModels.NotificationTypeFollow,
+			GroupKey:          "group-1",
+			Count:             2,
+			LatestCreatedAt:   now,
+			EarliestCreatedAt: now.Add(-time.Minute),
+			SampleAccounts: []notifications.NotificationAccount{
+				{ID: remoteActorID, CreatedAt: now},
+				{ID: "alice@example.net", CreatedAt: now.Add(-time.Minute)},
+			},
+			AllNotifications: []*storageModels.Notification{remote, external},
+		},
+	})
+
+	require.Len(t, out, 1)
+	require.Len(t, out[0].SampleAccounts, 2)
+	require.Equal(t, "riley", out[0].SampleAccounts[0].Username)
+	require.Equal(t, "Riley Remote", out[0].SampleAccounts[0].DisplayName)
+	require.Equal(t, "alice", out[0].SampleAccounts[1].Username)
+	require.Equal(t, "Alice External", out[0].SampleAccounts[1].DisplayName)
+	require.Contains(t, out[0].Summary, "Riley Remote")
+	require.Equal(t, 0, observed.FilterMessage("failed to get local actor for notification; trying remote cache/fallback").Len())
+}
+
+func TestNotifications_RendererHelperBranches_Round30(t *testing.T) {
+	cfg := round11TestConfig()
+	state := &round10QueryState{
+		actorsByUser: map[string]storageModels.Actor{
+			"local": {
+				Username: "local",
+				Actor: &activitypub.Actor{
+					BaseObject:        activitypub.BaseObject{ID: cfg.BaseURL() + "/users/local", Type: activitypub.PersonType},
+					PreferredUsername: "local",
+					Name:              "Local User",
+				},
+			},
+		},
+	}
+	h, _, _ := round11NewHandler(t, cfg, state)
+	ctx, err := round10NewLiftContext(http.MethodGet, "/test", nil, nil, nil)
+	require.NoError(t, err)
+
+	require.Nil(t, notificationViewFromModel(nil))
+	var nilView *notificationView
+	require.Nil(t, nilView.communicationData())
+	require.Equal(t, "", nilView.statusID())
+	require.Nil(t, h.convertNotificationViewToAPI(ctx, nil))
+	require.Nil(t, h.convertNotificationViewToAPI(ctx, &notificationView{ID: "missing-actor"}))
+	require.False(t, notificationActorIDLooksURL("not a url"))
+
+	localActor := h.notificationActorForView(ctx.Context(), &notificationView{
+		ActorID:   "local",
+		ActorType: notificationActorTypeUser,
+	})
+	require.NotNil(t, localActor)
+	require.Equal(t, "local", localActor.PreferredUsername)
+
+	remoteFallback := h.notificationActorForView(ctx.Context(), &notificationView{
+		ActorID:   "https://remote.example/users/missing",
+		ActorType: notificationActorTypeRemoteActor,
+	})
+	require.NotNil(t, remoteFallback)
+	require.Equal(t, "missing", remoteFallback.PreferredUsername)
+
+	emailFallback := h.notificationActorForView(ctx.Context(), &notificationView{ActorID: "bob@example.net"})
+	require.NotNil(t, emailFallback)
+	require.Equal(t, "bob", emailFallback.PreferredUsername)
+
+	require.Nil(t, h.externalNotificationActor(&notificationView{}))
+	require.Nil(t, h.resolveGroupedNotificationSampleAccounts(ctx.Context(), nil))
+	require.Nil(t, h.resolveGroupedNotificationSampleAccounts(ctx.Context(), &notifications.GroupedNotification{}))
+	require.Equal(t,
+		notifications.NotificationAccount{ID: "sample"},
+		h.resolveGroupedNotificationAccount(ctx.Context(), notifications.NotificationAccount{ID: "sample"}, nil),
+	)
+	require.Equal(t, "Display", notificationAccountDisplayName(notifications.NotificationAccount{DisplayName: "Display", Username: "user", ID: "id"}))
+	require.Equal(t, "user", notificationAccountDisplayName(notifications.NotificationAccount{Username: "user", ID: "id"}))
+	require.Equal(t, "id", notificationAccountDisplayName(notifications.NotificationAccount{ID: "id"}))
+}

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -1957,7 +1957,11 @@ type NotificationFilter struct {
 	ExcludeTypes []string `json:"exclude_types,omitempty"`
 }
 
-// Notification represents a user notification
+// Notification represents a user notification.
+//
+// Legacy DTO: notification API rendering uses pkg/storage/models.Notification
+// directly so actor and target semantics are preserved. Keep new rendering code
+// off this compatibility shape.
 type Notification struct {
 	ID        string                 `json:"id"`
 	Type      string                 `json:"type"` // "mention", "status", "reblog", "follow", etc.


### PR DESCRIPTION
## Milestone
Project 21 M0.5 — remove the legacy notification rendering path before M1.

Closes #946.

## Classification
Contract-stability + operational-reliability hardening.

## Surfaces affected
- Mastodon REST notification rendering:
  - `GET /api/v1/notifications`
  - `GET /api/v1/notifications/:id`
- Lesser grouped notifications:
  - `GET /api/v2/notifications/grouped`
- Internal legacy compatibility marker for `pkg/storage.Notification`

## Specialist walks referenced
- Advisor-brief review: Pilot brief from `pilot@lessersoul.ai` authorized by Aron in-session.
- Contract / API: semantic refinement only; external JSON boundary preserved (`id`, `type`, `created_at`, `account`, `status`, `read`, `communication`).
- Schema: no PK/SK/GSI/TableTheory tag change.
- Federation trust: no HTTP Signature, actor-object, inbox/outbox, or delivery behavior change.

## What changed
- Renders list and single-get notification API responses directly from canonical `pkg/storage/models.Notification` via a small lossless `notificationView`.
- Removes list/single rendering conversion through legacy `pkg/storage.Notification`, preserving `ActorType` and `TargetType` through rendering.
- Centralizes communication data merge (`Data`, plus `Title -> subject`, `Body -> body`).
- Adds semantic actor resolution:
  - local users use local actor lookup first;
  - `remote_actor` / URL actors use cached remote actor then URL fallback, without local URL lookup;
  - `external` / `communication:*` notifications synthesize from `Data.from` without local email lookup.
- Wires grouped notification sample accounts through the same semantic resolver.
- Marks `pkg/storage.Notification` as a legacy compatibility DTO for non-rendering seams.

## Consumer impact
- Mastodon clients: no response-shape change expected.
- Direct API integrations: same notification JSON shape, with fewer expected fallback warnings and more consistent list/single rendering.
- Sibling repos: no contract change required; lesser-body should not need notification-side workarounds.

## Validation
- `go test ./cmd/api/handlers ./pkg/services/notifications`
- `go test ./...`
- `go vet ./...`
- `gofmt -l .` (empty)
- `go build -o lesser ./cmd/lesser`
- `./lesser verify openapi --strict`
- `./lesser build lambdas`
- `./lesser verify ci`

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Ops reprobe after deploy
- `notifications_read(limit:30)`
- `notifications_read(since:probe_start)`
- typed notification reads
- notification dismiss follow-up
- log assertion: zero expected `failed to get local actor for notification; trying remote cache/fallback` warnings for expected `remote_actor` URL and external communication rows
