### PR TITLE
fix(statuses): structure direct self-post rejection

### DIFF
--- a/cmd/api/handlers/statuses_round16_create_more_coverage_test.go
+++ b/cmd/api/handlers/statuses_round16_create_more_coverage_test.go
@@ -307,6 +307,26 @@ func TestStatusesRound16_HandleCreateStatusLift(t *testing.T) {
 		requireStatus(t, http.StatusForbidden)(h.HandleCreateStatusLift(ctx))
 	})
 
+	t.Run("direct visibility self mention returns structured rejection", func(t *testing.T) {
+		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{}, &RegistryStub{
+			ConversationsSvc: conversations.NewService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "example.com"),
+		})
+
+		token := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{auth.ScopeWrite})
+		headers := map[string]string{"Authorization": "Bearer " + token}
+
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses", headers, nil, models.CreateStatusRequest{
+			Status:     "@alice hello myself",
+			Visibility: VisibilityDirect,
+		})
+		require.NoError(t, err)
+
+		resp := requireStatus(t, http.StatusBadRequest)(h.HandleCreateStatusLift(ctx))
+		decoded := decodeStandardErrorResponse(t, resp)
+		require.Equal(t, "DIRECT_SELF_POST_NOT_ALLOWED", decoded.Code)
+		require.Equal(t, "direct messages cannot be sent to yourself", decoded.Error)
+	})
+
 	t.Run("direct visibility surfaces generic service failures as 500", func(t *testing.T) {
 		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{}, &RegistryStub{
 			ConversationsSvc: &ConversationsServiceStub{

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -15372,7 +15372,7 @@ paths:
     /api/v1/statuses:
         post:
             operationId: post_api_v1_statuses
-            description: Create a status. `in_reply_to_id` accepts local status IDs and canonical remote status URLs. When a canonical remote URL is not yet materialized locally, Lesser performs request-scoped remote parent acquisition on the write path only. Direct replies continue through the conversations service. Failure classes distinguish invalid references (400), acquisition timeouts (408), fetched-but-unusable parents (422), and upstream unavailability (503).
+            description: Create a status. `in_reply_to_id` accepts local status IDs and canonical remote status URLs. When a canonical remote URL is not yet materialized locally, Lesser performs request-scoped remote parent acquisition on the write path only. Direct replies continue through the conversations service. Self-directed direct posts are intentionally rejected with `DIRECT_SELF_POST_NOT_ALLOWED`. Failure classes distinguish invalid references (400), acquisition timeouts (408), fetched-but-unusable parents (422), and upstream unavailability (503).
             tags:
                 - statuses
             security:

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -59,13 +59,14 @@ const (
 
 // Validation error codes
 const (
-	CodeValidationFailed     ErrorCode = "VALIDATION_FAILED"
-	CodeRequiredFieldMissing ErrorCode = "REQUIRED_FIELD_MISSING"
-	CodeFieldTooLong         ErrorCode = "FIELD_TOO_LONG"
-	CodeFieldTooShort        ErrorCode = "FIELD_TOO_SHORT"
-	CodeInvalidFormat        ErrorCode = "INVALID_FORMAT"
-	CodeInvalidCharacters    ErrorCode = "INVALID_CHARACTERS"
-	CodeValueOutOfRange      ErrorCode = "VALUE_OUT_OF_RANGE"
+	CodeValidationFailed         ErrorCode = "VALIDATION_FAILED"
+	CodeRequiredFieldMissing     ErrorCode = "REQUIRED_FIELD_MISSING"
+	CodeFieldTooLong             ErrorCode = "FIELD_TOO_LONG"
+	CodeFieldTooShort            ErrorCode = "FIELD_TOO_SHORT"
+	CodeInvalidFormat            ErrorCode = "INVALID_FORMAT"
+	CodeInvalidCharacters        ErrorCode = "INVALID_CHARACTERS"
+	CodeValueOutOfRange          ErrorCode = "VALUE_OUT_OF_RANGE"
+	CodeDirectSelfPostNotAllowed ErrorCode = "DIRECT_SELF_POST_NOT_ALLOWED"
 )
 
 // API error codes
@@ -163,7 +164,7 @@ func (c ErrorCode) GetHTTPStatusCode() int {
 		return 422
 	case CodeInvalidInput, CodeValidationFailed, CodeRequiredFieldMissing, CodeFieldTooLong,
 		CodeFieldTooShort, CodeInvalidFormat, CodeInvalidCharacters, CodeValueOutOfRange,
-		CodeBadRequest, CodeContentTooLarge:
+		CodeDirectSelfPostNotAllowed, CodeBadRequest, CodeContentTooLarge:
 		return 400
 	case CodeMethodNotAllowed:
 		return 405

--- a/pkg/services/conversations/errors.go
+++ b/pkg/services/conversations/errors.go
@@ -17,6 +17,13 @@ var (
 	// ErrInvalidRecipient is returned when recipient validation fails
 	ErrInvalidRecipient = apperrors.NewValidationError("recipient", "invalid")
 
+	// ErrDirectSelfPostNotAllowed is returned when a direct status targets the sender as its sole recipient.
+	ErrDirectSelfPostNotAllowed = apperrors.NewValidationErrorWithCode(
+		apperrors.CodeDirectSelfPostNotAllowed,
+		"recipient",
+		"direct messages cannot be sent to yourself",
+	)
+
 	// ErrLookupExistingConversation is returned when looking up existing conversation fails
 	ErrLookupExistingConversation = apperrors.FailedToQuery("existing conversation", errors.New("failed to lookup existing conversation"))
 

--- a/pkg/services/conversations/service.go
+++ b/pkg/services/conversations/service.go
@@ -426,15 +426,56 @@ func (s *Service) validateSendDirectMessageCommand(ctx context.Context, cmd *Sen
 	}
 
 	recipientID := cmd.Recipients[0]
-	if strings.TrimSpace(recipientID) == "" ||
-		models.CanonicalConversationParticipantID(recipientID) == models.CanonicalConversationParticipantID(cmd.SenderID) {
+	if strings.TrimSpace(recipientID) == "" {
 		s.auditDMEvent(ctx, cmd, "", false, "invalid_recipient", map[string]any{
 			"recipient_id": recipientID,
 		})
 		return "", errors.Join(ErrConversationValidationFailed, ErrInvalidRecipient)
 	}
+	if isDirectMessageSelfRecipient(cmd.SenderID, recipientID, s.domainName) {
+		s.auditDMEvent(ctx, cmd, "", false, "direct_self_post_not_allowed", map[string]any{
+			"recipient_id": recipientID,
+		})
+		return "", errors.Join(ErrDirectSelfPostNotAllowed, ErrConversationValidationFailed, ErrInvalidRecipient)
+	}
 
 	return recipientID, nil
+}
+
+func isDirectMessageSelfRecipient(senderID, recipientID, localDomain string) bool {
+	sender := models.CanonicalConversationParticipantID(senderID)
+	recipient := strings.TrimSpace(recipientID)
+	if sender == "" || recipient == "" {
+		return false
+	}
+
+	if models.CanonicalConversationParticipantID(recipient) == sender {
+		return true
+	}
+
+	normalizedLocalDomain := normalizeDirectMessageMentionDomain(localDomain)
+	if username, domain := directMessageMentionHandleParts(recipient); username != "" && domain != "" &&
+		normalizedLocalDomain != "" && normalizeDirectMessageMentionDomain(domain) == normalizedLocalDomain &&
+		models.CanonicalConversationParticipantID(username) == sender {
+		return true
+	}
+
+	parsed, err := url.Parse(recipient)
+	if err != nil || parsed.Scheme == "" || parsed.Hostname() == "" ||
+		normalizedLocalDomain == "" || normalizeDirectMessageMentionDomain(parsed.Hostname()) != normalizedLocalDomain {
+		return false
+	}
+
+	path := strings.Trim(parsed.EscapedPath(), "/")
+	parts := strings.Split(path, "/")
+	if len(parts) != 2 || parts[0] != "users" {
+		return false
+	}
+	username, err := url.PathUnescape(parts[1])
+	if err != nil {
+		username = parts[1]
+	}
+	return models.CanonicalConversationParticipantID(username) == sender
 }
 
 func (s *Service) enforceDirectMessageNotBlocked(ctx context.Context, cmd *SendDirectMessageCommand, recipientID string) error {

--- a/pkg/services/conversations/service_round37_more_coverage_test.go
+++ b/pkg/services/conversations/service_round37_more_coverage_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	apperrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
 	"github.com/equaltoai/lesser/pkg/storage/models"
@@ -345,12 +346,25 @@ func TestService_validateSendDirectMessageCommand_RejectsInvalidRecipientForms(t
 	})
 	require.ErrorIs(t, err, ErrInvalidRecipient)
 
-	_, err = service.validateSendDirectMessageCommand(ctx, &SendDirectMessageCommand{
+	for _, recipient := range []string{"alice", "Alice", "alice@example.com", "https://example.com/users/alice"} {
+		_, err = service.validateSendDirectMessageCommand(ctx, &SendDirectMessageCommand{
+			SenderID:   "alice",
+			Recipients: []string{recipient},
+			Content:    "hi",
+		})
+		require.ErrorIs(t, err, ErrInvalidRecipient)
+		appErr, ok := apperrors.AsAppError(err)
+		require.True(t, ok)
+		require.Equal(t, "DIRECT_SELF_POST_NOT_ALLOWED", appErr.Code.String())
+	}
+
+	recipientID, err := service.validateSendDirectMessageCommand(ctx, &SendDirectMessageCommand{
 		SenderID:   "alice",
-		Recipients: []string{"alice"},
+		Recipients: []string{"alice@remote.example"},
 		Content:    "hi",
 	})
-	require.ErrorIs(t, err, ErrInvalidRecipient)
+	require.NoError(t, err)
+	require.Equal(t, "alice@remote.example", recipientID)
 }
 
 func TestService_enforceDirectMessageNotBlocked_ReturnsValidationErrorOnRepoFailure(t *testing.T) {

--- a/tools/openapi/operation_overrides.go
+++ b/tools/openapi/operation_overrides.go
@@ -108,7 +108,7 @@ func applyStatusOverrides(op *operation, route routeDef) {
 		return
 	}
 
-	op.Description = "Create a status. `in_reply_to_id` accepts local status IDs and canonical remote status URLs. When a canonical remote URL is not yet materialized locally, Lesser performs request-scoped remote parent acquisition on the write path only. Direct replies continue through the conversations service. Failure classes distinguish invalid references (400), acquisition timeouts (408), fetched-but-unusable parents (422), and upstream unavailability (503)."
+	op.Description = "Create a status. `in_reply_to_id` accepts local status IDs and canonical remote status URLs. When a canonical remote URL is not yet materialized locally, Lesser performs request-scoped remote parent acquisition on the write path only. Direct replies continue through the conversations service. Self-directed direct posts are intentionally rejected with `DIRECT_SELF_POST_NOT_ALLOWED`. Failure classes distinguish invalid references (400), acquisition timeouts (408), fetched-but-unusable parents (422), and upstream unavailability (503)."
 	if op.Responses == nil {
 		op.Responses = map[string]response{}
 	}


### PR DESCRIPTION
## Milestone
Project 21 post-M0 follow-up — decide direct self-post semantics and return structured failure if invalid.

Closes #948.

## Classification
Contract-stability + operational-reliability bug fix.

## Surfaces affected
- Mastodon REST status creation: `POST /api/v1/statuses`
- Conversations service direct-message validation
- OpenAPI contract description for status creation

## Specialist walks referenced
- Contract / API: semantic refinement only; the existing 400 error envelope is preserved while self-directed direct posts now return `DIRECT_SELF_POST_NOT_ALLOWED` instead of generic `VALIDATION_FAILED`.
- Federation trust: no HTTP Signature, actor-object, inbox/outbox, or delivery behavior change.
- Schema: no PK/SK/GSI/TableTheory tag change.
- Framework: idiomatic AppTheory/common error-response usage; no framework workaround.

## What changed
- Keeps self-directed direct posts intentionally invalid under the current one-to-one conversation invariant.
- Adds `DIRECT_SELF_POST_NOT_ALLOWED` as a 400 validation error code.
- Detects self recipients across bare local usernames, case variants, local-domain acct handles, and local actor URLs.
- Preserves legacy `ErrInvalidRecipient` matching for service callers while making the first structured AppError the specific self-post code.
- Documents the behavior in the generated OpenAPI contract.

## Consumer impact
- Mastodon clients: same HTTP status and error envelope; more specific machine-readable `error_code` for this invalid direct-post case.
- lesser-body / MCP tools: can surface a clear reason to agents instead of generic validation failure.
- Remote ActivityPub peers: no impact; no peer inbox mutation is introduced.

## Tasks
- [x] Return structured direct self-post rejection

## Validation
- `gofmt -l .` (empty)
- `git diff --check`
- `go test ./pkg/services/conversations -run TestService_validateSendDirectMessageCommand_RejectsInvalidRecipientForms`
- `go test ./cmd/api/handlers -run 'TestStatusesRound16_HandleCreateStatusLift/direct_visibility_self_mention_returns_structured_rejection'`
- `go test ./cmd/api/handlers ./pkg/services/conversations ./pkg/errors`
- `go vet ./cmd/api/handlers ./pkg/services/conversations ./pkg/errors`
- `go test ./...`
- `go vet ./...`
- `./lesser verify openapi --strict`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None required for the lesser change. lesser-body can optionally map/surface `DIRECT_SELF_POST_NOT_ALLOWED`, but no workaround is required.

## Advisor-brief authorization
Pilot email `delivery-27d754dc98901d68` assigned #948 as post-M0/backlog work; Aron directed implementation in-session.