### PR TITLE
feat(souls): proxy self mint-conversation reads

### DIFF
--- a/cmd/api/handlers/souls_mint_conversations.go
+++ b/cmd/api/handlers/souls_mint_conversations.go
@@ -1,0 +1,441 @@
+package handlers
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	apimodels "github.com/equaltoai/lesser/cmd/api/models"
+	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/common"
+	soulservice "github.com/equaltoai/lesser/pkg/services/souls"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"go.uber.org/zap"
+)
+
+const (
+	soulPrivateMintConversationDefaultLimit = 20
+	soulPrivateMintConversationMaxLimit     = 50
+	soulPrivateMintConversationIDMaxLen     = 128
+	soulPrivateMintConversationListMaxBytes = 1 * 1024 * 1024
+	soulPrivateMintConversationGetMaxBytes  = 2 * 1024 * 1024
+)
+
+var soulPrivateMintConversationIDPattern = regexp.MustCompile(`^[A-Za-z0-9._:-]{1,128}$`)
+
+type soulPrivateHostReadResult struct {
+	status  int
+	headers http.Header
+	body    []byte
+}
+
+// HandleListBoundSoulMintConversationsLift returns compact private mint-conversation metadata
+// for the authenticated local principal's bound soul.
+func (h *Handler) HandleListBoundSoulMintConversationsLift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	start := time.Now()
+	claims, err := h.authenticateWithScope(ctx, auth.ScopeRead)
+	if err != nil {
+		if isInsufficientScopeError(err) {
+			return common.RespondForbidden(ctx, err.Error())
+		}
+		return common.RespondUnauthorized(ctx)
+	}
+
+	limit, resp := parseSoulPrivateMintConversationLimit(ctx)
+	if resp != nil {
+		h.logSoulPrivateRead(ctx, claims.Username, "", "", "list_mint_conversations", "denied", resp.Status, 0, limit, false, soulPrivateErrorCode(resp), 0, start)
+		return resp, nil
+	}
+	if resp := validateSoulPrivateReadQuery(ctx, map[string]struct{}{"limit": {}}); resp != nil {
+		h.logSoulPrivateRead(ctx, claims.Username, "", "", "list_mint_conversations", "denied", resp.Status, 0, limit, soulPrivateCursorPresent(ctx), "SOUL_PRIVATE_QUERY_UNSUPPORTED", 0, start)
+		return resp, nil
+	}
+	if len(ctx.Request.Body) > 0 {
+		resp, _ := respondSoulPrivateError(ctx, http.StatusBadRequest, "private soul read requests must not include a body", "SOUL_PRIVATE_REQUEST_BODY_UNSUPPORTED")
+		h.logSoulPrivateRead(ctx, claims.Username, "", "", "list_mint_conversations", "denied", resp.Status, 0, limit, false, "SOUL_PRIVATE_REQUEST_BODY_UNSUPPORTED", 0, start)
+		return resp, nil
+	}
+
+	soul, resp := h.resolveSoulPrivateBoundAgent(ctx, claims.Username)
+	if resp != nil {
+		h.logSoulPrivateRead(ctx, claims.Username, "", "", "list_mint_conversations", "denied", resp.Status, 0, limit, false, soulPrivateErrorCode(resp), 0, start)
+		return resp, nil
+	}
+
+	query := url.Values{}
+	query.Set("limit", strconv.Itoa(limit))
+	result, resp := h.getSoulPrivateHostRead(ctx, soul.AgentID, "", query, soulPrivateMintConversationListMaxBytes)
+	if resp != nil {
+		h.logSoulPrivateRead(ctx, claims.Username, soul.AgentID, "", "list_mint_conversations", "host_unavailable", resp.Status, 0, limit, false, soulPrivateErrorCode(resp), 0, start)
+		return resp, nil
+	}
+	if result.status != http.StatusOK {
+		resp, _ := h.translateSoulPrivateHostError(ctx, "list_mint_conversations", result.status, result.headers)
+		h.logSoulPrivateRead(ctx, claims.Username, soul.AgentID, "", "list_mint_conversations", "denied", resp.Status, len(result.body), limit, false, soulPrivateErrorCode(resp), result.status, start)
+		return resp, nil
+	}
+
+	var payload apimodels.SoulMintConversationsResponse
+	if err := json.Unmarshal(result.body, &payload); err != nil {
+		resp, _ := respondSoulPrivateError(ctx, http.StatusServiceUnavailable, "private soul conversation host response is unavailable", "SOUL_PRIVATE_HOST_RESPONSE_INVALID")
+		h.logSoulPrivateRead(ctx, claims.Username, soul.AgentID, "", "list_mint_conversations", "host_unavailable", resp.Status, len(result.body), limit, false, "SOUL_PRIVATE_HOST_RESPONSE_INVALID", result.status, start)
+		return resp, nil
+	}
+	if payload.Version == "" {
+		payload.Version = "1"
+	}
+	for _, conversation := range payload.Conversations {
+		if !sameSoulAgentID(conversation.AgentID, soul.AgentID) {
+			resp, _ := respondSoulPrivateError(ctx, http.StatusServiceUnavailable, "private soul conversation host response is unavailable", "SOUL_PRIVATE_UPSTREAM_SCOPE_MISMATCH")
+			h.logSoulPrivateRead(ctx, claims.Username, soul.AgentID, conversation.ConversationID, "list_mint_conversations", "denied", resp.Status, len(result.body), limit, false, "SOUL_PRIVATE_UPSTREAM_SCOPE_MISMATCH", result.status, start)
+			return resp, nil
+		}
+	}
+
+	resp, err = okJSON(payload)
+	if err == nil {
+		h.logSoulPrivateRead(ctx, claims.Username, soul.AgentID, "", "list_mint_conversations", "success", resp.Status, len(result.body), limit, false, "", result.status, start)
+	}
+	return resp, err
+}
+
+// HandleGetBoundSoulMintConversationLift returns one bounded private mint-conversation record
+// for the authenticated local principal's bound soul.
+func (h *Handler) HandleGetBoundSoulMintConversationLift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	start := time.Now()
+	claims, err := h.authenticateWithScope(ctx, auth.ScopeRead)
+	if err != nil {
+		if isInsufficientScopeError(err) {
+			return common.RespondForbidden(ctx, err.Error())
+		}
+		return common.RespondUnauthorized(ctx)
+	}
+
+	conversationID, resp := validateSoulPrivateConversationID(ctx)
+	if resp != nil {
+		h.logSoulPrivateRead(ctx, claims.Username, "", "", "get_mint_conversation", "denied", resp.Status, 0, 0, false, soulPrivateErrorCode(resp), 0, start)
+		return resp, nil
+	}
+	if resp := validateSoulPrivateReadQuery(ctx, nil); resp != nil {
+		h.logSoulPrivateRead(ctx, claims.Username, "", conversationID, "get_mint_conversation", "denied", resp.Status, 0, 0, soulPrivateCursorPresent(ctx), "SOUL_PRIVATE_QUERY_UNSUPPORTED", 0, start)
+		return resp, nil
+	}
+	if len(ctx.Request.Body) > 0 {
+		resp, _ := respondSoulPrivateError(ctx, http.StatusBadRequest, "private soul read requests must not include a body", "SOUL_PRIVATE_REQUEST_BODY_UNSUPPORTED")
+		h.logSoulPrivateRead(ctx, claims.Username, "", conversationID, "get_mint_conversation", "denied", resp.Status, 0, 0, false, "SOUL_PRIVATE_REQUEST_BODY_UNSUPPORTED", 0, start)
+		return resp, nil
+	}
+
+	soul, resp := h.resolveSoulPrivateBoundAgent(ctx, claims.Username)
+	if resp != nil {
+		h.logSoulPrivateRead(ctx, claims.Username, "", conversationID, "get_mint_conversation", "denied", resp.Status, 0, 0, false, soulPrivateErrorCode(resp), 0, start)
+		return resp, nil
+	}
+
+	result, resp := h.getSoulPrivateHostRead(ctx, soul.AgentID, conversationID, nil, soulPrivateMintConversationGetMaxBytes)
+	if resp != nil {
+		h.logSoulPrivateRead(ctx, claims.Username, soul.AgentID, conversationID, "get_mint_conversation", "host_unavailable", resp.Status, 0, 0, false, soulPrivateErrorCode(resp), 0, start)
+		return resp, nil
+	}
+	if result.status != http.StatusOK {
+		resp, _ := h.translateSoulPrivateHostError(ctx, "get_mint_conversation", result.status, result.headers)
+		h.logSoulPrivateRead(ctx, claims.Username, soul.AgentID, conversationID, "get_mint_conversation", "denied", resp.Status, len(result.body), 0, false, soulPrivateErrorCode(resp), result.status, start)
+		return resp, nil
+	}
+
+	var payload apimodels.SoulMintConversationResponse
+	if err := json.Unmarshal(result.body, &payload); err != nil {
+		resp, _ := respondSoulPrivateError(ctx, http.StatusServiceUnavailable, "private soul conversation host response is unavailable", "SOUL_PRIVATE_HOST_RESPONSE_INVALID")
+		h.logSoulPrivateRead(ctx, claims.Username, soul.AgentID, conversationID, "get_mint_conversation", "host_unavailable", resp.Status, len(result.body), 0, false, "SOUL_PRIVATE_HOST_RESPONSE_INVALID", result.status, start)
+		return resp, nil
+	}
+	if payload.Version == "" {
+		payload.Version = "1"
+	}
+	if !sameSoulAgentID(payload.Conversation.AgentID, soul.AgentID) || strings.TrimSpace(payload.Conversation.ConversationID) != conversationID {
+		resp, _ := respondSoulPrivateError(ctx, http.StatusServiceUnavailable, "private soul conversation host response is unavailable", "SOUL_PRIVATE_UPSTREAM_SCOPE_MISMATCH")
+		h.logSoulPrivateRead(ctx, claims.Username, soul.AgentID, conversationID, "get_mint_conversation", "denied", resp.Status, len(result.body), 0, false, "SOUL_PRIVATE_UPSTREAM_SCOPE_MISMATCH", result.status, start)
+		return resp, nil
+	}
+
+	resp, err = okJSON(payload)
+	if err == nil {
+		h.logSoulPrivateRead(ctx, claims.Username, soul.AgentID, conversationID, "get_mint_conversation", "success", resp.Status, len(result.body), 0, false, "", result.status, start)
+	}
+	return resp, err
+}
+
+func parseSoulPrivateMintConversationLimit(ctx *apptheory.Context) (int, *apptheory.Response) {
+	limit, err := common.ParseAndValidateIntWithBounds("limit", firstQueryValue(ctx, "limit"), 0, soulPrivateMintConversationMaxLimit, soulPrivateMintConversationDefaultLimit)
+	if err == nil {
+		return limit, nil
+	}
+	resp, _ := respondSoulPrivateError(ctx, http.StatusBadRequest, "limit must be between 1 and 50", "SOUL_PRIVATE_LIMIT_INVALID")
+	return 0, resp
+}
+
+func validateSoulPrivateReadQuery(ctx *apptheory.Context, allowed map[string]struct{}) *apptheory.Response {
+	for key := range ctx.Request.Query {
+		normalized := strings.TrimSpace(key)
+		if normalized == "" {
+			continue
+		}
+		if strings.EqualFold(normalized, "cursor") {
+			resp, _ := respondSoulPrivateError(ctx, http.StatusBadRequest, "cursor is not supported for private soul conversation reads", "SOUL_PRIVATE_CURSOR_UNSUPPORTED")
+			return resp
+		}
+		if _, ok := allowed[normalized]; !ok {
+			resp, _ := respondSoulPrivateError(ctx, http.StatusBadRequest, "unsupported private soul conversation query parameter", "SOUL_PRIVATE_QUERY_UNSUPPORTED")
+			return resp
+		}
+	}
+	return nil
+}
+
+func validateSoulPrivateConversationID(ctx *apptheory.Context) (string, *apptheory.Response) {
+	conversationID := strings.TrimSpace(ctx.Param("conversationId"))
+	if conversationID == "" {
+		resp, _ := respondSoulPrivateError(ctx, http.StatusBadRequest, "conversationId is required", "SOUL_PRIVATE_CONVERSATION_ID_REQUIRED")
+		return "", resp
+	}
+	if len(conversationID) > soulPrivateMintConversationIDMaxLen || !soulPrivateMintConversationIDPattern.MatchString(conversationID) {
+		resp, _ := respondSoulPrivateError(ctx, http.StatusBadRequest, "conversationId must be an opaque safe path value", "SOUL_PRIVATE_CONVERSATION_ID_INVALID")
+		return "", resp
+	}
+	return conversationID, nil
+}
+
+func (h *Handler) resolveSoulPrivateBoundAgent(ctx *apptheory.Context, username string) (*soulservice.Soul, *apptheory.Response) {
+	svc := h.getSoulService()
+	if svc == nil {
+		resp, _ := common.RespondInternalServerError(ctx)
+		return nil, resp
+	}
+
+	soul, err := svc.ResolveBoundAgent(ctx.Context(), username)
+	if err != nil {
+		switch {
+		case errors.Is(err, soulservice.ErrTrustNotConfigured):
+			resp, _ := respondSoulPrivateError(ctx, http.StatusUnprocessableEntity, "private soul trust is not configured", "SOUL_PRIVATE_TRUST_NOT_CONFIGURED")
+			return nil, resp
+		case errors.Is(err, soulservice.ErrSoulNotAvailable):
+			resp, _ := respondSoulPrivateError(ctx, http.StatusNotFound, "bound soul is not available", "SOUL_BOUND_AGENT_NOT_AVAILABLE")
+			return nil, resp
+		default:
+			resp, _ := common.RespondInternalServerError(ctx)
+			return nil, resp
+		}
+	}
+	if soul == nil || !soul.Bound || strings.TrimSpace(soul.AgentID) == "" {
+		resp, _ := respondSoulPrivateError(ctx, http.StatusNotFound, "no bound soul for authenticated principal", "SOUL_BOUND_AGENT_NOT_FOUND")
+		return nil, resp
+	}
+	return soul, nil
+}
+
+func (h *Handler) getSoulPrivateHostRead(ctx *apptheory.Context, agentID string, conversationID string, query url.Values, maxBytes int64) (*soulPrivateHostReadResult, *apptheory.Response) {
+	base := h.effectiveLesserHostTrustBaseURL(ctx.Context())
+	if base == "" {
+		h.warnTrustProxyMisconfigured("private soul read misconfigured: missing lesser-host base URL", zap.String("route_class", soulPrivateRouteClass(conversationID)))
+		resp, _ := respondSoulPrivateError(ctx, http.StatusUnprocessableEntity, "private soul trust is not configured", "SOUL_PRIVATE_TRUST_NOT_CONFIGURED")
+		return nil, resp
+	}
+	if err := validateTrustBaseURL(base); err != nil {
+		h.warnTrustProxyMisconfigured("private soul read misconfigured: invalid lesser-host base URL", zap.Error(err), zap.String("route_class", soulPrivateRouteClass(conversationID)))
+		resp, _ := respondSoulPrivateError(ctx, http.StatusUnprocessableEntity, "private soul trust is not configured", "SOUL_PRIVATE_TRUST_NOT_CONFIGURED")
+		return nil, resp
+	}
+
+	instanceKey, err := h.effectiveLesserHostInstanceKey(ctx.Context())
+	if err != nil {
+		h.warnTrustProxyMisconfigured("private soul read misconfigured: failed to resolve instance key", zap.Error(err), zap.String("route_class", soulPrivateRouteClass(conversationID)))
+		resp, _ := respondSoulPrivateError(ctx, http.StatusServiceUnavailable, "private soul conversation host is unavailable", "SOUL_PRIVATE_HOST_UNAVAILABLE")
+		return nil, resp
+	}
+	if strings.TrimSpace(instanceKey) == "" {
+		h.warnTrustProxyMisconfigured("private soul read misconfigured: missing instance key", zap.String("route_class", soulPrivateRouteClass(conversationID)))
+		resp, _ := respondSoulPrivateError(ctx, http.StatusUnprocessableEntity, "private soul trust is not configured", "SOUL_PRIVATE_TRUST_NOT_CONFIGURED")
+		return nil, resp
+	}
+
+	upstreamURL, err := soulPrivateHostURL(base, agentID, conversationID, query)
+	if err != nil {
+		resp, _ := respondSoulPrivateError(ctx, http.StatusServiceUnavailable, "private soul conversation host is unavailable", "SOUL_PRIVATE_HOST_UNAVAILABLE")
+		return nil, resp
+	}
+	if err := validateLesserHostProxyURL(upstreamURL); err != nil {
+		resp, _ := respondSoulPrivateError(ctx, http.StatusServiceUnavailable, "private soul conversation host is unavailable", "SOUL_PRIVATE_HOST_UNAVAILABLE")
+		return nil, resp
+	}
+
+	req, err := http.NewRequestWithContext(ctx.Context(), http.MethodGet, upstreamURL.String(), nil)
+	if err != nil {
+		resp, _ := respondSoulPrivateError(ctx, http.StatusServiceUnavailable, "private soul conversation host is unavailable", "SOUL_PRIVATE_HOST_UNAVAILABLE")
+		return nil, resp
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+instanceKey)
+
+	upstreamResp, err := newLesserHostProxyClient().Do(req)
+	if err != nil {
+		resp, _ := respondSoulPrivateError(ctx, http.StatusServiceUnavailable, "private soul conversation host is unavailable", "SOUL_PRIVATE_HOST_UNAVAILABLE")
+		return nil, resp
+	}
+	defer func() { _ = upstreamResp.Body.Close() }()
+
+	body, truncated, err := common.ReadUntrustedHTTPResponseBody(upstreamResp.Body, maxBytes)
+	if err != nil {
+		resp, _ := respondSoulPrivateError(ctx, http.StatusServiceUnavailable, "private soul conversation host is unavailable", "SOUL_PRIVATE_HOST_UNAVAILABLE")
+		return nil, resp
+	}
+	if truncated {
+		resp, _ := respondSoulPrivateError(ctx, http.StatusRequestEntityTooLarge, "private soul conversation response is too large", "SOUL_PRIVATE_RESPONSE_TOO_LARGE")
+		return nil, resp
+	}
+
+	return &soulPrivateHostReadResult{status: upstreamResp.StatusCode, headers: upstreamResp.Header, body: body}, nil
+}
+
+func soulPrivateHostURL(base string, agentID string, conversationID string, query url.Values) (*url.URL, error) {
+	path := "/api/v1/soul/instance/agents/" + url.PathEscape(agentID) + "/mint-conversations"
+	if strings.TrimSpace(conversationID) != "" {
+		path += "/" + url.PathEscape(conversationID)
+	}
+	upstreamURL, err := url.Parse(strings.TrimRight(base, "/") + path)
+	if err != nil {
+		return nil, err
+	}
+	if len(query) > 0 {
+		upstreamURL.RawQuery = query.Encode()
+	}
+	return upstreamURL, nil
+}
+
+func (h *Handler) translateSoulPrivateHostError(ctx *apptheory.Context, operation string, upstreamStatus int, upstreamHeaders http.Header) (*apptheory.Response, error) {
+	switch upstreamStatus {
+	case http.StatusBadRequest:
+		return respondSoulPrivateError(ctx, http.StatusBadRequest, "invalid private soul conversation request", "SOUL_PRIVATE_INVALID_REQUEST")
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return respondSoulPrivateError(ctx, http.StatusConflict, "private soul instance trust was rejected", "SOUL_PRIVATE_INSTANCE_TRUST_REJECTED")
+	case http.StatusNotFound:
+		if operation == "get_mint_conversation" {
+			return respondSoulPrivateError(ctx, http.StatusNotFound, "private soul conversation not found", "SOUL_PRIVATE_CONVERSATION_NOT_FOUND")
+		}
+		return respondSoulPrivateError(ctx, http.StatusNotFound, "bound soul is not available", "SOUL_BOUND_AGENT_NOT_AVAILABLE")
+	case http.StatusRequestEntityTooLarge:
+		return respondSoulPrivateError(ctx, http.StatusRequestEntityTooLarge, "private soul conversation response is too large", "SOUL_PRIVATE_RESPONSE_TOO_LARGE")
+	case http.StatusTooManyRequests:
+		resp, err := respondSoulPrivateError(ctx, http.StatusTooManyRequests, "private soul conversation read rate limited", "SOUL_PRIVATE_RATE_LIMITED")
+		if retryAfter := strings.TrimSpace(upstreamHeaders.Get("Retry-After")); retryAfter != "" {
+			if resp.Headers == nil {
+				resp.Headers = map[string][]string{}
+			}
+			resp.Headers["retry-after"] = []string{retryAfter}
+		}
+		return resp, err
+	default:
+		return respondSoulPrivateError(ctx, http.StatusServiceUnavailable, "private soul conversation host is unavailable", "SOUL_PRIVATE_HOST_UNAVAILABLE")
+	}
+}
+
+func respondSoulPrivateError(_ *apptheory.Context, status int, message string, code string) (*apptheory.Response, error) {
+	return apptheory.JSON(status, common.StandardErrorResponse{
+		Error:       message,
+		Description: message,
+		Code:        code,
+	})
+}
+
+func firstQueryValue(ctx *apptheory.Context, key string) string {
+	if ctx == nil || ctx.Request.Query == nil {
+		return ""
+	}
+	for queryKey, values := range ctx.Request.Query {
+		if !strings.EqualFold(queryKey, key) || len(values) == 0 {
+			continue
+		}
+		return strings.TrimSpace(values[0])
+	}
+	return ""
+}
+
+func soulPrivateCursorPresent(ctx *apptheory.Context) bool {
+	if ctx == nil || ctx.Request.Query == nil {
+		return false
+	}
+	for key := range ctx.Request.Query {
+		if strings.EqualFold(strings.TrimSpace(key), "cursor") {
+			return true
+		}
+	}
+	return false
+}
+
+func sameSoulAgentID(a, b string) bool {
+	return strings.EqualFold(strings.TrimSpace(a), strings.TrimSpace(b))
+}
+
+func soulPrivateRouteClass(conversationID string) string {
+	if strings.TrimSpace(conversationID) == "" {
+		return "list_mint_conversations"
+	}
+	return "get_mint_conversation"
+}
+
+func (h *Handler) logSoulPrivateRead(ctx *apptheory.Context, username string, agentID string, conversationID string, operation string, outcome string, status int, responseBytes int, limit int, cursorPresent bool, errorCode string, upstreamStatus int, start time.Time) {
+	if h == nil || h.logger == nil {
+		return
+	}
+	fields := []zap.Field{
+		zap.String("event", "soul.private_read"),
+		zap.String("request_id", strings.TrimSpace(ctx.RequestID)),
+		zap.String("actor_username_hash", soulPrivateHash(username)),
+		zap.String("agent_id_hash", soulPrivateHash(agentID)),
+		zap.String("conversation_id_hash", soulPrivateHash(conversationID)),
+		zap.String("operation", operation),
+		zap.Bool("self_scope_verified", strings.TrimSpace(agentID) != ""),
+		zap.String("host_route_class", operation),
+		zap.String("outcome", outcome),
+		zap.Int("status", status),
+		zap.Int("upstream_status", upstreamStatus),
+		zap.Int64("duration_ms", time.Since(start).Milliseconds()),
+		zap.Int("response_bytes", responseBytes),
+		zap.Int("limit", limit),
+		zap.Bool("cursor_present", cursorPresent),
+	}
+	if strings.TrimSpace(errorCode) != "" {
+		fields = append(fields, zap.String("error_code", errorCode))
+	}
+	h.logger.Info("soul private read", fields...)
+}
+
+func soulPrivateHash(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(value))
+	encoded := hex.EncodeToString(sum[:])
+	if len(encoded) > 16 {
+		return encoded[:16]
+	}
+	return encoded
+}
+
+func soulPrivateErrorCode(resp *apptheory.Response) string {
+	if resp == nil || len(resp.Body) == 0 {
+		return ""
+	}
+	var body common.StandardErrorResponse
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(body.Code)
+}

--- a/cmd/api/handlers/souls_test.go
+++ b/cmd/api/handlers/souls_test.go
@@ -4,7 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,6 +18,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	soulservice "github.com/equaltoai/lesser/pkg/services/souls"
 	"github.com/stretchr/testify/require"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
 )
 
 type stubSoulHandlerService struct {
@@ -42,6 +48,22 @@ func (s *stubSoulHandlerService) Incorporate(_ context.Context, username string,
 func (s *stubSoulHandlerService) ResolveBoundAgent(_ context.Context, agentUsername string) (*soulservice.Soul, error) {
 	s.lastTargetAgent = agentUsername
 	return s.resolveBoundOut, s.resolveBoundErr
+}
+
+type soulPrivateHostReadClientFunc func(*http.Request) (*http.Response, error)
+
+func (f soulPrivateHostReadClientFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type soulPrivateFailingBody struct{}
+
+func (soulPrivateFailingBody) Read([]byte) (int, error) {
+	return 0, errors.New("read failed")
+}
+
+func (soulPrivateFailingBody) Close() error {
+	return nil
 }
 
 func TestHandleGetMySoulsLift_ListsOwnedSoulsWithBindingState(t *testing.T) {
@@ -401,6 +423,746 @@ func TestHandleGetBoundSoulMeLift_ReturnsInternalWhenServiceUnavailable(t *testi
 	require.NoError(t, err)
 
 	requireStatus(t, http.StatusInternalServerError)(h.HandleGetBoundSoulMeLift(ctx))
+}
+
+func TestHandleListBoundSoulMintConversationsLift_ProxiesThroughInstanceTrust(t *testing.T) {
+	allowLocalLesserHostProxyForTests(t)
+
+	const (
+		agentID     = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		instanceKey = "instance-key-raw"
+	)
+
+	var sawUpstream atomic.Bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawUpstream.Store(true)
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/api/v1/soul/instance/agents/"+agentID+"/mint-conversations", r.URL.Path)
+		require.Equal(t, "20", r.URL.Query().Get("limit"))
+		require.Equal(t, "Bearer "+instanceKey, r.Header.Get("Authorization"))
+		require.NotContains(t, r.Header.Get("Authorization"), "user-token")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"version":"1",
+			"conversations":[{
+				"agent_id":"` + agentID + `",
+				"conversation_id":"conv-1",
+				"model":"gpt-test",
+				"messages":"private list leak",
+				"produced_declarations":"private declaration leak",
+				"status":"completed",
+				"usage":{"input_tokens":1},
+				"charged_credits":0,
+				"created_at":"2026-05-11T21:00:00Z",
+				"completed_at":"2026-05-11T21:01:00Z"
+			}],
+			"count":1,
+			"limit":20
+		}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	cfg := round10TestConfig()
+	cfg.LesserHostURL = upstream.URL
+	cfg.LesserHostInstanceKey = instanceKey
+	service := &stubSoulHandlerService{
+		resolveBoundOut: &soulservice.Soul{
+			AgentID:            agentID,
+			Domain:             "example.com",
+			LocalID:            "ops",
+			Status:             "active",
+			Bound:              true,
+			BoundAgentUsername: "ops",
+			BoundAt:            time.Date(2026, 5, 1, 14, 30, 0, 0, time.UTC),
+			BoundUpdatedAt:     time.Date(2026, 5, 1, 14, 30, 0, 0, time.UTC),
+		},
+	}
+	h := &Handler{cfg: cfg, logger: round10TestLogger(t), soulsService: service}
+	userToken := round11SignToken(t, cfg.JWTSecret, "ops", []string{auth.ScopeRead}, "user-token")
+
+	ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/souls/bound/me/mint-conversations", map[string]string{
+		"Authorization": "Bearer " + userToken,
+	}, nil, nil)
+	require.NoError(t, err)
+
+	resp := requireStatus(t, http.StatusOK)(h.HandleListBoundSoulMintConversationsLift(ctx))
+	require.True(t, sawUpstream.Load())
+	require.Equal(t, "ops", service.lastTargetAgent)
+	require.NotContains(t, string(resp.Body), "messages")
+	require.NotContains(t, string(resp.Body), "produced_declarations")
+	require.NotContains(t, string(resp.Body), "private list leak")
+
+	var body apimodels.SoulMintConversationsResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Equal(t, "1", body.Version)
+	require.Equal(t, 1, body.Count)
+	require.Equal(t, 20, body.Limit)
+	require.Len(t, body.Conversations, 1)
+	require.Equal(t, agentID, body.Conversations[0].AgentID)
+	require.Equal(t, "conv-1", body.Conversations[0].ConversationID)
+}
+
+func TestHandleGetBoundSoulMintConversationLift_ReturnsExplicitSingleRecord(t *testing.T) {
+	allowLocalLesserHostProxyForTests(t)
+
+	const (
+		agentID        = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+		conversationID = "conv:single.1"
+		instanceKey    = "instance-key-raw"
+	)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/api/v1/soul/instance/agents/"+agentID+"/mint-conversations/"+conversationID, r.URL.Path)
+		require.Empty(t, r.URL.RawQuery)
+		require.Equal(t, "Bearer "+instanceKey, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"version":"1",
+			"conversation":{
+				"agent_id":"` + agentID + `",
+				"conversation_id":"` + conversationID + `",
+				"model":"gpt-test",
+				"messages":"[{\"role\":\"user\",\"content\":\"private\"}]",
+				"produced_declarations":"{}",
+				"status":"completed",
+				"usage":{"output_tokens":2},
+				"charged_credits":7,
+				"created_at":"2026-05-11T21:00:00Z",
+				"completed_at":"2026-05-11T21:01:00Z"
+			}
+		}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	cfg := round10TestConfig()
+	cfg.LesserHostURL = upstream.URL
+	cfg.LesserHostInstanceKey = instanceKey
+	service := &stubSoulHandlerService{
+		resolveBoundOut: &soulservice.Soul{
+			AgentID:            agentID,
+			Domain:             "example.com",
+			LocalID:            "ops",
+			Status:             "active",
+			Bound:              true,
+			BoundAgentUsername: "ops",
+			BoundAt:            time.Date(2026, 5, 1, 14, 30, 0, 0, time.UTC),
+			BoundUpdatedAt:     time.Date(2026, 5, 1, 14, 30, 0, 0, time.UTC),
+		},
+	}
+	h := &Handler{cfg: cfg, logger: round10TestLogger(t), soulsService: service}
+	userToken := round11SignToken(t, cfg.JWTSecret, "ops", []string{auth.ScopeRead}, "sess-private-single")
+
+	ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/souls/bound/me/mint-conversations/"+conversationID, map[string]string{
+		"Authorization": "Bearer " + userToken,
+	}, nil, nil)
+	require.NoError(t, err)
+	ctx.Params["conversationId"] = conversationID
+
+	resp := requireStatus(t, http.StatusOK)(h.HandleGetBoundSoulMintConversationLift(ctx))
+
+	var body apimodels.SoulMintConversationResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Equal(t, "1", body.Version)
+	require.Equal(t, agentID, body.Conversation.AgentID)
+	require.Equal(t, conversationID, body.Conversation.ConversationID)
+	require.Contains(t, body.Conversation.Messages, "private")
+	require.Equal(t, "{}", body.Conversation.ProducedDeclarations)
+	require.NotNil(t, body.Conversation.ChargedCredits)
+	require.Equal(t, int64(7), *body.Conversation.ChargedCredits)
+}
+
+func TestBoundSoulMintConversationHandlers_GuardsInputsAndBinding(t *testing.T) {
+	allowLocalLesserHostProxyForTests(t)
+
+	const agentID = "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+
+	var upstreamHits atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHits.Add(1)
+		_, _ = w.Write([]byte(`{"version":"1","conversations":[],"count":0,"limit":20}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	cfg := round10TestConfig()
+	cfg.LesserHostURL = upstream.URL
+	cfg.LesserHostInstanceKey = "instance-key-raw"
+	readToken := round11SignToken(t, cfg.JWTSecret, "ops", []string{auth.ScopeRead}, "sess-private-guards")
+
+	boundService := &stubSoulHandlerService{
+		resolveBoundOut: &soulservice.Soul{
+			AgentID:            agentID,
+			Domain:             "example.com",
+			LocalID:            "ops",
+			Status:             "active",
+			Bound:              true,
+			BoundAgentUsername: "ops",
+		},
+	}
+
+	testCases := []struct {
+		name        string
+		handler     func(*Handler, *apptheory.Context) (*apptheory.Response, error)
+		path        string
+		query       map[string]string
+		param       string
+		service     *stubSoulHandlerService
+		headers     map[string]string
+		body        any
+		wantStatus  int
+		wantCode    string
+		wantNoProxy bool
+	}{
+		{
+			name: "missing auth",
+			handler: func(h *Handler, ctx *apptheory.Context) (*apptheory.Response, error) {
+				return h.HandleListBoundSoulMintConversationsLift(ctx)
+			},
+			path:        "/api/v1/souls/bound/me/mint-conversations",
+			service:     boundService,
+			wantStatus:  http.StatusUnauthorized,
+			wantNoProxy: true,
+		},
+		{
+			name: "unbound self",
+			handler: func(h *Handler, ctx *apptheory.Context) (*apptheory.Response, error) {
+				return h.HandleListBoundSoulMintConversationsLift(ctx)
+			},
+			path:        "/api/v1/souls/bound/me/mint-conversations",
+			headers:     map[string]string{"Authorization": "Bearer " + readToken},
+			service:     &stubSoulHandlerService{},
+			wantStatus:  http.StatusNotFound,
+			wantCode:    "SOUL_BOUND_AGENT_NOT_FOUND",
+			wantNoProxy: true,
+		},
+		{
+			name: "limit too high",
+			handler: func(h *Handler, ctx *apptheory.Context) (*apptheory.Response, error) {
+				return h.HandleListBoundSoulMintConversationsLift(ctx)
+			},
+			path:        "/api/v1/souls/bound/me/mint-conversations",
+			headers:     map[string]string{"Authorization": "Bearer " + readToken},
+			query:       map[string]string{"limit": "51"},
+			service:     boundService,
+			wantStatus:  http.StatusBadRequest,
+			wantCode:    "SOUL_PRIVATE_LIMIT_INVALID",
+			wantNoProxy: true,
+		},
+		{
+			name: "cursor unsupported",
+			handler: func(h *Handler, ctx *apptheory.Context) (*apptheory.Response, error) {
+				return h.HandleListBoundSoulMintConversationsLift(ctx)
+			},
+			path:        "/api/v1/souls/bound/me/mint-conversations",
+			headers:     map[string]string{"Authorization": "Bearer " + readToken},
+			query:       map[string]string{"cursor": "abc"},
+			service:     boundService,
+			wantStatus:  http.StatusBadRequest,
+			wantCode:    "SOUL_PRIVATE_CURSOR_UNSUPPORTED",
+			wantNoProxy: true,
+		},
+		{
+			name: "conversation id invalid",
+			handler: func(h *Handler, ctx *apptheory.Context) (*apptheory.Response, error) {
+				return h.HandleGetBoundSoulMintConversationLift(ctx)
+			},
+			path:        "/api/v1/souls/bound/me/mint-conversations/bad",
+			headers:     map[string]string{"Authorization": "Bearer " + readToken},
+			param:       "bad/slash",
+			service:     boundService,
+			wantStatus:  http.StatusBadRequest,
+			wantCode:    "SOUL_PRIVATE_CONVERSATION_ID_INVALID",
+			wantNoProxy: true,
+		},
+		{
+			name: "get query unsupported",
+			handler: func(h *Handler, ctx *apptheory.Context) (*apptheory.Response, error) {
+				return h.HandleGetBoundSoulMintConversationLift(ctx)
+			},
+			path:        "/api/v1/souls/bound/me/mint-conversations/conv-1",
+			headers:     map[string]string{"Authorization": "Bearer " + readToken},
+			query:       map[string]string{"agentId": agentID},
+			param:       "conv-1",
+			service:     boundService,
+			wantStatus:  http.StatusBadRequest,
+			wantCode:    "SOUL_PRIVATE_QUERY_UNSUPPORTED",
+			wantNoProxy: true,
+		},
+		{
+			name: "body rejected",
+			handler: func(h *Handler, ctx *apptheory.Context) (*apptheory.Response, error) {
+				return h.HandleListBoundSoulMintConversationsLift(ctx)
+			},
+			path:        "/api/v1/souls/bound/me/mint-conversations",
+			headers:     map[string]string{"Authorization": "Bearer " + readToken},
+			body:        map[string]string{"agent_id": agentID},
+			service:     boundService,
+			wantStatus:  http.StatusBadRequest,
+			wantCode:    "SOUL_PRIVATE_REQUEST_BODY_UNSUPPORTED",
+			wantNoProxy: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			before := upstreamHits.Load()
+			h := &Handler{cfg: cfg, logger: round10TestLogger(t), soulsService: tc.service}
+			ctx, err := round10NewLiftContext(http.MethodGet, tc.path, tc.headers, tc.query, tc.body)
+			require.NoError(t, err)
+			if strings.Contains(tc.path, "/mint-conversations/") {
+				ctx.Params["conversationId"] = tc.param
+			}
+
+			resp := requireStatus(t, tc.wantStatus)(tc.handler(h, ctx))
+			if tc.wantCode != "" {
+				require.Equal(t, tc.wantCode, decodeStandardErrorResponse(t, resp).Code)
+			}
+			if tc.wantNoProxy {
+				require.Equal(t, before, upstreamHits.Load())
+			}
+		})
+	}
+}
+
+func TestBoundSoulMintConversationHandlers_TranslateHostErrors(t *testing.T) {
+	allowLocalLesserHostProxyForTests(t)
+
+	const agentID = "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+
+	cfg := round10TestConfig()
+	readToken := round11SignToken(t, cfg.JWTSecret, "ops", []string{auth.ScopeRead}, "sess-private-errors")
+	service := &stubSoulHandlerService{
+		resolveBoundOut: &soulservice.Soul{
+			AgentID:            agentID,
+			Domain:             "example.com",
+			LocalID:            "ops",
+			Status:             "active",
+			Bound:              true,
+			BoundAgentUsername: "ops",
+		},
+	}
+
+	testCases := []struct {
+		upstreamStatus int
+		wantStatus     int
+		wantCode       string
+	}{
+		{upstreamStatus: http.StatusBadRequest, wantStatus: http.StatusBadRequest, wantCode: "SOUL_PRIVATE_INVALID_REQUEST"},
+		{upstreamStatus: http.StatusUnauthorized, wantStatus: http.StatusConflict, wantCode: "SOUL_PRIVATE_INSTANCE_TRUST_REJECTED"},
+		{upstreamStatus: http.StatusForbidden, wantStatus: http.StatusConflict, wantCode: "SOUL_PRIVATE_INSTANCE_TRUST_REJECTED"},
+		{upstreamStatus: http.StatusNotFound, wantStatus: http.StatusNotFound, wantCode: "SOUL_PRIVATE_CONVERSATION_NOT_FOUND"},
+		{upstreamStatus: http.StatusRequestEntityTooLarge, wantStatus: http.StatusRequestEntityTooLarge, wantCode: "SOUL_PRIVATE_RESPONSE_TOO_LARGE"},
+		{upstreamStatus: http.StatusTooManyRequests, wantStatus: http.StatusTooManyRequests, wantCode: "SOUL_PRIVATE_RATE_LIMITED"},
+		{upstreamStatus: http.StatusInternalServerError, wantStatus: http.StatusServiceUnavailable, wantCode: "SOUL_PRIVATE_HOST_UNAVAILABLE"},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(http.StatusText(tc.upstreamStatus), func(t *testing.T) {
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if tc.upstreamStatus == http.StatusTooManyRequests {
+					w.Header().Set("Retry-After", "7")
+				}
+				w.WriteHeader(tc.upstreamStatus)
+				_, _ = w.Write([]byte(`{"error":{"message":"private secret should not leak"}}`))
+			}))
+			t.Cleanup(upstream.Close)
+
+			cfg := *cfg
+			cfg.LesserHostURL = upstream.URL
+			cfg.LesserHostInstanceKey = "instance-key-raw"
+			h := &Handler{cfg: &cfg, logger: round10TestLogger(t), soulsService: service}
+			ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/souls/bound/me/mint-conversations/conv-err", map[string]string{
+				"Authorization": "Bearer " + readToken,
+			}, nil, nil)
+			require.NoError(t, err)
+			ctx.Params["conversationId"] = "conv-err"
+
+			resp := requireStatus(t, tc.wantStatus)(h.HandleGetBoundSoulMintConversationLift(ctx))
+			body := decodeStandardErrorResponse(t, resp)
+			require.Equal(t, tc.wantCode, body.Code)
+			require.NotContains(t, string(resp.Body), "private secret")
+			if tc.upstreamStatus == http.StatusTooManyRequests {
+				require.Equal(t, []string{"7"}, resp.Headers["retry-after"])
+			}
+		})
+	}
+}
+
+func TestBoundSoulMintConversationHandlers_FailClosedOnHostIdentityMismatch(t *testing.T) {
+	allowLocalLesserHostProxyForTests(t)
+
+	const (
+		agentID        = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+		otherAgentID   = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+		conversationID = "conv-mismatch"
+	)
+
+	cfg := round10TestConfig()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"version":"1",
+			"conversation":{
+				"agent_id":"` + otherAgentID + `",
+				"conversation_id":"` + conversationID + `",
+				"model":"gpt-test",
+				"messages":"private secret should not leak",
+				"status":"completed",
+				"created_at":"2026-05-11T21:00:00Z"
+			}
+		}`))
+	}))
+	t.Cleanup(upstream.Close)
+	cfg.LesserHostURL = upstream.URL
+	cfg.LesserHostInstanceKey = "instance-key-raw"
+
+	service := &stubSoulHandlerService{
+		resolveBoundOut: &soulservice.Soul{
+			AgentID:            agentID,
+			Domain:             "example.com",
+			LocalID:            "ops",
+			Status:             "active",
+			Bound:              true,
+			BoundAgentUsername: "ops",
+		},
+	}
+	h := &Handler{cfg: cfg, logger: round10TestLogger(t), soulsService: service}
+	readToken := round11SignToken(t, cfg.JWTSecret, "ops", []string{auth.ScopeRead}, "sess-private-mismatch")
+
+	ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/souls/bound/me/mint-conversations/"+conversationID, map[string]string{
+		"Authorization": "Bearer " + readToken,
+	}, nil, nil)
+	require.NoError(t, err)
+	ctx.Params["conversationId"] = conversationID
+
+	resp := requireStatus(t, http.StatusServiceUnavailable)(h.HandleGetBoundSoulMintConversationLift(ctx))
+	require.Equal(t, "SOUL_PRIVATE_UPSTREAM_SCOPE_MISMATCH", decodeStandardErrorResponse(t, resp).Code)
+	require.NotContains(t, string(resp.Body), "private secret")
+}
+
+func TestBoundSoulMintConversationHandlers_AdditionalFailureCoverage(t *testing.T) {
+	allowLocalLesserHostProxyForTests(t)
+
+	const (
+		agentID      = "0x1111111111111111111111111111111111111111111111111111111111111111"
+		otherAgentID = "0x2222222222222222222222222222222222222222222222222222222222222222"
+	)
+
+	cfg := round10TestConfig()
+	cfg.LesserHostInstanceKey = "instance-key-raw"
+	readToken := round11SignToken(t, cfg.JWTSecret, "ops", []string{auth.ScopeRead}, "sess-private-extra")
+	service := &stubSoulHandlerService{
+		resolveBoundOut: &soulservice.Soul{
+			AgentID:            agentID,
+			Domain:             "example.com",
+			LocalID:            "ops",
+			Status:             "active",
+			Bound:              true,
+			BoundAgentUsername: "ops",
+		},
+	}
+
+	t.Run("list invalid host json", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{`))
+		}))
+		t.Cleanup(upstream.Close)
+
+		cfg := *cfg
+		cfg.LesserHostURL = upstream.URL
+		h := &Handler{cfg: &cfg, logger: round10TestLogger(t), soulsService: service}
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/souls/bound/me/mint-conversations", map[string]string{
+			"Authorization": "Bearer " + readToken,
+		}, nil, nil)
+		require.NoError(t, err)
+
+		resp := requireStatus(t, http.StatusServiceUnavailable)(h.HandleListBoundSoulMintConversationsLift(ctx))
+		require.Equal(t, "SOUL_PRIVATE_HOST_RESPONSE_INVALID", decodeStandardErrorResponse(t, resp).Code)
+	})
+
+	t.Run("list scope mismatch", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{
+				"version":"1",
+				"conversations":[{
+					"agent_id":"` + otherAgentID + `",
+					"conversation_id":"conv-list-mismatch",
+					"status":"completed",
+					"created_at":"2026-05-11T21:00:00Z"
+				}],
+				"count":1,
+				"limit":20
+			}`))
+		}))
+		t.Cleanup(upstream.Close)
+
+		cfg := *cfg
+		cfg.LesserHostURL = upstream.URL
+		h := &Handler{cfg: &cfg, logger: round10TestLogger(t), soulsService: service}
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/souls/bound/me/mint-conversations", map[string]string{
+			"Authorization": "Bearer " + readToken,
+		}, nil, nil)
+		require.NoError(t, err)
+
+		resp := requireStatus(t, http.StatusServiceUnavailable)(h.HandleListBoundSoulMintConversationsLift(ctx))
+		require.Equal(t, "SOUL_PRIVATE_UPSTREAM_SCOPE_MISMATCH", decodeStandardErrorResponse(t, resp).Code)
+	})
+
+	t.Run("get invalid host json", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{`))
+		}))
+		t.Cleanup(upstream.Close)
+
+		cfg := *cfg
+		cfg.LesserHostURL = upstream.URL
+		h := &Handler{cfg: &cfg, logger: round10TestLogger(t), soulsService: service}
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/souls/bound/me/mint-conversations/conv-extra", map[string]string{
+			"Authorization": "Bearer " + readToken,
+		}, nil, nil)
+		require.NoError(t, err)
+		ctx.Params["conversationId"] = "conv-extra"
+
+		resp := requireStatus(t, http.StatusServiceUnavailable)(h.HandleGetBoundSoulMintConversationLift(ctx))
+		require.Equal(t, "SOUL_PRIVATE_HOST_RESPONSE_INVALID", decodeStandardErrorResponse(t, resp).Code)
+	})
+
+	t.Run("host response too large", func(t *testing.T) {
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(strings.Repeat("x", soulPrivateMintConversationListMaxBytes+1)))
+		}))
+		t.Cleanup(upstream.Close)
+
+		cfg := *cfg
+		cfg.LesserHostURL = upstream.URL
+		h := &Handler{cfg: &cfg, logger: round10TestLogger(t), soulsService: service}
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/souls/bound/me/mint-conversations", map[string]string{
+			"Authorization": "Bearer " + readToken,
+		}, nil, nil)
+		require.NoError(t, err)
+
+		resp := requireStatus(t, http.StatusRequestEntityTooLarge)(h.HandleListBoundSoulMintConversationsLift(ctx))
+		require.Equal(t, "SOUL_PRIVATE_RESPONSE_TOO_LARGE", decodeStandardErrorResponse(t, resp).Code)
+	})
+}
+
+func TestSoulPrivateMintConversationResolveBoundAgentFailures(t *testing.T) {
+	ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/souls/bound/me/mint-conversations", nil, nil, nil)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name       string
+		handler    *Handler
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "service nil",
+			handler:    &Handler{logger: round10TestLogger(t)},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:       "trust not configured",
+			handler:    &Handler{logger: round10TestLogger(t), soulsService: &stubSoulHandlerService{resolveBoundErr: soulservice.ErrTrustNotConfigured}},
+			wantStatus: http.StatusUnprocessableEntity,
+			wantCode:   "SOUL_PRIVATE_TRUST_NOT_CONFIGURED",
+		},
+		{
+			name:       "soul not available",
+			handler:    &Handler{logger: round10TestLogger(t), soulsService: &stubSoulHandlerService{resolveBoundErr: soulservice.ErrSoulNotAvailable}},
+			wantStatus: http.StatusNotFound,
+			wantCode:   "SOUL_BOUND_AGENT_NOT_AVAILABLE",
+		},
+		{
+			name:       "unexpected service error",
+			handler:    &Handler{logger: round10TestLogger(t), soulsService: &stubSoulHandlerService{resolveBoundErr: errors.New("boom")}},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:       "not bound",
+			handler:    &Handler{logger: round10TestLogger(t), soulsService: &stubSoulHandlerService{resolveBoundOut: &soulservice.Soul{AgentID: "", Bound: false}}},
+			wantStatus: http.StatusNotFound,
+			wantCode:   "SOUL_BOUND_AGENT_NOT_FOUND",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, resp := tc.handler.resolveSoulPrivateBoundAgent(ctx, "ops")
+			require.NotNil(t, resp)
+			require.Equal(t, tc.wantStatus, resp.Status)
+			if tc.wantCode != "" {
+				require.Equal(t, tc.wantCode, decodeStandardErrorResponse(t, resp).Code)
+			}
+		})
+	}
+}
+
+func TestSoulPrivateHostReadConfigurationFailures(t *testing.T) {
+	ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/souls/bound/me/mint-conversations", nil, nil, nil)
+	require.NoError(t, err)
+
+	t.Run("missing base url", func(t *testing.T) {
+		cfg := round10TestConfig()
+		cfg.LesserHostURL = ""
+		cfg.LesserHostInstanceKey = "instance-key-raw"
+		h := &Handler{cfg: cfg, logger: round10TestLogger(t)}
+
+		_, resp := h.getSoulPrivateHostRead(ctx, "agent", "", nil, 1024)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusUnprocessableEntity, resp.Status)
+		require.Equal(t, "SOUL_PRIVATE_TRUST_NOT_CONFIGURED", decodeStandardErrorResponse(t, resp).Code)
+	})
+
+	t.Run("invalid base url", func(t *testing.T) {
+		cfg := round10TestConfig()
+		cfg.LesserHostURL = "://bad"
+		cfg.LesserHostInstanceKey = "instance-key-raw"
+		h := &Handler{cfg: cfg, logger: round10TestLogger(t)}
+
+		_, resp := h.getSoulPrivateHostRead(ctx, "agent", "", nil, 1024)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusUnprocessableEntity, resp.Status)
+		require.Equal(t, "SOUL_PRIVATE_TRUST_NOT_CONFIGURED", decodeStandardErrorResponse(t, resp).Code)
+	})
+
+	t.Run("missing instance key", func(t *testing.T) {
+		cfg := round10TestConfig()
+		cfg.LesserHostURL = "https://lesser-host.example"
+		cfg.LesserHostInstanceKey = ""
+		h := &Handler{cfg: cfg, logger: round10TestLogger(t)}
+
+		_, resp := h.getSoulPrivateHostRead(ctx, "agent", "", nil, 1024)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusUnprocessableEntity, resp.Status)
+		require.Equal(t, "SOUL_PRIVATE_TRUST_NOT_CONFIGURED", decodeStandardErrorResponse(t, resp).Code)
+	})
+
+	t.Run("proxy url validation rejected", func(t *testing.T) {
+		prevValidate := validateLesserHostProxyURL
+		validateLesserHostProxyURL = func(*url.URL) error { return errors.New("blocked") }
+		t.Cleanup(func() { validateLesserHostProxyURL = prevValidate })
+
+		cfg := round10TestConfig()
+		cfg.LesserHostURL = "https://lesser-host.example"
+		cfg.LesserHostInstanceKey = "instance-key-raw"
+		h := &Handler{cfg: cfg, logger: round10TestLogger(t)}
+
+		_, resp := h.getSoulPrivateHostRead(ctx, "agent", "", nil, 1024)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusServiceUnavailable, resp.Status)
+		require.Equal(t, "SOUL_PRIVATE_HOST_UNAVAILABLE", decodeStandardErrorResponse(t, resp).Code)
+	})
+
+	t.Run("client error", func(t *testing.T) {
+		prevValidate := validateLesserHostProxyURL
+		prevClient := newLesserHostProxyClient
+		validateLesserHostProxyURL = func(*url.URL) error { return nil }
+		newLesserHostProxyClient = func() lesserHostProxyHTTPClient {
+			return soulPrivateHostReadClientFunc(func(*http.Request) (*http.Response, error) {
+				return nil, errors.New("dial failed")
+			})
+		}
+		t.Cleanup(func() {
+			validateLesserHostProxyURL = prevValidate
+			newLesserHostProxyClient = prevClient
+		})
+
+		cfg := round10TestConfig()
+		cfg.LesserHostURL = "https://lesser-host.example"
+		cfg.LesserHostInstanceKey = "instance-key-raw"
+		h := &Handler{cfg: cfg, logger: round10TestLogger(t)}
+
+		_, resp := h.getSoulPrivateHostRead(ctx, "agent", "", nil, 1024)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusServiceUnavailable, resp.Status)
+		require.Equal(t, "SOUL_PRIVATE_HOST_UNAVAILABLE", decodeStandardErrorResponse(t, resp).Code)
+	})
+
+	t.Run("response read error", func(t *testing.T) {
+		prevValidate := validateLesserHostProxyURL
+		prevClient := newLesserHostProxyClient
+		validateLesserHostProxyURL = func(*url.URL) error { return nil }
+		newLesserHostProxyClient = func() lesserHostProxyHTTPClient {
+			return soulPrivateHostReadClientFunc(func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{},
+					Body:       soulPrivateFailingBody{},
+				}, nil
+			})
+		}
+		t.Cleanup(func() {
+			validateLesserHostProxyURL = prevValidate
+			newLesserHostProxyClient = prevClient
+		})
+
+		cfg := round10TestConfig()
+		cfg.LesserHostURL = "https://lesser-host.example"
+		cfg.LesserHostInstanceKey = "instance-key-raw"
+		h := &Handler{cfg: cfg, logger: round10TestLogger(t)}
+
+		_, resp := h.getSoulPrivateHostRead(ctx, "agent", "", nil, 1024)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusServiceUnavailable, resp.Status)
+		require.Equal(t, "SOUL_PRIVATE_HOST_UNAVAILABLE", decodeStandardErrorResponse(t, resp).Code)
+	})
+
+	t.Run("success direct helper preserves status and body", func(t *testing.T) {
+		prevValidate := validateLesserHostProxyURL
+		prevClient := newLesserHostProxyClient
+		validateLesserHostProxyURL = func(*url.URL) error { return nil }
+		newLesserHostProxyClient = func() lesserHostProxyHTTPClient {
+			return soulPrivateHostReadClientFunc(func(req *http.Request) (*http.Response, error) {
+				require.Equal(t, "Bearer instance-key-raw", req.Header.Get("Authorization"))
+				require.Contains(t, req.URL.Path, "/mint-conversations/conv-direct")
+				return &http.Response{
+					StatusCode: http.StatusAccepted,
+					Header:     http.Header{"X-Test": []string{"ok"}},
+					Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+				}, nil
+			})
+		}
+		t.Cleanup(func() {
+			validateLesserHostProxyURL = prevValidate
+			newLesserHostProxyClient = prevClient
+		})
+
+		cfg := round10TestConfig()
+		cfg.LesserHostURL = "https://lesser-host.example"
+		cfg.LesserHostInstanceKey = "instance-key-raw"
+		h := &Handler{cfg: cfg, logger: round10TestLogger(t)}
+
+		result, resp := h.getSoulPrivateHostRead(ctx, "agent", "conv-direct", nil, 1024)
+		require.Nil(t, resp)
+		require.Equal(t, http.StatusAccepted, result.status)
+		require.Equal(t, []byte(`{"ok":true}`), result.body)
+		require.Equal(t, "ok", result.headers.Get("x-test"))
+	})
+}
+
+func TestSoulPrivateMintConversationUtilityBranches(t *testing.T) {
+	require.Empty(t, firstQueryValue(nil, "limit"))
+	require.False(t, soulPrivateCursorPresent(nil))
+	require.Empty(t, soulPrivateHash(""))
+	require.Empty(t, soulPrivateErrorCode(nil))
+	require.Empty(t, soulPrivateErrorCode(&apptheory.Response{Body: []byte(`not-json`)}))
+	require.Equal(t, "list_mint_conversations", soulPrivateRouteClass(""))
+	require.Equal(t, "get_mint_conversation", soulPrivateRouteClass("conv-1"))
+
+	ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/souls/bound/me/mint-conversations/", nil, nil, nil)
+	require.NoError(t, err)
+	conversationID, resp := validateSoulPrivateConversationID(ctx)
+	require.Empty(t, conversationID)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusBadRequest, resp.Status)
+	require.Equal(t, "SOUL_PRIVATE_CONVERSATION_ID_REQUIRED", decodeStandardErrorResponse(t, resp).Code)
+
+	var nilHandler *Handler
+	nilHandler.logSoulPrivateRead(ctx, "ops", "agent", "conv-1", "get_mint_conversation", "success", http.StatusOK, 0, 0, false, "", http.StatusOK, time.Now())
+	(&Handler{}).logSoulPrivateRead(ctx, "ops", "agent", "conv-1", "get_mint_conversation", "success", http.StatusOK, 0, 0, false, "", http.StatusOK, time.Now())
 }
 
 func TestHandleIncorporateSoulLift_MapsServiceResponses(t *testing.T) {

--- a/cmd/api/models/souls.go
+++ b/cmd/api/models/souls.go
@@ -76,6 +76,46 @@ type BoundSoulResponse struct {
 	Binding      SoulAgentBinding  `json:"binding"`
 }
 
+// SoulMintConversationSummary represents compact mint-conversation metadata for self-scoped private reads.
+type SoulMintConversationSummary struct {
+	AgentID        string         `json:"agent_id"`
+	ConversationID string         `json:"conversation_id"`
+	Model          string         `json:"model,omitempty"`
+	Status         string         `json:"status"`
+	Usage          map[string]any `json:"usage,omitempty"`
+	ChargedCredits *int64         `json:"charged_credits,omitempty"`
+	CreatedAt      string         `json:"created_at"`
+	CompletedAt    string         `json:"completed_at,omitempty"`
+}
+
+// SoulMintConversationsResponse represents GET /api/v1/souls/bound/me/mint-conversations.
+type SoulMintConversationsResponse struct {
+	Version       string                        `json:"version"`
+	Conversations []SoulMintConversationSummary `json:"conversations"`
+	Count         int                           `json:"count"`
+	Limit         int                           `json:"limit"`
+}
+
+// SoulMintConversation represents a bounded private mint-conversation record.
+type SoulMintConversation struct {
+	AgentID              string         `json:"agent_id"`
+	ConversationID       string         `json:"conversation_id"`
+	Model                string         `json:"model"`
+	Messages             string         `json:"messages,omitempty"`
+	ProducedDeclarations string         `json:"produced_declarations,omitempty"`
+	Status               string         `json:"status"`
+	Usage                map[string]any `json:"usage,omitempty"`
+	ChargedCredits       *int64         `json:"charged_credits,omitempty"`
+	CreatedAt            string         `json:"created_at"`
+	CompletedAt          string         `json:"completed_at,omitempty"`
+}
+
+// SoulMintConversationResponse represents GET /api/v1/souls/bound/me/mint-conversations/{conversationId}.
+type SoulMintConversationResponse struct {
+	Version      string               `json:"version"`
+	Conversation SoulMintConversation `json:"conversation"`
+}
+
 // SoulIncorporateRequest represents POST /api/v1/souls/{agentId}/incorporate.
 type SoulIncorporateRequest struct {
 	TargetAgentUsername string `json:"target_agent_username"`

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -381,6 +381,8 @@ func configureRoutes(app *apptheory.App) {
 
 	// Souls
 	app.Get("/api/v1/souls/bound/me", apiHandler.HandleGetBoundSoulMeLift, requireReadOrWrite)
+	app.Get("/api/v1/souls/bound/me/mint-conversations", apiHandler.HandleListBoundSoulMintConversationsLift, requireRead)
+	app.Get("/api/v1/souls/bound/me/mint-conversations/{conversationId}", apiHandler.HandleGetBoundSoulMintConversationLift, requireRead)
 	app.Get("/api/v1/souls/mine", apiHandler.HandleGetMySoulsLift, requireReadOrWrite)
 	app.Post("/api/v1/souls/{agentId}/incorporate", apiHandler.HandleIncorporateSoulLift, requireWrite)
 

--- a/cmd/api/testdata/routes_manifest.txt
+++ b/cmd/api/testdata/routes_manifest.txt
@@ -102,6 +102,8 @@ GET /api/v1/scheduled_statuses
 GET /api/v1/scheduled_statuses/{id}
 GET /api/v1/search/statuses
 GET /api/v1/souls/bound/me
+GET /api/v1/souls/bound/me/mint-conversations
+GET /api/v1/souls/bound/me/mint-conversations/{conversationId}
 GET /api/v1/souls/mine
 GET /api/v1/statuses/{id}
 GET /api/v1/statuses/{id}/context

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -5493,6 +5493,126 @@ components:
                 - available_for_incorporation
                 - binding_state
             type: object
+        SoulMintConversation:
+            additionalProperties: false
+            properties:
+                agent_id:
+                    pattern: ^0x[0-9a-fA-F]{64}$
+                    type: string
+                charged_credits:
+                    anyOf:
+                        - type: integer
+                        - type: "null"
+                    minimum: 0
+                completed_at:
+                    format: date-time
+                    type: string
+                conversation_id:
+                    maxLength: 128
+                    minLength: 1
+                    pattern: ^[A-Za-z0-9._:-]{1,128}$
+                    type: string
+                created_at:
+                    format: date-time
+                    type: string
+                messages:
+                    type: string
+                model:
+                    type: string
+                produced_declarations:
+                    type: string
+                status:
+                    enum:
+                        - in_progress
+                        - completed
+                        - failed
+                    type: string
+                usage:
+                    additionalProperties: {}
+                    type: object
+            required:
+                - agent_id
+                - conversation_id
+                - created_at
+                - model
+                - status
+            type: object
+        SoulMintConversationResponse:
+            additionalProperties: false
+            properties:
+                conversation:
+                    $ref: '#/components/schemas/SoulMintConversation'
+                version:
+                    enum:
+                        - "1"
+                    type: string
+            required:
+                - conversation
+                - version
+            type: object
+        SoulMintConversationSummary:
+            additionalProperties: false
+            properties:
+                agent_id:
+                    pattern: ^0x[0-9a-fA-F]{64}$
+                    type: string
+                charged_credits:
+                    anyOf:
+                        - type: integer
+                        - type: "null"
+                    minimum: 0
+                completed_at:
+                    format: date-time
+                    type: string
+                conversation_id:
+                    maxLength: 128
+                    minLength: 1
+                    pattern: ^[A-Za-z0-9._:-]{1,128}$
+                    type: string
+                created_at:
+                    format: date-time
+                    type: string
+                model:
+                    type: string
+                status:
+                    enum:
+                        - in_progress
+                        - completed
+                        - failed
+                    type: string
+                usage:
+                    additionalProperties: {}
+                    type: object
+            required:
+                - agent_id
+                - conversation_id
+                - created_at
+                - status
+            type: object
+        SoulMintConversationsResponse:
+            additionalProperties: false
+            properties:
+                conversations:
+                    items:
+                        $ref: '#/components/schemas/SoulMintConversationSummary'
+                    type: array
+                count:
+                    minimum: 0
+                    type: integer
+                limit:
+                    maximum: 50
+                    minimum: 1
+                    type: integer
+                version:
+                    enum:
+                        - "1"
+                    type: string
+            required:
+                - conversations
+                - count
+                - limit
+                - version
+            type: object
         SoulsMineResponse:
             additionalProperties: false
             properties:
@@ -15340,6 +15460,115 @@ paths:
             x-oauth-scopes:
                 - read
                 - write
+    /api/v1/souls/bound/me/mint-conversations:
+        get:
+            operationId: get_api_v1_souls_bound_me_mint_conversations
+            description: Return compact private mint-conversation metadata for the authenticated local principal's bound soul. Lesser derives the Host agent ID from the existing bound-self authority and calls lesser-host with instance trust only; caller bearer tokens are never forwarded upstream.
+            tags:
+                - souls
+            security:
+                - bearerAuth: []
+            parameters:
+                - name: limit
+                  in: query
+                  description: Maximum compact conversations to return. Defaults to 20 and is capped at 50.
+                  schema:
+                    type: integer
+                    default: 20
+                    minimum: 1
+                    maximum: 50
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/SoulMintConversationsResponse'
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "401":
+                    $ref: '#/components/responses/Unauthorized'
+                "403":
+                    $ref: '#/components/responses/Forbidden'
+                "404":
+                    $ref: '#/components/responses/NotFound'
+                "409":
+                    $ref: '#/components/responses/Conflict'
+                "413":
+                    description: Private conversation response too large
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "422":
+                    $ref: '#/components/responses/UnprocessableEntity'
+                "429":
+                    $ref: '#/components/responses/TooManyRequests'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+                "503":
+                    $ref: '#/components/responses/ServiceUnavailable'
+            x-lesser-handler: HandleListBoundSoulMintConversationsLift
+            x-lesser-lambda: api
+            x-lesser-routeSources:
+                - cmd/api/routes.go
+            x-oauth-scopes:
+                - read
+    /api/v1/souls/bound/me/mint-conversations/{conversationId}:
+        get:
+            operationId: get_api_v1_souls_bound_me_mint_conversations_by_conversationId
+            description: Return one bounded private mint-conversation record for the authenticated local principal's bound soul. Lesser validates the opaque conversation ID, derives the Host agent ID from bound self, and calls lesser-host with instance trust only.
+            tags:
+                - souls
+            security:
+                - bearerAuth: []
+            parameters:
+                - name: conversationId
+                  in: path
+                  required: true
+                  description: Opaque safe mint-conversation identifier.
+                  schema:
+                    type: string
+                    pattern: ^[A-Za-z0-9._:-]{1,128}$
+                    minLength: 1
+                    maxLength: 128
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/SoulMintConversationResponse'
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "401":
+                    $ref: '#/components/responses/Unauthorized'
+                "403":
+                    $ref: '#/components/responses/Forbidden'
+                "404":
+                    $ref: '#/components/responses/NotFound'
+                "409":
+                    $ref: '#/components/responses/Conflict'
+                "413":
+                    description: Private conversation response too large
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "422":
+                    $ref: '#/components/responses/UnprocessableEntity'
+                "429":
+                    $ref: '#/components/responses/TooManyRequests'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+                "503":
+                    $ref: '#/components/responses/ServiceUnavailable'
+            x-lesser-handler: HandleGetBoundSoulMintConversationLift
+            x-lesser-lambda: api
+            x-lesser-routeSources:
+                - cmd/api/routes.go
+            x-oauth-scopes:
+                - read
     /api/v1/souls/mine:
         get:
             operationId: get_api_v1_souls_mine

--- a/docs/specs/graphql_coverage.yaml
+++ b/docs/specs/graphql_coverage.yaml
@@ -66,6 +66,8 @@ exemptions:
       match:
         exact:
             - /api/v1/souls/bound/me
+            - /api/v1/souls/bound/me/mint-conversations
+            - /api/v1/souls/bound/me/mint-conversations/{conversationId}
     - id: admin_agent_unlock
       reason: Agent operator unlock is currently exposed as a REST-only admin operation.
       match:
@@ -1168,6 +1170,14 @@ routes:
         - Query.search
     - method: GET
       path: /api/v1/souls/bound/me
+      policy: rest_only
+      exemptedBy: lesser_body_mcp
+    - method: GET
+      path: /api/v1/souls/bound/me/mint-conversations
+      policy: rest_only
+      exemptedBy: lesser_body_mcp
+    - method: GET
+      path: /api/v1/souls/bound/me/mint-conversations/{conversationId}
       policy: rest_only
       exemptedBy: lesser_body_mcp
     - method: GET

--- a/pkg/services/souls/service.go
+++ b/pkg/services/souls/service.go
@@ -246,6 +246,13 @@ func (s *Service) ResolveBoundAgent(ctx context.Context, agentUsername string) (
 	if err != nil {
 		return nil, err
 	}
+	bindingAgentID, err := validateAgentID(binding.AgentID)
+	if err != nil {
+		return nil, ErrSoulNotAvailable
+	}
+	if !strings.EqualFold(identity.AgentID, bindingAgentID) {
+		return nil, ErrSoulNotAvailable
+	}
 	if !domainMatches(identity.Domain, instanceDomain) || !identityIsActive(identity) {
 		return nil, ErrSoulNotAvailable
 	}

--- a/pkg/services/souls/service_test.go
+++ b/pkg/services/souls/service_test.go
@@ -1401,6 +1401,50 @@ func TestService_ResolveBoundAgent_FailsClosedForUnavailableHostIdentity(t *test
 	}
 }
 
+func TestService_ResolveBoundAgent_FailsClosedWhenHostIdentityAgentIDMismatchesBinding(t *testing.T) {
+	t.Parallel()
+
+	const (
+		agentAlpha = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		agentBeta  = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	)
+
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/soul/agents/"+agentAlpha, r.URL.Path)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"version": "1",
+			"agent": map[string]any{
+				"agent_id":         agentBeta,
+				"domain":           "example.com",
+				"local_id":         "beta",
+				"wallet":           "0x1111111111111111111111111111111111111111",
+				"status":           "active",
+				"lifecycle_status": "active",
+			},
+		}))
+	}))
+	defer host.Close()
+
+	service := NewService(
+		nil,
+		&fakeInstanceRepo{
+			trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL},
+			bindingsByUser: map[string]*storageModels.InstanceSoulBodyBinding{
+				"agent-alpha": {
+					AgentID:  agentAlpha,
+					Username: "agent-alpha",
+				},
+			},
+		},
+		&config.Config{Domain: "example.com"},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	soul, err := service.ResolveBoundAgent(context.Background(), "agent-alpha")
+	require.ErrorIs(t, err, ErrSoulNotAvailable)
+	require.Nil(t, soul)
+}
+
 func TestService_ResolveBoundAgent_FailsClosedWhenHostIdentityMissing(t *testing.T) {
 	t.Parallel()
 

--- a/tools/openapi/main.go
+++ b/tools/openapi/main.go
@@ -114,6 +114,12 @@ type schemaRef struct {
 	Type                 string               `yaml:"type,omitempty"`
 	Format               string               `yaml:"format,omitempty"`
 	Ref                  string               `yaml:"$ref,omitempty"`
+	Pattern              string               `yaml:"pattern,omitempty"`
+	Default              any                  `yaml:"default,omitempty"`
+	Minimum              *int                 `yaml:"minimum,omitempty"`
+	Maximum              *int                 `yaml:"maximum,omitempty"`
+	MinLength            *int                 `yaml:"minLength,omitempty"`
+	MaxLength            *int                 `yaml:"maxLength,omitempty"`
 	Properties           map[string]schemaRef `yaml:"properties,omitempty"`
 	Required             []string             `yaml:"required,omitempty"`
 	AdditionalProperties any                  `yaml:"additionalProperties,omitempty"`

--- a/tools/openapi/operation_overrides.go
+++ b/tools/openapi/operation_overrides.go
@@ -21,16 +21,80 @@ func applySoulOverrides(op *operation, route routeDef) {
 		return
 	}
 
-	if route.Method != methodGET || route.Path != "/api/v1/souls/bound/me" {
+	if route.Method != methodGET {
 		return
 	}
 
+	switch route.Path {
+	case "/api/v1/souls/bound/me":
+		applyBoundSoulMeOverride(op)
+	case "/api/v1/souls/bound/me/mint-conversations":
+		applyBoundSoulMintConversationsOverride(op)
+	case "/api/v1/souls/bound/me/mint-conversations/{conversationId}":
+		applyBoundSoulMintConversationOverride(op)
+	}
+}
+
+func applyBoundSoulMeOverride(op *operation) {
 	op.Description = "Return the active soul identity bound to the authenticated local runtime-agent principal. The endpoint is fail-closed: unbound, inactive, missing host identity, or wrong-domain identities return 404."
 	if op.Responses == nil {
 		op.Responses = map[string]response{}
 	}
 	ensureResponseRef(op.Responses, "404", "NotFound")
 	ensureResponseRef(op.Responses, "422", "UnprocessableEntity")
+}
+
+func applyBoundSoulMintConversationsOverride(op *operation) {
+	op.Description = "Return compact private mint-conversation metadata for the authenticated local principal's bound soul. Lesser derives the Host agent ID from the existing bound-self authority and calls lesser-host with instance trust only; caller bearer tokens are never forwarded upstream."
+	ensureQueryParam(op, parameter{
+		Name:        "limit",
+		In:          "query",
+		Required:    false,
+		Description: "Maximum compact conversations to return. Defaults to 20 and is capped at 50.",
+		Schema: schemaRef{
+			Type:    "integer",
+			Default: 20,
+			Minimum: intPtr(1),
+			Maximum: intPtr(50),
+		},
+	})
+	ensureSoulMintConversationErrorResponses(op)
+}
+
+func applyBoundSoulMintConversationOverride(op *operation) {
+	op.Description = "Return one bounded private mint-conversation record for the authenticated local principal's bound soul. Lesser validates the opaque conversation ID, derives the Host agent ID from bound self, and calls lesser-host with instance trust only."
+	ensureQueryParam(op, parameter{
+		Name:        "conversationId",
+		In:          "path",
+		Required:    true,
+		Description: "Opaque safe mint-conversation identifier.",
+		Schema: schemaRef{
+			Type:      "string",
+			Pattern:   "^[A-Za-z0-9._:-]{1,128}$",
+			MinLength: intPtr(1),
+			MaxLength: intPtr(128),
+		},
+	})
+	ensureSoulMintConversationErrorResponses(op)
+}
+
+func ensureSoulMintConversationErrorResponses(op *operation) {
+	if op.Responses == nil {
+		op.Responses = map[string]response{}
+	}
+	ensureResponseRef(op.Responses, "404", "NotFound")
+	ensureResponseRef(op.Responses, "409", "Conflict")
+	ensureResponseRef(op.Responses, "422", "UnprocessableEntity")
+	ensureResponseRef(op.Responses, "429", "TooManyRequests")
+	ensureResponseRef(op.Responses, "503", "ServiceUnavailable")
+	if _, ok := op.Responses["413"]; !ok {
+		op.Responses["413"] = response{
+			Description: "Private conversation response too large",
+			Content: map[string]mediaType{
+				"application/json": {Schema: schemaRef{Ref: "#/components/schemas/Error"}},
+			},
+		}
+	}
 }
 
 func applyGraphQLOverrides(op *operation, route routeDef) {
@@ -504,4 +568,8 @@ func ensureJSONResponseSchema(op *operation, statusCode, schemaName string) {
 	mt.Schema = schemaRef{Ref: "#/components/schemas/" + schemaName}
 	resp.Content["application/json"] = mt
 	op.Responses[statusCode] = resp
+}
+
+func intPtr(value int) *int {
+	return &value
 }

--- a/tools/openapi/schema_overrides.go
+++ b/tools/openapi/schema_overrides.go
@@ -8,6 +8,7 @@ func applySchemaOverrides(spec *openAPISpec) {
 	overrideCreateStatusRequest(spec.Components.Schemas)
 	overrideOAuthClientSchemas(spec.Components.Schemas)
 	overrideCommunityNoteSchemas(spec.Components.Schemas)
+	overrideSoulMintConversationSchemas(spec.Components.Schemas)
 }
 
 func overrideCreateStatusRequest(schemas map[string]any) {
@@ -70,6 +71,45 @@ func overrideCommunityNoteSchemas(schemas map[string]any) {
 	})
 	mutateSchemaProperty(schemas, "VoteCommunityNoteRequest", "reason", func(property map[string]any) {
 		property["maxLength"] = 200
+	})
+}
+
+func overrideSoulMintConversationSchemas(schemas map[string]any) {
+	for _, schemaName := range []string{"SoulMintConversation", "SoulMintConversationSummary"} {
+		mutateSchemaProperty(schemas, schemaName, "agent_id", func(property map[string]any) {
+			property["pattern"] = "^0x[0-9a-fA-F]{64}$"
+		})
+		mutateSchemaProperty(schemas, schemaName, "conversation_id", func(property map[string]any) {
+			property["minLength"] = 1
+			property["maxLength"] = 128
+			property["pattern"] = "^[A-Za-z0-9._:-]{1,128}$"
+		})
+		mutateSchemaProperty(schemas, schemaName, "status", func(property map[string]any) {
+			property["enum"] = []string{"in_progress", "completed", "failed"}
+		})
+		mutateSchemaProperty(schemas, schemaName, "charged_credits", func(property map[string]any) {
+			property["minimum"] = 0
+		})
+		mutateSchemaProperty(schemas, schemaName, "created_at", func(property map[string]any) {
+			property["format"] = "date-time"
+		})
+		mutateSchemaProperty(schemas, schemaName, "completed_at", func(property map[string]any) {
+			property["format"] = "date-time"
+		})
+	}
+
+	mutateSchemaProperty(schemas, "SoulMintConversationsResponse", "version", func(property map[string]any) {
+		property["enum"] = []string{"1"}
+	})
+	mutateSchemaProperty(schemas, "SoulMintConversationsResponse", "count", func(property map[string]any) {
+		property["minimum"] = 0
+	})
+	mutateSchemaProperty(schemas, "SoulMintConversationsResponse", "limit", func(property map[string]any) {
+		property["minimum"] = 1
+		property["maximum"] = 50
+	})
+	mutateSchemaProperty(schemas, "SoulMintConversationResponse", "version", func(property map[string]any) {
+		property["enum"] = []string{"1"}
 	})
 }
 


### PR DESCRIPTION
## Summary

Implements the advisor-authorized Project 21 M2 / lesser#697 self-scoped private mint-conversation proxy:

- Adds `GET /api/v1/souls/bound/me/mint-conversations` and `GET /api/v1/souls/bound/me/mint-conversations/{conversationId}`.
- Derives the upstream Host `agentId` only from the authenticated local principal's bound soul (`ResolveBoundAgent`); no caller-supplied agent ID is accepted.
- Calls lesser-host instance-key routes with server-side instance trust only; caller bearer tokens are never forwarded upstream.
- Validates `limit` (default 20, max 50), rejects cursor/unsupported query/body inputs, validates `conversationId` as a safe opaque path value, caps upstream response size, and fail-closes on Host scope mismatches.
- Updates REST/OpenAPI and GraphQL coverage contracts for the additive REST-only private self-scope endpoints.

## Stewardship notes

- Federation trust: no ActivityPub actor/inbox/outbox/signature behavior changed.
- Mastodon/API contract: additive Lesser-exclusive `/api/v1` endpoints only; `docs/contracts/openapi.yaml` regenerated.
- Schema: no DynamoDB PK/SK/GSI/TableTheory tag changes.
- Cross-repo: Body private read integration remains dependent on consuming these Lesser routes after deploy/probe; no sibling repo edits made.

## Validation

- `gofmt -l .`
- `go test ./...`
- `go vet ./...`
- `./lesser verify openapi --strict`
- `go run ./tools/graphql_coverage --check --strict`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`

Closes #697.