### PR TITLE
feat(skills): add canonical skill authority foundation

### DIFF
--- a/docs/architecture/dynamodb/gsi_usage_guide.md
+++ b/docs/architecture/dynamodb/gsi_usage_guide.md
@@ -62,6 +62,21 @@ This model uses GSIs to track media transcoding jobs.
     -   **gsi1PK:** `USER_TRANSCODING#{userID}`
     -   **gsi2PK:** `MEDIA_TRANSCODING#{mediaID}`
 
+### d. Skill authority models (`pkg/storage/models/skill.go`)
+
+These models use sparse GSI keys to support later approval, catalog, digest, and assignment queries without adding a new physical index.
+
+-   **GSI1: Lifecycle and parent-scoped listings**
+    -   `Skill`: `SKILL#STATUS#{status}` / `UPDATED#{time}#SKILL#{skillID}`
+    -   `SkillRevision`: `SKILL_REVISION#STATUS#{status}` / `UPDATED#{time}#SKILL#{skillID}#REVISION#{n}`
+    -   `SkillProposal`: `SKILL#{skillID}#PROPOSAL` / `STATUS#{status}#CREATED#{time}#PROPOSAL#{proposalID}`
+    -   `SkillAssignment`: `SKILL#{skillID}#ASSIGNMENT` / `SUBJECT#{type}#{id}#ASSIGNMENT#{assignmentID}`
+-   **GSI2: Exposure, digest, and review queues**
+    -   `Skill`: `SKILL#EXPOSURE#{exposure}` / `NAME#{slug}#SKILL#{skillID}`
+    -   `SkillRevision`: `SKILL_REVISION_DIGEST#{manifestDigest}` / `SKILL#{skillID}#REVISION#{n}`
+    -   `SkillProposal`: `SKILL_PROPOSAL#STATUS#{status}` / `CREATED#{time}#SKILL#{skillID}#PROPOSAL#{proposalID}`
+    -   `SkillAssignment`: `SKILL_ASSIGNMENT#STATUS#{status}` / `UPDATED#{time}#SUBJECT#{type}#{id}#SKILL#{skillID}`
+
 **Note on Naming Consistency:** Some models and repositories use descriptive index names (e.g., `index:user-jobs-index`). DynamoDB does **not** provide index aliases, so these names must match a real DynamoDB `IndexName` on the table to work. For clarity and correctness, standardize on one physical naming scheme end-to-end (CDK ↔ DynamoDB ↔ model tags ↔ `.Index(...)` calls).
 
 ## 3. Guide to Adding a New Query Pattern

--- a/docs/architecture/skills/canonical-skill-authority.md
+++ b/docs/architecture/skills/canonical-skill-authority.md
@@ -1,0 +1,145 @@
+# Canonical skill authority foundation
+
+Status: Project 21 M3 foundation (#698/#699), model layer only.
+
+## Purpose
+
+M3 establishes **Lesser as the canonical skill authority**. Repo-backed `SKILL.md`
+files and lesser-host mint conversations may be used as source material or
+provenance, but neither is the system of record. The canonical authority lives in
+Lesser's single DynamoDB table and later milestones expose approval, exposure,
+effective-resolution, and publication APIs from that state.
+
+This slice intentionally stops at storage models, repository seams, and seed
+inventory. It does **not** implement approval/revoke/resolve APIs, conversation
+promotion, runtime bundle publication, or lesser-body catalog tooling.
+
+## Entity model
+
+| Entity | Role | Primary key |
+|---|---|---|
+| `Skill` | Canonical skill root metadata and current revision pointer. | `PK=SKILL#{skillID}`, `SK=SKILL` |
+| `SkillRevision` | Canonical revision content/manifest/provenance under a skill. | `PK=SKILL#{skillID}`, `SK=REVISION#{revisionNumber:08d}` |
+| `SkillProposal` | Non-authoritative source material proposed for canonicalization. | `PK=SKILL_PROPOSAL#{proposalID}`, `SK=PROPOSAL` |
+| `SkillAssignment` | Explicit subject boundary for future effective-skill resolution. | `PK=SKILL_ASSIGNMENT#{subjectType}#{subjectID}`, `SK=SKILL#{skillID}#ASSIGNMENT#{assignmentID}` |
+
+The model keeps revision and assignment boundaries separate:
+
+- A `Skill` names the canonical concept and points at a current revision when one exists.
+- A `SkillRevision` stores digestable revision material. It can reference a proposal,
+  principal approval, and provenance without making the proposal or source canonical.
+- A `SkillProposal` represents import/source material from local files, lesser-host
+  conversations, or manual drafting. It is never authoritative by itself.
+- A `SkillAssignment` binds a skill/revision to a subject (`instance`, `actor`, or
+  `principal`) with exposure and lifecycle state for later resolution APIs.
+
+## Exposure, approval, and provenance hooks
+
+The foundation records hooks for later milestones without implementing their APIs:
+
+- exposure: `public`, `instance`, `private`
+- revision/proposal/assignment status fields
+- `approvalID`, `principalID`, `principalApprovalID`
+- source fields for `local_file`, `host_conversation`, and `manual`
+- manifest/content/bundle digests and file-level digests
+- conversation IDs as provenance only; lesser-host remains non-canonical
+
+## Schema-integrity audit
+
+### Proposed change
+
+Add canonical skill authority records (`Skill`, `SkillRevision`, `SkillProposal`,
+`SkillAssignment`) to the existing single DynamoDB table using TableTheory model
+tags and existing generic GSI slots.
+
+### Entity types affected
+
+Only new skill authority entity types are added. Existing account, actor,
+federation, ActivityPub object, notification, conversation, and governance item
+shapes are unchanged.
+
+### PK impact
+
+- Existing PK formats: unchanged.
+- `USER#{username}` semantics: unchanged.
+- New non-user partitions:
+  - `SKILL#{skillID}`
+  - `SKILL_PROPOSAL#{proposalID}`
+  - `SKILL_ASSIGNMENT#{subjectType}#{subjectID}`
+
+### SK impact
+
+- New SK patterns:
+  - `SKILL`
+  - `REVISION#{revisionNumber:08d}`
+  - `PROPOSAL`
+  - `SKILL#{skillID}#ASSIGNMENT#{assignmentID}`
+- Existing SK patterns: unchanged.
+- Removed SK patterns: none.
+- Convention compliance: uppercase prefixes with `#` separators.
+
+### GSI impact
+
+No new physical GSI is added and no existing GSI is restructured. The models use
+sparse prefixes on existing `gsi1`/`gsi2`:
+
+| Model | GSI | Pattern | Purpose |
+|---|---|---|---|
+| `Skill` | `gsi1` | `SKILL#STATUS#{status}` / `UPDATED#{time}#SKILL#{skillID}` | later lifecycle/catalog listing |
+| `Skill` | `gsi2` | `SKILL#EXPOSURE#{exposure}` / `NAME#{slug}#SKILL#{skillID}` | later exposure-scoped catalog listing |
+| `SkillRevision` | `gsi1` | `SKILL_REVISION#STATUS#{status}` / `UPDATED#{time}#SKILL#{skillID}#REVISION#{n}` | later approval/revision queues |
+| `SkillRevision` | `gsi2` | `SKILL_REVISION_DIGEST#{digest}` / `SKILL#{skillID}#REVISION#{n}` | manifest digest de-duplication |
+| `SkillProposal` | `gsi1` | `SKILL#{skillID}#PROPOSAL` / `STATUS#{status}#CREATED#{time}#PROPOSAL#{proposalID}` | proposals for a skill |
+| `SkillProposal` | `gsi2` | `SKILL_PROPOSAL#STATUS#{status}` / `CREATED#{time}#SKILL#{skillID}#PROPOSAL#{proposalID}` | later review queues |
+| `SkillAssignment` | `gsi1` | `SKILL#{skillID}#ASSIGNMENT` / `SUBJECT#{type}#{id}#ASSIGNMENT#{assignmentID}` | assignment audit/revocation by skill |
+| `SkillAssignment` | `gsi2` | `SKILL_ASSIGNMENT#STATUS#{status}` / `UPDATED#{time}#SUBJECT#{type}#{id}#SKILL#{skillID}` | pending/revoked queues |
+
+Consumer impact is additive: no existing repository, Lambda, GraphQL resolver,
+Mastodon REST handler, or ActivityPub endpoint reads these prefixes today.
+
+### Attribute-semantics impact
+
+New attributes are additive and scoped to the new item types. They include IDs,
+status/exposure fields, manifest and bundle digest strings, file summaries,
+capability strings, provenance references, optional approval references, and
+created/updated timestamps. They do not contain credentials, actor signing keys,
+JWTs, private wallet keys, raw passwords, or private conversation bodies.
+
+Each mutable model includes `Version int` tagged as `theorydb:"version,attr:version"`
+for optimistic concurrency from day one.
+
+### DynamoDB Streams / async processors
+
+The stream shape is additive because new item types will appear as ordinary
+INSERT/MODIFY/REMOVE records. Current async processors do not consume skill item
+prefixes, and no processor update is required in this slice. Later approval,
+promotion, or bundle-publication processors must explicitly opt into these
+prefixes rather than relying on generic stream scans.
+
+TTL is not used for canonical skill authority records.
+
+### Consumer propagation
+
+- Mastodon REST: no impact.
+- GraphQL: no schema or resolver change in this slice.
+- ActivityPub: no actor/object/collection/inbox/outbox shape change.
+- `lesser-body`: later catalog/tooling work will consume approved Lesser skill
+  state, but this slice introduces no runtime MCP contract.
+- `lesser-host`: host conversation IDs may be recorded as provenance only; host
+  is not canonical.
+- Rollback: code rollback leaves additive skill rows inert. No migration of
+  existing rows is required.
+
+### TableTheory tag correctness
+
+The new models use `theorydb` tags for PK/SK, sparse GSI fields with `omitempty`,
+attribute names, and version fields. Model tests cover key construction,
+normalization, sparse digest indexing, and assignment boundaries.
+
+### Security / PII / credential implications
+
+The schema stores metadata, digests, provenance IDs, approval references, and
+conversation/message identifiers. It deliberately avoids storing private
+conversation content, secrets, signing material, OAuth/JWT bearer tokens, or raw
+credentials. Any later API exposing this state must apply the public/instance/private
+exposure policy and principal approval semantics defined by #700/#701.

--- a/docs/architecture/skills/seed-skill-inventory.md
+++ b/docs/architecture/skills/seed-skill-inventory.md
@@ -1,0 +1,109 @@
+# Repo-backed SKILL.md seed inventory
+
+Status: Project 21 M3 seed inventory (#699), generated from the Lesser repo on 2026-05-13.
+
+## Authority boundary
+
+This inventory is source material only. Local `SKILL.md` files are useful seeds for canonical `Skill`, `SkillRevision`, and `SkillProposal` records, but they are not the system of record. Canonical authority lives in Lesser after an explicit import/proposal/approval flow.
+
+## Summary
+
+- Files found: 26
+- Unique skill names: 14
+- Duplicate digest groups: 12 `.claude`/`.codex` pairs are byte-for-byte copies.
+- Unique repo-root-only skill: `skills/high-risk-domain-planning/SKILL.md`
+- Claude-only direct authorized email skill: `.claude/skills/check-authorized-email/SKILL.md`
+
+## Inventory
+
+| Path | Skill name | SHA-256 | Bytes | Seed role | Publishability gaps |
+|---|---|---|---:|---|---|
+| `.claude/skills/check-authorized-email/SKILL.md` | `check-authorized-email` | `a230c458652a30cbd84e157a4085076e5dc18dd3b6f0aea6d6a5526b22f2dac3` | 7693 | Claude-only local authorized-email seed; private review required | manifest, approval, exposure, capability policy, private routing |
+| `.claude/skills/coordinate-framework-feedback/SKILL.md` | `coordinate-framework-feedback` | `9b1b9fd9ebba18303bf4ddf5f4bb29de350ed58b07272e05b92569969983c548` | 10249 | duplicate Claude-runtime seed; retain as provenance only | manifest, approval, exposure, capabilities, bundle metadata |
+| `.claude/skills/create-github-project/SKILL.md` | `create-github-project` | `8912e838cd1731231d221202f68942d14af7dd77c26f203cb58a8bc6300a4a5c` | 9704 | duplicate Claude-runtime seed; retain as provenance only | manifest, approval, exposure, capabilities, bundle metadata |
+| `.claude/skills/deploy-instance/SKILL.md` | `deploy-instance` | `a8cba5eab37b24a63b4bd64df2b46c1f23e393c2eedec7a0b983e0a504ea6a40` | 13354 | duplicate Claude-runtime seed; retain as provenance only | manifest, approval, exposure, capabilities, bundle metadata |
+| `.claude/skills/enumerate-changes/SKILL.md` | `enumerate-changes` | `841b80fd7c38495936e54056041bb25206fa5c3e33fb672a0e089771c025ceb3` | 10825 | duplicate Claude-runtime seed; retain as provenance only | manifest, approval, exposure, capabilities, bundle metadata |
+| `.claude/skills/implement-milestone/SKILL.md` | `implement-milestone` | `641a273b7aa051e8971cb1873b2c7bf5d89f4acf935f8cf706dbaa2c3474661d` | 9761 | duplicate Claude-runtime seed; retain as provenance only | manifest, approval, exposure, capabilities, bundle metadata |
+| `.claude/skills/investigate-issue/SKILL.md` | `investigate-issue` | `227f8a4f590e58db97e39170ec9eede597f5f369aee1074cbce6ec38409b0205` | 9693 | duplicate Claude-runtime seed; retain as provenance only | manifest, approval, exposure, capabilities, bundle metadata |
+| `.claude/skills/plan-roadmap/SKILL.md` | `plan-roadmap` | `24de5037d629765a367d14b73605ca9329518da5227d4162c996bd85fc26b7cd` | 10730 | duplicate Claude-runtime seed; retain as provenance only | manifest, approval, exposure, capabilities, bundle metadata |
+| `.claude/skills/preserve-mastodon-api-compat/SKILL.md` | `preserve-mastodon-api-compat` | `b5081eb525243ab3d393ab0122dde6f6d87b97baebef9d40bf35726a516f6c46` | 13403 | duplicate Claude-runtime seed; retain as provenance only | manifest, approval, exposure, capabilities, bundle metadata |
+| `.claude/skills/protect-federation-trust/SKILL.md` | `protect-federation-trust` | `69ae488636fc4bd8d4ce587a1dbcc2a5c866dd01dde7924209f584fa7664f7db` | 13143 | duplicate Claude-runtime seed; retain as provenance only | manifest, approval, exposure, capabilities, bundle metadata |
+| `.claude/skills/review-advisor-brief/SKILL.md` | `review-advisor-brief` | `9be0b1877c959f1687d59b687e8449ce6c3692572328861d95d374cf33c750bf` | 9940 | duplicate Claude-runtime seed; retain as provenance only | manifest, approval, exposure, capabilities, bundle metadata |
+| `.claude/skills/scope-need/SKILL.md` | `scope-need` | `5264637e109a0b312354f0e07da8900137832eae87956aecc3b6c150a7411e46` | 11220 | duplicate Claude-runtime seed; retain as provenance only | manifest, approval, exposure, capabilities, bundle metadata |
+| `.claude/skills/validate-schema/SKILL.md` | `validate-schema` | `9a1399a0b863a32a31c4dc6bb2bfc3e55b4e62f4f02bd5ccef25ef87da688d25` | 14040 | duplicate Claude-runtime seed; retain as provenance only | manifest, approval, exposure, capabilities, bundle metadata |
+| `.codex/skills/coordinate-framework-feedback/SKILL.md` | `coordinate-framework-feedback` | `9b1b9fd9ebba18303bf4ddf5f4bb29de350ed58b07272e05b92569969983c548` | 10249 | preferred Codex-runtime seed; non-authoritative until imported | manifest, approval, exposure, capabilities, bundle metadata |
+| `.codex/skills/create-github-project/SKILL.md` | `create-github-project` | `8912e838cd1731231d221202f68942d14af7dd77c26f203cb58a8bc6300a4a5c` | 9704 | preferred Codex-runtime seed; non-authoritative until imported | manifest, approval, exposure, capabilities, bundle metadata |
+| `.codex/skills/deploy-instance/SKILL.md` | `deploy-instance` | `a8cba5eab37b24a63b4bd64df2b46c1f23e393c2eedec7a0b983e0a504ea6a40` | 13354 | preferred Codex-runtime seed; non-authoritative until imported | manifest, approval, exposure, capabilities, bundle metadata |
+| `.codex/skills/enumerate-changes/SKILL.md` | `enumerate-changes` | `841b80fd7c38495936e54056041bb25206fa5c3e33fb672a0e089771c025ceb3` | 10825 | preferred Codex-runtime seed; non-authoritative until imported | manifest, approval, exposure, capabilities, bundle metadata |
+| `.codex/skills/implement-milestone/SKILL.md` | `implement-milestone` | `641a273b7aa051e8971cb1873b2c7bf5d89f4acf935f8cf706dbaa2c3474661d` | 9761 | preferred Codex-runtime seed; non-authoritative until imported | manifest, approval, exposure, capabilities, bundle metadata |
+| `.codex/skills/investigate-issue/SKILL.md` | `investigate-issue` | `227f8a4f590e58db97e39170ec9eede597f5f369aee1074cbce6ec38409b0205` | 9693 | preferred Codex-runtime seed; non-authoritative until imported | manifest, approval, exposure, capabilities, bundle metadata |
+| `.codex/skills/plan-roadmap/SKILL.md` | `plan-roadmap` | `24de5037d629765a367d14b73605ca9329518da5227d4162c996bd85fc26b7cd` | 10730 | preferred Codex-runtime seed; non-authoritative until imported | manifest, approval, exposure, capabilities, bundle metadata |
+| `.codex/skills/preserve-mastodon-api-compat/SKILL.md` | `preserve-mastodon-api-compat` | `b5081eb525243ab3d393ab0122dde6f6d87b97baebef9d40bf35726a516f6c46` | 13403 | preferred Codex-runtime seed; non-authoritative until imported | manifest, approval, exposure, capabilities, bundle metadata |
+| `.codex/skills/protect-federation-trust/SKILL.md` | `protect-federation-trust` | `69ae488636fc4bd8d4ce587a1dbcc2a5c866dd01dde7924209f584fa7664f7db` | 13143 | preferred Codex-runtime seed; non-authoritative until imported | manifest, approval, exposure, capabilities, bundle metadata |
+| `.codex/skills/review-advisor-brief/SKILL.md` | `review-advisor-brief` | `9be0b1877c959f1687d59b687e8449ce6c3692572328861d95d374cf33c750bf` | 9940 | preferred Codex-runtime seed; non-authoritative until imported | manifest, approval, exposure, capabilities, bundle metadata |
+| `.codex/skills/scope-need/SKILL.md` | `scope-need` | `5264637e109a0b312354f0e07da8900137832eae87956aecc3b6c150a7411e46` | 11220 | preferred Codex-runtime seed; non-authoritative until imported | manifest, approval, exposure, capabilities, bundle metadata |
+| `.codex/skills/validate-schema/SKILL.md` | `validate-schema` | `9a1399a0b863a32a31c4dc6bb2bfc3e55b4e62f4f02bd5ccef25ef87da688d25` | 14040 | preferred Codex-runtime seed; non-authoritative until imported | manifest, approval, exposure, capabilities, bundle metadata |
+| `skills/high-risk-domain-planning/SKILL.md` | `high-risk-domain-planning` | `464a2a51aae6fa1e71b2bebc0395a8635f7cb28a6451ad6d76830d616b816068` | 2932 | repo-root shared seed; import-proposal candidate | manifest, approval, exposure, capabilities, bundle metadata |
+
+## Duplicate digest groups
+
+These files should de-duplicate by digest during any future import while preserving runtime/source provenance.
+
+- `9b1b9fd9ebba18303bf4ddf5f4bb29de350ed58b07272e05b92569969983c548`
+  - `.claude/skills/coordinate-framework-feedback/SKILL.md`
+  - `.codex/skills/coordinate-framework-feedback/SKILL.md`
+- `8912e838cd1731231d221202f68942d14af7dd77c26f203cb58a8bc6300a4a5c`
+  - `.claude/skills/create-github-project/SKILL.md`
+  - `.codex/skills/create-github-project/SKILL.md`
+- `a8cba5eab37b24a63b4bd64df2b46c1f23e393c2eedec7a0b983e0a504ea6a40`
+  - `.claude/skills/deploy-instance/SKILL.md`
+  - `.codex/skills/deploy-instance/SKILL.md`
+- `841b80fd7c38495936e54056041bb25206fa5c3e33fb672a0e089771c025ceb3`
+  - `.claude/skills/enumerate-changes/SKILL.md`
+  - `.codex/skills/enumerate-changes/SKILL.md`
+- `641a273b7aa051e8971cb1873b2c7bf5d89f4acf935f8cf706dbaa2c3474661d`
+  - `.claude/skills/implement-milestone/SKILL.md`
+  - `.codex/skills/implement-milestone/SKILL.md`
+- `227f8a4f590e58db97e39170ec9eede597f5f369aee1074cbce6ec38409b0205`
+  - `.claude/skills/investigate-issue/SKILL.md`
+  - `.codex/skills/investigate-issue/SKILL.md`
+- `24de5037d629765a367d14b73605ca9329518da5227d4162c996bd85fc26b7cd`
+  - `.claude/skills/plan-roadmap/SKILL.md`
+  - `.codex/skills/plan-roadmap/SKILL.md`
+- `b5081eb525243ab3d393ab0122dde6f6d87b97baebef9d40bf35726a516f6c46`
+  - `.claude/skills/preserve-mastodon-api-compat/SKILL.md`
+  - `.codex/skills/preserve-mastodon-api-compat/SKILL.md`
+- `69ae488636fc4bd8d4ce587a1dbcc2a5c866dd01dde7924209f584fa7664f7db`
+  - `.claude/skills/protect-federation-trust/SKILL.md`
+  - `.codex/skills/protect-federation-trust/SKILL.md`
+- `9be0b1877c959f1687d59b687e8449ce6c3692572328861d95d374cf33c750bf`
+  - `.claude/skills/review-advisor-brief/SKILL.md`
+  - `.codex/skills/review-advisor-brief/SKILL.md`
+- `5264637e109a0b312354f0e07da8900137832eae87956aecc3b6c150a7411e46`
+  - `.claude/skills/scope-need/SKILL.md`
+  - `.codex/skills/scope-need/SKILL.md`
+- `9a1399a0b863a32a31c4dc6bb2bfc3e55b4e62f4f02bd5ccef25ef87da688d25`
+  - `.claude/skills/validate-schema/SKILL.md`
+  - `.codex/skills/validate-schema/SKILL.md`
+
+## Publishability gaps
+
+The existing files are workspace instructions, not publishable canonical skill revisions. Import/promotion must account for these gaps:
+
+1. **No canonical manifest.** Front matter has `name` and `description`, but no stable skill ID, version, exposure policy, capabilities, file manifest, or bundle digest.
+2. **No approval metadata.** Files do not identify approving principal, approval digest/signature, review state, or revocation status.
+3. **Mixed runtime targeting.** `.claude` and `.codex` copies are duplicated for local agent runtimes; canonical revisions should de-duplicate by digest while preserving runtime compatibility metadata.
+4. **No public/private exposure policy.** Some skills are steward-internal and should not become public catalog entries by default.
+5. **No provenance chain.** The repo path and commit can be source provenance, but imports need canonical `SkillProposal` records and `SkillRevision` provenance refs.
+6. **No bundle shape.** Runtime publication later needs files, digests, install hints, compatibility targets, and AGPL/source provenance.
+
+## Model fields informed by inventory
+
+The inventory supports these fields in the M3 foundation model:
+
+- `Skill.slug`, `Skill.name`, `Skill.description`
+- `SkillRevision.manifestDigest`, `bundleDigest`, `contentDigest`, and `files[]`
+- `SkillRevision.capabilities` and `Skill.tags`
+- `SkillProposal.sourceType`, `sourceURI`, `sourceDigest`
+- `SkillProvenanceRef` for repo path / commit / digest provenance
+- `defaultExposure` / assignment `exposure` for public, instance, and private boundaries

--- a/pkg/storage/factory/factory.go
+++ b/pkg/storage/factory/factory.go
@@ -87,6 +87,7 @@ type RepositoryFactory struct {
 	mediaPopularityRepo     *repositories.MediaPopularityRepository
 	mediaSessionRepo        *repositories.MediaSessionRepository
 	streamingConnectionRepo *repositories.StreamingConnectionRepository
+	skillRepo               *repositories.SkillRepository
 
 	// CMS Repositories
 	articleRepo           *repositories.ArticleRepository
@@ -218,6 +219,7 @@ func (f *RepositoryFactory) initializeRepositories() {
 	f.mediaPopularityRepo = repositories.NewMediaPopularityRepository(f.db, f.tableName, f.logger, nil)
 	f.mediaSessionRepo = repositories.NewMediaSessionRepository(f.db, f.logger, nil)
 	f.streamingConnectionRepo = repositories.NewStreamingConnectionRepository(f.db, f.tableName, f.db, f.tableName, f.logger, nil)
+	f.skillRepo = repositories.NewSkillRepository(f.db, f.tableName, f.logger, nil)
 
 	// Initialize CMS repositories
 	f.articleRepo = repositories.NewArticleRepository(f.db, f.tableName, f.logger, nil)
@@ -592,6 +594,11 @@ func (f *RepositoryFactory) MediaSession() interfaces.MediaSessionRepository {
 // StreamingConnection returns the StreamingConnection repository instance
 func (f *RepositoryFactory) StreamingConnection() interfaces.StreamingConnectionRepository {
 	return f.streamingConnectionRepo
+}
+
+// Skill returns the Skill repository instance.
+func (f *RepositoryFactory) Skill() interfaces.SkillRepository {
+	return f.skillRepo
 }
 
 // CMS Repository Getters (interface types for mockability)

--- a/pkg/storage/interfaces/skill.go
+++ b/pkg/storage/interfaces/skill.go
@@ -1,0 +1,40 @@
+// Package interfaces defines the repository interfaces for the Lesser application.
+package interfaces //nolint:revive // Standard interfaces package name
+
+import (
+	"context"
+
+	"github.com/equaltoai/lesser/pkg/storage/models"
+)
+
+// SkillRepository defines canonical skill authority storage operations.
+// Local SKILL.md files and lesser-host conversations may feed proposals or provenance,
+// but these records are the Lesser-owned system of record.
+type SkillRepository interface {
+	// Skill root operations.
+	CreateSkill(ctx context.Context, skill *models.Skill) error
+	GetSkill(ctx context.Context, skillID string) (*models.Skill, error)
+	UpdateSkill(ctx context.Context, skill *models.Skill) error
+	ListSkillsByStatus(ctx context.Context, status string, limit int, cursor string) ([]*models.Skill, string, error)
+
+	// Revision operations.
+	CreateSkillRevision(ctx context.Context, revision *models.SkillRevision) error
+	GetSkillRevision(ctx context.Context, skillID string, revisionNumber int) (*models.SkillRevision, error)
+	UpdateSkillRevision(ctx context.Context, revision *models.SkillRevision) error
+	ListSkillRevisions(ctx context.Context, skillID string, limit int, cursor string) ([]*models.SkillRevision, string, error)
+	GetSkillRevisionByDigest(ctx context.Context, manifestDigest string) (*models.SkillRevision, error)
+
+	// Proposal operations.
+	CreateSkillProposal(ctx context.Context, proposal *models.SkillProposal) error
+	GetSkillProposal(ctx context.Context, proposalID string) (*models.SkillProposal, error)
+	UpdateSkillProposal(ctx context.Context, proposal *models.SkillProposal) error
+	ListSkillProposalsForSkill(ctx context.Context, skillID string, limit int, cursor string) ([]*models.SkillProposal, string, error)
+	ListSkillProposalsByStatus(ctx context.Context, status string, limit int, cursor string) ([]*models.SkillProposal, string, error)
+
+	// Assignment operations.
+	CreateSkillAssignment(ctx context.Context, assignment *models.SkillAssignment) error
+	GetSkillAssignment(ctx context.Context, subjectType, subjectID, skillID, assignmentID string) (*models.SkillAssignment, error)
+	UpdateSkillAssignment(ctx context.Context, assignment *models.SkillAssignment) error
+	ListSkillAssignmentsForSubject(ctx context.Context, subjectType, subjectID string, limit int, cursor string) ([]*models.SkillAssignment, string, error)
+	ListSkillAssignmentsForSkill(ctx context.Context, skillID string, limit int, cursor string) ([]*models.SkillAssignment, string, error)
+}

--- a/pkg/storage/models/skill.go
+++ b/pkg/storage/models/skill.go
@@ -1,0 +1,756 @@
+package models
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/common"
+)
+
+const (
+	// SKSkill is the root sort key for a canonical skill authority record.
+	SKSkill = "SKILL"
+
+	// SKSkillRevisionPrefix is the sort-key prefix for canonical skill revisions.
+	SKSkillRevisionPrefix = "REVISION#"
+
+	// SKSkillProposal is the sort key for proposal records.
+	SKSkillProposal = "PROPOSAL"
+
+	// SKSkillAssignmentPrefix is the sort-key prefix for skill assignments under a subject partition.
+	SKSkillAssignmentPrefix = "SKILL#"
+)
+
+const (
+	// SkillStatusDraft indicates a canonical skill record exists but has no exposed approved revision yet.
+	SkillStatusDraft = "draft"
+	// SkillStatusActive indicates a canonical skill has at least one active revision or assignment path.
+	SkillStatusActive = "active"
+	// SkillStatusArchived indicates a canonical skill is retained but no longer assignable by default.
+	SkillStatusArchived = "archived"
+)
+
+const (
+	// SkillRevisionStatusDraft indicates a revision is still being formed inside Lesser.
+	SkillRevisionStatusDraft = "draft"
+	// SkillRevisionStatusProposed indicates a revision is ready for a later approval flow.
+	SkillRevisionStatusProposed = "proposed"
+	// SkillRevisionStatusApproved indicates a revision has passed a later approval flow.
+	SkillRevisionStatusApproved = "approved"
+	// SkillRevisionStatusSuperseded indicates a revision was replaced by a newer approved revision.
+	SkillRevisionStatusSuperseded = "superseded"
+	// SkillRevisionStatusRevoked indicates a revision should no longer be used.
+	SkillRevisionStatusRevoked = "revoked"
+)
+
+const (
+	// SkillProposalStatusProposed indicates a proposal is awaiting review.
+	SkillProposalStatusProposed = "proposed"
+	// SkillProposalStatusAccepted indicates a proposal produced or will produce a canonical revision.
+	SkillProposalStatusAccepted = "accepted"
+	// SkillProposalStatusRejected indicates a proposal was rejected.
+	SkillProposalStatusRejected = "rejected"
+	// SkillProposalStatusWithdrawn indicates a proposal was withdrawn before approval.
+	SkillProposalStatusWithdrawn = "withdrawn"
+)
+
+const (
+	// SkillAssignmentStatusActive indicates an assignment currently participates in effective resolution.
+	SkillAssignmentStatusActive = "active"
+	// SkillAssignmentStatusPending indicates an assignment is staged but not effective yet.
+	SkillAssignmentStatusPending = "pending"
+	// SkillAssignmentStatusRevoked indicates an assignment was explicitly revoked.
+	SkillAssignmentStatusRevoked = "revoked"
+)
+
+const (
+	// SkillExposurePublic means the skill can be exposed publicly once approved.
+	SkillExposurePublic = "public"
+	// SkillExposureInstance means the skill is visible within the local Lesser instance.
+	SkillExposureInstance = "instance"
+	// SkillExposurePrivate means the skill is only visible to explicitly assigned/private principals.
+	SkillExposurePrivate = "private"
+)
+
+const (
+	// SkillSourceTypeLocalFile records SKILL.md seed material imported from a repo/workspace.
+	SkillSourceTypeLocalFile = "local_file"
+	// SkillSourceTypeHostConversation records lesser-host mint conversation provenance without making host canonical.
+	SkillSourceTypeHostConversation = "host_conversation"
+	// SkillSourceTypeManual records operator or maintainer-created skill material.
+	SkillSourceTypeManual = "manual"
+)
+
+const (
+	// SkillAssignmentSubjectInstance assigns a skill at instance scope.
+	SkillAssignmentSubjectInstance = "instance"
+	// SkillAssignmentSubjectActor assigns a skill to a local actor/body.
+	SkillAssignmentSubjectActor = "actor"
+	// SkillAssignmentSubjectPrincipal assigns a skill to an approving or owning principal.
+	SkillAssignmentSubjectPrincipal = "principal"
+)
+
+// SkillProvenanceRef captures source/provenance for canonical skills, proposals, and revisions.
+type SkillProvenanceRef struct {
+	SourceType string `theorydb:"attr:sourceType" json:"source_type"`
+	SourceURI  string `theorydb:"attr:sourceURI,omitempty" json:"source_uri,omitempty"`
+	Digest     string `theorydb:"attr:digest,omitempty" json:"digest,omitempty"`
+	Ref        string `theorydb:"attr:ref,omitempty" json:"ref,omitempty"`
+	Notes      string `theorydb:"attr:notes,omitempty" json:"notes,omitempty"`
+}
+
+// SkillRevisionFile records a publishable file included in a canonical skill revision manifest.
+type SkillRevisionFile struct {
+	Path        string `theorydb:"attr:path" json:"path"`
+	Digest      string `theorydb:"attr:digest" json:"digest"`
+	ContentType string `theorydb:"attr:contentType,omitempty" json:"content_type,omitempty"`
+	Role        string `theorydb:"attr:role,omitempty" json:"role,omitempty"`
+	SizeBytes   int64  `theorydb:"attr:sizeBytes,omitempty" json:"size_bytes,omitempty"`
+}
+
+// Skill stores canonical instance-owned skill authority metadata.
+type Skill struct {
+	_ struct{} `theorydb:"naming:camelCase"`
+
+	PK string `theorydb:"pk,attr:PK" json:"-"`
+	SK string `theorydb:"sk,attr:SK" json:"-"`
+
+	// GSI1 lists canonical skills by lifecycle status for later approval/catalog APIs.
+	GSI1PK string `theorydb:"index:gsi1,pk,attr:gsi1PK,omitempty" json:"-"`
+	GSI1SK string `theorydb:"index:gsi1,sk,attr:gsi1SK,omitempty" json:"-"`
+
+	// GSI2 lists canonical skills by default exposure class without exposing private content.
+	GSI2PK string `theorydb:"index:gsi2,pk,attr:gsi2PK,omitempty" json:"-"`
+	GSI2SK string `theorydb:"index:gsi2,sk,attr:gsi2SK,omitempty" json:"-"`
+
+	ID                    string               `theorydb:"attr:id" json:"id"`
+	Slug                  string               `theorydb:"attr:slug" json:"slug"`
+	Name                  string               `theorydb:"attr:name" json:"name"`
+	Description           string               `theorydb:"attr:description,omitempty" json:"description,omitempty"`
+	Status                string               `theorydb:"attr:status" json:"status"`
+	DefaultExposure       string               `theorydb:"attr:defaultExposure" json:"default_exposure"`
+	CurrentRevisionID     string               `theorydb:"attr:currentRevisionID,omitempty" json:"current_revision_id,omitempty"`
+	CurrentRevisionNumber int                  `theorydb:"attr:currentRevisionNumber,omitempty" json:"current_revision_number,omitempty"`
+	Capabilities          []string             `theorydb:"attr:capabilities" json:"capabilities,omitempty"`
+	Tags                  []string             `theorydb:"attr:tags" json:"tags,omitempty"`
+	Provenance            []SkillProvenanceRef `theorydb:"attr:provenance" json:"provenance,omitempty"`
+	CreatedBy             string               `theorydb:"attr:createdBy,omitempty" json:"created_by,omitempty"`
+	UpdatedBy             string               `theorydb:"attr:updatedBy,omitempty" json:"updated_by,omitempty"`
+	CreatedAt             time.Time            `theorydb:"attr:createdAt" json:"created_at"`
+	UpdatedAt             time.Time            `theorydb:"attr:updatedAt" json:"updated_at"`
+	Version               int                  `theorydb:"version,attr:version" json:"version"`
+}
+
+// SkillRevision stores a canonical revision under its skill partition.
+type SkillRevision struct {
+	_ struct{} `theorydb:"naming:camelCase"`
+
+	PK string `theorydb:"pk,attr:PK" json:"-"`
+	SK string `theorydb:"sk,attr:SK" json:"-"`
+
+	// GSI1 supports later review/effective-resolution queues by revision status.
+	GSI1PK string `theorydb:"index:gsi1,pk,attr:gsi1PK,omitempty" json:"-"`
+	GSI1SK string `theorydb:"index:gsi1,sk,attr:gsi1SK,omitempty" json:"-"`
+
+	// GSI2 is sparse and supports digest/provenance de-duplication for imported manifests.
+	GSI2PK string `theorydb:"index:gsi2,pk,attr:gsi2PK,omitempty" json:"-"`
+	GSI2SK string `theorydb:"index:gsi2,sk,attr:gsi2SK,omitempty" json:"-"`
+
+	ID                  string               `theorydb:"attr:id" json:"id"`
+	SkillID             string               `theorydb:"attr:skillID" json:"skill_id"`
+	RevisionNumber      int                  `theorydb:"attr:revisionNumber" json:"revision_number"`
+	Status              string               `theorydb:"attr:status" json:"status"`
+	ProposalID          string               `theorydb:"attr:proposalID,omitempty" json:"proposal_id,omitempty"`
+	ManifestJSON        string               `theorydb:"attr:manifestJSON,omitempty" json:"manifest_json,omitempty"`
+	ManifestDigest      string               `theorydb:"attr:manifestDigest,omitempty" json:"manifest_digest,omitempty"`
+	BundleDigest        string               `theorydb:"attr:bundleDigest,omitempty" json:"bundle_digest,omitempty"`
+	ContentDigest       string               `theorydb:"attr:contentDigest,omitempty" json:"content_digest,omitempty"`
+	Files               []SkillRevisionFile  `theorydb:"attr:files" json:"files,omitempty"`
+	Capabilities        []string             `theorydb:"attr:capabilities" json:"capabilities,omitempty"`
+	DefaultExposure     string               `theorydb:"attr:defaultExposure" json:"default_exposure"`
+	ApprovalID          string               `theorydb:"attr:approvalID,omitempty" json:"approval_id,omitempty"`
+	ApprovedBy          string               `theorydb:"attr:approvedBy,omitempty" json:"approved_by,omitempty"`
+	ApprovedAt          *time.Time           `theorydb:"attr:approvedAt" json:"approved_at,omitempty"`
+	PrincipalID         string               `theorydb:"attr:principalID,omitempty" json:"principal_id,omitempty"`
+	PrincipalApprovalID string               `theorydb:"attr:principalApprovalID,omitempty" json:"principal_approval_id,omitempty"`
+	Provenance          []SkillProvenanceRef `theorydb:"attr:provenance" json:"provenance,omitempty"`
+	CreatedBy           string               `theorydb:"attr:createdBy,omitempty" json:"created_by,omitempty"`
+	UpdatedBy           string               `theorydb:"attr:updatedBy,omitempty" json:"updated_by,omitempty"`
+	CreatedAt           time.Time            `theorydb:"attr:createdAt" json:"created_at"`
+	UpdatedAt           time.Time            `theorydb:"attr:updatedAt" json:"updated_at"`
+	Version             int                  `theorydb:"version,attr:version" json:"version"`
+}
+
+// SkillProposal stores non-authoritative source material proposed for canonicalization.
+type SkillProposal struct {
+	_ struct{} `theorydb:"naming:camelCase"`
+
+	PK string `theorydb:"pk,attr:PK" json:"-"`
+	SK string `theorydb:"sk,attr:SK" json:"-"`
+
+	// GSI1 lists proposals for a skill.
+	GSI1PK string `theorydb:"index:gsi1,pk,attr:gsi1PK,omitempty" json:"-"`
+	GSI1SK string `theorydb:"index:gsi1,sk,attr:gsi1SK,omitempty" json:"-"`
+
+	// GSI2 supports later proposal review queues by status.
+	GSI2PK string `theorydb:"index:gsi2,pk,attr:gsi2PK,omitempty" json:"-"`
+	GSI2SK string `theorydb:"index:gsi2,sk,attr:gsi2SK,omitempty" json:"-"`
+
+	ID                     string               `theorydb:"attr:id" json:"id"`
+	SkillID                string               `theorydb:"attr:skillID" json:"skill_id"`
+	Title                  string               `theorydb:"attr:title,omitempty" json:"title,omitempty"`
+	Summary                string               `theorydb:"attr:summary,omitempty" json:"summary,omitempty"`
+	Status                 string               `theorydb:"attr:status" json:"status"`
+	RequestedExposure      string               `theorydb:"attr:requestedExposure" json:"requested_exposure"`
+	ProposedRevisionNumber int                  `theorydb:"attr:proposedRevisionNumber,omitempty" json:"proposed_revision_number,omitempty"`
+	ProposedManifestJSON   string               `theorydb:"attr:proposedManifestJSON,omitempty" json:"proposed_manifest_json,omitempty"`
+	ProposedManifestDigest string               `theorydb:"attr:proposedManifestDigest,omitempty" json:"proposed_manifest_digest,omitempty"`
+	SourceType             string               `theorydb:"attr:sourceType,omitempty" json:"source_type,omitempty"`
+	SourceURI              string               `theorydb:"attr:sourceURI,omitempty" json:"source_uri,omitempty"`
+	SourceDigest           string               `theorydb:"attr:sourceDigest,omitempty" json:"source_digest,omitempty"`
+	ConversationID         string               `theorydb:"attr:conversationID,omitempty" json:"conversation_id,omitempty"`
+	ConversationMessageID  string               `theorydb:"attr:conversationMessageID,omitempty" json:"conversation_message_id,omitempty"`
+	PrincipalID            string               `theorydb:"attr:principalID,omitempty" json:"principal_id,omitempty"`
+	PrincipalApprovalID    string               `theorydb:"attr:principalApprovalID,omitempty" json:"principal_approval_id,omitempty"`
+	Provenance             []SkillProvenanceRef `theorydb:"attr:provenance" json:"provenance,omitempty"`
+	CreatedBy              string               `theorydb:"attr:createdBy,omitempty" json:"created_by,omitempty"`
+	ReviewedBy             string               `theorydb:"attr:reviewedBy,omitempty" json:"reviewed_by,omitempty"`
+	ReviewedAt             *time.Time           `theorydb:"attr:reviewedAt" json:"reviewed_at,omitempty"`
+	ReviewReason           string               `theorydb:"attr:reviewReason,omitempty" json:"review_reason,omitempty"`
+	CreatedAt              time.Time            `theorydb:"attr:createdAt" json:"created_at"`
+	UpdatedAt              time.Time            `theorydb:"attr:updatedAt" json:"updated_at"`
+	Version                int                  `theorydb:"version,attr:version" json:"version"`
+}
+
+// SkillAssignment stores an explicit skill assignment for effective-resolution APIs added later.
+type SkillAssignment struct {
+	_ struct{} `theorydb:"naming:camelCase"`
+
+	PK string `theorydb:"pk,attr:PK" json:"-"`
+	SK string `theorydb:"sk,attr:SK" json:"-"`
+
+	// GSI1 lists assignments by skill for audit and revocation walks.
+	GSI1PK string `theorydb:"index:gsi1,pk,attr:gsi1PK,omitempty" json:"-"`
+	GSI1SK string `theorydb:"index:gsi1,sk,attr:gsi1SK,omitempty" json:"-"`
+
+	// GSI2 supports sparse status queues for pending/revoked assignment processing.
+	GSI2PK string `theorydb:"index:gsi2,pk,attr:gsi2PK,omitempty" json:"-"`
+	GSI2SK string `theorydb:"index:gsi2,sk,attr:gsi2SK,omitempty" json:"-"`
+
+	ID                  string               `theorydb:"attr:id" json:"id"`
+	SkillID             string               `theorydb:"attr:skillID" json:"skill_id"`
+	RevisionID          string               `theorydb:"attr:revisionID,omitempty" json:"revision_id,omitempty"`
+	RevisionNumber      int                  `theorydb:"attr:revisionNumber,omitempty" json:"revision_number,omitempty"`
+	SubjectType         string               `theorydb:"attr:subjectType" json:"subject_type"`
+	SubjectID           string               `theorydb:"attr:subjectID" json:"subject_id"`
+	Exposure            string               `theorydb:"attr:exposure" json:"exposure"`
+	Status              string               `theorydb:"attr:status" json:"status"`
+	ApprovalID          string               `theorydb:"attr:approvalID,omitempty" json:"approval_id,omitempty"`
+	PrincipalID         string               `theorydb:"attr:principalID,omitempty" json:"principal_id,omitempty"`
+	PrincipalApprovalID string               `theorydb:"attr:principalApprovalID,omitempty" json:"principal_approval_id,omitempty"`
+	Provenance          []SkillProvenanceRef `theorydb:"attr:provenance" json:"provenance,omitempty"`
+	AssignedBy          string               `theorydb:"attr:assignedBy,omitempty" json:"assigned_by,omitempty"`
+	AssignedAt          time.Time            `theorydb:"attr:assignedAt" json:"assigned_at"`
+	RevokedBy           string               `theorydb:"attr:revokedBy,omitempty" json:"revoked_by,omitempty"`
+	RevokedAt           *time.Time           `theorydb:"attr:revokedAt" json:"revoked_at,omitempty"`
+	RevokedReason       string               `theorydb:"attr:revokedReason,omitempty" json:"revoked_reason,omitempty"`
+	CreatedAt           time.Time            `theorydb:"attr:createdAt" json:"created_at"`
+	UpdatedAt           time.Time            `theorydb:"attr:updatedAt" json:"updated_at"`
+	Version             int                  `theorydb:"version,attr:version" json:"version"`
+}
+
+// TableName returns the DynamoDB table backing Skill.
+func (Skill) TableName() string { return MainTableName }
+
+// TableName returns the DynamoDB table backing SkillRevision.
+func (SkillRevision) TableName() string { return MainTableName }
+
+// TableName returns the DynamoDB table backing SkillProposal.
+func (SkillProposal) TableName() string { return MainTableName }
+
+// TableName returns the DynamoDB table backing SkillAssignment.
+func (SkillAssignment) TableName() string { return MainTableName }
+
+// SkillPartitionKey returns the canonical partition for a skill and its revisions.
+func SkillPartitionKey(skillID string) string {
+	skillID = normalizeSkillID(skillID)
+	if skillID == "" {
+		return ""
+	}
+	return "SKILL#" + skillID
+}
+
+// SkillRevisionSortKey returns the zero-padded revision sort key.
+func SkillRevisionSortKey(revisionNumber int) string {
+	if revisionNumber <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s%08d", SKSkillRevisionPrefix, revisionNumber)
+}
+
+// SkillProposalPartitionKey returns the primary partition for a proposal.
+func SkillProposalPartitionKey(proposalID string) string {
+	proposalID = normalizeSkillID(proposalID)
+	if proposalID == "" {
+		return ""
+	}
+	return "SKILL_PROPOSAL#" + proposalID
+}
+
+// SkillAssignmentPartitionKey returns the primary partition for a subject assignment set.
+func SkillAssignmentPartitionKey(subjectType, subjectID string) string {
+	subjectType = normalizeSkillToken(subjectType)
+	subjectID = normalizeSkillID(subjectID)
+	if subjectType == "" || subjectID == "" {
+		return ""
+	}
+	return fmt.Sprintf("SKILL_ASSIGNMENT#%s#%s", subjectType, subjectID)
+}
+
+// SkillAssignmentSortKey returns the sort key for a subject assignment.
+func SkillAssignmentSortKey(skillID, assignmentID string) string {
+	skillID = normalizeSkillID(skillID)
+	assignmentID = normalizeSkillID(assignmentID)
+	if skillID == "" || assignmentID == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s%s#ASSIGNMENT#%s", SKSkillAssignmentPrefix, skillID, assignmentID)
+}
+
+// BeforeCreate normalizes a Skill before insert.
+func (s *Skill) BeforeCreate() error { return s.prepareForWrite(true) }
+
+// BeforeUpdate normalizes a Skill before update.
+func (s *Skill) BeforeUpdate() error { return s.prepareForWrite(false) }
+
+// UpdateKeys refreshes Skill primary and secondary keys.
+func (s *Skill) UpdateKeys() error { return s.prepareForWrite(false) }
+
+// GetPK returns the partition key.
+func (s *Skill) GetPK() string {
+	if s == nil {
+		return ""
+	}
+	return s.PK
+}
+
+// GetSK returns the sort key.
+func (s *Skill) GetSK() string {
+	if s == nil {
+		return ""
+	}
+	return s.SK
+}
+
+// BeforeCreate normalizes a SkillRevision before insert.
+func (r *SkillRevision) BeforeCreate() error { return r.prepareForWrite(true) }
+
+// BeforeUpdate normalizes a SkillRevision before update.
+func (r *SkillRevision) BeforeUpdate() error { return r.prepareForWrite(false) }
+
+// UpdateKeys refreshes SkillRevision primary and secondary keys.
+func (r *SkillRevision) UpdateKeys() error { return r.prepareForWrite(false) }
+
+// GetPK returns the partition key.
+func (r *SkillRevision) GetPK() string {
+	if r == nil {
+		return ""
+	}
+	return r.PK
+}
+
+// GetSK returns the sort key.
+func (r *SkillRevision) GetSK() string {
+	if r == nil {
+		return ""
+	}
+	return r.SK
+}
+
+// BeforeCreate normalizes a SkillProposal before insert.
+func (p *SkillProposal) BeforeCreate() error { return p.prepareForWrite(true) }
+
+// BeforeUpdate normalizes a SkillProposal before update.
+func (p *SkillProposal) BeforeUpdate() error { return p.prepareForWrite(false) }
+
+// UpdateKeys refreshes SkillProposal primary and secondary keys.
+func (p *SkillProposal) UpdateKeys() error { return p.prepareForWrite(false) }
+
+// GetPK returns the partition key.
+func (p *SkillProposal) GetPK() string {
+	if p == nil {
+		return ""
+	}
+	return p.PK
+}
+
+// GetSK returns the sort key.
+func (p *SkillProposal) GetSK() string {
+	if p == nil {
+		return ""
+	}
+	return p.SK
+}
+
+// BeforeCreate normalizes a SkillAssignment before insert.
+func (a *SkillAssignment) BeforeCreate() error { return a.prepareForWrite(true) }
+
+// BeforeUpdate normalizes a SkillAssignment before update.
+func (a *SkillAssignment) BeforeUpdate() error { return a.prepareForWrite(false) }
+
+// UpdateKeys refreshes SkillAssignment primary and secondary keys.
+func (a *SkillAssignment) UpdateKeys() error { return a.prepareForWrite(false) }
+
+// GetPK returns the partition key.
+func (a *SkillAssignment) GetPK() string {
+	if a == nil {
+		return ""
+	}
+	return a.PK
+}
+
+// GetSK returns the sort key.
+func (a *SkillAssignment) GetSK() string {
+	if a == nil {
+		return ""
+	}
+	return a.SK
+}
+
+func (s *Skill) prepareForWrite(isCreate bool) error {
+	if s == nil {
+		return fmt.Errorf("skill is required")
+	}
+	s.ID = normalizeSkillID(s.ID)
+	if err := common.ValidateRequiredParam("ID", s.ID); err != nil {
+		return err
+	}
+	s.Slug = normalizeSkillSlug(defaultString(s.Slug, s.ID))
+	s.Name = strings.TrimSpace(s.Name)
+	if s.Name == "" {
+		s.Name = s.Slug
+	}
+	s.Status = normalizeSkillStatus(s.Status, SkillStatusDraft)
+	s.DefaultExposure = normalizeSkillExposure(s.DefaultExposure, SkillExposurePrivate)
+	s.CurrentRevisionID = normalizeSkillID(s.CurrentRevisionID)
+	s.Capabilities = normalizeSkillStringSet(s.Capabilities, false)
+	s.Tags = normalizeSkillStringSet(s.Tags, true)
+	s.Provenance = normalizeSkillProvenance(s.Provenance)
+	s.CreatedBy = strings.TrimSpace(s.CreatedBy)
+	s.UpdatedBy = strings.TrimSpace(s.UpdatedBy)
+	s.applyTimestamps(isCreate)
+	s.PK = SkillPartitionKey(s.ID)
+	s.SK = SKSkill
+	s.GSI1PK = "SKILL#STATUS#" + s.Status
+	s.GSI1SK = fmt.Sprintf("UPDATED#%s#SKILL#%s", formatSkillTime(s.UpdatedAt), s.ID)
+	s.GSI2PK = "SKILL#EXPOSURE#" + s.DefaultExposure
+	s.GSI2SK = fmt.Sprintf("NAME#%s#SKILL#%s", s.Slug, s.ID)
+	return nil
+}
+
+func (r *SkillRevision) prepareForWrite(isCreate bool) error {
+	if r == nil {
+		return fmt.Errorf("skill revision is required")
+	}
+	r.SkillID = normalizeSkillID(r.SkillID)
+	if err := common.ValidateRequiredParam("SkillID", r.SkillID); err != nil {
+		return err
+	}
+	if r.RevisionNumber <= 0 {
+		return fmt.Errorf("revision number is required")
+	}
+	r.ID = normalizeSkillID(r.ID)
+	if r.ID == "" {
+		r.ID = fmt.Sprintf("%s-r%d", r.SkillID, r.RevisionNumber)
+	}
+	r.Status = normalizeSkillStatus(r.Status, SkillRevisionStatusDraft)
+	r.ProposalID = normalizeSkillID(r.ProposalID)
+	r.ManifestDigest = normalizeSkillDigest(r.ManifestDigest)
+	r.BundleDigest = normalizeSkillDigest(r.BundleDigest)
+	r.ContentDigest = normalizeSkillDigest(r.ContentDigest)
+	r.Files = normalizeSkillRevisionFiles(r.Files)
+	r.Capabilities = normalizeSkillStringSet(r.Capabilities, false)
+	r.DefaultExposure = normalizeSkillExposure(r.DefaultExposure, SkillExposurePrivate)
+	r.ApprovalID = strings.TrimSpace(r.ApprovalID)
+	r.ApprovedBy = strings.TrimSpace(r.ApprovedBy)
+	r.ApprovedAt = normalizeSkillTimePtr(r.ApprovedAt)
+	r.PrincipalID = strings.TrimSpace(r.PrincipalID)
+	r.PrincipalApprovalID = strings.TrimSpace(r.PrincipalApprovalID)
+	r.Provenance = normalizeSkillProvenance(r.Provenance)
+	r.CreatedBy = strings.TrimSpace(r.CreatedBy)
+	r.UpdatedBy = strings.TrimSpace(r.UpdatedBy)
+	r.applyTimestamps(isCreate)
+	r.PK = SkillPartitionKey(r.SkillID)
+	r.SK = SkillRevisionSortKey(r.RevisionNumber)
+	r.GSI1PK = "SKILL_REVISION#STATUS#" + r.Status
+	r.GSI1SK = fmt.Sprintf("UPDATED#%s#SKILL#%s#REVISION#%08d", formatSkillTime(r.UpdatedAt), r.SkillID, r.RevisionNumber)
+	if r.ManifestDigest != "" {
+		r.GSI2PK = "SKILL_REVISION_DIGEST#" + r.ManifestDigest
+		r.GSI2SK = fmt.Sprintf("SKILL#%s#REVISION#%08d", r.SkillID, r.RevisionNumber)
+	} else {
+		r.GSI2PK = ""
+		r.GSI2SK = ""
+	}
+	return nil
+}
+
+func (p *SkillProposal) prepareForWrite(isCreate bool) error {
+	if p == nil {
+		return fmt.Errorf("skill proposal is required")
+	}
+	p.ID = normalizeSkillID(p.ID)
+	if err := common.ValidateRequiredParam("ID", p.ID); err != nil {
+		return err
+	}
+	p.SkillID = normalizeSkillID(p.SkillID)
+	if err := common.ValidateRequiredParam("SkillID", p.SkillID); err != nil {
+		return err
+	}
+	p.Title = strings.TrimSpace(p.Title)
+	p.Summary = strings.TrimSpace(p.Summary)
+	p.Status = normalizeSkillStatus(p.Status, SkillProposalStatusProposed)
+	p.RequestedExposure = normalizeSkillExposure(p.RequestedExposure, SkillExposurePrivate)
+	p.ProposedManifestDigest = normalizeSkillDigest(p.ProposedManifestDigest)
+	p.SourceType = normalizeSkillSourceType(p.SourceType)
+	p.SourceURI = strings.TrimSpace(p.SourceURI)
+	p.SourceDigest = normalizeSkillDigest(p.SourceDigest)
+	p.ConversationID = strings.TrimSpace(p.ConversationID)
+	p.ConversationMessageID = strings.TrimSpace(p.ConversationMessageID)
+	p.PrincipalID = strings.TrimSpace(p.PrincipalID)
+	p.PrincipalApprovalID = strings.TrimSpace(p.PrincipalApprovalID)
+	p.Provenance = normalizeSkillProvenance(p.Provenance)
+	p.CreatedBy = strings.TrimSpace(p.CreatedBy)
+	p.ReviewedBy = strings.TrimSpace(p.ReviewedBy)
+	p.ReviewedAt = normalizeSkillTimePtr(p.ReviewedAt)
+	p.ReviewReason = strings.TrimSpace(p.ReviewReason)
+	p.applyTimestamps(isCreate)
+	p.PK = SkillProposalPartitionKey(p.ID)
+	p.SK = SKSkillProposal
+	p.GSI1PK = "SKILL#" + p.SkillID + "#PROPOSAL"
+	p.GSI1SK = fmt.Sprintf("STATUS#%s#CREATED#%s#PROPOSAL#%s", p.Status, formatSkillTime(p.CreatedAt), p.ID)
+	p.GSI2PK = "SKILL_PROPOSAL#STATUS#" + p.Status
+	p.GSI2SK = fmt.Sprintf("CREATED#%s#SKILL#%s#PROPOSAL#%s", formatSkillTime(p.CreatedAt), p.SkillID, p.ID)
+	return nil
+}
+
+func (a *SkillAssignment) prepareForWrite(isCreate bool) error {
+	if a == nil {
+		return fmt.Errorf("skill assignment is required")
+	}
+	a.ID = normalizeSkillID(a.ID)
+	if err := common.ValidateRequiredParam("ID", a.ID); err != nil {
+		return err
+	}
+	a.SkillID = normalizeSkillID(a.SkillID)
+	if err := common.ValidateRequiredParam("SkillID", a.SkillID); err != nil {
+		return err
+	}
+	a.RevisionID = normalizeSkillID(a.RevisionID)
+	a.SubjectType = normalizeSkillSubjectType(a.SubjectType)
+	if err := common.ValidateRequiredParam("SubjectType", a.SubjectType); err != nil {
+		return err
+	}
+	a.SubjectID = normalizeSkillID(a.SubjectID)
+	if err := common.ValidateRequiredParam("SubjectID", a.SubjectID); err != nil {
+		return err
+	}
+	a.Exposure = normalizeSkillExposure(a.Exposure, SkillExposurePrivate)
+	a.Status = normalizeSkillStatus(a.Status, SkillAssignmentStatusActive)
+	a.ApprovalID = strings.TrimSpace(a.ApprovalID)
+	a.PrincipalID = strings.TrimSpace(a.PrincipalID)
+	a.PrincipalApprovalID = strings.TrimSpace(a.PrincipalApprovalID)
+	a.Provenance = normalizeSkillProvenance(a.Provenance)
+	a.AssignedBy = strings.TrimSpace(a.AssignedBy)
+	a.RevokedBy = strings.TrimSpace(a.RevokedBy)
+	a.RevokedAt = normalizeSkillTimePtr(a.RevokedAt)
+	a.RevokedReason = strings.TrimSpace(a.RevokedReason)
+	a.applyTimestamps(isCreate)
+	if a.AssignedAt.IsZero() {
+		a.AssignedAt = a.CreatedAt
+	}
+	a.AssignedAt = a.AssignedAt.UTC()
+	a.PK = SkillAssignmentPartitionKey(a.SubjectType, a.SubjectID)
+	a.SK = SkillAssignmentSortKey(a.SkillID, a.ID)
+	a.GSI1PK = "SKILL#" + a.SkillID + "#ASSIGNMENT"
+	a.GSI1SK = fmt.Sprintf("SUBJECT#%s#%s#ASSIGNMENT#%s", a.SubjectType, a.SubjectID, a.ID)
+	a.GSI2PK = "SKILL_ASSIGNMENT#STATUS#" + a.Status
+	a.GSI2SK = fmt.Sprintf("UPDATED#%s#SUBJECT#%s#%s#SKILL#%s", formatSkillTime(a.UpdatedAt), a.SubjectType, a.SubjectID, a.SkillID)
+	return nil
+}
+
+func (s *Skill) applyTimestamps(isCreate bool) {
+	applySkillTimestamps(&s.CreatedAt, &s.UpdatedAt, isCreate)
+}
+
+func (r *SkillRevision) applyTimestamps(isCreate bool) {
+	applySkillTimestamps(&r.CreatedAt, &r.UpdatedAt, isCreate)
+}
+
+func (p *SkillProposal) applyTimestamps(isCreate bool) {
+	applySkillTimestamps(&p.CreatedAt, &p.UpdatedAt, isCreate)
+}
+
+func (a *SkillAssignment) applyTimestamps(isCreate bool) {
+	applySkillTimestamps(&a.CreatedAt, &a.UpdatedAt, isCreate)
+}
+
+func applySkillTimestamps(createdAt, updatedAt *time.Time, isCreate bool) {
+	now := time.Now().UTC()
+	if isCreate && createdAt.IsZero() {
+		*createdAt = now
+	}
+	if createdAt.IsZero() {
+		*createdAt = now
+	}
+	if !isCreate {
+		if updatedAt.IsZero() {
+			*updatedAt = now
+		}
+	} else if updatedAt.IsZero() {
+		*updatedAt = *createdAt
+	}
+	*createdAt = createdAt.UTC()
+	*updatedAt = updatedAt.UTC()
+}
+
+func normalizeSkillID(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func normalizeSkillSlug(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func normalizeSkillToken(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func normalizeSkillDigest(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func normalizeSkillStatus(value, fallback string) string {
+	value = normalizeSkillToken(value)
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func normalizeSkillExposure(value, fallback string) string {
+	value = normalizeSkillToken(value)
+	switch value {
+	case SkillExposurePublic, SkillExposureInstance, SkillExposurePrivate:
+		return value
+	case "":
+		return fallback
+	default:
+		return value
+	}
+}
+
+func normalizeSkillSourceType(value string) string {
+	return normalizeSkillToken(value)
+}
+
+func normalizeSkillSubjectType(value string) string {
+	return normalizeSkillToken(value)
+}
+
+func normalizeSkillStringSet(values []string, lower bool) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if lower {
+			trimmed = strings.ToLower(trimmed)
+		}
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		out = append(out, trimmed)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	slices.Sort(out)
+	return out
+}
+
+func normalizeSkillProvenance(values []SkillProvenanceRef) []SkillProvenanceRef {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]SkillProvenanceRef, 0, len(values))
+	for _, value := range values {
+		value.SourceType = normalizeSkillSourceType(value.SourceType)
+		value.SourceURI = strings.TrimSpace(value.SourceURI)
+		value.Digest = normalizeSkillDigest(value.Digest)
+		value.Ref = strings.TrimSpace(value.Ref)
+		value.Notes = strings.TrimSpace(value.Notes)
+		if value.SourceType == "" && value.SourceURI == "" && value.Digest == "" && value.Ref == "" && value.Notes == "" {
+			continue
+		}
+		out = append(out, value)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func normalizeSkillRevisionFiles(values []SkillRevisionFile) []SkillRevisionFile {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]SkillRevisionFile, 0, len(values))
+	for _, value := range values {
+		value.Path = strings.TrimSpace(value.Path)
+		value.Digest = normalizeSkillDigest(value.Digest)
+		value.ContentType = strings.TrimSpace(value.ContentType)
+		value.Role = normalizeSkillToken(value.Role)
+		if value.Path == "" && value.Digest == "" {
+			continue
+		}
+		out = append(out, value)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	slices.SortFunc(out, func(a, b SkillRevisionFile) int {
+		return strings.Compare(a.Path, b.Path)
+	})
+	return out
+}
+
+func normalizeSkillTimePtr(value *time.Time) *time.Time {
+	if value == nil || value.IsZero() {
+		return nil
+	}
+	t := value.UTC()
+	return &t
+}
+
+func formatSkillTime(value time.Time) string {
+	if value.IsZero() {
+		value = time.Now().UTC()
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
+func defaultString(value, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	return value
+}

--- a/pkg/storage/models/skill_test.go
+++ b/pkg/storage/models/skill_test.go
@@ -1,0 +1,179 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkillAuthorityKeyHelpers(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "SKILL#skill-a", SkillPartitionKey(" Skill-A "))
+	require.Equal(t, "", SkillPartitionKey(" "))
+	require.Equal(t, "REVISION#00000042", SkillRevisionSortKey(42))
+	require.Equal(t, "", SkillRevisionSortKey(0))
+	require.Equal(t, "SKILL_PROPOSAL#proposal-1", SkillProposalPartitionKey(" Proposal-1 "))
+	require.Equal(t, "", SkillProposalPartitionKey(" "))
+	require.Equal(t, "SKILL_ASSIGNMENT#actor#alice", SkillAssignmentPartitionKey(" Actor ", " Alice "))
+	require.Equal(t, "", SkillAssignmentPartitionKey("actor", " "))
+	require.Equal(t, "SKILL#skill-a#ASSIGNMENT#assign-1", SkillAssignmentSortKey(" Skill-A ", " Assign-1 "))
+	require.Equal(t, "", SkillAssignmentSortKey("skill-a", " "))
+}
+
+func TestSkill_UpdateKeysNormalizesAuthorityMetadata(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2026, 5, 13, 3, 30, 0, 0, time.UTC)
+	skill := &Skill{
+		ID:              " Skill-A ",
+		Slug:            " Skill-Alias ",
+		Name:            "  Skill Alpha  ",
+		Status:          " Active ",
+		DefaultExposure: " Instance ",
+		Capabilities:    []string{"write", "read", "write", "  "},
+		Tags:            []string{"Governance", "governance", " skills "},
+		Provenance: []SkillProvenanceRef{{
+			SourceType: " Local_File ",
+			SourceURI:  " .codex/skills/example/SKILL.md ",
+			Digest:     " SHA256:ABC ",
+		}},
+		CreatedAt: created,
+		UpdatedAt: created,
+	}
+
+	require.NoError(t, skill.UpdateKeys())
+	require.Equal(t, "SKILL#skill-a", skill.PK)
+	require.Equal(t, SKSkill, skill.SK)
+	require.Equal(t, "skill-a", skill.ID)
+	require.Equal(t, "skill-alias", skill.Slug)
+	require.Equal(t, "Skill Alpha", skill.Name)
+	require.Equal(t, SkillStatusActive, skill.Status)
+	require.Equal(t, SkillExposureInstance, skill.DefaultExposure)
+	require.Equal(t, []string{"read", "write"}, skill.Capabilities)
+	require.Equal(t, []string{"governance", "skills"}, skill.Tags)
+	require.Equal(t, "SKILL#STATUS#active", skill.GSI1PK)
+	require.Contains(t, skill.GSI1SK, "#SKILL#skill-a")
+	require.Equal(t, "SKILL#EXPOSURE#instance", skill.GSI2PK)
+	require.Equal(t, "NAME#skill-alias#SKILL#skill-a", skill.GSI2SK)
+	require.Equal(t, SkillSourceTypeLocalFile, skill.Provenance[0].SourceType)
+	require.Equal(t, "sha256:abc", skill.Provenance[0].Digest)
+	require.Equal(t, MainTableName, skill.TableName())
+	require.Equal(t, skill.PK, skill.GetPK())
+	require.Equal(t, skill.SK, skill.GetSK())
+}
+
+func TestSkillRevision_UpdateKeysCapturesDigestAndRevisionBoundary(t *testing.T) {
+	t.Parallel()
+
+	approved := time.Date(2026, 5, 13, 4, 0, 0, 0, time.UTC)
+	revision := &SkillRevision{
+		SkillID:        " Skill-A ",
+		RevisionNumber: 7,
+		Status:         " Approved ",
+		ManifestDigest: " SHA256:ABCDEF ",
+		BundleDigest:   " SHA256:BUNDLE ",
+		Files: []SkillRevisionFile{
+			{Path: " skill.json ", Digest: " SHA256:2 ", Role: " Manifest "},
+			{Path: " SKILL.md ", Digest: " SHA256:1 ", Role: " Primary "},
+		},
+		Capabilities:    []string{"memory.read", "memory.read", "social.post"},
+		DefaultExposure: " Public ",
+		ApprovedAt:      &approved,
+	}
+
+	require.NoError(t, revision.UpdateKeys())
+	require.Equal(t, "SKILL#skill-a", revision.PK)
+	require.Equal(t, "REVISION#00000007", revision.SK)
+	require.Equal(t, "skill-a-r7", revision.ID)
+	require.Equal(t, SkillRevisionStatusApproved, revision.Status)
+	require.Equal(t, "sha256:abcdef", revision.ManifestDigest)
+	require.Equal(t, SkillExposurePublic, revision.DefaultExposure)
+	require.Equal(t, "SKILL_REVISION#STATUS#approved", revision.GSI1PK)
+	require.Contains(t, revision.GSI1SK, "#SKILL#skill-a#REVISION#00000007")
+	require.Equal(t, "SKILL_REVISION_DIGEST#sha256:abcdef", revision.GSI2PK)
+	require.Equal(t, "SKILL#skill-a#REVISION#00000007", revision.GSI2SK)
+	require.Equal(t, "SKILL.md", revision.Files[0].Path)
+	require.Equal(t, "skill.json", revision.Files[1].Path)
+	require.Equal(t, []string{"memory.read", "social.post"}, revision.Capabilities)
+	require.NotNil(t, revision.ApprovedAt)
+	require.Equal(t, approved, *revision.ApprovedAt)
+	require.Equal(t, MainTableName, revision.TableName())
+}
+
+func TestSkillProposal_UpdateKeysKeepsSeedSourceNonCanonical(t *testing.T) {
+	t.Parallel()
+
+	reviewed := time.Date(2026, 5, 13, 5, 0, 0, 0, time.UTC)
+	proposal := &SkillProposal{
+		ID:                     " Proposal-1 ",
+		SkillID:                " Skill-A ",
+		Status:                 " Proposed ",
+		RequestedExposure:      " Private ",
+		ProposedRevisionNumber: 2,
+		SourceType:             " Local_File ",
+		SourceURI:              " .codex/skills/example/SKILL.md ",
+		SourceDigest:           " SHA256:ABC ",
+		ConversationID:         " conv-1 ",
+		PrincipalApprovalID:    " approval-1 ",
+		ReviewedAt:             &reviewed,
+	}
+
+	require.NoError(t, proposal.UpdateKeys())
+	require.Equal(t, "SKILL_PROPOSAL#proposal-1", proposal.PK)
+	require.Equal(t, SKSkillProposal, proposal.SK)
+	require.Equal(t, SkillProposalStatusProposed, proposal.Status)
+	require.Equal(t, SkillSourceTypeLocalFile, proposal.SourceType)
+	require.Equal(t, "sha256:abc", proposal.SourceDigest)
+	require.Equal(t, "SKILL#skill-a#PROPOSAL", proposal.GSI1PK)
+	require.Contains(t, proposal.GSI1SK, "STATUS#proposed#")
+	require.Contains(t, proposal.GSI1SK, "#PROPOSAL#proposal-1")
+	require.Equal(t, "SKILL_PROPOSAL#STATUS#proposed", proposal.GSI2PK)
+	require.Contains(t, proposal.GSI2SK, "#SKILL#skill-a#PROPOSAL#proposal-1")
+	require.NotNil(t, proposal.ReviewedAt)
+	require.Equal(t, reviewed, *proposal.ReviewedAt)
+	require.Equal(t, MainTableName, proposal.TableName())
+}
+
+func TestSkillAssignment_UpdateKeysDefinesSubjectBoundary(t *testing.T) {
+	t.Parallel()
+
+	revoked := time.Date(2026, 5, 13, 6, 0, 0, 0, time.UTC)
+	assignment := &SkillAssignment{
+		ID:                  " Assignment-1 ",
+		SkillID:             " Skill-A ",
+		RevisionNumber:      3,
+		SubjectType:         " Actor ",
+		SubjectID:           " Alice ",
+		Exposure:            " Instance ",
+		Status:              " Pending ",
+		PrincipalApprovalID: " approval-1 ",
+		RevokedAt:           &revoked,
+	}
+
+	require.NoError(t, assignment.UpdateKeys())
+	require.Equal(t, "SKILL_ASSIGNMENT#actor#alice", assignment.PK)
+	require.Equal(t, "SKILL#skill-a#ASSIGNMENT#assignment-1", assignment.SK)
+	require.Equal(t, SkillAssignmentSubjectActor, assignment.SubjectType)
+	require.Equal(t, "alice", assignment.SubjectID)
+	require.Equal(t, SkillExposureInstance, assignment.Exposure)
+	require.Equal(t, SkillAssignmentStatusPending, assignment.Status)
+	require.Equal(t, "SKILL#skill-a#ASSIGNMENT", assignment.GSI1PK)
+	require.Equal(t, "SUBJECT#actor#alice#ASSIGNMENT#assignment-1", assignment.GSI1SK)
+	require.Equal(t, "SKILL_ASSIGNMENT#STATUS#pending", assignment.GSI2PK)
+	require.Contains(t, assignment.GSI2SK, "#SUBJECT#actor#alice#SKILL#skill-a")
+	require.False(t, assignment.AssignedAt.IsZero())
+	require.NotNil(t, assignment.RevokedAt)
+	require.Equal(t, revoked, *assignment.RevokedAt)
+	require.Equal(t, MainTableName, assignment.TableName())
+}
+
+func TestSkillAuthorityModels_RequireIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	require.Error(t, (&Skill{}).UpdateKeys())
+	require.Error(t, (&SkillRevision{SkillID: "skill-a"}).UpdateKeys())
+	require.Error(t, (&SkillProposal{ID: "proposal-1"}).UpdateKeys())
+	require.Error(t, (&SkillAssignment{ID: "assignment-1", SkillID: "skill-a", SubjectType: "actor"}).UpdateKeys())
+}

--- a/pkg/storage/repositories/skill_repository.go
+++ b/pkg/storage/repositories/skill_repository.go
@@ -1,0 +1,281 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/cost"
+	"github.com/equaltoai/lesser/pkg/storage/interfaces"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	"go.uber.org/zap"
+)
+
+const (
+	defaultSkillQueryLimit = 25
+	maxSkillQueryLimit     = 100
+)
+
+// SkillRepository implements canonical skill authority storage operations.
+type SkillRepository struct {
+	db             core.DB
+	skillRepo      *EnhancedBaseRepository[*models.Skill]
+	revisionRepo   *EnhancedBaseRepository[*models.SkillRevision]
+	proposalRepo   *EnhancedBaseRepository[*models.SkillProposal]
+	assignmentRepo *EnhancedBaseRepository[*models.SkillAssignment]
+}
+
+// NewSkillRepository creates a repository for canonical skill authority records.
+func NewSkillRepository(db core.DB, tableName string, logger *zap.Logger, costService *cost.TrackingService) *SkillRepository {
+	return &SkillRepository{
+		db:             db,
+		skillRepo:      newSkillEntityRepository[*models.Skill](db, tableName, logger, costService, "SkillRepository", "skill"),
+		revisionRepo:   newSkillEntityRepository[*models.SkillRevision](db, tableName, logger, costService, "SkillRevisionRepository", "skill_revision"),
+		proposalRepo:   newSkillEntityRepository[*models.SkillProposal](db, tableName, logger, costService, "SkillProposalRepository", "skill_proposal"),
+		assignmentRepo: newSkillEntityRepository[*models.SkillAssignment](db, tableName, logger, costService, "SkillAssignmentRepository", "skill_assignment"),
+	}
+}
+
+func newSkillEntityRepository[T BaseModel](db core.DB, tableName string, logger *zap.Logger, costService *cost.TrackingService, repoName, entityName string) *EnhancedBaseRepository[T] {
+	repo := NewEnhancedBaseRepository[T](db, tableName, logger, costService, repoName, entityName)
+	repo.SetValidationService(NewDefaultValidationService())
+	repo.SetPermissionService(NewDefaultPermissionService())
+	repo.SetCachingService(NewInMemoryCachingService())
+	repo.SetEventService(NewDefaultEventService())
+	return repo
+}
+
+// CreateSkill creates a canonical skill root.
+func (r *SkillRepository) CreateSkill(ctx context.Context, skill *models.Skill) error {
+	return r.skillRepo.ValidateAndCreate(ctx, skill)
+}
+
+// GetSkill retrieves a canonical skill root.
+func (r *SkillRepository) GetSkill(ctx context.Context, skillID string) (*models.Skill, error) {
+	var skill models.Skill
+	if err := r.skillRepo.Get(ctx, models.SkillPartitionKey(skillID), models.SKSkill, &skill); err != nil {
+		return nil, err
+	}
+	return &skill, nil
+}
+
+// UpdateSkill updates a canonical skill root.
+func (r *SkillRepository) UpdateSkill(ctx context.Context, skill *models.Skill) error {
+	return r.skillRepo.ValidateAndUpdate(ctx, skill)
+}
+
+// ListSkillsByStatus lists canonical skills by lifecycle status.
+func (r *SkillRepository) ListSkillsByStatus(ctx context.Context, status string, limit int, cursor string) ([]*models.Skill, string, error) {
+	status = strings.ToLower(strings.TrimSpace(status))
+	if status == "" {
+		status = models.SkillStatusActive
+	}
+	return querySkillGSIPage[*models.Skill](ctx, r.db, &models.Skill{}, models.IndexGSI1, "gsi1PK", gsi1SKField, "SKILL#STATUS#"+status, limit, cursor)
+}
+
+// CreateSkillRevision creates a canonical skill revision.
+func (r *SkillRepository) CreateSkillRevision(ctx context.Context, revision *models.SkillRevision) error {
+	return r.revisionRepo.ValidateAndCreate(ctx, revision)
+}
+
+// GetSkillRevision retrieves a canonical skill revision by skill and revision number.
+func (r *SkillRepository) GetSkillRevision(ctx context.Context, skillID string, revisionNumber int) (*models.SkillRevision, error) {
+	var revision models.SkillRevision
+	if err := r.revisionRepo.Get(ctx, models.SkillPartitionKey(skillID), models.SkillRevisionSortKey(revisionNumber), &revision); err != nil {
+		return nil, err
+	}
+	return &revision, nil
+}
+
+// UpdateSkillRevision updates a canonical skill revision.
+func (r *SkillRepository) UpdateSkillRevision(ctx context.Context, revision *models.SkillRevision) error {
+	return r.revisionRepo.ValidateAndUpdate(ctx, revision)
+}
+
+// ListSkillRevisions lists revisions for a canonical skill.
+func (r *SkillRepository) ListSkillRevisions(ctx context.Context, skillID string, limit int, cursor string) ([]*models.SkillRevision, string, error) {
+	skillID = strings.ToLower(strings.TrimSpace(skillID))
+	if err := common.ValidateRequiredParam("skillID", skillID); err != nil {
+		return nil, "", err
+	}
+	return listByPKSKPrefixPaginated[*models.SkillRevision](ctx, r.db, &models.SkillRevision{}, models.SkillPartitionKey(skillID), models.SKSkillRevisionPrefix, sanitizeSkillLimit(limit), cursor)
+}
+
+// GetSkillRevisionByDigest resolves a revision by manifest digest when the digest index is populated.
+func (r *SkillRepository) GetSkillRevisionByDigest(ctx context.Context, manifestDigest string) (*models.SkillRevision, error) {
+	manifestDigest = strings.ToLower(strings.TrimSpace(manifestDigest))
+	if err := common.ValidateRequiredParam("manifestDigest", manifestDigest); err != nil {
+		return nil, err
+	}
+	items, _, err := querySkillGSIPage[*models.SkillRevision](ctx, r.db, &models.SkillRevision{}, models.IndexGSI2, "gsi2PK", gsi2SKField, "SKILL_REVISION_DIGEST#"+manifestDigest, 1, "")
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, fmt.Errorf("skill revision digest not found: %s", manifestDigest)
+	}
+	return items[0], nil
+}
+
+// CreateSkillProposal creates a non-authoritative proposal for later canonicalization.
+func (r *SkillRepository) CreateSkillProposal(ctx context.Context, proposal *models.SkillProposal) error {
+	return r.proposalRepo.ValidateAndCreate(ctx, proposal)
+}
+
+// GetSkillProposal retrieves a skill proposal by ID.
+func (r *SkillRepository) GetSkillProposal(ctx context.Context, proposalID string) (*models.SkillProposal, error) {
+	var proposal models.SkillProposal
+	if err := r.proposalRepo.Get(ctx, models.SkillProposalPartitionKey(proposalID), models.SKSkillProposal, &proposal); err != nil {
+		return nil, err
+	}
+	return &proposal, nil
+}
+
+// UpdateSkillProposal updates a skill proposal.
+func (r *SkillRepository) UpdateSkillProposal(ctx context.Context, proposal *models.SkillProposal) error {
+	return r.proposalRepo.ValidateAndUpdate(ctx, proposal)
+}
+
+// ListSkillProposalsForSkill lists proposals associated with a canonical skill.
+func (r *SkillRepository) ListSkillProposalsForSkill(ctx context.Context, skillID string, limit int, cursor string) ([]*models.SkillProposal, string, error) {
+	skillID = strings.ToLower(strings.TrimSpace(skillID))
+	if err := common.ValidateRequiredParam("skillID", skillID); err != nil {
+		return nil, "", err
+	}
+	return querySkillGSIPage[*models.SkillProposal](ctx, r.db, &models.SkillProposal{}, models.IndexGSI1, "gsi1PK", gsi1SKField, "SKILL#"+skillID+"#PROPOSAL", limit, cursor)
+}
+
+// ListSkillProposalsByStatus lists proposals by lifecycle status for later review APIs.
+func (r *SkillRepository) ListSkillProposalsByStatus(ctx context.Context, status string, limit int, cursor string) ([]*models.SkillProposal, string, error) {
+	status = strings.ToLower(strings.TrimSpace(status))
+	if status == "" {
+		status = models.SkillProposalStatusProposed
+	}
+	return querySkillGSIPage[*models.SkillProposal](ctx, r.db, &models.SkillProposal{}, models.IndexGSI2, "gsi2PK", gsi2SKField, "SKILL_PROPOSAL#STATUS#"+status, limit, cursor)
+}
+
+// CreateSkillAssignment creates an effective-resolution assignment placeholder.
+func (r *SkillRepository) CreateSkillAssignment(ctx context.Context, assignment *models.SkillAssignment) error {
+	return r.assignmentRepo.ValidateAndCreate(ctx, assignment)
+}
+
+// GetSkillAssignment retrieves an assignment by subject, skill, and assignment ID.
+func (r *SkillRepository) GetSkillAssignment(ctx context.Context, subjectType, subjectID, skillID, assignmentID string) (*models.SkillAssignment, error) {
+	var assignment models.SkillAssignment
+	if err := r.assignmentRepo.Get(ctx, models.SkillAssignmentPartitionKey(subjectType, subjectID), models.SkillAssignmentSortKey(skillID, assignmentID), &assignment); err != nil {
+		return nil, err
+	}
+	return &assignment, nil
+}
+
+// UpdateSkillAssignment updates a skill assignment.
+func (r *SkillRepository) UpdateSkillAssignment(ctx context.Context, assignment *models.SkillAssignment) error {
+	return r.assignmentRepo.ValidateAndUpdate(ctx, assignment)
+}
+
+// ListSkillAssignmentsForSubject lists assignments for a subject boundary.
+func (r *SkillRepository) ListSkillAssignmentsForSubject(ctx context.Context, subjectType, subjectID string, limit int, cursor string) ([]*models.SkillAssignment, string, error) {
+	pk := models.SkillAssignmentPartitionKey(subjectType, subjectID)
+	if err := common.ValidateRequiredParam("assignmentSubject", pk); err != nil {
+		return nil, "", err
+	}
+	return listByPKSKPrefixPaginated[*models.SkillAssignment](ctx, r.db, &models.SkillAssignment{}, pk, models.SKSkillAssignmentPrefix, sanitizeSkillLimit(limit), cursor)
+}
+
+// ListSkillAssignmentsForSkill lists assignment references for a skill.
+func (r *SkillRepository) ListSkillAssignmentsForSkill(ctx context.Context, skillID string, limit int, cursor string) ([]*models.SkillAssignment, string, error) {
+	skillID = strings.ToLower(strings.TrimSpace(skillID))
+	if err := common.ValidateRequiredParam("skillID", skillID); err != nil {
+		return nil, "", err
+	}
+	return querySkillGSIPage[*models.SkillAssignment](ctx, r.db, &models.SkillAssignment{}, models.IndexGSI1, "gsi1PK", gsi1SKField, "SKILL#"+skillID+"#ASSIGNMENT", limit, cursor)
+}
+
+type skillGSIItem interface {
+	GetSK() string
+}
+
+func querySkillGSIPage[T skillGSIItem](ctx context.Context, db core.DB, model any, indexName, pkAttr, skAttr, pk string, limit int, cursor string) ([]T, string, error) {
+	if db == nil {
+		return nil, "", fmt.Errorf("database client is nil")
+	}
+	limit = sanitizeSkillLimit(limit)
+	query := db.WithContext(ctx).Model(model).
+		Index(indexName).
+		Where(pkAttr, "=", pk).
+		OrderBy(skAttr, "ASC")
+
+	cursor = strings.TrimSpace(cursor)
+	if cursor != "" {
+		query = query.Where(skAttr, ">", cursor)
+	}
+
+	query = query.Limit(limit + 1)
+
+	var items []T
+	if err := query.All(&items); err != nil {
+		return nil, "", err
+	}
+
+	nextCursor := ""
+	if len(items) > limit {
+		nextCursor = skillGSIItemCursor(items[limit-1], skAttr)
+		if nextCursor == "" {
+			nextCursor = items[limit-1].GetSK()
+		}
+		items = items[:limit]
+	}
+	return items, nextCursor, nil
+}
+
+func skillGSIItemCursor(item any, attr string) string {
+	value := reflect.ValueOf(item)
+	if !value.IsValid() {
+		return ""
+	}
+	if value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return ""
+		}
+		value = value.Elem()
+	}
+	if value.Kind() != reflect.Struct {
+		return ""
+	}
+	fieldName := skillGSIFieldName(attr)
+	if fieldName == "" {
+		return ""
+	}
+	field := value.FieldByName(fieldName)
+	if !field.IsValid() || field.Kind() != reflect.String {
+		return ""
+	}
+	return field.String()
+}
+
+func skillGSIFieldName(attr string) string {
+	switch attr {
+	case gsi1SKField:
+		return "GSI1SK"
+	case gsi2SKField:
+		return "GSI2SK"
+	default:
+		return ""
+	}
+}
+
+func sanitizeSkillLimit(limit int) int {
+	switch {
+	case limit <= 0:
+		return defaultSkillQueryLimit
+	case limit > maxSkillQueryLimit:
+		return maxSkillQueryLimit
+	default:
+		return limit
+	}
+}
+
+var _ interfaces.SkillRepository = (*SkillRepository)(nil)

--- a/pkg/storage/repositories/skill_repository_test.go
+++ b/pkg/storage/repositories/skill_repository_test.go
@@ -1,0 +1,186 @@
+package repositories
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/theory-cloud/tabletheory/pkg/mocks"
+	"go.uber.org/zap"
+)
+
+func TestSkillGSIItemCursorUsesCanonicalGSIFieldNames(t *testing.T) {
+	t.Parallel()
+
+	skill := &models.Skill{
+		GSI1SK: "UPDATED#2026-05-13T00:00:00Z#SKILL#example",
+		GSI2SK: "NAME#example#SKILL#example",
+	}
+
+	require.Equal(t, skill.GSI1SK, skillGSIItemCursor(skill, gsi1SKField))
+	require.Equal(t, skill.GSI2SK, skillGSIItemCursor(skill, gsi2SKField))
+	require.Empty(t, skillGSIItemCursor(skill, "gsi3SK"))
+	require.Empty(t, skillGSIItemCursor((*models.Skill)(nil), gsi1SKField))
+}
+
+func TestSkillRepositoryNilDatabasePaths(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := NewSkillRepository(nil, "test-table", zap.NewNop(), nil)
+
+	now := time.Date(2026, 5, 13, 8, 0, 0, 0, time.UTC)
+	skill := &models.Skill{
+		ID:              "skill-a",
+		Name:            "Skill A",
+		Status:          models.SkillStatusDraft,
+		DefaultExposure: models.SkillExposurePrivate,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	require.Error(t, repo.CreateSkill(ctx, skill))
+	require.Error(t, repo.UpdateSkill(ctx, skill))
+	_, err := repo.GetSkill(ctx, "skill-a")
+	require.Error(t, err)
+	_, _, err = repo.ListSkillsByStatus(ctx, "", 0, "")
+	require.Error(t, err)
+
+	revision := &models.SkillRevision{
+		ID:              "skill-a-r1",
+		SkillID:         "skill-a",
+		RevisionNumber:  1,
+		Status:          models.SkillRevisionStatusDraft,
+		DefaultExposure: models.SkillExposurePrivate,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	require.Error(t, repo.CreateSkillRevision(ctx, revision))
+	require.Error(t, repo.UpdateSkillRevision(ctx, revision))
+	_, err = repo.GetSkillRevision(ctx, "skill-a", 1)
+	require.Error(t, err)
+	_, err = repo.GetSkillRevisionByDigest(ctx, "sha256:abc")
+	require.Error(t, err)
+	_, err = repo.GetSkillRevisionByDigest(ctx, "")
+	require.Error(t, err)
+	_, _, err = repo.ListSkillRevisions(ctx, "", 0, "")
+	require.Error(t, err)
+
+	proposal := &models.SkillProposal{
+		ID:                "proposal-1",
+		SkillID:           "skill-a",
+		Status:            models.SkillProposalStatusProposed,
+		RequestedExposure: models.SkillExposurePrivate,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+	require.Error(t, repo.CreateSkillProposal(ctx, proposal))
+	require.Error(t, repo.UpdateSkillProposal(ctx, proposal))
+	_, err = repo.GetSkillProposal(ctx, "proposal-1")
+	require.Error(t, err)
+	_, _, err = repo.ListSkillProposalsForSkill(ctx, "skill-a", 0, "")
+	require.Error(t, err)
+	_, _, err = repo.ListSkillProposalsForSkill(ctx, "", 0, "")
+	require.Error(t, err)
+	_, _, err = repo.ListSkillProposalsByStatus(ctx, "", 0, "")
+	require.Error(t, err)
+
+	assignment := &models.SkillAssignment{
+		ID:                  "assignment-1",
+		SkillID:             "skill-a",
+		SubjectType:         models.SkillAssignmentSubjectActor,
+		SubjectID:           "alice",
+		Exposure:            models.SkillExposurePrivate,
+		Status:              models.SkillAssignmentStatusActive,
+		AssignedAt:          now,
+		CreatedAt:           now,
+		UpdatedAt:           now,
+		RevisionNumber:      1,
+		PrincipalID:         "principal-1",
+		ApprovalID:          "approval-1",
+		RevisionID:          "skill-a-r1",
+		AssignedBy:          "operator",
+		RevokedReason:       "",
+		RevokedBy:           "",
+		RevokedAt:           nil,
+		PrincipalApprovalID: "principal-approval-1",
+	}
+	require.Error(t, repo.CreateSkillAssignment(ctx, assignment))
+	require.Error(t, repo.UpdateSkillAssignment(ctx, assignment))
+	_, err = repo.GetSkillAssignment(ctx, "actor", "alice", "skill-a", "assignment-1")
+	require.Error(t, err)
+	_, _, err = repo.ListSkillAssignmentsForSkill(ctx, "skill-a", 0, "")
+	require.Error(t, err)
+	_, _, err = repo.ListSkillAssignmentsForSkill(ctx, "", 0, "")
+	require.Error(t, err)
+	_, _, err = repo.ListSkillAssignmentsForSubject(ctx, "", "", 0, "")
+	require.Error(t, err)
+}
+
+func TestQuerySkillGSIPagePagination(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB).Once()
+	mockDB.On("Model", mock.Anything).Return(mockQuery).Once()
+	mockQuery.On("Index", models.IndexGSI1).Return(mockQuery).Once()
+	mockQuery.On("Where", "gsi1PK", "=", "SKILL#STATUS#active").Return(mockQuery).Once()
+	mockQuery.On("OrderBy", gsi1SKField, "ASC").Return(mockQuery).Once()
+	mockQuery.On("Where", gsi1SKField, ">", "cursor").Return(mockQuery).Once()
+	mockQuery.On("Limit", 3).Return(mockQuery).Once()
+	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
+		out := args.Get(0).(*[]*models.Skill)
+		*out = []*models.Skill{
+			{ID: "a", GSI1SK: "a"},
+			{ID: "b", GSI1SK: "b"},
+			{ID: "c", GSI1SK: "c"},
+		}
+	}).Return(nil).Once()
+
+	items, cursor, err := querySkillGSIPage[*models.Skill](
+		ctx,
+		mockDB,
+		&models.Skill{},
+		models.IndexGSI1,
+		"gsi1PK",
+		gsi1SKField,
+		"SKILL#STATUS#active",
+		2,
+		"cursor",
+	)
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	require.Equal(t, "b", cursor)
+	mockDB.AssertExpectations(t)
+	mockQuery.AssertExpectations(t)
+}
+
+func TestQuerySkillGSIPageErrorsAndLimits(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := querySkillGSIPage[*models.Skill](context.Background(), nil, &models.Skill{}, models.IndexGSI1, "gsi1PK", gsi1SKField, "pk", 1, "")
+	require.Error(t, err)
+	require.Equal(t, defaultSkillQueryLimit, sanitizeSkillLimit(0))
+	require.Equal(t, defaultSkillQueryLimit, sanitizeSkillLimit(-1))
+	require.Equal(t, maxSkillQueryLimit, sanitizeSkillLimit(maxSkillQueryLimit+1))
+	require.Equal(t, 2, sanitizeSkillLimit(2))
+
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+	mockDB.On("WithContext", mock.Anything).Return(mockDB).Once()
+	mockDB.On("Model", mock.Anything).Return(mockQuery).Once()
+	mockQuery.On("Index", models.IndexGSI1).Return(mockQuery).Once()
+	mockQuery.On("Where", "gsi1PK", "=", "pk").Return(mockQuery).Once()
+	mockQuery.On("OrderBy", gsi1SKField, "ASC").Return(mockQuery).Once()
+	mockQuery.On("Limit", 2).Return(mockQuery).Once()
+	mockQuery.On("All", mock.Anything).Return(errors.New("query failed")).Once()
+
+	_, _, err = querySkillGSIPage[*models.Skill](context.Background(), mockDB, &models.Skill{}, models.IndexGSI1, "gsi1PK", gsi1SKField, "pk", 1, "")
+	require.Error(t, err)
+}

--- a/pkg/testing/mock_repository_storage.go
+++ b/pkg/testing/mock_repository_storage.go
@@ -86,6 +86,7 @@ type MockRepositoryStorage struct {
 	mediaPopularityRepo  interfaces.MediaPopularityRepository
 	mediaSessionRepo     interfaces.MediaSessionRepository
 	streamingConnRepo    interfaces.StreamingConnectionRepository
+	skillRepo            interfaces.SkillRepository
 
 	// CMS repositories (interface types for mockability)
 	articleRepo           interfaces.ArticleRepository
@@ -211,6 +212,14 @@ func WithMediaSessionRepository(repo interfaces.MediaSessionRepository) Option {
 func WithStreamingConnectionRepository(repo interfaces.StreamingConnectionRepository) Option {
 	return func(s *MockRepositoryStorage) {
 		s.streamingConnRepo = repo
+	}
+}
+
+// WithSkillRepository sets a custom canonical skill repository implementation.
+// Use this to inject a mock for testing specific skill authority behavior.
+func WithSkillRepository(repo interfaces.SkillRepository) Option {
+	return func(s *MockRepositoryStorage) {
+		s.skillRepo = repo
 	}
 }
 
@@ -597,6 +606,11 @@ func (s *MockRepositoryStorage) MediaSession() interfaces.MediaSessionRepository
 // StreamingConnection returns the streaming connection repository.
 func (s *MockRepositoryStorage) StreamingConnection() interfaces.StreamingConnectionRepository {
 	return s.streamingConnRepo
+}
+
+// Skill returns the skill repository (interface type for mockability).
+func (s *MockRepositoryStorage) Skill() interfaces.SkillRepository {
+	return s.skillRepo
 }
 
 // CMS Repository accessors


### PR DESCRIPTION
## Milestone
Project 21 M3 foundation — canonical skill authority models + repo-backed seed inventory.

Closes #698
Closes #699

## Classification
Schema / data-integrity + cross-repo skill authority foundation. This is intentionally model/docs only.

## Surfaces affected
- `pkg/storage/models/skill.go` and model tests
- `pkg/storage/interfaces/skill.go`
- `pkg/storage/repositories/skill_repository.go` and repository tests
- `pkg/storage/factory/factory.go`
- `pkg/testing/mock_repository_storage.go`
- `docs/architecture/skills/*`
- `docs/architecture/dynamodb/gsi_usage_guide.md`

## Specialist walks referenced
- Federation trust: no ActivityPub, inbox/outbox, signing, delivery, relay, moderation, or domain-blocking surface changed.
- Contract / API: no Mastodon REST, GraphQL, OpenAPI, ActivityPub actor, or JSON-LD shape changed.
- Schema: completed in `docs/architecture/skills/canonical-skill-authority.md`; additive new PK/SK patterns only; existing `USER#{username}` semantics and existing entity patterns are unchanged.
- Framework: uses TableTheory model tags and existing repository patterns idiomatically; no AppTheory/TableTheory workaround or framework patch.

## Consumer impact
- Operators: no deploy-time behavior change; new item shapes are inert until later APIs import/write skill records.
- Mastodon clients / remote AP peers: no impact.
- `lesser-body` / `lesser-host`: future #700/#701/#702/#703 work can consume this contract, but this PR does not change their runtime contract.
- Local `SKILL.md` files and lesser-host conversations remain provenance/source material only, not canonical authority.

## Tasks
- [x] #698 Design and implement `Skill`, `SkillRevision`, `SkillProposal`, and `SkillAssignment` models.
- [x] #699 Inventory repo-backed `SKILL.md` files as non-authoritative seed content and document publishability gaps.

## Validation
- `gofmt -l .` (empty)
- `go test ./pkg/storage/models ./pkg/storage/interfaces ./pkg/storage/repositories ./pkg/storage/factory ./pkg/testing`
- `go test ./...`
- `go vet ./...`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
Arch review requested next per Aron. Body/host coordination is expected for later API/runtime milestones, not required for this model/docs foundation.

## Advisor-brief authorization
Pilot assignment retrieved from `pilot@lessersoul.ai` delivery `delivery-977de258b0f0afa8`; Aron authorized implementation in-session after investigation.