### PR TITLE
feat(skills): promote accepted proposals into revisions

### DIFF
--- a/cmd/api/handlers/skills.go
+++ b/cmd/api/handlers/skills.go
@@ -24,6 +24,7 @@ type skillHandlerService interface {
 	ListAssignmentsForSkill(context.Context, string, int, string) ([]*storagemodels.SkillAssignment, string, error)
 	ApproveRevision(context.Context, string, int, skillservice.ApprovalCommand) (*storagemodels.SkillRevision, error)
 	RevokeRevision(context.Context, string, int, skillservice.RevocationCommand) (*storagemodels.SkillRevision, error)
+	PromoteProposal(context.Context, string, skillservice.PromotionCommand) (*skillservice.PromotionResult, error)
 	AssignSkill(context.Context, skillservice.AssignmentCommand) (*storagemodels.SkillAssignment, error)
 	RevokeAssignment(context.Context, skillservice.AssignmentRevocationCommand) (*storagemodels.SkillAssignment, error)
 	ResolveEffectiveSkills(context.Context, skillservice.Viewer, skillservice.ResolveCommand) (*skillservice.ResolveResult, error)
@@ -236,6 +237,42 @@ func (h *Handler) HandleAdminRevokeSkillRevisionLift(ctx *apptheory.Context) (*a
 	return okJSON(apimodels.SkillRevisionResponse{Revision: toAPISkillRevision(revision)})
 }
 
+// HandleAdminPromoteSkillProposalLift handles POST /api/v1/admin/skills/{skillId}/proposals/{proposalId}/promote.
+func (h *Handler) HandleAdminPromoteSkillProposalLift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	claims, resp, err := h.requireSkillAdmin(ctx, "admin:write")
+	if resp != nil || err != nil {
+		return resp, err
+	}
+	var req apimodels.PromoteSkillProposalRequest
+	if err := h.parseRequestBody(ctx, &req); err != nil {
+		return common.RespondBadRequest(ctx, "invalid request body")
+	}
+	result, err := h.getSkillService().PromoteProposal(ctx.Context(), ctx.Param("skillId"), skillservice.PromotionCommand{
+		ActorUsername:          claims.Username,
+		ProposalID:             ctx.Param("proposalId"),
+		ExpectedManifestDigest: req.ExpectedManifestDigest,
+		ExpectedSourceDigest:   req.ExpectedSourceDigest,
+		ApprovalID:             req.ApprovalID,
+		PrincipalID:            req.PrincipalID,
+		PrincipalApprovalID:    req.PrincipalApprovalID,
+		ApprovalAuthorityType:  req.ApprovalAuthorityType,
+		ApprovalAuthorityID:    req.ApprovalAuthorityID,
+		ApprovalDigest:         req.ApprovalDigest,
+		ApprovalSignature:      req.ApprovalSignature,
+		ApprovalRef:            req.ApprovalRef,
+		ApprovalReason:         req.ApprovalReason,
+	})
+	if err != nil {
+		return h.respondSkillServiceError(ctx, err)
+	}
+	out := apimodels.PromoteSkillProposalResponse{
+		Revision: toAPISkillRevision(result.Revision),
+		Proposal: toAPISkillProposal(result.Proposal),
+		Created:  result.Created,
+	}
+	return createdJSON(out)
+}
+
 // HandleAdminCreateSkillAssignmentLift handles POST /api/v1/admin/skills/{skillId}/assignments.
 func (h *Handler) HandleAdminCreateSkillAssignmentLift(ctx *apptheory.Context) (*apptheory.Response, error) {
 	claims, resp, err := h.requireSkillAdmin(ctx, "admin:write")
@@ -351,6 +388,10 @@ func (h *Handler) respondSkillServiceError(ctx *apptheory.Context, err error) (*
 		return common.RespondUnprocessableEntity(ctx, "invalid skill state")
 	case errors.Is(err, skillservice.ErrApprovalDigestMismatch):
 		return common.RespondUnprocessableEntity(ctx, "approval digest mismatch")
+	case errors.Is(err, skillservice.ErrPromotionDigestMismatch):
+		return common.RespondUnprocessableEntity(ctx, "promotion digest mismatch")
+	case errors.Is(err, skillservice.ErrPromotionConflict):
+		return common.RespondConflict(ctx, "skill promotion conflict")
 	case errors.Is(err, skillservice.ErrExposureViolation):
 		return common.RespondForbidden(ctx, "skill exposure violation")
 	default:
@@ -460,6 +501,11 @@ func toAPISkillProposal(proposal *storagemodels.SkillProposal) apimodels.SkillPr
 		ConversationMessageID:  proposal.ConversationMessageID,
 		PrincipalID:            proposal.PrincipalID,
 		PrincipalApprovalID:    proposal.PrincipalApprovalID,
+		PromotedRevisionID:     proposal.PromotedRevisionID,
+		PromotedRevisionNumber: proposal.PromotedRevisionNumber,
+		PromotionDigest:        proposal.PromotionDigest,
+		PromotedBy:             proposal.PromotedBy,
+		PromotedAt:             proposal.PromotedAt,
 		Provenance:             toAPISkillProvenance(proposal.Provenance),
 		CreatedBy:              proposal.CreatedBy,
 		ReviewedBy:             proposal.ReviewedBy,
@@ -560,6 +606,9 @@ func (nilSkillService) ApproveRevision(context.Context, string, int, skillservic
 	return nil, skillservice.ErrRepositoryUnavailable
 }
 func (nilSkillService) RevokeRevision(context.Context, string, int, skillservice.RevocationCommand) (*storagemodels.SkillRevision, error) {
+	return nil, skillservice.ErrRepositoryUnavailable
+}
+func (nilSkillService) PromoteProposal(context.Context, string, skillservice.PromotionCommand) (*skillservice.PromotionResult, error) {
 	return nil, skillservice.ErrRepositoryUnavailable
 }
 func (nilSkillService) AssignSkill(context.Context, skillservice.AssignmentCommand) (*storagemodels.SkillAssignment, error) {

--- a/cmd/api/handlers/skills_test.go
+++ b/cmd/api/handlers/skills_test.go
@@ -32,6 +32,8 @@ func TestSkillHandlers_ServiceErrorMapping(t *testing.T) {
 		{name: "invalid_input", err: skillservice.ErrInvalidInput, wantStatus: http.StatusBadRequest},
 		{name: "invalid_state", err: skillservice.ErrInvalidState, wantStatus: http.StatusUnprocessableEntity},
 		{name: "digest_mismatch", err: skillservice.ErrApprovalDigestMismatch, wantStatus: http.StatusUnprocessableEntity},
+		{name: "promotion_digest_mismatch", err: skillservice.ErrPromotionDigestMismatch, wantStatus: http.StatusUnprocessableEntity},
+		{name: "promotion_conflict", err: skillservice.ErrPromotionConflict, wantStatus: http.StatusConflict},
 		{name: "exposure_violation", err: skillservice.ErrExposureViolation, wantStatus: http.StatusForbidden},
 		{name: "unknown", err: errors.New("boom"), wantStatus: http.StatusInternalServerError},
 	}
@@ -95,6 +97,7 @@ type skillHandlerStub struct {
 	proposal    *storagemodels.SkillProposal
 	assignment  *storagemodels.SkillAssignment
 	resolveItem skillservice.EffectiveSkill
+	promotion   *skillservice.PromotionResult
 }
 
 func (s *skillHandlerStub) ListSkills(context.Context, skillservice.Viewer, skillservice.ListFilter) ([]*storagemodels.Skill, string, error) {
@@ -236,10 +239,13 @@ func TestSkillHandlers_MappingHelpers(t *testing.T) {
 		RequestedExposure: storagemodels.SkillExposurePublic, ProposedRevisionNumber: 2, ProposedManifestDigest: "sha256:manifest",
 		SourceType: storagemodels.SkillSourceTypeLocalFile, SourceURI: "file://skill", SourceDigest: "sha256:source",
 		ConversationID: "conv", ConversationMessageID: "msg", PrincipalID: "principal-1", PrincipalApprovalID: "principal-approval-1",
+		PromotedRevisionID: "skill-a-r2", PromotedRevisionNumber: 2, PromotionDigest: "sha256:promotion", PromotedBy: "ops", PromotedAt: &now,
 		Provenance: provenance, CreatedBy: "ops", ReviewedBy: "ops", ReviewedAt: &now, ReviewReason: "ok", CreatedAt: now, UpdatedAt: now, Version: 4,
 	})
 	require.Equal(t, "proposal-1", proposal.ID)
 	require.Equal(t, "principal-approval-1", proposal.PrincipalApprovalID)
+	require.Equal(t, "skill-a-r2", proposal.PromotedRevisionID)
+	require.Equal(t, "sha256:promotion", proposal.PromotionDigest)
 
 	assignment := toAPISkillAssignment(&storagemodels.SkillAssignment{
 		ID: "assign-1", SkillID: "skill-a", RevisionID: "skill-a-r1", RevisionNumber: 1,
@@ -269,6 +275,13 @@ func (s *skillHandlerStub) ApproveRevision(context.Context, string, int, skillse
 
 func (s *skillHandlerStub) RevokeRevision(context.Context, string, int, skillservice.RevocationCommand) (*storagemodels.SkillRevision, error) {
 	return s.revisions[0], nil
+}
+
+func (s *skillHandlerStub) PromoteProposal(context.Context, string, skillservice.PromotionCommand) (*skillservice.PromotionResult, error) {
+	if s.promotion != nil {
+		return s.promotion, nil
+	}
+	return &skillservice.PromotionResult{Revision: s.revisions[0], Proposal: s.proposal, Created: true}, nil
 }
 
 func (s *skillHandlerStub) AssignSkill(context.Context, skillservice.AssignmentCommand) (*storagemodels.SkillAssignment, error) {
@@ -321,6 +334,10 @@ func (s skillHandlerErrorStub) ApproveRevision(context.Context, string, int, ski
 }
 
 func (s skillHandlerErrorStub) RevokeRevision(context.Context, string, int, skillservice.RevocationCommand) (*storagemodels.SkillRevision, error) {
+	return nil, s.err
+}
+
+func (s skillHandlerErrorStub) PromoteProposal(context.Context, string, skillservice.PromotionCommand) (*skillservice.PromotionResult, error) {
 	return nil, s.err
 }
 
@@ -456,6 +473,17 @@ func TestSkillHandlers_ServiceErrorsFromEndpoints(t *testing.T) {
 			handle: h.HandleAdminRevokeSkillRevisionLift,
 		},
 		{
+			name: "promote proposal",
+			context: func() *apptheory.Context {
+				ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/admin/skills/skill-a/proposals/proposal-1/promote", adminWriteHeaders, nil, apimodels.PromoteSkillProposalRequest{ExpectedManifestDigest: "sha256:manifest"})
+				require.NoError(t, err)
+				ctx.Params["skillId"] = "skill-a"
+				ctx.Params["proposalId"] = "proposal-1"
+				return ctx
+			},
+			handle: h.HandleAdminPromoteSkillProposalLift,
+		},
+		{
 			name: "create assignment",
 			context: func() *apptheory.Context {
 				ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/admin/skills/skill-a/assignments", adminWriteHeaders, nil, apimodels.CreateSkillAssignmentRequest{SubjectType: "actor", SubjectID: "alice", RevisionNumber: 1})
@@ -542,6 +570,22 @@ func TestSkillHandlers_AuthenticatedAndAdminHandlers(t *testing.T) {
 	resp = requireStatus(t, http.StatusOK)(h.HandleAdminRevokeSkillRevisionLift(ctx))
 	require.Contains(t, string(resp.Body), "skill-a-r1")
 
+	ctx, err = round10NewLiftContext(http.MethodPost, "/api/v1/admin/skills/skill-a/proposals/proposal-1/promote", adminWriteHeaders, nil, apimodels.PromoteSkillProposalRequest{ExpectedManifestDigest: "sha256:manifest"})
+	require.NoError(t, err)
+	ctx.Params["skillId"] = "skill-a"
+	ctx.Params["proposalId"] = "proposal-1"
+	resp = requireStatus(t, http.StatusCreated)(h.HandleAdminPromoteSkillProposalLift(ctx))
+	require.Contains(t, string(resp.Body), "skill-a-r1")
+	require.Contains(t, string(resp.Body), "\"created\":true")
+
+	stub.promotion = &skillservice.PromotionResult{Revision: stub.revisions[0], Proposal: stub.proposal, Created: false}
+	ctx, err = round10NewLiftContext(http.MethodPost, "/api/v1/admin/skills/skill-a/proposals/proposal-1/promote", adminWriteHeaders, nil, apimodels.PromoteSkillProposalRequest{ExpectedManifestDigest: "sha256:manifest"})
+	require.NoError(t, err)
+	ctx.Params["skillId"] = "skill-a"
+	ctx.Params["proposalId"] = "proposal-1"
+	resp = requireStatus(t, http.StatusCreated)(h.HandleAdminPromoteSkillProposalLift(ctx))
+	require.Contains(t, string(resp.Body), "\"created\":false")
+
 	ctx, err = round10NewLiftContext(http.MethodPost, "/api/v1/admin/skills/skill-a/assignments", adminWriteHeaders, nil, apimodels.CreateSkillAssignmentRequest{SubjectType: "actor", SubjectID: "alice", RevisionNumber: 1})
 	require.NoError(t, err)
 	ctx.Params["skillId"] = "skill-a"
@@ -580,6 +624,12 @@ func TestSkillHandlers_AdminValidationBranches(t *testing.T) {
 	ctxWithReq.Params["revisionNumber"] = "bad"
 	resp = requireStatus(t, http.StatusBadRequest)(h.HandleAdminRevokeSkillRevisionLift(ctxWithReq))
 	require.Contains(t, string(resp.Body), "revision_number")
+
+	ctx = round10NewLiftContextWithBodyBytes(http.MethodPost, "/api/v1/admin/skills/skill-a/proposals/proposal-1/promote", adminWriteHeaders, nil, []byte("{"))
+	ctx.Params["skillId"] = "skill-a"
+	ctx.Params["proposalId"] = "proposal-1"
+	resp = requireStatus(t, http.StatusBadRequest)(h.HandleAdminPromoteSkillProposalLift(ctx))
+	require.Contains(t, string(resp.Body), "invalid request body")
 
 	ctx = round10NewLiftContextWithBodyBytes(http.MethodPost, "/api/v1/admin/skills/skill-a/assignments", adminWriteHeaders, nil, []byte("{"))
 	ctx.Params["skillId"] = "skill-a"
@@ -640,6 +690,8 @@ func TestSkillHandlers_AdminAuthFailuresAndNilService(t *testing.T) {
 	_, err = nilSvc.ApproveRevision(context.Background(), "skill-a", 1, skillservice.ApprovalCommand{})
 	require.ErrorIs(t, err, skillservice.ErrRepositoryUnavailable)
 	_, err = nilSvc.RevokeRevision(context.Background(), "skill-a", 1, skillservice.RevocationCommand{})
+	require.ErrorIs(t, err, skillservice.ErrRepositoryUnavailable)
+	_, err = nilSvc.PromoteProposal(context.Background(), "skill-a", skillservice.PromotionCommand{})
 	require.ErrorIs(t, err, skillservice.ErrRepositoryUnavailable)
 	_, err = nilSvc.AssignSkill(context.Background(), skillservice.AssignmentCommand{})
 	require.ErrorIs(t, err, skillservice.ErrRepositoryUnavailable)

--- a/cmd/api/models/skills.go
+++ b/cmd/api/models/skills.go
@@ -92,6 +92,11 @@ type SkillProposalResource struct {
 	ConversationMessageID  string               `json:"conversation_message_id,omitempty"`
 	PrincipalID            string               `json:"principal_id,omitempty"`
 	PrincipalApprovalID    string               `json:"principal_approval_id,omitempty"`
+	PromotedRevisionID     string               `json:"promoted_revision_id,omitempty"`
+	PromotedRevisionNumber int                  `json:"promoted_revision_number,omitempty"`
+	PromotionDigest        string               `json:"promotion_digest,omitempty"`
+	PromotedBy             string               `json:"promoted_by,omitempty"`
+	PromotedAt             *time.Time           `json:"promoted_at,omitempty"`
 	Provenance             []SkillProvenanceRef `json:"provenance,omitempty"`
 	CreatedBy              string               `json:"created_by,omitempty"`
 	ReviewedBy             string               `json:"reviewed_by,omitempty"`
@@ -206,6 +211,28 @@ type ApproveSkillRevisionRequest struct {
 // RevokeSkillRevisionRequest represents an admin revision revocation request.
 type RevokeSkillRevisionRequest struct {
 	Reason string `json:"reason,omitempty"`
+}
+
+// PromoteSkillProposalRequest represents an admin proposal promotion request.
+type PromoteSkillProposalRequest struct {
+	ExpectedManifestDigest string `json:"expected_manifest_digest,omitempty"`
+	ExpectedSourceDigest   string `json:"expected_source_digest,omitempty"`
+	ApprovalID             string `json:"approval_id,omitempty"`
+	PrincipalID            string `json:"principal_id,omitempty"`
+	PrincipalApprovalID    string `json:"principal_approval_id,omitempty"`
+	ApprovalAuthorityType  string `json:"approval_authority_type,omitempty"`
+	ApprovalAuthorityID    string `json:"approval_authority_id,omitempty"`
+	ApprovalDigest         string `json:"approval_digest,omitempty"`
+	ApprovalSignature      string `json:"approval_signature,omitempty"`
+	ApprovalRef            string `json:"approval_ref,omitempty"`
+	ApprovalReason         string `json:"approval_reason,omitempty"`
+}
+
+// PromoteSkillProposalResponse represents the canonical revision produced by promotion.
+type PromoteSkillProposalResponse struct {
+	Revision SkillRevisionResource `json:"revision"`
+	Proposal SkillProposalResource `json:"proposal"`
+	Created  bool                  `json:"created"`
 }
 
 // CreateSkillAssignmentRequest represents an admin assignment request.

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -461,6 +461,7 @@ func configureRoutes(app *apptheory.App) {
 	app.Get("/api/v1/admin/skills/{skillId}/assignments", apiHandler.HandleAdminListSkillAssignmentsLift, requireAdminRead)
 	app.Post("/api/v1/admin/skills/{skillId}/revisions/{revisionNumber}/approve", apiHandler.HandleAdminApproveSkillRevisionLift, requireAdminWrite)
 	app.Post("/api/v1/admin/skills/{skillId}/revisions/{revisionNumber}/revoke", apiHandler.HandleAdminRevokeSkillRevisionLift, requireAdminWrite)
+	app.Post("/api/v1/admin/skills/{skillId}/proposals/{proposalId}/promote", apiHandler.HandleAdminPromoteSkillProposalLift, requireAdminWrite)
 	app.Post("/api/v1/admin/skills/{skillId}/assignments", apiHandler.HandleAdminCreateSkillAssignmentLift, requireAdminWrite)
 	app.Post("/api/v1/admin/skills/{skillId}/assignments/{assignmentId}/revoke", apiHandler.HandleAdminRevokeSkillAssignmentLift, requireAdminWrite)
 

--- a/cmd/api/testdata/routes_manifest.txt
+++ b/cmd/api/testdata/routes_manifest.txt
@@ -197,6 +197,7 @@ POST /api/v1/admin/reports/{id}/resolve
 POST /api/v1/admin/reports/{id}/unassign
 POST /api/v1/admin/skills/{skillId}/assignments
 POST /api/v1/admin/skills/{skillId}/assignments/{assignmentId}/revoke
+POST /api/v1/admin/skills/{skillId}/proposals/{proposalId}/promote
 POST /api/v1/admin/skills/{skillId}/revisions/{revisionNumber}/approve
 POST /api/v1/admin/skills/{skillId}/revisions/{revisionNumber}/revoke
 POST /api/v1/admin/statuses/{id}/sensitive

--- a/docs/architecture/skills/canonical-skill-authority.md
+++ b/docs/architecture/skills/canonical-skill-authority.md
@@ -1,18 +1,17 @@
 # Canonical skill authority foundation
 
-Status: Project 21 M3 foundation (#698/#699), model layer only.
+Status: Project 21 M3 canonical authority (#698/#699/#700/#701/#702).
 
 ## Purpose
 
 M3 establishes **Lesser as the canonical skill authority**. Repo-backed `SKILL.md`
 files and lesser-host mint conversations may be used as source material or
 provenance, but neither is the system of record. The canonical authority lives in
-Lesser's single DynamoDB table and later milestones expose approval, exposure,
-effective-resolution, and publication APIs from that state.
+Lesser's single DynamoDB table and exposes approval, exposure, effective-resolution,
+and proposal-promotion APIs from that state.
 
-This slice intentionally stops at storage models, repository seams, and seed
-inventory. It does **not** implement approval/revoke/resolve APIs, conversation
-promotion, runtime bundle publication, or lesser-body catalog tooling.
+This milestone intentionally stops before M4 publication/catalog/bundle behavior
+and before lesser-body skills MCP tool work.
 
 ## Entity model
 
@@ -30,6 +29,9 @@ The model keeps revision and assignment boundaries separate:
   principal approval, and provenance without making the proposal or source canonical.
 - A `SkillProposal` represents import/source material from local files, lesser-host
   conversations, or manual drafting. It is never authoritative by itself.
+  Accepted proposals may be promoted into canonical `SkillRevision` rows; the
+  proposal then records the resulting promoted revision ID/number, promotion
+  digest, promoting actor, and promotion timestamp.
 - A `SkillAssignment` binds a skill/revision to a subject (`instance`, `actor`, or
   `principal`) with exposure and lifecycle state for later resolution APIs.
 
@@ -49,6 +51,23 @@ The foundation records hooks for later milestones without implementing their API
 - source fields for `local_file`, `host_conversation`, and `manual`
 - manifest/content/bundle digests and file-level digests
 - conversation IDs as provenance only; lesser-host remains non-canonical
+
+Promotion from conversation output is fail-closed:
+
+- the source `SkillProposal` must already be `accepted`;
+- `proposedManifestJSON` must be present, valid JSON object material and its
+  canonical digest must match `proposedManifestDigest` and any caller-supplied
+  expected digest;
+- optional source digest expectations must match the proposal's source digest;
+- the resulting `SkillRevision` is written as an approved canonical row using the
+  same approval/principal digest semantics as direct revision approval;
+- idempotent replays return the existing revision when proposal, revision,
+  manifest digest, approval digest, and promotion digest match;
+- conflicting existing revisions or conflicting promoted proposal metadata return
+  a conflict rather than silently rewriting authority;
+- promotion updates the skill's current revision pointer but does not create any
+  `SkillAssignment` rows and does not broaden exposure beyond the proposal's
+  accepted requested exposure.
 
 ## Schema-integrity audit
 

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -4429,6 +4429,46 @@ components:
             items:
                 $ref: '#/components/schemas/PreviewCard'
             type: array
+        PromoteSkillProposalRequest:
+            additionalProperties: false
+            properties:
+                approval_authority_id:
+                    type: string
+                approval_authority_type:
+                    type: string
+                approval_digest:
+                    type: string
+                approval_id:
+                    type: string
+                approval_reason:
+                    type: string
+                approval_ref:
+                    type: string
+                approval_signature:
+                    type: string
+                expected_manifest_digest:
+                    type: string
+                expected_source_digest:
+                    type: string
+                principal_approval_id:
+                    type: string
+                principal_id:
+                    type: string
+            type: object
+        PromoteSkillProposalResponse:
+            additionalProperties: false
+            properties:
+                created:
+                    type: boolean
+                proposal:
+                    $ref: '#/components/schemas/SkillProposalResource'
+                revision:
+                    $ref: '#/components/schemas/SkillRevisionResource'
+            required:
+                - created
+                - proposal
+                - revision
+            type: object
         PushNotification:
             additionalProperties: false
             properties:
@@ -5533,6 +5573,18 @@ components:
                 principal_approval_id:
                     type: string
                 principal_id:
+                    type: string
+                promoted_at:
+                    anyOf:
+                        - $ref: '#/components/schemas/RFC3339DateTime'
+                        - type: "null"
+                promoted_by:
+                    type: string
+                promoted_revision_id:
+                    type: string
+                promoted_revision_number:
+                    type: integer
+                promotion_digest:
                     type: string
                 proposed_manifest_digest:
                     type: string
@@ -11618,6 +11670,56 @@ paths:
                 "500":
                     $ref: '#/components/responses/InternalServerError'
             x-lesser-handler: HandleAdminRevokeSkillAssignmentLift
+            x-lesser-lambda: api
+            x-lesser-routeSources:
+                - cmd/api/routes.go
+            x-oauth-scopes:
+                - admin:write
+    /api/v1/admin/skills/{skillId}/proposals/{proposalId}/promote:
+        post:
+            operationId: post_api_v1_admin_skills_by_skillId_proposals_by_proposalId_promote
+            tags:
+                - admin
+            security:
+                - bearerAuth: []
+            parameters:
+                - name: proposalId
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: skillId
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/PromoteSkillProposalRequest'
+            responses:
+                "201":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/PromoteSkillProposalResponse'
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "401":
+                    $ref: '#/components/responses/Unauthorized'
+                "403":
+                    $ref: '#/components/responses/Forbidden'
+                "404":
+                    $ref: '#/components/responses/NotFound'
+                "409":
+                    $ref: '#/components/responses/Conflict'
+                "422":
+                    $ref: '#/components/responses/UnprocessableEntity'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+            x-lesser-handler: HandleAdminPromoteSkillProposalLift
             x-lesser-lambda: api
             x-lesser-routeSources:
                 - cmd/api/routes.go

--- a/docs/specs/graphql_coverage.yaml
+++ b/docs/specs/graphql_coverage.yaml
@@ -513,6 +513,10 @@ routes:
       policy: rest_only
       exemptedBy: canonical_skill_authority
     - method: POST
+      path: /api/v1/admin/skills/{skillId}/proposals/{proposalId}/promote
+      policy: rest_only
+      exemptedBy: canonical_skill_authority
+    - method: POST
       path: /api/v1/admin/skills/{skillId}/revisions/{revisionNumber}/approve
       policy: rest_only
       exemptedBy: canonical_skill_authority

--- a/pkg/services/skills/service.go
+++ b/pkg/services/skills/service.go
@@ -3,13 +3,18 @@ package skills
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
 	"github.com/equaltoai/lesser/pkg/storage/models"
+	tableerrors "github.com/theory-cloud/tabletheory/pkg/errors"
 )
 
 var (
@@ -33,6 +38,10 @@ var (
 	ErrApprovalDigestMismatch = errors.New("approval digest mismatch")
 	// ErrExposureViolation indicates the requested exposure exceeds the canonical revision exposure.
 	ErrExposureViolation = errors.New("skill exposure violation")
+	// ErrPromotionDigestMismatch indicates promotion source/output digest validation failed.
+	ErrPromotionDigestMismatch = errors.New("skill promotion digest mismatch")
+	// ErrPromotionConflict indicates a proposal was already promoted into a conflicting canonical revision.
+	ErrPromotionConflict = errors.New("skill promotion conflict")
 )
 
 // Viewer identifies the caller for exposure and self-resolution checks.
@@ -96,6 +105,24 @@ type AssignmentRevocationCommand struct {
 	RevocationCommand
 }
 
+// PromotionCommand promotes accepted proposal/conversation output into a canonical revision.
+type PromotionCommand struct {
+	ActorUsername          string
+	ProposalID             string
+	ExpectedManifestDigest string
+	ExpectedSourceDigest   string
+	ApprovalID             string
+	PrincipalID            string
+	PrincipalApprovalID    string
+	ApprovalAuthorityType  string
+	ApprovalAuthorityID    string
+	ApprovalDigest         string
+	ApprovalSignature      string
+	ApprovalRef            string
+	ApprovalReason         string
+	ApprovedAt             time.Time
+}
+
 // ResolveCommand resolves active assignments for a subject.
 type ResolveCommand struct {
 	SubjectType string
@@ -117,6 +144,13 @@ type ResolveResult struct {
 	SubjectID   string
 	Items       []EffectiveSkill
 	NextCursor  string
+}
+
+// PromotionResult describes the canonical revision produced by a proposal promotion.
+type PromotionResult struct {
+	Revision *models.SkillRevision
+	Proposal *models.SkillProposal
+	Created  bool
 }
 
 // Service owns canonical skill approval, assignment, and resolution semantics.
@@ -339,6 +373,76 @@ func (s *Service) RevokeAssignment(ctx context.Context, cmd AssignmentRevocation
 		return nil, err
 	}
 	return assignment, nil
+}
+
+// PromoteProposal promotes accepted proposal output into an approved canonical revision.
+func (s *Service) PromoteProposal(ctx context.Context, skillID string, cmd PromotionCommand) (*PromotionResult, error) {
+	if err := s.ensureRepo(); err != nil {
+		return nil, err
+	}
+	cmd = normalizePromotionCommand(cmd)
+	if cmd.ActorUsername == "" {
+		return nil, errors.Join(ErrInvalidInput, errors.New("promotion actor is required"))
+	}
+	if cmd.ProposalID == "" {
+		return nil, errors.Join(ErrInvalidInput, errors.New("proposal id is required"))
+	}
+	skill, err := s.repo.GetSkill(ctx, skillID)
+	if err != nil {
+		return nil, ErrSkillNotFound
+	}
+	proposal, err := s.repo.GetSkillProposal(ctx, cmd.ProposalID)
+	if err != nil {
+		return nil, ErrSkillProposalNotFound
+	}
+	if !strings.EqualFold(strings.TrimSpace(proposal.SkillID), strings.TrimSpace(skill.ID)) {
+		return nil, ErrPromotionConflict
+	}
+	if proposal.Status != models.SkillProposalStatusAccepted {
+		return nil, ErrInvalidState
+	}
+
+	manifestJSON, manifestDigest, err := canonicalizeSkillManifest(proposal.ProposedManifestJSON)
+	if err != nil {
+		return nil, errors.Join(ErrInvalidInput, err)
+	}
+	if proposal.ProposedManifestDigest == "" {
+		return nil, errors.Join(ErrInvalidInput, errors.New("proposal manifest digest is required"))
+	}
+	if !sameDigest(proposal.ProposedManifestDigest, manifestDigest) {
+		return nil, ErrPromotionDigestMismatch
+	}
+	if cmd.ExpectedManifestDigest != "" && !sameDigest(cmd.ExpectedManifestDigest, manifestDigest) {
+		return nil, ErrPromotionDigestMismatch
+	}
+	if cmd.ExpectedSourceDigest != "" && !sameDigest(cmd.ExpectedSourceDigest, proposal.SourceDigest) {
+		return nil, ErrPromotionDigestMismatch
+	}
+
+	revision := buildPromotionRevision(skill, proposal, manifestJSON, manifestDigest, cmd, s.currentTime())
+	if err := applyPromotionApproval(revision, proposal, cmd, s.currentTime()); err != nil {
+		return nil, err
+	}
+	promotionDigest, err := models.SkillPromotionDigest(proposal, revision)
+	if err != nil {
+		return nil, errors.Join(ErrInvalidInput, err)
+	}
+
+	if result, ok, err := s.resolveExistingPromotion(ctx, skill, proposal, revision, promotionDigest, cmd.ActorUsername); ok || err != nil {
+		return result, err
+	}
+
+	if err := s.repo.CreateSkillRevision(ctx, revision); err != nil {
+		return nil, err
+	}
+	if err := s.promoteSkillPointer(ctx, skill, revision, cmd.ActorUsername); err != nil {
+		return nil, err
+	}
+	applyProposalPromotion(proposal, revision, promotionDigest, cmd.ActorUsername, s.currentTime())
+	if err := s.repo.UpdateSkillProposal(ctx, proposal); err != nil {
+		return nil, err
+	}
+	return &PromotionResult{Revision: revision, Proposal: proposal, Created: true}, nil
 }
 
 // ResolveEffectiveSkills returns active approved skill revisions for a subject.
@@ -656,6 +760,251 @@ func applyAssignmentRevocation(assignment *models.SkillAssignment, cmd Revocatio
 	assignment.RevokedAt = ptrTime(when)
 	assignment.RevokedReason = strings.TrimSpace(cmd.Reason)
 	_ = assignment.UpdateKeys()
+}
+
+func normalizePromotionCommand(cmd PromotionCommand) PromotionCommand {
+	cmd.ActorUsername = strings.TrimSpace(cmd.ActorUsername)
+	cmd.ProposalID = strings.ToLower(strings.TrimSpace(cmd.ProposalID))
+	cmd.ExpectedManifestDigest = strings.ToLower(strings.TrimSpace(cmd.ExpectedManifestDigest))
+	cmd.ExpectedSourceDigest = strings.ToLower(strings.TrimSpace(cmd.ExpectedSourceDigest))
+	cmd.ApprovalID = strings.TrimSpace(cmd.ApprovalID)
+	cmd.PrincipalID = strings.TrimSpace(cmd.PrincipalID)
+	cmd.PrincipalApprovalID = strings.TrimSpace(cmd.PrincipalApprovalID)
+	cmd.ApprovalAuthorityType = strings.ToLower(strings.TrimSpace(cmd.ApprovalAuthorityType))
+	cmd.ApprovalAuthorityID = strings.TrimSpace(cmd.ApprovalAuthorityID)
+	cmd.ApprovalDigest = strings.ToLower(strings.TrimSpace(cmd.ApprovalDigest))
+	cmd.ApprovalSignature = strings.TrimSpace(cmd.ApprovalSignature)
+	cmd.ApprovalRef = strings.TrimSpace(cmd.ApprovalRef)
+	cmd.ApprovalReason = strings.TrimSpace(cmd.ApprovalReason)
+	return cmd
+}
+
+func canonicalizeSkillManifest(raw string) (string, string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", errors.New("proposal manifest json is required")
+	}
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.UseNumber()
+	var manifest map[string]any
+	if err := decoder.Decode(&manifest); err != nil {
+		return "", "", fmt.Errorf("proposal manifest json is malformed: %w", err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return "", "", errors.New("proposal manifest json has trailing data")
+	}
+	if len(manifest) == 0 {
+		return "", "", errors.New("proposal manifest json must be a non-empty object")
+	}
+	canonical, err := json.Marshal(manifest)
+	if err != nil {
+		return "", "", fmt.Errorf("canonicalize proposal manifest: %w", err)
+	}
+	sum := sha256.Sum256(canonical)
+	return string(canonical), "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func buildPromotionRevision(skill *models.Skill, proposal *models.SkillProposal, manifestJSON, manifestDigest string, cmd PromotionCommand, now time.Time) *models.SkillRevision {
+	revisionNumber := proposal.ProposedRevisionNumber
+	if revisionNumber <= 0 && skill != nil {
+		revisionNumber = skill.CurrentRevisionNumber + 1
+	}
+	if revisionNumber <= 0 {
+		revisionNumber = 1
+	}
+	exposure := proposal.RequestedExposure
+	if exposure == "" {
+		exposure = models.SkillExposurePrivate
+	}
+	actor := strings.TrimSpace(cmd.ActorUsername)
+	revision := &models.SkillRevision{
+		SkillID:         skill.ID,
+		RevisionNumber:  revisionNumber,
+		Status:          models.SkillRevisionStatusProposed,
+		ProposalID:      proposal.ID,
+		ManifestJSON:    manifestJSON,
+		ManifestDigest:  manifestDigest,
+		ContentDigest:   proposal.SourceDigest,
+		Capabilities:    capabilitiesFromManifest(manifestJSON),
+		DefaultExposure: exposure,
+		CreatedBy:       actor,
+		UpdatedBy:       actor,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		Provenance:      promotionProvenance(proposal, manifestDigest),
+	}
+	if revision.ID == "" {
+		revision.ID = fmt.Sprintf("%s-r%d", skill.ID, revisionNumber)
+	}
+	return revision
+}
+
+func capabilitiesFromManifest(manifestJSON string) []string {
+	var manifest struct {
+		Capabilities []string `json:"capabilities"`
+	}
+	if err := json.Unmarshal([]byte(manifestJSON), &manifest); err != nil {
+		return nil
+	}
+	return manifest.Capabilities
+}
+
+func promotionProvenance(proposal *models.SkillProposal, manifestDigest string) []models.SkillProvenanceRef {
+	out := append([]models.SkillProvenanceRef(nil), proposal.Provenance...)
+	sourceType := proposal.SourceType
+	if sourceType == "" {
+		sourceType = models.SkillSourceTypeManual
+	}
+	sourceRef := strings.TrimSpace(proposal.ConversationMessageID)
+	if sourceRef == "" {
+		sourceRef = strings.TrimSpace(proposal.ConversationID)
+	}
+	sourceDigest := strings.TrimSpace(proposal.SourceDigest)
+	if sourceDigest == "" {
+		sourceDigest = manifestDigest
+	}
+	out = append(out, models.SkillProvenanceRef{
+		SourceType: sourceType,
+		SourceURI:  strings.TrimSpace(proposal.SourceURI),
+		Digest:     sourceDigest,
+		Ref:        sourceRef,
+	})
+	out = append(out, models.SkillProvenanceRef{
+		SourceType: models.SkillSourceTypeProposal,
+		Digest:     manifestDigest,
+		Ref:        proposal.ID,
+	})
+	return out
+}
+
+func applyPromotionApproval(revision *models.SkillRevision, proposal *models.SkillProposal, cmd PromotionCommand, now time.Time) error {
+	approval := ApprovalCommand{
+		ActorUsername:         cmd.ActorUsername,
+		ApprovalID:            cmd.ApprovalID,
+		PrincipalID:           defaultTrimmed(cmd.PrincipalID, proposal.PrincipalID),
+		PrincipalApprovalID:   defaultTrimmed(cmd.PrincipalApprovalID, proposal.PrincipalApprovalID),
+		ApprovalAuthorityType: cmd.ApprovalAuthorityType,
+		ApprovalAuthorityID:   cmd.ApprovalAuthorityID,
+		ApprovalDigest:        cmd.ApprovalDigest,
+		ApprovalSignature:     cmd.ApprovalSignature,
+		ApprovalRef:           cmd.ApprovalRef,
+		ApprovalReason:        defaultTrimmed(cmd.ApprovalReason, proposal.ReviewReason),
+		ApprovedAt:            cmd.ApprovedAt,
+	}
+	applyApprovalDefaults(&approval, revision, now)
+	return applyApprovalCommand(revision, approval)
+}
+
+func (s *Service) resolveExistingPromotion(ctx context.Context, skill *models.Skill, proposal *models.SkillProposal, revision *models.SkillRevision, promotionDigest, actor string) (*PromotionResult, bool, error) {
+	if proposal.PromotedRevisionID != "" || proposal.PromotedRevisionNumber > 0 || proposal.PromotionDigest != "" {
+		if !samePromotionMetadata(proposal, revision, promotionDigest) {
+			return nil, true, ErrPromotionConflict
+		}
+		existing, err := s.repo.GetSkillRevision(ctx, skill.ID, proposal.PromotedRevisionNumber)
+		if err != nil {
+			return nil, true, ErrPromotionConflict
+		}
+		if !samePromotedRevision(existing, proposal, revision) {
+			return nil, true, ErrPromotionConflict
+		}
+		if err := s.promoteSkillPointer(ctx, skill, existing, actor); err != nil {
+			return nil, true, err
+		}
+		return &PromotionResult{Revision: existing, Proposal: proposal, Created: false}, true, nil
+	}
+
+	existing, err := s.repo.GetSkillRevision(ctx, skill.ID, revision.RevisionNumber)
+	if err == nil {
+		return s.reconcileExistingPromotion(ctx, skill, proposal, existing, revision, promotionDigest, actor)
+	}
+	if !isSkillNotFound(err) {
+		return nil, true, err
+	}
+
+	existing, err = s.repo.GetSkillRevisionByDigest(ctx, revision.ManifestDigest)
+	if err == nil {
+		return s.reconcileExistingPromotion(ctx, skill, proposal, existing, revision, promotionDigest, actor)
+	}
+	if !isSkillNotFound(err) {
+		return nil, true, err
+	}
+	return nil, false, nil
+}
+
+func (s *Service) reconcileExistingPromotion(ctx context.Context, skill *models.Skill, proposal *models.SkillProposal, existing, expected *models.SkillRevision, promotionDigest, actor string) (*PromotionResult, bool, error) {
+	if !samePromotedRevision(existing, proposal, expected) {
+		return nil, true, ErrPromotionConflict
+	}
+	if err := s.promoteSkillPointer(ctx, skill, existing, actor); err != nil {
+		return nil, true, err
+	}
+	applyProposalPromotion(proposal, existing, promotionDigest, actor, s.currentTime())
+	if err := s.repo.UpdateSkillProposal(ctx, proposal); err != nil {
+		return nil, true, err
+	}
+	return &PromotionResult{Revision: existing, Proposal: proposal, Created: false}, true, nil
+}
+
+func (s *Service) promoteSkillPointer(ctx context.Context, skill *models.Skill, revision *models.SkillRevision, actor string) error {
+	if skill == nil || revision == nil {
+		return ErrInvalidInput
+	}
+	if skill.CurrentRevisionNumber > revision.RevisionNumber {
+		return nil
+	}
+	if skill.CurrentRevisionNumber != revision.RevisionNumber {
+		if err := s.supersedeCurrentRevision(ctx, skill, revision); err != nil {
+			return err
+		}
+	}
+	updateSkillCurrentRevision(skill, revision, actor)
+	skill.UpdatedAt = s.currentTime()
+	return s.repo.UpdateSkill(ctx, skill)
+}
+
+func applyProposalPromotion(proposal *models.SkillProposal, revision *models.SkillRevision, promotionDigest, actor string, now time.Time) {
+	proposal.Status = models.SkillProposalStatusAccepted
+	proposal.ProposedRevisionNumber = revision.RevisionNumber
+	proposal.ProposedManifestDigest = revision.ManifestDigest
+	proposal.PromotedRevisionID = revision.ID
+	proposal.PromotedRevisionNumber = revision.RevisionNumber
+	proposal.PromotionDigest = promotionDigest
+	proposal.PromotedBy = strings.TrimSpace(actor)
+	proposal.PromotedAt = ptrTime(now)
+	proposal.UpdatedAt = now.UTC()
+	_ = proposal.UpdateKeys()
+}
+
+func samePromotionMetadata(proposal *models.SkillProposal, revision *models.SkillRevision, promotionDigest string) bool {
+	return proposal.PromotedRevisionNumber == revision.RevisionNumber &&
+		strings.EqualFold(proposal.PromotedRevisionID, revision.ID) &&
+		sameDigest(proposal.PromotionDigest, promotionDigest)
+}
+
+func samePromotedRevision(existing *models.SkillRevision, proposal *models.SkillProposal, expected *models.SkillRevision) bool {
+	if existing == nil || proposal == nil || expected == nil {
+		return false
+	}
+	return existing.Status == models.SkillRevisionStatusApproved &&
+		strings.EqualFold(existing.SkillID, expected.SkillID) &&
+		existing.RevisionNumber == expected.RevisionNumber &&
+		strings.EqualFold(existing.ProposalID, proposal.ID) &&
+		sameDigest(existing.ManifestDigest, expected.ManifestDigest) &&
+		sameDigest(existing.ApprovalDigest, expected.ApprovalDigest)
+}
+
+func sameDigest(left, right string) bool {
+	left = strings.ToLower(strings.TrimSpace(left))
+	right = strings.ToLower(strings.TrimSpace(right))
+	return left != "" && left == right
+}
+
+func isSkillNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	return tableerrors.IsNotFound(err) || strings.Contains(strings.ToLower(err.Error()), "not found")
 }
 
 func canExposeAssignment(viewer Viewer, assignment *models.SkillAssignment) bool {

--- a/pkg/services/skills/service_test.go
+++ b/pkg/services/skills/service_test.go
@@ -501,6 +501,75 @@ func TestServicePromoteProposalIdempotencyAndConflict(t *testing.T) {
 	require.ErrorIs(t, err, ErrPromotionConflict)
 }
 
+func TestServicePromoteProposalReconcilesExistingRevision(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 5, 13, 18, 30, 0, 0, time.UTC)
+	repo := newFakeSkillRepo()
+	svc := NewService(repo).WithNow(func() time.Time { return now })
+	require.NoError(t, repo.CreateSkill(ctx, &models.Skill{
+		ID:                    "skill-a",
+		Status:                models.SkillStatusActive,
+		DefaultExposure:       models.SkillExposurePrivate,
+		CurrentRevisionNumber: 1,
+		CurrentRevisionID:     "skill-a-r1",
+	}))
+	proposal := acceptedPromotionProposal(t, "proposal-1", "skill-a")
+	proposal.ProposedRevisionNumber = 2
+	require.NoError(t, repo.CreateSkillProposal(ctx, proposal))
+
+	manifestJSON, manifestDigest, err := canonicalizeSkillManifest(proposal.ProposedManifestJSON)
+	require.NoError(t, err)
+	expected := buildPromotionRevision(&models.Skill{ID: "skill-a", CurrentRevisionNumber: 1}, proposal, manifestJSON, manifestDigest, PromotionCommand{ActorUsername: "ops"}, now)
+	require.NoError(t, applyPromotionApproval(expected, proposal, PromotionCommand{ActorUsername: "ops"}, now))
+	require.NoError(t, repo.CreateSkillRevision(ctx, expected))
+
+	result, err := svc.PromoteProposal(ctx, "skill-a", PromotionCommand{
+		ActorUsername:          "ops",
+		ProposalID:             "proposal-1",
+		ExpectedManifestDigest: manifestDigest,
+	})
+	require.NoError(t, err)
+	require.False(t, result.Created)
+	require.Equal(t, expected.ID, result.Revision.ID)
+
+	promoted, err := repo.GetSkillProposal(ctx, "proposal-1")
+	require.NoError(t, err)
+	require.Equal(t, expected.ID, promoted.PromotedRevisionID)
+	require.NotEmpty(t, promoted.PromotionDigest)
+
+	skill, err := repo.GetSkill(ctx, "skill-a")
+	require.NoError(t, err)
+	require.Equal(t, 2, skill.CurrentRevisionNumber)
+}
+
+func TestServicePromotionHelperBranches(t *testing.T) {
+	_, _, err := canonicalizeSkillManifest(`{"name":"Skill"} trailing`)
+	require.Error(t, err)
+
+	require.Nil(t, capabilitiesFromManifest("{"))
+
+	fallbackProposal := &models.SkillProposal{
+		ID:                "proposal-1",
+		SkillID:           "skill-a",
+		SourceType:        models.SkillSourceTypeManual,
+		RequestedExposure: models.SkillExposurePrivate,
+	}
+	provenance := promotionProvenance(fallbackProposal, "sha256:manifest")
+	require.Len(t, provenance, 2)
+	require.Equal(t, "sha256:manifest", provenance[0].Digest)
+
+	require.False(t, samePromotedRevision(nil, fallbackProposal, &models.SkillRevision{}))
+	require.False(t, isSkillNotFound(errors.New("boom")))
+
+	ctx := context.Background()
+	repo := newFakeSkillRepo()
+	svc := NewService(repo)
+	skill := &models.Skill{ID: "skill-a", CurrentRevisionNumber: 3, CurrentRevisionID: "skill-a-r3"}
+	revision := &models.SkillRevision{ID: "skill-a-r2", SkillID: "skill-a", RevisionNumber: 2}
+	require.NoError(t, svc.promoteSkillPointer(ctx, skill, revision, "ops"))
+	require.Equal(t, 3, skill.CurrentRevisionNumber)
+}
+
 func TestServiceAssignAndResolveEffectiveSkills(t *testing.T) {
 	ctx := context.Background()
 	repo := newFakeSkillRepo()

--- a/pkg/services/skills/service_test.go
+++ b/pkg/services/skills/service_test.go
@@ -75,6 +75,32 @@ func seedApprovedRevision(t *testing.T, ctx context.Context, repo *fakeSkillRepo
 	require.NoError(t, repo.CreateSkillRevision(ctx, revision))
 }
 
+func acceptedPromotionProposal(t *testing.T, id, skillID string) *models.SkillProposal {
+	t.Helper()
+	manifestJSON, manifestDigest, err := canonicalizeSkillManifest(`{"capabilities":["social.post","memory.read"],"name":"Skill A","version":1}`)
+	require.NoError(t, err)
+	reviewedAt := time.Date(2026, 5, 13, 12, 15, 0, 0, time.UTC)
+	return &models.SkillProposal{
+		ID:                     id,
+		SkillID:                skillID,
+		Status:                 models.SkillProposalStatusAccepted,
+		RequestedExposure:      models.SkillExposurePrivate,
+		ProposedRevisionNumber: 1,
+		ProposedManifestJSON:   manifestJSON,
+		ProposedManifestDigest: manifestDigest,
+		SourceType:             models.SkillSourceTypeHostConversation,
+		SourceURI:              "lesser-host://conversations/conv-1/messages/msg-1",
+		SourceDigest:           "sha256:source",
+		ConversationID:         "conv-1",
+		ConversationMessageID:  "msg-1",
+		PrincipalID:            "principal-1",
+		PrincipalApprovalID:    "principal-approval-1",
+		ReviewedBy:             "ops",
+		ReviewedAt:             &reviewedAt,
+		ReviewReason:           "reviewed source output",
+	}
+}
+
 func (f *fakeSkillRepo) CreateSkill(_ context.Context, skill *models.Skill) error {
 	if err := skill.UpdateKeys(); err != nil {
 		return err
@@ -336,6 +362,143 @@ func TestServiceApproveRevisionRejectsDigestMismatch(t *testing.T) {
 		ApprovalDigest: "sha256:not-the-server-digest",
 	})
 	require.ErrorIs(t, err, ErrApprovalDigestMismatch)
+}
+
+func TestServicePromoteProposalCreatesApprovedRevision(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 5, 13, 17, 0, 0, 0, time.UTC)
+	repo := newFakeSkillRepo()
+	svc := NewService(repo).WithNow(func() time.Time { return now })
+	require.NoError(t, repo.CreateSkill(ctx, &models.Skill{ID: "skill-a", Status: models.SkillStatusDraft, DefaultExposure: models.SkillExposurePrivate}))
+	proposal := acceptedPromotionProposal(t, "proposal-1", "skill-a")
+	require.NoError(t, repo.CreateSkillProposal(ctx, proposal))
+
+	result, err := svc.PromoteProposal(ctx, "skill-a", PromotionCommand{
+		ActorUsername:          "ops",
+		ProposalID:             "proposal-1",
+		ExpectedManifestDigest: proposal.ProposedManifestDigest,
+		ExpectedSourceDigest:   proposal.SourceDigest,
+		ApprovalRef:            "lesser://approvals/principal-approval-1",
+	})
+	require.NoError(t, err)
+	require.True(t, result.Created)
+	require.Equal(t, models.SkillRevisionStatusApproved, result.Revision.Status)
+	require.Equal(t, "skill-a-r1", result.Revision.ID)
+	require.Equal(t, "proposal-1", result.Revision.ProposalID)
+	require.Equal(t, proposal.ProposedManifestDigest, result.Revision.ManifestDigest)
+	require.Equal(t, "sha256:source", result.Revision.ContentDigest)
+	require.Equal(t, []string{"memory.read", "social.post"}, result.Revision.Capabilities)
+	require.Equal(t, models.SkillExposurePrivate, result.Revision.DefaultExposure)
+	require.Equal(t, "principal-1", result.Revision.PrincipalID)
+	require.Equal(t, "principal-approval-1", result.Revision.PrincipalApprovalID)
+	require.Equal(t, "ops", result.Revision.ApprovedBy)
+	require.NotEmpty(t, result.Revision.ApprovalDigest)
+	require.Len(t, result.Revision.Provenance, 3)
+	require.Equal(t, models.SkillSourceTypeHostConversation, result.Revision.Provenance[0].SourceType)
+	require.Equal(t, "msg-1", result.Revision.Provenance[0].Ref)
+	require.Equal(t, models.SkillSourceTypeProposal, result.Revision.Provenance[1].SourceType)
+	require.Equal(t, models.SkillSourceTypeApproval, result.Revision.Provenance[2].SourceType)
+
+	skill, err := repo.GetSkill(ctx, "skill-a")
+	require.NoError(t, err)
+	require.Equal(t, models.SkillStatusActive, skill.Status)
+	require.Equal(t, 1, skill.CurrentRevisionNumber)
+	require.Equal(t, models.SkillExposurePrivate, skill.DefaultExposure)
+
+	promoted, err := repo.GetSkillProposal(ctx, "proposal-1")
+	require.NoError(t, err)
+	require.Equal(t, "skill-a-r1", promoted.PromotedRevisionID)
+	require.Equal(t, 1, promoted.PromotedRevisionNumber)
+	require.NotEmpty(t, promoted.PromotionDigest)
+	require.Equal(t, "ops", promoted.PromotedBy)
+	require.NotNil(t, promoted.PromotedAt)
+}
+
+func TestServicePromoteProposalFailsClosedForSourceAndApprovalState(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeSkillRepo()
+	svc := NewService(repo)
+	require.NoError(t, repo.CreateSkill(ctx, &models.Skill{ID: "skill-a"}))
+
+	proposed := acceptedPromotionProposal(t, "proposal-proposed", "skill-a")
+	proposed.Status = models.SkillProposalStatusProposed
+	require.NoError(t, repo.CreateSkillProposal(ctx, proposed))
+	_, err := svc.PromoteProposal(ctx, "skill-a", PromotionCommand{ActorUsername: "ops", ProposalID: "proposal-proposed"})
+	require.ErrorIs(t, err, ErrInvalidState)
+
+	missing := acceptedPromotionProposal(t, "proposal-missing", "skill-a")
+	missing.ProposedManifestJSON = ""
+	require.NoError(t, repo.CreateSkillProposal(ctx, missing))
+	_, err = svc.PromoteProposal(ctx, "skill-a", PromotionCommand{ActorUsername: "ops", ProposalID: "proposal-missing"})
+	require.ErrorIs(t, err, ErrInvalidInput)
+
+	malformed := acceptedPromotionProposal(t, "proposal-malformed", "skill-a")
+	malformed.ProposedManifestJSON = "{"
+	require.NoError(t, repo.CreateSkillProposal(ctx, malformed))
+	_, err = svc.PromoteProposal(ctx, "skill-a", PromotionCommand{ActorUsername: "ops", ProposalID: "proposal-malformed"})
+	require.ErrorIs(t, err, ErrInvalidInput)
+
+	mismatch := acceptedPromotionProposal(t, "proposal-mismatch", "skill-a")
+	mismatch.ProposedManifestDigest = "sha256:not-the-manifest"
+	require.NoError(t, repo.CreateSkillProposal(ctx, mismatch))
+	_, err = svc.PromoteProposal(ctx, "skill-a", PromotionCommand{ActorUsername: "ops", ProposalID: "proposal-mismatch"})
+	require.ErrorIs(t, err, ErrPromotionDigestMismatch)
+
+	proposal := acceptedPromotionProposal(t, "proposal-unauthorized", "skill-a")
+	require.NoError(t, repo.CreateSkillProposal(ctx, proposal))
+	_, err = svc.PromoteProposal(ctx, "skill-a", PromotionCommand{ProposalID: "proposal-unauthorized"})
+	require.ErrorIs(t, err, ErrInvalidInput)
+}
+
+func TestServicePromoteProposalIdempotencyAndConflict(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 5, 13, 18, 0, 0, 0, time.UTC)
+	repo := newFakeSkillRepo()
+	svc := NewService(repo).WithNow(func() time.Time { return now })
+	require.NoError(t, repo.CreateSkill(ctx, &models.Skill{ID: "skill-a"}))
+	proposal := acceptedPromotionProposal(t, "proposal-1", "skill-a")
+	require.NoError(t, repo.CreateSkillProposal(ctx, proposal))
+
+	first, err := svc.PromoteProposal(ctx, "skill-a", PromotionCommand{ActorUsername: "ops", ProposalID: "proposal-1"})
+	require.NoError(t, err)
+	require.True(t, first.Created)
+	second, err := svc.PromoteProposal(ctx, "skill-a", PromotionCommand{ActorUsername: "ops", ProposalID: "proposal-1"})
+	require.NoError(t, err)
+	require.False(t, second.Created)
+	require.Equal(t, first.Revision.ID, second.Revision.ID)
+
+	conflictRepo := newFakeSkillRepo()
+	conflictSvc := NewService(conflictRepo).WithNow(func() time.Time { return now })
+	require.NoError(t, conflictRepo.CreateSkill(ctx, &models.Skill{ID: "skill-b"}))
+	conflictProposal := acceptedPromotionProposal(t, "proposal-2", "skill-b")
+	require.NoError(t, conflictRepo.CreateSkillProposal(ctx, conflictProposal))
+	seedApprovedRevision(t, ctx, conflictRepo, &models.SkillRevision{
+		SkillID:         "skill-b",
+		RevisionNumber:  1,
+		ProposalID:      "other-proposal",
+		ManifestDigest:  conflictProposal.ProposedManifestDigest,
+		DefaultExposure: models.SkillExposurePrivate,
+		PrincipalID:     "principal-1",
+	})
+	_, err = conflictSvc.PromoteProposal(ctx, "skill-b", PromotionCommand{ActorUsername: "ops", ProposalID: "proposal-2"})
+	require.ErrorIs(t, err, ErrPromotionConflict)
+
+	digestConflictRepo := newFakeSkillRepo()
+	digestConflictSvc := NewService(digestConflictRepo).WithNow(func() time.Time { return now })
+	require.NoError(t, digestConflictRepo.CreateSkill(ctx, &models.Skill{ID: "skill-c"}))
+	digestConflictProposal := acceptedPromotionProposal(t, "proposal-3", "skill-c")
+	digestConflictProposal.ProposedRevisionNumber = 2
+	require.NoError(t, digestConflictRepo.CreateSkillProposal(ctx, digestConflictProposal))
+	seedApprovedRevision(t, ctx, digestConflictRepo, &models.SkillRevision{
+		SkillID:         "skill-c",
+		RevisionNumber:  1,
+		ProposalID:      "other-proposal",
+		ManifestDigest:  digestConflictProposal.ProposedManifestDigest,
+		DefaultExposure: models.SkillExposurePrivate,
+		PrincipalID:     "principal-1",
+	})
+	_, err = digestConflictSvc.PromoteProposal(ctx, "skill-c", PromotionCommand{ActorUsername: "ops", ProposalID: "proposal-3"})
+	require.ErrorIs(t, err, ErrPromotionConflict)
 }
 
 func TestServiceAssignAndResolveEffectiveSkills(t *testing.T) {

--- a/pkg/storage/models/skill.go
+++ b/pkg/storage/models/skill.go
@@ -238,6 +238,11 @@ type SkillProposal struct {
 	ConversationMessageID  string               `theorydb:"attr:conversationMessageID,omitempty" json:"conversation_message_id,omitempty"`
 	PrincipalID            string               `theorydb:"attr:principalID,omitempty" json:"principal_id,omitempty"`
 	PrincipalApprovalID    string               `theorydb:"attr:principalApprovalID,omitempty" json:"principal_approval_id,omitempty"`
+	PromotedRevisionID     string               `theorydb:"attr:promotedRevisionID,omitempty" json:"promoted_revision_id,omitempty"`
+	PromotedRevisionNumber int                  `theorydb:"attr:promotedRevisionNumber,omitempty" json:"promoted_revision_number,omitempty"`
+	PromotionDigest        string               `theorydb:"attr:promotionDigest,omitempty" json:"promotion_digest,omitempty"`
+	PromotedBy             string               `theorydb:"attr:promotedBy,omitempty" json:"promoted_by,omitempty"`
+	PromotedAt             *time.Time           `theorydb:"attr:promotedAt" json:"promoted_at,omitempty"`
 	Provenance             []SkillProvenanceRef `theorydb:"attr:provenance" json:"provenance,omitempty"`
 	CreatedBy              string               `theorydb:"attr:createdBy,omitempty" json:"created_by,omitempty"`
 	ReviewedBy             string               `theorydb:"attr:reviewedBy,omitempty" json:"reviewed_by,omitempty"`
@@ -385,6 +390,59 @@ func SkillRevisionApprovalDigest(revision *SkillRevision, principalID, authority
 		principalID,
 		authorityType,
 		authorityID,
+	}, "\x1f")
+	sum := sha256.Sum256([]byte(material))
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+// SkillPromotionDigest returns the canonical digest that identifies a proposal promotion.
+func SkillPromotionDigest(proposal *SkillProposal, revision *SkillRevision) (string, error) {
+	if proposal == nil {
+		return "", fmt.Errorf("skill proposal is required")
+	}
+	if revision == nil {
+		return "", fmt.Errorf("skill revision is required")
+	}
+	proposalID := normalizeSkillID(proposal.ID)
+	if err := common.ValidateRequiredParam("proposalID", proposalID); err != nil {
+		return "", err
+	}
+	skillID := normalizeSkillID(proposal.SkillID)
+	if err := common.ValidateRequiredParam("proposalSkillID", skillID); err != nil {
+		return "", err
+	}
+	revisionSkillID := normalizeSkillID(revision.SkillID)
+	if err := common.ValidateRequiredParam("revisionSkillID", revisionSkillID); err != nil {
+		return "", err
+	}
+	if skillID != revisionSkillID {
+		return "", fmt.Errorf("proposal skill does not match revision skill")
+	}
+	if revision.RevisionNumber <= 0 {
+		return "", fmt.Errorf("revision number is required")
+	}
+	if normalizeSkillID(revision.ID) == "" {
+		return "", fmt.Errorf("revision id is required")
+	}
+	if normalizeSkillDigest(revision.ManifestDigest) == "" {
+		return "", fmt.Errorf("manifest digest is required")
+	}
+	if normalizeSkillDigest(revision.ApprovalDigest) == "" {
+		return "", fmt.Errorf("approval digest is required")
+	}
+
+	material := strings.Join([]string{
+		"lesser-skill-promotion-v1",
+		proposalID,
+		skillID,
+		normalizeSkillDigest(proposal.ProposedManifestDigest),
+		normalizeSkillDigest(proposal.SourceDigest),
+		strings.TrimSpace(proposal.ConversationID),
+		strings.TrimSpace(proposal.ConversationMessageID),
+		normalizeSkillID(revision.ID),
+		fmt.Sprintf("%08d", revision.RevisionNumber),
+		normalizeSkillDigest(revision.ManifestDigest),
+		normalizeSkillDigest(revision.ApprovalDigest),
 	}, "\x1f")
 	sum := sha256.Sum256([]byte(material))
 	return "sha256:" + hex.EncodeToString(sum[:]), nil
@@ -633,6 +691,13 @@ func (p *SkillProposal) prepareForWrite(isCreate bool) error {
 	p.ConversationMessageID = strings.TrimSpace(p.ConversationMessageID)
 	p.PrincipalID = strings.TrimSpace(p.PrincipalID)
 	p.PrincipalApprovalID = strings.TrimSpace(p.PrincipalApprovalID)
+	p.PromotedRevisionID = normalizeSkillID(p.PromotedRevisionID)
+	p.PromotionDigest = normalizeSkillDigest(p.PromotionDigest)
+	p.PromotedBy = strings.TrimSpace(p.PromotedBy)
+	p.PromotedAt = normalizeSkillTimePtr(p.PromotedAt)
+	if err := p.validatePromotionState(); err != nil {
+		return err
+	}
 	p.Provenance = normalizeSkillProvenance(p.Provenance)
 	if err := validateSkillProvenance(p.Provenance); err != nil {
 		return err
@@ -705,6 +770,39 @@ func (a *SkillAssignment) prepareForWrite(isCreate bool) error {
 	a.GSI1SK = fmt.Sprintf("SUBJECT#%s#%s#ASSIGNMENT#%s", a.SubjectType, a.SubjectID, a.ID)
 	a.GSI2PK = "SKILL_ASSIGNMENT#STATUS#" + a.Status
 	a.GSI2SK = fmt.Sprintf("UPDATED#%s#SUBJECT#%s#%s#SKILL#%s#REVISION#%08d#ASSIGNMENT#%s", formatSkillTime(a.UpdatedAt), a.SubjectType, a.SubjectID, a.SkillID, a.RevisionNumber, a.ID)
+	return nil
+}
+
+func (p *SkillProposal) validatePromotionState() error {
+	if p == nil {
+		return fmt.Errorf("skill proposal is required")
+	}
+	hasPromotion := p.PromotedRevisionID != "" || p.PromotedRevisionNumber > 0 || p.PromotionDigest != "" || p.PromotedBy != "" || p.PromotedAt != nil
+	if !hasPromotion {
+		return nil
+	}
+	required := []struct {
+		name  string
+		value string
+	}{
+		{"promotedRevisionID", p.PromotedRevisionID},
+		{"promotionDigest", p.PromotionDigest},
+		{"promotedBy", p.PromotedBy},
+	}
+	for _, field := range required {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("%s is required for promoted skill proposal", field.name)
+		}
+	}
+	if p.PromotedRevisionNumber <= 0 {
+		return fmt.Errorf("promoted revision number is required for promoted skill proposal")
+	}
+	if p.PromotedAt == nil {
+		return fmt.Errorf("promoted at is required for promoted skill proposal")
+	}
+	if p.Status != SkillProposalStatusAccepted {
+		return fmt.Errorf("promoted skill proposal must be accepted")
+	}
 	return nil
 }
 

--- a/pkg/storage/models/skill_test.go
+++ b/pkg/storage/models/skill_test.go
@@ -148,6 +148,33 @@ func TestSkillProposal_UpdateKeysKeepsSeedSourceNonCanonical(t *testing.T) {
 	require.Equal(t, MainTableName, proposal.TableName())
 }
 
+func TestSkillProposal_UpdateKeysValidatesPromotionMetadata(t *testing.T) {
+	t.Parallel()
+
+	promotedAt := time.Date(2026, 5, 13, 8, 0, 0, 0, time.UTC)
+	proposal := &SkillProposal{
+		ID:                     " Proposal-1 ",
+		SkillID:                " Skill-A ",
+		Status:                 SkillProposalStatusAccepted,
+		RequestedExposure:      SkillExposurePrivate,
+		ProposedRevisionNumber: 2,
+		PromotedRevisionID:     " Skill-A-R2 ",
+		PromotedRevisionNumber: 2,
+		PromotionDigest:        " SHA256:PROMOTION ",
+		PromotedBy:             " ops ",
+		PromotedAt:             &promotedAt,
+	}
+
+	require.NoError(t, proposal.UpdateKeys())
+	require.Equal(t, "skill-a-r2", proposal.PromotedRevisionID)
+	require.Equal(t, "sha256:promotion", proposal.PromotionDigest)
+	require.Equal(t, "ops", proposal.PromotedBy)
+	require.NotNil(t, proposal.PromotedAt)
+
+	proposal.Status = SkillProposalStatusProposed
+	require.ErrorContains(t, proposal.UpdateKeys(), "promoted skill proposal must be accepted")
+}
+
 func TestSkillAssignment_UpdateKeysDefinesSubjectBoundary(t *testing.T) {
 	t.Parallel()
 
@@ -238,6 +265,43 @@ func TestSkillRevisionApprovalDigestIsStableAndAuthorityScoped(t *testing.T) {
 	_, err = SkillRevisionApprovalDigest(revision, "", SkillApprovalAuthorityAdmin, "ops")
 	require.Error(t, err)
 	_, err = SkillRevisionApprovalDigest(revision, "principal-1", "unknown", "ops")
+	require.Error(t, err)
+}
+
+func TestSkillPromotionDigestBindsProposalAndRevision(t *testing.T) {
+	t.Parallel()
+
+	proposal := &SkillProposal{
+		ID:                     "proposal-1",
+		SkillID:                "skill-a",
+		ProposedManifestDigest: "sha256:manifest",
+		SourceDigest:           "sha256:source",
+		ConversationID:         "conv-1",
+		ConversationMessageID:  "msg-1",
+	}
+	revision := &SkillRevision{
+		ID:              "skill-a-r1",
+		SkillID:         "skill-a",
+		RevisionNumber:  1,
+		ManifestDigest:  "sha256:manifest",
+		ApprovalDigest:  "sha256:approval",
+		DefaultExposure: SkillExposurePrivate,
+	}
+
+	first, err := SkillPromotionDigest(proposal, revision)
+	require.NoError(t, err)
+	second, err := SkillPromotionDigest(proposal, revision)
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+	require.Contains(t, first, "sha256:")
+
+	revision.ApprovalDigest = "sha256:other"
+	other, err := SkillPromotionDigest(proposal, revision)
+	require.NoError(t, err)
+	require.NotEqual(t, first, other)
+
+	revision.SkillID = "skill-b"
+	_, err = SkillPromotionDigest(proposal, revision)
 	require.Error(t, err)
 }
 

--- a/tools/openapi/operation_overrides.go
+++ b/tools/openapi/operation_overrides.go
@@ -13,7 +13,20 @@ func applyOperationOverrides(op *operation, route routeDef) {
 	applyAppRegistrationOverrides(op, route)
 	applyMediaOverrides(op, route)
 	applySoulOverrides(op, route)
+	applySkillOverrides(op, route)
 	applyStatusOverrides(op, route)
+}
+
+func applySkillOverrides(op *operation, route routeDef) {
+	if op == nil {
+		return
+	}
+	if route.Path == "/api/v1/admin/skills/{skillId}/proposals/{proposalId}/promote" && route.Method == methodPOST {
+		if op.Responses == nil {
+			op.Responses = map[string]response{}
+		}
+		ensureResponseRef(op.Responses, "409", "Conflict")
+	}
 }
 
 func applySoulOverrides(op *operation, route routeDef) {


### PR DESCRIPTION
## Milestone
Project 21 M3.4 / lesser#702 — promote accepted conversation/proposal output into canonical `SkillRevision` rows.

## Classification
Schema/data-integrity + additive REST contract + approval/provenance security semantics.

## Surfaces affected
- `pkg/storage/models/skill.go`: additive promotion metadata on `SkillProposal`, canonical promotion digest helper.
- `pkg/services/skills`: promotion service flow with fail-closed source/approval/digest/idempotency checks.
- `/api/v1/admin/skills/{skillId}/proposals/{proposalId}/promote`: additive admin-only REST endpoint.
- Generated contracts: `docs/contracts/openapi.yaml`, `docs/specs/graphql_coverage.yaml`, route manifest.

## Specialist walks referenced
- Advisor brief: Pilot email `delivery-b957a1fc629def60` verified from `pilot@lessersoul.ai`; Aron authorized investigation + implementation in-session.
- Investigation: fix locus is `lesser`; no ActivityPub/federation surface; no sibling repo edits; implements final M3 child issue #702.
- Schema: additive optional attributes on existing `SkillProposal`; no PK/SK/GSI restructure; existing `version` handling preserved; stream impact is additive.
- Contract/API: additive Lesser-exclusive admin endpoint under `/api/v1/admin/skills`; OpenAPI regenerated; GraphQL coverage marks REST-only; no Mastodon-compat endpoint shape changes.

## Consumer impact
- Operators/admin API callers get a new admin-only promotion endpoint.
- Mastodon clients: no impact.
- Remote ActivityPub peers: no impact.
- lesser-body/lesser-host: no contract change in this slice; conversation output remains provenance only, not the skill authority.

## Tasks
- [x] Add fail-closed promotion service from accepted `SkillProposal` to approved canonical `SkillRevision`.
- [x] Preserve proposal/conversation/source/approval provenance and promotion digest metadata.
- [x] Make idempotency and conflicting-promotion behavior explicit and tested.
- [x] Add additive admin REST endpoint + request/response models.
- [x] Regenerate OpenAPI and GraphQL coverage artifacts.
- [x] Update skill authority docs.

## Validation
- `gofmt -l .`
- `go test ./...`
- `go vet ./...`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`
- Targeted during development: `go test ./pkg/storage/models ./pkg/services/skills ./cmd/api/handlers ./cmd/api`
- Targeted contract checks: `./lesser verify openapi --strict`, `./lesser verify graphql-coverage --strict`

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None required for this M3 slice. M4 publishing/catalog/bundle behavior and lesser-body MCP tool work remain explicit non-goals.

## Advisor-brief authorization
Aron: “pilot has emailed you a new assignment at my request, proceed to investigate issue and move directly into implement-milestone.” Pilot assignment: Project 21 M3 final slice, lesser#702.

Closes #702.