### PR TITLE
feat(skills): publish approved catalog bundles

### DIFF
--- a/cmd/api/handlers/skills.go
+++ b/cmd/api/handlers/skills.go
@@ -19,6 +19,8 @@ type skillHandlerService interface {
 	GetSkill(context.Context, skillservice.Viewer, string) (*storagemodels.Skill, error)
 	ListRevisions(context.Context, skillservice.Viewer, string, int, string) ([]*storagemodels.SkillRevision, string, error)
 	GetRevision(context.Context, skillservice.Viewer, string, int) (*storagemodels.SkillRevision, error)
+	ListCatalog(context.Context, skillservice.Viewer, skillservice.CatalogFilter) ([]skillservice.CatalogEntry, string, error)
+	GetBundle(context.Context, skillservice.Viewer, string, int, bool) (*skillservice.CatalogEntry, error)
 	ListProposals(context.Context, string, string, int, string) ([]*storagemodels.SkillProposal, string, error)
 	GetProposal(context.Context, string) (*storagemodels.SkillProposal, error)
 	ListAssignmentsForSkill(context.Context, string, int, string) ([]*storagemodels.SkillAssignment, string, error)
@@ -92,6 +94,44 @@ func (h *Handler) HandleGetSkillRevisionLift(ctx *apptheory.Context) (*apptheory
 		return h.respondSkillServiceError(ctx, err)
 	}
 	return okJSON(apimodels.SkillRevisionResponse{Revision: toAPISkillRevision(revision)})
+}
+
+// HandleListSkillCatalogLift handles GET /api/v1/skills/catalog.
+func (h *Handler) HandleListSkillCatalogLift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	claims := h.optionalAuthenticatedClaimsLift(ctx)
+	items, cursor, err := h.getSkillService().ListCatalog(ctx.Context(), h.skillViewer(ctx.Context(), claims), skillservice.CatalogFilter{
+		Exposure: queryValue(ctx, "exposure"),
+		Limit:    parseSkillLimit(queryValue(ctx, "limit")),
+		Cursor:   queryValue(ctx, "cursor"),
+	})
+	if err != nil {
+		return h.respondSkillServiceError(ctx, err)
+	}
+	out := make([]apimodels.SkillCatalogEntryResource, 0, len(items))
+	for _, item := range items {
+		out = append(out, toAPISkillCatalogEntry(item))
+	}
+	return okJSON(apimodels.SkillCatalogResponse{Entries: out, Count: len(out), NextCursor: cursor})
+}
+
+// HandleGetSkillBundleLift handles GET /api/v1/skills/{skillId}/revisions/{revisionNumber}/bundle.
+func (h *Handler) HandleGetSkillBundleLift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	revisionNumber, err := parseSkillRevisionNumber(ctx.Param("revisionNumber"))
+	if err != nil {
+		return common.RespondBadRequest(ctx, "revision_number is invalid")
+	}
+	claims := h.optionalAuthenticatedClaimsLift(ctx)
+	entry, err := h.getSkillService().GetBundle(
+		ctx.Context(),
+		h.skillViewer(ctx.Context(), claims),
+		ctx.Param("skillId"),
+		revisionNumber,
+		parseSkillBool(queryValue(ctx, "include_content")),
+	)
+	if err != nil {
+		return h.respondSkillServiceError(ctx, err)
+	}
+	return okJSON(apimodels.SkillBundleResponse{Bundle: toAPISkillBundle(entry)})
 }
 
 // HandleResolveEffectiveSkillsLift handles GET /api/v1/skills/resolve.
@@ -410,6 +450,15 @@ func parseSkillLimit(value string) int {
 	return limit
 }
 
+func parseSkillBool(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", boolTrue, "yes", "y", "on":
+		return true
+	default:
+		return false
+	}
+}
+
 func parseSkillRevisionNumber(value string) (int, error) {
 	n, err := strconv.Atoi(strings.TrimSpace(value))
 	if err != nil || n <= 0 {
@@ -545,6 +594,82 @@ func toAPISkillAssignment(assignment *storagemodels.SkillAssignment) apimodels.S
 	}
 }
 
+func toAPISkillCatalogEntry(entry skillservice.CatalogEntry) apimodels.SkillCatalogEntryResource {
+	return apimodels.SkillCatalogEntryResource{
+		Skill:    toAPISkill(entry.Skill),
+		Revision: toAPISkillRevision(entry.Revision),
+		Bundle:   toAPISkillBundle(&entry),
+	}
+}
+
+func toAPISkillBundle(entry *skillservice.CatalogEntry) apimodels.SkillBundleResource {
+	if entry == nil || entry.Revision == nil {
+		return apimodels.SkillBundleResource{}
+	}
+	revision := entry.Revision
+	bundle := entry.Bundle
+	return apimodels.SkillBundleResource{
+		SchemaVersion:   bundle.SchemaVersion,
+		BundleID:        bundle.BundleID,
+		Source:          "canonical_skill_revision",
+		Published:       revision.Status == storagemodels.SkillRevisionStatusApproved,
+		SkillID:         revision.SkillID,
+		RevisionID:      revision.ID,
+		RevisionNumber:  revision.RevisionNumber,
+		DefaultExposure: revision.DefaultExposure,
+		Digests: apimodels.SkillBundleDigestsResource{
+			ManifestDigest:    bundle.ManifestDigest,
+			BundleDigest:      bundle.BundleDigest,
+			PublicationDigest: bundle.PublicationDigest,
+			ContentDigest:     bundle.ContentDigest,
+			ApprovalDigest:    bundle.ApprovalDigest,
+		},
+		Files:                 toAPISkillBundleFiles(bundle.Files),
+		InstallHints:          toAPISkillInstallHints(bundle.InstallHints),
+		Provenance:            toAPISkillProvenance(bundle.Provenance),
+		ApprovalID:            revision.ApprovalID,
+		ApprovalAuthorityType: revision.ApprovalAuthorityType,
+		ApprovalAuthorityID:   revision.ApprovalAuthorityID,
+		ApprovalSignature:     revision.ApprovalSignature,
+		ApprovalRef:           revision.ApprovalRef,
+		ApprovedBy:            revision.ApprovedBy,
+		ApprovedAt:            revision.ApprovedAt,
+		PrincipalID:           revision.PrincipalID,
+		PrincipalApprovalID:   revision.PrincipalApprovalID,
+	}
+}
+
+func toAPISkillBundleFiles(values []skillservice.SkillBundleFile) []apimodels.SkillBundleFileResource {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]apimodels.SkillBundleFileResource, 0, len(values))
+	for _, value := range values {
+		out = append(out, apimodels.SkillBundleFileResource{
+			Path:            value.Path,
+			Digest:          value.Digest,
+			ContentType:     value.ContentType,
+			Role:            value.Role,
+			SizeBytes:       value.SizeBytes,
+			InstallPath:     value.InstallPath,
+			Content:         value.Content,
+			Encoding:        value.Encoding,
+			ContentIncluded: value.ContentIncluded,
+		})
+	}
+	return out
+}
+
+func toAPISkillInstallHints(value skillservice.SkillInstallHints) apimodels.SkillInstallHintsResource {
+	return apimodels.SkillInstallHintsResource{
+		Layout:         value.Layout,
+		RuntimeTargets: append([]string(nil), value.RuntimeTargets...),
+		DirectoryName:  value.DirectoryName,
+		EntryPoint:     value.EntryPoint,
+		RequiredFiles:  append([]string(nil), value.RequiredFiles...),
+	}
+}
+
 func toAPISkillProvenance(values []storagemodels.SkillProvenanceRef) []apimodels.SkillProvenanceRef {
 	if len(values) == 0 {
 		return nil
@@ -591,6 +716,12 @@ func (nilSkillService) ListRevisions(context.Context, skillservice.Viewer, strin
 	return nil, "", skillservice.ErrRepositoryUnavailable
 }
 func (nilSkillService) GetRevision(context.Context, skillservice.Viewer, string, int) (*storagemodels.SkillRevision, error) {
+	return nil, skillservice.ErrRepositoryUnavailable
+}
+func (nilSkillService) ListCatalog(context.Context, skillservice.Viewer, skillservice.CatalogFilter) ([]skillservice.CatalogEntry, string, error) {
+	return nil, "", skillservice.ErrRepositoryUnavailable
+}
+func (nilSkillService) GetBundle(context.Context, skillservice.Viewer, string, int, bool) (*skillservice.CatalogEntry, error) {
 	return nil, skillservice.ErrRepositoryUnavailable
 }
 func (nilSkillService) ListProposals(context.Context, string, string, int, string) ([]*storagemodels.SkillProposal, string, error) {

--- a/cmd/api/handlers/skills_test.go
+++ b/cmd/api/handlers/skills_test.go
@@ -94,6 +94,8 @@ type skillHandlerStub struct {
 	nilSkillService
 	skill       *storagemodels.Skill
 	revisions   []*storagemodels.SkillRevision
+	catalog     []skillservice.CatalogEntry
+	bundle      *skillservice.CatalogEntry
 	proposal    *storagemodels.SkillProposal
 	assignment  *storagemodels.SkillAssignment
 	resolveItem skillservice.EffectiveSkill
@@ -114,6 +116,56 @@ func (s *skillHandlerStub) ListRevisions(context.Context, skillservice.Viewer, s
 
 func (s *skillHandlerStub) GetRevision(context.Context, skillservice.Viewer, string, int) (*storagemodels.SkillRevision, error) {
 	return s.revisions[0], nil
+}
+
+func (s *skillHandlerStub) ListCatalog(context.Context, skillservice.Viewer, skillservice.CatalogFilter) ([]skillservice.CatalogEntry, string, error) {
+	if s.catalog != nil {
+		return s.catalog, "next-catalog", nil
+	}
+	return []skillservice.CatalogEntry{{Skill: s.skill, Revision: s.revisions[0], Bundle: testSkillBundle()}}, "next-catalog", nil
+}
+
+func (s *skillHandlerStub) GetBundle(context.Context, skillservice.Viewer, string, int, bool) (*skillservice.CatalogEntry, error) {
+	if s.bundle != nil {
+		return s.bundle, nil
+	}
+	entry := skillservice.CatalogEntry{Skill: s.skill, Revision: s.revisions[0], Bundle: testSkillBundle()}
+	return &entry, nil
+}
+
+func testSkillBundle() skillservice.SkillBundle {
+	return skillservice.SkillBundle{
+		SchemaVersion:     skillservice.SkillBundleSchemaVersion,
+		BundleID:          "skill:skill-a:revision:00000001",
+		BundleDigest:      "sha256:bundle",
+		PublicationDigest: "sha256:publication",
+		ManifestDigest:    "sha256:manifest",
+		ContentDigest:     "sha256:content",
+		ApprovalDigest:    "sha256:approval",
+		Files: []skillservice.SkillBundleFile{{
+			Path:            "SKILL.md",
+			Digest:          "sha256:file",
+			ContentType:     "text/markdown",
+			Role:            "entrypoint",
+			SizeBytes:       42,
+			InstallPath:     "skill-a/SKILL.md",
+			Content:         "# Skill A\n",
+			Encoding:        "utf-8",
+			ContentIncluded: true,
+		}},
+		InstallHints: skillservice.SkillInstallHints{
+			Layout:         "skill-directory-v1",
+			RuntimeTargets: []string{"codex"},
+			DirectoryName:  "skill-a",
+			EntryPoint:     "SKILL.md",
+			RequiredFiles:  []string{"SKILL.md"},
+		},
+		Provenance: []storagemodels.SkillProvenanceRef{{
+			SourceType: storagemodels.SkillSourceTypeProposal,
+			Digest:     "sha256:manifest",
+			Ref:        "proposal-1",
+		}},
+	}
 }
 
 func TestSkillHandlers_PublicReadHandlers(t *testing.T) {
@@ -172,6 +224,24 @@ func TestSkillHandlers_PublicReadHandlers(t *testing.T) {
 	ctx.Params["revisionNumber"] = "bad"
 	resp = requireStatus(t, http.StatusBadRequest)(h.HandleGetSkillRevisionLift(ctx))
 	require.Contains(t, string(resp.Body), "revision_number")
+
+	ctx, err = round10NewLiftContext(http.MethodGet, "/api/v1/skills/catalog", nil, map[string]string{"limit": "1"}, nil)
+	require.NoError(t, err)
+	resp = requireStatus(t, http.StatusOK)(h.HandleListSkillCatalogLift(ctx))
+	require.Contains(t, string(resp.Body), "next-catalog")
+	require.Contains(t, string(resp.Body), "publication_digest")
+
+	ctx, err = round10NewLiftContext(http.MethodGet, "/api/v1/skills/skill-a/revisions/1/bundle", nil, map[string]string{"include_content": "true"}, nil)
+	require.NoError(t, err)
+	ctx.Params["skillId"] = "skill-a"
+	ctx.Params["revisionNumber"] = "1"
+	resp = requireStatus(t, http.StatusOK)(h.HandleGetSkillBundleLift(ctx))
+	require.Contains(t, string(resp.Body), "skill:skill-a:revision:00000001")
+	require.Contains(t, string(resp.Body), "# Skill A")
+
+	ctx.Params["revisionNumber"] = "bad"
+	resp = requireStatus(t, http.StatusBadRequest)(h.HandleGetSkillBundleLift(ctx))
+	require.Contains(t, string(resp.Body), "revision_number")
 }
 
 func TestSkillHandlers_HelperCoverage(t *testing.T) {
@@ -181,6 +251,9 @@ func TestSkillHandlers_HelperCoverage(t *testing.T) {
 	require.Equal(t, 25, parseSkillLimit("-1"))
 	require.Equal(t, 100, parseSkillLimit("500"))
 	require.Equal(t, 10, parseSkillLimit("10"))
+	require.True(t, parseSkillBool("true"))
+	require.True(t, parseSkillBool("1"))
+	require.False(t, parseSkillBool("false"))
 	_, err := parseSkillRevisionNumber("0")
 	require.Error(t, err)
 	gotRevision, err := parseSkillRevisionNumber("7")
@@ -255,6 +328,32 @@ func TestSkillHandlers_MappingHelpers(t *testing.T) {
 	})
 	require.Equal(t, "assign-1", assignment.ID)
 	require.Equal(t, "rotated", assignment.RevokedReason)
+
+	entry := skillservice.CatalogEntry{
+		Skill: &storagemodels.Skill{ID: "skill-a", Slug: "skill-a", Name: "Skill A"},
+		Revision: &storagemodels.SkillRevision{
+			ID: "skill-a-r1", SkillID: "skill-a", RevisionNumber: 1, Status: storagemodels.SkillRevisionStatusApproved,
+			DefaultExposure:       storagemodels.SkillExposurePublic,
+			ApprovalID:            "approval-1",
+			ApprovalAuthorityType: storagemodels.SkillApprovalAuthorityAdmin,
+			ApprovalAuthorityID:   "ops",
+			ApprovalDigest:        "sha256:approval",
+			ApprovalSignature:     "sig",
+			ApprovalRef:           "ref",
+			ApprovedBy:            "ops",
+			ApprovedAt:            &now,
+			PrincipalID:           "principal-1",
+			PrincipalApprovalID:   "principal-approval-1",
+		},
+		Bundle: testSkillBundle(),
+	}
+	catalogEntry := toAPISkillCatalogEntry(entry)
+	require.Equal(t, "skill-a", catalogEntry.Skill.ID)
+	require.Equal(t, "sha256:publication", catalogEntry.Bundle.Digests.PublicationDigest)
+	require.True(t, catalogEntry.Bundle.Published)
+	require.Equal(t, "# Skill A\n", catalogEntry.Bundle.Files[0].Content)
+	require.Equal(t, []string{"codex"}, catalogEntry.Bundle.InstallHints.RuntimeTargets)
+	require.Empty(t, toAPISkillBundle(nil).BundleID)
 }
 
 func (s *skillHandlerStub) ListProposals(context.Context, string, string, int, string) ([]*storagemodels.SkillProposal, string, error) {
@@ -314,6 +413,14 @@ func (s skillHandlerErrorStub) ListRevisions(context.Context, skillservice.Viewe
 }
 
 func (s skillHandlerErrorStub) GetRevision(context.Context, skillservice.Viewer, string, int) (*storagemodels.SkillRevision, error) {
+	return nil, s.err
+}
+
+func (s skillHandlerErrorStub) ListCatalog(context.Context, skillservice.Viewer, skillservice.CatalogFilter) ([]skillservice.CatalogEntry, string, error) {
+	return nil, "", s.err
+}
+
+func (s skillHandlerErrorStub) GetBundle(context.Context, skillservice.Viewer, string, int, bool) (*skillservice.CatalogEntry, error) {
 	return nil, s.err
 }
 
@@ -411,6 +518,26 @@ func TestSkillHandlers_ServiceErrorsFromEndpoints(t *testing.T) {
 				return ctx
 			},
 			handle: h.HandleGetSkillRevisionLift,
+		},
+		{
+			name: "catalog",
+			context: func() *apptheory.Context {
+				ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/skills/catalog", nil, nil, nil)
+				require.NoError(t, err)
+				return ctx
+			},
+			handle: h.HandleListSkillCatalogLift,
+		},
+		{
+			name: "bundle",
+			context: func() *apptheory.Context {
+				ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/skills/skill-a/revisions/1/bundle", nil, nil, nil)
+				require.NoError(t, err)
+				ctx.Params["skillId"] = "skill-a"
+				ctx.Params["revisionNumber"] = "1"
+				return ctx
+			},
+			handle: h.HandleGetSkillBundleLift,
 		},
 		{
 			name: "resolve",
@@ -538,6 +665,18 @@ func TestSkillHandlers_AuthenticatedAndAdminHandlers(t *testing.T) {
 	require.NoError(t, err)
 	resp := requireStatus(t, http.StatusOK)(h.HandleResolveEffectiveSkillsLift(ctx))
 	require.Contains(t, string(resp.Body), "next-effective")
+
+	ctx, err = round10NewLiftContext(http.MethodGet, "/api/v1/skills/catalog", nil, nil, nil)
+	require.NoError(t, err)
+	resp = requireStatus(t, http.StatusOK)(h.HandleListSkillCatalogLift(ctx))
+	require.Contains(t, string(resp.Body), "next-catalog")
+
+	ctx, err = round10NewLiftContext(http.MethodGet, "/api/v1/skills/skill-a/revisions/1/bundle", nil, nil, nil)
+	require.NoError(t, err)
+	ctx.Params["skillId"] = "skill-a"
+	ctx.Params["revisionNumber"] = "1"
+	resp = requireStatus(t, http.StatusOK)(h.HandleGetSkillBundleLift(ctx))
+	require.Contains(t, string(resp.Body), "bundle_id")
 
 	ctx, err = round10NewLiftContext(http.MethodGet, "/api/v1/admin/skills/proposals", adminReadHeaders, nil, nil)
 	require.NoError(t, err)
@@ -680,6 +819,10 @@ func TestSkillHandlers_AdminAuthFailuresAndNilService(t *testing.T) {
 	_, _, err = nilSvc.ListRevisions(context.Background(), skillservice.Viewer{}, "skill-a", 10, "")
 	require.ErrorIs(t, err, skillservice.ErrRepositoryUnavailable)
 	_, err = nilSvc.GetRevision(context.Background(), skillservice.Viewer{}, "skill-a", 1)
+	require.ErrorIs(t, err, skillservice.ErrRepositoryUnavailable)
+	_, _, err = nilSvc.ListCatalog(context.Background(), skillservice.Viewer{}, skillservice.CatalogFilter{})
+	require.ErrorIs(t, err, skillservice.ErrRepositoryUnavailable)
+	_, err = nilSvc.GetBundle(context.Background(), skillservice.Viewer{}, "skill-a", 1, false)
 	require.ErrorIs(t, err, skillservice.ErrRepositoryUnavailable)
 	_, _, err = nilSvc.ListProposals(context.Background(), "", "", 10, "")
 	require.ErrorIs(t, err, skillservice.ErrRepositoryUnavailable)

--- a/cmd/api/models/skills.go
+++ b/cmd/api/models/skills.go
@@ -131,6 +131,69 @@ type SkillAssignmentResource struct {
 	Version             int                  `json:"version"`
 }
 
+// SkillBundleFileResource represents one file in a published approved skill bundle.
+type SkillBundleFileResource struct {
+	Path            string `json:"path"`
+	Digest          string `json:"digest"`
+	ContentType     string `json:"content_type,omitempty"`
+	Role            string `json:"role,omitempty"`
+	SizeBytes       int64  `json:"size_bytes,omitempty"`
+	InstallPath     string `json:"install_path"`
+	Content         string `json:"content,omitempty"`
+	Encoding        string `json:"encoding,omitempty"`
+	ContentIncluded bool   `json:"content_included"`
+}
+
+// SkillInstallHintsResource gives clients advisory placement hints without mutating their workspace.
+type SkillInstallHintsResource struct {
+	Layout         string   `json:"layout"`
+	RuntimeTargets []string `json:"runtime_targets,omitempty"`
+	DirectoryName  string   `json:"directory_name"`
+	EntryPoint     string   `json:"entrypoint"`
+	RequiredFiles  []string `json:"required_files,omitempty"`
+}
+
+// SkillBundleDigestsResource groups stable digests that downstream clients verify.
+type SkillBundleDigestsResource struct {
+	ManifestDigest    string `json:"manifest_digest,omitempty"`
+	BundleDigest      string `json:"bundle_digest"`
+	PublicationDigest string `json:"publication_digest"`
+	ContentDigest     string `json:"content_digest,omitempty"`
+	ApprovalDigest    string `json:"approval_digest,omitempty"`
+}
+
+// SkillBundleResource represents the approved revision bundle publication contract.
+type SkillBundleResource struct {
+	SchemaVersion         string                     `json:"schema_version"`
+	BundleID              string                     `json:"bundle_id"`
+	Source                string                     `json:"source"`
+	Published             bool                       `json:"published"`
+	SkillID               string                     `json:"skill_id"`
+	RevisionID            string                     `json:"revision_id"`
+	RevisionNumber        int                        `json:"revision_number"`
+	DefaultExposure       string                     `json:"default_exposure"`
+	Digests               SkillBundleDigestsResource `json:"digests"`
+	Files                 []SkillBundleFileResource  `json:"files,omitempty"`
+	InstallHints          SkillInstallHintsResource  `json:"install_hints"`
+	Provenance            []SkillProvenanceRef       `json:"provenance,omitempty"`
+	ApprovalID            string                     `json:"approval_id,omitempty"`
+	ApprovalAuthorityType string                     `json:"approval_authority_type,omitempty"`
+	ApprovalAuthorityID   string                     `json:"approval_authority_id,omitempty"`
+	ApprovalSignature     string                     `json:"approval_signature,omitempty"`
+	ApprovalRef           string                     `json:"approval_ref,omitempty"`
+	ApprovedBy            string                     `json:"approved_by,omitempty"`
+	ApprovedAt            *time.Time                 `json:"approved_at,omitempty"`
+	PrincipalID           string                     `json:"principal_id,omitempty"`
+	PrincipalApprovalID   string                     `json:"principal_approval_id,omitempty"`
+}
+
+// SkillCatalogEntryResource represents one approved catalog entry.
+type SkillCatalogEntryResource struct {
+	Skill    SkillResource         `json:"skill"`
+	Revision SkillRevisionResource `json:"revision"`
+	Bundle   SkillBundleResource   `json:"bundle"`
+}
+
 // SkillListResponse represents GET /api/v1/skills.
 type SkillListResponse struct {
 	Skills     []SkillResource `json:"skills"`
@@ -153,6 +216,18 @@ type SkillRevisionsResponse struct {
 // SkillRevisionResponse represents one skill revision response.
 type SkillRevisionResponse struct {
 	Revision SkillRevisionResource `json:"revision"`
+}
+
+// SkillCatalogResponse represents GET /api/v1/skills/catalog.
+type SkillCatalogResponse struct {
+	Entries    []SkillCatalogEntryResource `json:"entries"`
+	Count      int                         `json:"count"`
+	NextCursor string                      `json:"next_cursor,omitempty"`
+}
+
+// SkillBundleResponse represents GET /api/v1/skills/{skillId}/revisions/{revisionNumber}/bundle.
+type SkillBundleResponse struct {
+	Bundle SkillBundleResource `json:"bundle"`
 }
 
 // SkillProposalsResponse represents admin proposal listings.

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -383,10 +383,12 @@ func configureRoutes(app *apptheory.App) {
 
 	// Canonical skill authority (Lesser-exclusive additive API)
 	app.Get("/api/v1/skills", apiHandler.HandleListSkillsLift, optionalAuth)
+	app.Get("/api/v1/skills/catalog", apiHandler.HandleListSkillCatalogLift, optionalAuth)
 	app.Get("/api/v1/skills/resolve", apiHandler.HandleResolveEffectiveSkillsLift, requireRead)
 	app.Get("/api/v1/skills/{skillId}", apiHandler.HandleGetSkillLift, optionalAuth)
 	app.Get("/api/v1/skills/{skillId}/revisions", apiHandler.HandleListSkillRevisionsLift, optionalAuth)
 	app.Get("/api/v1/skills/{skillId}/revisions/{revisionNumber}", apiHandler.HandleGetSkillRevisionLift, optionalAuth)
+	app.Get("/api/v1/skills/{skillId}/revisions/{revisionNumber}/bundle", apiHandler.HandleGetSkillBundleLift, optionalAuth)
 
 	// Souls
 	app.Get("/api/v1/souls/bound/me", apiHandler.HandleGetBoundSoulMeLift, requireReadOrWrite)

--- a/cmd/api/testdata/routes_manifest.txt
+++ b/cmd/api/testdata/routes_manifest.txt
@@ -105,10 +105,12 @@ GET /api/v1/scheduled_statuses
 GET /api/v1/scheduled_statuses/{id}
 GET /api/v1/search/statuses
 GET /api/v1/skills
+GET /api/v1/skills/catalog
 GET /api/v1/skills/resolve
 GET /api/v1/skills/{skillId}
 GET /api/v1/skills/{skillId}/revisions
 GET /api/v1/skills/{skillId}/revisions/{revisionNumber}
+GET /api/v1/skills/{skillId}/revisions/{revisionNumber}/bundle
 GET /api/v1/souls/bound/me
 GET /api/v1/souls/bound/me/mint-conversations
 GET /api/v1/souls/bound/me/mint-conversations/{conversationId}

--- a/docs/architecture/dynamodb/gsi_usage_guide.md
+++ b/docs/architecture/dynamodb/gsi_usage_guide.md
@@ -66,9 +66,9 @@ This model uses GSIs to track media transcoding jobs.
 
 These models use sparse GSI keys to support later approval, catalog, digest, and assignment queries without adding a new physical index.
 
--   **GSI1: Lifecycle and parent-scoped listings**
+-   **GSI1: Lifecycle, catalog, and parent-scoped listings**
     -   `Skill`: `SKILL#STATUS#{status}` / `UPDATED#{time}#SKILL#{skillID}`
-    -   `SkillRevision`: `SKILL_REVISION#STATUS#{status}` / `UPDATED#{time}#SKILL#{skillID}#REVISION#{n}`
+    -   `SkillRevision`: `SKILL_REVISION#STATUS#{status}` / `UPDATED#{time}#SKILL#{skillID}#REVISION#{n}` (approved catalog publication reads `status=approved`)
     -   `SkillProposal`: `SKILL#{skillID}#PROPOSAL` / `STATUS#{status}#CREATED#{time}#PROPOSAL#{proposalID}`
     -   `SkillAssignment`: `SKILL#{skillID}#ASSIGNMENT` / `SUBJECT#{type}#{id}#ASSIGNMENT#{assignmentID}`
 -   **GSI2: Exposure, digest, and review queues**

--- a/docs/architecture/skills/canonical-skill-authority.md
+++ b/docs/architecture/skills/canonical-skill-authority.md
@@ -1,6 +1,8 @@
 # Canonical skill authority foundation
 
-Status: Project 21 M3 canonical authority (#698/#699/#700/#701/#702).
+Status: Project 21 M3 canonical authority (#698/#699/#700/#701/#702), with M4.1
+catalog/bundle publication defined in
+[`catalog-bundle-publication.md`](catalog-bundle-publication.md).
 
 ## Purpose
 
@@ -8,10 +10,10 @@ M3 establishes **Lesser as the canonical skill authority**. Repo-backed `SKILL.m
 files and lesser-host mint conversations may be used as source material or
 provenance, but neither is the system of record. The canonical authority lives in
 Lesser's single DynamoDB table and exposes approval, exposure, effective-resolution,
-and proposal-promotion APIs from that state.
+proposal-promotion, approved catalog, and bundle-publication APIs from that state.
 
-This milestone intentionally stops before M4 publication/catalog/bundle behavior
-and before lesser-body skills MCP tool work.
+M4.1 adds the approved catalog and bundle publication contract; lesser-body MCP
+tool implementation and local install-state verification remain downstream work.
 
 ## Entity model
 
@@ -112,7 +114,7 @@ sparse prefixes on existing `gsi1`/`gsi2`:
 |---|---|---|---|
 | `Skill` | `gsi1` | `SKILL#STATUS#{status}` / `UPDATED#{time}#SKILL#{skillID}` | later lifecycle/catalog listing |
 | `Skill` | `gsi2` | `SKILL#EXPOSURE#{exposure}` / `NAME#{slug}#SKILL#{skillID}` | later exposure-scoped catalog listing |
-| `SkillRevision` | `gsi1` | `SKILL_REVISION#STATUS#{status}` / `UPDATED#{time}#SKILL#{skillID}#REVISION#{n}` | later approval/revision queues |
+| `SkillRevision` | `gsi1` | `SKILL_REVISION#STATUS#{status}` / `UPDATED#{time}#SKILL#{skillID}#REVISION#{n}` | approval/revision queues and approved catalog publication |
 | `SkillRevision` | `gsi2` | `SKILL_REVISION_DIGEST#{digest}` / `SKILL#{skillID}#REVISION#{n}` | manifest digest de-duplication |
 | `SkillProposal` | `gsi1` | `SKILL#{skillID}#PROPOSAL` / `STATUS#{status}#CREATED#{time}#PROPOSAL#{proposalID}` | proposals for a skill |
 | `SkillProposal` | `gsi2` | `SKILL_PROPOSAL#STATUS#{status}` / `CREATED#{time}#SKILL#{skillID}#PROPOSAL#{proposalID}` | later review queues |

--- a/docs/architecture/skills/catalog-bundle-publication.md
+++ b/docs/architecture/skills/catalog-bundle-publication.md
@@ -48,7 +48,7 @@ Each bundle includes:
   `digests.publication_digest`, `digests.content_digest`, and
   `digests.approval_digest` when available;
 - `files[]` with path, file digest, content type, role, size, and advisory
-  install path;
+  install path derived from the resolved `install_hints.directory_name`;
 - `install_hints` with layout, runtime targets, directory name, entrypoint, and
   required files;
 - proposal/source/provenance references copied from the approved revision;
@@ -89,12 +89,17 @@ manifest fields:
 
 If file content is present and the caller passes `include_content=true`, the
 bundle response includes that content with `encoding` and
-`content_included=true`. If file content is absent, Lesser still publishes the
-metadata/digest contract and downstream clients report local state as
-`unknown_local_state` or equivalent until a later content source exists.
+`content_included=true`. When inline content is present, Lesser computes
+`sha256(decoded_bytes)` and fails closed unless any supplied `files[].digest`
+matches that digest. If the digest is omitted, Lesser derives it from the inline
+content. If file content is absent, Lesser still publishes the metadata/digest
+contract and downstream clients report local state as `unknown_local_state` or
+equivalent until a later content source exists.
 
 Unsafe file paths (absolute paths or `..` traversal) are never published as
-install hints.
+install hints. `files[].install_path` is derived from the resolved
+`install_hints.directory_name`, so Body receives one placement contract even
+when the approved manifest supplies a custom directory name.
 
 ## Cross-repo handoff for M4.2/M4.3
 

--- a/docs/architecture/skills/catalog-bundle-publication.md
+++ b/docs/architecture/skills/catalog-bundle-publication.md
@@ -1,0 +1,141 @@
+# Skill catalog and bundle publication contract
+
+Status: Project 21 M4.1 (`lesser#703`).
+
+## Purpose
+
+Lesser publishes approved canonical `SkillRevision` rows as catalog entries and
+verifiable bundle descriptions. This contract lets downstream MCP clients such as
+`lesser-body` fetch approved skill metadata, verify digests, and decide how to
+install files locally without pretending Lesser writes into a client workspace.
+
+Only Lesser-owned canonical state is authoritative:
+
+- `Skill` describes the canonical skill root.
+- `SkillRevision` describes approved revision material, files, digests, approval,
+  principal metadata, and provenance.
+- `SkillProposal`, local `SKILL.md` files, and lesser-host conversations remain
+  provenance only. They never publish a bundle directly.
+
+## REST surface
+
+The M4.1 publication API is Lesser-exclusive and additive under `/api/v1/skills`:
+
+| Endpoint | Auth | Purpose |
+|---|---|---|
+| `GET /api/v1/skills/catalog` | optional bearer | Lists visible approved catalog entries. Query: `exposure`, `limit`, `cursor`. |
+| `GET /api/v1/skills/{skillId}/revisions/{revisionNumber}/bundle` | optional bearer | Resolves one approved revision bundle. Query: `include_content=true` includes inline content only when it is present in the approved manifest. |
+
+Both endpoints apply the same exposure boundaries as the M3 skill authority APIs:
+
+- anonymous callers see approved `public` revisions only;
+- authenticated local callers see approved `public` and `instance` revisions;
+- admins can inspect private skill state elsewhere, but bundle publication still
+  requires `SkillRevision.status == approved`.
+
+Unapproved, revoked, superseded, missing, or malformed bundles fail closed: they
+are omitted from catalog listing or returned as not found / invalid state on
+direct bundle fetch.
+
+## Bundle shape
+
+Bundles use `schema_version = "lesser.skill.bundle.v1"`.
+
+Each bundle includes:
+
+- stable `bundle_id` (`skill:<skillID>:revision:<zero-padded revision number>`);
+- `digests.manifest_digest`, `digests.bundle_digest`,
+  `digests.publication_digest`, `digests.content_digest`, and
+  `digests.approval_digest` when available;
+- `files[]` with path, file digest, content type, role, size, and advisory
+  install path;
+- `install_hints` with layout, runtime targets, directory name, entrypoint, and
+  required files;
+- proposal/source/provenance references copied from the approved revision;
+- approval authority, principal approval, approver, and approval reference
+  metadata needed for trust display and verification.
+
+When a revision has no stored `bundleDigest`, Lesser computes a stable bundle
+digest from the approved revision identity, content/manifest/approval digests,
+file metadata, and install hints. `publication_digest` is computed over the
+published contract shape so downstream clients can detect contract-shape drift
+separately from file-content drift.
+
+## Manifest and inline content
+
+The approved revision may carry `ManifestJSON`. M4.1 understands these optional
+manifest fields:
+
+```json
+{
+  "runtime_targets": ["codex", "generic"],
+  "install_hints": {
+    "layout": "skill-directory-v1",
+    "directory_name": "example-skill",
+    "entrypoint": "SKILL.md",
+    "required_files": ["SKILL.md"]
+  },
+  "files": [
+    {
+      "path": "SKILL.md",
+      "role": "entrypoint",
+      "content_type": "text/markdown",
+      "digest": "sha256:...",
+      "content": "# Example skill\n"
+    }
+  ]
+}
+```
+
+If file content is present and the caller passes `include_content=true`, the
+bundle response includes that content with `encoding` and
+`content_included=true`. If file content is absent, Lesser still publishes the
+metadata/digest contract and downstream clients report local state as
+`unknown_local_state` or equivalent until a later content source exists.
+
+Unsafe file paths (absolute paths or `..` traversal) are never published as
+install hints.
+
+## Cross-repo handoff for M4.2/M4.3
+
+`lesser-body#137` should consume these Lesser endpoints rather than inventing a
+local catalog shape. Body can expose MCP tools that list catalog entries, fetch a
+selected bundle, and choose inline vs metadata-only responses.
+
+`lesser-body#138` should verify local install state against:
+
+- `bundle.digests.bundle_digest` for approved bundle content/metadata identity;
+- `bundle.digests.publication_digest` for the exact publication contract shape;
+- each `bundle.files[].digest` for local file drift.
+
+This slice partially unblocks body work: Body has a stable catalog and bundle
+contract, but metadata-only bundles still require body-side `unknown_local_state`
+handling until approved revisions include inline file content or another
+content-addressed fetch path is added.
+
+## Contract audit
+
+- Compatibility classification: additive, backward-compatible Lesser-exclusive
+  REST API. No existing Mastodon-compatible endpoint changes shape.
+- Mastodon clients: no impact; this is not a Mastodon endpoint.
+- Remote ActivityPub peers: no impact; actor, object, inbox, outbox, WebFinger,
+  and NodeInfo shapes are unchanged.
+- GraphQL: no schema change; routes are recorded as REST-only in
+  `docs/specs/graphql_coverage.yaml`.
+- Sibling repos: `lesser-body` is the intended downstream consumer; `host`,
+  `soul`, `greater`, and `sim` have no immediate contract change.
+- Rollout: normal dev → staging → live deployment; body M4.2/M4.3 should remain
+  blocked until this Lesser contract lands.
+
+## Schema audit
+
+M4.1 adds no new DynamoDB attributes, TableTheory tags, PK/SK patterns, or
+physical GSIs. It adds a new read path through the existing sparse
+`SkillRevision` GSI1 status pattern:
+
+`SKILL_REVISION#STATUS#approved / UPDATED#{time}#SKILL#{skillID}#REVISION#{n}`
+
+The read path is fail-closed: it loads the corresponding `Skill`, applies
+existing exposure checks, requires `SkillRevision.status == approved`, and
+publishes only the approved revision bundle. Existing stream processors do not
+consume skill rows and require no update in this slice.

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -5542,6 +5542,172 @@ components:
                 - assignments
                 - count
             type: object
+        SkillBundleDigestsResource:
+            additionalProperties: false
+            properties:
+                approval_digest:
+                    type: string
+                bundle_digest:
+                    type: string
+                content_digest:
+                    type: string
+                manifest_digest:
+                    type: string
+                publication_digest:
+                    type: string
+            required:
+                - bundle_digest
+                - publication_digest
+            type: object
+        SkillBundleFileResource:
+            additionalProperties: false
+            properties:
+                content:
+                    type: string
+                content_included:
+                    type: boolean
+                content_type:
+                    type: string
+                digest:
+                    type: string
+                encoding:
+                    type: string
+                install_path:
+                    type: string
+                path:
+                    type: string
+                role:
+                    type: string
+                size_bytes:
+                    type: integer
+            required:
+                - content_included
+                - digest
+                - install_path
+                - path
+            type: object
+        SkillBundleResource:
+            additionalProperties: false
+            properties:
+                approval_authority_id:
+                    type: string
+                approval_authority_type:
+                    type: string
+                approval_id:
+                    type: string
+                approval_ref:
+                    type: string
+                approval_signature:
+                    type: string
+                approved_at:
+                    anyOf:
+                        - $ref: '#/components/schemas/RFC3339DateTime'
+                        - type: "null"
+                approved_by:
+                    type: string
+                bundle_id:
+                    type: string
+                default_exposure:
+                    type: string
+                digests:
+                    $ref: '#/components/schemas/SkillBundleDigestsResource'
+                files:
+                    items:
+                        $ref: '#/components/schemas/SkillBundleFileResource'
+                    type: array
+                install_hints:
+                    $ref: '#/components/schemas/SkillInstallHintsResource'
+                principal_approval_id:
+                    type: string
+                principal_id:
+                    type: string
+                provenance:
+                    items:
+                        $ref: '#/components/schemas/SkillProvenanceRef'
+                    type: array
+                published:
+                    type: boolean
+                revision_id:
+                    type: string
+                revision_number:
+                    type: integer
+                schema_version:
+                    type: string
+                skill_id:
+                    type: string
+                source:
+                    type: string
+            required:
+                - bundle_id
+                - default_exposure
+                - digests
+                - install_hints
+                - published
+                - revision_id
+                - revision_number
+                - schema_version
+                - skill_id
+                - source
+            type: object
+        SkillBundleResponse:
+            additionalProperties: false
+            properties:
+                bundle:
+                    $ref: '#/components/schemas/SkillBundleResource'
+            required:
+                - bundle
+            type: object
+        SkillCatalogEntryResource:
+            additionalProperties: false
+            properties:
+                bundle:
+                    $ref: '#/components/schemas/SkillBundleResource'
+                revision:
+                    $ref: '#/components/schemas/SkillRevisionResource'
+                skill:
+                    $ref: '#/components/schemas/SkillResource'
+            required:
+                - bundle
+                - revision
+                - skill
+            type: object
+        SkillCatalogResponse:
+            additionalProperties: false
+            properties:
+                count:
+                    type: integer
+                entries:
+                    items:
+                        $ref: '#/components/schemas/SkillCatalogEntryResource'
+                    type: array
+                next_cursor:
+                    type: string
+            required:
+                - count
+                - entries
+            type: object
+        SkillInstallHintsResource:
+            additionalProperties: false
+            properties:
+                directory_name:
+                    type: string
+                entrypoint:
+                    type: string
+                layout:
+                    type: string
+                required_files:
+                    items:
+                        type: string
+                    type: array
+                runtime_targets:
+                    items:
+                        type: string
+                    type: array
+            required:
+                - directory_name
+                - entrypoint
+                - layout
+            type: object
         SkillListResponse:
             additionalProperties: false
             properties:
@@ -16358,6 +16524,86 @@ paths:
                 "500":
                     $ref: '#/components/responses/InternalServerError'
             x-lesser-handler: HandleGetSkillRevisionLift
+            x-lesser-lambda: api
+            x-lesser-routeSources:
+                - cmd/api/routes.go
+    /api/v1/skills/{skillId}/revisions/{revisionNumber}/bundle:
+        get:
+            operationId: get_api_v1_skills_by_skillId_revisions_by_revisionNumber_bundle
+            tags:
+                - skills
+            parameters:
+                - name: revisionNumber
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: skillId
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: include_content
+                  in: query
+                  description: When true, include inline file content that is present in the approved canonical revision manifest. Lesser never writes files into the caller workspace.
+                  schema:
+                    type: boolean
+                    default: false
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/SkillBundleResponse'
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "404":
+                    $ref: '#/components/responses/NotFound'
+                "422":
+                    $ref: '#/components/responses/UnprocessableEntity'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+            x-lesser-handler: HandleGetSkillBundleLift
+            x-lesser-lambda: api
+            x-lesser-routeSources:
+                - cmd/api/routes.go
+    /api/v1/skills/catalog:
+        get:
+            operationId: get_api_v1_skills_catalog
+            tags:
+                - skills
+            parameters:
+                - name: exposure
+                  in: query
+                  description: 'Optional approved catalog exposure filter: public, instance, or private. Visibility remains fail-closed for the caller.'
+                  schema:
+                    type: string
+                - name: limit
+                  in: query
+                  description: Maximum catalog entries to return. Defaults to 25 and is capped at 100.
+                  schema:
+                    type: integer
+                    default: 25
+                    minimum: 1
+                    maximum: 100
+                - name: cursor
+                  in: query
+                  description: Opaque pagination cursor returned by a previous catalog response.
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/SkillCatalogResponse'
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+            x-lesser-handler: HandleListSkillCatalogLift
             x-lesser-lambda: api
             x-lesser-routeSources:
                 - cmd/api/routes.go

--- a/docs/specs/graphql_coverage.yaml
+++ b/docs/specs/graphql_coverage.yaml
@@ -69,7 +69,7 @@ exemptions:
             - /api/v1/souls/bound/me/mint-conversations
             - /api/v1/souls/bound/me/mint-conversations/{conversationId}
     - id: canonical_skill_authority
-      reason: Canonical skill authority approval, exposure, assignment, and effective-resolution APIs are REST-only for Project 21 M3.
+      reason: Canonical skill authority approval, exposure, assignment, effective-resolution, catalog, and bundle-publication APIs are REST-only for Project 21 M3/M4.
       match:
         prefixes:
             - /api/v1/skills
@@ -1211,6 +1211,10 @@ routes:
       policy: rest_only
       exemptedBy: canonical_skill_authority
     - method: GET
+      path: /api/v1/skills/catalog
+      policy: rest_only
+      exemptedBy: canonical_skill_authority
+    - method: GET
       path: /api/v1/skills/resolve
       policy: rest_only
       exemptedBy: canonical_skill_authority
@@ -1224,6 +1228,10 @@ routes:
       exemptedBy: canonical_skill_authority
     - method: GET
       path: /api/v1/skills/{skillId}/revisions/{revisionNumber}
+      policy: rest_only
+      exemptedBy: canonical_skill_authority
+    - method: GET
+      path: /api/v1/skills/{skillId}/revisions/{revisionNumber}/bundle
       policy: rest_only
       exemptedBy: canonical_skill_authority
     - method: GET

--- a/pkg/services/skills/service.go
+++ b/pkg/services/skills/service.go
@@ -979,14 +979,13 @@ func revisionFilesFromManifest(manifestJSON string) []models.SkillRevisionFile {
 		if cleanPath == "" {
 			continue
 		}
-		digest := strings.ToLower(strings.TrimSpace(file.Digest))
 		_, _, decoded, hasContent, err := manifestFileContent(file)
 		if err != nil {
 			continue
 		}
-		if digest == "" && hasContent {
-			sum := sha256.Sum256(decoded)
-			digest = "sha256:" + hex.EncodeToString(sum[:])
+		digest, err := verifiedBundleFileDigest(file.Digest, decoded, hasContent)
+		if err != nil {
+			continue
 		}
 		size := file.SizeBytes
 		if size <= 0 && hasContent {
@@ -1254,11 +1253,12 @@ func buildSkillBundle(skill *models.Skill, revision *models.SkillRevision, inclu
 	if err != nil {
 		return SkillBundle{}, err
 	}
-	files, err := bundleFiles(skill, revision, manifest, includeContent)
+	installDirectory := resolvedInstallDirectory(skill, manifest)
+	files, err := bundleFiles(revision, manifest, includeContent, installDirectory)
 	if err != nil {
 		return SkillBundle{}, err
 	}
-	hints := buildInstallHints(skill, manifest, files)
+	hints := buildInstallHints(manifest, files, installDirectory)
 	bundle := SkillBundle{
 		SchemaVersion:  SkillBundleSchemaVersion,
 		BundleID:       skillBundleID(revision),
@@ -1292,7 +1292,7 @@ func parseSkillBundleManifest(raw string) (skillBundleManifest, error) {
 	return manifest, nil
 }
 
-func bundleFiles(skill *models.Skill, revision *models.SkillRevision, manifest skillBundleManifest, includeContent bool) ([]SkillBundleFile, error) {
+func bundleFiles(revision *models.SkillRevision, manifest skillBundleManifest, includeContent bool, installDirectory string) ([]SkillBundleFile, error) {
 	manifestByPath := map[string]skillManifestBundleFile{}
 	for _, file := range manifest.Files {
 		cleanPath := safeBundlePath(file.Path)
@@ -1311,7 +1311,7 @@ func bundleFiles(skill *models.Skill, revision *models.SkillRevision, manifest s
 			return nil, fmt.Errorf("skill bundle file path is unsafe")
 		}
 		manifestFile := manifestByPath[cleanPath]
-		bundleFile, err := materializeBundleFile(skill, file, manifestFile, includeContent)
+		bundleFile, err := materializeBundleFile(file, manifestFile, includeContent, installDirectory)
 		if err != nil {
 			return nil, err
 		}
@@ -1322,7 +1322,7 @@ func bundleFiles(skill *models.Skill, revision *models.SkillRevision, manifest s
 		if _, ok := seen[file.Path]; ok {
 			continue
 		}
-		bundleFile, err := materializeBundleFile(skill, models.SkillRevisionFile{}, file, includeContent)
+		bundleFile, err := materializeBundleFile(models.SkillRevisionFile{}, file, includeContent, installDirectory)
 		if err != nil {
 			return nil, err
 		}
@@ -1331,7 +1331,7 @@ func bundleFiles(skill *models.Skill, revision *models.SkillRevision, manifest s
 	return files, nil
 }
 
-func materializeBundleFile(skill *models.Skill, file models.SkillRevisionFile, manifestFile skillManifestBundleFile, includeContent bool) (SkillBundleFile, error) {
+func materializeBundleFile(file models.SkillRevisionFile, manifestFile skillManifestBundleFile, includeContent bool, installDirectory string) (SkillBundleFile, error) {
 	cleanPath := safeBundlePath(defaultTrimmed(file.Path, manifestFile.Path))
 	if cleanPath == "" {
 		return SkillBundleFile{}, fmt.Errorf("skill bundle file path is unsafe")
@@ -1340,10 +1340,9 @@ func materializeBundleFile(skill *models.Skill, file models.SkillRevisionFile, m
 	if err != nil {
 		return SkillBundleFile{}, err
 	}
-	digest := strings.ToLower(strings.TrimSpace(defaultTrimmed(file.Digest, manifestFile.Digest)))
-	if digest == "" && hasContent {
-		sum := sha256.Sum256(decodedBytes)
-		digest = "sha256:" + hex.EncodeToString(sum[:])
+	digest, err := verifiedBundleFileDigest(defaultTrimmed(file.Digest, manifestFile.Digest), decodedBytes, hasContent)
+	if err != nil {
+		return SkillBundleFile{}, err
 	}
 	if digest == "" {
 		return SkillBundleFile{}, fmt.Errorf("skill bundle file digest is required")
@@ -1361,7 +1360,7 @@ func materializeBundleFile(skill *models.Skill, file models.SkillRevisionFile, m
 		ContentType: defaultTrimmed(file.ContentType, manifestFile.ContentType),
 		Role:        defaultTrimmed(file.Role, manifestFile.Role),
 		SizeBytes:   size,
-		InstallPath: skillInstallPath(skill, cleanPath),
+		InstallPath: skillInstallPath(installDirectory, cleanPath),
 	}
 	if out.ContentType == "" {
 		out.ContentType = "text/markdown"
@@ -1375,6 +1374,26 @@ func materializeBundleFile(skill *models.Skill, file models.SkillRevisionFile, m
 		out.ContentIncluded = true
 	}
 	return out, nil
+}
+
+func verifiedBundleFileDigest(provided string, decodedBytes []byte, hasContent bool) (string, error) {
+	digest := strings.ToLower(strings.TrimSpace(provided))
+	if !hasContent {
+		return digest, nil
+	}
+	computed := sha256Digest(decodedBytes)
+	if digest == "" {
+		return computed, nil
+	}
+	if digest != computed {
+		return "", fmt.Errorf("skill bundle file digest does not match inline content")
+	}
+	return digest, nil
+}
+
+func sha256Digest(content []byte) string {
+	sum := sha256.Sum256(content)
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 func manifestFileContent(file skillManifestBundleFile) (content string, encoding string, decoded []byte, ok bool, err error) {
@@ -1407,11 +1426,11 @@ func manifestFileContent(file skillManifestBundleFile) (content string, encoding
 	return content, encoding, []byte(content), true, nil
 }
 
-func buildInstallHints(skill *models.Skill, manifest skillBundleManifest, files []SkillBundleFile) SkillInstallHints {
+func buildInstallHints(manifest skillBundleManifest, files []SkillBundleFile, installDirectory string) SkillInstallHints {
 	hints := SkillInstallHints{
 		Layout:         strings.TrimSpace(manifest.InstallHints.Layout),
 		RuntimeTargets: normalizedBundleStrings(manifest.InstallHints.RuntimeTargets),
-		DirectoryName:  safeBundlePath(manifest.InstallHints.DirectoryName),
+		DirectoryName:  safeBundlePath(installDirectory),
 		EntryPoint:     safeBundlePath(manifest.InstallHints.EntryPoint),
 		RequiredFiles:  safeBundlePaths(manifest.InstallHints.RequiredFiles),
 	}
@@ -1428,9 +1447,6 @@ func buildInstallHints(skill *models.Skill, manifest skillBundleManifest, files 
 		hints.RuntimeTargets = []string{defaultRuntimeTarget}
 	}
 	if hints.DirectoryName == "" {
-		hints.DirectoryName = safeBundlePath(defaultTrimmed(skill.Slug, skill.ID))
-	}
-	if hints.DirectoryName == "" {
 		hints.DirectoryName = defaultSkillDirectory
 	}
 	if hints.EntryPoint == "" {
@@ -1444,6 +1460,18 @@ func buildInstallHints(skill *models.Skill, manifest skillBundleManifest, files 
 	}
 	sort.Strings(hints.RequiredFiles)
 	return hints
+}
+
+func resolvedInstallDirectory(skill *models.Skill, manifest skillBundleManifest) string {
+	if directory := safeBundlePath(manifest.InstallHints.DirectoryName); directory != "" {
+		return directory
+	}
+	if skill != nil {
+		if directory := safeBundlePath(defaultTrimmed(skill.Slug, skill.ID)); directory != "" {
+			return directory
+		}
+	}
+	return defaultSkillDirectory
 }
 
 func entryPointFromFiles(files []SkillBundleFile) string {
@@ -1520,13 +1548,10 @@ func safeBundlePath(value string) string {
 	return clean
 }
 
-func skillInstallPath(skill *models.Skill, filePath string) string {
-	dir := defaultSkillDirectory
-	if skill != nil {
-		dir = safeBundlePath(defaultTrimmed(skill.Slug, skill.ID))
-		if dir == "" {
-			dir = defaultSkillDirectory
-		}
+func skillInstallPath(directoryName, filePath string) string {
+	dir := safeBundlePath(directoryName)
+	if dir == "" {
+		dir = defaultSkillDirectory
 	}
 	return path.Join(dir, filePath)
 }

--- a/pkg/services/skills/service.go
+++ b/pkg/services/skills/service.go
@@ -4,11 +4,14 @@ package skills
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"path"
+	"sort"
 	"strings"
 	"time"
 
@@ -57,6 +60,66 @@ type ListFilter struct {
 	Exposure string
 	Limit    int
 	Cursor   string
+}
+
+const (
+	// SkillBundleSchemaVersion is the stable publication contract version emitted by Lesser.
+	SkillBundleSchemaVersion = "lesser.skill.bundle.v1"
+	defaultSkillBundleLayout = "skill-directory-v1"
+	defaultRuntimeTarget     = "generic"
+	defaultSkillEntrypoint   = "SKILL.md"
+	defaultSkillDirectory    = "skill"
+	skillBundleBase64        = "base64"
+)
+
+// CatalogFilter constrains approved skill catalog listing.
+type CatalogFilter struct {
+	Exposure string
+	Limit    int
+	Cursor   string
+}
+
+// CatalogEntry binds an approved canonical revision to its publication bundle.
+type CatalogEntry struct {
+	Skill    *models.Skill
+	Revision *models.SkillRevision
+	Bundle   SkillBundle
+}
+
+// SkillBundle is the approved revision publication contract consumed by downstream clients.
+type SkillBundle struct {
+	SchemaVersion     string
+	BundleID          string
+	BundleDigest      string
+	PublicationDigest string
+	ManifestDigest    string
+	ContentDigest     string
+	ApprovalDigest    string
+	Files             []SkillBundleFile
+	InstallHints      SkillInstallHints
+	Provenance        []models.SkillProvenanceRef
+}
+
+// SkillBundleFile is one file record in a published skill bundle.
+type SkillBundleFile struct {
+	Path            string
+	Digest          string
+	ContentType     string
+	Role            string
+	SizeBytes       int64
+	InstallPath     string
+	Content         string
+	Encoding        string
+	ContentIncluded bool
+}
+
+// SkillInstallHints are advisory, client-consumed placement hints. Lesser never writes a client workspace.
+type SkillInstallHints struct {
+	Layout         string
+	RuntimeTargets []string
+	DirectoryName  string
+	EntryPoint     string
+	RequiredFiles  []string
 }
 
 // ApprovalCommand approves a canonical skill revision.
@@ -239,6 +302,60 @@ func (s *Service) GetRevision(ctx context.Context, viewer Viewer, skillID string
 		return nil, ErrSkillRevisionNotFound
 	}
 	return revision, nil
+}
+
+// ListCatalog returns approved canonical skill revisions as publishable catalog entries.
+func (s *Service) ListCatalog(ctx context.Context, viewer Viewer, filter CatalogFilter) ([]CatalogEntry, string, error) {
+	if err := s.ensureRepo(); err != nil {
+		return nil, "", err
+	}
+	if err := validateCatalogFilter(filter); err != nil {
+		return nil, "", err
+	}
+	revisions, cursor, err := s.repo.ListSkillRevisionsByStatus(ctx, models.SkillRevisionStatusApproved, filter.Limit, filter.Cursor)
+	if err != nil {
+		return nil, "", err
+	}
+	exposure := strings.ToLower(strings.TrimSpace(filter.Exposure))
+	out := make([]CatalogEntry, 0, len(revisions))
+	for _, revision := range revisions {
+		if revision == nil || revision.Status != models.SkillRevisionStatusApproved {
+			continue
+		}
+		if exposure != "" && revision.DefaultExposure != exposure {
+			continue
+		}
+		skill, err := s.repo.GetSkill(ctx, revision.SkillID)
+		if err != nil || !CanInspectSkill(viewer, skill) || !CanInspectRevision(viewer, revision) {
+			continue
+		}
+		entry, err := buildCatalogEntry(skill, revision, false)
+		if err != nil {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out, cursor, nil
+}
+
+// GetBundle returns the publication bundle for one approved canonical skill revision.
+func (s *Service) GetBundle(ctx context.Context, viewer Viewer, skillID string, revisionNumber int, includeContent bool) (*CatalogEntry, error) {
+	skill, err := s.GetSkill(ctx, viewer, skillID)
+	if err != nil {
+		return nil, err
+	}
+	revision, err := s.repo.GetSkillRevision(ctx, skillID, revisionNumber)
+	if err != nil {
+		return nil, ErrSkillRevisionNotFound
+	}
+	if revision.Status != models.SkillRevisionStatusApproved || !CanInspectRevision(viewer, revision) {
+		return nil, ErrSkillRevisionNotFound
+	}
+	entry, err := buildCatalogEntry(skill, revision, includeContent)
+	if err != nil {
+		return nil, ErrInvalidState
+	}
+	return &entry, nil
 }
 
 // ListProposals returns proposal records for admin inspection.
@@ -826,6 +943,7 @@ func buildPromotionRevision(skill *models.Skill, proposal *models.SkillProposal,
 		ManifestJSON:    manifestJSON,
 		ManifestDigest:  manifestDigest,
 		ContentDigest:   proposal.SourceDigest,
+		Files:           revisionFilesFromManifest(manifestJSON),
 		Capabilities:    capabilitiesFromManifest(manifestJSON),
 		DefaultExposure: exposure,
 		CreatedBy:       actor,
@@ -848,6 +966,41 @@ func capabilitiesFromManifest(manifestJSON string) []string {
 		return nil
 	}
 	return manifest.Capabilities
+}
+
+func revisionFilesFromManifest(manifestJSON string) []models.SkillRevisionFile {
+	manifest, err := parseSkillBundleManifest(manifestJSON)
+	if err != nil {
+		return nil
+	}
+	files := make([]models.SkillRevisionFile, 0, len(manifest.Files))
+	for _, file := range manifest.Files {
+		cleanPath := safeBundlePath(file.Path)
+		if cleanPath == "" {
+			continue
+		}
+		digest := strings.ToLower(strings.TrimSpace(file.Digest))
+		_, _, decoded, hasContent, err := manifestFileContent(file)
+		if err != nil {
+			continue
+		}
+		if digest == "" && hasContent {
+			sum := sha256.Sum256(decoded)
+			digest = "sha256:" + hex.EncodeToString(sum[:])
+		}
+		size := file.SizeBytes
+		if size <= 0 && hasContent {
+			size = int64(len(decoded))
+		}
+		files = append(files, models.SkillRevisionFile{
+			Path:        cleanPath,
+			Digest:      digest,
+			ContentType: strings.TrimSpace(file.ContentType),
+			Role:        strings.TrimSpace(file.Role),
+			SizeBytes:   size,
+		})
+	}
+	return files
 }
 
 func promotionProvenance(proposal *models.SkillProposal, manifestDigest string) []models.SkillProvenanceRef {
@@ -1053,6 +1206,403 @@ func defaultTrimmed(value, fallback string) string {
 		return strings.TrimSpace(fallback)
 	}
 	return value
+}
+
+type skillBundleManifest struct {
+	RuntimeTargets []string                  `json:"runtime_targets"`
+	Runtimes       []string                  `json:"runtimes"`
+	InstallHints   skillManifestInstallHints `json:"install_hints"`
+	Files          []skillManifestBundleFile `json:"files"`
+}
+
+type skillManifestInstallHints struct {
+	Layout         string   `json:"layout"`
+	RuntimeTargets []string `json:"runtime_targets"`
+	DirectoryName  string   `json:"directory_name"`
+	EntryPoint     string   `json:"entrypoint"`
+	RequiredFiles  []string `json:"required_files"`
+}
+
+type skillManifestBundleFile struct {
+	Path         string `json:"path"`
+	Digest       string `json:"digest"`
+	ContentType  string `json:"content_type"`
+	Role         string `json:"role"`
+	SizeBytes    int64  `json:"size_bytes"`
+	Content      string `json:"content"`
+	InlineText   string `json:"inline_text"`
+	InlineBase64 string `json:"inline_base64"`
+	Encoding     string `json:"encoding"`
+}
+
+func buildCatalogEntry(skill *models.Skill, revision *models.SkillRevision, includeContent bool) (CatalogEntry, error) {
+	if skill == nil || revision == nil {
+		return CatalogEntry{}, ErrInvalidInput
+	}
+	if revision.Status != models.SkillRevisionStatusApproved {
+		return CatalogEntry{}, ErrSkillRevisionNotFound
+	}
+	bundle, err := buildSkillBundle(skill, revision, includeContent)
+	if err != nil {
+		return CatalogEntry{}, err
+	}
+	return CatalogEntry{Skill: skill, Revision: revision, Bundle: bundle}, nil
+}
+
+func buildSkillBundle(skill *models.Skill, revision *models.SkillRevision, includeContent bool) (SkillBundle, error) {
+	manifest, err := parseSkillBundleManifest(revision.ManifestJSON)
+	if err != nil {
+		return SkillBundle{}, err
+	}
+	files, err := bundleFiles(skill, revision, manifest, includeContent)
+	if err != nil {
+		return SkillBundle{}, err
+	}
+	hints := buildInstallHints(skill, manifest, files)
+	bundle := SkillBundle{
+		SchemaVersion:  SkillBundleSchemaVersion,
+		BundleID:       skillBundleID(revision),
+		BundleDigest:   effectiveBundleDigest(revision, files, hints),
+		ManifestDigest: strings.TrimSpace(revision.ManifestDigest),
+		ContentDigest:  strings.TrimSpace(revision.ContentDigest),
+		ApprovalDigest: strings.TrimSpace(revision.ApprovalDigest),
+		Files:          files,
+		InstallHints:   hints,
+		Provenance:     append([]models.SkillProvenanceRef(nil), revision.Provenance...),
+	}
+	bundle.PublicationDigest = skillBundlePublicationDigest(skill, revision, bundle)
+	return bundle, nil
+}
+
+func parseSkillBundleManifest(raw string) (skillBundleManifest, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return skillBundleManifest{}, nil
+	}
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.UseNumber()
+	var manifest skillBundleManifest
+	if err := decoder.Decode(&manifest); err != nil {
+		return skillBundleManifest{}, fmt.Errorf("skill manifest json is malformed: %w", err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return skillBundleManifest{}, errors.New("skill manifest json has trailing data")
+	}
+	return manifest, nil
+}
+
+func bundleFiles(skill *models.Skill, revision *models.SkillRevision, manifest skillBundleManifest, includeContent bool) ([]SkillBundleFile, error) {
+	manifestByPath := map[string]skillManifestBundleFile{}
+	for _, file := range manifest.Files {
+		cleanPath := safeBundlePath(file.Path)
+		if cleanPath == "" {
+			return nil, fmt.Errorf("skill bundle file path is unsafe")
+		}
+		file.Path = cleanPath
+		manifestByPath[cleanPath] = file
+	}
+
+	files := make([]SkillBundleFile, 0, len(revision.Files)+len(manifest.Files))
+	seen := map[string]struct{}{}
+	for _, file := range revision.Files {
+		cleanPath := safeBundlePath(file.Path)
+		if cleanPath == "" {
+			return nil, fmt.Errorf("skill bundle file path is unsafe")
+		}
+		manifestFile := manifestByPath[cleanPath]
+		bundleFile, err := materializeBundleFile(skill, file, manifestFile, includeContent)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, bundleFile)
+		seen[cleanPath] = struct{}{}
+	}
+	for _, file := range manifest.Files {
+		if _, ok := seen[file.Path]; ok {
+			continue
+		}
+		bundleFile, err := materializeBundleFile(skill, models.SkillRevisionFile{}, file, includeContent)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, bundleFile)
+	}
+	return files, nil
+}
+
+func materializeBundleFile(skill *models.Skill, file models.SkillRevisionFile, manifestFile skillManifestBundleFile, includeContent bool) (SkillBundleFile, error) {
+	cleanPath := safeBundlePath(defaultTrimmed(file.Path, manifestFile.Path))
+	if cleanPath == "" {
+		return SkillBundleFile{}, fmt.Errorf("skill bundle file path is unsafe")
+	}
+	content, encoding, decodedBytes, hasContent, err := manifestFileContent(manifestFile)
+	if err != nil {
+		return SkillBundleFile{}, err
+	}
+	digest := strings.ToLower(strings.TrimSpace(defaultTrimmed(file.Digest, manifestFile.Digest)))
+	if digest == "" && hasContent {
+		sum := sha256.Sum256(decodedBytes)
+		digest = "sha256:" + hex.EncodeToString(sum[:])
+	}
+	if digest == "" {
+		return SkillBundleFile{}, fmt.Errorf("skill bundle file digest is required")
+	}
+	size := file.SizeBytes
+	if size <= 0 {
+		size = manifestFile.SizeBytes
+	}
+	if size <= 0 && hasContent {
+		size = int64(len(decodedBytes))
+	}
+	out := SkillBundleFile{
+		Path:        cleanPath,
+		Digest:      digest,
+		ContentType: defaultTrimmed(file.ContentType, manifestFile.ContentType),
+		Role:        defaultTrimmed(file.Role, manifestFile.Role),
+		SizeBytes:   size,
+		InstallPath: skillInstallPath(skill, cleanPath),
+	}
+	if out.ContentType == "" {
+		out.ContentType = "text/markdown"
+	}
+	if out.Role == "" && cleanPath == defaultSkillEntrypoint {
+		out.Role = "entrypoint"
+	}
+	if includeContent && hasContent {
+		out.Content = content
+		out.Encoding = encoding
+		out.ContentIncluded = true
+	}
+	return out, nil
+}
+
+func manifestFileContent(file skillManifestBundleFile) (content string, encoding string, decoded []byte, ok bool, err error) {
+	encoding = strings.ToLower(strings.TrimSpace(file.Encoding))
+	switch {
+	case strings.TrimSpace(file.InlineBase64) != "":
+		content = strings.TrimSpace(file.InlineBase64)
+		decoded, err = base64.StdEncoding.DecodeString(content)
+		if err != nil {
+			return "", "", nil, false, fmt.Errorf("skill bundle file content is invalid base64: %w", err)
+		}
+		return content, skillBundleBase64, decoded, true, nil
+	case encoding == skillBundleBase64 && strings.TrimSpace(file.Content) != "":
+		content = strings.TrimSpace(file.Content)
+		decoded, err = base64.StdEncoding.DecodeString(content)
+		if err != nil {
+			return "", "", nil, false, fmt.Errorf("skill bundle file content is invalid base64: %w", err)
+		}
+		return content, skillBundleBase64, decoded, true, nil
+	case file.InlineText != "":
+		content = file.InlineText
+	case file.Content != "":
+		content = file.Content
+	default:
+		return "", "", nil, false, nil
+	}
+	if encoding == "" || encoding == "text" {
+		encoding = "utf-8"
+	}
+	return content, encoding, []byte(content), true, nil
+}
+
+func buildInstallHints(skill *models.Skill, manifest skillBundleManifest, files []SkillBundleFile) SkillInstallHints {
+	hints := SkillInstallHints{
+		Layout:         strings.TrimSpace(manifest.InstallHints.Layout),
+		RuntimeTargets: normalizedBundleStrings(manifest.InstallHints.RuntimeTargets),
+		DirectoryName:  safeBundlePath(manifest.InstallHints.DirectoryName),
+		EntryPoint:     safeBundlePath(manifest.InstallHints.EntryPoint),
+		RequiredFiles:  safeBundlePaths(manifest.InstallHints.RequiredFiles),
+	}
+	if hints.Layout == "" {
+		hints.Layout = defaultSkillBundleLayout
+	}
+	if len(hints.RuntimeTargets) == 0 {
+		hints.RuntimeTargets = normalizedBundleStrings(manifest.RuntimeTargets)
+	}
+	if len(hints.RuntimeTargets) == 0 {
+		hints.RuntimeTargets = normalizedBundleStrings(manifest.Runtimes)
+	}
+	if len(hints.RuntimeTargets) == 0 {
+		hints.RuntimeTargets = []string{defaultRuntimeTarget}
+	}
+	if hints.DirectoryName == "" {
+		hints.DirectoryName = safeBundlePath(defaultTrimmed(skill.Slug, skill.ID))
+	}
+	if hints.DirectoryName == "" {
+		hints.DirectoryName = defaultSkillDirectory
+	}
+	if hints.EntryPoint == "" {
+		hints.EntryPoint = entryPointFromFiles(files)
+	}
+	if hints.EntryPoint == "" {
+		hints.EntryPoint = defaultSkillEntrypoint
+	}
+	if len(hints.RequiredFiles) == 0 {
+		hints.RequiredFiles = requiredFilesFromBundle(files, hints.EntryPoint)
+	}
+	sort.Strings(hints.RequiredFiles)
+	return hints
+}
+
+func entryPointFromFiles(files []SkillBundleFile) string {
+	for _, file := range files {
+		if strings.EqualFold(file.Role, "entrypoint") || strings.EqualFold(file.Role, "skill") {
+			return file.Path
+		}
+	}
+	for _, file := range files {
+		if file.Path == defaultSkillEntrypoint {
+			return file.Path
+		}
+	}
+	if len(files) > 0 {
+		return files[0].Path
+	}
+	return ""
+}
+
+func requiredFilesFromBundle(files []SkillBundleFile, entryPoint string) []string {
+	set := map[string]struct{}{}
+	for _, file := range files {
+		if file.Path != "" {
+			set[file.Path] = struct{}{}
+		}
+	}
+	if entryPoint != "" {
+		set[entryPoint] = struct{}{}
+	}
+	out := make([]string, 0, len(set))
+	for value := range set {
+		out = append(out, value)
+	}
+	return out
+}
+
+func normalizedBundleStrings(values []string) []string {
+	set := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value == "" {
+			continue
+		}
+		if _, ok := set[value]; ok {
+			continue
+		}
+		set[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func safeBundlePaths(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if clean := safeBundlePath(value); clean != "" {
+			out = append(out, clean)
+		}
+	}
+	return out
+}
+
+func safeBundlePath(value string) string {
+	value = strings.TrimSpace(strings.ReplaceAll(value, "\\", "/"))
+	if value == "" {
+		return ""
+	}
+	clean := path.Clean(value)
+	if clean == "." || strings.HasPrefix(clean, "../") || clean == ".." || strings.HasPrefix(clean, "/") {
+		return ""
+	}
+	return clean
+}
+
+func skillInstallPath(skill *models.Skill, filePath string) string {
+	dir := defaultSkillDirectory
+	if skill != nil {
+		dir = safeBundlePath(defaultTrimmed(skill.Slug, skill.ID))
+		if dir == "" {
+			dir = defaultSkillDirectory
+		}
+	}
+	return path.Join(dir, filePath)
+}
+
+func skillBundleID(revision *models.SkillRevision) string {
+	if revision == nil {
+		return ""
+	}
+	return fmt.Sprintf("skill:%s:revision:%08d", revision.SkillID, revision.RevisionNumber)
+}
+
+func effectiveBundleDigest(revision *models.SkillRevision, files []SkillBundleFile, hints SkillInstallHints) string {
+	if revision == nil {
+		return ""
+	}
+	if digest := strings.ToLower(strings.TrimSpace(revision.BundleDigest)); digest != "" {
+		return digest
+	}
+	material := []string{
+		"lesser-skill-bundle-v1",
+		strings.TrimSpace(revision.SkillID),
+		fmt.Sprintf("%08d", revision.RevisionNumber),
+		strings.TrimSpace(revision.ID),
+		strings.ToLower(strings.TrimSpace(revision.ManifestDigest)),
+		strings.ToLower(strings.TrimSpace(revision.ContentDigest)),
+		strings.ToLower(strings.TrimSpace(revision.ApprovalDigest)),
+		hints.Layout,
+		strings.Join(hints.RuntimeTargets, ","),
+		hints.DirectoryName,
+		hints.EntryPoint,
+	}
+	for _, file := range sortedBundleFiles(files) {
+		material = append(material, file.Path, strings.ToLower(strings.TrimSpace(file.Digest)), file.ContentType, file.Role, fmt.Sprintf("%d", file.SizeBytes))
+	}
+	sum := sha256.Sum256([]byte(strings.Join(material, "\x1f")))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func skillBundlePublicationDigest(skill *models.Skill, revision *models.SkillRevision, bundle SkillBundle) string {
+	material := []string{
+		"lesser-skill-bundle-publication-v1",
+		defaultTrimmed(skill.ID, ""),
+		defaultTrimmed(skill.Slug, ""),
+		strings.TrimSpace(revision.ID),
+		fmt.Sprintf("%08d", revision.RevisionNumber),
+		strings.TrimSpace(revision.Status),
+		strings.TrimSpace(revision.DefaultExposure),
+		bundle.BundleID,
+		bundle.BundleDigest,
+		bundle.ManifestDigest,
+		bundle.ContentDigest,
+		bundle.ApprovalDigest,
+	}
+	for _, file := range sortedBundleFiles(bundle.Files) {
+		material = append(material, file.Path, strings.ToLower(strings.TrimSpace(file.Digest)), file.InstallPath)
+	}
+	sum := sha256.Sum256([]byte(strings.Join(material, "\x1f")))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func sortedBundleFiles(files []SkillBundleFile) []SkillBundleFile {
+	out := append([]SkillBundleFile(nil), files...)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Path == out[j].Path {
+			return out[i].Digest < out[j].Digest
+		}
+		return out[i].Path < out[j].Path
+	})
+	return out
+}
+
+func validateCatalogFilter(filter CatalogFilter) error {
+	if filter.Exposure != "" && exposureRank(strings.ToLower(strings.TrimSpace(filter.Exposure))) < 0 {
+		return errors.Join(ErrInvalidInput, errors.New("unsupported exposure"))
+	}
+	return nil
 }
 
 func validateListFilter(filter ListFilter) error {

--- a/pkg/services/skills/service_test.go
+++ b/pkg/services/skills/service_test.go
@@ -197,6 +197,19 @@ func (f *fakeSkillRepo) ListSkillRevisions(_ context.Context, skillID string, _ 
 	return out, "", nil
 }
 
+func (f *fakeSkillRepo) ListSkillRevisionsByStatus(_ context.Context, status string, _ int, _ string) ([]*models.SkillRevision, string, error) {
+	if f.listRevisionsErr != nil {
+		return nil, "", f.listRevisionsErr
+	}
+	out := []*models.SkillRevision{}
+	for _, revision := range f.revisions {
+		if status == "" || revision.Status == status {
+			out = append(out, revision)
+		}
+	}
+	return out, "", nil
+}
+
 func (f *fakeSkillRepo) GetSkillRevisionByDigest(_ context.Context, manifestDigest string) (*models.SkillRevision, error) {
 	for _, revision := range f.revisions {
 		if revision.ManifestDigest == manifestDigest {
@@ -654,6 +667,199 @@ func TestServiceListSkillsAppliesExposure(t *testing.T) {
 	items, _, err = svc.ListSkills(ctx, Viewer{Username: "ops", Authenticated: true, Admin: true}, ListFilter{Status: models.SkillStatusActive})
 	require.NoError(t, err)
 	require.Len(t, items, 3)
+}
+
+func TestServiceListCatalogPublishesApprovedVisibleBundles(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeSkillRepo()
+	svc := NewService(repo)
+	manifestJSON, manifestDigest, err := canonicalizeSkillManifest(`{
+		"capabilities":["social.post"],
+		"runtime_targets":["codex"],
+		"install_hints":{"layout":"skill-directory-v1","directory_name":"skill-a","entrypoint":"SKILL.md"},
+		"files":[{"path":"SKILL.md","role":"entrypoint","content_type":"text/markdown","content":"# Skill A\n"}]
+	}`)
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateSkill(ctx, &models.Skill{
+		ID: "skill-a", Slug: "skill-a", Name: "Skill A", Status: models.SkillStatusActive,
+		DefaultExposure: models.SkillExposurePublic, CurrentRevisionID: "skill-a-r1", CurrentRevisionNumber: 1,
+	}))
+	seedApprovedRevision(t, ctx, repo, &models.SkillRevision{
+		SkillID:         "skill-a",
+		RevisionNumber:  1,
+		ManifestJSON:    manifestJSON,
+		ManifestDigest:  manifestDigest,
+		ContentDigest:   "sha256:content",
+		DefaultExposure: models.SkillExposurePublic,
+		Provenance: []models.SkillProvenanceRef{{
+			SourceType: models.SkillSourceTypeProposal,
+			Digest:     manifestDigest,
+			Ref:        "proposal-1",
+		}},
+	})
+	require.NoError(t, repo.CreateSkill(ctx, &models.Skill{ID: "private", Status: models.SkillStatusActive, DefaultExposure: models.SkillExposurePrivate}))
+	seedApprovedRevision(t, ctx, repo, &models.SkillRevision{
+		SkillID:         "private",
+		RevisionNumber:  1,
+		DefaultExposure: models.SkillExposurePrivate,
+	})
+	require.NoError(t, repo.CreateSkill(ctx, &models.Skill{ID: "draft", Status: models.SkillStatusActive, DefaultExposure: models.SkillExposurePublic}))
+	require.NoError(t, repo.CreateSkillRevision(ctx, &models.SkillRevision{SkillID: "draft", RevisionNumber: 1, Status: models.SkillRevisionStatusDraft, DefaultExposure: models.SkillExposurePublic}))
+
+	catalog, _, err := svc.ListCatalog(ctx, Viewer{}, CatalogFilter{})
+	require.NoError(t, err)
+	require.Len(t, catalog, 1)
+	require.Equal(t, "skill-a", catalog[0].Skill.ID)
+	require.Equal(t, SkillBundleSchemaVersion, catalog[0].Bundle.SchemaVersion)
+	require.Equal(t, "skill:skill-a:revision:00000001", catalog[0].Bundle.BundleID)
+	require.NotEmpty(t, catalog[0].Bundle.BundleDigest)
+	require.NotEmpty(t, catalog[0].Bundle.PublicationDigest)
+	require.Equal(t, []string{"codex"}, catalog[0].Bundle.InstallHints.RuntimeTargets)
+	require.Equal(t, "SKILL.md", catalog[0].Bundle.InstallHints.EntryPoint)
+	require.Len(t, catalog[0].Bundle.Files, 1)
+	require.Equal(t, "skill-a/SKILL.md", catalog[0].Bundle.Files[0].InstallPath)
+	require.False(t, catalog[0].Bundle.Files[0].ContentIncluded)
+
+	catalog, _, err = svc.ListCatalog(ctx, Viewer{Username: "ops", Authenticated: true, Admin: true}, CatalogFilter{Exposure: models.SkillExposurePrivate})
+	require.NoError(t, err)
+	require.Len(t, catalog, 1)
+	require.Equal(t, "private", catalog[0].Skill.ID)
+}
+
+func TestServiceGetBundleIncludesContentAndRejectsUnpublished(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeSkillRepo()
+	svc := NewService(repo)
+	manifestJSON, manifestDigest, err := canonicalizeSkillManifest(`{
+		"runtime_targets":["codex","generic"],
+		"files":[{"path":"SKILL.md","role":"entrypoint","content":"# Skill A\n"}]
+	}`)
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateSkill(ctx, &models.Skill{ID: "skill-a", Slug: "skill-a", Status: models.SkillStatusActive, DefaultExposure: models.SkillExposurePublic, CurrentRevisionNumber: 1}))
+	seedApprovedRevision(t, ctx, repo, &models.SkillRevision{
+		SkillID:         "skill-a",
+		RevisionNumber:  1,
+		ManifestJSON:    manifestJSON,
+		ManifestDigest:  manifestDigest,
+		DefaultExposure: models.SkillExposurePublic,
+	})
+	require.NoError(t, repo.CreateSkillRevision(ctx, &models.SkillRevision{SkillID: "skill-a", RevisionNumber: 2, Status: models.SkillRevisionStatusProposed, DefaultExposure: models.SkillExposurePublic}))
+
+	entry, err := svc.GetBundle(ctx, Viewer{}, "skill-a", 1, true)
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	require.Len(t, entry.Bundle.Files, 1)
+	require.True(t, entry.Bundle.Files[0].ContentIncluded)
+	require.Equal(t, "# Skill A\n", entry.Bundle.Files[0].Content)
+	require.Equal(t, "utf-8", entry.Bundle.Files[0].Encoding)
+	require.Equal(t, int64(len("# Skill A\n")), entry.Bundle.Files[0].SizeBytes)
+	require.NotEmpty(t, entry.Bundle.Files[0].Digest)
+
+	_, err = svc.GetBundle(ctx, Viewer{}, "skill-a", 2, true)
+	require.ErrorIs(t, err, ErrSkillRevisionNotFound)
+}
+
+func TestServiceGetBundleFailsClosedOnUnsafeFilePath(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeSkillRepo()
+	svc := NewService(repo)
+	manifestJSON, manifestDigest, err := canonicalizeSkillManifest(`{"files":[{"path":"../SKILL.md","content":"unsafe"}]}`)
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateSkill(ctx, &models.Skill{ID: "skill-a", Status: models.SkillStatusActive, DefaultExposure: models.SkillExposurePublic, CurrentRevisionNumber: 1}))
+	seedApprovedRevision(t, ctx, repo, &models.SkillRevision{
+		SkillID:         "skill-a",
+		RevisionNumber:  1,
+		ManifestJSON:    manifestJSON,
+		ManifestDigest:  manifestDigest,
+		DefaultExposure: models.SkillExposurePublic,
+	})
+
+	_, err = svc.GetBundle(ctx, Viewer{}, "skill-a", 1, false)
+	require.ErrorIs(t, err, ErrInvalidState)
+}
+
+func TestSkillBundleHelpersCoverContractEdges(t *testing.T) {
+	encoded := "IyBTa2lsbCBCCg=="
+	manifestJSON := `{
+		"runtime_targets":["generic","codex","codex"],
+		"install_hints":{"runtime_targets":["codex"],"required_files":["SKILL.md","../blocked"]},
+		"files":[
+			{"path":"docs/README.md","role":"support","digest":"sha256:readme"},
+			{"path":"SKILL.md","role":"skill","content":"` + encoded + `","encoding":"base64"}
+		]
+	}`
+	skill := &models.Skill{ID: "skill-a", Slug: "skill-a"}
+	revision := &models.SkillRevision{
+		ID:              "skill-a-r1",
+		SkillID:         "skill-a",
+		RevisionNumber:  1,
+		Status:          models.SkillRevisionStatusApproved,
+		ManifestJSON:    manifestJSON,
+		ManifestDigest:  "sha256:manifest",
+		BundleDigest:    "sha256:stored-bundle",
+		ContentDigest:   "sha256:content",
+		ApprovalDigest:  "sha256:approval",
+		DefaultExposure: models.SkillExposurePublic,
+	}
+
+	entry, err := buildCatalogEntry(skill, revision, true)
+	require.NoError(t, err)
+	require.Equal(t, "sha256:stored-bundle", entry.Bundle.BundleDigest)
+	require.Equal(t, "skill:skill-a:revision:00000001", entry.Bundle.BundleID)
+	require.Equal(t, []string{"codex"}, entry.Bundle.InstallHints.RuntimeTargets)
+	require.Equal(t, []string{"SKILL.md"}, entry.Bundle.InstallHints.RequiredFiles)
+	require.Len(t, entry.Bundle.Files, 2)
+	require.Equal(t, "docs/README.md", entry.Bundle.Files[0].Path)
+	require.Equal(t, "SKILL.md", entry.Bundle.Files[1].Path)
+	require.Equal(t, encoded, entry.Bundle.Files[1].Content)
+	require.Equal(t, skillBundleBase64, entry.Bundle.Files[1].Encoding)
+	require.True(t, entry.Bundle.Files[1].ContentIncluded)
+
+	files := revisionFilesFromManifest(manifestJSON)
+	require.Len(t, files, 2)
+	require.Equal(t, "SKILL.md", files[1].Path)
+	require.NotEmpty(t, files[1].Digest)
+
+	_, err = buildCatalogEntry(nil, revision, false)
+	require.ErrorIs(t, err, ErrInvalidInput)
+	_, err = buildCatalogEntry(skill, &models.SkillRevision{Status: models.SkillRevisionStatusDraft}, false)
+	require.ErrorIs(t, err, ErrSkillRevisionNotFound)
+	_, err = parseSkillBundleManifest(`{"files":[]}{}`)
+	require.Error(t, err)
+	_, err = buildSkillBundle(skill, &models.SkillRevision{ManifestJSON: `{"files":[{"path":"SKILL.md"}]}`}, false)
+	require.Error(t, err)
+	_, _, _, _, err = manifestFileContent(skillManifestBundleFile{InlineBase64: "not-base64"})
+	require.Error(t, err)
+	var ok bool
+	_, _, _, ok, err = manifestFileContent(skillManifestBundleFile{InlineText: "plain"})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Empty(t, skillBundleID(nil))
+	require.Equal(t, []string{"safe/file.md"}, safeBundlePaths([]string{"safe/file.md", "../blocked", "/also-blocked"}))
+	require.Equal(t, "skill/SKILL.md", skillInstallPath(nil, "SKILL.md"))
+	require.ErrorIs(t, validateCatalogFilter(CatalogFilter{Exposure: "world"}), ErrInvalidInput)
+	require.NotEmpty(t, effectiveBundleDigest(&models.SkillRevision{SkillID: "skill-a", ID: "skill-a-r2", RevisionNumber: 2}, entry.Bundle.Files, entry.Bundle.InstallHints))
+	require.Len(t, sortedBundleFiles([]SkillBundleFile{{Path: "z"}, {Path: "a"}}), 2)
+
+	revisionWithStoredFiles := *revision
+	revisionWithStoredFiles.BundleDigest = ""
+	revisionWithStoredFiles.Files = []models.SkillRevisionFile{{
+		Path:        "SKILL.md",
+		Digest:      "sha256:stored-file",
+		ContentType: "text/markdown",
+		Role:        "entrypoint",
+		SizeBytes:   99,
+	}}
+	bundle, err := buildSkillBundle(skill, &revisionWithStoredFiles, false)
+	require.NoError(t, err)
+	require.NotEqual(t, "sha256:stored-bundle", bundle.BundleDigest)
+	require.Len(t, bundle.Files, 2)
+	require.False(t, bundle.Files[0].ContentIncluded)
+
+	repo := newFakeSkillRepo()
+	repo.listRevisionsErr = errors.New("list failed")
+	_, _, err = NewService(repo).ListCatalog(context.Background(), Viewer{}, CatalogFilter{})
+	require.Error(t, err)
 }
 
 func TestServiceInspectAndAdminReadPaths(t *testing.T) {

--- a/pkg/services/skills/service_test.go
+++ b/pkg/services/skills/service_test.go
@@ -778,6 +778,56 @@ func TestServiceGetBundleFailsClosedOnUnsafeFilePath(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidState)
 }
 
+func TestServiceGetBundleFailsClosedOnInlineDigestMismatch(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeSkillRepo()
+	svc := NewService(repo)
+	manifestJSON, manifestDigest, err := canonicalizeSkillManifest(`{
+		"files":[{
+			"path":"SKILL.md",
+			"digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			"content":"# Skill A\n"
+		}]
+	}`)
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateSkill(ctx, &models.Skill{ID: "skill-a", Status: models.SkillStatusActive, DefaultExposure: models.SkillExposurePublic, CurrentRevisionNumber: 1}))
+	seedApprovedRevision(t, ctx, repo, &models.SkillRevision{
+		SkillID:         "skill-a",
+		RevisionNumber:  1,
+		ManifestJSON:    manifestJSON,
+		ManifestDigest:  manifestDigest,
+		DefaultExposure: models.SkillExposurePublic,
+	})
+
+	_, err = svc.GetBundle(ctx, Viewer{}, "skill-a", 1, true)
+	require.ErrorIs(t, err, ErrInvalidState)
+}
+
+func TestServiceGetBundleUsesResolvedInstallDirectory(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeSkillRepo()
+	svc := NewService(repo)
+	manifestJSON, manifestDigest, err := canonicalizeSkillManifest(`{
+		"install_hints":{"directory_name":"manifest-dir","entrypoint":"SKILL.md"},
+		"files":[{"path":"SKILL.md","content":"# Skill A\n"}]
+	}`)
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateSkill(ctx, &models.Skill{ID: "skill-a", Slug: "skill-slug", Status: models.SkillStatusActive, DefaultExposure: models.SkillExposurePublic, CurrentRevisionNumber: 1}))
+	seedApprovedRevision(t, ctx, repo, &models.SkillRevision{
+		SkillID:         "skill-a",
+		RevisionNumber:  1,
+		ManifestJSON:    manifestJSON,
+		ManifestDigest:  manifestDigest,
+		DefaultExposure: models.SkillExposurePublic,
+	})
+
+	entry, err := svc.GetBundle(ctx, Viewer{}, "skill-a", 1, false)
+	require.NoError(t, err)
+	require.Equal(t, "manifest-dir", entry.Bundle.InstallHints.DirectoryName)
+	require.Len(t, entry.Bundle.Files, 1)
+	require.Equal(t, "manifest-dir/SKILL.md", entry.Bundle.Files[0].InstallPath)
+}
+
 func TestSkillBundleHelpersCoverContractEdges(t *testing.T) {
 	encoded := "IyBTa2lsbCBCCg=="
 	manifestJSON := `{
@@ -836,7 +886,7 @@ func TestSkillBundleHelpersCoverContractEdges(t *testing.T) {
 	require.True(t, ok)
 	require.Empty(t, skillBundleID(nil))
 	require.Equal(t, []string{"safe/file.md"}, safeBundlePaths([]string{"safe/file.md", "../blocked", "/also-blocked"}))
-	require.Equal(t, "skill/SKILL.md", skillInstallPath(nil, "SKILL.md"))
+	require.Equal(t, "skill/SKILL.md", skillInstallPath("", "SKILL.md"))
 	require.ErrorIs(t, validateCatalogFilter(CatalogFilter{Exposure: "world"}), ErrInvalidInput)
 	require.NotEmpty(t, effectiveBundleDigest(&models.SkillRevision{SkillID: "skill-a", ID: "skill-a-r2", RevisionNumber: 2}, entry.Bundle.Files, entry.Bundle.InstallHints))
 	require.Len(t, sortedBundleFiles([]SkillBundleFile{{Path: "z"}, {Path: "a"}}), 2)
@@ -845,7 +895,7 @@ func TestSkillBundleHelpersCoverContractEdges(t *testing.T) {
 	revisionWithStoredFiles.BundleDigest = ""
 	revisionWithStoredFiles.Files = []models.SkillRevisionFile{{
 		Path:        "SKILL.md",
-		Digest:      "sha256:stored-file",
+		Digest:      sha256Digest([]byte("# Skill B\n")),
 		ContentType: "text/markdown",
 		Role:        "entrypoint",
 		SizeBytes:   99,

--- a/pkg/storage/interfaces/skill.go
+++ b/pkg/storage/interfaces/skill.go
@@ -23,6 +23,7 @@ type SkillRepository interface {
 	GetSkillRevision(ctx context.Context, skillID string, revisionNumber int) (*models.SkillRevision, error)
 	UpdateSkillRevision(ctx context.Context, revision *models.SkillRevision) error
 	ListSkillRevisions(ctx context.Context, skillID string, limit int, cursor string) ([]*models.SkillRevision, string, error)
+	ListSkillRevisionsByStatus(ctx context.Context, status string, limit int, cursor string) ([]*models.SkillRevision, string, error)
 	GetSkillRevisionByDigest(ctx context.Context, manifestDigest string) (*models.SkillRevision, error)
 
 	// Proposal operations.

--- a/pkg/storage/repositories/skill_repository.go
+++ b/pkg/storage/repositories/skill_repository.go
@@ -113,6 +113,15 @@ func (r *SkillRepository) ListSkillRevisions(ctx context.Context, skillID string
 	return listByPKSKPrefixPaginated[*models.SkillRevision](ctx, r.db, &models.SkillRevision{}, models.SkillPartitionKey(skillID), models.SKSkillRevisionPrefix, sanitizeSkillLimit(limit), cursor)
 }
 
+// ListSkillRevisionsByStatus lists canonical revisions by lifecycle status.
+func (r *SkillRepository) ListSkillRevisionsByStatus(ctx context.Context, status string, limit int, cursor string) ([]*models.SkillRevision, string, error) {
+	status = strings.ToLower(strings.TrimSpace(status))
+	if status == "" {
+		status = models.SkillRevisionStatusApproved
+	}
+	return querySkillGSIPage[*models.SkillRevision](ctx, r.db, &models.SkillRevision{}, models.IndexGSI1, "gsi1PK", gsi1SKField, "SKILL_REVISION#STATUS#"+status, limit, cursor)
+}
+
 // GetSkillRevisionByDigest resolves a revision by manifest digest when the digest index is populated.
 func (r *SkillRepository) GetSkillRevisionByDigest(ctx context.Context, manifestDigest string) (*models.SkillRevision, error) {
 	manifestDigest = strings.ToLower(strings.TrimSpace(manifestDigest))

--- a/tools/openapi/operation_overrides.go
+++ b/tools/openapi/operation_overrides.go
@@ -21,6 +21,50 @@ func applySkillOverrides(op *operation, route routeDef) {
 	if op == nil {
 		return
 	}
+	if route.Path == "/api/v1/skills/catalog" && route.Method == methodGET {
+		ensureQueryParam(op, parameter{
+			Name:        "exposure",
+			In:          "query",
+			Required:    false,
+			Description: "Optional approved catalog exposure filter: public, instance, or private. Visibility remains fail-closed for the caller.",
+			Schema:      schemaRef{Type: "string"},
+		})
+		ensureQueryParam(op, parameter{
+			Name:        "limit",
+			In:          "query",
+			Required:    false,
+			Description: "Maximum catalog entries to return. Defaults to 25 and is capped at 100.",
+			Schema: schemaRef{
+				Type:    "integer",
+				Default: 25,
+				Minimum: intPtr(1),
+				Maximum: intPtr(100),
+			},
+		})
+		ensureQueryParam(op, parameter{
+			Name:        "cursor",
+			In:          "query",
+			Required:    false,
+			Description: "Opaque pagination cursor returned by a previous catalog response.",
+			Schema:      schemaRef{Type: "string"},
+		})
+	}
+	if route.Path == "/api/v1/skills/{skillId}/revisions/{revisionNumber}/bundle" && route.Method == methodGET {
+		ensureQueryParam(op, parameter{
+			Name:        "include_content",
+			In:          "query",
+			Required:    false,
+			Description: "When true, include inline file content that is present in the approved canonical revision manifest. Lesser never writes files into the caller workspace.",
+			Schema: schemaRef{
+				Type:    "boolean",
+				Default: false,
+			},
+		})
+		if op.Responses == nil {
+			op.Responses = map[string]response{}
+		}
+		ensureResponseRef(op.Responses, "422", "UnprocessableEntity")
+	}
 	if route.Path == "/api/v1/admin/skills/{skillId}/proposals/{proposalId}/promote" && route.Method == methodPOST {
 		if op.Responses == nil {
 			op.Responses = map[string]response{}


### PR DESCRIPTION
## Summary

Implements Project 21 M4.1 / #703 by publishing the approved skill catalog and stable bundle contract from Lesser’s canonical skill authority.

- Adds additive Lesser-exclusive REST endpoints:
  - `GET /api/v1/skills/catalog`
  - `GET /api/v1/skills/{skillId}/revisions/{revisionNumber}/bundle`
- Publishes approved, visible `SkillRevision` bundles with stable bundle IDs, bundle/publication digests, per-file digests, install hints, approval/principal/provenance metadata, and optional inline content inclusion.
- Adds repository support for listing revisions by existing status GSI, handler/model tests, OpenAPI/route manifest updates, GraphQL REST-only coverage exemptions, and architecture docs.

Closes #703.

## Stewardship / contract walks

- **Federation trust:** no ActivityPub, inbox/outbox, delivery, HTTP Signature, actor-object, relay, moderation, or federation peer behavior changes.
- **Mastodon/API compatibility:** additive Lesser-exclusive `/api/v1/skills/*` endpoints only; no existing Mastodon-compatible endpoint response/request/error shape changes. OpenAPI regenerated.
- **Schema:** no PK/SK patterns, GSI definitions, TableTheory tags, projections, or optimistic concurrency changes. The new list path uses existing `SkillRevision` GSI1 status pattern: `SKILL_REVISION#STATUS#approved`.
- **Framework discipline:** no AppTheory/TableTheory monkey-patches or local framework workarounds.
- **Sibling handoff:** body #137/#138 should consume these Lesser catalog/bundle endpoints and verify `bundle_digest`, `publication_digest`, and per-file digests rather than inventing a local catalog shape.

## Acceptance mapping

1. **Approved catalog contract exists:** `GET /api/v1/skills/catalog` lists approved visible bundles with exposure filtering and pagination parameters.
2. **Bundle publication contract exists:** `GET /api/v1/skills/{skillId}/revisions/{revisionNumber}/bundle` publishes one approved visible bundle by skill/revision.
3. **Bundle metadata is complete:** response includes file digests, install hints, provenance/source/proposal/approval fields, approved principals, approval digests, publication digest, and optional inline content inclusion flag.
4. **Contracts/docs/tests current:** OpenAPI, route manifest, GraphQL coverage, skill architecture docs, service tests, and handler tests updated.

## Non-goals honored

- No lesser-body MCP tool implementation in this repo.
- No assignment or installation state verification.
- No marketplace/ranking/scoring behavior.
- No ActivityPub or Mastodon-compatible endpoint behavior changes.
- No sibling repo edits.

## Validation

- `gofmt -l .`
- `git diff --check`
- `go test ./...`
- `go vet ./...`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`

Final `./lesser verify ci` passed, including strict OpenAPI/GraphQL checks and coverage gates (`pkg` 90.004%, `cmd` 90.081%).

## Advisor authorization

Pilot assignment delivery `delivery-3d1de35c99bced3b` was reviewed with the advisor-brief discipline, and Aron confirmed this is authorized work in-session.