### PR TITLE
fix(api): harden private mint conversation logging

### DIFF
--- a/cmd/api/handlers/helpers.go
+++ b/cmd/api/handlers/helpers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/config"
 	apperrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/federation"
+	"github.com/equaltoai/lesser/pkg/logging"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/core"
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
@@ -1154,7 +1155,7 @@ func (h *Handler) parsePaginationParams(ctx *apptheory.Context) *PaginationParam
 func (h *Handler) respondWithError(ctx *apptheory.Context, statusCode int, message string) (*apptheory.Response, error) {
 	path := ""
 	if ctx != nil {
-		path = ctx.Request.Path
+		path = logging.SanitizeLogPath(ctx.Request.Path)
 	}
 
 	h.logger.Error("API error",

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -512,7 +512,7 @@ func extractRequestInfo(ctx *apptheory.Context) requestInfo {
 		info.method = method
 	}
 	if path := strings.TrimSpace(ctx.Request.Path); path != "" {
-		info.path = path
+		info.path = sanitizeLogPath(path)
 	}
 	info.userAgent = headerValue(ctx, "User-Agent")
 	info.clientIP = headerValue(ctx, "X-Forwarded-For")
@@ -702,7 +702,7 @@ func createEMFMetricsMiddleware() apptheory.Middleware {
 
 			// Extract endpoint information
 			method := ctx.Request.Method
-			path := ctx.Request.Path
+			path := sanitizeLogPath(ctx.Request.Path)
 			endpoint := method + " " + path
 			dimensions := map[string]string{
 				observability.DimensionEndpoint: path,
@@ -919,7 +919,7 @@ func createTracingMiddleware() apptheory.Middleware {
 
 			// Extract request info
 			method := ctx.Request.Method
-			url := ctx.Request.Path
+			url := sanitizeLogPath(ctx.Request.Path)
 			userAgent := headerValue(ctx, "User-Agent")
 			clientIP := headerValue(ctx, "X-Forwarded-For")
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/cost"
 	"github.com/equaltoai/lesser/pkg/crawler"
 	"github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/logging"
 	"github.com/equaltoai/lesser/pkg/observability"
 	browsercors "github.com/equaltoai/lesser/pkg/security/cors"
 	"github.com/equaltoai/lesser/pkg/storage/core"
@@ -512,7 +513,7 @@ func extractRequestInfo(ctx *apptheory.Context) requestInfo {
 		info.method = method
 	}
 	if path := strings.TrimSpace(ctx.Request.Path); path != "" {
-		info.path = sanitizeLogPath(path)
+		info.path = logging.SanitizeLogPath(path)
 	}
 	info.userAgent = headerValue(ctx, "User-Agent")
 	info.clientIP = headerValue(ctx, "X-Forwarded-For")
@@ -702,7 +703,7 @@ func createEMFMetricsMiddleware() apptheory.Middleware {
 
 			// Extract endpoint information
 			method := ctx.Request.Method
-			path := sanitizeLogPath(ctx.Request.Path)
+			path := logging.SanitizeLogPath(ctx.Request.Path)
 			endpoint := method + " " + path
 			dimensions := map[string]string{
 				observability.DimensionEndpoint: path,
@@ -919,7 +920,7 @@ func createTracingMiddleware() apptheory.Middleware {
 
 			// Extract request info
 			method := ctx.Request.Method
-			url := sanitizeLogPath(ctx.Request.Path)
+			url := logging.SanitizeLogPath(ctx.Request.Path)
 			userAgent := headerValue(ctx, "User-Agent")
 			clientIP := headerValue(ctx, "X-Forwarded-For")
 

--- a/cmd/api/middleware.go
+++ b/cmd/api/middleware.go
@@ -11,6 +11,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/cost"
+	"github.com/equaltoai/lesser/pkg/logging"
 	"github.com/equaltoai/lesser/pkg/observability"
 	browsercors "github.com/equaltoai/lesser/pkg/security/cors"
 	"github.com/equaltoai/lesser/pkg/storage/core"
@@ -46,7 +47,7 @@ func createLoggingMiddleware(logger *zap.Logger) apptheory.Middleware {
 			ctx.Set("logger", contextLogger)
 
 			// Log request start
-			logPath := sanitizeLogPath(ctx.Request.Path)
+			logPath := logging.SanitizeLogPath(ctx.Request.Path)
 			contextLogger.Info("request_start",
 				zap.String("method", ctx.Request.Method),
 				zap.String("path", logPath),
@@ -223,7 +224,7 @@ func handleLockedReadRequest(ctx *apptheory.Context, repos core.RepositoryStorag
 		logger.Warn("failed to get instance lock state; defaulting to locked",
 			zap.Error(err),
 			zap.String("method", method),
-			zap.String("path", path))
+			zap.String("path", logging.SanitizeLogPath(path)))
 	}
 	if !locked {
 		return next(ctx)
@@ -238,7 +239,7 @@ func handleLockedWriteRequest(ctx *apptheory.Context, repos core.RepositoryStora
 		logger.Warn("failed to get instance lock state; defaulting to locked",
 			zap.Error(err),
 			zap.String("method", method),
-			zap.String("path", path))
+			zap.String("path", logging.SanitizeLogPath(path)))
 		return common.RespondForbidden(ctx, "instance is locked")
 	}
 	if !locked {

--- a/cmd/api/middleware.go
+++ b/cmd/api/middleware.go
@@ -46,9 +46,10 @@ func createLoggingMiddleware(logger *zap.Logger) apptheory.Middleware {
 			ctx.Set("logger", contextLogger)
 
 			// Log request start
+			logPath := sanitizeLogPath(ctx.Request.Path)
 			contextLogger.Info("request_start",
 				zap.String("method", ctx.Request.Method),
-				zap.String("path", ctx.Request.Path),
+				zap.String("path", logPath),
 				zap.String("user_agent", headerValue(ctx, "User-Agent")),
 				zap.String("remote_addr", headerValue(ctx, "X-Forwarded-For")),
 			)
@@ -75,7 +76,7 @@ func createLoggingMiddleware(logger *zap.Logger) apptheory.Middleware {
 
 			contextLogger.Log(logLevel, "request_complete",
 				zap.String("method", ctx.Request.Method),
-				zap.String("path", ctx.Request.Path),
+				zap.String("path", logPath),
 				zap.Int("status", statusCode),
 				zap.Duration("duration", duration),
 				zap.Bool("success", err == nil && statusCode < 400),

--- a/cmd/api/path_redaction.go
+++ b/cmd/api/path_redaction.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+const privateConversationLogHashPrefix = "sha256:"
+
+// sanitizeLogPath normalizes private route path segments before generic
+// request/access logs and derived metrics persist them. It intentionally keeps
+// the route class visible while replacing the private conversation identifier
+// with a stable short hash for correlation.
+func sanitizeLogPath(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	path, _ := splitLogPathSuffix(trimmed)
+	if path == "" {
+		return trimmed
+	}
+	if sanitized, ok := sanitizeLesserSelfScopeMintConversationPath(path); ok {
+		return sanitized
+	}
+	if sanitized, ok := sanitizeLesserSelfScopeMintConversationListPath(path); ok {
+		return sanitized
+	}
+	return trimmed
+}
+
+func splitLogPathSuffix(raw string) (path string, suffix string) {
+	for i, r := range raw {
+		if r == '?' || r == '#' {
+			return raw[:i], raw[i:]
+		}
+	}
+	return raw, ""
+}
+
+func sanitizeLesserSelfScopeMintConversationPath(path string) (string, bool) {
+	segments, leadingSlash := splitLogPathSegments(path)
+	if len(segments) != 7 ||
+		segments[0] != "api" ||
+		segments[1] != "v1" ||
+		segments[2] != "souls" ||
+		segments[3] != "bound" ||
+		segments[4] != "me" ||
+		segments[5] != "mint-conversations" ||
+		strings.TrimSpace(segments[6]) == "" {
+		return "", false
+	}
+
+	segments[6] = "conversation-" + shortLogHash(segments[6])
+	return joinLogPathSegments(segments, leadingSlash), true
+}
+
+func sanitizeLesserSelfScopeMintConversationListPath(path string) (string, bool) {
+	segments, leadingSlash := splitLogPathSegments(path)
+	if len(segments) != 6 ||
+		segments[0] != "api" ||
+		segments[1] != "v1" ||
+		segments[2] != "souls" ||
+		segments[3] != "bound" ||
+		segments[4] != "me" ||
+		segments[5] != "mint-conversations" {
+		return "", false
+	}
+
+	return joinLogPathSegments(segments, leadingSlash), true
+}
+
+func splitLogPathSegments(path string) ([]string, bool) {
+	leadingSlash := strings.HasPrefix(path, "/")
+	trimmed := strings.Trim(path, "/")
+	if trimmed == "" {
+		return nil, leadingSlash
+	}
+	return strings.Split(trimmed, "/"), leadingSlash
+}
+
+func joinLogPathSegments(segments []string, leadingSlash bool) string {
+	joined := strings.Join(segments, "/")
+	if leadingSlash {
+		return "/" + joined
+	}
+	return joined
+}
+
+func shortLogHash(raw string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(raw)))
+	return privateConversationLogHashPrefix + hex.EncodeToString(sum[:])[:16]
+}

--- a/cmd/api/path_redaction_test.go
+++ b/cmd/api/path_redaction_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,62 +11,6 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 )
-
-func TestSanitizeLogPathRedactsPrivateMintConversationIDs(t *testing.T) {
-	t.Parallel()
-
-	for name, tc := range map[string]struct {
-		in          string
-		rawSecret   string
-		wantPrefix  string
-		mustNotLeak []string
-	}{
-		"single read": {
-			in:         "/api/v1/souls/bound/me/mint-conversations/conv-private-1",
-			rawSecret:  "conv-private-1",
-			wantPrefix: "/api/v1/souls/bound/me/mint-conversations/conversation-sha256:",
-		},
-		"single read strips query cursor": {
-			in:          "/api/v1/souls/bound/me/mint-conversations/conv-private-2?cursor=raw-cursor",
-			rawSecret:   "conv-private-2",
-			wantPrefix:  "/api/v1/souls/bound/me/mint-conversations/conversation-sha256:",
-			mustNotLeak: []string{"raw-cursor"},
-		},
-		"single read strips fragment": {
-			in:          "/api/v1/souls/bound/me/mint-conversations/conv-private-3#raw-fragment",
-			rawSecret:   "conv-private-3",
-			wantPrefix:  "/api/v1/souls/bound/me/mint-conversations/conversation-sha256:",
-			mustNotLeak: []string{"raw-fragment"},
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			got := sanitizeLogPath(tc.in)
-			require.Truef(t, strings.HasPrefix(got, tc.wantPrefix), "expected sanitized prefix %q, got %q", tc.wantPrefix, got)
-			require.NotContains(t, got, tc.rawSecret)
-			for _, forbidden := range tc.mustNotLeak {
-				require.NotContains(t, got, forbidden)
-			}
-		})
-	}
-}
-
-func TestSanitizeLogPathHandlesPrivateMintConversationListRoute(t *testing.T) {
-	t.Parallel()
-
-	raw := "/api/v1/souls/bound/me/mint-conversations?cursor=raw-cursor"
-	got := sanitizeLogPath(raw)
-	require.Equal(t, "/api/v1/souls/bound/me/mint-conversations", got)
-	require.NotContains(t, got, "raw-cursor")
-}
-
-func TestSanitizeLogPathLeavesOtherRoutesUnchanged(t *testing.T) {
-	t.Parallel()
-
-	path := "/api/v1/statuses/conv-private-1?cursor=raw-cursor"
-	require.Equal(t, path, sanitizeLogPath(path))
-}
 
 func TestCreateLoggingMiddlewareSanitizesPrivateMintConversationPath(t *testing.T) {
 	core, observed := observer.New(zapcore.DebugLevel)

--- a/cmd/api/path_redaction_test.go
+++ b/cmd/api/path_redaction_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestSanitizeLogPathRedactsPrivateMintConversationIDs(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		in          string
+		rawSecret   string
+		wantPrefix  string
+		mustNotLeak []string
+	}{
+		"single read": {
+			in:         "/api/v1/souls/bound/me/mint-conversations/conv-private-1",
+			rawSecret:  "conv-private-1",
+			wantPrefix: "/api/v1/souls/bound/me/mint-conversations/conversation-sha256:",
+		},
+		"single read strips query cursor": {
+			in:          "/api/v1/souls/bound/me/mint-conversations/conv-private-2?cursor=raw-cursor",
+			rawSecret:   "conv-private-2",
+			wantPrefix:  "/api/v1/souls/bound/me/mint-conversations/conversation-sha256:",
+			mustNotLeak: []string{"raw-cursor"},
+		},
+		"single read strips fragment": {
+			in:          "/api/v1/souls/bound/me/mint-conversations/conv-private-3#raw-fragment",
+			rawSecret:   "conv-private-3",
+			wantPrefix:  "/api/v1/souls/bound/me/mint-conversations/conversation-sha256:",
+			mustNotLeak: []string{"raw-fragment"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := sanitizeLogPath(tc.in)
+			require.Truef(t, strings.HasPrefix(got, tc.wantPrefix), "expected sanitized prefix %q, got %q", tc.wantPrefix, got)
+			require.NotContains(t, got, tc.rawSecret)
+			for _, forbidden := range tc.mustNotLeak {
+				require.NotContains(t, got, forbidden)
+			}
+		})
+	}
+}
+
+func TestSanitizeLogPathHandlesPrivateMintConversationListRoute(t *testing.T) {
+	t.Parallel()
+
+	raw := "/api/v1/souls/bound/me/mint-conversations?cursor=raw-cursor"
+	got := sanitizeLogPath(raw)
+	require.Equal(t, "/api/v1/souls/bound/me/mint-conversations", got)
+	require.NotContains(t, got, "raw-cursor")
+}
+
+func TestSanitizeLogPathLeavesOtherRoutesUnchanged(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v1/statuses/conv-private-1?cursor=raw-cursor"
+	require.Equal(t, path, sanitizeLogPath(path))
+}
+
+func TestCreateLoggingMiddlewareSanitizesPrivateMintConversationPath(t *testing.T) {
+	core, observed := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core)
+	mw := createLoggingMiddleware(logger)
+
+	rawConversationID := "conv-private-log"
+	rawCursor := "raw-cursor"
+	ctx := newTestAppTheoryContext(http.MethodGet, "/api/v1/souls/bound/me/mint-conversations/"+rawConversationID+"?cursor="+rawCursor)
+
+	resp, err := mw(func(*apptheory.Context) (*apptheory.Response, error) {
+		return apptheory.Text(http.StatusOK, ""), nil
+	})(ctx)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.Status)
+
+	for _, entry := range observed.All() {
+		fields := entry.ContextMap()
+		path, ok := fields["path"].(string)
+		require.Truef(t, ok, "expected log path field in %s", entry.Message)
+		require.Contains(t, path, "/api/v1/souls/bound/me/mint-conversations/conversation-sha256:")
+		require.NotContains(t, path, rawConversationID)
+		require.NotContains(t, path, rawCursor)
+	}
+}
+
+func TestCreateLoggingMiddlewareSanitizesPathOnErrors(t *testing.T) {
+	core, observed := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core)
+	mw := createLoggingMiddleware(logger)
+
+	rawConversationID := "conv-private-error"
+	ctx := newTestAppTheoryContext(http.MethodGet, "/api/v1/souls/bound/me/mint-conversations/"+rawConversationID)
+
+	_, err := mw(func(*apptheory.Context) (*apptheory.Response, error) {
+		return nil, errors.New("boom")
+	})(ctx)
+	require.Error(t, err)
+
+	require.NotEmpty(t, observed.All())
+	for _, entry := range observed.All() {
+		fields := entry.ContextMap()
+		path, ok := fields["path"].(string)
+		require.Truef(t, ok, "expected log path field in %s", entry.Message)
+		require.Contains(t, path, "/api/v1/souls/bound/me/mint-conversations/conversation-sha256:")
+		require.NotContains(t, path, rawConversationID)
+	}
+}
+
+func TestExtractRequestInfoSanitizesPrivateMintConversationPath(t *testing.T) {
+	rawConversationID := "conv-private-metric"
+	ctx := newTestAppTheoryContext(http.MethodGet, "/api/v1/souls/bound/me/mint-conversations/"+rawConversationID+"?cursor=raw-cursor")
+
+	info := extractRequestInfo(ctx)
+	require.Equal(t, http.MethodGet, info.method)
+	require.Contains(t, info.path, "/api/v1/souls/bound/me/mint-conversations/conversation-sha256:")
+	require.NotContains(t, info.path, rawConversationID)
+	require.NotContains(t, info.path, "raw-cursor")
+	require.Equal(t, info.method+" "+info.path, info.endpoint)
+}

--- a/infra/cdk/constructs/api_routes.go
+++ b/infra/cdk/constructs/api_routes.go
@@ -65,7 +65,7 @@ func CreateAPIGateway(scope constructs.Construct, props *APIGatewayProps) *APIGa
 			StageName:          jsii.String(string(apiStage)),
 			AccessLogging:      logGroup,
 			DetailedMetrics:    jsii.Bool(true),
-			AccessLogFormat:    awsapigateway.AccessLogFormat_Custom(jsii.String(`{"requestId":"$context.requestId","extendedRequestId":"$context.extendedRequestId","requestTime":"$context.requestTime","ip":"$context.identity.sourceIp","httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath","path":"$context.path","status":"$context.status","responseLength":"$context.responseLength","integrationStatus":"$context.integration.status","integrationLatency":"$context.integration.latency","integrationError":"$context.integrationErrorMessage","errorMessage":"$context.error.messageString","errorResponseType":"$context.error.responseType"}`)),
+			AccessLogFormat:    awsapigateway.AccessLogFormat_Custom(jsii.String(`{"requestId":"$context.requestId","extendedRequestId":"$context.extendedRequestId","requestTime":"$context.requestTime","ip":"$context.identity.sourceIp","httpMethod":"$context.httpMethod","resourcePath":"$context.resourcePath","path":"$context.resourcePath","status":"$context.status","responseLength":"$context.responseLength","integrationStatus":"$context.integration.status","integrationLatency":"$context.integration.latency","integrationError":"$context.integrationErrorMessage","errorMessage":"$context.error.messageString","errorResponseType":"$context.error.responseType"}`)),
 			AccessLogRetention: awslogs.RetentionDays_ONE_WEEK,
 		},
 	}
@@ -303,6 +303,11 @@ func addRestRoutes(api apptheorycdk.AppTheoryRestApiRouter, functions *LambdaFun
 	addLambdaIntegrationWithPreflight(api, "/api/v1/streaming/list", &[]*string{jsii.String("GET")}, sseFn, sseOptions, preflight)
 	addLambdaIntegrationWithPreflight(api, "/api/v1/streaming/direct", &[]*string{jsii.String("GET")}, sseFn, sseOptions, preflight)
 	addLambdaIntegrationWithPreflight(api, "/api/v1/streaming/oauth/device", &[]*string{jsii.String("GET")}, sseFn, sseOptions, preflight)
+
+	// Lesser-exclusive private route gets an explicit API Gateway resource so access logs use
+	// a templated resourcePath instead of a raw private conversation ID. Lift still handles
+	// the endpoint in the API Lambda.
+	addLambdaIntegrationWithPreflight(api, "/api/v1/souls/bound/me/mint-conversations/{conversationId}", &[]*string{jsii.String("GET")}, apiFn, nil, preflight)
 
 	// Mastodon API routes (Lift handles internal routing).
 	addLambdaIntegrationWithPreflight(api, "/api/v1/{proxy+}", &[]*string{jsii.String("ANY")}, apiFn, nil, preflight)

--- a/infra/cdk/constructs/api_routes_access_logs_test.go
+++ b/infra/cdk/constructs/api_routes_access_logs_test.go
@@ -1,0 +1,85 @@
+package constructs
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-cdk-go/awscdk/v2"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awslambda"
+	_jsii "github.com/aws/jsii-runtime-go"
+	"github.com/equaltoai/lesser/pkg/deploy/naming"
+)
+
+func TestAPIGatewayAccessLogsUseTemplatedResourcePath(t *testing.T) {
+	outdir := t.TempDir()
+	app := awscdk.NewApp(&awscdk.AppProps{Outdir: _jsii.String(outdir)})
+	stack := awscdk.NewStack(app, _jsii.String("TestStack"), nil)
+
+	dummy := awslambda.NewFunction(stack, _jsii.String("DummyFn"), &awslambda.FunctionProps{
+		FunctionName: _jsii.String(naming.ResourceName("api", "development")),
+		Runtime:      awslambda.Runtime_NODEJS_20_X(),
+		Handler:      _jsii.String("index.handler"),
+		Code:         awslambda.Code_FromInline(_jsii.String("exports.handler = async () => ({ statusCode: 200, body: 'ok' });")),
+	})
+
+	functions := &LambdaFunctions{
+		Functions: map[string]awslambda.Function{
+			"api":         dummy,
+			"graphql":     dummy,
+			"graphql-ws":  dummy,
+			"sse":         dummy,
+			"streaming":   dummy,
+			"actor":       dummy,
+			"collections": dummy,
+			"inbox":       dummy,
+			"objects":     dummy,
+			"outbox":      dummy,
+			"webfinger":   dummy,
+		},
+	}
+
+	_ = CreateAPIGateway(stack, &APIGatewayProps{
+		AppName:     naming.DefaultAppName,
+		Environment: "development",
+		Functions:   functions,
+	})
+
+	template := synthStackTemplate(t, app, outdir, "TestStack")
+	encoded, err := json.Marshal(template)
+	if err != nil {
+		t.Fatalf("marshal template: %v", err)
+	}
+	templateText := string(encoded)
+	if strings.Contains(templateText, "$context.path") {
+		t.Fatalf("API Gateway access logs must not persist raw $context.path: %s", templateText)
+	}
+	if !strings.Contains(templateText, `\"path\":\"$context.resourcePath\"`) {
+		t.Fatalf("expected access log path field to use $context.resourcePath")
+	}
+
+	gotRoutes := extractHttpRouteToFunctionName(t, template)
+	routeKey := "GET /api/v1/souls/bound/me/mint-conversations/{conversationId}"
+	if got, ok := gotRoutes[routeKey]; !ok || got != naming.ResourceName("api", "development") {
+		t.Fatalf("expected explicit private mint-conversation route to integrate with api lambda (got %q, present=%v)", got, ok)
+	}
+}
+
+func synthStackTemplate(t *testing.T, app awscdk.App, outdir string, stackName string) map[string]any {
+	t.Helper()
+
+	app.Synth(nil)
+	templatePath := filepath.Join(outdir, stackName+".template.json")
+	b, err := os.ReadFile(templatePath)
+	if err != nil {
+		t.Fatalf("read template %s: %v", templatePath, err)
+	}
+
+	var template map[string]any
+	if err := json.Unmarshal(b, &template); err != nil {
+		t.Fatalf("unmarshal template: %v", err)
+	}
+	return template
+}

--- a/pkg/auth/apptheory_principal.go
+++ b/pkg/auth/apptheory_principal.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/logging"
 	"github.com/golang-jwt/jwt/v5"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	"go.uber.org/zap"
@@ -234,7 +235,7 @@ func (r *appTheoryPrincipalResolver) logFields(ctx *apptheory.Context, fields ..
 		out = append(out, zap.String("service", serviceName))
 	}
 	if ctx != nil {
-		out = append(out, zap.String("path", ctx.Request.Path))
+		out = append(out, zap.String("path", logging.SanitizeLogPath(ctx.Request.Path)))
 		out = append(out, zap.Bool("has_auth_header", common.ExtractAuthHeader(ctx) != ""))
 	}
 	out = append(out, fields...)

--- a/pkg/auth/apptheory_principal_path_redaction_test.go
+++ b/pkg/auth/apptheory_principal_path_redaction_test.go
@@ -1,0 +1,92 @@
+package auth
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestAppTheoryPrincipalResolverSanitizesPrivateMintConversationPathInAuthFailureLogs(t *testing.T) {
+	t.Run("malformed bearer header", func(t *testing.T) {
+		core, observed := observer.New(zapcore.DebugLevel)
+		resolver := newAppTheoryPrincipalResolver(func(string) (*Claims, error) {
+			t.Fatal("validator should not run for malformed bearer headers")
+			return nil, nil
+		}, zap.New(core), "api")
+
+		rawConversationID := "conv-principal-malformed"
+		rawCursor := "raw-principal-cursor"
+		ctx := newTestContext("GET", "/api/v1/souls/bound/me/mint-conversations/"+rawConversationID+"?cursor="+rawCursor, withHeaders(map[string]string{
+			"Authorization": "Token nope",
+		}))
+
+		principal, err := resolver.Resolve(ctx)
+		require.NoError(t, err)
+		require.Nil(t, principal)
+
+		requireAuthLogSanitizedPath(t, observed, "principal authentication skipped - invalid bearer token format", rawConversationID, rawCursor)
+	})
+
+	t.Run("invalid bearer token", func(t *testing.T) {
+		core, observed := observer.New(zapcore.DebugLevel)
+		resolver := newAppTheoryPrincipalResolver(func(token string) (*Claims, error) {
+			require.Equal(t, "bad-token", token)
+			return nil, errors.New("bad token")
+		}, zap.New(core), "api")
+
+		rawConversationID := "conv-principal-invalid"
+		rawCursor := "raw-invalid-cursor"
+		ctx := newTestContext("GET", "/api/v1/souls/bound/me/mint-conversations/"+rawConversationID+"?cursor="+rawCursor, withHeaders(map[string]string{
+			"Authorization": "Bearer bad-token",
+		}))
+
+		principal, err := resolver.Resolve(ctx)
+		require.NoError(t, err)
+		require.Nil(t, principal)
+
+		requireAuthLogSanitizedPath(t, observed, "principal authentication failed - header present but validation failed", rawConversationID, rawCursor)
+	})
+}
+
+func TestOptionalAuthMiddlewareSanitizesPrivateMintConversationPathInAuthFailureLogs(t *testing.T) {
+	core, observed := observer.New(zapcore.DebugLevel)
+
+	rawConversationID := "conv-optional-invalid"
+	rawCursor := "raw-optional-cursor"
+	ctx := newTestContext("GET", "/api/v1/souls/bound/me/mint-conversations/"+rawConversationID+"?cursor="+rawCursor, withHeaders(map[string]string{
+		"Authorization": "Bearer bad-token",
+	}))
+
+	resp, err := OptionalAuth(MiddlewareConfig{
+		OAuthService: oauthServiceStub{err: errors.New("bad token")},
+		Logger:       zap.New(core),
+		ServiceName:  "api",
+	})(func(*apptheory.Context) (*apptheory.Response, error) {
+		return &apptheory.Response{Status: 200}, nil
+	})(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	requireAuthLogSanitizedPath(t, observed, "optional authentication failed - header present but validation failed", rawConversationID, rawCursor)
+}
+
+func requireAuthLogSanitizedPath(t *testing.T, observed *observer.ObservedLogs, message string, rawParts ...string) {
+	t.Helper()
+
+	entries := observed.FilterMessage(message).All()
+	require.Len(t, entries, 1)
+	fields := entries[0].ContextMap()
+	require.Equal(t, "api", fields["service"])
+	require.Equal(t, true, fields["has_auth_header"])
+	path, ok := fields["path"].(string)
+	require.True(t, ok)
+	require.Contains(t, path, "/api/v1/souls/bound/me/mint-conversations/conversation-sha256:")
+	for _, raw := range rawParts {
+		require.NotContains(t, path, raw)
+	}
+}

--- a/pkg/auth/middleware_unified.go
+++ b/pkg/auth/middleware_unified.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/logging"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	"go.uber.org/zap"
 )
@@ -117,7 +118,7 @@ func OptionalAuth(config MiddlewareConfig) apptheory.Middleware {
 					if authHeader != "" {
 						config.Logger.Warn("optional authentication failed - header present but validation failed",
 							zap.String("service", config.ServiceName),
-							zap.String("path", ctx.Request.Path),
+							zap.String("path", logging.SanitizeLogPath(ctx.Request.Path)),
 							zap.Bool("has_auth_header", true),
 						)
 					}

--- a/pkg/common/auth_helpers.go
+++ b/pkg/common/auth_helpers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/equaltoai/lesser/pkg/logging"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	"go.uber.org/zap"
 )
@@ -168,7 +169,7 @@ func ExtractOptionalAuth(ctx *apptheory.Context, oauthService OAuthServiceInterf
 		if logger := Logger(); logger != nil {
 			logger.Debug("optional auth: invalid bearer token format",
 				zap.Error(err),
-				zap.String("path", ctx.Request.Path),
+				zap.String("path", logging.SanitizeLogPath(ctx.Request.Path)),
 			)
 		}
 		return &AuthenticationResult{
@@ -188,7 +189,7 @@ func ExtractOptionalAuth(ctx *apptheory.Context, oauthService OAuthServiceInterf
 			}
 			logger.Warn("optional auth: token validation failed",
 				zap.Error(err),
-				zap.String("path", ctx.Request.Path),
+				zap.String("path", logging.SanitizeLogPath(ctx.Request.Path)),
 				zap.String("token_preview", tokenPreview),
 			)
 		}

--- a/pkg/common/error_middleware.go
+++ b/pkg/common/error_middleware.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/logging"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	"go.uber.org/zap"
 )
@@ -50,7 +51,7 @@ func ErrorHandlingMiddleware(config ErrorMiddlewareConfig) apptheory.Middleware 
 
 						config.Logger.Error("panic recovered in error middleware",
 							zap.String("service", config.ServiceName),
-							zap.String("path", ctx.Request.Path),
+							zap.String("path", sanitizedRequestLogPath(ctx)),
 							zap.String("method", ctx.Request.Method),
 							zap.Any("panic", r),
 							zap.String("stack", string(buf)))
@@ -158,6 +159,13 @@ func appTheoryStatusForErrorCode(code string) int {
 	}
 }
 
+func sanitizedRequestLogPath(ctx *apptheory.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	return logging.SanitizeLogPath(ctx.Request.Path)
+}
+
 // handleAppError processes AppError instances with safe user message handling
 func handleAppError(ctx *apptheory.Context, appErr *errors.AppError, config ErrorMiddlewareConfig) (*apptheory.Response, error) {
 	path := ""
@@ -165,7 +173,7 @@ func handleAppError(ctx *apptheory.Context, appErr *errors.AppError, config Erro
 	requestID := ""
 	var username any
 	if ctx != nil {
-		path = ctx.Request.Path
+		path = sanitizedRequestLogPath(ctx)
 		method = ctx.Request.Method
 		requestID = ctx.RequestID
 		username = ctx.Get("username")
@@ -299,7 +307,7 @@ func TimeoutErrorMiddleware(serviceName string, logger *zap.Logger) apptheory.Mi
 			if err != nil && isTimeoutError(err) {
 				logger.Warn("request timeout",
 					zap.String("service", serviceName),
-					zap.String("path", ctx.Request.Path),
+					zap.String("path", sanitizedRequestLogPath(ctx)),
 					zap.Error(err))
 
 				return RespondServiceUnavailable(ctx, "request timeout")

--- a/pkg/common/error_middleware_path_redaction_test.go
+++ b/pkg/common/error_middleware_path_redaction_test.go
@@ -1,0 +1,82 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/errors"
+	"github.com/stretchr/testify/require"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestErrorHandlingMiddlewareSanitizesPrivateMintConversationPathInPanicLogs(t *testing.T) {
+	core, observed := observer.New(zapcore.DebugLevel)
+	cfg := ErrorMiddlewareConfig{
+		Logger:              zap.New(core),
+		ServiceName:         "svc",
+		EnablePanicRecovery: true,
+		MaxErrorLogLength:   100,
+	}
+
+	rawConversationID := "conv-panic-private"
+	rawCursor := "raw-panic-cursor"
+	ctx := newTestContext("GET", "/api/v1/souls/bound/me/mint-conversations/"+rawConversationID+"?cursor="+rawCursor)
+	resp, err := ErrorHandlingMiddleware(cfg)(func(*apptheory.Context) (*apptheory.Response, error) {
+		panic("boom")
+	})(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	requireObservedSanitizedPath(t, observed, "panic recovered in error middleware", rawConversationID, rawCursor)
+}
+
+func TestErrorHandlingMiddlewareSanitizesPrivateMintConversationPathInAppErrorLogs(t *testing.T) {
+	core, observed := observer.New(zapcore.DebugLevel)
+	cfg := ErrorMiddlewareConfig{
+		Logger:              zap.New(core),
+		ServiceName:         "svc",
+		EnablePanicRecovery: false,
+		MaxErrorLogLength:   100,
+	}
+
+	rawConversationID := "conv-app-error-private"
+	ctx := newTestContext("GET", "/api/v1/souls/bound/me/mint-conversations/"+rawConversationID)
+	resp, err := ErrorHandlingMiddleware(cfg)(func(*apptheory.Context) (*apptheory.Response, error) {
+		return nil, errors.Forbidden("nope")
+	})(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	requireObservedSanitizedPath(t, observed, "client error", rawConversationID)
+}
+
+func TestTimeoutErrorMiddlewareSanitizesPrivateMintConversationPathLogs(t *testing.T) {
+	core, observed := observer.New(zapcore.DebugLevel)
+
+	rawConversationID := "conv-timeout-private"
+	rawCursor := "raw-timeout-cursor"
+	ctx := newTestContext("GET", "/api/v1/souls/bound/me/mint-conversations/"+rawConversationID+"?cursor="+rawCursor)
+	resp, err := TimeoutErrorMiddleware("svc", zap.New(core))(func(*apptheory.Context) (*apptheory.Response, error) {
+		return nil, context.DeadlineExceeded
+	})(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	requireObservedSanitizedPath(t, observed, "request timeout", rawConversationID, rawCursor)
+}
+
+func requireObservedSanitizedPath(t *testing.T, observed *observer.ObservedLogs, message string, rawParts ...string) {
+	t.Helper()
+
+	entries := observed.FilterMessage(message).All()
+	require.Len(t, entries, 1)
+	path, ok := entries[0].ContextMap()["path"].(string)
+	require.True(t, ok)
+	require.Contains(t, path, "/api/v1/souls/bound/me/mint-conversations/conversation-sha256:")
+	for _, raw := range rawParts {
+		require.NotContains(t, path, raw)
+	}
+}

--- a/pkg/common/security_logger.go
+++ b/pkg/common/security_logger.go
@@ -139,7 +139,7 @@ func LogCSRFFailure(reason string, username string, ip string, path string, user
 		zap.String("reason", reason),
 		zap.String("username", username),
 		zap.String("ip", normalizeIPPrefix(ip)),
-		zap.String("path", path),
+		zap.String("path", logging.SanitizeLogPath(path)),
 		zap.String("user_agent", userAgent),
 		zap.String("request_id", requestID),
 	)

--- a/pkg/crawler/middleware.go
+++ b/pkg/crawler/middleware.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	cloudwatchTypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/equaltoai/lesser/pkg/logging"
 	"github.com/equaltoai/lesser/pkg/observability"
 	apptheoryLimited "github.com/theory-cloud/apptheory/pkg/limited"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
@@ -404,7 +405,7 @@ func Middleware(mode protectionMode, logger *zap.Logger) apptheory.Middleware {
 			logger.Debug("crawler classification",
 				zap.String("request_id", strings.TrimSpace(ctx.RequestID)),
 				zap.String("method", strings.TrimSpace(ctx.Request.Method)),
-				zap.String("path", strings.TrimSpace(ctx.Request.Path)),
+				zap.String("path", logging.SanitizeLogPath(ctx.Request.Path)),
 				zap.String("route_class", routeClass),
 				zap.String("category", category.String()),
 				zap.String("reason", reason),

--- a/pkg/crawler/middleware_test.go
+++ b/pkg/crawler/middleware_test.go
@@ -15,6 +15,8 @@ import (
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	tablecore "github.com/theory-cloud/tabletheory/pkg/core"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 type stubLimiter struct {
@@ -147,6 +149,37 @@ func TestMiddleware_Observe_SetsContext(t *testing.T) {
 	require.NotNil(t, resp)
 	require.Equal(t, 200, resp.Status)
 	require.Equal(t, 1, called)
+}
+
+func TestMiddleware_Observe_SanitizesPrivateMintConversationPathInClassificationLogs(t *testing.T) {
+	core, observed := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core)
+
+	rawConversationID := "conv-crawler-private"
+	rawCursor := "raw-crawler-cursor"
+	ctx := &apptheory.Context{Request: apptheory.Request{
+		Method: "GET",
+		Path:   "/api/v1/souls/bound/me/mint-conversations/" + rawConversationID + "?cursor=" + rawCursor,
+		Headers: map[string][]string{
+			"user-agent": {"GPTBot/1.0"},
+			"accept":     {"application/activity+json"},
+		},
+	}}
+
+	resp, err := Middleware(protectionModeObserve, logger)(func(*apptheory.Context) (*apptheory.Response, error) {
+		return apptheory.Text(200, "ok"), nil
+	})(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, 200, resp.Status)
+
+	entries := observed.FilterMessage("crawler classification").All()
+	require.Len(t, entries, 1)
+	path, ok := entries[0].ContextMap()["path"].(string)
+	require.True(t, ok)
+	require.Contains(t, path, "/api/v1/souls/bound/me/mint-conversations/conversation-sha256:")
+	require.NotContains(t, path, rawConversationID)
+	require.NotContains(t, path, rawCursor)
 }
 
 func TestMiddleware_NilContext(t *testing.T) {

--- a/pkg/logging/path_redaction.go
+++ b/pkg/logging/path_redaction.go
@@ -1,4 +1,4 @@
-package main
+package logging
 
 import (
 	"crypto/sha256"
@@ -8,11 +8,11 @@ import (
 
 const privateConversationLogHashPrefix = "sha256:"
 
-// sanitizeLogPath normalizes private route path segments before generic
+// SanitizeLogPath normalizes private route path segments before generic
 // request/access logs and derived metrics persist them. It intentionally keeps
 // the route class visible while replacing the private conversation identifier
 // with a stable short hash for correlation.
-func sanitizeLogPath(raw string) string {
+func SanitizeLogPath(raw string) string {
 	trimmed := strings.TrimSpace(raw)
 	path, _ := splitLogPathSuffix(trimmed)
 	if path == "" {

--- a/pkg/logging/path_redaction_test.go
+++ b/pkg/logging/path_redaction_test.go
@@ -1,0 +1,64 @@
+package logging
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeLogPathRedactsPrivateMintConversationIDs(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		in          string
+		rawSecret   string
+		wantPrefix  string
+		mustNotLeak []string
+	}{
+		"single read": {
+			in:         "/api/v1/souls/bound/me/mint-conversations/conv-private-1",
+			rawSecret:  "conv-private-1",
+			wantPrefix: "/api/v1/souls/bound/me/mint-conversations/conversation-sha256:",
+		},
+		"single read strips query cursor": {
+			in:          "/api/v1/souls/bound/me/mint-conversations/conv-private-2?cursor=raw-cursor",
+			rawSecret:   "conv-private-2",
+			wantPrefix:  "/api/v1/souls/bound/me/mint-conversations/conversation-sha256:",
+			mustNotLeak: []string{"raw-cursor"},
+		},
+		"single read strips fragment": {
+			in:          "/api/v1/souls/bound/me/mint-conversations/conv-private-3#raw-fragment",
+			rawSecret:   "conv-private-3",
+			wantPrefix:  "/api/v1/souls/bound/me/mint-conversations/conversation-sha256:",
+			mustNotLeak: []string{"raw-fragment"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := SanitizeLogPath(tc.in)
+			require.Truef(t, strings.HasPrefix(got, tc.wantPrefix), "expected sanitized prefix %q, got %q", tc.wantPrefix, got)
+			require.NotContains(t, got, tc.rawSecret)
+			for _, forbidden := range tc.mustNotLeak {
+				require.NotContains(t, got, forbidden)
+			}
+		})
+	}
+}
+
+func TestSanitizeLogPathHandlesPrivateMintConversationListRoute(t *testing.T) {
+	t.Parallel()
+
+	raw := "/api/v1/souls/bound/me/mint-conversations?cursor=raw-cursor"
+	got := SanitizeLogPath(raw)
+	require.Equal(t, "/api/v1/souls/bound/me/mint-conversations", got)
+	require.NotContains(t, got, "raw-cursor")
+}
+
+func TestSanitizeLogPathLeavesOtherRoutesUnchanged(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v1/statuses/conv-private-1?cursor=raw-cursor"
+	require.Equal(t, path, SanitizeLogPath(path))
+}

--- a/pkg/services/skills/bundle_helpers_extra_test.go
+++ b/pkg/services/skills/bundle_helpers_extra_test.go
@@ -1,0 +1,55 @@
+package skills
+
+import (
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBundleHelperFallbacksExtraCoverage(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "skill.md", entryPointFromFiles([]SkillBundleFile{
+		{Path: "notes.md"},
+		{Path: "skill.md", Role: "skill"},
+	}))
+	require.Equal(t, defaultSkillEntrypoint, entryPointFromFiles([]SkillBundleFile{
+		{Path: "docs/README.md"},
+		{Path: defaultSkillEntrypoint},
+	}))
+	require.Equal(t, "first.md", entryPointFromFiles([]SkillBundleFile{{Path: "first.md"}}))
+	require.Empty(t, entryPointFromFiles(nil))
+
+	require.Equal(t, []string{"alpha", "beta"}, normalizedBundleStrings([]string{" beta ", "ALPHA", "", "alpha"}))
+
+	require.Equal(t, "custom-dir", resolvedInstallDirectory(nil, skillBundleManifest{
+		InstallHints: skillManifestInstallHints{DirectoryName: "custom-dir"},
+	}))
+	require.Equal(t, "safe-slug", resolvedInstallDirectory(&models.Skill{
+		ID:   "skill-id",
+		Slug: "safe-slug",
+	}, skillBundleManifest{InstallHints: skillManifestInstallHints{DirectoryName: "../unsafe"}}))
+	require.Equal(t, defaultSkillDirectory, resolvedInstallDirectory(&models.Skill{
+		ID:   "../unsafe",
+		Slug: "../unsafe",
+	}, skillBundleManifest{}))
+}
+
+func TestSortedBundleFilesOrdersByPathThenDigest(t *testing.T) {
+	t.Parallel()
+
+	files := []SkillBundleFile{
+		{Path: "b.md", Digest: "sha256:b"},
+		{Path: "a.md", Digest: "sha256:z"},
+		{Path: "a.md", Digest: "sha256:a"},
+	}
+
+	got := sortedBundleFiles(files)
+	require.Equal(t, []SkillBundleFile{
+		{Path: "a.md", Digest: "sha256:a"},
+		{Path: "a.md", Digest: "sha256:z"},
+		{Path: "b.md", Digest: "sha256:b"},
+	}, got)
+	require.Equal(t, "b.md", files[0].Path, "sorting should not mutate caller slice")
+}


### PR DESCRIPTION
## Summary

Closes #955.

- Adds a narrow API log-path sanitizer for `/api/v1/souls/bound/me/mint-conversations/{conversationId}` that replaces the private `conversationId` segment with `conversation-sha256:<16hex>` and strips query/fragment suffixes for the private mint-conversation routes.
- Applies the sanitized path to generic API request logs, latency/EMF metric dimensions, and tracing annotations without mutating the actual request path, response DTOs, MCP behavior, or authorization semantics.
- Updates API Gateway access logging to persist the templated `$context.resourcePath` instead of raw `$context.path`, and adds an explicit REST API resource for the private single-read route so access logs preserve route class without raw conversation IDs.
- Adds a small skills-service helper coverage cushion to resolve the latest `main` CI failure from PR #954 (`pkg` coverage was 89.999% < 90.000%).

## Root cause

The Lesser-owned self-scope proxy route was handled safely at the dedicated private-read audit layer, but generic request/access surfaces still derived log and metric path fields from raw request paths. API Gateway access logs also persisted `$context.path`, which can contain concrete path parameters.

The latest `main` CI failure was unrelated to #955 behavior: the PR #954 merge landed with package coverage at 89.999%, just below the required 90.000% gate.

## Contract / stewardship notes

- Federation trust: no ActivityPub, inbox/outbox, delivery, HTTP Signature, actor object, relay, or federation peer behavior changes.
- Mastodon/API compatibility: no response/request/error shape changes; this is logging/infra hardening only for an existing Lesser-exclusive endpoint.
- Schema: no PK/SK, GSI, TableTheory tag, or DynamoDB model changes.
- MCP behavior: unchanged.
- Authorization/reachability: unchanged.
- Private content: no bearer tokens, instance keys, message bodies, produced declarations, raw cursors, or raw private conversation content are logged by this change.

## Ops probe notes

After deploying to the normal dev stage, call:

```bash
curl -sS \
  -H "Authorization: Bearer <user-token>" \
  "https://dev.<domain>/api/v1/souls/bound/me/mint-conversations/<raw-conversation-id>"
```

Then verify:

- API Lambda `request_start` / `request_complete` logs show `/api/v1/souls/bound/me/mint-conversations/conversation-sha256:<16hex>` rather than the raw conversation ID.
- API latency/EMF/tracing path-derived fields use the same sanitized path.
- API Gateway access logs show the templated resource path `/api/v1/souls/bound/me/mint-conversations/{conversationId}` rather than raw `$context.path`.
- Dedicated `soul.private_read` logs continue to show hashed actor/agent/conversation identifiers only.

## Validation

- `go test ./cmd/api ./pkg/services/skills`
- `cd infra/cdk && go test ./constructs -run 'TestAPIGatewayAccessLogsUseTemplatedResourcePath|TestBodyEnabledAddsMcpRoute'`
- `go test ./...`
- `go vet ./...`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci` — passes; `pkg` coverage now 90.012%, `cmd` coverage 90.086%.
