### PR TITLE
fix(skills): hide private catalog cursor state

### DIFF
--- a/pkg/services/skills/service.go
+++ b/pkg/services/skills/service.go
@@ -70,6 +70,8 @@ const (
 	defaultSkillEntrypoint   = "SKILL.md"
 	defaultSkillDirectory    = "skill"
 	skillBundleBase64        = "base64"
+	defaultCatalogListLimit  = 25
+	maxCatalogListLimit      = 100
 )
 
 // CatalogFilter constrains approved skill catalog listing.
@@ -312,30 +314,78 @@ func (s *Service) ListCatalog(ctx context.Context, viewer Viewer, filter Catalog
 	if err := validateCatalogFilter(filter); err != nil {
 		return nil, "", err
 	}
-	revisions, cursor, err := s.repo.ListSkillRevisionsByStatus(ctx, models.SkillRevisionStatusApproved, filter.Limit, filter.Cursor)
-	if err != nil {
-		return nil, "", err
-	}
+
+	limit := sanitizeCatalogListLimit(filter.Limit)
+	cursor := strings.TrimSpace(filter.Cursor)
 	exposure := strings.ToLower(strings.TrimSpace(filter.Exposure))
-	out := make([]CatalogEntry, 0, len(revisions))
-	for _, revision := range revisions {
-		if revision == nil || revision.Status != models.SkillRevisionStatusApproved {
-			continue
-		}
-		if exposure != "" && revision.DefaultExposure != exposure {
-			continue
-		}
-		skill, err := s.repo.GetSkill(ctx, revision.SkillID)
-		if err != nil || !CanInspectSkill(viewer, skill) || !CanInspectRevision(viewer, revision) {
-			continue
-		}
-		entry, err := buildCatalogEntry(skill, revision, false)
+	out := make([]CatalogEntry, 0, limit)
+	nextCursor := ""
+
+	for len(out) < limit {
+		revisions, rawNextCursor, err := s.repo.ListSkillRevisionsByStatus(ctx, models.SkillRevisionStatusApproved, limit, cursor)
 		if err != nil {
-			continue
+			return nil, "", err
 		}
-		out = append(out, entry)
+		if len(revisions) == 0 {
+			return out, "", nil
+		}
+
+		rawNextCursor = strings.TrimSpace(rawNextCursor)
+		for index, revision := range revisions {
+			entry, ok := s.catalogEntryForRevision(ctx, viewer, exposure, revision)
+			if !ok {
+				continue
+			}
+			out = append(out, entry)
+			if visibleCursor := catalogCursorForRevision(revision); visibleCursor != "" {
+				nextCursor = visibleCursor
+			}
+			if len(out) >= limit {
+				return out, catalogCursorAfterVisibleLimit(index, len(revisions), rawNextCursor, nextCursor), nil
+			}
+		}
+
+		nextRawCursor, ok := advanceCatalogRawCursor(cursor, rawNextCursor)
+		if !ok {
+			return out, "", nil
+		}
+		cursor = nextRawCursor
 	}
-	return out, cursor, nil
+
+	return out, nextCursor, nil
+}
+
+func (s *Service) catalogEntryForRevision(ctx context.Context, viewer Viewer, exposure string, revision *models.SkillRevision) (CatalogEntry, bool) {
+	if revision == nil || revision.Status != models.SkillRevisionStatusApproved {
+		return CatalogEntry{}, false
+	}
+	if exposure != "" && revision.DefaultExposure != exposure {
+		return CatalogEntry{}, false
+	}
+	skill, err := s.repo.GetSkill(ctx, revision.SkillID)
+	if err != nil || !CanInspectSkill(viewer, skill) || !CanInspectRevision(viewer, revision) {
+		return CatalogEntry{}, false
+	}
+	entry, err := buildCatalogEntry(skill, revision, false)
+	if err != nil {
+		return CatalogEntry{}, false
+	}
+	return entry, true
+}
+
+func catalogCursorAfterVisibleLimit(index int, pageLen int, rawNextCursor string, visibleCursor string) string {
+	if index == pageLen-1 && strings.TrimSpace(rawNextCursor) == "" {
+		return ""
+	}
+	return visibleCursor
+}
+
+func advanceCatalogRawCursor(current string, next string) (string, bool) {
+	next = strings.TrimSpace(next)
+	if next == "" || next == strings.TrimSpace(current) {
+		return "", false
+	}
+	return next, true
 }
 
 // GetBundle returns the publication bundle for one approved canonical skill revision.
@@ -1628,6 +1678,34 @@ func validateCatalogFilter(filter CatalogFilter) error {
 		return errors.Join(ErrInvalidInput, errors.New("unsupported exposure"))
 	}
 	return nil
+}
+
+func sanitizeCatalogListLimit(limit int) int {
+	switch {
+	case limit <= 0:
+		return defaultCatalogListLimit
+	case limit > maxCatalogListLimit:
+		return maxCatalogListLimit
+	default:
+		return limit
+	}
+}
+
+func catalogCursorForRevision(revision *models.SkillRevision) string {
+	if revision == nil {
+		return ""
+	}
+	if cursor := strings.TrimSpace(revision.GSI1SK); cursor != "" {
+		return cursor
+	}
+
+	clone := *revision
+	if err := clone.UpdateKeys(); err == nil {
+		if cursor := strings.TrimSpace(clone.GSI1SK); cursor != "" {
+			return cursor
+		}
+	}
+	return strings.TrimSpace(revision.GetSK())
 }
 
 func validateListFilter(filter ListFilter) error {

--- a/pkg/services/skills/service_test.go
+++ b/pkg/services/skills/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -197,7 +198,7 @@ func (f *fakeSkillRepo) ListSkillRevisions(_ context.Context, skillID string, _ 
 	return out, "", nil
 }
 
-func (f *fakeSkillRepo) ListSkillRevisionsByStatus(_ context.Context, status string, _ int, _ string) ([]*models.SkillRevision, string, error) {
+func (f *fakeSkillRepo) ListSkillRevisionsByStatus(_ context.Context, status string, limit int, cursor string) ([]*models.SkillRevision, string, error) {
 	if f.listRevisionsErr != nil {
 		return nil, "", f.listRevisionsErr
 	}
@@ -207,7 +208,39 @@ func (f *fakeSkillRepo) ListSkillRevisionsByStatus(_ context.Context, status str
 			out = append(out, revision)
 		}
 	}
+	sort.Slice(out, func(i, j int) bool {
+		return fakeSkillRevisionCursor(out[i]) < fakeSkillRevisionCursor(out[j])
+	})
+
+	cursor = strings.TrimSpace(cursor)
+	if cursor != "" {
+		filtered := out[:0]
+		for _, revision := range out {
+			if fakeSkillRevisionCursor(revision) > cursor {
+				filtered = append(filtered, revision)
+			}
+		}
+		out = filtered
+	}
+
+	if limit <= 0 {
+		return out, "", nil
+	}
+	if len(out) > limit {
+		nextCursor := fakeSkillRevisionCursor(out[limit-1])
+		return out[:limit], nextCursor, nil
+	}
 	return out, "", nil
+}
+
+func fakeSkillRevisionCursor(revision *models.SkillRevision) string {
+	if revision == nil {
+		return ""
+	}
+	if revision.GSI1SK != "" {
+		return revision.GSI1SK
+	}
+	return revision.GetSK()
 }
 
 func (f *fakeSkillRepo) GetSkillRevisionByDigest(_ context.Context, manifestDigest string) (*models.SkillRevision, error) {
@@ -724,6 +757,52 @@ func TestServiceListCatalogPublishesApprovedVisibleBundles(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, catalog, 1)
 	require.Equal(t, "private", catalog[0].Skill.ID)
+}
+
+func TestServiceListCatalogCursorDoesNotRevealHiddenRevisions(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeSkillRepo()
+	svc := NewService(repo)
+
+	seedCatalogSkill := func(skillID, exposure string, updatedAt time.Time) {
+		t.Helper()
+		require.NoError(t, repo.CreateSkill(ctx, &models.Skill{
+			ID:                    skillID,
+			Slug:                  skillID,
+			Name:                  skillID,
+			Status:                models.SkillStatusActive,
+			DefaultExposure:       exposure,
+			CurrentRevisionID:     skillID + "-r1",
+			CurrentRevisionNumber: 1,
+			UpdatedAt:             updatedAt,
+		}))
+		seedApprovedRevision(t, ctx, repo, &models.SkillRevision{
+			SkillID:         skillID,
+			RevisionNumber:  1,
+			DefaultExposure: exposure,
+			UpdatedAt:       updatedAt,
+		})
+	}
+
+	base := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	seedCatalogSkill("private-a", models.SkillExposurePrivate, base)
+	seedCatalogSkill("private-b", models.SkillExposurePrivate, base.Add(time.Minute))
+	seedCatalogSkill("public-a", models.SkillExposurePublic, base.Add(2*time.Minute))
+	seedCatalogSkill("public-b", models.SkillExposurePublic, base.Add(3*time.Minute))
+
+	catalog, cursor, err := svc.ListCatalog(ctx, Viewer{}, CatalogFilter{Limit: 1})
+	require.NoError(t, err)
+	require.Len(t, catalog, 1)
+	require.Equal(t, "public-a", catalog[0].Skill.ID)
+	require.NotEmpty(t, cursor)
+	require.Contains(t, cursor, "SKILL#public-a")
+	require.NotContains(t, cursor, "private")
+
+	catalog, cursor, err = svc.ListCatalog(ctx, Viewer{}, CatalogFilter{Limit: 1, Cursor: cursor})
+	require.NoError(t, err)
+	require.Len(t, catalog, 1)
+	require.Equal(t, "public-b", catalog[0].Skill.ID)
+	require.Empty(t, cursor)
 }
 
 func TestServiceGetBundleIncludesContentAndRejectsUnpublished(t *testing.T) {


### PR DESCRIPTION
## Milestone
Security Remediation M2.1 — Enforce Lesser public-read visibility across search, notifications, skills cursors, and agent identity surfaces

Closes #960.

## Classification
security / privacy / contract-stability / Mastodon API semantic refinement

## Surfaces affected
- `GET /api/v1/skills/catalog` pagination semantics (`next_cursor` no longer encodes hidden revision state)
- `pkg/services/skills` catalog pagination internals
- Regression coverage in `pkg/services/skills/service_test.go`

## Contract audit

### Proposed change
Keep `/api/v1/skills/catalog` response shape unchanged, but only emit `next_cursor` values derived from catalog entries visible to the caller. Hidden/private approved revisions are consumed internally and never returned as cursor state.

### Compatibility classification
Semantic privacy refinement. Clients still receive the same JSON fields and can pass returned cursors back unchanged. Clients relying on raw GSI cursor internals were depending on an implementation leak, not the public contract.

### Consumer-class enumeration
- Mastodon clients: not affected; this is a Lesser-exclusive endpoint.
- Remote ActivityPub peers: not affected.
- greater/sim/direct clients: affected only by safer opaque-ish cursor semantics; response shape unchanged.
- body/host/soul: no direct contract impact.
- Operators: safer public catalog behavior; no deployment config change.

### Versioning / transition
No version split required. Old client behavior (store and replay returned `next_cursor`) continues to work.

### Rollout mechanics
Normal dev → staging/live rollout. Watch API error rate and catalog pagination behavior; rollback signal would be catalog pagination failures or unexpected empty pages.

### OpenAPI / GraphQL
No schema shape change; OpenAPI path count and GraphQL coverage verified by `./lesser verify ci`.

## Finding map
- `lesser.csv:2` — public search indexes/exposes non-public statuses: already fixed on `main` via `status-indexer` public-addressing/visibility checks, `SearchStatusesWithPrivacy`, and handler-level `statusVisibleInSearch` rechecks.
- `lesser.csv:3` — catalog cursor leaks hidden skill revision metadata: fixed in this PR by scanning hidden approved revisions server-side and returning only visible-entry cursors.
- `lesser.csv:4` / `lesser.csv:12` — notification get/list status visibility: already fixed on `main` by user-scoped notification identity, snapshot/object visibility checks before status expansion, and direct/private recipient handling.
- `lesser.csv:7` — public agent endpoints leak soul binding IDs: already fixed on `main` by REST/GraphQL private-field redaction (`UNBOUND`/empty public identity semantics unless owner/admin).
- `lesser.csv:15` — private-status hashtags indexed/exposed: already fixed on `main` by public-only hashtag metadata/timeline indexing and status-indexer non-public skip logic.

## Specialist walks referenced
- Contract/API: `preserve-mastodon-api-compat` audit above; semantic privacy refinement, no shape break.
- Schema: no PK/SK/GSI/tag changes.
- Federation trust: no ActivityPub signing/inbox/outbox/delivery changes.
- Framework: no AppTheory/TableTheory changes.

## Consumer impact
- Operators: security-hardening release note only.
- Mastodon clients: none.
- Remote AP peers: none.
- Sibling repos: none required.

## Tasks
- [x] Verify existing search/status index visibility evidence.
- [x] Verify existing notification status expansion visibility evidence.
- [x] Verify existing agent identity redaction evidence.
- [x] Verify existing public-only hashtag indexing evidence.
- [x] Fix skill catalog cursor leakage for hidden revisions.
- [x] Add regression coverage for visible-only catalog cursors.

## Validation
- `gofmt -l .` (empty)
- `go test ./pkg/services/skills -run 'TestServiceListCatalogPublishesApprovedVisibleBundles|TestServiceListCatalogCursorDoesNotRevealHiddenRevisions'`
- `go test ./pkg/services/skills`
- `golangci-lint run --config .golangci.yml --timeout 20m --disable gosec --concurrency 20 ./pkg/services/skills`
- `go test ./pkg/services/skills ./cmd/api/handlers ./cmd/status-indexer ./pkg/storage/repositories ./graph -run 'TestServiceListCatalogCursorDoesNotRevealHiddenRevisions|TestServiceListCatalogPublishesApprovedVisibleBundles|TestStatusIndexer|TestServiceListSkillsAppliesExposure|TestGraphAgent|TestHashtagRepository_IndexHashtag'`
- `go test ./...`
- `go vet ./...`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci` (pkg 90.007%, cmd 90.086%)

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None.

## Advisor-brief authorization
Not applicable; this is Project 28 issue work from the active Codex goal.
