### PR TITLE
fix: harden federated social controls

### DIFF
--- a/graph/notification_resolver_test.go
+++ b/graph/notification_resolver_test.go
@@ -81,3 +81,25 @@ func TestFallbackNotificationActorRemoteUser(t *testing.T) {
 		t.Fatalf("expected remote actor endpoints to be empty, got inbox=%q outbox=%q", actor.Inbox, actor.Outbox)
 	}
 }
+
+func TestNotificationActorLocalLookupPreservesRemoteDomainBoundary(t *testing.T) {
+	resolver := &Resolver{
+		Config: &config.Config{Domain: "dev.lesser.host"},
+	}
+
+	cases := map[string]string{
+		"admin":                                     "admin",
+		"@admin@dev.lesser.host":                    "admin",
+		"https://dev.lesser.host/users/admin":       "admin",
+		"https://remote.example/users/admin":        "",
+		"@admin@remote.example":                     "",
+		"admin@remote.example":                      "",
+		"https://remote.example/users/nested/admin": "",
+	}
+
+	for input, expected := range cases {
+		if actual := resolver.localUsernameForLookup(input); actual != expected {
+			t.Fatalf("localUsernameForLookup(%q) = %q, want %q", input, actual, expected)
+		}
+	}
+}

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -395,23 +395,21 @@ func (r *Resolver) loadNotificationActor(ctx context.Context, notif *models.Noti
 		return nil
 	}
 
-	lookupCandidates := []string{actorID}
-
-	if username := extractUsernameFromActorIdentifier(actorID); username != "" && !strings.EqualFold(username, actorID) {
-		lookupCandidates = append(lookupCandidates, username)
+	if resolution, err := r.resolveStoredActorLookup(ctx, actorID); err == nil && resolution != nil {
+		return r.materializeActorResolution(ctx, resolution)
 	}
 
-	if strings.Contains(actorID, "@") {
-		if parts := strings.Split(actorID, "@"); len(parts) == 2 && parts[0] != "" {
-			lookupCandidates = append(lookupCandidates, parts[0])
-		}
+	localUsername := r.localUsernameForLookup(actorID)
+	if localUsername == "" && !strings.Contains(actorID, "://") && !strings.Contains(strings.TrimPrefix(actorID, "@"), "@") {
+		localUsername = strings.TrimPrefix(actorID, "@")
+	}
+	if localUsername == "" {
+		return nil
 	}
 
-	for _, candidate := range lookupCandidates {
-		account, err := accountsService.GetAccount(ctx, candidate)
-		if err == nil && account != nil {
-			return r.convertAccountToActor(account)
-		}
+	account, err := accountsService.GetAccount(ctx, localUsername)
+	if err == nil && account != nil {
+		return r.convertAccountToActor(account)
 	}
 
 	return nil

--- a/pkg/reputation/actor_id.go
+++ b/pkg/reputation/actor_id.go
@@ -10,29 +10,34 @@ import (
 
 // ValidateActorID validates a canonical ActivityPub actor URI used by reputation lookups.
 func ValidateActorID(actorID string) error {
+	_, err := canonicalActorID(actorID)
+	return err
+}
+
+func canonicalActorID(actorID string) (string, error) {
 	actorID = strings.TrimSpace(actorID)
 	if actorID == "" {
-		return fmt.Errorf("actor ID is required")
+		return "", fmt.Errorf("actor ID is required")
 	}
 	if containsControlRune(actorID) || strings.ContainsAny(actorID, " \t\r\n") {
-		return fmt.Errorf("actor ID contains invalid characters")
+		return "", fmt.Errorf("actor ID contains invalid characters")
 	}
 	if err := common.ValidateActivityPubURL(actorID, "actor_id"); err != nil {
-		return err
+		return "", err
 	}
 
 	parsed, err := url.Parse(actorID)
 	if err != nil || parsed == nil {
-		return fmt.Errorf("actor ID must be a valid URL")
+		return "", fmt.Errorf("actor ID must be a valid URL")
 	}
 	if parsed.User != nil {
-		return fmt.Errorf("actor ID must not contain userinfo")
+		return "", fmt.Errorf("actor ID must not contain userinfo")
 	}
 	if parsed.RawQuery != "" || parsed.Fragment != "" {
-		return fmt.Errorf("actor ID must not contain query or fragment")
+		return "", fmt.Errorf("actor ID must not contain query or fragment")
 	}
 	if parsed.Opaque != "" || strings.TrimSpace(parsed.Hostname()) == "" || strings.TrimSpace(parsed.Path) == "" || parsed.Path == "/" {
-		return fmt.Errorf("actor ID must include host and path")
+		return "", fmt.Errorf("actor ID must include host and path")
 	}
 	for _, segment := range strings.Split(parsed.EscapedPath(), "/") {
 		if segment == "" {
@@ -40,13 +45,33 @@ func ValidateActorID(actorID string) error {
 		}
 		unescaped, err := url.PathUnescape(segment)
 		if err != nil {
-			return fmt.Errorf("actor ID path contains invalid escaping")
+			return "", fmt.Errorf("actor ID path contains invalid escaping")
 		}
 		if unescaped == "." || unescaped == ".." || containsControlRune(unescaped) {
-			return fmt.Errorf("actor ID path contains unsafe segment")
+			return "", fmt.Errorf("actor ID path contains unsafe segment")
 		}
 	}
-	return nil
+
+	path := strings.TrimRight(parsed.EscapedPath(), "/")
+	if path == "/users" || path == "/@" {
+		return "", fmt.Errorf("actor ID must include host and path")
+	}
+
+	return strings.ToLower(parsed.Scheme) + "://" + strings.ToLower(parsed.Host) + path, nil
+}
+
+func sameCanonicalActorID(left, right string) bool {
+	leftCanonical, leftErr := canonicalActorID(left)
+	rightCanonical, rightErr := canonicalActorID(right)
+	return leftErr == nil && rightErr == nil && leftCanonical == rightCanonical
+}
+
+func actorIDHost(actorID string) string {
+	parsed, err := url.Parse(strings.TrimSpace(actorID))
+	if err != nil || parsed == nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(parsed.Hostname()))
 }
 
 func containsControlRune(value string) bool {

--- a/pkg/reputation/service.go
+++ b/pkg/reputation/service.go
@@ -746,30 +746,58 @@ func (s *Service) countNoteHelpfulVotes(ctx context.Context, noteID string) int 
 	return count
 }
 
+type storeReputationOptions struct {
+	forceCanonicalActorKey bool
+}
+
+type storeReputationOption func(*storeReputationOptions)
+
+func withCanonicalActorKey() storeReputationOption {
+	return func(opts *storeReputationOptions) {
+		opts.forceCanonicalActorKey = true
+	}
+}
+
+func (s *Service) importedReputationStoreOptions(actorID string) []storeReputationOption {
+	localHost := actorIDHost(s.instanceURL)
+	actorHost := actorIDHost(actorID)
+	if localHost == "" || actorHost == "" || actorHost != localHost {
+		return []storeReputationOption{withCanonicalActorKey()}
+	}
+	return nil
+}
+
 // storeReputation stores reputation using the storage layer
-func (s *Service) storeReputation(ctx context.Context, rep *Reputation) error {
+func (s *Service) storeReputation(ctx context.Context, rep *Reputation, options ...storeReputationOption) error {
+	storeOpts := storeReputationOptions{}
+	for _, option := range options {
+		if option != nil {
+			option(&storeOpts)
+		}
+	}
 	// Convert reputation.Reputation to storage.Reputation
 	storedRep := &storage.Reputation{
-		ActorID:           rep.ActorID,
-		InstanceURL:       rep.InstanceURL,
-		TrustScore:        float64(rep.TrustScore),
-		ActivityScore:     float64(rep.ActivityScore),
-		ModerationScore:   float64(rep.ModerationScore),
-		CommunityScore:    float64(rep.CommunityScore),
-		TotalScore:        float64(rep.TotalScore),
-		CalculatedAt:      rep.CalculatedAt,
-		Version:           func() int { v, _ := strconv.Atoi(rep.Version); return v }(),
-		TotalPosts:        rep.TotalPosts,
-		TotalFollowers:    rep.TotalFollowers,
-		AccountAge:        rep.AccountAge,
-		VouchCount:        rep.VouchCount,
-		TrustingActors:    []string{}, // We don't store individual actors in this conversion
-		AverageTrustScore: rep.AverageTrustScore,
-		ReportsReceived:   rep.ReportsReceived,
-		ReportsUpheld:     rep.ReportsUpheld,
-		FalseReports:      rep.FalseReports,
-		Signature:         rep.Signature,
-		PublicKey:         rep.PublicKey,
+		ActorID:                rep.ActorID,
+		InstanceURL:            rep.InstanceURL,
+		TrustScore:             float64(rep.TrustScore),
+		ActivityScore:          float64(rep.ActivityScore),
+		ModerationScore:        float64(rep.ModerationScore),
+		CommunityScore:         float64(rep.CommunityScore),
+		TotalScore:             float64(rep.TotalScore),
+		CalculatedAt:           rep.CalculatedAt,
+		Version:                func() int { v, _ := strconv.Atoi(rep.Version); return v }(),
+		TotalPosts:             rep.TotalPosts,
+		TotalFollowers:         rep.TotalFollowers,
+		AccountAge:             rep.AccountAge,
+		VouchCount:             rep.VouchCount,
+		TrustingActors:         []string{}, // We don't store individual actors in this conversion
+		AverageTrustScore:      rep.AverageTrustScore,
+		ReportsReceived:        rep.ReportsReceived,
+		ReportsUpheld:          rep.ReportsUpheld,
+		FalseReports:           rep.FalseReports,
+		Signature:              rep.Signature,
+		PublicKey:              rep.PublicKey,
+		ForceCanonicalActorKey: storeOpts.forceCanonicalActorKey,
 	}
 
 	return s.userRepo.StoreReputation(ctx, rep.ActorID, storedRep)
@@ -852,7 +880,7 @@ func (s *Service) ImportReputation(ctx context.Context, document string) (*Impor
 	if pr.Reputation != nil {
 		// Store imported reputation with special marker
 		pr.Reputation.InstanceURL = pr.Issuer // Mark as imported
-		if err := s.storeReputation(ctx, pr.Reputation); err != nil {
+		if err := s.storeReputation(ctx, pr.Reputation, s.importedReputationStoreOptions(pr.Actor)...); err != nil {
 			return &ImportResult{
 				Success: false,
 				Error:   "Failed to store reputation",

--- a/pkg/reputation/service.go
+++ b/pkg/reputation/service.go
@@ -30,6 +30,10 @@ type actorRepository interface {
 	GetActorByUsername(ctx context.Context, username string) (*activitypub.Actor, error)
 }
 
+type cachedRemoteActorRepository interface {
+	GetCachedRemoteActor(ctx context.Context, identifier string) (*activitypub.Actor, error)
+}
+
 type statusRepository interface {
 	CountStatusesByAuthor(ctx context.Context, username string) (int, error)
 	GetUserTimeline(ctx context.Context, userID string, opts interfaces.PaginationOptions) (*interfaces.PaginatedResult[*models.Status], error)
@@ -233,6 +237,12 @@ func (s *Service) GetReputation(ctx context.Context, actorID string) (*Reputatio
 		// No reputation history, calculate new
 		return s.calculateAndStore(ctx, actorID)
 	}
+	if !sameCanonicalActorID(storedRep.ActorID, actorID) {
+		s.logger.Warn("stored reputation actor did not match requested actor; recalculating",
+			zap.String("requested_actor", actorID),
+			zap.String("stored_actor", storedRep.ActorID))
+		return s.calculateAndStore(ctx, actorID)
+	}
 
 	// Convert storage.Reputation to reputation.Reputation
 	rep := &Reputation{
@@ -355,6 +365,10 @@ func (s *Service) extractUsername(actorID string) string {
 
 // getActorData retrieves actor data from storage
 func (s *Service) getActorData(ctx context.Context, actorID, username string) (*activitypub.Actor, error) {
+	if s.isRemoteActorID(actorID) {
+		return s.getRemoteActorData(ctx, actorID)
+	}
+
 	actor, err := s.actorRepo.GetActorByUsername(ctx, username)
 	if err != nil {
 		s.logger.Error("Failed to get actor",
@@ -362,6 +376,30 @@ func (s *Service) getActorData(ctx context.Context, actorID, username string) (*
 			zap.String("username", username),
 			zap.Error(err))
 		return nil, fmt.Errorf("failed to get actor: %w", err)
+	}
+	return actor, nil
+}
+
+func (s *Service) isRemoteActorID(actorID string) bool {
+	localHost := actorIDHost(s.instanceURL)
+	actorHost := actorIDHost(actorID)
+	return localHost != "" && actorHost != "" && actorHost != localHost
+}
+
+func (s *Service) getRemoteActorData(ctx context.Context, actorID string) (*activitypub.Actor, error) {
+	remoteRepo, ok := s.actorRepo.(cachedRemoteActorRepository)
+	if !ok || remoteRepo == nil {
+		return nil, fmt.Errorf("actor not found: %s", actorID)
+	}
+	actor, err := remoteRepo.GetCachedRemoteActor(ctx, actorID)
+	if err != nil {
+		s.logger.Error("Failed to get cached remote actor",
+			zap.String("actorID", actorID),
+			zap.Error(err))
+		return nil, fmt.Errorf("actor not found: %w", err)
+	}
+	if actor == nil || !sameCanonicalActorID(actor.ID, actorID) {
+		return nil, fmt.Errorf("actor not found: %s", actorID)
 	}
 	return actor, nil
 }

--- a/pkg/reputation/service.go
+++ b/pkg/reputation/service.go
@@ -869,6 +869,13 @@ func (s *Service) ImportReputation(ctx context.Context, document string) (*Impor
 		}, nil
 	}
 
+	if pr.Reputation != nil && !sameCanonicalActorID(pr.Actor, pr.Reputation.ActorID) {
+		return &ImportResult{
+			Success: false,
+			Error:   "Reputation actor does not match document actor",
+		}, nil
+	}
+
 	// Get current reputation
 	currentRep, _ := s.GetReputation(ctx, pr.Actor)
 	previousScore := 0
@@ -880,7 +887,7 @@ func (s *Service) ImportReputation(ctx context.Context, document string) (*Impor
 	if pr.Reputation != nil {
 		// Store imported reputation with special marker
 		pr.Reputation.InstanceURL = pr.Issuer // Mark as imported
-		if err := s.storeReputation(ctx, pr.Reputation, s.importedReputationStoreOptions(pr.Actor)...); err != nil {
+		if err := s.storeReputation(ctx, pr.Reputation, s.importedReputationStoreOptions(pr.Reputation.ActorID)...); err != nil {
 			return &ImportResult{
 				Success: false,
 				Error:   "Failed to store reputation",

--- a/pkg/reputation/service_round20_coverage_test.go
+++ b/pkg/reputation/service_round20_coverage_test.go
@@ -165,16 +165,35 @@ func (r *round20UserRepo) StoreReputation(ctx context.Context, actorID string, r
 type round20ActorRepo struct {
 	actorByUsername map[string]*activitypub.Actor
 	errByUsername   map[string]error
+	cachedRemote    map[string]*activitypub.Actor
+	errRemote       map[string]error
+	usernameCalls   int
+	remoteCalls     int
 }
 
 func (r *round20ActorRepo) GetActorByUsername(ctx context.Context, username string) (*activitypub.Actor, error) {
 	_ = ctx
+	r.usernameCalls++
 	if r.errByUsername != nil {
 		if err, ok := r.errByUsername[username]; ok {
 			return nil, err
 		}
 	}
 	if actor, ok := r.actorByUsername[username]; ok {
+		return actor, nil
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+func (r *round20ActorRepo) GetCachedRemoteActor(ctx context.Context, identifier string) (*activitypub.Actor, error) {
+	_ = ctx
+	r.remoteCalls++
+	if r.errRemote != nil {
+		if err, ok := r.errRemote[identifier]; ok {
+			return nil, err
+		}
+	}
+	if actor, ok := r.cachedRemote[identifier]; ok {
 		return actor, nil
 	}
 	return nil, fmt.Errorf("not found")
@@ -659,6 +678,55 @@ func TestService_Round20_GetReputation_CalculateAndStore_ExportImport(t *testing
 		require.NoError(t, err)
 		require.False(t, vr.Valid)
 	})
+}
+
+func TestService_GetReputation_RemoteActorDoesNotUseLocalUsername(t *testing.T) {
+	ctx := context.Background()
+	remoteActorID := "https://evil.example/users/alice"
+	localActorID := "https://example.com/users/alice"
+	actorRepo := &round20ActorRepo{
+		actorByUsername: map[string]*activitypub.Actor{
+			"alice": {BaseObject: activitypub.BaseObject{ID: localActorID}},
+		},
+	}
+
+	svc := &Service{
+		userRepo:    &round20UserRepo{},
+		actorRepo:   actorRepo,
+		calculator:  &round20Calculator{rep: &Reputation{ActorID: remoteActorID, InstanceURL: "https://example.com", CalculatedAt: time.Now()}},
+		signer:      &round20Signer{},
+		logger:      zap.NewNop(),
+		instanceURL: "https://example.com",
+	}
+
+	rep, err := svc.GetReputation(ctx, remoteActorID)
+	require.Error(t, err)
+	require.Nil(t, rep)
+	require.Contains(t, err.Error(), "actor not found")
+	require.Equal(t, 0, actorRepo.usernameCalls, "remote actor reputation must not fall back to local username lookup")
+	require.Equal(t, 1, actorRepo.remoteCalls)
+}
+
+func TestService_getActorData_UsesCachedRemoteActorForRemoteIDs(t *testing.T) {
+	ctx := context.Background()
+	remoteActorID := "https://remote.example/users/alice"
+	actorRepo := &round20ActorRepo{
+		cachedRemote: map[string]*activitypub.Actor{
+			remoteActorID: {BaseObject: activitypub.BaseObject{ID: remoteActorID}},
+		},
+	}
+	svc := &Service{
+		actorRepo:   actorRepo,
+		logger:      zap.NewNop(),
+		instanceURL: "https://example.com",
+	}
+
+	actor, err := svc.getActorData(ctx, remoteActorID, "alice")
+	require.NoError(t, err)
+	require.NotNil(t, actor)
+	require.Equal(t, remoteActorID, actor.ID)
+	require.Equal(t, 0, actorRepo.usernameCalls)
+	require.Equal(t, 1, actorRepo.remoteCalls)
 }
 
 func TestService_Round20_CacheExpiry_And_ErrorPaths(t *testing.T) {

--- a/pkg/reputation/service_round20_coverage_test.go
+++ b/pkg/reputation/service_round20_coverage_test.go
@@ -522,6 +522,47 @@ func TestImportReputationForcesCanonicalActorPartitionForRemoteSameNameActors(t 
 	require.NotContains(t, storedPKs, "ACTOR#alice")
 }
 
+func TestImportReputationRejectsMismatchedOuterAndInnerActors(t *testing.T) {
+	ctx := context.Background()
+	storeCalled := false
+	userRepo := &round20UserRepo{
+		getFn: func(_ context.Context, _ string) (*storage.Reputation, error) {
+			return nil, nil
+		},
+		storeFn: func(_ context.Context, _ string, _ *storage.Reputation) error {
+			storeCalled = true
+			return nil
+		},
+	}
+	svc := &Service{
+		userRepo:     userRepo,
+		verifier:     &round20Verifier{verifyResult: &VerificationResult{Valid: true}},
+		vouchManager: &round20VouchManager{},
+		logger:       zap.NewNop(),
+		instanceURL:  "https://local.example",
+	}
+
+	doc := PortableReputation{
+		Actor:  "https://local.example/users/bob",
+		Issuer: "https://remote1.example",
+		Reputation: &Reputation{
+			ActorID:      "https://remote1.example/users/alice",
+			InstanceURL:  "https://remote1.example",
+			TotalScore:   100,
+			CalculatedAt: time.Now().UTC(),
+			Version:      "1",
+		},
+	}
+	docBytes, err := json.Marshal(doc)
+	require.NoError(t, err)
+
+	result, err := svc.ImportReputation(ctx, string(docBytes))
+	require.NoError(t, err)
+	require.False(t, result.Success)
+	require.Equal(t, "Reputation actor does not match document actor", result.Error)
+	require.False(t, storeCalled, "mismatched imported reputation must not be stored")
+}
+
 func TestService_Round20_ExtractUsername_ParseSeverity_AndOutcome(t *testing.T) {
 	svc := &Service{logger: zap.NewNop()}
 

--- a/pkg/reputation/service_round20_coverage_test.go
+++ b/pkg/reputation/service_round20_coverage_test.go
@@ -461,6 +461,67 @@ func (m *round20VouchManager) RevokeVouch(ctx context.Context, vouchID, actorID 
 	return m.revokeErr
 }
 
+func TestImportReputationForcesCanonicalActorPartitionForRemoteSameNameActors(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	var storedPKs []string
+	userRepo := &round20UserRepo{
+		storeFn: func(_ context.Context, actorID string, reputation *storage.Reputation) error {
+			reputationModel := &models.Reputation{}
+			require.NoError(t, reputationModel.UpdateKeys(actorID, reputation))
+			storedPKs = append(storedPKs, reputationModel.PK)
+			return nil
+		},
+	}
+
+	svc := &Service{
+		userRepo:     userRepo,
+		verifier:     &round20Verifier{verifyResult: &VerificationResult{Valid: true}},
+		vouchManager: &round20VouchManager{},
+		logger:       zap.NewNop(),
+		instanceURL:  "https://local.example",
+	}
+
+	for _, doc := range []PortableReputation{
+		{
+			Actor:  "https://remote1.example/users/alice",
+			Issuer: "https://remote1.example",
+			Reputation: &Reputation{
+				ActorID:      "https://remote1.example/users/alice",
+				InstanceURL:  "https://remote1.example",
+				TotalScore:   100,
+				CalculatedAt: now,
+				Version:      "1",
+			},
+		},
+		{
+			Actor:  "https://remote2.example/users/alice",
+			Issuer: "https://remote2.example",
+			Reputation: &Reputation{
+				ActorID:      "https://remote2.example/users/alice",
+				InstanceURL:  "https://remote2.example",
+				TotalScore:   200,
+				CalculatedAt: now.Add(time.Second),
+				Version:      "1",
+			},
+		},
+	} {
+		docBytes, err := json.Marshal(doc)
+		require.NoError(t, err)
+
+		result, err := svc.ImportReputation(ctx, string(docBytes))
+		require.NoError(t, err)
+		require.True(t, result.Success)
+	}
+
+	require.Equal(t, []string{
+		"ACTOR#https://remote1.example/users/alice",
+		"ACTOR#https://remote2.example/users/alice",
+	}, storedPKs)
+	require.NotContains(t, storedPKs, "ACTOR#alice")
+}
+
 func TestService_Round20_ExtractUsername_ParseSeverity_AndOutcome(t *testing.T) {
 	svc := &Service{logger: zap.NewNop()}
 

--- a/pkg/services/conversations/service.go
+++ b/pkg/services/conversations/service.go
@@ -1558,7 +1558,12 @@ func (s *Service) createSendMessageStatus(_ context.Context, cmd *SendMessageCom
 	return status, messageID, nil
 }
 
-func (s *Service) executeSendMessageAttempt(ctx context.Context, cmd *SendMessageCommand, requestRateLimitConsumed *bool) (*MessageResult, bool, error) {
+func (s *Service) executeSendMessageAttempt(
+	ctx context.Context,
+	cmd *SendMessageCommand,
+	totalRateLimitConsumed *bool,
+	requestRateLimitConsumed *bool,
+) (*MessageResult, bool, error) {
 	conversation, recipientID, err := s.loadConversationAndRecipientForSendMessage(ctx, cmd)
 	if err != nil {
 		return nil, false, err
@@ -1576,6 +1581,15 @@ func (s *Service) executeSendMessageAttempt(ctx context.Context, cmd *SendMessag
 	sender, recipient, err := s.getSendMessageAccountsForSend(ctx, sendCmd, conversation, cmd.SenderID, recipientID)
 	if err != nil {
 		return nil, false, err
+	}
+
+	if totalRateLimitConsumed == nil || !*totalRateLimitConsumed {
+		if err := s.enforceDirectMessageTotalRateLimit(ctx, sendCmd, recipientID); err != nil {
+			return nil, false, err
+		}
+		if totalRateLimitConsumed != nil {
+			*totalRateLimitConsumed = true
+		}
 	}
 
 	recipientRequestState := models.DmRequestState("")
@@ -1639,9 +1653,10 @@ func (s *Service) SendMessage(ctx context.Context, cmd *SendMessageCommand) (*Me
 	}
 
 	var retryErr error
+	totalRateLimitConsumed := false
 	requestRateLimitConsumed := false
 	for attempt := 0; attempt < directMessageSendRetryLimit; attempt++ {
-		result, retry, err := s.executeSendMessageAttempt(ctx, cmd, &requestRateLimitConsumed)
+		result, retry, err := s.executeSendMessageAttempt(ctx, cmd, &totalRateLimitConsumed, &requestRateLimitConsumed)
 		if err != nil {
 			if retry {
 				retryErr = err

--- a/pkg/services/conversations/service_round39_rate_limit_regression_test.go
+++ b/pkg/services/conversations/service_round39_rate_limit_regression_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/storage/interfaces"
+	"github.com/equaltoai/lesser/pkg/storage/models"
 	testmocks "github.com/equaltoai/lesser/pkg/testing/mocks"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -52,7 +55,7 @@ func TestService_SendDirectMessage_ConsumesRateLimitBeforeWrites(t *testing.T) {
 		nil,
 		rateLimitRepo,
 		nil,
-		nil,
+		&mockPublisher{},
 		nil,
 		zaptest.NewLogger(t),
 		"example.com",
@@ -79,6 +82,112 @@ func TestService_SendDirectMessage_ConsumesRateLimitBeforeWrites(t *testing.T) {
 	})
 	require.ErrorIs(t, err, ErrCreateDirectMessage)
 
+	rateLimitRepo.AssertExpectations(t)
+}
+
+func TestService_SendMessage_ConsumesTotalRateLimitBeforeWrite(t *testing.T) {
+	ctx := context.Background()
+
+	conversationRepo := &mockConversationRepository{}
+	accountRepo := &mockAccountRepository{}
+	rateLimitRepo := testmocks.NewMockRateLimitRepository()
+	resetTime := time.Now().UTC().Add(time.Minute)
+
+	service := NewService(
+		conversationRepo,
+		nil,
+		nil,
+		accountRepo,
+		nil,
+		nil,
+		rateLimitRepo,
+		nil,
+		nil,
+		nil,
+		zaptest.NewLogger(t),
+		"example.com",
+	)
+
+	conversation := createTestConversation("conv-existing", []string{"alice", "bob"})
+	conversationRepo.On("GetConversation", ctx, "conv-existing").Return(conversation, nil).Once()
+	accountRepo.On("GetAccount", ctx, "alice").Return(createTestAccount("alice", "alice"), nil).Once()
+	accountRepo.On("GetAccount", ctx, "bob").Return(createTestAccount("bob", "bob"), nil).Once()
+	rateLimitRepo.
+		On("CheckFixedWindowRateLimit", mock.Anything, "dm:alice", "dm_send_total", dmSendTotalLimit, dmSendTotalWindow).
+		Return(false, 0, resetTime, nil).
+		Once()
+
+	_, err := service.SendMessage(ctx, &SendMessageCommand{
+		SenderID:       "alice",
+		ConversationID: "conv-existing",
+		Content:        "blocked by total rate limit",
+	})
+	require.ErrorIs(t, err, storage.ErrRateLimited)
+
+	conversationRepo.AssertNotCalled(t, "ApplyDirectMessageSend", mock.Anything, mock.Anything, mock.Anything)
+	conversationRepo.AssertExpectations(t)
+	accountRepo.AssertExpectations(t)
+	rateLimitRepo.AssertExpectations(t)
+}
+
+func TestService_SendMessage_ConsumesTotalRateLimitOnceAcrossRetry(t *testing.T) {
+	ctx := context.Background()
+
+	conversationRepo := &mockConversationRepository{}
+	accountRepo := &mockAccountRepository{}
+	rateLimitRepo := testmocks.NewMockRateLimitRepository()
+	resetTime := time.Now().UTC().Add(time.Minute)
+
+	service := NewService(
+		conversationRepo,
+		nil,
+		nil,
+		accountRepo,
+		nil,
+		nil,
+		rateLimitRepo,
+		nil,
+		&mockPublisher{},
+		nil,
+		zaptest.NewLogger(t),
+		"example.com",
+	)
+
+	initialConversation := createTestConversation("conv-existing", []string{"alice", "bob"})
+	reloadedConversation := createTestConversation("conv-existing", []string{"alice", "bob"})
+	conversationRepo.On("GetConversation", ctx, "conv-existing").Return(initialConversation, nil).Once()
+	conversationRepo.On("GetConversation", ctx, "conv-existing").Return(reloadedConversation, nil).Once()
+	accountRepo.On("GetAccount", ctx, "alice").Return(createTestAccount("alice", "alice"), nil).Twice()
+	accountRepo.On("GetAccount", ctx, "bob").Return(createTestAccount("bob", "bob"), nil).Twice()
+	rateLimitRepo.
+		On("CheckFixedWindowRateLimit", mock.Anything, "dm:alice", "dm_send_total", dmSendTotalLimit, dmSendTotalWindow).
+		Return(true, dmSendTotalLimit-1, resetTime, nil).
+		Once()
+	conversationRepo.On("GetUserConversationState", ctx, "bob", "conv-existing").
+		Return(testConversationStateContract("bob", "conv-existing", func(state *interfaces.UserConversationStateContract) {
+			state.RequestState = models.DmRequestStateAccepted
+		}), nil).
+		Twice()
+	conversationRepo.On("GetUserConversationState", ctx, "alice", "conv-existing").
+		Return(testConversationStateContract("alice", "conv-existing", nil), nil).
+		Twice()
+	conversationRepo.On("ApplyDirectMessageSend", ctx, mock.AnythingOfType("*models.DirectMessageSendTransition"), mock.Anything).
+		Return(storage.ErrVersionConflict).
+		Once()
+	conversationRepo.On("ApplyDirectMessageSend", ctx, mock.AnythingOfType("*models.DirectMessageSendTransition"), mock.Anything).
+		Return(nil).
+		Once()
+
+	result, err := service.SendMessage(ctx, &SendMessageCommand{
+		SenderID:       "alice",
+		ConversationID: "conv-existing",
+		Content:        "allowed once across retry",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	conversationRepo.AssertExpectations(t)
+	accountRepo.AssertExpectations(t)
 	rateLimitRepo.AssertExpectations(t)
 }
 

--- a/pkg/storage/models/reputation.go
+++ b/pkg/storage/models/reputation.go
@@ -3,6 +3,8 @@ package models
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/equaltoai/lesser/pkg/common"
@@ -29,9 +31,8 @@ type Reputation struct {
 
 // UpdateKeys updates the PK and SK based on the reputation data
 func (r *Reputation) UpdateKeys(actorID string, reputation interface{}) error {
-	// Extract username from actorID using the same logic as legacy
-	username := extractUsernameFromActorID(actorID)
-	if err := common.ValidateRequiredParam("username", username); err != nil {
+	pk, err := ReputationActorPartitionKeyForRecord(actorID, reputation)
+	if err != nil {
 		return fmt.Errorf("%w: %s", ErrInvalidActorIDFormat, actorID)
 	}
 
@@ -80,8 +81,10 @@ func (r *Reputation) UpdateKeys(actorID string, reputation interface{}) error {
 		totalScore = totalScoreInt
 	}
 
-	// Set keys - preserve EXACT case from legacy
-	r.PK = fmt.Sprintf(KeyPatternActor, username)
+	// Set keys. Local actor reputations keep the legacy actor partition for
+	// backward compatibility; remote actor reputations use the canonical actor
+	// URI so same-username actors on different domains cannot collide.
+	r.PK = pk
 	r.SK = fmt.Sprintf("REP#%s", calculatedAt.Format(time.RFC3339))
 
 	// Set fields
@@ -93,6 +96,125 @@ func (r *Reputation) UpdateKeys(actorID string, reputation interface{}) error {
 	r.TTL = time.Now().Add(90 * 24 * time.Hour).Unix()
 
 	return nil
+}
+
+// ReputationActorPartitionKeyForRecord returns the partition key for a
+// reputation record. Local actor reputations preserve the legacy
+// ACTOR#<username> key because deployed instances already have those rows.
+// Remote actor reputations are keyed by the canonical actor URI to bind the
+// reputation row to the actor's domain.
+func ReputationActorPartitionKeyForRecord(actorID string, reputation interface{}) (string, error) {
+	actorID = strings.TrimSpace(actorID)
+	canonicalActorID, err := canonicalReputationActorID(actorID)
+	if err != nil {
+		return "", err
+	}
+
+	instanceURL := reputationInstanceURL(reputation)
+	if instanceURL != "" && reputationActorHostMatchesInstance(canonicalActorID, instanceURL) {
+		username := strings.TrimSpace(strings.TrimPrefix(extractUsernameFromActorID(strings.TrimRight(actorID, "/")), "@"))
+		if err := common.ValidateRequiredParam("username", username); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf(KeyPatternActor, username), nil
+	}
+
+	return fmt.Sprintf(KeyPatternActor, canonicalActorID), nil
+}
+
+// ReputationActorPartitionKeyCandidates returns read candidates in canonical
+// order. The legacy username key remains a fallback so local cached reputation
+// rows can be read during the transition; callers must still verify the stored
+// ActorID matches the requested actor before trusting a fallback row.
+func ReputationActorPartitionKeyCandidates(actorID string) ([]string, error) {
+	canonicalActorID, err := canonicalReputationActorID(actorID)
+	if err != nil {
+		return nil, err
+	}
+
+	candidates := []string{fmt.Sprintf(KeyPatternActor, canonicalActorID)}
+	username := strings.TrimSpace(strings.TrimPrefix(extractUsernameFromActorID(strings.TrimRight(actorID, "/")), "@"))
+	if username != "" {
+		legacy := fmt.Sprintf(KeyPatternActor, username)
+		if legacy != candidates[0] {
+			candidates = append(candidates, legacy)
+		}
+	}
+	return candidates, nil
+}
+
+// ReputationActorIDsMatch reports whether two reputation actor identifiers
+// resolve to the same canonical ActivityPub actor URI.
+func ReputationActorIDsMatch(left, right string) bool {
+	leftCanonical, leftErr := canonicalReputationActorID(left)
+	rightCanonical, rightErr := canonicalReputationActorID(right)
+	return leftErr == nil && rightErr == nil && leftCanonical == rightCanonical
+}
+
+func reputationInstanceURL(reputation interface{}) string {
+	repJSON, err := json.Marshal(reputation)
+	if err != nil {
+		return ""
+	}
+	var repMap map[string]interface{}
+	if err := json.Unmarshal(repJSON, &repMap); err != nil {
+		return ""
+	}
+	for _, key := range []string{"instance", "instanceURL", "instance_url"} {
+		if value, ok := repMap[key].(string); ok && strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func reputationActorHostMatchesInstance(actorID, instanceURL string) bool {
+	actorURL, err := url.Parse(strings.TrimSpace(actorID))
+	if err != nil || actorURL == nil {
+		return false
+	}
+	instance, err := url.Parse(strings.TrimSpace(instanceURL))
+	if err != nil || instance == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(actorURL.Hostname()), strings.TrimSpace(instance.Hostname()))
+}
+
+func canonicalReputationActorID(actorID string) (string, error) {
+	actorID = strings.TrimSpace(actorID)
+	if actorID == "" {
+		return "", fmt.Errorf("actor ID is required")
+	}
+	if strings.IndexFunc(actorID, func(r rune) bool { return r < 0x20 || r == 0x7f }) >= 0 {
+		return "", fmt.Errorf("actor ID contains control characters")
+	}
+	if err := common.ValidateActivityPubURL(actorID, "actor_id"); err != nil {
+		return "", err
+	}
+
+	parsed, err := url.Parse(actorID)
+	if err != nil || parsed == nil {
+		return "", err
+	}
+	scheme := strings.ToLower(strings.TrimSpace(parsed.Scheme))
+	if scheme != schemeHTTP && scheme != schemeHTTPS {
+		return "", fmt.Errorf("actor ID must use HTTP or HTTPS")
+	}
+	if parsed.User != nil || strings.TrimSpace(parsed.Hostname()) == "" {
+		return "", fmt.Errorf("actor ID must include a bare host")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("actor ID must not include query or fragment")
+	}
+	path := strings.TrimRight(parsed.EscapedPath(), "/")
+	if path == "" {
+		return "", fmt.Errorf("actor ID must include a path")
+	}
+	if path == "/users" || path == "/@" {
+		return "", fmt.Errorf("actor ID must include a concrete actor path")
+	}
+
+	return fmt.Sprintf("%s://%s%s", scheme, strings.ToLower(parsed.Host), path), nil
 }
 
 // ToStorageReputation converts the model back to a map that can be used as storage.Reputation

--- a/pkg/storage/models/reputation.go
+++ b/pkg/storage/models/reputation.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"reflect"
 	"strings"
 	"time"
 
@@ -110,6 +111,10 @@ func ReputationActorPartitionKeyForRecord(actorID string, reputation interface{}
 		return "", err
 	}
 
+	if reputationForcesCanonicalActorKey(reputation) {
+		return fmt.Sprintf(KeyPatternActor, canonicalActorID), nil
+	}
+
 	instanceURL := reputationInstanceURL(reputation)
 	if instanceURL != "" && reputationActorHostMatchesInstance(canonicalActorID, instanceURL) {
 		username := strings.TrimSpace(strings.TrimPrefix(extractUsernameFromActorID(strings.TrimRight(actorID, "/")), "@"))
@@ -149,6 +154,24 @@ func ReputationActorIDsMatch(left, right string) bool {
 	leftCanonical, leftErr := canonicalReputationActorID(left)
 	rightCanonical, rightErr := canonicalReputationActorID(right)
 	return leftErr == nil && rightErr == nil && leftCanonical == rightCanonical
+}
+
+func reputationForcesCanonicalActorKey(reputation interface{}) bool {
+	if reputation == nil {
+		return false
+	}
+	value := reflect.ValueOf(reputation)
+	for value.Kind() == reflect.Ptr {
+		if value.IsNil() {
+			return false
+		}
+		value = value.Elem()
+	}
+	if value.Kind() != reflect.Struct {
+		return false
+	}
+	field := value.FieldByName("ForceCanonicalActorKey")
+	return field.IsValid() && field.Kind() == reflect.Bool && field.Bool()
 }
 
 func reputationInstanceURL(reputation interface{}) string {

--- a/pkg/storage/models/reputation_actor_key_test.go
+++ b/pkg/storage/models/reputation_actor_key_test.go
@@ -72,3 +72,27 @@ func TestReputationActorPartitionKeyForRecordReadsInstanceURLAliases(t *testing.
 		require.Equal(t, "ACTOR#alice", pk)
 	}
 }
+
+func TestReputationActorPartitionKeyForRecordForcedCanonicalForImportedRemote(t *testing.T) {
+	remoteImported := &storage.Reputation{
+		ActorID:                "https://remote1.example/users/alice",
+		InstanceURL:            "https://remote1.example",
+		ForceCanonicalActorKey: true,
+		CalculatedAt:           time.Now().UTC(),
+	}
+
+	pk, err := models.ReputationActorPartitionKeyForRecord(remoteImported.ActorID, remoteImported)
+	require.NoError(t, err)
+	require.Equal(t, "ACTOR#https://remote1.example/users/alice", pk)
+
+	secondRemote := &storage.Reputation{
+		ActorID:                "https://remote2.example/users/alice",
+		InstanceURL:            "https://remote2.example",
+		ForceCanonicalActorKey: true,
+		CalculatedAt:           time.Now().UTC(),
+	}
+	secondPK, err := models.ReputationActorPartitionKeyForRecord(secondRemote.ActorID, secondRemote)
+	require.NoError(t, err)
+	require.Equal(t, "ACTOR#https://remote2.example/users/alice", secondPK)
+	require.NotEqual(t, pk, secondPK)
+}

--- a/pkg/storage/models/reputation_actor_key_test.go
+++ b/pkg/storage/models/reputation_actor_key_test.go
@@ -1,0 +1,74 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReputationActorPartitionKeyForRecordBindsRemoteDomain(t *testing.T) {
+	localRep := &storage.Reputation{
+		InstanceURL:  "https://example.com",
+		CalculatedAt: time.Now().UTC(),
+	}
+	localPK, err := models.ReputationActorPartitionKeyForRecord("https://example.com/users/alice", localRep)
+	require.NoError(t, err)
+	require.Equal(t, "ACTOR#alice", localPK)
+
+	remotePK, err := models.ReputationActorPartitionKeyForRecord("https://remote.example/users/alice", localRep)
+	require.NoError(t, err)
+	require.Equal(t, "ACTOR#https://remote.example/users/alice", remotePK)
+	require.NotEqual(t, localPK, remotePK)
+
+	otherRemotePK, err := models.ReputationActorPartitionKeyForRecord("https://other.example/users/alice", localRep)
+	require.NoError(t, err)
+	require.Equal(t, "ACTOR#https://other.example/users/alice", otherRemotePK)
+	require.NotEqual(t, remotePK, otherRemotePK)
+}
+
+func TestReputationActorPartitionKeyCandidatesIncludeLegacyFallback(t *testing.T) {
+	candidates, err := models.ReputationActorPartitionKeyCandidates("https://remote.example/users/alice")
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"ACTOR#https://remote.example/users/alice",
+		"ACTOR#alice",
+	}, candidates)
+}
+
+func TestReputationActorIDHelpersCanonicalizeAndRejectUnsafeIDs(t *testing.T) {
+	require.True(t, models.ReputationActorIDsMatch(
+		"https://Example.com/users/alice/",
+		"https://example.com/users/alice",
+	))
+	require.False(t, models.ReputationActorIDsMatch(
+		"https://remote.example/users/alice",
+		"https://other.example/users/alice",
+	))
+	require.False(t, models.ReputationActorIDsMatch(
+		"acct:alice@example.com",
+		"https://example.com/users/alice",
+	))
+
+	_, err := models.ReputationActorPartitionKeyCandidates("acct:alice@example.com")
+	require.Error(t, err)
+
+	_, err = models.ReputationActorPartitionKeyForRecord("https://example.com/users/", map[string]any{
+		"instance_url": "https://example.com",
+	})
+	require.Error(t, err)
+}
+
+func TestReputationActorPartitionKeyForRecordReadsInstanceURLAliases(t *testing.T) {
+	for _, reputation := range []map[string]any{
+		{"instanceURL": "https://example.com"},
+		{"instance_url": "https://example.com"},
+		{"instance": "https://example.com"},
+	} {
+		pk, err := models.ReputationActorPartitionKeyForRecord("https://example.com/users/alice", reputation)
+		require.NoError(t, err)
+		require.Equal(t, "ACTOR#alice", pk)
+	}
+}

--- a/pkg/storage/models/round15_zero_coverage_models_test.go
+++ b/pkg/storage/models/round15_zero_coverage_models_test.go
@@ -180,9 +180,11 @@ func TestReputation(t *testing.T) {
 		calculatedAt := time.Unix(1700000000, 0).UTC().Format(time.RFC3339)
 		input := struct {
 			CalculatedAt string `json:"calculatedAt"`
+			Instance     string `json:"instance"`
 			TotalScore   int    `json:"totalScore"`
 		}{
 			CalculatedAt: calculatedAt,
+			Instance:     "https://example.com",
 			TotalScore:   42,
 		}
 

--- a/pkg/storage/models/status_identity.go
+++ b/pkg/storage/models/status_identity.go
@@ -11,7 +11,11 @@ import (
 	"github.com/equaltoai/lesser/pkg/config"
 )
 
-const remoteStatusIDPrefix = "remote_"
+const (
+	remoteStatusIDPrefix = "remote_"
+	schemeHTTP           = "http"
+	schemeHTTPS          = "https"
+)
 
 // CanonicalStatusID normalizes local and remote status identifiers into one
 // storage-safe contract. Local status URLs collapse to their path identifier,
@@ -102,7 +106,7 @@ func isHTTPStatusURL(raw string) bool {
 	if err != nil || parsed == nil {
 		return false
 	}
-	return (parsed.Scheme == "http" || parsed.Scheme == "https") && parsed.Host != ""
+	return (parsed.Scheme == schemeHTTP || parsed.Scheme == schemeHTTPS) && parsed.Host != ""
 }
 
 func statusAppearsRemote(status *Status, localDomain string) bool {
@@ -248,9 +252,9 @@ func normalizeStatusIdentifierURL(raw string) (string, *url.URL, bool) {
 
 	port := parsed.Port()
 	switch {
-	case parsed.Scheme == "https" && port == "443":
+	case parsed.Scheme == schemeHTTPS && port == "443":
 		port = ""
-	case parsed.Scheme == "http" && port == "80":
+	case parsed.Scheme == schemeHTTP && port == "80":
 		port = ""
 	}
 

--- a/pkg/storage/repositories/account_repository.go
+++ b/pkg/storage/repositories/account_repository.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -575,6 +576,11 @@ func (r *AccountRepository) normalizeUsername(username string) string {
 
 	if strings.HasPrefix(trimmed, "https://") || strings.HasPrefix(trimmed, "http://") {
 		urlWithoutScheme := strings.TrimSuffix(trimmed, "/")
+		parsed, _ := url.Parse(urlWithoutScheme)
+		remoteDomain := ""
+		if parsed != nil && strings.TrimSpace(parsed.Hostname()) != "" && !r.isLocalDomain(parsed.Hostname()) {
+			remoteDomain = strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+		}
 		if idx := strings.Index(urlWithoutScheme, "/users/"); idx != -1 && idx+7 < len(urlWithoutScheme) {
 			trimmed = urlWithoutScheme[idx+7:]
 		} else if idx := strings.LastIndex(urlWithoutScheme, "/@"); idx != -1 && idx+2 < len(urlWithoutScheme) {
@@ -586,6 +592,9 @@ func (r *AccountRepository) normalizeUsername(username string) string {
 			}
 		}
 		trimmed = strings.TrimPrefix(trimmed, "@")
+		if remoteDomain != "" && !strings.Contains(trimmed, "@") {
+			trimmed = fmt.Sprintf("%s@%s", trimmed, remoteDomain)
+		}
 	}
 
 	if at := strings.LastIndex(trimmed, "@"); at != -1 {

--- a/pkg/storage/repositories/account_repository_case_normalization_test.go
+++ b/pkg/storage/repositories/account_repository_case_normalization_test.go
@@ -20,6 +20,7 @@ func TestAccountRepository_CanonicalUsername_LowercasesNormalizedHandles(t *test
 	require.Equal(t, "arch", repo.canonicalUsername("acct:@Arch@example.com"))
 	require.Equal(t, "arch", repo.canonicalUsername("https://example.com/users/Arch"))
 	require.Equal(t, "arch@remote.example", repo.canonicalUsername("@Arch@Remote.Example"))
+	require.Equal(t, "arch@remote.example", repo.canonicalUsername("https://Remote.Example/users/Arch"))
 }
 
 func TestAccountRepository_GetUser_FallsBackToLegacyMixedCaseKeys(t *testing.T) {

--- a/pkg/storage/repositories/account_repository_core_coverage_test.go
+++ b/pkg/storage/repositories/account_repository_core_coverage_test.go
@@ -41,6 +41,7 @@ func TestAccountRepository_CoreCoverageSweep(t *testing.T) {
 	require.Equal(t, "alice", repo.canonicalUsername("acct:@alice@example.com"))
 	require.Equal(t, "alice", repo.canonicalUsername("https://example.com/users/alice"))
 	require.Equal(t, "alice@remote.example", repo.canonicalUsername("@alice@remote.example"))
+	require.Equal(t, "alice@remote.example", repo.canonicalUsername("https://remote.example/users/alice"))
 	require.True(t, repo.isLocalDomain("example.com"))
 	require.Equal(t, "https://example.com", repo.actorBaseURL())
 	require.Equal(t, "https://example.com", extractBaseURL("https://example.com/@alice", "/@alice"))

--- a/pkg/storage/repositories/account_repository_go_additional_coverage_test.go
+++ b/pkg/storage/repositories/account_repository_go_additional_coverage_test.go
@@ -118,6 +118,7 @@ func TestAccountRepository_UserAndDomainBranchCoverage(t *testing.T) {
 	require.Equal(t, "alice", repo.canonicalUsername("acct:alice"))
 	require.Equal(t, "alice", repo.canonicalUsername("https://example.com/@alice"))
 	require.Equal(t, "alice", repo.canonicalUsername("https://example.com/profile/alice"))
+	require.Equal(t, "alice@remote.example", repo.canonicalUsername("https://remote.example/@alice"))
 	require.False(t, repo.isLocalDomain(""))
 	require.False(t, repo.isLocalDomain("remote.example"))
 }

--- a/pkg/storage/repositories/reputation_test.go
+++ b/pkg/storage/repositories/reputation_test.go
@@ -14,6 +14,10 @@ import (
 	"go.uber.org/zap"
 )
 
+func matchAliceReputationPK(pk string) bool {
+	return pk == "ACTOR#https://example.com/users/alice" || pk == "ACTOR#alice"
+}
+
 func TestStoreReputation(t *testing.T) {
 	logger := zap.NewNop()
 	mockDB := new(mocks.MockDB)
@@ -89,7 +93,7 @@ func TestGetReputation(t *testing.T) {
 	// Set up expectations
 	mockDB.On("WithContext", mock.Anything).Return(mockDB).Maybe()
 	mockDB.On("Model", mock.AnythingOfType("*models.Reputation")).Return(mockQuery).Maybe()
-	mockQuery.On("Where", "PK", "=", "ACTOR#alice").Return(mockQuery).Maybe()
+	mockQuery.On("Where", "PK", "=", "ACTOR#https://example.com/users/alice").Return(mockQuery).Maybe()
 	mockQuery.On("Filter", "SK", "BEGINS_WITH", "REP#").Return(mockQuery).Maybe()
 	mockQuery.On("OrderBy", "SK", "DESC").Return(mockQuery).Maybe()
 	mockQuery.On("Limit", 1).Return(mockQuery).Maybe()
@@ -110,6 +114,56 @@ func TestGetReputation(t *testing.T) {
 	mockQuery.AssertExpectations(t)
 }
 
+func TestGetReputationDoesNotReturnLegacyMismatchedActor(t *testing.T) {
+	logger := zap.NewNop()
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+
+	repo := NewUserRepository(mockDB, "test-table", logger)
+	ctx := context.Background()
+
+	calculatedAt := time.Now().UTC()
+	localReputationData := fmt.Sprintf(`{
+		"actor_id": "https://example.com/users/alice",
+		"instance_url": "https://example.com",
+		"total_score": 825,
+		"calculated_at": "%s"
+	}`, calculatedAt.Format(time.RFC3339))
+	localRep := models.Reputation{
+		PK:             "ACTOR#alice",
+		SK:             "REP#" + calculatedAt.Format(time.RFC3339),
+		ReputationData: localReputationData,
+		TotalScore:     825,
+		CalculatedAt:   calculatedAt.Format(time.RFC3339),
+	}
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB).Maybe()
+	mockDB.On("Model", mock.AnythingOfType("*models.Reputation")).Return(mockQuery).Maybe()
+	mockQuery.On("Where", "PK", "=", mock.MatchedBy(func(pk string) bool {
+		return pk == "ACTOR#https://evil.example/users/alice" || pk == "ACTOR#alice"
+	})).Return(mockQuery).Maybe()
+	mockQuery.On("Filter", "SK", "BEGINS_WITH", "REP#").Return(mockQuery).Maybe()
+	mockQuery.On("OrderBy", "SK", "DESC").Return(mockQuery).Maybe()
+	mockQuery.On("Limit", 1).Return(mockQuery).Maybe()
+	call := 0
+	mockQuery.On("All", mock.AnythingOfType("*[]models.Reputation")).Run(func(args mock.Arguments) {
+		reps := args.Get(0).(*[]models.Reputation)
+		if call == 0 {
+			*reps = []models.Reputation{}
+		} else {
+			*reps = []models.Reputation{localRep}
+		}
+		call++
+	}).Return(nil)
+
+	reputation, err := repo.GetReputation(ctx, "https://evil.example/users/alice")
+
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+	assert.Nil(t, reputation)
+	mockDB.AssertExpectations(t)
+	mockQuery.AssertExpectations(t)
+}
+
 func TestGetReputationHistory(t *testing.T) {
 	logger := zap.NewNop()
 	mockDB := new(mocks.MockDB)
@@ -121,7 +175,7 @@ func TestGetReputationHistory(t *testing.T) {
 	// Set up expectations
 	mockDB.On("WithContext", mock.Anything).Return(mockDB).Maybe()
 	mockDB.On("Model", mock.AnythingOfType("*models.Reputation")).Return(mockQuery).Maybe()
-	mockQuery.On("Where", "PK", "=", "ACTOR#alice").Return(mockQuery).Maybe()
+	mockQuery.On("Where", "PK", "=", mock.MatchedBy(matchAliceReputationPK)).Return(mockQuery).Maybe()
 	mockQuery.On("Filter", "SK", "BEGINS_WITH", "REP#").Return(mockQuery).Maybe()
 	mockQuery.On("OrderBy", "SK", "DESC").Return(mockQuery).Maybe()
 	mockQuery.On("Limit", 10).Return(mockQuery).Maybe()
@@ -141,6 +195,50 @@ func TestGetReputationHistory(t *testing.T) {
 	mockQuery.AssertExpectations(t)
 }
 
+func TestGetReputationHistoryReturnsCanonicalRows(t *testing.T) {
+	logger := zap.NewNop()
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+
+	repo := NewUserRepository(mockDB, "test-table", logger)
+	ctx := context.Background()
+
+	calculatedAt := time.Now().UTC()
+	reputationData := fmt.Sprintf(`{
+		"actor_id": "https://remote.example/users/alice",
+		"instance_url": "https://example.com",
+		"total_score": 700,
+		"calculated_at": "%s"
+	}`, calculatedAt.Format(time.RFC3339))
+	mockRep := models.Reputation{
+		PK:             "ACTOR#https://remote.example/users/alice",
+		SK:             "REP#" + calculatedAt.Format(time.RFC3339),
+		ReputationData: reputationData,
+		TotalScore:     700,
+		CalculatedAt:   calculatedAt.Format(time.RFC3339),
+	}
+
+	mockDB.On("WithContext", mock.Anything).Return(mockDB).Maybe()
+	mockDB.On("Model", mock.AnythingOfType("*models.Reputation")).Return(mockQuery).Maybe()
+	mockQuery.On("Where", "PK", "=", "ACTOR#https://remote.example/users/alice").Return(mockQuery).Once()
+	mockQuery.On("Filter", "SK", "BEGINS_WITH", "REP#").Return(mockQuery).Once()
+	mockQuery.On("OrderBy", "SK", "DESC").Return(mockQuery).Once()
+	mockQuery.On("Limit", 1).Return(mockQuery).Once()
+	mockQuery.On("All", mock.AnythingOfType("*[]models.Reputation")).Run(func(args mock.Arguments) {
+		reps := args.Get(0).(*[]models.Reputation)
+		*reps = []models.Reputation{mockRep}
+	}).Return(nil).Once()
+
+	history, err := repo.GetReputationHistory(ctx, "https://remote.example/users/alice", 1)
+
+	assert.NoError(t, err)
+	assert.Len(t, history, 1)
+	assert.Equal(t, "https://remote.example/users/alice", history[0].ActorID)
+	assert.Equal(t, 700.0, history[0].TotalScore)
+	mockDB.AssertExpectations(t)
+	mockQuery.AssertExpectations(t)
+}
+
 func TestGetUserTrustScore(t *testing.T) {
 	logger := zap.NewNop()
 	mockDB := new(mocks.MockDB)
@@ -151,7 +249,7 @@ func TestGetUserTrustScore(t *testing.T) {
 
 	// Test data
 	calculatedAt := time.Now()
-	reputationData := `{"total_score": 825, "calculated_at": "` + calculatedAt.Format(time.RFC3339) + `"}`
+	reputationData := `{"actor_id":"https://example.com/users/alice","total_score": 825, "calculated_at": "` + calculatedAt.Format(time.RFC3339) + `"}`
 
 	mockRep := models.Reputation{
 		ReputationData: reputationData,
@@ -161,7 +259,7 @@ func TestGetUserTrustScore(t *testing.T) {
 	// Set up expectations
 	mockDB.On("WithContext", mock.Anything).Return(mockDB).Maybe()
 	mockDB.On("Model", mock.AnythingOfType("*models.Reputation")).Return(mockQuery).Maybe()
-	mockQuery.On("Where", "PK", "=", "ACTOR#alice").Return(mockQuery).Maybe()
+	mockQuery.On("Where", "PK", "=", "ACTOR#https://example.com/users/alice").Return(mockQuery).Maybe()
 	mockQuery.On("Filter", "SK", "BEGINS_WITH", "REP#").Return(mockQuery).Maybe()
 	mockQuery.On("OrderBy", "SK", "DESC").Return(mockQuery).Maybe()
 	mockQuery.On("Limit", 1).Return(mockQuery).Maybe()
@@ -191,14 +289,14 @@ func TestGetUserTrustScoreNoReputation(t *testing.T) {
 	// Set up expectations - no reputation found
 	mockDB.On("WithContext", mock.Anything).Return(mockDB).Maybe()
 	mockDB.On("Model", mock.AnythingOfType("*models.Reputation")).Return(mockQuery).Maybe()
-	mockQuery.On("Where", "PK", "=", "ACTOR#alice").Return(mockQuery).Maybe()
+	mockQuery.On("Where", "PK", "=", mock.MatchedBy(matchAliceReputationPK)).Return(mockQuery).Maybe()
 	mockQuery.On("Filter", "SK", "BEGINS_WITH", "REP#").Return(mockQuery).Maybe()
 	mockQuery.On("OrderBy", "SK", "DESC").Return(mockQuery).Maybe()
 	mockQuery.On("Limit", 1).Return(mockQuery).Maybe()
 	mockQuery.On("All", mock.AnythingOfType("*[]models.Reputation")).Run(func(args mock.Arguments) {
 		reps := args.Get(0).(*[]models.Reputation)
 		*reps = []models.Reputation{} // Empty
-	}).Return(nil).Once()
+	}).Return(nil)
 
 	// Test
 	score, err := repo.GetUserTrustScore(ctx, "https://example.com/users/alice")

--- a/pkg/storage/repositories/user_repository.go
+++ b/pkg/storage/repositories/user_repository.go
@@ -934,99 +934,127 @@ func (r *UserRepository) GetReputation(ctx context.Context, actorID string) (*st
 		return nil, ErrorHandler.HandleGetError(storage.ErrInvalidInput, "reputation", actorID)
 	}
 
-	username := extractUsernameFromActorID(actorID)
-	if err := common.ValidateEntityID(username, "user"); err != nil {
+	pkCandidates, err := models.ReputationActorPartitionKeyCandidates(actorID)
+	if err != nil || len(pkCandidates) == 0 {
 		return nil, ErrorHandler.HandleGetError(storage.ErrInvalidInput, "reputation", actorID)
 	}
 
-	// Build query for latest reputation
-	pk := fmt.Sprintf("ACTOR#%s", username)
-	skPrefix := "REP#"
+	var lastErr error
+	for _, pk := range pkCandidates {
+		reputation, found, err := r.getLatestReputationByPK(ctx, actorID, pk)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if found {
+			return reputation, nil
+		}
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, ErrorHandler.HandleGetError(storage.ErrNotFound, "reputation", actorID)
+}
 
-	// Query for latest reputation (most recent first)
+func (r *UserRepository) getLatestReputationByPK(ctx context.Context, actorID, pk string) (*storage.Reputation, bool, error) {
 	var reputations []models.Reputation
 	err := r.GetDB().WithContext(ctx).
 		Model(&models.Reputation{}).
 		Where("PK", "=", pk).
-		Filter("SK", "BEGINS_WITH", skPrefix).
-		OrderBy("SK", "DESC"). // Descending order to get latest first
+		Filter("SK", "BEGINS_WITH", "REP#").
+		OrderBy("SK", "DESC").
 		Limit(1).
 		All(&reputations)
-
 	if err != nil {
 		r.logger.Error("failed to query reputation", zap.Error(err))
-		return nil, ErrorHandler.HandleQueryError(err, "reputation", "query")
+		return nil, false, ErrorHandler.HandleQueryError(err, "reputation", "query")
 	}
-
-	// No reputation found
 	if err := common.ValidateSliceNotEmpty("reputations", reputations); err != nil {
-		return nil, ErrorHandler.HandleGetError(storage.ErrNotFound, "reputation", actorID)
+		return nil, false, nil
 	}
-
 	// Convert to storage.Reputation
 	repInterface, err := reputations[0].ToStorageReputation()
 	if err != nil {
 		r.logger.Error("failed to unmarshal reputation", zap.Error(err))
-		return nil, ErrorHandler.HandleQueryError(err, "reputation", "unmarshal")
+		return nil, false, ErrorHandler.HandleQueryError(err, "reputation", "unmarshal")
 	}
 
 	// Convert interface back to storage.Reputation
 	var reputation storage.Reputation
 	repJSON, _ := json.Marshal(repInterface)
 	if err := json.Unmarshal(repJSON, &reputation); err != nil {
-		return nil, ErrorHandler.HandleQueryError(err, "reputation", "convert")
+		return nil, false, ErrorHandler.HandleQueryError(err, "reputation", "convert")
+	}
+	if !models.ReputationActorIDsMatch(reputation.ActorID, actorID) {
+		return nil, false, nil
 	}
 
-	return &reputation, nil
+	return &reputation, true, nil
 }
 
 // GetReputationHistory retrieves reputation history for an actor
 func (r *UserRepository) GetReputationHistory(ctx context.Context, actorID string, limit int) ([]*storage.Reputation, error) {
-	// Extract username from actorID
-	username := extractUsernameFromActorID(actorID)
-	if err := common.ValidateEntityID(username, "user"); err != nil {
+	pkCandidates, err := models.ReputationActorPartitionKeyCandidates(actorID)
+	if err != nil || len(pkCandidates) == 0 {
 		return []*storage.Reputation{}, nil // Return empty slice when invalid actorID
 	}
 
-	// Build query
-	pk := fmt.Sprintf("ACTOR#%s", username)
 	skPrefix := "REP#"
 
-	// Query for reputation history
-	var reputations []models.Reputation
-	query := r.GetDB().WithContext(ctx).
-		Model(&models.Reputation{}).
-		Where("PK", "=", pk).
-		Filter("SK", "BEGINS_WITH", skPrefix).
-		OrderBy("SK", "DESC") // Descending order (most recent first)
+	history := make([]*storage.Reputation, 0)
+	seen := make(map[string]struct{})
+	for _, pk := range pkCandidates {
+		remaining := limit - len(history)
+		if limit <= 0 {
+			remaining = 0
+		} else if remaining <= 0 {
+			break
+		}
 
-	if limit > 0 {
-		query = query.Limit(limit)
-	}
+		var reputations []models.Reputation
+		query := r.GetDB().WithContext(ctx).
+			Model(&models.Reputation{}).
+			Where("PK", "=", pk).
+			Filter("SK", "BEGINS_WITH", skPrefix).
+			OrderBy("SK", "DESC") // Descending order (most recent first)
 
-	err := query.All(&reputations)
-	if err != nil {
-		r.logger.Error("failed to query reputation history", zap.Error(err))
-		return nil, ErrorHandler.HandleQueryError(err, "reputation", "history")
-	}
+		if remaining > 0 {
+			query = query.Limit(remaining)
+		}
 
-	// Convert to storage.Reputation slice
-	history := make([]*storage.Reputation, 0, len(reputations))
-	for _, rep := range reputations {
-		repInterface, err := rep.ToStorageReputation()
+		err := query.All(&reputations)
 		if err != nil {
-			r.logger.Warn("Failed to unmarshal reputation data", zap.Error(err))
-			continue
+			r.logger.Error("failed to query reputation history", zap.Error(err))
+			return nil, ErrorHandler.HandleQueryError(err, "reputation", "history")
 		}
 
-		// Convert interface back to storage.Reputation
-		var reputation storage.Reputation
-		repJSON, _ := json.Marshal(repInterface)
-		if err := json.Unmarshal(repJSON, &reputation); err != nil {
-			r.logger.Warn("Failed to convert reputation", zap.Error(err))
-			continue
+		for _, rep := range reputations {
+			identity := rep.PK + "|" + rep.SK
+			if _, ok := seen[identity]; ok {
+				continue
+			}
+			seen[identity] = struct{}{}
+
+			repInterface, err := rep.ToStorageReputation()
+			if err != nil {
+				r.logger.Warn("Failed to unmarshal reputation data", zap.Error(err))
+				continue
+			}
+
+			var reputation storage.Reputation
+			repJSON, _ := json.Marshal(repInterface)
+			if err := json.Unmarshal(repJSON, &reputation); err != nil {
+				r.logger.Warn("Failed to convert reputation", zap.Error(err))
+				continue
+			}
+			if !models.ReputationActorIDsMatch(reputation.ActorID, actorID) {
+				continue
+			}
+			history = append(history, &reputation)
+			if limit > 0 && len(history) >= limit {
+				break
+			}
 		}
-		history = append(history, &reputation)
 	}
 
 	return history, nil

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -1252,30 +1252,37 @@ type ScheduledStatus struct {
 
 // Reputation represents reputation score for an actor
 type Reputation struct {
-	ActorID           string    `json:"actor_id"`
-	InstanceURL       string    `json:"instance_url"`
-	Score             float64   `json:"score"`
-	TotalScore        float64   `json:"total_score"`
-	TrustScore        float64   `json:"trust_score"`
-	ActivityScore     float64   `json:"activity_score"`
-	ModerationScore   float64   `json:"moderation_score"`
-	CommunityScore    float64   `json:"community_score"`
-	Timestamp         time.Time `json:"timestamp"`
-	CalculatedAt      time.Time `json:"calculated_at"`
-	Evidence          []string  `json:"evidence,omitempty"`
-	Category          string    `json:"category"`
-	Version           int       `json:"version"`
-	TotalPosts        int       `json:"total_posts"`
-	TotalFollowers    int       `json:"total_followers"`
-	AccountAge        int       `json:"account_age"`
-	VouchCount        int       `json:"vouch_count"`
-	TrustingActors    []string  `json:"trusting_actors,omitempty"`
-	AverageTrustScore float64   `json:"average_trust_score"`
-	ReportsReceived   int       `json:"reports_received"`
-	ReportsUpheld     int       `json:"reports_upheld"`
-	FalseReports      int       `json:"false_reports"`
-	Signature         string    `json:"signature,omitempty"`
-	PublicKey         string    `json:"public_key,omitempty"`
+	ActorID     string `json:"actor_id"`
+	InstanceURL string `json:"instance_url"`
+
+	// ForceCanonicalActorKey is a write-only storage hint for imported or
+	// otherwise remote reputation rows. It is intentionally omitted from JSON
+	// and persisted reputation payloads; it only affects PK construction so
+	// remote same-username actors cannot collapse into legacy ACTOR#<username>
+	// partitions.
+	ForceCanonicalActorKey bool      `json:"-"`
+	Score                  float64   `json:"score"`
+	TotalScore             float64   `json:"total_score"`
+	TrustScore             float64   `json:"trust_score"`
+	ActivityScore          float64   `json:"activity_score"`
+	ModerationScore        float64   `json:"moderation_score"`
+	CommunityScore         float64   `json:"community_score"`
+	Timestamp              time.Time `json:"timestamp"`
+	CalculatedAt           time.Time `json:"calculated_at"`
+	Evidence               []string  `json:"evidence,omitempty"`
+	Category               string    `json:"category"`
+	Version                int       `json:"version"`
+	TotalPosts             int       `json:"total_posts"`
+	TotalFollowers         int       `json:"total_followers"`
+	AccountAge             int       `json:"account_age"`
+	VouchCount             int       `json:"vouch_count"`
+	TrustingActors         []string  `json:"trusting_actors,omitempty"`
+	AverageTrustScore      float64   `json:"average_trust_score"`
+	ReportsReceived        int       `json:"reports_received"`
+	ReportsUpheld          int       `json:"reports_upheld"`
+	FalseReports           int       `json:"false_reports"`
+	Signature              string    `json:"signature,omitempty"`
+	PublicKey              string    `json:"public_key,omitempty"`
 }
 
 // Report represents a moderation report


### PR DESCRIPTION
## Summary
- Enforce existing-conversation DM total-send rate limits at the authoritative write path, including retry-safe single consumption.
- Bind reputation storage and reads to canonical ActivityPub actor URIs for remote actors while preserving local legacy `ACTOR#<username>` rows.
- Preserve remote domains in account/GraphQL actor lookups so remote actor identifiers cannot fall back to same-name local accounts.

## Finding map
- `lesser.csv:11` — audited as already covered on main: community note rate limiting uses the canonical `https://<domain>/users/<username>` author ID and exact `AUTHOR#<authorID>#NOTES` keys.
- `lesser.csv:5` — audited as already covered on main: inbound direct replay detection skips repeated remote direct creates before conversation metadata writes.
- `lesser.csv:6` — audited as already covered on main: forwarded hosts are normalized and inbound signature host checks require the instance domain.
- `lesser.csv:8` — fixed here: `SendMessage` now consumes `dm_send_total` before status/conversation writes and only once across version-conflict retries.
- `lesser.csv:9` — fixed here: remote reputation rows use `ACTOR#<canonical actor URI>`; legacy username fallback rows are only trusted when stored `ActorID` canonically matches the requested actor.
- `lesser.csv:13` — audited as already covered on main: notification fallback actor IDs reject unsafe URL/userinfo/query/fragment/control/markup input.
- `lesser.csv:14` — fixed here: account repository URL normalization preserves remote domains, and GraphQL notification actor loading no longer strips remote actor IDs/handles into local lookups.

## Federation-trust audit
- No HTTP Signature signing or verification paths are weakened.
- Actor identity handling is stricter: remote actor reputation calculation requires a cached remote actor whose canonical ID matches the requested actor, and remote GraphQL/account lookups keep the origin domain boundary.
- Inbound replay and forwarded-host protections were verified against existing regression coverage; this PR does not relax inbox/outbox delivery semantics.
- DM rate limiting now happens before the write transition for both new and existing conversation sends.

## Schema-integrity audit
- No table, GSI, or TableTheory tag shape changes.
- Reputation partition-key behavior is additive for remote actors: remote writes use the canonical actor URI key to avoid same-username cross-domain collisions.
- Local reputation writes keep legacy `ACTOR#<username>` keys when the reputation instance matches the actor host.
- Reads try canonical keys first, then legacy fallback keys, and filter fallback data by canonical stored `ActorID` match before returning it.

## API compatibility
- No REST, GraphQL, or ActivityPub response shapes change.
- Behavior is a semantic tightening for rate limits and actor identity boundaries only.

## Validation
- `gofmt -l .`
- `go test ./pkg/services/conversations -run 'TestService_SendMessage_ConsumesTotalRateLimit|TestService_SendDirectMessage_ConsumesRateLimitBeforeWrites'`
- `go test ./pkg/storage/models -run 'TestReputationActorPartitionKey'`
- `go test ./pkg/storage/repositories -run 'TestGetReputation|TestGetUserTrustScore|TestUserRepository_GetReputation|TestAccountRepository_CanonicalUsername|TestAccountRepository_UserAndDomainBranchCoverage'`
- `go test ./pkg/reputation -run 'TestValidateActorID|TestService_Round20_GetReputation|TestService_GetReputation_RemoteActorDoesNotUseLocalUsername'`
- `go test ./graph -run 'Test.*Notification|Test.*Actor|Test.*ExactIdentity|TestNotificationActorLocalLookupPreservesRemoteDomainBoundary'`
- `go test ./cmd/api/handlers -run 'TestReputationHandlersRound12|TestNotes|TestFallbackNotificationActor|TestInbox'`
- `go test ./cmd/inbox/internal/routing -run 'TestInboxHandler_M14_ReplayedRemoteDirectDoesNotOverwriteConversationMetadata|Test.*Signature|Test.*Forwarded|Test.*Host'`
- `go test ./...`
- `go vet ./...`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci` (pkg 90.008%, cmd 90.086%)

Closes #962


## Arch review follow-up
- Addressed Arch blocker from https://github.com/equaltoai/lesser/pull/966#issuecomment-4454597230.
- Imported portable reputation writes now pass a write-only canonical-key hint when the imported actor is not local to the storing lesser instance, so issuer-host-matching remote actors do not preserve `ACTOR#<username>` legacy partitions.
- Added regression coverage for imported portable reputation rows from `remote1.example/users/alice` and `remote2.example/users/alice` producing distinct `ACTOR#https://...` partitions and never `ACTOR#alice`.

## Additional validation after Arch blocker fix
- `go test ./pkg/storage/models -run 'TestReputationActorPartitionKey'`
- `go test ./pkg/reputation -run 'TestImportReputationForcesCanonicalActorPartitionForRemoteSameNameActors|TestService_Round20_GetReputation|TestService_GetReputation_RemoteActorDoesNotUseLocalUsername|TestValidateActorID'`
- `go test ./pkg/reputation ./pkg/storage/models ./pkg/storage/repositories`
- `go test ./...`
- `go vet ./...`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci` (overall 87.667%, pkg 90.008%, cmd 90.086%)

## Arch second re-review follow-up
- Addressed second Arch blocker from https://github.com/equaltoai/lesser/pull/966#issuecomment-4454819386.
- `ImportReputation` now rejects documents whose outer `PortableReputation.Actor` and inner `Reputation.ActorID` do not match canonically before any reputation storage write.
- The import path now derives canonical-key options from the actual storage actor (`pr.Reputation.ActorID`) rather than the outer document actor.
- Added regression coverage proving a local outer actor cannot route a remote inner reputation actor into `ACTOR#<username>`.

## Additional validation after second Arch blocker fix
- `go test ./pkg/reputation -run 'TestImportReputationForcesCanonicalActorPartitionForRemoteSameNameActors|TestImportReputationRejectsMismatchedOuterAndInnerActors|TestService_Round20_GetReputation|TestService_GetReputation_RemoteActorDoesNotUseLocalUsername|TestValidateActorID'`
- `go test ./pkg/storage/models -run 'TestReputationActorPartitionKey'`
- `go test ./pkg/reputation ./pkg/storage/models ./pkg/storage/repositories`
- `gofmt -l .`
- `go test ./...`
- `go vet ./...`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci` (overall 87.667%, pkg 90.008%, cmd 90.084%)