### PR TITLE
fix(storage): make lambda table clients timeout aware

### DIFF
--- a/pkg/storage/theorydb/base.go
+++ b/pkg/storage/theorydb/base.go
@@ -2,22 +2,10 @@ package theorydb
 
 import (
 	"context"
-	"os"
-	"strings"
 	"time"
 
-	"github.com/theory-cloud/tabletheory"
 	"github.com/theory-cloud/tabletheory/pkg/core"
-	"github.com/theory-cloud/tabletheory/pkg/session"
 )
-
-var newDynamormClient = func(cfg session.Config) (core.DB, error) {
-	db, err := tabletheory.New(cfg)
-	if err != nil {
-		return nil, err
-	}
-	return db, nil
-}
 
 // BaseModel provides common fields for all DynamORM models
 type BaseModel struct {
@@ -75,34 +63,17 @@ func (r *BaseRepository) GetDB() core.DB {
 
 // NewLambdaOptimizedClient creates a new DynamORM client optimized for Lambda functions
 // This should be used in the init() function of Lambda handlers to ensure connection reuse
-func NewLambdaOptimizedClient(_ context.Context, region string) (core.DB, error) {
-	trimmed := strings.TrimSpace(region)
-	if trimmed == "" {
-		if envRegion := strings.TrimSpace(os.Getenv("AWS_REGION")); envRegion != "" {
-			trimmed = envRegion
-		} else if envDefault := strings.TrimSpace(os.Getenv("AWS_DEFAULT_REGION")); envDefault != "" {
-			trimmed = envDefault
-		} else {
-			trimmed = "us-east-1"
-		}
-	}
-
-	config := session.Config{
-		Region: trimmed,
-	}
-
-	// Use the standard client creation method with the latest DynamORM version
-	client, err := newDynamormClient(config)
+func NewLambdaOptimizedClient(ctx context.Context, region string) (core.DB, error) {
+	lambdaClient, err := newConfiguredLambdaOptimizedClient(lambdaOptimizedClientOptionsFor(region))
 	if err != nil {
 		return nil, err
 	}
 
-	if err := registerDefaultTypeConverters(client); err != nil {
-		return nil, err
+	if ctx != nil {
+		return lambdaClient.WithLambdaTimeout(ctx), nil
 	}
 
-	// Return the client as a core.DB interface
-	return client, nil
+	return lambdaClient, nil
 }
 
 // PreRegisterModels pre-registers models with the DynamORM client to reduce cold start time

--- a/pkg/storage/theorydb/base_test.go
+++ b/pkg/storage/theorydb/base_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	stdErrors "errors"
 	"testing"
+	"time"
 
+	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/theory-cloud/tabletheory"
 	"github.com/theory-cloud/tabletheory/pkg/core"
 	"github.com/theory-cloud/tabletheory/pkg/session"
 )
@@ -40,13 +43,25 @@ func TestBaseModel_Hooks(t *testing.T) {
 }
 
 func TestNewLambdaOptimizedClient_RegionSelection(t *testing.T) {
-	orig := newDynamormClient
-	t.Cleanup(func() { newDynamormClient = orig })
+	origGetConfig := getAppConfig
+	origLambdaClient := newDynamormLambdaOptimizedWithEnv
+	origStandardClient := newDynamormStandardClient
+	t.Cleanup(func() {
+		getAppConfig = origGetConfig
+		newDynamormLambdaOptimizedWithEnv = origLambdaClient
+		newDynamormStandardClient = origStandardClient
+	})
 
-	var gotCfg session.Config
-	newDynamormClient = func(cfg session.Config) (core.DB, error) {
-		gotCfg = cfg
-		return fakeDB{}, nil
+	getAppConfig = func() *config.Config { return &config.Config{} }
+	newDynamormStandardClient = func(cfg session.Config) (core.DB, error) {
+		t.Fatalf("NewLambdaOptimizedClient must not create a standard TableTheory DB: %#v", cfg)
+		return nil, nil
+	}
+
+	var gotOpts lambdaOptimizedClientOptions
+	newDynamormLambdaOptimizedWithEnv = func(opts lambdaOptimizedClientOptions) (*tabletheory.LambdaDB, error) {
+		gotOpts = opts
+		return tabletheory.NewLambdaOptimized()
 	}
 
 	t.Run("explicit region wins", func(t *testing.T) {
@@ -55,7 +70,7 @@ func TestNewLambdaOptimizedClient_RegionSelection(t *testing.T) {
 
 		_, err := NewLambdaOptimizedClient(context.Background(), " us-west-2 ")
 		require.NoError(t, err)
-		assert.Equal(t, "us-west-2", gotCfg.Region)
+		assert.Equal(t, "us-west-2", gotOpts.Region)
 	})
 
 	t.Run("AWS_REGION fallback", func(t *testing.T) {
@@ -64,7 +79,7 @@ func TestNewLambdaOptimizedClient_RegionSelection(t *testing.T) {
 
 		_, err := NewLambdaOptimizedClient(context.Background(), "")
 		require.NoError(t, err)
-		assert.Equal(t, "eu-central-1", gotCfg.Region)
+		assert.Equal(t, "eu-central-1", gotOpts.Region)
 	})
 
 	t.Run("AWS_DEFAULT_REGION fallback", func(t *testing.T) {
@@ -73,7 +88,7 @@ func TestNewLambdaOptimizedClient_RegionSelection(t *testing.T) {
 
 		_, err := NewLambdaOptimizedClient(context.Background(), "")
 		require.NoError(t, err)
-		assert.Equal(t, "ap-southeast-1", gotCfg.Region)
+		assert.Equal(t, "ap-southeast-1", gotOpts.Region)
 	})
 
 	t.Run("default when env empty", func(t *testing.T) {
@@ -82,12 +97,12 @@ func TestNewLambdaOptimizedClient_RegionSelection(t *testing.T) {
 
 		_, err := NewLambdaOptimizedClient(context.Background(), "")
 		require.NoError(t, err)
-		assert.Equal(t, "us-east-1", gotCfg.Region)
+		assert.Equal(t, "us-east-1", gotOpts.Region)
 	})
 
 	t.Run("propagates init errors", func(t *testing.T) {
-		newDynamormClient = func(cfg session.Config) (core.DB, error) {
-			gotCfg = cfg
+		newDynamormLambdaOptimizedWithEnv = func(opts lambdaOptimizedClientOptions) (*tabletheory.LambdaDB, error) {
+			gotOpts = opts
 			return nil, stdErrors.New("boom")
 		}
 
@@ -96,6 +111,56 @@ func TestNewLambdaOptimizedClient_RegionSelection(t *testing.T) {
 
 		_, err := NewLambdaOptimizedClient(context.Background(), "")
 		require.Error(t, err)
+		assert.Equal(t, "us-east-1", gotOpts.Region)
+	})
+}
+
+func TestNewLambdaOptimizedClient_LocalEndpointBehavior(t *testing.T) {
+	origGetConfig := getAppConfig
+	origLambdaClient := newDynamormLambdaOptimizedWithEnv
+	t.Cleanup(func() {
+		getAppConfig = origGetConfig
+		newDynamormLambdaOptimizedWithEnv = origLambdaClient
+	})
+
+	getAppConfig = func() *config.Config {
+		return &config.Config{DynamoDBEndpoint: " http://localhost:8000 "}
+	}
+
+	var gotOpts lambdaOptimizedClientOptions
+	newDynamormLambdaOptimizedWithEnv = func(opts lambdaOptimizedClientOptions) (*tabletheory.LambdaDB, error) {
+		gotOpts = opts
+		return tabletheory.NewLambdaOptimized()
+	}
+
+	db, err := NewLambdaOptimizedClient(nil, "us-west-2")
+	require.NoError(t, err)
+	require.IsType(t, &tabletheory.LambdaDB{}, db)
+	assert.Equal(t, "us-west-2", gotOpts.Region)
+	assert.Equal(t, "http://localhost:8000", gotOpts.Endpoint)
+}
+
+func TestNewLambdaOptimizedClient_ContextHandling(t *testing.T) {
+	t.Run("nil context returns buffered lambda client without deadline", func(t *testing.T) {
+		db, err := NewLambdaOptimizedClient(nil, "us-east-1")
+		require.NoError(t, err)
+		require.IsType(t, &tabletheory.LambdaDB{}, db)
+
+		assert.Equal(t, defaultTimeoutBuffer, lambdaTimeoutBufferOf(t, db))
+		assert.True(t, lambdaDeadlineOf(t, db).IsZero())
+	})
+
+	t.Run("deadline context applies lambda timeout", func(t *testing.T) {
+		deadline := time.Now().Add(30 * time.Second).Round(0)
+		ctx, cancel := context.WithDeadline(context.Background(), deadline)
+		defer cancel()
+
+		db, err := NewLambdaOptimizedClient(ctx, "us-east-1")
+		require.NoError(t, err)
+		require.IsType(t, &tabletheory.LambdaDB{}, db)
+
+		assert.Equal(t, defaultTimeoutBuffer, lambdaTimeoutBufferOf(t, db))
+		assert.Equal(t, deadline, lambdaDeadlineOf(t, db))
 	})
 }
 

--- a/pkg/storage/theorydb/client.go
+++ b/pkg/storage/theorydb/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -31,10 +32,114 @@ var (
 	getAppConfig               = config.Get
 	newDynamormStandardClient  = func(cfg session.Config) (core.DB, error) { return tabletheory.New(cfg) }
 	newDynamormLambdaOptimized = tabletheory.NewLambdaOptimized
+
+	lambdaClientEnvMu                 sync.Mutex
+	newDynamormLambdaOptimizedWithEnv = func(opts lambdaOptimizedClientOptions) (*tabletheory.LambdaDB, error) {
+		lambdaClientEnvMu.Lock()
+		defer lambdaClientEnvMu.Unlock()
+
+		return withLambdaOptimizedEnvironment(opts, newDynamormLambdaOptimized)
+	}
 )
 
 type typeConverterRegistrar interface {
 	RegisterTypeConverter(reflect.Type, tabletypes.CustomConverter) error
+}
+
+type lambdaOptimizedClientOptions struct {
+	Region   string
+	Endpoint string
+}
+
+func lambdaOptimizedClientOptionsFor(region string) lambdaOptimizedClientOptions {
+	opts := lambdaOptimizedClientOptions{
+		Region: selectLambdaOptimizedRegion(region),
+	}
+
+	if cfg := getAppConfig(); cfg != nil {
+		opts.Endpoint = strings.TrimSpace(cfg.DynamoDBEndpoint)
+	}
+
+	return opts
+}
+
+func selectLambdaOptimizedRegion(region string) string {
+	if trimmed := strings.TrimSpace(region); trimmed != "" {
+		return trimmed
+	}
+	if envRegion := strings.TrimSpace(os.Getenv("AWS_REGION")); envRegion != "" {
+		return envRegion
+	}
+	if envDefault := strings.TrimSpace(os.Getenv("AWS_DEFAULT_REGION")); envDefault != "" {
+		return envDefault
+	}
+	return "us-east-1"
+}
+
+func withLambdaOptimizedEnvironment(
+	opts lambdaOptimizedClientOptions,
+	factory func() (*tabletheory.LambdaDB, error),
+) (*tabletheory.LambdaDB, error) {
+	if factory == nil {
+		return nil, fmt.Errorf("lambda-optimized DynamORM factory is nil")
+	}
+
+	// TableTheory's Lambda helper intentionally reads AWS runtime settings from
+	// the environment. Keep lesser's explicit-region and local-endpoint behavior
+	// by bridging them through the AWS SDK environment variables only while the
+	// Lambda-optimized client is constructed.
+	restoreRegion := setTemporaryEnv("AWS_REGION", opts.Region)
+	defer restoreRegion()
+
+	restoreEndpoint := func() {}
+	if opts.Endpoint != "" {
+		ensureLocalDynamoDBCredentials()
+		restoreEndpoint = setTemporaryEnv("AWS_ENDPOINT_URL_DYNAMODB", opts.Endpoint)
+	}
+	defer restoreEndpoint()
+
+	return factory()
+}
+
+func setTemporaryEnv(key, value string) func() {
+	previous, existed := os.LookupEnv(key)
+	_ = os.Setenv(key, value)
+
+	return func() {
+		if existed {
+			_ = os.Setenv(key, previous)
+			return
+		}
+		_ = os.Unsetenv(key)
+	}
+}
+
+func ensureLocalDynamoDBCredentials() {
+	if strings.TrimSpace(os.Getenv("AWS_ACCESS_KEY_ID")) == "" {
+		_ = os.Setenv("AWS_ACCESS_KEY_ID", "fakeMyKeyId")
+	}
+	if strings.TrimSpace(os.Getenv("AWS_SECRET_ACCESS_KEY")) == "" {
+		_ = os.Setenv("AWS_SECRET_ACCESS_KEY", "fakeSecretAccessKey")
+	}
+}
+
+func newConfiguredLambdaOptimizedClient(opts lambdaOptimizedClientOptions) (*tabletheory.LambdaDB, error) {
+	lambdaClient, err := newDynamormLambdaOptimizedWithEnv(opts)
+	if err != nil {
+		return nil, err
+	}
+	if lambdaClient == nil {
+		return nil, fmt.Errorf("initialize Lambda-optimized DynamORM: nil client")
+	}
+
+	lambdaClient = lambdaClient.WithLambdaTimeoutConfig(tabletheory.LambdaTimeoutConfig{
+		Buffer: defaultTimeoutBuffer,
+	})
+	if err := registerDefaultTypeConverters(lambdaClient); err != nil {
+		return nil, err
+	}
+
+	return lambdaClient, nil
 }
 
 func registerDefaultTypeConverters(db core.DB) error {
@@ -119,25 +224,10 @@ func getLambdaOptimizedClient() (*tabletheory.LambdaDB, error) {
 
 		// Create Lambda-optimized client
 		var err error
-		lambdaDB, err = newDynamormLambdaOptimized()
+		lambdaDB, err = newConfiguredLambdaOptimizedClient(lambdaOptimizedClientOptionsFor(""))
 		if err != nil {
 			clientErr = err
 			zap.L().Error("failed to initialize DynamORM", zap.Error(err))
-			return
-		}
-		if lambdaDB == nil {
-			clientErr = fmt.Errorf("initialize Lambda-optimized DynamORM: nil client")
-			zap.L().Error("failed to initialize DynamORM", zap.Error(clientErr))
-			return
-		}
-
-		// Store the standard client interface for compatibility
-		lambdaDB = lambdaDB.WithLambdaTimeoutConfig(tabletheory.LambdaTimeoutConfig{
-			Buffer: defaultTimeoutBuffer,
-		})
-		if err := registerDefaultTypeConverters(lambdaDB); err != nil {
-			clientErr = err
-			zap.L().Error("failed to register type converters", zap.Error(err))
 			return
 		}
 		client = lambdaDB

--- a/pkg/storage/theorydb/client_test.go
+++ b/pkg/storage/theorydb/client_test.go
@@ -2,6 +2,7 @@ package theorydb
 
 import (
 	"context"
+	stdErrors "errors"
 	"os"
 	"reflect"
 	"sync"
@@ -12,6 +13,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/theory-cloud/tabletheory"
 	"github.com/theory-cloud/tabletheory/pkg/core"
 	"github.com/theory-cloud/tabletheory/pkg/session"
 	pkgtypes "github.com/theory-cloud/tabletheory/pkg/types"
@@ -158,6 +160,61 @@ func TestGetLambdaClientNilContextReturnsBufferedClient(t *testing.T) {
 	assert.True(t, lambdaDeadlineOf(t, db).IsZero())
 }
 
+func TestNewLambdaOptimizedClient_RegistersDefaultTypeConverters(t *testing.T) {
+	db, err := NewLambdaOptimizedClient(nil, "us-east-1")
+	require.NoError(t, err)
+	require.NotNil(t, db)
+
+	assertDefaultTypeConvertersRegistered(t, db)
+}
+
+func TestNewLambdaOptimizedClient_TimeoutSurvivesOperationBoundary(t *testing.T) {
+	deadline := time.Now().Add(30 * time.Second).Round(0)
+	lambdaCtx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+
+	db, err := NewLambdaOptimizedClient(lambdaCtx, "us-east-1")
+	require.NoError(t, err)
+	require.NotNil(t, db)
+
+	operationCtx := context.WithValue(context.Background(), testContextKey{}, "repository-operation")
+	query := db.WithContext(operationCtx).Model(&lambdaTimeoutProbeModel{
+		PK: "PROBE#1",
+		SK: "META",
+	})
+
+	assert.Equal(t, defaultTimeoutBuffer, queryExecutorLambdaTimeoutBufferOf(t, query))
+	assert.Equal(t, deadline, queryExecutorLambdaDeadlineOf(t, query))
+}
+
+func TestWithLambdaOptimizedEnvironmentAppliesLocalEndpoint(t *testing.T) {
+	errSentinel := stdErrors.New("stop after env inspection")
+	t.Setenv("AWS_REGION", "original-region")
+	t.Setenv("AWS_ENDPOINT_URL_DYNAMODB", "")
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+
+	_, err := withLambdaOptimizedEnvironment(
+		lambdaOptimizedClientOptions{
+			Region:   "us-west-2",
+			Endpoint: "http://localhost:8000",
+		},
+		func() (*tabletheory.LambdaDB, error) {
+			assert.Equal(t, "us-west-2", os.Getenv("AWS_REGION"))
+			assert.Equal(t, "http://localhost:8000", os.Getenv("AWS_ENDPOINT_URL_DYNAMODB"))
+			assert.Equal(t, "fakeMyKeyId", os.Getenv("AWS_ACCESS_KEY_ID"))
+			assert.Equal(t, "fakeSecretAccessKey", os.Getenv("AWS_SECRET_ACCESS_KEY"))
+			return nil, errSentinel
+		},
+	)
+
+	require.ErrorIs(t, err, errSentinel)
+	assert.Equal(t, "original-region", os.Getenv("AWS_REGION"))
+	assert.Empty(t, os.Getenv("AWS_ENDPOINT_URL_DYNAMODB"))
+	assert.Equal(t, "fakeMyKeyId", os.Getenv("AWS_ACCESS_KEY_ID"))
+	assert.Equal(t, "fakeSecretAccessKey", os.Getenv("AWS_SECRET_ACCESS_KEY"))
+}
+
 func lambdaTimeoutBufferOf(t *testing.T, db core.DB) time.Duration {
 	t.Helper()
 
@@ -195,6 +252,68 @@ func tableTheoryDBField(t *testing.T, db core.DB, name string) reflect.Value {
 	return field
 }
 
+func assertDefaultTypeConvertersRegistered(t *testing.T, db core.DB) {
+	t.Helper()
+
+	field := tableTheoryDBField(t, db, "converter")
+	converter := reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Interface()
+
+	hasCustomConverter, ok := converter.(interface{ HasCustomConverter(reflect.Type) bool })
+	require.True(t, ok, "expected TableTheory converter to expose HasCustomConverter")
+
+	for _, typ := range []reflect.Type{
+		mapStringAnyType,
+		sliceAnyType,
+		activityPubNoteType,
+		activityPubContextValueType,
+		agentsCapabilitiesType,
+	} {
+		assert.True(t, hasCustomConverter.HasCustomConverter(typ), "expected custom converter for %s", typ)
+	}
+}
+
+func queryExecutorLambdaTimeoutBufferOf(t *testing.T, query core.Query) time.Duration {
+	t.Helper()
+
+	field := queryExecutorDBField(t, query, "lambdaTimeoutBuffer")
+	return time.Duration(field.Int())
+}
+
+func queryExecutorLambdaDeadlineOf(t *testing.T, query core.Query) time.Time {
+	t.Helper()
+
+	field := queryExecutorDBField(t, query, "lambdaDeadline")
+	return reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Interface().(time.Time)
+}
+
+func queryExecutorDBField(t *testing.T, query core.Query, name string) reflect.Value {
+	t.Helper()
+
+	value := reflect.ValueOf(query)
+	require.Equal(t, reflect.Ptr, value.Kind())
+	elem := value.Elem()
+
+	executorField := elem.FieldByName("executor")
+	require.True(t, executorField.IsValid(), "expected TableTheory query to expose executor")
+
+	executorValue := reflect.NewAt(executorField.Type(), unsafe.Pointer(executorField.UnsafeAddr())).Elem()
+	require.False(t, executorValue.IsNil(), "expected TableTheory query executor")
+
+	executor := reflect.ValueOf(executorValue.Interface())
+	require.Equal(t, reflect.Ptr, executor.Kind())
+	executorElem := executor.Elem()
+
+	dbField := executorElem.FieldByName("db")
+	require.True(t, dbField.IsValid(), "expected TableTheory query executor DB")
+	require.Equal(t, reflect.Ptr, dbField.Kind())
+	require.False(t, dbField.IsNil())
+
+	dbValue := reflect.NewAt(dbField.Type(), unsafe.Pointer(dbField.UnsafeAddr())).Elem()
+	field := dbValue.Elem().FieldByName(name)
+	require.True(t, field.IsValid(), "expected query executor DB to expose %s", name)
+	return field
+}
+
 type recordingRegistrarDB struct {
 	fakeDB
 	registered []reflect.Type
@@ -204,3 +323,12 @@ func (db *recordingRegistrarDB) RegisterTypeConverter(typ reflect.Type, _ pkgtyp
 	db.registered = append(db.registered, typ)
 	return nil
 }
+
+type testContextKey struct{}
+
+type lambdaTimeoutProbeModel struct {
+	PK string `theorydb:"pk,attr:PK"`
+	SK string `theorydb:"sk,attr:SK"`
+}
+
+func (*lambdaTimeoutProbeModel) TableName() string { return "lambda_timeout_probe" }


### PR DESCRIPTION
## Milestone
Framework Leverage Phase 1a — TableTheory Lambda client semantics

Closes #969.

## Classification
framework-consumption / operational-reliability / test-coverage

## Surfaces affected
- `pkg/storage/theorydb.NewLambdaOptimizedClient`
- shared TableTheory Lambda client construction helper path
- storage-layer tests for Lambda timeout semantics

## Specialist walks referenced
- Federation trust: none; no signing, verification, actor identity, inbox/outbox, delivery, moderation, or blocking behavior changed.
- Contract / API: none; no Mastodon REST, GraphQL, OpenAPI, or ActivityPub response shape changed.
- Schema: none; no PK/SK/GSI/TableTheory model tag/stored item shape changed.
- Framework: idiomatic TableTheory LambdaDB construction, `WithLambdaTimeoutConfig`, and `WithLambdaTimeout(ctx)` usage. No framework patch or fork.

## Consumer impact
- Operators: Lambda TableTheory clients now preserve the configured timeout safety buffer and deadline behavior on the helper used by Lambda initialization paths.
- Mastodon clients / remote ActivityPub peers: no observable API or federation contract impact.
- Sibling repos: no contract impact.

## Tasks
- [x] #969 — TableTheory: prove Lambda client timeout semantics

## Validation
- [x] `go test ./pkg/storage/theorydb`
- [x] `go test ./pkg/storage/...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (empty)
- [x] `go build -o lesser ./cmd/lesser && ./lesser build lambdas && ./lesser verify ci`
  - overall coverage: 87.672%
  - pkg coverage: 90.014%
  - cmd coverage: 90.084%

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live
- [ ] Post-deploy monitoring verified

## Cross-repo coordination
None required.

## Advisor / Arch coordination
Aron authorized Arch-requested work for this initiative. Arch's Phase 1a constraints are respected here: no broad Lambda call-site migration, timeout behavior is proven at the repository/operation boundary, and TableTheory is consumed idiomatically without a local framework workaround.
