### PR TITLE
fix(runtime): thread app contexts into import clients

### DIFF
--- a/cmd/import-processor/main.go
+++ b/cmd/import-processor/main.go
@@ -233,7 +233,7 @@ func init() {
 	// AWS config no longer needed - DynamORM handles configuration internally
 
 	// Initialize DynamORM with Lambda optimizations
-	db, err := theorydb.NewLambdaOptimizedClient(context.Background(), lambdaCtx.Config.Region)
+	db, err := theorydb.NewLambdaOptimizedClient(context.TODO(), lambdaCtx.Config.Region)
 	if err != nil {
 		lambdaCtx.Logger.Fatal("Failed to initialize DynamORM", zap.Error(err))
 	}
@@ -307,6 +307,8 @@ func (p *ImportProcessor) HandleSQSMessage(ctx *apptheory.EventContext, message 
 		}
 	}
 
+	runner := p.withInvocationTableContext(runCtx)
+
 	// Try parsing as services.ImportJobMessage first (new format)
 	var importMsg services.ImportJobMessage
 	if err := common.ParseRequestBody([]byte(message.Body), &importMsg); err == nil {
@@ -318,16 +320,16 @@ func (p *ImportProcessor) HandleSQSMessage(ctx *apptheory.EventContext, message 
 			Mode:     importMsg.Mode,
 			S3Key:    importMsg.S3Key,
 		}
-		if err := p.processImportJob(runCtx, importEvent); err != nil {
-			p.logger.Error("failed to process import job",
+		if err := runner.processImportJob(runCtx, importEvent); err != nil {
+			runner.logger.Error("failed to process import job",
 				zap.String("import_id", importEvent.ImportID),
 				zap.String("username", importEvent.Username),
 				zap.String("request_id", requestID),
 				zap.Error(err),
 			)
 			// Update job status as failed
-			if updateErr := p.importRepo.UpdateImportStatus(runCtx, importEvent.ImportID, "failed", nil, err.Error()); updateErr != nil {
-				p.logger.Error("failed to update import status to failed",
+			if updateErr := runner.importRepo.UpdateImportStatus(runCtx, importEvent.ImportID, "failed", nil, err.Error()); updateErr != nil {
+				runner.logger.Error("failed to update import status to failed",
 					zap.String("import_id", importEvent.ImportID),
 					zap.Error(updateErr),
 				)
@@ -339,7 +341,7 @@ func (p *ImportProcessor) HandleSQSMessage(ctx *apptheory.EventContext, message 
 	// Fallback to legacy format
 	var importEvent ImportProcessorEvent
 	if err := common.ParseRequestBody([]byte(message.Body), &importEvent); err != nil {
-		p.logger.Error("failed to unmarshal event",
+		runner.logger.Error("failed to unmarshal event",
 			zap.String("message_id", message.MessageId),
 			zap.String("request_id", requestID),
 			zap.Error(err),
@@ -347,16 +349,16 @@ func (p *ImportProcessor) HandleSQSMessage(ctx *apptheory.EventContext, message 
 		return nil
 	}
 
-	if err := p.processImportJob(runCtx, importEvent); err != nil {
-		p.logger.Error("failed to process import job",
+	if err := runner.processImportJob(runCtx, importEvent); err != nil {
+		runner.logger.Error("failed to process import job",
 			zap.String("import_id", importEvent.ImportID),
 			zap.String("username", importEvent.Username),
 			zap.String("request_id", requestID),
 			zap.Error(err),
 		)
 		// Update job status as failed
-		if updateErr := p.importRepo.UpdateImportStatus(runCtx, importEvent.ImportID, "failed", nil, err.Error()); updateErr != nil {
-			p.logger.Error("failed to update import status to failed",
+		if updateErr := runner.importRepo.UpdateImportStatus(runCtx, importEvent.ImportID, "failed", nil, err.Error()); updateErr != nil {
+			runner.logger.Error("failed to update import status to failed",
 				zap.String("import_id", importEvent.ImportID),
 				zap.Error(updateErr),
 			)
@@ -364,6 +366,45 @@ func (p *ImportProcessor) HandleSQSMessage(ctx *apptheory.EventContext, message 
 	}
 
 	return nil
+}
+
+func (p *ImportProcessor) withInvocationTableContext(ctx context.Context) *ImportProcessor {
+	if p == nil || p.db == nil || ctx == nil {
+		return p
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		return p
+	}
+
+	invocationDB := theorydb.WithLambdaTimeout(ctx, p.db)
+	if invocationDB == nil || invocationDB == p.db {
+		return p
+	}
+
+	runner := *p
+	runner.db = invocationDB
+
+	tableName := ""
+	if p.cfg != nil {
+		tableName = strings.TrimSpace(p.cfg.DynamoTableName)
+	}
+	if tableName == "" {
+		return &runner
+	}
+
+	runner.importRepo = repositories.NewImportRepository(invocationDB, tableName, p.logger)
+	runner.costTrackingRepo = repositories.NewTrackingRepository(invocationDB, tableName, p.logger, nil)
+
+	repos, err := factory.NewRepositoryFactory(invocationDB, tableName, p.logger)
+	if err != nil {
+		if p.logger != nil {
+			p.logger.Warn("failed to create invocation-scoped repository factory", zap.Error(err))
+		}
+		return &runner
+	}
+	runner.repos = importStorageAdapter{storage: repos}
+
+	return &runner
 }
 
 func (p *ImportProcessor) initializeAWSClients(ctx context.Context) error {

--- a/cmd/import-processor/round12_import_processor_more_paths_test.go
+++ b/cmd/import-processor/round12_import_processor_more_paths_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -17,6 +18,8 @@ import (
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/require"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	tablecore "github.com/theory-cloud/tabletheory/pkg/core"
 	"go.uber.org/zap"
 )
 
@@ -391,6 +394,76 @@ func TestImportProcessor_ProcessImportJob_AndHandleSQS_Round12(t *testing.T) {
 	})
 }
 
+func TestImportProcessor_WithInvocationTableContext_Round12(t *testing.T) {
+	baseDB := &lambdaTimeoutRecorderDB{}
+	p := &ImportProcessor{
+		db:               baseDB,
+		importRepo:       &importRepoRecorder{},
+		costTrackingRepo: &costTrackingRepoRecorder{},
+		cfg:              &config.Config{DynamoTableName: "table"},
+		logger:           zap.NewNop(),
+	}
+
+	require.Same(t, p, p.withInvocationTableContext(context.Background()))
+
+	deadline := time.Now().Add(time.Minute).Round(0)
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+
+	runner := p.withInvocationTableContext(ctx)
+	require.NotSame(t, p, runner)
+	require.Equal(t, 1, baseDB.lambdaTimeoutCalls)
+	require.NotNil(t, runner.importRepo)
+	require.NotNil(t, runner.costTrackingRepo)
+	require.NotNil(t, runner.repos)
+
+	timedDB, ok := runner.db.(*lambdaTimeoutRecorderDB)
+	require.True(t, ok)
+	require.Equal(t, deadline, timedDB.lambdaDeadline)
+}
+
+func TestImportProcessor_HandleSQSMessageAppliesEventContextDeadline_Round12(t *testing.T) {
+	setAWSEnvForS3Test(t, "https://example.com")
+
+	baseDB := &lambdaTimeoutRecorderDB{}
+	repo := &importRepoRecorder{}
+	costRepo := &costTrackingRepoRecorder{}
+	p := &ImportProcessor{
+		db:               baseDB,
+		importRepo:       repo,
+		costTrackingRepo: costRepo,
+		s3Client: &s3ClientStub{getObjectFn: func(_ *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+			return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader([]byte("Account address\nalice@example.com\n")))}, nil
+		}},
+		cfg:        &config.Config{},
+		logger:     zap.NewNop(),
+		bucketName: "bucket",
+		baseURL:    "https://example.com",
+		repos: importStorageStub{
+			object: objectCreatorFunc(func(_ context.Context, _ any) error { return nil }),
+		},
+	}
+
+	deadline := time.Now().Add(time.Minute).Round(0)
+	runCtx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+
+	msg := events.SQSMessage{
+		MessageId:      "1",
+		EventSourceARN: "arn:aws:sqs:us-east-1:123456789012:import-queue",
+		Body:           `{"import_id":"imp-1","username":"alice","type":"followers","mode":"merge","s3_key":"followers.csv","timestamp":123}`,
+	}
+
+	app := apptheory.New()
+	app.SQS("import-queue", p.HandleSQSMessage)
+	resp := app.ServeSQS(runCtx, events.SQSEvent{Records: []events.SQSMessage{msg}})
+
+	require.Empty(t, resp.BatchItemFailures)
+	require.Equal(t, 1, baseDB.lambdaTimeoutCalls)
+	require.Contains(t, repo.statusCalls, "processing")
+	require.Contains(t, repo.statusCalls, "completed")
+}
+
 type s3ClientStub struct {
 	getObjectFn func(input *s3.GetObjectInput) (*s3.GetObjectOutput, error)
 }
@@ -400,6 +473,27 @@ func (s *s3ClientStub) GetObject(_ context.Context, input *s3.GetObjectInput, _ 
 		return s.getObjectFn(input)
 	}
 	return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(nil))}, nil
+}
+
+type lambdaTimeoutRecorderDB struct {
+	lambdaTimeoutCalls int
+	lambdaDeadline     time.Time
+}
+
+func (db *lambdaTimeoutRecorderDB) Model(any) tablecore.Query { return nil }
+func (db *lambdaTimeoutRecorderDB) Transaction(fn func(tx *tablecore.Tx) error) error {
+	return fn(&tablecore.Tx{})
+}
+func (db *lambdaTimeoutRecorderDB) Migrate() error           { return nil }
+func (db *lambdaTimeoutRecorderDB) AutoMigrate(...any) error { return nil }
+func (db *lambdaTimeoutRecorderDB) Close() error             { return nil }
+func (db *lambdaTimeoutRecorderDB) WithContext(context.Context) tablecore.DB {
+	return db
+}
+func (db *lambdaTimeoutRecorderDB) WithLambdaTimeout(ctx context.Context) tablecore.DB {
+	db.lambdaTimeoutCalls++
+	deadline, _ := ctx.Deadline()
+	return &lambdaTimeoutRecorderDB{lambdaDeadline: deadline}
 }
 
 func TestImportTransaction_RollbackFailure_Round12(t *testing.T) {

--- a/pkg/storage/theorydb/client.go
+++ b/pkg/storage/theorydb/client.go
@@ -289,3 +289,25 @@ func WithTimeoutBuffer(db core.DB, buffer time.Duration) core.DB {
 		Buffer: buffer,
 	})
 }
+
+type lambdaTimeoutApplier interface {
+	WithLambdaTimeout(context.Context) core.DB
+}
+
+// WithLambdaTimeout returns a DB scoped to the supplied Lambda invocation
+// deadline when the client supports TableTheory Lambda timeout handling.
+func WithLambdaTimeout(ctx context.Context, db core.DB) core.DB {
+	if db == nil || ctx == nil {
+		return db
+	}
+
+	if lambdaDB, ok := db.(*tabletheory.LambdaDB); ok {
+		return lambdaDB.WithLambdaTimeout(ctx)
+	}
+
+	if timeoutDB, ok := db.(lambdaTimeoutApplier); ok {
+		return timeoutDB.WithLambdaTimeout(ctx)
+	}
+
+	return db
+}


### PR DESCRIPTION
## Milestone
Phase 1b (#970) — import-processor runtime-context slice for TableTheory Lambda deadline semantics.

Refs #970. This PR intentionally does **not** close #970; `cmd/activity-processor` still has a standard `GetClient(context.Background())` call for a later bounded slice.

## Classification
operational-reliability / framework-consumption

## Surfaces affected
- `cmd/import-processor/main.go`
- `cmd/import-processor/round12_import_processor_more_paths_test.go`
- `pkg/storage/theorydb/client.go`

## Specialist walks referenced
- Federation trust: none; import processing only, no HTTP Signature, inbox/outbox, delivery, relay, or moderation-gate behavior changed.
- Contract / API: none; no Mastodon REST, GraphQL, OpenAPI, or ActivityPub actor/object shape changes.
- Schema: none; no TableTheory model tags, PK/SK/GSI definitions, attribute names, or migrations changed.
- Framework: idiomatic AppTheory `EventContext.Context()` deadline propagation into TableTheory Lambda timeout handling.

## Consumer impact
Operators only: import-processor repository work now inherits the Lambda invocation deadline for safer timeout behavior. No client-visible API or federation behavior change.

## Tasks
- [x] Import-processor SQS handling scopes TableTheory access to the real AppTheory event context deadline.
- [x] Add a small `theorydb.WithLambdaTimeout(ctx, db)` helper so Lambda timeout scoping can be reused without type-specific call-site assertions.
- [x] Test no-deadline fallback, deadline propagation, repository rebinding, and real AppTheory `ServeSQS` event-context propagation.

## Validation
- `go test ./cmd/import-processor ./pkg/storage/theorydb`
- `go test ./... && go vet ./... && test -z "$(gofmt -l .)"`
- `go build -o lesser ./cmd/lesser && ./lesser build lambdas && ./lesser verify ci`
  - coverage overall 87.667%, pkg 90.008%, cmd 90.080%

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None.

## Advisor-brief authorization (if applicable)
Not advisor-dispatched. Aron authorized Arch-directed work, and Arch approved Phase 1a before this bounded Phase 1b slice started.

## Arch coordination
Arch requested Phase 1b be sliced by Lambda family. This PR is the import-processor slice only and is ready for Arch review before any next slice begins.
