### PR TITLE
refactor(routes): prove strict webfinger registration

### DIFF
--- a/cmd/webfinger/main.go
+++ b/cmd/webfinger/main.go
@@ -66,10 +66,34 @@ func parseWebFingerResource(resource string) (username, domain string, err error
 	return username, domain, nil
 }
 
-// RegisterRoutes registers all webfinger routes
-func (wh *WebFingerHandler) RegisterRoutes(app *apptheory.App) {
-	// WebFinger endpoint (inventory-owned).
-	_ = app.Get("/.well-known/webfinger", wh.handleWebFinger)
+type webfingerRouteInventoryEntry struct {
+	Method string `json:"method"`
+	Path   string `json:"path"`
+}
+
+func webfingerRouteInventory() []webfingerRouteInventoryEntry {
+	return []webfingerRouteInventoryEntry{
+		{Method: http.MethodGet, Path: "/.well-known/webfinger"},
+	}
+}
+
+// RegisterRoutes registers all webfinger routes.
+func (wh *WebFingerHandler) RegisterRoutes(app *apptheory.App) error {
+	return registerWebFingerRoutes(app, wh.handleWebFinger)
+}
+
+func registerWebFingerRoutes(app *apptheory.App, handler apptheory.Handler) error {
+	for _, route := range webfingerRouteInventory() {
+		switch route.Method {
+		case http.MethodGet:
+			if _, err := app.GetStrict(route.Path, handler); err != nil {
+				return fmt.Errorf("register webfinger route %s %s: %w", route.Method, route.Path, err)
+			}
+		default:
+			return fmt.Errorf("unsupported webfinger route method %q for %s", route.Method, route.Path)
+		}
+	}
+	return nil
 }
 
 // handleWebFinger handles webfinger requests using DynamORM
@@ -426,8 +450,10 @@ func buildApp(handler *WebFingerHandler, lambdaLogger *zap.Logger) *apptheory.Ap
 		}
 	})
 
-	// Register webfinger routes
-	handler.RegisterRoutes(app)
+	// Register webfinger routes.
+	if err := handler.RegisterRoutes(app); err != nil {
+		lambdaLogger.Fatal("failed to register webfinger routes", zap.Error(err))
+	}
 
 	return app
 }

--- a/cmd/webfinger/round13_routes_test.go
+++ b/cmd/webfinger/round13_routes_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+)
+
+func TestWebFingerStrictRouteInventoryParity_Round13(t *testing.T) {
+	artifactBytes, err := os.ReadFile("testdata/route_inventory.json")
+	require.NoError(t, err)
+
+	var artifact []webfingerRouteInventoryEntry
+	require.NoError(t, json.Unmarshal(artifactBytes, &artifact))
+	require.Equal(t, []webfingerRouteInventoryEntry{{Method: http.MethodGet, Path: "/.well-known/webfinger"}}, artifact)
+	require.Equal(t, artifact, webfingerRouteInventory())
+
+	hits := 0
+	app := apptheory.New()
+	require.NoError(t, registerWebFingerRoutes(app, func(*apptheory.Context) (*apptheory.Response, error) {
+		hits++
+		return &apptheory.Response{Status: http.StatusNoContent}, nil
+	}))
+
+	resp := app.Serve(context.Background(), apptheory.Request{
+		Method: http.MethodGet,
+		Path:   "/.well-known/webfinger",
+	})
+	require.Equal(t, http.StatusNoContent, resp.Status)
+	require.Equal(t, 1, hits)
+
+	resp = app.Serve(context.Background(), apptheory.Request{
+		Method: http.MethodPost,
+		Path:   "/.well-known/webfinger",
+	})
+	require.Equal(t, http.StatusMethodNotAllowed, resp.Status)
+	require.Equal(t, 1, hits)
+
+	resp = app.Serve(context.Background(), apptheory.Request{
+		Method: http.MethodGet,
+		Path:   "/.well-known/nodeinfo",
+	})
+	require.Equal(t, http.StatusNotFound, resp.Status)
+	require.Equal(t, 1, hits)
+}
+
+func TestRegisterWebFingerRoutesStrictFailure_Round13(t *testing.T) {
+	err := registerWebFingerRoutes(nil, func(*apptheory.Context) (*apptheory.Response, error) {
+		return &apptheory.Response{Status: http.StatusNoContent}, nil
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "register webfinger route GET /.well-known/webfinger")
+}

--- a/cmd/webfinger/testdata/route_inventory.json
+++ b/cmd/webfinger/testdata/route_inventory.json
@@ -1,0 +1,6 @@
+[
+  {
+    "method": "GET",
+    "path": "/.well-known/webfinger"
+  }
+]


### PR DESCRIPTION
## Milestone
Phase 2a (#971) — prove strict AppTheory route registration on one low-risk surface.

Closes #971.

## Classification
contract-stability / framework-consumption / operational-reliability

## Surfaces affected
- `cmd/webfinger/main.go`
- `cmd/webfinger/round13_routes_test.go`
- `cmd/webfinger/testdata/route_inventory.json`

## Specialist walks referenced
- Federation trust: none; WebFinger discovery route shape is unchanged and no actor/object/federation signing/verification behavior changed.
- Contract / API: backward-compatible route-registration proof only. Public method/path remains exactly `GET /.well-known/webfinger`; no response, status, error-shape, OpenAPI path, or GraphQL schema changes.
- Schema: none; no TableTheory model tags, PK/SK/GSI definitions, attributes, or migrations changed.
- Framework: idiomatic AppTheory `GetStrict` use with fail-fast registration handling.

## Contract audit
### Proposed change
WebFinger route registration now uses a small strict-registration helper backed by an explicit route inventory.

### Surfaces affected
- WebFinger: `GET /.well-known/webfinger`
- Mastodon REST: none
- GraphQL: none
- Streaming/subscriptions: none
- ActivityPub actor/objects/collections: none

### Compatibility classification
Backward-compatible/internal hardening. The observable WebFinger method/path set is unchanged.

### Consumer-class enumeration
- Remote ActivityPub servers: not affected; they continue to discover actors through `GET /.well-known/webfinger`.
- Mastodon clients and third-party tools: not affected; no `/api/v1/*` route or response shape changed.
- Sibling equaltoai repos: no body/soul/host/greater/sim coordination required.
- Operators/direct tooling: no operator action required.

### Versioning / rollout
No versioning needed. Standard dev → staging → live deploy soak is sufficient after merge.

### Contract artifacts
- Checked-in route inventory/parity artifact: `cmd/webfinger/testdata/route_inventory.json`
- Static OpenAPI verification: `./lesser verify openapi` passed; `docs/contracts/openapi.yaml` remains unchanged at 291 paths.

## Consumer impact
No consumer-visible behavior change. Operators get fail-fast detection if WebFinger route registration drifts from AppTheory's strict route dialect.

## Tasks
- [x] Convert low-risk WebFinger route registration to AppTheory `GetStrict`.
- [x] Add a route inventory/parity artifact for `GET /.well-known/webfinger`.
- [x] Add tests proving strict registration, method/path parity, method-not-allowed behavior, and registration failure surfacing.

## Validation
- `./lesser verify openapi`
- `go test ./cmd/webfinger`
- `go test ./... && go vet ./... && test -z "$(gofmt -l .)"`
- `go build -o lesser ./cmd/lesser && ./lesser build lambdas && ./lesser verify ci`
  - coverage overall 87.667%, pkg 90.008%, cmd 90.078%

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None.

## Advisor-brief authorization (if applicable)
Not advisor-dispatched. Aron authorized Arch-directed work; Arch approved and merged Phase 1b before this milestone started.

## Arch coordination
This follows Arch's Phase 2a constraints: do not start with all `cmd/api/routes.go`, prove strict route dialect/canonicalization on a small surface first, and include a route inventory/parity artifact. Holding Phase 2b until Arch review/approval or merge.
