### PR TITLE
refactor(routes): expand strict objects registration

### DIFF
--- a/cmd/objects/main.go
+++ b/cmd/objects/main.go
@@ -135,6 +135,18 @@ type relationshipChecker interface {
 	IsFollowing(ctx context.Context, followerUsername, targetActorID string) (bool, error)
 }
 
+type objectsRouteInventoryEntry struct {
+	Method string `json:"method"`
+	Path   string `json:"path"`
+}
+
+func objectsRouteInventory() []objectsRouteInventoryEntry {
+	return []objectsRouteInventoryEntry{
+		{Method: http.MethodGet, Path: "/objects/:id"},
+		{Method: http.MethodGet, Path: "/users/:username/statuses/:id"},
+	}
+}
+
 // NewHandler creates a new objects handler using standardized services
 func NewHandler() *Handler {
 	// Initialize object repository
@@ -156,6 +168,25 @@ func NewHandler() *Handler {
 		instanceRepo:           repos.Instance(),
 		relationshipRepo:       repos.Relationship(),
 	}
+}
+
+// RegisterRoutes registers all ActivityPub object routes.
+func (h *Handler) RegisterRoutes(app *apptheory.App) error {
+	return registerObjectsRoutes(app, h.HandleGetObject)
+}
+
+func registerObjectsRoutes(app *apptheory.App, handleGetObject apptheory.Handler) error {
+	for _, route := range objectsRouteInventory() {
+		switch route.Method {
+		case http.MethodGet:
+			if _, err := app.GetStrict(route.Path, handleGetObject); err != nil {
+				return fmt.Errorf("register objects route %s %s: %w", route.Method, route.Path, err)
+			}
+		default:
+			return fmt.Errorf("unsupported objects route method %q for %s", route.Method, route.Path)
+		}
+	}
+	return nil
 }
 
 // HandleGetObject handles GET requests for ActivityPub objects
@@ -959,8 +990,9 @@ func buildApp(handler *Handler, lambdaLogger *zap.Logger) *apptheory.App {
 	})
 
 	// ActivityPub federation endpoints.
-	app.Get("/objects/:id", handler.HandleGetObject)
-	app.Get("/users/:username/statuses/:id", handler.HandleGetObject)
+	if err := handler.RegisterRoutes(app); err != nil {
+		lambdaLogger.Fatal("failed to register objects routes", zap.Error(err))
+	}
 
 	return app
 }

--- a/cmd/objects/round13_routes_test.go
+++ b/cmd/objects/round13_routes_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+)
+
+func TestObjectsStrictRouteInventoryParity_Round13(t *testing.T) {
+	artifactBytes, err := os.ReadFile("testdata/route_inventory.json")
+	require.NoError(t, err)
+
+	var artifact []objectsRouteInventoryEntry
+	require.NoError(t, json.Unmarshal(artifactBytes, &artifact))
+	require.Equal(t, []objectsRouteInventoryEntry{
+		{Method: http.MethodGet, Path: "/objects/:id"},
+		{Method: http.MethodGet, Path: "/users/:username/statuses/:id"},
+	}, artifact)
+	require.Equal(t, artifact, objectsRouteInventory())
+
+	var params []map[string]string
+	app := apptheory.New()
+	require.NoError(t, registerObjectsRoutes(app, func(ctx *apptheory.Context) (*apptheory.Response, error) {
+		params = append(params, map[string]string{
+			"id":       ctx.Param("id"),
+			"username": ctx.Param("username"),
+		})
+		return &apptheory.Response{Status: http.StatusNoContent}, nil
+	}))
+
+	resp := app.Serve(context.Background(), apptheory.Request{
+		Method: http.MethodGet,
+		Path:   "/objects/note-1",
+	})
+	require.Equal(t, http.StatusNoContent, resp.Status)
+	require.Equal(t, map[string]string{"id": "note-1", "username": ""}, params[0])
+
+	resp = app.Serve(context.Background(), apptheory.Request{
+		Method: http.MethodGet,
+		Path:   "/users/alice/statuses/note-2",
+	})
+	require.Equal(t, http.StatusNoContent, resp.Status)
+	require.Equal(t, map[string]string{"id": "note-2", "username": "alice"}, params[1])
+
+	resp = app.Serve(context.Background(), apptheory.Request{
+		Method: http.MethodPost,
+		Path:   "/objects/note-1",
+	})
+	require.Equal(t, http.StatusMethodNotAllowed, resp.Status)
+	require.Len(t, params, 2)
+
+	resp = app.Serve(context.Background(), apptheory.Request{
+		Method: http.MethodGet,
+		Path:   "/users/alice/statuses",
+	})
+	require.Equal(t, http.StatusNotFound, resp.Status)
+	require.Len(t, params, 2)
+}
+
+func TestRegisterObjectsRoutesStrictFailure_Round13(t *testing.T) {
+	err := registerObjectsRoutes(nil, func(*apptheory.Context) (*apptheory.Response, error) {
+		return &apptheory.Response{Status: http.StatusNoContent}, nil
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "register objects route GET /objects/:id")
+}

--- a/cmd/objects/testdata/route_inventory.json
+++ b/cmd/objects/testdata/route_inventory.json
@@ -1,0 +1,10 @@
+[
+  {
+    "method": "GET",
+    "path": "/objects/:id"
+  },
+  {
+    "method": "GET",
+    "path": "/users/:username/statuses/:id"
+  }
+]


### PR DESCRIPTION
## Milestone
Phase 2b (#972) — expand strict AppTheory route registration by one bounded surface.

Closes #972.

## Classification
contract-stability / framework-consumption / operational-reliability

## Surfaces affected
- `cmd/objects/main.go`
- `cmd/objects/round13_routes_test.go`
- `cmd/objects/testdata/route_inventory.json`

## Specialist walks referenced
- Federation trust: route-only hardening; no object resolution, authorized fetch, HTTP Signature signing/verification, inbox/outbox, delivery, relay, or moderation behavior changed.
- Contract / API: backward-compatible route-registration expansion only. Public method/path set remains exactly `GET /objects/:id` and `GET /users/:username/statuses/:id`; no response/status/error-shape or OpenAPI path changes.
- Schema: none; no TableTheory model tags, PK/SK/GSI definitions, attributes, or migrations changed.
- Framework: idiomatic AppTheory `GetStrict` use, following Phase 2a's approved WebFinger proof.

## Contract audit
### Proposed change
The bounded ActivityPub objects surface now registers through a strict route helper backed by an explicit route inventory.

### Surfaces affected
- ActivityPub objects: `GET /objects/:id`
- ActivityPub status object aliases: `GET /users/:username/statuses/:id`
- Mastodon REST: none
- GraphQL: none
- Streaming/subscriptions: none

### Compatibility classification
Backward-compatible/internal hardening. The observable objects method/path set is unchanged.

### Consumer-class enumeration
- Remote ActivityPub servers: not affected; object dereference URLs and status-object alias URLs remain unchanged.
- Mastodon clients and third-party tools: not affected; no `/api/v1/*` route or response shape changed.
- Sibling equaltoai repos: no body/soul/host/greater/sim coordination required.
- Operators/direct tooling: no operator action required.

### Versioning / rollout
No versioning needed. Standard dev → staging → live deploy soak is sufficient after merge.

### Contract artifacts
- Checked-in route inventory/parity artifact: `cmd/objects/testdata/route_inventory.json`
- Static OpenAPI verification: `./lesser verify openapi` passed; `docs/contracts/openapi.yaml` remains unchanged at 291 paths.

## Consumer impact
No consumer-visible behavior change. Operators get fail-fast detection if the objects route set drifts from AppTheory's strict route dialect.

## Tasks
- [x] Convert bounded objects route registration to AppTheory `GetStrict`.
- [x] Add a route inventory/parity artifact for the two object routes.
- [x] Add tests proving strict registration, path-param parity, method-not-allowed behavior, unknown-path behavior, and registration failure surfacing.

## Validation
- `./lesser verify openapi`
- `go test ./cmd/objects`
- `go test ./... && go vet ./... && test -z "$(gofmt -l .)"`
- `go build -o lesser ./cmd/lesser && ./lesser build lambdas && ./lesser verify ci`
  - coverage overall 87.666%, pkg 90.008%, cmd 90.075%

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None.

## Advisor-brief authorization (if applicable)
Not advisor-dispatched. Aron authorized Arch-directed work; Arch approved and merged Phase 2a before this milestone started.

## Arch coordination
This follows Arch's Phase 2b constraints: expand only after Phase 2a, one bounded surface per PR, and include route inventory/parity evidence beyond OpenAPI checks. Holding Phase 3a until Arch review/approval or merge.
