### PR TITLE
refactor(cdk): adopt apptheory lambda constructs

### DIFF
--- a/infra/cdk/constructs/lambda_functions.go
+++ b/infra/cdk/constructs/lambda_functions.go
@@ -46,6 +46,58 @@ type LambdaFunctions struct {
 	Functions map[string]awslambda.Function
 }
 
+// preAppTheoryLambdaLogicalIDs records the CloudFormation logical IDs generated
+// by the native CDK Lambda construct before the AppTheoryFunction adoption.
+//
+// AppTheoryFunction wraps the underlying AWS::Lambda::Function under a nested
+// "Function" child. That is idiomatic for new constructs, but migrating existing
+// lesser Lambdas without preserving these logical IDs would ask CloudFormation to
+// replace every function even though physical FunctionName values are unchanged.
+// Keep this map for the pre-existing inventory Lambdas only; new inventory
+// Lambdas should use AppTheoryFunction's natural logical IDs.
+const preAppTheoryLambdaLogicalIDCount = 38
+
+var preAppTheoryLambdaLogicalIDs = map[string]string{
+	"activity-processor":            "activityprocessorFunction363D35B9",
+	"actor":                         "actorFunction4F1B5B35",
+	"ai-processor":                  "aiprocessorFunction80F9FEE9",
+	"api":                           "apiFunction73599D16",
+	"cms-scheduler":                 "cmsschedulerFunction7389FCD5",
+	"collections":                   "collectionsFunctionB3956451",
+	"cost-aggregator":               "costaggregatorFunction6A1DA294",
+	"dlq-processor":                 "dlqprocessorFunction1B32771C",
+	"enhanced-federation-processor": "enhancedfederationprocessorFunction1B66F94B",
+	"export-generator":              "exportgeneratorFunctionF1137BBF",
+	"federation-aggregator":         "federationaggregatorFunction2454A6CE",
+	"federation-delivery":           "federationdeliveryFunction0574D778",
+	"federation-timeseries":         "federationtimeseriesFunction5655FEB8",
+	"federation-tracker":            "federationtrackerFunction998CD9D6",
+	"graphql":                       "graphqlFunction067C62D4",
+	"graphql-ws":                    "graphqlwsFunction2605C748",
+	"import-processor":              "importprocessorFunction03DACDBF",
+	"inbox":                         "inboxFunction22ED6D87",
+	"media-processor":               "mediaprocessorFunction55166D54",
+	"metrics-aggregator":            "metricsaggregatorFunction61E5EE49",
+	"metrics-processor":             "metricsprocessorFunction985F65E4",
+	"ml-training-processor":         "mltrainingprocessorFunction1F30198A",
+	"moderation-processor":          "moderationprocessorFunction33714409",
+	"note-processor":                "noteprocessorFunction71938A48",
+	"notification-processor":        "notificationprocessorFunctionC222A047",
+	"objects":                       "objectsFunction46AD58EB",
+	"outbox":                        "outboxFunction51296F97",
+	"push-delivery":                 "pushdeliveryFunctionB7BE0F3C",
+	"report-trust-updater":          "reporttrustupdaterFunctionA287D274",
+	"search-indexer":                "searchindexerFunction2D70A8F2",
+	"severance-processor":           "severanceprocessorFunction879E1935",
+	"sse":                           "sseFunction277E5041",
+	"status-indexer":                "statusindexerFunction70FCBEBE",
+	"stream-router":                 "streamrouterFunction3BCEAE5E",
+	"streaming":                     "streamingFunction6A4849EF",
+	"trend-aggregator":              "trendaggregatorFunction8820FAD6",
+	"webfinger":                     "webfingerFunctionB71806D6",
+	"websocket-cost-aggregator":     "websocketcostaggregatorFunction0068CAA1",
+}
+
 // Must returns the named function or panics if missing.
 func (l *LambdaFunctions) Must(name string) awslambda.Function {
 	if fn, ok := l.Functions[name]; ok {
@@ -248,7 +300,7 @@ func CreateLambdaFunctions(stack awscdk.Stack, props *LambdaFunctionsProps) *Lam
 			validateScheduleCapable(spec)
 		}
 
-		fn := awslambda.NewFunction(stack, jsii.String(spec.Name+"Function"), &fnProps)
+		fn := newInventoryLambdaFunction(stack, spec, &fnProps)
 		functions.Functions[spec.Name] = fn
 
 		if len(spec.ScheduleTriggers) == 0 {
@@ -289,6 +341,57 @@ func CreateLambdaFunctions(stack awscdk.Stack, props *LambdaFunctionsProps) *Lam
 	}
 
 	return functions
+}
+
+func newInventoryLambdaFunction(stack awscdk.Stack, spec inventory.LambdaSpec, fnProps *awslambda.FunctionProps) awslambda.Function {
+	if !usesAppTheoryFunction(spec) {
+		return awslambda.NewFunction(stack, jsii.String(spec.Name+"Function"), fnProps)
+	}
+
+	appTheoryFn := apptheorycdk.NewAppTheoryFunction(stack, jsii.String(spec.Name+"Function"), appTheoryFunctionProps(fnProps))
+	fn := appTheoryFn.Fn()
+	preservePreAppTheoryLambdaLogicalID(fn, spec.Name)
+	return fn
+}
+
+func usesAppTheoryFunction(spec inventory.LambdaSpec) bool {
+	// Phase 3b adopts AppTheoryFunction only for Lambdas whose downstream
+	// resources do not derive logical IDs from the Lambda construct path.
+	// Stream/SQS mappings and schedule permissions need a separate parity proof
+	// before their functions migrate, because AppTheoryFunction's nested child
+	// path changes those dependent resource logical IDs even when the Lambda
+	// resource itself is preserved.
+	return len(spec.SQSTriggers) == 0 && len(spec.StreamTriggers) == 0 && len(spec.ScheduleTriggers) == 0
+}
+
+func appTheoryFunctionProps(props *awslambda.FunctionProps) *apptheorycdk.AppTheoryFunctionProps {
+	return &apptheorycdk.AppTheoryFunctionProps{
+		Runtime:      props.Runtime,
+		Architecture: props.Architecture,
+		MemorySize:   props.MemorySize,
+		Timeout:      props.Timeout,
+		Environment:  props.Environment,
+		Tracing:      props.Tracing,
+		FunctionName: props.FunctionName,
+		Code:         props.Code,
+		Handler:      props.Handler,
+		LogGroup:     props.LogGroup,
+		Role:         props.Role,
+	}
+}
+
+func preservePreAppTheoryLambdaLogicalID(fn awslambda.Function, lambdaName string) {
+	logicalID, ok := preAppTheoryLambdaLogicalIDs[lambdaName]
+	if !ok {
+		return
+	}
+
+	child := fn.Node().DefaultChild()
+	cfn, ok := child.(awslambda.CfnFunction)
+	if !ok {
+		panic(fmt.Sprintf("lambda %s default child is %T, want awslambda.CfnFunction", lambdaName, child))
+	}
+	cfn.OverrideLogicalId(jsii.String(logicalID))
 }
 
 func copyEnv(src map[string]*string) map[string]*string {

--- a/infra/cdk/constructs/lambda_functions_test.go
+++ b/infra/cdk/constructs/lambda_functions_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-cdk-go/awscdk/v2/awssecretsmanager"
 	"github.com/aws/jsii-runtime-go"
 	"github.com/equaltoai/lesser/pkg/deploy/naming"
+	apptheorycdk "github.com/theory-cloud/apptheory/cdk-go/apptheorycdk"
 )
 
 func TestLambdaFunctionsGeneratedFromInventory(t *testing.T) {
@@ -123,12 +124,39 @@ func TestLambdaFunctionsGeneratedFromInventory(t *testing.T) {
 
 	// Synthesis triggers asset binding and metadata attachment.
 	app.Synth(nil)
+	template := loadTemplate(t, filepath.Join(outdir, "TestStack.template.json"))
+	logicalIDsByName := collectLambdaLogicalIDsByFunctionName(t, template)
+	if got := len(preAppTheoryLambdaLogicalIDs); got != preAppTheoryLambdaLogicalIDCount {
+		t.Fatalf("legacy logical ID map size changed: got %d want %d", got, preAppTheoryLambdaLogicalIDCount)
+	}
+	legacyLogicalIDsSeen := 0
 
 	for _, spec := range inventory.LambdaInventory.Lambdas {
 		fn := functions.Must(spec.Name)
 		wantName := naming.ResourceName(spec.Name, environment)
 		if got := resolveConfiguredFunctionName(t, fn); got != wantName {
 			t.Fatalf("unexpected function name for %s: %s", spec.Name, got)
+		}
+
+		construct := stack.Node().FindChild(jsii.String(spec.Name + "Function"))
+		if construct == nil {
+			t.Fatalf("function construct not found for %s", spec.Name)
+		}
+		if usesAppTheoryFunction(spec) {
+			if _, ok := construct.(apptheorycdk.AppTheoryFunction); !ok {
+				t.Fatalf("expected AppTheoryFunction construct for %s, got %T", spec.Name, construct)
+			}
+		} else if _, ok := construct.(awslambda.Function); !ok {
+			t.Fatalf("triggered lambda %s should remain native CDK until downstream logical ID parity is proven, got %T", spec.Name, construct)
+		}
+
+		if wantLogicalID, ok := preAppTheoryLambdaLogicalIDs[spec.Name]; ok {
+			legacyLogicalIDsSeen++
+			if got := logicalIDsByName[wantName]; got != wantLogicalID {
+				t.Fatalf("lambda logical ID changed for %s: got %s want %s", spec.Name, got, wantLogicalID)
+			}
+		} else if got := logicalIDsByName[wantName]; got == "" {
+			t.Fatalf("lambda logical ID missing for %s", spec.Name)
 		}
 
 		logGroupName := resolveLogGroupName(t, stack, spec.Name)
@@ -153,6 +181,35 @@ func TestLambdaFunctionsGeneratedFromInventory(t *testing.T) {
 	if apiFn.Architecture() != awslambda.Architecture_ARM_64() {
 		t.Fatalf("unexpected architecture: %v", apiFn.Architecture())
 	}
+	if legacyLogicalIDsSeen != preAppTheoryLambdaLogicalIDCount {
+		t.Fatalf("legacy logical ID map has stale entries: saw %d of %d", legacyLogicalIDsSeen, preAppTheoryLambdaLogicalIDCount)
+	}
+}
+
+func collectLambdaLogicalIDsByFunctionName(t *testing.T, tpl map[string]any) map[string]string {
+	t.Helper()
+
+	resources, ok := tpl["Resources"].(map[string]any)
+	if !ok {
+		t.Fatalf("template resources missing or wrong type")
+	}
+	result := make(map[string]string)
+	for logicalID, raw := range resources {
+		res, ok := raw.(map[string]any)
+		if !ok || res["Type"] != "AWS::Lambda::Function" {
+			continue
+		}
+		props, ok := res["Properties"].(map[string]any)
+		if !ok {
+			continue
+		}
+		functionName, ok := props["FunctionName"].(string)
+		if !ok || functionName == "" {
+			continue
+		}
+		result[functionName] = logicalID
+	}
+	return result
 }
 
 func resolveConfiguredFunctionName(t *testing.T, fn awslambda.Function) string {

--- a/infra/cdk/stacks/lesser_api_stack.go
+++ b/infra/cdk/stacks/lesser_api_stack.go
@@ -286,6 +286,9 @@ func (s *LesserApiStack) createClientInfrastructure(domain string) {
 	clientPolicy := localconstructs.NewClientSSRResponseHeadersPolicy(s.Stack)
 	rewriteFn := newClientFrontendRewriteFunction(s.Stack)
 
+	// Keep the SSR host on native CDK until it has its own AppTheoryFunction parity proof.
+	// Phase 3b adoption is limited to inventory Lambdas created by CreateLambdaFunctions;
+	// this helper has Function URL + CloudFront-origin behavior outside that proof surface.
 	clientSSRFn := awslambda.NewFunction(s.Stack, jsii.String("ClientSSRHostFunction"), &awslambda.FunctionProps{
 		Runtime:      awslambda.Runtime_NODEJS_22_X(),
 		Handler:      jsii.String("index.handler"),


### PR DESCRIPTION
## Milestone
Phase 3b / #974 — adopt AppTheory Lambda constructs after Phase 3a parity proof.

## Classification
operational-reliability, framework-consumption, deploy-safety

## Surfaces affected
- `infra/cdk/constructs/lambda_functions.go`
- `infra/cdk/constructs/lambda_functions_test.go`
- `infra/cdk/stacks/lesser_api_stack.go` comment documenting non-adoption of the SSR helper

## What changed
- Adopted `AppTheoryFunction` for triggerless inventory Lambdas only:
  - `actor`, `api`, `collections`, `graphql`, `graphql-ws`, `inbox`, `objects`, `outbox`, `sse`, `streaming`, `webfinger`
- Preserved pre-adoption CloudFormation logical IDs for those Lambda resources to avoid function replacement.
- Left SQS/stream/scheduled inventory Lambdas on native CDK because their downstream event-source mappings / schedule Lambda permissions derive logical IDs from the Lambda construct path.
- Left `ClientSSRHostFunction` on native CDK because it has Function URL + CloudFront-origin behavior outside the Phase 3a proof surface.

## Specialist walks referenced
- Federation trust: none — no signing, inbox/outbox runtime logic, delivery, relay, or moderation behavior changed
- Contract / API: none — no REST/GraphQL/OpenAPI/ActivityPub shape change
- Schema: none — no DynamoDB model, key, GSI, TableTheory tag, or stream record schema change
- Framework: Phase 3a AppTheoryFunction parity proof (#981) plus this PR's bounded adoption; downstream logical-ID churn is captured as framework feedback below

## Consumer impact
- Operators: synthesized resource semantics are unchanged for adopted Lambdas except CDK metadata paths; Lambda logical IDs are preserved. Triggered Lambdas remain native to avoid replacement churn.
- Mastodon clients / remote ActivityPub peers: none
- Sibling repos: none

## Synth/template diff evidence
Compared `lesser-dev` synth before/after using:

```bash
CDK_DEFAULT_ACCOUNT=123456789012 CDK_DEFAULT_REGION=us-east-1 \
  cdk synth lesser-dev \
  --context app=lesser \
  --context baseDomain=example.com \
  --context hostedZoneId=Z1234567890 \
  --context stage=dev \
  --context lambdaAssetRoot=../..
```

Result:
- Resources added: `0`
- Resources removed: `0`
- Changed resources excluding `Metadata`: `CDKMetadata` only
- Changed Lambda resources with metadata-only path diffs: the 11 adopted triggerless Lambdas above
- Existing CDK warnings/resource-count info only

## Framework-feedback signal: AppTheoryFunction migration logical IDs

### Target framework
AppTheory CDK (`github.com/theory-cloud/apptheory` v1.6.0)

### The concern
`AppTheoryFunction` wraps the underlying Lambda under a nested `Function` child. That is fine for new constructs, but when migrating an existing native `awslambda.Function`, it changes CloudFormation logical IDs for the Lambda and for downstream resources that derive IDs from the Lambda construct path.

### Ideal framework support
A migration-oriented option such as a stable child ID / legacy logical ID hook / migration helper, so existing functions and their event-source or permission resources can adopt AppTheory constructs without app-level logical-ID maps.

### Current workaround in lesser
- Override Lambda `CfnFunction` logical IDs for pre-existing triggerless inventory Lambdas.
- Keep stream/SQS/scheduled Lambdas native until downstream event-source mapping and schedule-permission logical ID parity has a separate proof.
- Add tests to enforce the bounded adoption and logical-ID preservation.

### Cost
- Partial adoption instead of full inventory adoption.
- Local logical-ID preservation map for existing Lambdas.
- Additional test burden to guard replacement-sensitive resources.

### Proposed next step
Framework steward scopes whether `AppTheoryFunction` should offer migration ergonomics for existing CDK resources. lesser will continue the bounded workaround and not patch AppTheory locally.

## Tasks
- [x] #974 CDK: adopt AppTheory Lambda constructs after parity proof

## Validation
- [x] `cd infra/cdk && go test ./...`
- [x] `cd infra/cdk && go vet ./...`
- [x] Representative `cdk synth` command above without timeouts
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (empty)
- [x] `git diff --check`
- [x] `go build -o lesser ./cmd/lesser && ./lesser build lambdas && ./lesser verify ci`

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None required before merge. Framework feedback is surfaced above for AppTheory stewardship; no framework code is patched here.

## Advisor-brief authorization
Aron authorized all work requested by Arch; Arch requested milestone-by-milestone review before proceeding beyond each phase.

Closes #974.
