### PR TITLE
docs: record framework leverage guidance

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,24 @@ Lesser runtime configuration is managed through:
 
 If a bootstrap mnemonic is generated on first deploy, `--out <path>` is required to persist it locally.
 
+## Framework-managed runtime behavior
+
+These behaviors come from lesser's pinned Theory Cloud framework usage. Operators normally do not configure them
+directly, but they are relevant during release validation and rollback planning.
+
+- **TableTheory Lambda timeout safety**: Lambda-optimized DynamoDB clients use TableTheory's Lambda timeout handling when
+  a request/event context has a deadline. The framework keeps a safety buffer before the Lambda hard timeout so storage
+  operations can fail predictably instead of being cut off by the runtime. There is no operator-facing env var to disable
+  this; validate timeout-sensitive changes with the full CI gate before rollout.
+- **AppTheory strict route registration**: selected HTTP surfaces register already-existing routes with strict AppTheory
+  helpers. Strict registration is a startup/test-time drift guard only; it does not introduce new route paths or response
+  shapes.
+- **AppTheory CDK functions**: selected triggerless inventory Lambdas are synthesized through AppTheory CDK constructs
+  while preserving their historical CloudFormation logical IDs. Triggered/scheduled Lambdas remain on native CDK
+  constructs where downstream event-source or permission parity has not yet been proven.
+- **No schema toggle**: the framework baseline does not change DynamoDB PK/SK patterns, GSI usage, TableTheory model tags,
+  or optimistic-concurrency versioning.
+
 ## Deploy-time integration flags
 
 Some integration inputs are consumed by `./lesser up` and CDK synthesis rather than by the normal runtime config path.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -18,6 +18,37 @@ Current state:
   `~/.lesser/<app>/<base-domain>/deploy/lambda-assets/`.
 - The published contract for that release path lives in `docs/contracts/release-driven-deploy-contract.md`.
 
+## Theory Cloud framework baseline
+
+The current deployable baseline consumes the latest released Theory Cloud framework line that was evaluated on
+2026-05-16:
+
+- AppTheory `v1.6.0` in the Go runtime and CDK app.
+- TableTheory `v1.8.3` in the Go runtime.
+- FaceTheory `v3.1.2` as the recommended client-app dependency in `docs/guides/CLIENT_APP_GUIDE.md`.
+
+Deploy implications:
+
+- There is no new `lesser up` flag for these framework updates and the published release asset shape is unchanged.
+- Lambda-optimized TableTheory clients now keep TableTheory's Lambda timeout safety buffer when a request/event context
+  has a deadline. This is runtime hardening only; it does not change DynamoDB PK/SK/GSI schema.
+- AppTheory strict route registration has been adopted only where route parity was proven (`webfinger` and `objects`).
+  It is a fail-fast guard against route drift, not a URL or response-shape change.
+- AppTheory CDK `AppTheoryFunction` is adopted only for triggerless inventory Lambdas where synth parity was proven and
+  pre-existing Lambda logical IDs are preserved. Stream/SQS/scheduled Lambdas and the client SSR host remain on native CDK
+  constructs until their downstream permissions/event-source behavior can be proven separately.
+
+Release and rollback considerations:
+
+- Run the normal hard gate before publishing or deploying a framework-update release:
+  `go build -o lesser ./cmd/lesser`, `./lesser build lambdas`, and `./lesser verify ci`.
+- For CDK-adjacent releases, review a representative `cdk synth`/CloudFormation diff before stage rollout. Do not set
+  timeouts on CDK commands.
+- Deploy through the normal `dev` → optional `staging` → `live` path with soak evidence at each stage. Framework-only
+  work does not make stage soak optional.
+- Roll back by deploying the previous release/commit through `./lesser up`. No schema migration is part of this framework
+  baseline, and prior Lambda versions must remain available as rollback targets.
+
 ## Prerequisites
 
 - A public Route53 hosted zone that exactly matches your `base-domain` (for example: `example.com`)

--- a/docs/guides/CLIENT_APP_GUIDE.md
+++ b/docs/guides/CLIENT_APP_GUIDE.md
@@ -69,7 +69,7 @@ Example:
 Contract requirements:
 
 - `schema_version` must currently be `1`.
-- `package.json` must include `@theory-cloud/facetheory`; the current pinned release asset is:
+- `package.json` must include `@theory-cloud/facetheory`; the current recommended release pin is:
 
   ```json
   {
@@ -79,6 +79,9 @@ Contract requirements:
   }
   ```
 
+- `lesser client install` validates that the dependency is present; it does not require this exact URL so local workspace
+  development remains possible. For operator releases, use the pinned release asset (or an explicitly reviewed newer
+  FaceTheory release) so the client artifact has clear provenance.
 - `server.dir` must contain the built SSR bundle.
 - `server.entry` must point at a file inside `server.dir`.
 - `server.export` defaults to `handler` when omitted.

--- a/docs/planning/theory-cloud-framework-leverage-roadmap.md
+++ b/docs/planning/theory-cloud-framework-leverage-roadmap.md
@@ -16,7 +16,7 @@ moving to the next milestone. Aron additionally authorized work requested by Arc
 | --- | --- | --- | --- |
 | Phase 0 dependency/security baseline | #968 / #976 | Merged | AppTheory `v1.6.0`, TableTheory `v1.8.3`, FaceTheory `v3.1.2` guidance, auth UI dependency remediation, CDK asset-root canonicalization. |
 | Phase 1a TableTheory Lambda client semantics | #969 / #977 | Merged | `NewLambdaOptimizedClient` now uses TableTheory Lambda-optimized timeout behavior with tests proving context/deadline handling. |
-| Phase 1b AppTheory invocation-context threading | #970 / #978 | Merged | Import-processor DB initialization now receives the AppTheory event context instead of an unrelated background context. |
+| Phase 1b AppTheory invocation-context threading | #970 / #978 | Merged | Import-processor SQS handling now scopes TableTheory repository access to the AppTheory event context deadline via `WithLambdaTimeout`; the cold-start client remains initialized once and is rebound per invocation. |
 | Phase 2a strict route proof | #971 / #979 | Merged | WebFinger route registration uses AppTheory strict registration with route-parity tests. |
 | Phase 2b strict route expansion | #972 / #980 | Merged | Objects/status object route registration uses AppTheory strict registration with route-parity tests. |
 | Phase 3a CDK parity proof | #973 / #981 | Merged | Test-only proof compares a representative Lambda synthesized natively and through AppTheoryFunction. |
@@ -63,8 +63,8 @@ moving to the next milestone. Aron additionally authorized work requested by Arc
 - `pkg/storage/theorydb.NewLambdaOptimizedClient(ctx, region)` now uses TableTheory Lambda-optimized behavior and applies
   the supplied context's timeout semantics, with tests covering deadline and local-endpoint behavior.
 - AppTheory `Context` and `EventContext` expose `.Context() context.Context`, and `EventContext` carries
-  `RemainingMS`. The import-processor now threads the event context into TableTheory client creation; other Lambda
-  families should continue to move one bounded slice at a time.
+  `RemainingMS`. The import-processor now scopes per-invocation TableTheory repository work to the event context
+  deadline via `WithLambdaTimeout`; other Lambda families should continue to move one bounded slice at a time.
 - lesser already uses several AppTheory CDK constructs: Dynamo tables, Rest API router, queues, queue consumers,
   EventBridge handlers, media CDN, Lambda roles, KMS keys, stream mappings. Lambda functions themselves are still
   created directly with AWS CDK `awslambda.NewFunction` where they have triggers or unproven downstream construct-path

--- a/docs/planning/theory-cloud-framework-leverage-roadmap.md
+++ b/docs/planning/theory-cloud-framework-leverage-roadmap.md
@@ -1,7 +1,7 @@
 # Theory Cloud Framework Leverage Roadmap
 
-Status: Phase 0 PR packaged; Arch scope review constraints incorporated (written 2026-05-16)
-Branch with baseline bump: `chore/framework-deps-2026-05-16`
+Status: Phase 4 docs closeout in progress; Phases 0 through 3b are merged to `main` (updated 2026-05-16)
+Current closeout branch: `codex/issue-975-framework-docs`
 
 ## Reported need
 
@@ -9,6 +9,19 @@ Aron asked whether there are new Theory Cloud framework updates lesser should co
 framework pins. He then authorized the full workflow: investigate deeply, enumerate changes, plan a roadmap, create a
 GitHub Project, email `arch@lessersoul.ai`, and iterate milestone-by-milestone with Arch review and approval before
 moving to the next milestone. Aron additionally authorized work requested by Arch on 2026-05-16.
+
+## Implementation status
+
+| Phase | Issue / PR | Status | Landed outcome |
+| --- | --- | --- | --- |
+| Phase 0 dependency/security baseline | #968 / #976 | Merged | AppTheory `v1.6.0`, TableTheory `v1.8.3`, FaceTheory `v3.1.2` guidance, auth UI dependency remediation, CDK asset-root canonicalization. |
+| Phase 1a TableTheory Lambda client semantics | #969 / #977 | Merged | `NewLambdaOptimizedClient` now uses TableTheory Lambda-optimized timeout behavior with tests proving context/deadline handling. |
+| Phase 1b AppTheory invocation-context threading | #970 / #978 | Merged | Import-processor DB initialization now receives the AppTheory event context instead of an unrelated background context. |
+| Phase 2a strict route proof | #971 / #979 | Merged | WebFinger route registration uses AppTheory strict registration with route-parity tests. |
+| Phase 2b strict route expansion | #972 / #980 | Merged | Objects/status object route registration uses AppTheory strict registration with route-parity tests. |
+| Phase 3a CDK parity proof | #973 / #981 | Merged | Test-only proof compares a representative Lambda synthesized natively and through AppTheoryFunction. |
+| Phase 3b CDK adoption | #974 / #982 | Merged | Triggerless inventory Lambdas use AppTheoryFunction with historical Lambda logical IDs preserved; triggered/scheduled/SSR functions remain native where parity is not yet proven. |
+| Phase 4 release/docs closeout | #975 | In progress | Operator docs and release checklist are being updated to describe landed behavior, validation gates, rollback, and non-goals. |
 
 ## Investigation note
 
@@ -38,23 +51,24 @@ moving to the next milestone. Aron additionally authorized work requested by Arc
 
 ### What is definitely true in lesser today
 
-- The baseline branch pins:
+- `main` pins:
   - root `go.mod`: AppTheory `v1.6.0`, TableTheory `v1.8.3`;
   - `infra/cdk/go.mod`: AppTheory `v1.6.0`, AWS CDK Go `v2.254.0`, jsii runtime `v1.129.0`;
   - FaceTheory client-install tests/docs: `v3.1.2` GitHub release asset;
   - auth UI: Astro `6.3.3`, Svelte `5.55.7`, devalue override `5.8.1`.
-- The baseline branch already fixed one CDK/jsii surfaced issue by canonicalizing `LambdaAssetRoot` to an absolute path
+- The baseline already fixed one CDK/jsii surfaced issue by canonicalizing `LambdaAssetRoot` to an absolute path
   before `Code_FromAsset`.
 - `pkg/storage/theorydb.GetLambdaClient(ctx)` uses `tabletheory.NewLambdaOptimized()` and applies
   `WithLambdaTimeoutConfig` / `WithLambdaTimeout(ctx)`.
-- `pkg/storage/theorydb.NewLambdaOptimizedClient(ctx, region)` currently creates a standard `tabletheory.New` client and
-  ignores the supplied context. Many Lambda entrypoints use this helper, often with `context.Background()`.
+- `pkg/storage/theorydb.NewLambdaOptimizedClient(ctx, region)` now uses TableTheory Lambda-optimized behavior and applies
+  the supplied context's timeout semantics, with tests covering deadline and local-endpoint behavior.
 - AppTheory `Context` and `EventContext` expose `.Context() context.Context`, and `EventContext` carries
-  `RemainingMS`, but many handler initialization paths and some handler paths do not consistently thread that context
-  to TableTheory client creation.
+  `RemainingMS`. The import-processor now threads the event context into TableTheory client creation; other Lambda
+  families should continue to move one bounded slice at a time.
 - lesser already uses several AppTheory CDK constructs: Dynamo tables, Rest API router, queues, queue consumers,
   EventBridge handlers, media CDN, Lambda roles, KMS keys, stream mappings. Lambda functions themselves are still
-  created directly with AWS CDK `awslambda.NewFunction` in `infra/cdk/constructs/lambda_functions.go`.
+  created directly with AWS CDK `awslambda.NewFunction` where they have triggers or unproven downstream construct-path
+  behavior. Triggerless inventory Lambdas with proven parity now use AppTheory `AppTheoryFunction`.
 - The generated/verified Lambda inventory is still consistent after the baseline bump; `./lesser verify ci` passed.
 
 ### Specialist elevation check

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -14,6 +14,25 @@ This checklist is for maintainers preparing a release/deployable build.
   - Generates a module inventory snapshot in `report/module_inventory.txt`
 - [ ] Run artifact-driven deploy certification: `bash scripts/verify_artifact_deploy.sh [dist/release]`
 
+## Theory Cloud framework baseline
+
+- [ ] Confirm release notes name the pinned framework baseline:
+  - AppTheory `v1.6.0`
+  - TableTheory `v1.8.3`
+  - FaceTheory `v3.1.2` for client-app guidance
+- [ ] Confirm auth UI dependency remediation remains intact (`cd auth-ui && corepack pnpm audit --prod` when touching
+      `auth-ui/package.json` or `auth-ui/pnpm-lock.yaml`)
+- [ ] Confirm any framework-release notes say what did **not** change: no DynamoDB schema migration, no Mastodon REST /
+      GraphQL / ActivityPub response-shape change, no federation signing/verification behavior change, and no release
+      artifact shape change unless the release intentionally includes one.
+- [ ] For TableTheory timeout work, confirm Lambda-optimized clients retain the timeout safety buffer and that
+      timeout-sensitive changes passed `./lesser verify ci`.
+- [ ] For AppTheory strict-route work, confirm the affected route inventory/parity tests passed and the OpenAPI/GraphQL
+      static contract files did not drift unexpectedly.
+- [ ] For AppTheory CDK function work, confirm a representative `cdk synth`/template diff was reviewed and no unexpected
+      Lambda replacement, permission, event-source, or log-retention changes were introduced. Never set timeouts on CDK
+      commands.
+
 ## Release contract scope
 
 - [ ] Confirm the release contract still matches reality in `docs/contracts/release-driven-deploy-contract.md`
@@ -26,4 +45,7 @@ This checklist is for maintainers preparing a release/deployable build.
 ## Deploy
 
 - [ ] Deploy with `./lesser up ...` and validate the setup wizard endpoints
+- [ ] Roll out through `dev` → optional `staging` → `live` with soak evidence; framework-maintenance releases do not
+      skip stage soak
 - [ ] Confirm monitoring/alerts and federation health checks look normal
+- [ ] Keep prior Lambda function versions and the previous release/commit available as rollback targets


### PR DESCRIPTION
## Milestone
Phase 4 — Release/docs closeout for Theory Cloud framework leverage (#975)

Closes #975.

## Classification
docs, operational-reliability, framework-consumption

## Surfaces affected
- `docs/deployment.md`
- `docs/configuration.md`
- `docs/guides/CLIENT_APP_GUIDE.md`
- `docs/release-checklist.md`
- `docs/planning/theory-cloud-framework-leverage-roadmap.md`

## Specialist walks referenced
- Federation trust: none; docs-only change and no signing, verification, inbox/outbox, delivery, moderation, or blocking behavior changes.
- Contract / API: none; no REST, GraphQL, ActivityPub object, OpenAPI, or error-shape changes.
- Schema: none; no PK/SK/GSI/TableTheory tag/model changes.
- Framework: documents the landed canonical AppTheory/TableTheory/FaceTheory usage and the framework-feedback signal produced during Phase 3b.

## Consumer impact
- Operators get release/deploy guidance for the landed framework baseline, validation gates, stage soak, and rollback.
- Mastodon clients: no contract change.
- Remote ActivityPub peers: no behavior change.
- Sibling repos: no release artifact shape change; managed consumers can continue the existing `--release-dir` flow.

## Tasks
- [x] Document framework baseline, timeout behavior, strict route/CDK adoption status, FaceTheory dependency guidance, and release/rollback considerations.

## Validation
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (empty)
- [x] `bash scripts/verify_docs.sh`
- [x] `git diff --check`
- [x] `go build -o lesser ./cmd/lesser`
- [x] `./lesser build lambdas`
- [x] `./lesser verify ci`

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None required. This PR documents lesser-side landed behavior only and does not change release artifact shape, JSON-LD namespace, MCP contract, client API contracts, or deployment SSM contracts.

## Advisor-brief authorization
Not applicable. Aron directly authorized the initiative and Arch-reviewed milestone sequence.
