### PR TITLE
[codex] verify auth ui csp freshness before release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Verify auth UI CSP freshness
+        run: bash scripts/verify_auth_ui_csp.sh
 
       - name: Set up Go
         id: setup-go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify auth UI CSP freshness
+        run: bash scripts/verify_auth_ui_csp.sh
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/docs/contracts/release-driven-deploy-contract.md
+++ b/docs/contracts/release-driven-deploy-contract.md
@@ -342,8 +342,8 @@ The release-driven deploy contract is enforced by:
   - `docs/contracts/examples/lesser-deploy-assembly.example.json`
 - release asset verification in `lesser verify artifact-deploy --release-dir ...`
 - CI and release publication running `bash scripts/verify_artifact_deploy.sh`
-- release publication running `bash scripts/verify_auth_ui_csp.sh` after the final auth UI build, before
-  `lesser-auth-ui.tar.gz` is packaged
+- CI and release publication running `bash scripts/verify_auth_ui_csp.sh` as a fail-fast freshness check before release
+  assets are built
 - targeted stack and CLI tests that prove release-mode deploys avoid repo-local rebuilds and repo-local `cdk synth`
 
 The certification goal is straightforward:

--- a/docs/contracts/release-driven-deploy-contract.md
+++ b/docs/contracts/release-driven-deploy-contract.md
@@ -342,6 +342,8 @@ The release-driven deploy contract is enforced by:
   - `docs/contracts/examples/lesser-deploy-assembly.example.json`
 - release asset verification in `lesser verify artifact-deploy --release-dir ...`
 - CI and release publication running `bash scripts/verify_artifact_deploy.sh`
+- release publication running `bash scripts/verify_auth_ui_csp.sh` after the final auth UI build, before
+  `lesser-auth-ui.tar.gz` is packaged
 - targeted stack and CLI tests that prove release-mode deploys avoid repo-local rebuilds and repo-local `cdk synth`
 
 The certification goal is straightforward:

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -10,6 +10,8 @@ This checklist is for maintainers preparing a release/deployable build.
 ## Verify gates (local or CI)
 
 - [ ] Build lambdas: `./lesser build lambdas`
+- [ ] Build auth UI and verify CloudFront CSP hashes:
+      `corepack pnpm --dir auth-ui -s build && bash scripts/verify_auth_ui_csp.sh`
 - [ ] Run the CI gate: `./lesser verify ci`
   - Generates a module inventory snapshot in `report/module_inventory.txt`
 - [ ] Run artifact-driven deploy certification: `bash scripts/verify_artifact_deploy.sh [dist/release]`
@@ -22,6 +24,8 @@ This checklist is for maintainers preparing a release/deployable build.
   - FaceTheory `v3.1.2` for client-app guidance
 - [ ] Confirm auth UI dependency remediation remains intact (`cd auth-ui && corepack pnpm audit --prod` when touching
       `auth-ui/package.json` or `auth-ui/pnpm-lock.yaml`)
+- [ ] Confirm the auth UI CSP hash gate passed after the final release auth UI build. The release asset builder runs
+      `bash scripts/verify_auth_ui_csp.sh` before packaging `lesser-auth-ui.tar.gz`.
 - [ ] Confirm any framework-release notes say what did **not** change: no DynamoDB schema migration, no Mastodon REST /
       GraphQL / ActivityPub response-shape change, no federation signing/verification behavior change, and no release
       artifact shape change unless the release intentionally includes one.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -10,8 +10,7 @@ This checklist is for maintainers preparing a release/deployable build.
 ## Verify gates (local or CI)
 
 - [ ] Build lambdas: `./lesser build lambdas`
-- [ ] Build auth UI and verify CloudFront CSP hashes:
-      `corepack pnpm --dir auth-ui -s build && bash scripts/verify_auth_ui_csp.sh`
+- [ ] Fail-fast auth UI CSP freshness check: `bash scripts/verify_auth_ui_csp.sh`
 - [ ] Run the CI gate: `./lesser verify ci`
   - Generates a module inventory snapshot in `report/module_inventory.txt`
 - [ ] Run artifact-driven deploy certification: `bash scripts/verify_artifact_deploy.sh [dist/release]`
@@ -24,8 +23,8 @@ This checklist is for maintainers preparing a release/deployable build.
   - FaceTheory `v3.1.2` for client-app guidance
 - [ ] Confirm auth UI dependency remediation remains intact (`cd auth-ui && corepack pnpm audit --prod` when touching
       `auth-ui/package.json` or `auth-ui/pnpm-lock.yaml`)
-- [ ] Confirm the auth UI CSP hash gate passed after the final release auth UI build. The release asset builder runs
-      `bash scripts/verify_auth_ui_csp.sh` before packaging `lesser-auth-ui.tar.gz`.
+- [ ] Confirm the auth UI CSP freshness gate passed before release asset build. It verifies the CloudFront CSP hash
+      definitions are at least as new as the auth UI source/config that can affect generated inline snippets.
 - [ ] Confirm any framework-release notes say what did **not** change: no DynamoDB schema migration, no Mastodon REST /
       GraphQL / ActivityPub response-shape change, no federation signing/verification behavior change, and no release
       artifact shape change unless the release intentionally includes one.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -52,6 +52,7 @@ bash scripts/reproduce_ci_verify.sh
 This is equivalent to:
 
 ```bash
+bash scripts/verify_auth_ui_csp.sh
 bash scripts/install_ci_tools.sh
 go build -o lesser ./cmd/lesser
 ./lesser build lambdas
@@ -62,6 +63,8 @@ bash scripts/verify_artifact_deploy.sh
 Notes:
 
 - `./lesser verify ci` is stricter than `./lesser verify` (adds lint, security scans, supply chain verification, strict OpenAPI, and coverage gates).
+- `scripts/verify_auth_ui_csp.sh` is a fail-fast CI/release freshness gate. It verifies the CloudFront auth UI CSP hash
+  definitions are at least as new as auth UI source/config changes without rebuilding or comparing generated `dist`.
 - Artifact-driven deploy certification is a separate CI/release step because it exercises focused `cmd/lesser` and nested `infra/cdk/stacks` regressions that protect `--release-dir` stage-stack behavior.
 - By default, the `./lesser` CLI caps Go/lint parallelism on high-core machines to avoid host OOMs (sets `GOMAXPROCS` and `GOFLAGS=-p` up to 4). Override with `LESSER_JOBS` (or your own `GOMAXPROCS` / `GOFLAGS`).
 - CI runs coverage in short mode and skips HTML generation to keep runtime down (`./lesser test coverage --scope overall --short --verbose=false --exclude-generated=false --html=false`).

--- a/infra/cdk/constructs/frontend_response_headers.go
+++ b/infra/cdk/constructs/frontend_response_headers.go
@@ -145,8 +145,7 @@ func buildFrontendStaticCSP(domainName *string) string {
 func authUIInlineScriptHashes() []string {
 	return []string{
 		// Astro/Svelte island runtime snippets generated into auth-ui/dist/*.html.
-		// Verified for every release after the auth UI build with:
-		//   pnpm --dir auth-ui install --frozen-lockfile && pnpm --dir auth-ui build
+		// CI verifies these hashes are refreshed at least as recently as auth-ui source:
 		//   bash scripts/verify_auth_ui_csp.sh
 		"'sha256-QzWFZi+FLIx23tnm9SBU4aEgx4x8DsuASP07mfqol/c='",
 		"'sha256-SaCkFfPruIdTXT8/97JArQmGxiJAL2o4bBDvSgJ5y3Q='",

--- a/infra/cdk/constructs/frontend_response_headers.go
+++ b/infra/cdk/constructs/frontend_response_headers.go
@@ -145,11 +145,11 @@ func buildFrontendStaticCSP(domainName *string) string {
 func authUIInlineScriptHashes() []string {
 	return []string{
 		// Astro/Svelte island runtime snippets generated into auth-ui/dist/*.html.
-		// Refresh after auth-ui dependency bumps with:
+		// Verified for every release after the auth UI build with:
 		//   pnpm --dir auth-ui install --frozen-lockfile && pnpm --dir auth-ui build
+		//   bash scripts/verify_auth_ui_csp.sh
 		"'sha256-QzWFZi+FLIx23tnm9SBU4aEgx4x8DsuASP07mfqol/c='",
-		"'sha256-BrDhGE1lwa85arfXcrBxSo+n37uVSX5CAROXnIM6Q+g='",
-		"'sha256-QJZDUlo/qa5AJCrG6vHyWcatjwCeWidEHQfJc601lzw='",
+		"'sha256-SaCkFfPruIdTXT8/97JArQmGxiJAL2o4bBDvSgJ5y3Q='",
 		"'sha256-eIXWvAmxkr251LJZkjniEK5LcPF3NkapbJepohwYRIc='",
 		"'sha256-IV0HjYu959C/EiJIL2l/9Ty8PA4757JXhA/g112YXVE='",
 	}
@@ -157,11 +157,6 @@ func authUIInlineScriptHashes() []string {
 
 func authUIInlineStyleHashes() []string {
 	return []string{
-		"'sha256-Eq62DWSZ57jJZCUv6mhFsTpy7vjhvM2oZhAX+bvTTN4='",
-		"'sha256-Np+0wo4qGeEiSfIZluf224zV9nNLY+nOGde1KcwOB8g='",
-		"'sha256-1mD1INqKidrIyg8naC+GEWKaF7uCtCKeBQqXOxf8LM8='",
-		"'sha256-iegu0Wb3dMBfhqOyzQ8kCD9W04jq6I7g1SiDlmvSiSg='",
-		"'sha256-qkbV7mmkk3RRKy6Ha/Sdwvz6VwoEghyumJdMY397/D0='",
 		"'sha256-vv9IoKo7BSLbWcUHr3tNmfNVmm5L/9Cfn2H6LMk7/ow='",
 	}
 }

--- a/infra/cdk/stacks/frontend_csp_test.go
+++ b/infra/cdk/stacks/frontend_csp_test.go
@@ -1,6 +1,12 @@
 package stacks
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -16,8 +22,7 @@ func TestFrontendStaticCSPIsStrictAndBehaviorScoped(t *testing.T) {
 	}
 	requireContainsAll(t, csp, []string{
 		"'sha256-QzWFZi+FLIx23tnm9SBU4aEgx4x8DsuASP07mfqol/c='",
-		"'sha256-BrDhGE1lwa85arfXcrBxSo+n37uVSX5CAROXnIM6Q+g='",
-		"'sha256-QJZDUlo/qa5AJCrG6vHyWcatjwCeWidEHQfJc601lzw='",
+		"'sha256-SaCkFfPruIdTXT8/97JArQmGxiJAL2o4bBDvSgJ5y3Q='",
 		"'sha256-eIXWvAmxkr251LJZkjniEK5LcPF3NkapbJepohwYRIc='",
 		"'sha256-IV0HjYu959C/EiJIL2l/9Ty8PA4757JXhA/g112YXVE='",
 		"'sha256-vv9IoKo7BSLbWcUHr3tNmfNVmm5L/9Cfn2H6LMk7/ow='",
@@ -76,6 +81,25 @@ func TestFrontendStaticCSPIsStrictAndBehaviorScoped(t *testing.T) {
 			t.Fatalf("behavior %q must not attach ResponseHeadersPolicyId (API-owned route)", pathPattern)
 		}
 	}
+}
+
+func TestFrontendStaticCSPMatchesBuiltAuthUIDist(t *testing.T) {
+	repoRoot := findRepoRootForAuthUITest(t)
+	distDir := filepath.Join(repoRoot, "auth-ui", "dist")
+	if _, err := os.Stat(filepath.Join(distDir, "index.html")); err != nil {
+		if os.Getenv("LESSER_REQUIRE_AUTH_UI_CSP_DIST") == "1" {
+			t.Fatalf("auth-ui/dist is required for release CSP verification; run `corepack pnpm --dir auth-ui -s build`: %v", err)
+		}
+		t.Skipf("auth-ui/dist is not built: %v", err)
+	}
+
+	distHashes := collectAuthUIInlineHashes(t, distDir)
+	resources := synthClientFrontendResources(t)
+	_, authPolicy, _, _ := findFrontendResponseHeadersPolicies(t, resources)
+	csp := extractResponseHeadersPolicyCSP(t, authPolicy)
+
+	assertCSPHashSet(t, csp, "script-src", distHashes.scripts)
+	assertCSPHashSet(t, csp, "style-src", distHashes.styles)
 }
 
 func findFrontendResponseHeadersPolicies(t *testing.T, resources map[string]any) (string, map[string]any, string, map[string]any) {
@@ -257,4 +281,126 @@ func requireContainsAll(t *testing.T, haystack string, needles []string) {
 			t.Fatalf("expected CSP to contain %q", needle)
 		}
 	}
+}
+
+type authUIInlineHashes struct {
+	scripts map[string]struct{}
+	styles  map[string]struct{}
+}
+
+func findRepoRootForAuthUITest(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	for dir := wd; ; dir = filepath.Dir(dir) {
+		if _, err := os.Stat(filepath.Join(dir, "auth-ui", "package.json")); err == nil {
+			return dir
+		}
+		next := filepath.Dir(dir)
+		if next == dir {
+			t.Fatalf("could not find repo root containing auth-ui/package.json from %s", wd)
+		}
+	}
+}
+
+func collectAuthUIInlineHashes(t *testing.T, distDir string) authUIInlineHashes {
+	t.Helper()
+	result := authUIInlineHashes{
+		scripts: map[string]struct{}{},
+		styles:  map[string]struct{}{},
+	}
+	scriptRe := regexp.MustCompile(`(?is)<script([^>]*)>(.*?)</script>`)
+	styleRe := regexp.MustCompile(`(?is)<style([^>]*)>(.*?)</style>`)
+
+	err := filepath.WalkDir(distDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".html" {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		html := string(data)
+		for _, match := range scriptRe.FindAllStringSubmatch(html, -1) {
+			if len(match) < 3 || strings.Contains(strings.ToLower(match[1]), "src=") {
+				continue
+			}
+			result.scripts[cspSHA256Source(match[2])] = struct{}{}
+		}
+		for _, match := range styleRe.FindAllStringSubmatch(html, -1) {
+			if len(match) < 3 {
+				continue
+			}
+			result.styles[cspSHA256Source(match[2])] = struct{}{}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk auth-ui dist: %v", err)
+	}
+	if len(result.scripts) == 0 {
+		t.Fatalf("auth-ui dist has no inline scripts to verify")
+	}
+	return result
+}
+
+func cspSHA256Source(content string) string {
+	sum := sha256.Sum256([]byte(content))
+	return "'sha256-" + base64.StdEncoding.EncodeToString(sum[:]) + "'"
+}
+
+func assertCSPHashSet(t *testing.T, csp string, directive string, want map[string]struct{}) {
+	t.Helper()
+	got := map[string]struct{}{}
+	for _, source := range cspDirectiveSources(csp, directive) {
+		if strings.HasPrefix(source, "'sha256-") {
+			got[source] = struct{}{}
+		}
+	}
+	if !sameStringSet(got, want) {
+		t.Fatalf("%s CSP hashes do not match built auth-ui/dist\nmissing from CSP: %v\nstale in CSP: %v",
+			directive,
+			setDifference(want, got),
+			setDifference(got, want),
+		)
+	}
+}
+
+func cspDirectiveSources(csp string, directive string) []string {
+	for _, part := range strings.Split(csp, ";") {
+		fields := strings.Fields(strings.TrimSpace(part))
+		if len(fields) == 0 || fields[0] != directive {
+			continue
+		}
+		return fields[1:]
+	}
+	return nil
+}
+
+func sameStringSet(left map[string]struct{}, right map[string]struct{}) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for key := range left {
+		if _, ok := right[key]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func setDifference(left map[string]struct{}, right map[string]struct{}) []string {
+	var diff []string
+	for key := range left {
+		if _, ok := right[key]; !ok {
+			diff = append(diff, key)
+		}
+	}
+	sort.Strings(diff)
+	return diff
 }

--- a/infra/cdk/stacks/frontend_csp_test.go
+++ b/infra/cdk/stacks/frontend_csp_test.go
@@ -1,12 +1,6 @@
 package stacks
 
 import (
-	"crypto/sha256"
-	"encoding/base64"
-	"os"
-	"path/filepath"
-	"regexp"
-	"sort"
 	"strings"
 	"testing"
 )
@@ -81,25 +75,6 @@ func TestFrontendStaticCSPIsStrictAndBehaviorScoped(t *testing.T) {
 			t.Fatalf("behavior %q must not attach ResponseHeadersPolicyId (API-owned route)", pathPattern)
 		}
 	}
-}
-
-func TestFrontendStaticCSPMatchesBuiltAuthUIDist(t *testing.T) {
-	repoRoot := findRepoRootForAuthUITest(t)
-	distDir := filepath.Join(repoRoot, "auth-ui", "dist")
-	if _, err := os.Stat(filepath.Join(distDir, "index.html")); err != nil {
-		if os.Getenv("LESSER_REQUIRE_AUTH_UI_CSP_DIST") == "1" {
-			t.Fatalf("auth-ui/dist is required for release CSP verification; run `corepack pnpm --dir auth-ui -s build`: %v", err)
-		}
-		t.Skipf("auth-ui/dist is not built: %v", err)
-	}
-
-	distHashes := collectAuthUIInlineHashes(t, distDir)
-	resources := synthClientFrontendResources(t)
-	_, authPolicy, _, _ := findFrontendResponseHeadersPolicies(t, resources)
-	csp := extractResponseHeadersPolicyCSP(t, authPolicy)
-
-	assertCSPHashSet(t, csp, "script-src", distHashes.scripts)
-	assertCSPHashSet(t, csp, "style-src", distHashes.styles)
 }
 
 func findFrontendResponseHeadersPolicies(t *testing.T, resources map[string]any) (string, map[string]any, string, map[string]any) {
@@ -281,126 +256,4 @@ func requireContainsAll(t *testing.T, haystack string, needles []string) {
 			t.Fatalf("expected CSP to contain %q", needle)
 		}
 	}
-}
-
-type authUIInlineHashes struct {
-	scripts map[string]struct{}
-	styles  map[string]struct{}
-}
-
-func findRepoRootForAuthUITest(t *testing.T) string {
-	t.Helper()
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("get working directory: %v", err)
-	}
-	for dir := wd; ; dir = filepath.Dir(dir) {
-		if _, err := os.Stat(filepath.Join(dir, "auth-ui", "package.json")); err == nil {
-			return dir
-		}
-		next := filepath.Dir(dir)
-		if next == dir {
-			t.Fatalf("could not find repo root containing auth-ui/package.json from %s", wd)
-		}
-	}
-}
-
-func collectAuthUIInlineHashes(t *testing.T, distDir string) authUIInlineHashes {
-	t.Helper()
-	result := authUIInlineHashes{
-		scripts: map[string]struct{}{},
-		styles:  map[string]struct{}{},
-	}
-	scriptRe := regexp.MustCompile(`(?is)<script([^>]*)>(.*?)</script>`)
-	styleRe := regexp.MustCompile(`(?is)<style([^>]*)>(.*?)</style>`)
-
-	err := filepath.WalkDir(distDir, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() || filepath.Ext(path) != ".html" {
-			return nil
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		html := string(data)
-		for _, match := range scriptRe.FindAllStringSubmatch(html, -1) {
-			if len(match) < 3 || strings.Contains(strings.ToLower(match[1]), "src=") {
-				continue
-			}
-			result.scripts[cspSHA256Source(match[2])] = struct{}{}
-		}
-		for _, match := range styleRe.FindAllStringSubmatch(html, -1) {
-			if len(match) < 3 {
-				continue
-			}
-			result.styles[cspSHA256Source(match[2])] = struct{}{}
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk auth-ui dist: %v", err)
-	}
-	if len(result.scripts) == 0 {
-		t.Fatalf("auth-ui dist has no inline scripts to verify")
-	}
-	return result
-}
-
-func cspSHA256Source(content string) string {
-	sum := sha256.Sum256([]byte(content))
-	return "'sha256-" + base64.StdEncoding.EncodeToString(sum[:]) + "'"
-}
-
-func assertCSPHashSet(t *testing.T, csp string, directive string, want map[string]struct{}) {
-	t.Helper()
-	got := map[string]struct{}{}
-	for _, source := range cspDirectiveSources(csp, directive) {
-		if strings.HasPrefix(source, "'sha256-") {
-			got[source] = struct{}{}
-		}
-	}
-	if !sameStringSet(got, want) {
-		t.Fatalf("%s CSP hashes do not match built auth-ui/dist\nmissing from CSP: %v\nstale in CSP: %v",
-			directive,
-			setDifference(want, got),
-			setDifference(got, want),
-		)
-	}
-}
-
-func cspDirectiveSources(csp string, directive string) []string {
-	for _, part := range strings.Split(csp, ";") {
-		fields := strings.Fields(strings.TrimSpace(part))
-		if len(fields) == 0 || fields[0] != directive {
-			continue
-		}
-		return fields[1:]
-	}
-	return nil
-}
-
-func sameStringSet(left map[string]struct{}, right map[string]struct{}) bool {
-	if len(left) != len(right) {
-		return false
-	}
-	for key := range left {
-		if _, ok := right[key]; !ok {
-			return false
-		}
-	}
-	return true
-}
-
-func setDifference(left map[string]struct{}, right map[string]struct{}) []string {
-	var diff []string
-	for key := range left {
-		if _, ok := right[key]; !ok {
-			diff = append(diff, key)
-		}
-	}
-	sort.Strings(diff)
-	return diff
 }

--- a/scripts/build_release_assets.sh
+++ b/scripts/build_release_assets.sh
@@ -65,6 +65,8 @@ corepack pnpm install --frozen-lockfile
 corepack pnpm build
 cd "${ROOT_DIR}"
 
+bash "${ROOT_DIR}/scripts/verify_auth_ui_csp.sh"
+
 echo "Building canonical Lambda zip artifacts"
 go run ./cmd/lesser build lambdas --rebuild
 

--- a/scripts/build_release_assets.sh
+++ b/scripts/build_release_assets.sh
@@ -59,13 +59,13 @@ TARGETS=(
   "darwin arm64"
 )
 
+bash "${ROOT_DIR}/scripts/verify_auth_ui_csp.sh"
+
 echo "Building auth UI release bundle"
 cd "${ROOT_DIR}/auth-ui"
 corepack pnpm install --frozen-lockfile
 corepack pnpm build
 cd "${ROOT_DIR}"
-
-bash "${ROOT_DIR}/scripts/verify_auth_ui_csp.sh"
 
 echo "Building canonical Lambda zip artifacts"
 go run ./cmd/lesser build lambdas --rebuild

--- a/scripts/reproduce_ci_verify.sh
+++ b/scripts/reproduce_ci_verify.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
+bash scripts/verify_auth_ui_csp.sh
 bash scripts/install_ci_tools.sh
 go build -o lesser ./cmd/lesser
 ./lesser build lambdas

--- a/scripts/verify_auth_ui_csp.sh
+++ b/scripts/verify_auth_ui_csp.sh
@@ -2,17 +2,107 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
 
-if [[ ! -f "${ROOT_DIR}/auth-ui/dist/index.html" ]]; then
-  echo "auth-ui/dist is missing; run: corepack pnpm --dir auth-ui -s build" >&2
+AUTH_UI_SOURCE_PATHS=(
+  auth-ui/src
+  auth-ui/public
+  auth-ui/package.json
+  auth-ui/pnpm-lock.yaml
+  auth-ui/astro.config.mjs
+  auth-ui/tsconfig.json
+  auth-ui/components.json
+)
+
+CSP_HASH_PATHS=(
+  infra/cdk/constructs/frontend_response_headers.go
+)
+
+format_commit() {
+  git log -1 --format='%h %cs %s' -- "$@"
+}
+
+latest_commit() {
+  git log -1 --format='%H' -- "$@"
+}
+
+untracked_auth_ui_sources() {
+  git ls-files --others --exclude-standard -- "${AUTH_UI_SOURCE_PATHS[@]}"
+}
+
+ensure_history_for_ancestry_check() {
+  if [[ "$(git rev-parse --is-shallow-repository)" != "true" ]]; then
+    return
+  fi
+
+  echo "Repository is shallow; fetching history for auth UI CSP freshness check"
+  git fetch --unshallow --quiet || git fetch --depth=1000 --quiet
+}
+
+fail_stale_hashes() {
+  cat >&2 <<EOF
+auth UI source is newer than the CloudFront CSP hash definitions.
+
+Latest auth UI source change:
+  $(format_commit "${AUTH_UI_SOURCE_PATHS[@]}")
+
+Latest CSP hash definition change:
+  $(format_commit "${CSP_HASH_PATHS[@]}")
+
+Refresh the auth UI CSP hash definitions in:
+  ${CSP_HASH_PATHS[*]}
+
+Then rerun:
+  bash scripts/verify_auth_ui_csp.sh
+EOF
+  exit 1
+}
+
+echo "==> Verifying auth UI CSP hash freshness"
+
+ensure_history_for_ancestry_check
+
+auth_ui_commit="$(latest_commit "${AUTH_UI_SOURCE_PATHS[@]}")"
+csp_commit="$(latest_commit "${CSP_HASH_PATHS[@]}")"
+
+if [[ -z "${auth_ui_commit}" ]]; then
+  echo "could not find a git commit for auth UI source paths" >&2
+  exit 1
+fi
+if [[ -z "${csp_commit}" ]]; then
+  echo "could not find a git commit for auth UI CSP hash paths" >&2
   exit 1
 fi
 
-echo "==> Verifying auth UI CSP hashes against built auth-ui/dist"
-(
-  cd "${ROOT_DIR}/infra/cdk"
-  LESSER_REQUIRE_AUTH_UI_CSP_DIST=1 \
-    go test ./stacks -run 'TestFrontendStaticCSP(IsStrictAndBehaviorScoped|MatchesBuiltAuthUIDist)' -count=1
-)
+if ! git merge-base --is-ancestor "${auth_ui_commit}" "${csp_commit}"; then
+  fail_stale_hashes
+fi
 
-echo "✅ Auth UI CSP hashes match built auth-ui/dist"
+untracked_sources="$(untracked_auth_ui_sources)"
+if [[ -n "${untracked_sources}" ]]; then
+  cat >&2 <<EOF
+Untracked auth UI source/config files are present, so CSP freshness cannot be proven:
+${untracked_sources}
+
+Track or remove these files, and refresh CSP hash definitions if they can affect generated inline script/style snippets.
+EOF
+  exit 1
+fi
+
+if {
+  ! git diff --quiet -- "${AUTH_UI_SOURCE_PATHS[@]}" ||
+    ! git diff --cached --quiet -- "${AUTH_UI_SOURCE_PATHS[@]}"
+} && {
+  git diff --quiet -- "${CSP_HASH_PATHS[@]}" &&
+    git diff --cached --quiet -- "${CSP_HASH_PATHS[@]}"
+}; then
+  cat >&2 <<EOF
+Uncommitted auth UI source changes are present without corresponding CSP hash definition changes.
+
+If these auth UI changes can affect generated inline script/style snippets, refresh:
+  ${CSP_HASH_PATHS[*]}
+EOF
+  exit 1
+fi
+
+echo "✅ Auth UI CSP hashes are at least as new as auth-ui source"

--- a/scripts/verify_auth_ui_csp.sh
+++ b/scripts/verify_auth_ui_csp.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ ! -f "${ROOT_DIR}/auth-ui/dist/index.html" ]]; then
+  echo "auth-ui/dist is missing; run: corepack pnpm --dir auth-ui -s build" >&2
+  exit 1
+fi
+
+echo "==> Verifying auth UI CSP hashes against built auth-ui/dist"
+(
+  cd "${ROOT_DIR}/infra/cdk"
+  LESSER_REQUIRE_AUTH_UI_CSP_DIST=1 \
+    go test ./stacks -run 'TestFrontendStaticCSP(IsStrictAndBehaviorScoped|MatchesBuiltAuthUIDist)' -count=1
+)
+
+echo "✅ Auth UI CSP hashes match built auth-ui/dist"


### PR DESCRIPTION
## Summary
- fix the current auth UI CSP hash drift by refreshing the static CloudFront CSP hashes for the current auth UI output
- add a fail-fast `scripts/verify_auth_ui_csp.sh` freshness check that verifies CSP hash definitions are at least as new as auth UI source/config changes, without rebuilding or comparing generated `dist`
- run that check at the start of CI, release publication, release asset build, and local CI reproduction docs

## Why
A browser OAuth login failure showed the deployed auth UI could emit inline Astro/Svelte snippets newer than the CloudFront CSP hash allowlist. This makes CSP drift fail early in PR CI, before release assets are built or published.

## Contract impact
- No DynamoDB schema change
- No Mastodon REST / GraphQL / ActivityPub response-shape change
- No release artifact shape change
- Deployment impact is limited to CloudFront auth UI response header policy bytes after normal `./lesser up` rollout

## Validation
- `bash -n scripts/verify_auth_ui_csp.sh scripts/build_release_assets.sh scripts/reproduce_ci_verify.sh`
- `bash scripts/verify_auth_ui_csp.sh`
- `cd infra/cdk && go test ./stacks -run TestFrontendStaticCSPIsStrictAndBehaviorScoped -count=1`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`
- `bash scripts/verify_artifact_deploy.sh`