### PR TITLE
[codex] repair processor storage startup paths

### DIFF
--- a/cmd/ai-processor/main.go
+++ b/cmd/ai-processor/main.go
@@ -22,6 +22,8 @@ import (
 	pkgErrors "github.com/equaltoai/lesser/pkg/errors"
 	aiService "github.com/equaltoai/lesser/pkg/services/ai"
 	storageCore "github.com/equaltoai/lesser/pkg/storage/core"
+	"github.com/equaltoai/lesser/pkg/storage/factory"
+	"github.com/equaltoai/lesser/pkg/storage/theorydb"
 	"github.com/equaltoai/lesser/pkg/storage/theorydb/stream"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	"github.com/theory-cloud/tabletheory/pkg/core"
@@ -291,21 +293,42 @@ func (ap *AIProcessor) determineSeverity(analysis *ai.AIAnalysis) string {
 }
 
 var (
-	lambdaCtx       *common.LambdaContext
-	cfg             *config.Config //nolint:unused // Reserved for dependency injection pattern
-	logger          *zap.Logger
-	repos           storageCore.RepositoryStorage //nolint:unused // Reserved for dependency injection pattern
-	processor       *AIProcessor
-	unmarshalItemFn = stream.UnmarshalItem
-	lambdaStartFn   = lambda.Start
+	lambdaCtx                  *common.LambdaContext
+	cfg                        *config.Config //nolint:unused // Reserved for dependency injection pattern
+	logger                     *zap.Logger
+	repos                      storageCore.RepositoryStorage //nolint:unused // Reserved for dependency injection pattern
+	processor                  *AIProcessor
+	unmarshalItemFn            = stream.UnmarshalItem
+	runningUnitTestsFn         = common.RunningUnitTests
+	mustInitializeLambdaFn     = common.MustInitializeLambda
+	newLambdaOptimizedClientFn = theorydb.NewLambdaOptimizedClient
+	newRepositoryFactoryFn     = func(db core.DB, tableName string, logger *zap.Logger) (storageCore.RepositoryStorage, error) {
+		return factory.NewRepositoryFactory(db, tableName, logger)
+	}
+	newContentAnalyzerFn = func(lambdaCtx *common.LambdaContext) (contentAnalyzer, error) {
+		if lambdaCtx == nil || lambdaCtx.AWSServices == nil {
+			return nil, fmt.Errorf("AI processor AWS services are not initialized")
+		}
+		return ai.NewAIService(lambdaCtx.AWSServices.Config, ai.DefaultAIConfig()), nil
+	}
+	newAnalysisSaverFn = func(repos storageCore.RepositoryStorage, _ core.DB, logger *zap.Logger) analysisSaver {
+		return aiService.NewService(repos, nil, logger)
+	}
+	lambdaStartFn = lambda.Start
 )
 
 func init() {
-	if common.RunningUnitTests() {
+	if runningUnitTestsFn() {
 		return
 	}
+	if err := initializeAIProcessor(); err != nil {
+		logger.Fatal("failed to initialize AI processor", zap.Error(err))
+	}
+}
+
+func initializeAIProcessor() error {
 	// Standardized Lambda initialization for processor functions
-	lambdaCtx = common.MustInitializeLambda(common.LambdaConfig{
+	lambdaCtx = mustInitializeLambdaFn(common.LambdaConfig{
 		ServiceName: "ai-processor",
 		LambdaType:  common.LambdaTypeProcessor,
 	})
@@ -313,28 +336,108 @@ func init() {
 	// Automatic dependency injection
 	cfg = lambdaCtx.Config
 	logger = lambdaCtx.Logger
-	if lambdaCtx.Repos != nil {
-		repos = lambdaCtx.Repos.(storageCore.RepositoryStorage)
-	}
 
-	// Initialize with processor-specific defaults
-	err := lambdaCtx.InitializeWithDefaults()
+	var err error
+	repos, err = initializeAIStorage(lambdaCtx)
 	if err != nil {
-		logger.Warn("failed to initialize with defaults", zap.Error(err))
+		return err
 	}
 
 	// Initialize processor with simplified configuration
-	processor = NewSimplifiedAIProcessor(lambdaCtx)
+	processor, err = NewSimplifiedAIProcessor(lambdaCtx)
+	return err
+}
+
+func initializeAIStorage(lambdaCtx *common.LambdaContext) (storageCore.RepositoryStorage, error) {
+	if lambdaCtx == nil {
+		return nil, fmt.Errorf("AI processor lambda context is nil")
+	}
+	if lambdaCtx.Config == nil {
+		return nil, fmt.Errorf("AI processor config is nil")
+	}
+
+	if lambdaCtx.Repos != nil {
+		repos, ok := lambdaCtx.Repos.(storageCore.RepositoryStorage)
+		if !ok || repos == nil {
+			return nil, fmt.Errorf("AI processor invalid repository storage")
+		}
+		return repos, nil
+	}
+
+	tableName := strings.TrimSpace(lambdaCtx.Config.DynamoTableName)
+	if tableName == "" {
+		return nil, fmt.Errorf("AI processor dynamodb table name is required")
+	}
+
+	region := strings.TrimSpace(lambdaCtx.Config.Region)
+	if region == "" {
+		return nil, fmt.Errorf("AI processor AWS region is required")
+	}
+
+	var db core.DB
+	if lambdaCtx.DynamoDB != nil {
+		var ok bool
+		db, ok = lambdaCtx.DynamoDB.(core.DB)
+		if !ok || db == nil {
+			return nil, fmt.Errorf("AI processor invalid dynamodb client")
+		}
+	} else {
+		var err error
+		db, err = newLambdaOptimizedClientFn(context.Background(), region)
+		if err != nil {
+			return nil, fmt.Errorf("AI processor storage client initialization failed: %w", err)
+		}
+		lambdaCtx.DynamoDB = db
+	}
+
+	repos, err := newRepositoryFactoryFn(db, tableName, logger)
+	if err != nil {
+		return nil, fmt.Errorf("AI processor repository initialization failed: %w", err)
+	}
+	lambdaCtx.Repos = repos
+	return repos, nil
 }
 
 // NewSimplifiedAIProcessor creates a new AI processor instance with simplified Lambda context
-func NewSimplifiedAIProcessor(lambdaCtx *common.LambdaContext) *AIProcessor {
+func NewSimplifiedAIProcessor(lambdaCtx *common.LambdaContext) (*AIProcessor, error) {
+	if lambdaCtx == nil {
+		return nil, fmt.Errorf("AI processor lambda context is nil")
+	}
+	if lambdaCtx.Config == nil {
+		return nil, fmt.Errorf("AI processor config is nil")
+	}
+
+	db, ok := lambdaCtx.DynamoDB.(core.DB)
+	if !ok || db == nil {
+		return nil, fmt.Errorf("AI processor dynamodb client is not initialized")
+	}
+
+	repoStorage, ok := lambdaCtx.Repos.(storageCore.RepositoryStorage)
+	if !ok || repoStorage == nil {
+		return nil, fmt.Errorf("AI processor repository storage is not initialized")
+	}
+
+	analyzer, err := newContentAnalyzerFn(lambdaCtx)
+	if err != nil {
+		return nil, err
+	}
+	if analyzer == nil {
+		return nil, fmt.Errorf("AI processor content analyzer is not initialized")
+	}
+
+	saver := newAnalysisSaverFn(repoStorage, db, lambdaCtx.Logger)
+	if saver == nil {
+		return nil, fmt.Errorf("AI processor analysis saver is not initialized")
+	}
+
 	// Initialize simplified processor with essential components
 	return &AIProcessor{
-		db:        lambdaCtx.DynamoDB.(core.DB),
-		tableName: lambdaCtx.Config.DynamoTableName,
-		logger:    lambdaCtx.Logger,
-	}
+		db:         db,
+		tableName:  lambdaCtx.Config.DynamoTableName,
+		aiAnalyzer: analyzer,
+		aiService:  saver,
+		logger:     lambdaCtx.Logger,
+	}, nil
 }
 
 func main() {

--- a/cmd/ai-processor/round12_ai_processor_test.go
+++ b/cmd/ai-processor/round12_ai_processor_test.go
@@ -12,9 +12,12 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
 	aiService "github.com/equaltoai/lesser/pkg/services/ai"
+	storageCore "github.com/equaltoai/lesser/pkg/storage/core"
+	testingmocks "github.com/equaltoai/lesser/pkg/testing/mocks"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"github.com/theory-cloud/tabletheory/pkg/core"
 	"github.com/theory-cloud/tabletheory/pkg/mocks"
 	"go.uber.org/zap"
 )
@@ -474,8 +477,12 @@ func TestAIProcessor_HandleDynamoDBRecord_PanicRecovery_Round12(t *testing.T) {
 func TestAIProcessor_Entrypoint_Round12(t *testing.T) {
 	origStart := lambdaStartFn
 	origUnmarshal := unmarshalItemFn
+	origAnalyzerFn := newContentAnalyzerFn
+	origSaverFn := newAnalysisSaverFn
 	t.Cleanup(func() { lambdaStartFn = origStart })
 	t.Cleanup(func() { unmarshalItemFn = origUnmarshal })
+	t.Cleanup(func() { newContentAnalyzerFn = origAnalyzerFn })
+	t.Cleanup(func() { newAnalysisSaverFn = origSaverFn })
 
 	analysis := &ai.AIAnalysis{
 		ID:               "analysis-1",
@@ -545,11 +552,15 @@ func TestAIProcessor_Entrypoint_Round12(t *testing.T) {
 	require.Equal(t, 1, analyzer.calls)
 	require.Equal(t, 1, saver.calls)
 
-	p := NewSimplifiedAIProcessor(&common.LambdaContext{
+	newContentAnalyzerFn = func(*common.LambdaContext) (contentAnalyzer, error) { return analyzer, nil }
+	newAnalysisSaverFn = func(storageCore.RepositoryStorage, core.DB, *zap.Logger) analysisSaver { return saver }
+	p, err := NewSimplifiedAIProcessor(&common.LambdaContext{
 		DynamoDB: new(mocks.MockDB),
 		Config:   &config.Config{DynamoTableName: "test-table"},
 		Logger:   zap.NewNop(),
+		Repos:    testingmocks.NewMockRepositoryStorage(),
 	})
+	require.NoError(t, err)
 	require.NotNil(t, p)
 }
 
@@ -559,4 +570,70 @@ func TestHandleAIProcessorStreamRecord_MissingProcessor_Round12(t *testing.T) {
 
 	processor = nil
 	require.Error(t, handleAIProcessorStreamRecord(nil, events.DynamoDBEventRecord{EventID: "1", EventName: "INSERT"}))
+}
+
+func TestInitializeAIProcessor_FailsClosedOnStorageError(t *testing.T) {
+	origMust := mustInitializeLambdaFn
+	origNewClient := newLambdaOptimizedClientFn
+	t.Cleanup(func() {
+		mustInitializeLambdaFn = origMust
+		newLambdaOptimizedClientFn = origNewClient
+	})
+
+	mustInitializeLambdaFn = func(common.LambdaConfig) *common.LambdaContext {
+		return &common.LambdaContext{
+			Config: &config.Config{Region: "us-east-1", DynamoTableName: "test-table"},
+			Logger: zap.NewNop(),
+		}
+	}
+	newLambdaOptimizedClientFn = func(context.Context, string) (core.DB, error) {
+		return nil, errors.New("storage unavailable")
+	}
+
+	err := initializeAIProcessor()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "storage client initialization failed")
+}
+
+func TestInitializeAIStorage_CreatesReposAndStoresClient(t *testing.T) {
+	origNewClient := newLambdaOptimizedClientFn
+	origNewFactory := newRepositoryFactoryFn
+	t.Cleanup(func() {
+		newLambdaOptimizedClientFn = origNewClient
+		newRepositoryFactoryFn = origNewFactory
+	})
+
+	db := new(mocks.MockDB)
+	expectedRepos := testingmocks.NewMockRepositoryStorage()
+	var gotRegion, gotTable string
+	newLambdaOptimizedClientFn = func(_ context.Context, region string) (core.DB, error) {
+		gotRegion = region
+		return db, nil
+	}
+	newRepositoryFactoryFn = func(gotDB core.DB, tableName string, _ *zap.Logger) (storageCore.RepositoryStorage, error) {
+		require.Same(t, db, gotDB)
+		gotTable = tableName
+		return expectedRepos, nil
+	}
+
+	ctx := &common.LambdaContext{
+		Config: &config.Config{Region: "us-east-1", DynamoTableName: "ai-table"},
+		Logger: zap.NewNop(),
+	}
+	gotRepos, err := initializeAIStorage(ctx)
+	require.NoError(t, err)
+	require.Same(t, expectedRepos, gotRepos)
+	require.Same(t, db, ctx.DynamoDB)
+	require.Same(t, expectedRepos, ctx.Repos)
+	require.Equal(t, "us-east-1", gotRegion)
+	require.Equal(t, "ai-table", gotTable)
+}
+
+func TestNewSimplifiedAIProcessor_FailsClosedWithoutStorage(t *testing.T) {
+	_, err := NewSimplifiedAIProcessor(&common.LambdaContext{
+		Config: &config.Config{DynamoTableName: "test-table"},
+		Logger: zap.NewNop(),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dynamodb client is not initialized")
 }

--- a/cmd/dlq-processor/main.go
+++ b/cmd/dlq-processor/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/dlq"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
+	"github.com/equaltoai/lesser/pkg/storage/theorydb"
 )
 
 type dlqProcessor interface {
@@ -184,20 +185,29 @@ func (h *DLQProcessorHandler) handleAnalytics(ctx context.Context) error {
 
 // Global variables for standardized Lambda initialization.
 var (
-	lambdaCtx     *common.LambdaContext
-	cfg           *config.Config
-	logger        *zap.Logger
-	repos         interface{} //nolint:unused // dependency injection pattern - available for processor extensions
-	handler       *DLQProcessorHandler
-	lambdaStartFn = lambda.Start
+	lambdaCtx                  *common.LambdaContext
+	cfg                        *config.Config
+	logger                     *zap.Logger
+	repos                      interface{} //nolint:unused // dependency injection pattern - available for processor extensions
+	handler                    *DLQProcessorHandler
+	runningUnitTestsFn         = common.RunningUnitTests
+	mustInitializeLambdaFn     = common.MustInitializeLambda
+	newLambdaOptimizedClientFn = theorydb.NewLambdaOptimizedClient
+	lambdaStartFn              = lambda.Start
 )
 
 func init() {
-	if common.RunningUnitTests() {
+	if runningUnitTestsFn() {
 		return
 	}
 
-	lambdaCtx = common.MustInitializeLambda(common.LambdaConfig{
+	if err := initializeDLQProcessor(); err != nil {
+		logger.Fatal("failed to initialize dlq processor", zap.Error(err))
+	}
+}
+
+func initializeDLQProcessor() error {
+	lambdaCtx = mustInitializeLambdaFn(common.LambdaConfig{
 		ServiceName: "dlq-processor",
 		LambdaType:  common.LambdaTypeProcessor,
 	})
@@ -206,15 +216,48 @@ func init() {
 	logger = lambdaCtx.Logger
 	repos = lambdaCtx.Repos
 
-	if err := lambdaCtx.InitializeWithDefaults(); err != nil {
-		logger.Warn("failed to initialize with defaults", zap.Error(err))
+	db, err := initializeDLQStorage(lambdaCtx)
+	if err != nil {
+		return err
 	}
-
-	db := lambdaCtx.DynamoDB.(core.DB)
 	processor := dlq.NewProcessor(db, cfg.DynamoTableName, logger)
 	handler = NewDLQProcessorHandler(processor, logger)
 
 	logger.Info("DLQ processor initialized successfully")
+	return nil
+}
+
+func initializeDLQStorage(lambdaCtx *common.LambdaContext) (core.DB, error) {
+	if lambdaCtx == nil {
+		return nil, fmt.Errorf("dlq-processor lambda context is nil")
+	}
+	if lambdaCtx.Config == nil {
+		return nil, fmt.Errorf("dlq-processor config is nil")
+	}
+	if lambdaCtx.DynamoDB != nil {
+		db, ok := lambdaCtx.DynamoDB.(core.DB)
+		if !ok || db == nil {
+			return nil, fmt.Errorf("dlq-processor invalid dynamodb client")
+		}
+		return db, nil
+	}
+
+	tableName := strings.TrimSpace(lambdaCtx.Config.DynamoTableName)
+	if tableName == "" {
+		return nil, fmt.Errorf("dlq-processor dynamodb table name is required")
+	}
+
+	region := strings.TrimSpace(lambdaCtx.Config.Region)
+	if region == "" {
+		return nil, fmt.Errorf("dlq-processor AWS region is required")
+	}
+
+	db, err := newLambdaOptimizedClientFn(context.Background(), region)
+	if err != nil {
+		return nil, fmt.Errorf("dlq-processor storage client initialization failed: %w", err)
+	}
+	lambdaCtx.DynamoDB = db
+	return db, nil
 }
 
 func main() {

--- a/cmd/dlq-processor/round12_additional_test.go
+++ b/cmd/dlq-processor/round12_additional_test.go
@@ -7,8 +7,12 @@ import (
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/stretchr/testify/require"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	dynamormmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
 	"go.uber.org/zap"
 
 	"github.com/equaltoai/lesser/pkg/storage/models"
@@ -245,4 +249,51 @@ func TestMain_WiresAppTheoryAndStartsLambda(t *testing.T) {
 
 	main()
 	require.Equal(t, 1, startCalls)
+}
+
+func TestInitializeDLQStorage_FailsClosed(t *testing.T) {
+	origNewClient := newLambdaOptimizedClientFn
+	t.Cleanup(func() { newLambdaOptimizedClientFn = origNewClient })
+
+	newLambdaOptimizedClientFn = func(context.Context, string) (core.DB, error) {
+		return nil, errors.New("storage unavailable")
+	}
+
+	ctx := &common.LambdaContext{
+		Config: &config.Config{Region: "us-east-1", DynamoTableName: "test-table"},
+		Logger: zap.NewNop(),
+	}
+	_, err := initializeDLQStorage(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "storage client initialization failed")
+}
+
+func TestInitializeDLQProcessor_SucceedsWithInjectedDB(t *testing.T) {
+	origMust := mustInitializeLambdaFn
+	origLogger := logger
+	origCtx := lambdaCtx
+	origCfg := cfg
+	origHandler := handler
+	t.Cleanup(func() {
+		mustInitializeLambdaFn = origMust
+		logger = origLogger
+		lambdaCtx = origCtx
+		cfg = origCfg
+		handler = origHandler
+	})
+
+	db := new(dynamormmocks.MockDB)
+	mustInitializeLambdaFn = func(common.LambdaConfig) *common.LambdaContext {
+		return &common.LambdaContext{
+			Config:   &config.Config{Region: "us-east-1", DynamoTableName: "dlq-table"},
+			Logger:   zap.NewNop(),
+			DynamoDB: db,
+		}
+	}
+
+	err := initializeDLQProcessor()
+	require.NoError(t, err)
+	require.NotNil(t, handler)
+	require.Same(t, db, lambdaCtx.DynamoDB)
+	require.Equal(t, "dlq-table", cfg.DynamoTableName)
 }

--- a/cmd/federation-aggregator/main.go
+++ b/cmd/federation-aggregator/main.go
@@ -101,6 +101,7 @@ type DomainStat struct {
 
 // NewFederationAggregatorProcessor creates a new federation aggregator processor
 func NewFederationAggregatorProcessor(db dynamormCore.DB, tableName string, lambdaCtx *common.LambdaContext) *FederationAggregatorProcessor {
+	federationAggregationTableName = tableName
 	federationActivityRepository := repositories.NewFederationActivityRepository(db, tableName, lambdaCtx.Logger, nil)
 
 	return &FederationAggregatorProcessor{
@@ -183,12 +184,12 @@ func (p *FederationAggregatorProcessor) processSQSMessage(ctx context.Context, r
 }
 
 var (
-	lambdaCtx *common.LambdaContext
-	cfg       *config.Config
-	logger    *zap.Logger
-	repos     core.RepositoryStorage //nolint:unused // dependency injection pattern - available for processor extensions
-	processor *FederationAggregatorProcessor
-	db        dynamormCore.DB
+	lambdaCtx                      *common.LambdaContext
+	cfg                            *config.Config
+	repos                          core.RepositoryStorage //nolint:unused // dependency injection pattern - available for processor extensions
+	processor                      *FederationAggregatorProcessor
+	db                             dynamormCore.DB
+	federationAggregationTableName string
 )
 
 func init() {
@@ -202,7 +203,6 @@ func init() {
 
 var (
 	mustInitializeLambdaFn     = common.MustInitializeLambda
-	initializeWithDefaultsFn   = func(ctx *common.LambdaContext) error { return ctx.InitializeWithDefaults() }
 	newLambdaOptimizedClientFn = theorydb.NewLambdaOptimizedClient
 	newProcessorFn             = NewFederationAggregatorProcessor
 	lambdaStartFn              = lambda.Start
@@ -217,16 +217,10 @@ func initializeFederationAggregator() error {
 
 	// Automatic dependency injection
 	cfg = lambdaCtx.Config
-	logger = lambdaCtx.Logger
 	if lambdaCtx.Repos != nil {
 		if repoStorage, ok := lambdaCtx.Repos.(core.RepositoryStorage); ok {
 			repos = repoStorage
 		}
-	}
-
-	// Initialize with processor-specific defaults
-	if err := initializeWithDefaultsFn(lambdaCtx); err != nil {
-		logger.Warn("failed to initialize with defaults", zap.Error(err))
 	}
 
 	// Initialize DynamORM with Lambda optimizations
@@ -237,6 +231,7 @@ func initializeFederationAggregator() error {
 	}
 
 	processor = newProcessorFn(db, cfg.DynamoTableName, lambdaCtx)
+	federationAggregationTableName = cfg.DynamoTableName
 	return nil
 }
 
@@ -378,9 +373,10 @@ func (p *FederationAggregatorProcessor) triggerAggregation(ctx context.Context, 
 		return pkgErrors.WrapError(err, pkgErrors.CodeEventProcessingFailed, pkgErrors.CategoryLambda, "Failed to marshal aggregation event")
 	}
 
-	// Option 1: Use SQS for async processing (preferred for resilience)
-	queueURL := fmt.Sprintf("https://sqs.%s.amazonaws.com/%s/federation-aggregator-queue",
-		p.lambdaCtx.Config.Region, p.lambdaCtx.Config.AWSAccountID)
+	queueURL, err := p.federationAggregatorQueueURL()
+	if err != nil {
+		return err
+	}
 
 	sqsInput := &sqs.SendMessageInput{
 		QueueUrl:    &queueURL,
@@ -411,7 +407,7 @@ func (p *FederationAggregatorProcessor) triggerAggregation(ctx context.Context, 
 		zap.Error(sqsErr))
 
 	// Option 2: Direct Lambda invocation (fallback)
-	functionName := "federation-aggregator" // This Lambda function name
+	functionName := p.federationAggregatorFunctionName()
 
 	lambdaInput := &awslambda.InvokeInput{
 		FunctionName:   aws.String(functionName),
@@ -447,11 +443,58 @@ func (p *FederationAggregatorProcessor) triggerAggregation(ctx context.Context, 
 	return nil
 }
 
+func (p *FederationAggregatorProcessor) federationAggregatorQueueURL() (string, error) {
+	if p == nil || p.lambdaCtx == nil || p.lambdaCtx.Config == nil {
+		return "", pkgErrors.NewAppError(pkgErrors.CodeInternal, pkgErrors.CategoryLambda, "Lambda config not available")
+	}
+
+	cfg := p.lambdaCtx.Config
+	region := strings.TrimSpace(cfg.Region)
+	accountID := strings.TrimSpace(cfg.AWSAccountID)
+	if region == "" {
+		return "", pkgErrors.NewAppError(pkgErrors.CodeInternal, pkgErrors.CategoryLambda, "AWS region not configured")
+	}
+	if accountID == "" {
+		return "", pkgErrors.NewAppError(pkgErrors.CodeInternal, pkgErrors.CategoryLambda, "AWS account ID not configured")
+	}
+
+	queueName := naming.ResourceNameWithApp(
+		os.Getenv("APP_NAME"),
+		"federation-aggregator-queue",
+		firstNonEmpty(cfg.Stage, cfg.Environment, os.Getenv("STAGE"), os.Getenv("ENVIRONMENT")),
+	)
+	return fmt.Sprintf("https://sqs.%s.amazonaws.com/%s/%s", region, accountID, queueName), nil
+}
+
+func (p *FederationAggregatorProcessor) federationAggregatorFunctionName() string {
+	if p == nil || p.lambdaCtx == nil || p.lambdaCtx.Config == nil {
+		return naming.ResourceNameWithApp(os.Getenv("APP_NAME"), "federation-aggregator", os.Getenv("STAGE"))
+	}
+	cfg := p.lambdaCtx.Config
+	return naming.ResourceNameWithApp(
+		os.Getenv("APP_NAME"),
+		"federation-aggregator",
+		firstNonEmpty(cfg.Stage, cfg.Environment, os.Getenv("STAGE"), os.Getenv("ENVIRONMENT")),
+	)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
 // Helper functions - removed as we use aws.String, aws.Int32 instead
 
 // TableName returns the DynamoDB table name for FederationAggregation
 func (FederationAggregation) TableName() string {
-	return "lesser-main"
+	if tableName := strings.TrimSpace(federationAggregationTableName); tableName != "" {
+		return tableName
+	}
+	return config.GetMainTableName()
 }
 
 // BeforeCreate hook for FederationAggregation

--- a/cmd/federation-aggregator/round12_federation_aggregator_test.go
+++ b/cmd/federation-aggregator/round12_federation_aggregator_test.go
@@ -93,12 +93,10 @@ func (f *fakeLambdaClient) Invoke(context.Context, *awslambda.InvokeInput, ...fu
 
 func TestInitializeFederationAggregator_Round12(t *testing.T) {
 	origMust := mustInitializeLambdaFn
-	origInit := initializeWithDefaultsFn
 	origNewClient := newLambdaOptimizedClientFn
 	origNewProcessor := newProcessorFn
 	t.Cleanup(func() {
 		mustInitializeLambdaFn = origMust
-		initializeWithDefaultsFn = origInit
 		newLambdaOptimizedClientFn = origNewClient
 		newProcessorFn = origNewProcessor
 	})
@@ -112,7 +110,6 @@ func TestInitializeFederationAggregator_Round12(t *testing.T) {
 			},
 		}
 	}
-	initializeWithDefaultsFn = func(*common.LambdaContext) error { return errors.New("boom") }
 	newLambdaOptimizedClientFn = func(context.Context, string) (dynamormCore.DB, error) { return dynamormmocks.NewMockExtendedDB(), nil }
 	newProcessorFn = func(db dynamormCore.DB, tableName string, ctx *common.LambdaContext) *FederationAggregatorProcessor {
 		return &FederationAggregatorProcessor{
@@ -130,11 +127,9 @@ func TestInitializeFederationAggregator_Round12(t *testing.T) {
 
 func TestInitializeFederationAggregator_Error_Round12(t *testing.T) {
 	origMust := mustInitializeLambdaFn
-	origInit := initializeWithDefaultsFn
 	origNewClient := newLambdaOptimizedClientFn
 	t.Cleanup(func() {
 		mustInitializeLambdaFn = origMust
-		initializeWithDefaultsFn = origInit
 		newLambdaOptimizedClientFn = origNewClient
 	})
 
@@ -145,7 +140,6 @@ func TestInitializeFederationAggregator_Error_Round12(t *testing.T) {
 			AWSServices: &awsInit.AWSServices{Config: aws.Config{Region: "us-east-1"}},
 		}
 	}
-	initializeWithDefaultsFn = func(*common.LambdaContext) error { return nil }
 	newLambdaOptimizedClientFn = func(context.Context, string) (dynamormCore.DB, error) { return nil, errors.New("boom") }
 
 	require.Error(t, initializeFederationAggregator())
@@ -354,8 +348,12 @@ func TestIsDomainIncluded_AndTriggerNextLevelAggregation_Round12(t *testing.T) {
 }
 
 func TestHooksAndTableName_Round12(t *testing.T) {
+	originalTableName := federationAggregationTableName
+	t.Cleanup(func() { federationAggregationTableName = originalTableName })
+	federationAggregationTableName = "configured-table"
+
 	agg := &FederationAggregation{}
-	require.Equal(t, "lesser-main", agg.TableName())
+	require.Equal(t, "configured-table", agg.TableName())
 	require.NoError(t, agg.BeforeCreate())
 	before := agg.UpdatedAt
 	require.NoError(t, agg.BeforeUpdate())
@@ -462,4 +460,50 @@ func TestFederationAggregator_TriggerAggregation_Round12(t *testing.T) {
 
 	p.lambdaClient = &fakeLambdaClient{err: errors.New("boom")}
 	require.Error(t, p.triggerAggregation(context.Background(), AggregationEvent{Type: "daily", StartTime: time.Now().Add(-24 * time.Hour), EndTime: time.Now()}))
+}
+
+func TestFederationAggregator_UsesDeployedResourceNames_Round12(t *testing.T) {
+	t.Setenv("APP_NAME", "simulacrum")
+	p := &FederationAggregatorProcessor{
+		lambdaCtx: &common.LambdaContext{Config: &config.Config{
+			Region:       "us-west-2",
+			AWSAccountID: "123456789012",
+			Stage:        "live",
+		}},
+	}
+
+	queueURL, err := p.federationAggregatorQueueURL()
+	require.NoError(t, err)
+	require.Equal(t, "https://sqs.us-west-2.amazonaws.com/123456789012/simulacrum-live-federation-aggregator-queue", queueURL)
+	require.Equal(t, "simulacrum-live-federation-aggregator", p.federationAggregatorFunctionName())
+}
+
+func TestFederationAggregator_ResourceNameFallbacks_Round12(t *testing.T) {
+	t.Setenv("APP_NAME", "")
+	t.Setenv("STAGE", "")
+	t.Setenv("ENVIRONMENT", "")
+
+	var nilProcessor *FederationAggregatorProcessor
+	_, err := nilProcessor.federationAggregatorQueueURL()
+	require.Error(t, err)
+	require.Equal(t, "lesser-dev-federation-aggregator", nilProcessor.federationAggregatorFunctionName())
+
+	p := &FederationAggregatorProcessor{lambdaCtx: &common.LambdaContext{Config: &config.Config{
+		Region:       "us-east-2",
+		AWSAccountID: "111122223333",
+		Environment:  "production",
+	}}}
+	queueURL, err := p.federationAggregatorQueueURL()
+	require.NoError(t, err)
+	require.Equal(t, "https://sqs.us-east-2.amazonaws.com/111122223333/lesser-live-federation-aggregator-queue", queueURL)
+	require.Equal(t, "lesser-live-federation-aggregator", p.federationAggregatorFunctionName())
+
+	p.lambdaCtx.Config.Region = ""
+	_, err = p.federationAggregatorQueueURL()
+	require.Error(t, err)
+
+	p.lambdaCtx.Config.Region = "us-east-2"
+	p.lambdaCtx.Config.AWSAccountID = ""
+	_, err = p.federationAggregatorQueueURL()
+	require.Error(t, err)
 }

--- a/cmd/metrics-processor/main.go
+++ b/cmd/metrics-processor/main.go
@@ -17,11 +17,14 @@ import (
 	"github.com/equaltoai/lesser/pkg/deploy/naming"
 	appErrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/storage/core"
+	"github.com/equaltoai/lesser/pkg/storage/factory"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
+	"github.com/equaltoai/lesser/pkg/storage/theorydb"
 	"github.com/equaltoai/lesser/pkg/streaming"
 	"github.com/google/uuid"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+	dynamormCore "github.com/theory-cloud/tabletheory/pkg/core"
 	"go.uber.org/zap"
 )
 
@@ -768,13 +771,66 @@ var (
 )
 
 var (
-	mustInitializeLambdaFn   = common.MustInitializeLambda
-	initializeWithDefaultsFn = func(ctx *common.LambdaContext) error { return ctx.InitializeWithDefaults() }
-	lambdaStartFn            = lambda.Start
-	newUUIDFn                = func() string { return uuid.New().String() }
-	validateUUIDFn           = common.ValidateUUID
-	runningUnitTestsFn       = common.RunningUnitTests
+	mustInitializeLambdaFn     = common.MustInitializeLambda
+	newLambdaOptimizedClientFn = theorydb.NewLambdaOptimizedClient
+	newRepositoryFactoryFn     = func(db dynamormCore.DB, tableName string, logger *zap.Logger) (core.RepositoryStorage, error) {
+		return factory.NewRepositoryFactory(db, tableName, logger)
+	}
+	lambdaStartFn      = lambda.Start
+	newUUIDFn          = func() string { return uuid.New().String() }
+	validateUUIDFn     = common.ValidateUUID
+	runningUnitTestsFn = common.RunningUnitTests
 )
+
+func initializeMetricsStorage(lambdaCtx *common.LambdaContext) (core.RepositoryStorage, error) {
+	if lambdaCtx == nil {
+		return nil, fmt.Errorf("metrics-processor lambda context is nil")
+	}
+	if lambdaCtx.Config == nil {
+		return nil, fmt.Errorf("metrics-processor config is nil")
+	}
+
+	if lambdaCtx.Repos != nil {
+		repos, ok := lambdaCtx.Repos.(core.RepositoryStorage)
+		if !ok || repos == nil {
+			return nil, fmt.Errorf("metrics-processor invalid repository storage")
+		}
+		return repos, nil
+	}
+
+	tableName := strings.TrimSpace(lambdaCtx.Config.DynamoTableName)
+	if tableName == "" {
+		return nil, fmt.Errorf("metrics-processor dynamodb table name is required")
+	}
+
+	region := strings.TrimSpace(lambdaCtx.Config.Region)
+	if region == "" {
+		return nil, fmt.Errorf("metrics-processor AWS region is required")
+	}
+
+	var db dynamormCore.DB
+	if lambdaCtx.DynamoDB != nil {
+		var ok bool
+		db, ok = lambdaCtx.DynamoDB.(dynamormCore.DB)
+		if !ok || db == nil {
+			return nil, fmt.Errorf("metrics-processor invalid dynamodb client")
+		}
+	} else {
+		var err error
+		db, err = newLambdaOptimizedClientFn(context.Background(), region)
+		if err != nil {
+			return nil, fmt.Errorf("metrics-processor storage client initialization failed: %w", err)
+		}
+		lambdaCtx.DynamoDB = db
+	}
+
+	repos, err := newRepositoryFactoryFn(db, tableName, logger)
+	if err != nil {
+		return nil, fmt.Errorf("metrics-processor repository initialization failed: %w", err)
+	}
+	lambdaCtx.Repos = repos
+	return repos, nil
+}
 
 func initializeMetricsProcessor() error {
 	lambdaCtx = mustInitializeLambdaFn(common.LambdaConfig{
@@ -789,16 +845,10 @@ func initializeMetricsProcessor() error {
 		logger = zap.NewNop()
 	}
 
-	var ok bool
-	repos, ok = lambdaCtx.Repos.(core.RepositoryStorage)
-	if !ok || repos == nil {
-		return fmt.Errorf("metrics-processor invalid repository storage")
-	}
-
-	// Initialize with processor-specific defaults
-	err := initializeWithDefaultsFn(lambdaCtx)
+	var err error
+	repos, err = initializeMetricsStorage(lambdaCtx)
 	if err != nil {
-		logger.Warn("failed to initialize with defaults", zap.Error(err))
+		return err
 	}
 
 	// Function-specific initialization only

--- a/cmd/metrics-processor/round12_metrics_processor_test.go
+++ b/cmd/metrics-processor/round12_metrics_processor_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/equaltoai/lesser/pkg/streaming"
 	"github.com/equaltoai/lesser/pkg/testing/mocks"
 	"github.com/stretchr/testify/require"
+	dynamormCore "github.com/theory-cloud/tabletheory/pkg/core"
+	dynamormmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
 	"go.uber.org/zap"
 )
 
@@ -389,12 +391,10 @@ func TestHandler_HandleDynamoDBRecord_FailureSendsToDLQ(t *testing.T) {
 
 func TestInitializeMetricsProcessor_AndMain(t *testing.T) {
 	originalMustInitializeLambdaFn := mustInitializeLambdaFn
-	originalInitializeWithDefaultsFn := initializeWithDefaultsFn
 	originalLambdaStartFn := lambdaStartFn
 	originalRunningUnitTestsFn := runningUnitTestsFn
 	t.Cleanup(func() {
 		mustInitializeLambdaFn = originalMustInitializeLambdaFn
-		initializeWithDefaultsFn = originalInitializeWithDefaultsFn
 		lambdaStartFn = originalLambdaStartFn
 		runningUnitTestsFn = originalRunningUnitTestsFn
 	})
@@ -410,7 +410,6 @@ func TestInitializeMetricsProcessor_AndMain(t *testing.T) {
 			Repos:  repoStorage,
 		}
 	}
-	initializeWithDefaultsFn = func(_ *common.LambdaContext) error { return errors.New("defaults failed") }
 	runningUnitTestsFn = func() bool { return false }
 
 	initializeMetricsProcessorOnStart()
@@ -465,4 +464,63 @@ func TestInitializeMetricsProcessor_AndMain(t *testing.T) {
 
 	_, ok = any(repos).(core.RepositoryStorage)
 	require.True(t, ok)
+}
+
+func TestInitializeMetricsProcessor_FailsClosedOnStorageError(t *testing.T) {
+	originalMustInitializeLambdaFn := mustInitializeLambdaFn
+	originalNewLambdaOptimizedClientFn := newLambdaOptimizedClientFn
+	originalNewRepositoryFactoryFn := newRepositoryFactoryFn
+	t.Cleanup(func() {
+		mustInitializeLambdaFn = originalMustInitializeLambdaFn
+		newLambdaOptimizedClientFn = originalNewLambdaOptimizedClientFn
+		newRepositoryFactoryFn = originalNewRepositoryFactoryFn
+	})
+
+	mustInitializeLambdaFn = func(common.LambdaConfig) *common.LambdaContext {
+		return &common.LambdaContext{
+			Config: &config.Config{Region: "us-east-1", DynamoTableName: "test-table"},
+			Logger: zap.NewNop(),
+		}
+	}
+	newLambdaOptimizedClientFn = func(context.Context, string) (dynamormCore.DB, error) {
+		return nil, errors.New("storage unavailable")
+	}
+
+	err := initializeMetricsProcessor()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "storage client initialization failed")
+}
+
+func TestInitializeMetricsStorage_CreatesReposAndStoresClient(t *testing.T) {
+	originalNewLambdaOptimizedClientFn := newLambdaOptimizedClientFn
+	originalNewRepositoryFactoryFn := newRepositoryFactoryFn
+	t.Cleanup(func() {
+		newLambdaOptimizedClientFn = originalNewLambdaOptimizedClientFn
+		newRepositoryFactoryFn = originalNewRepositoryFactoryFn
+	})
+
+	db := dynamormmocks.NewMockExtendedDB()
+	expectedRepos := mocks.NewMockRepositoryStorage()
+	var gotRegion, gotTable string
+	newLambdaOptimizedClientFn = func(_ context.Context, region string) (dynamormCore.DB, error) {
+		gotRegion = region
+		return db, nil
+	}
+	newRepositoryFactoryFn = func(gotDB dynamormCore.DB, tableName string, _ *zap.Logger) (core.RepositoryStorage, error) {
+		require.Same(t, db, gotDB)
+		gotTable = tableName
+		return expectedRepos, nil
+	}
+
+	ctx := &common.LambdaContext{
+		Config: &config.Config{Region: "us-east-1", DynamoTableName: "test-table"},
+		Logger: zap.NewNop(),
+	}
+	gotRepos, err := initializeMetricsStorage(ctx)
+	require.NoError(t, err)
+	require.Same(t, expectedRepos, gotRepos)
+	require.Same(t, db, ctx.DynamoDB)
+	require.Same(t, expectedRepos, ctx.Repos)
+	require.Equal(t, "us-east-1", gotRegion)
+	require.Equal(t, "test-table", gotTable)
 }

--- a/cmd/ml-training-processor/main.go
+++ b/cmd/ml-training-processor/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
+	"github.com/equaltoai/lesser/pkg/storage/theorydb"
 	"github.com/equaltoai/lesser/pkg/storage/theorydb/stream"
 )
 
@@ -73,14 +74,14 @@ type moderationMLRepository interface {
 }
 
 var (
-	runningUnitTestsFn       = common.RunningUnitTests
-	mustInitializeLambdaFn   = common.MustInitializeLambda
-	initializeWithDefaultsFn = func(ctx *common.LambdaContext) error { return ctx.InitializeWithDefaults() }
-	newMLTrainingProcessorFn = NewMLTrainingProcessor
-	lambdaStartFn            = lambda.Start
-	newBedrockClientFn       = func(cfg aws.Config) bedrockJobGetter { return bedrock.NewFromConfig(cfg) }
-	newS3ClientFn            = func(cfg aws.Config) s3ObjectGetter { return s3.NewFromConfig(cfg) }
-	newModerationMLRepoFn    = func(db core.DB, tableName string, logger *zap.Logger) moderationMLRepository {
+	runningUnitTestsFn         = common.RunningUnitTests
+	mustInitializeLambdaFn     = common.MustInitializeLambda
+	newLambdaOptimizedClientFn = theorydb.NewLambdaOptimizedClient
+	newMLTrainingProcessorFn   = NewMLTrainingProcessor
+	lambdaStartFn              = lambda.Start
+	newBedrockClientFn         = func(cfg aws.Config) bedrockJobGetter { return bedrock.NewFromConfig(cfg) }
+	newS3ClientFn              = func(cfg aws.Config) s3ObjectGetter { return s3.NewFromConfig(cfg) }
+	newModerationMLRepoFn      = func(db core.DB, tableName string, logger *zap.Logger) moderationMLRepository {
 		return repositories.NewModerationMLRepository(db, tableName, logger)
 	}
 	writeStreamingEventFn = func(ctx context.Context, db core.DB, event *models.StreamingEvent) error {
@@ -109,9 +110,8 @@ func initializeMLTraining() error {
 		LambdaType:  common.LambdaTypeProcessor,
 	})
 
-	// Initialize with processor-specific defaults
-	if err := initializeWithDefaultsFn(lambdaCtx); err != nil {
-		lambdaCtx.Logger.Warn("failed to initialize with defaults", zap.Error(err))
+	if err := initializeMLTrainingStorage(lambdaCtx); err != nil {
+		return err
 	}
 
 	// Initialize processor
@@ -124,14 +124,62 @@ func initializeMLTraining() error {
 	return nil
 }
 
+func initializeMLTrainingStorage(lambdaCtx *common.LambdaContext) error {
+	if lambdaCtx == nil {
+		return fmt.Errorf("ml-training-processor lambda context is nil")
+	}
+	if lambdaCtx.Config == nil {
+		return fmt.Errorf("ml-training-processor config is nil")
+	}
+	if lambdaCtx.DynamoDB != nil {
+		db, ok := lambdaCtx.DynamoDB.(core.DB)
+		if !ok || db == nil {
+			return fmt.Errorf("ml-training-processor invalid dynamodb client")
+		}
+		return nil
+	}
+
+	tableName := strings.TrimSpace(lambdaCtx.Config.DynamoTableName)
+	if tableName == "" {
+		return fmt.Errorf("ml-training-processor dynamodb table name is required")
+	}
+
+	region := strings.TrimSpace(lambdaCtx.Config.Region)
+	if region == "" {
+		return fmt.Errorf("ml-training-processor AWS region is required")
+	}
+
+	db, err := newLambdaOptimizedClientFn(context.Background(), region)
+	if err != nil {
+		return fmt.Errorf("ml-training-processor storage client initialization failed: %w", err)
+	}
+	lambdaCtx.DynamoDB = db
+	return nil
+}
+
 // NewMLTrainingProcessor creates a new ML training processor
 func NewMLTrainingProcessor() (*MLTrainingProcessor, error) {
+	if lambdaCtx == nil {
+		return nil, fmt.Errorf("ml-training-processor lambda context is nil")
+	}
+	if lambdaCtx.Config == nil {
+		return nil, fmt.Errorf("ml-training-processor config is nil")
+	}
+	if lambdaCtx.AWSServices == nil {
+		return nil, fmt.Errorf("ml-training-processor AWS services are not initialized")
+	}
 	// Get config from the initialized lambda context
 	globalCfg := lambdaCtx.AWSServices.Config
 
 	// Use the standardized database connection
-	db := lambdaCtx.DynamoDB.(core.DB)
+	db, ok := lambdaCtx.DynamoDB.(core.DB)
+	if !ok || db == nil {
+		return nil, fmt.Errorf("ml-training-processor dynamodb client is not initialized")
+	}
 	tableName := lambdaCtx.Config.DynamoTableName
+	if strings.TrimSpace(tableName) == "" {
+		return nil, fmt.Errorf("ml-training-processor dynamodb table name is required")
+	}
 
 	// Initialize Bedrock client
 	bedrockClient := newBedrockClientFn(globalCfg)

--- a/cmd/ml-training-processor/round12_ml_training_processor_test.go
+++ b/cmd/ml-training-processor/round12_ml_training_processor_test.go
@@ -617,14 +617,12 @@ func TestNewMLTrainingProcessor_AndMain_Round12(t *testing.T) {
 func TestInitializeMLTraining_Branches_Round12(t *testing.T) {
 	originalRunning := runningUnitTestsFn
 	originalMustInit := mustInitializeLambdaFn
-	originalInitDefaults := initializeWithDefaultsFn
 	originalNewProc := newMLTrainingProcessorFn
 	originalLambdaCtx := lambdaCtx
 	originalProcessor := processor
 	t.Cleanup(func() {
 		runningUnitTestsFn = originalRunning
 		mustInitializeLambdaFn = originalMustInit
-		initializeWithDefaultsFn = originalInitDefaults
 		newMLTrainingProcessorFn = originalNewProc
 		lambdaCtx = originalLambdaCtx
 		processor = originalProcessor
@@ -640,7 +638,6 @@ func TestInitializeMLTraining_Branches_Round12(t *testing.T) {
 	}
 
 	mustInitializeLambdaFn = func(_ common.LambdaConfig) *common.LambdaContext { return fakeLambda }
-	initializeWithDefaultsFn = func(*common.LambdaContext) error { return errors.New("defaults failed") }
 	newMLTrainingProcessorFn = func() (*MLTrainingProcessor, error) {
 		return &MLTrainingProcessor{logger: zaptest.NewLogger(t)}, nil
 	}
@@ -656,7 +653,6 @@ func TestInitializeMLTraining_Branches_Round12(t *testing.T) {
 	initializeMLTrainingOnStart()
 
 	runningUnitTestsFn = func() bool { return false }
-	initializeWithDefaultsFn = func(*common.LambdaContext) error { return nil }
 	newMLTrainingProcessorFn = func() (*MLTrainingProcessor, error) {
 		return &MLTrainingProcessor{logger: zaptest.NewLogger(t)}, nil
 	}
@@ -951,4 +947,56 @@ func TestMetricsExtractionHelpers_Branches_Round12(t *testing.T) {
 		_, err := p.marshalToRawMetrics(&types.TrainingMetrics{TrainingLoss: &nan})
 		require.Error(t, err)
 	})
+}
+
+func TestInitializeMLTrainingStorage_FailsClosed(t *testing.T) {
+	origNewClient := newLambdaOptimizedClientFn
+	t.Cleanup(func() { newLambdaOptimizedClientFn = origNewClient })
+
+	newLambdaOptimizedClientFn = func(context.Context, string) (dynamormCore.DB, error) {
+		return nil, errors.New("storage unavailable")
+	}
+
+	ctx := &common.LambdaContext{
+		Config: &config.Config{Region: "us-east-1", DynamoTableName: "test-table"},
+		Logger: zap.NewNop(),
+	}
+	err := initializeMLTrainingStorage(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "storage client initialization failed")
+}
+
+func TestInitializeMLTrainingStorage_CreatesClient(t *testing.T) {
+	origNewClient := newLambdaOptimizedClientFn
+	t.Cleanup(func() { newLambdaOptimizedClientFn = origNewClient })
+
+	db := &fakeDB{}
+	var gotRegion string
+	newLambdaOptimizedClientFn = func(_ context.Context, region string) (dynamormCore.DB, error) {
+		gotRegion = region
+		return db, nil
+	}
+
+	ctx := &common.LambdaContext{
+		Config: &config.Config{Region: "us-east-1", DynamoTableName: "ml-table"},
+		Logger: zap.NewNop(),
+	}
+	err := initializeMLTrainingStorage(ctx)
+	require.NoError(t, err)
+	require.Same(t, db, ctx.DynamoDB)
+	require.Equal(t, "us-east-1", gotRegion)
+}
+
+func TestNewMLTrainingProcessor_FailsClosedWithoutStorage(t *testing.T) {
+	origLambdaCtx := lambdaCtx
+	t.Cleanup(func() { lambdaCtx = origLambdaCtx })
+
+	lambdaCtx = &common.LambdaContext{
+		Config:      &config.Config{DynamoTableName: "test-table"},
+		Logger:      zap.NewNop(),
+		AWSServices: &awsinit.AWSServices{Config: aws.Config{Region: "us-east-1"}},
+	}
+	_, err := NewMLTrainingProcessor()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dynamodb client is not initialized")
 }

--- a/cmd/severance-processor/main.go
+++ b/cmd/severance-processor/main.go
@@ -16,8 +16,11 @@ import (
 	"github.com/equaltoai/lesser/pkg/services"
 	severanceService "github.com/equaltoai/lesser/pkg/services/severance"
 	storageCore "github.com/equaltoai/lesser/pkg/storage/core"
+	"github.com/equaltoai/lesser/pkg/storage/factory"
 	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/equaltoai/lesser/pkg/storage/theorydb"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+	dynamormCore "github.com/theory-cloud/tabletheory/pkg/core"
 	"go.uber.org/zap"
 )
 
@@ -29,10 +32,13 @@ var (
 	registry  *services.Registry
 	processor *SeveranceProcessor
 
-	mustInitializeLambdaFn   = common.MustInitializeLambda
-	initializeWithDefaultsFn = (*common.LambdaContext).InitializeWithDefaults
-	newRegistryFn            = services.NewRegistry
-	lambdaStartFn            = lambda.Start
+	mustInitializeLambdaFn     = common.MustInitializeLambda
+	newLambdaOptimizedClientFn = theorydb.NewLambdaOptimizedClient
+	newRepositoryFactoryFn     = func(db dynamormCore.DB, tableName string, logger *zap.Logger) (storageCore.RepositoryStorage, error) {
+		return factory.NewRepositoryFactory(db, tableName, logger)
+	}
+	newRegistryFn = services.NewRegistry
+	lambdaStartFn = lambda.Start
 )
 
 func init() {
@@ -55,13 +61,11 @@ func initializeSeveranceProcessor() error {
 	// Automatic dependency injection
 	cfg = lambdaCtx.Config
 	logger = lambdaCtx.Logger
-	if lambdaCtx.Repos != nil {
-		repos = lambdaCtx.Repos.(storageCore.RepositoryStorage)
-	}
 
-	// Initialize with processor-specific defaults
-	if err := initializeWithDefaultsFn(lambdaCtx); err != nil {
-		logger.Warn("failed to initialize with defaults", zap.Error(err))
+	var err error
+	repos, err = initializeSeveranceStorage(lambdaCtx)
+	if err != nil {
+		return err
 	}
 
 	// Create service registry
@@ -84,6 +88,56 @@ func initializeSeveranceProcessor() error {
 	}
 
 	return nil
+}
+
+func initializeSeveranceStorage(lambdaCtx *common.LambdaContext) (storageCore.RepositoryStorage, error) {
+	if lambdaCtx == nil {
+		return nil, fmt.Errorf("severance-processor lambda context is nil")
+	}
+	if lambdaCtx.Config == nil {
+		return nil, fmt.Errorf("severance-processor config is nil")
+	}
+
+	if lambdaCtx.Repos != nil {
+		repos, ok := lambdaCtx.Repos.(storageCore.RepositoryStorage)
+		if !ok || repos == nil {
+			return nil, fmt.Errorf("severance-processor invalid repository storage")
+		}
+		return repos, nil
+	}
+
+	tableName := strings.TrimSpace(lambdaCtx.Config.DynamoTableName)
+	if tableName == "" {
+		return nil, fmt.Errorf("severance-processor dynamodb table name is required")
+	}
+
+	region := strings.TrimSpace(lambdaCtx.Config.Region)
+	if region == "" {
+		return nil, fmt.Errorf("severance-processor AWS region is required")
+	}
+
+	var db dynamormCore.DB
+	if lambdaCtx.DynamoDB != nil {
+		var ok bool
+		db, ok = lambdaCtx.DynamoDB.(dynamormCore.DB)
+		if !ok || db == nil {
+			return nil, fmt.Errorf("severance-processor invalid dynamodb client")
+		}
+	} else {
+		var err error
+		db, err = newLambdaOptimizedClientFn(context.Background(), region)
+		if err != nil {
+			return nil, fmt.Errorf("severance-processor storage client initialization failed: %w", err)
+		}
+		lambdaCtx.DynamoDB = db
+	}
+
+	repos, err := newRepositoryFactoryFn(db, tableName, logger)
+	if err != nil {
+		return nil, fmt.Errorf("severance-processor repository initialization failed: %w", err)
+	}
+	lambdaCtx.Repos = repos
+	return repos, nil
 }
 
 // SeveranceProcessor handles severance detection from DynamoDB streams

--- a/cmd/severance-processor/round12_additional_test.go
+++ b/cmd/severance-processor/round12_additional_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+	dynamormCore "github.com/theory-cloud/tabletheory/pkg/core"
+	dynamormmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
 	"go.uber.org/zap"
 )
 
@@ -53,11 +55,9 @@ func (f *fakeRegistry) GetStorage() storageCore.RepositoryStorage { return f.sto
 
 func TestInitializeSeveranceProcessor_SetsGlobalsAndAdapter(t *testing.T) {
 	originalMustInitialize := mustInitializeLambdaFn
-	originalInitializeDefaults := initializeWithDefaultsFn
 	originalNewRegistry := newRegistryFn
 	t.Cleanup(func() {
 		mustInitializeLambdaFn = originalMustInitialize
-		initializeWithDefaultsFn = originalInitializeDefaults
 		newRegistryFn = originalNewRegistry
 	})
 
@@ -73,7 +73,6 @@ func TestInitializeSeveranceProcessor_SetsGlobalsAndAdapter(t *testing.T) {
 	}
 
 	mustInitializeLambdaFn = func(common.LambdaConfig) *common.LambdaContext { return fakeLambdaCtx }
-	initializeWithDefaultsFn = func(*common.LambdaContext) error { return errors.New("defaults") }
 	newRegistryFn = services.NewRegistry
 
 	require.NoError(t, initializeSeveranceProcessor())
@@ -89,11 +88,9 @@ func TestInitializeSeveranceProcessor_SetsGlobalsAndAdapter(t *testing.T) {
 
 func TestInitializeSeveranceProcessor_RegistryError(t *testing.T) {
 	originalMustInitialize := mustInitializeLambdaFn
-	originalInitializeDefaults := initializeWithDefaultsFn
 	originalNewRegistry := newRegistryFn
 	t.Cleanup(func() {
 		mustInitializeLambdaFn = originalMustInitialize
-		initializeWithDefaultsFn = originalInitializeDefaults
 		newRegistryFn = originalNewRegistry
 	})
 
@@ -105,7 +102,6 @@ func TestInitializeSeveranceProcessor_RegistryError(t *testing.T) {
 	}
 
 	mustInitializeLambdaFn = func(common.LambdaConfig) *common.LambdaContext { return fakeLambdaCtx }
-	initializeWithDefaultsFn = func(*common.LambdaContext) error { return nil }
 	newRegistryFn = func(...services.RegistryOption) (*services.Registry, error) {
 		return nil, errors.New("boom")
 	}
@@ -438,4 +434,55 @@ func TestMain_UsesLambdaStartFn(t *testing.T) {
 
 	main()
 	require.True(t, called)
+}
+
+func TestInitializeSeveranceStorage_FailsClosed(t *testing.T) {
+	origNewClient := newLambdaOptimizedClientFn
+	t.Cleanup(func() { newLambdaOptimizedClientFn = origNewClient })
+
+	newLambdaOptimizedClientFn = func(context.Context, string) (dynamormCore.DB, error) {
+		return nil, errors.New("storage unavailable")
+	}
+
+	ctx := &common.LambdaContext{
+		Config: &config.Config{Region: "us-east-1", DynamoTableName: "test-table"},
+		Logger: zap.NewNop(),
+	}
+	_, err := initializeSeveranceStorage(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "storage client initialization failed")
+}
+
+func TestInitializeSeveranceStorage_CreatesReposAndStoresClient(t *testing.T) {
+	origNewClient := newLambdaOptimizedClientFn
+	origNewFactory := newRepositoryFactoryFn
+	t.Cleanup(func() {
+		newLambdaOptimizedClientFn = origNewClient
+		newRepositoryFactoryFn = origNewFactory
+	})
+
+	db := dynamormmocks.NewMockExtendedDB()
+	expectedRepos := testingmocks.NewMockRepositoryStorage()
+	var gotRegion, gotTable string
+	newLambdaOptimizedClientFn = func(_ context.Context, region string) (dynamormCore.DB, error) {
+		gotRegion = region
+		return db, nil
+	}
+	newRepositoryFactoryFn = func(gotDB dynamormCore.DB, tableName string, _ *zap.Logger) (storageCore.RepositoryStorage, error) {
+		require.Same(t, db, gotDB)
+		gotTable = tableName
+		return expectedRepos, nil
+	}
+
+	ctx := &common.LambdaContext{
+		Config: &config.Config{Region: "us-east-1", DynamoTableName: "severance-table"},
+		Logger: zap.NewNop(),
+	}
+	gotRepos, err := initializeSeveranceStorage(ctx)
+	require.NoError(t, err)
+	require.Same(t, expectedRepos, gotRepos)
+	require.Same(t, db, ctx.DynamoDB)
+	require.Same(t, expectedRepos, ctx.Repos)
+	require.Equal(t, "us-east-1", gotRegion)
+	require.Equal(t, "severance-table", gotTable)
 }


### PR DESCRIPTION
## Summary

- replace storm-prone `common.InitializeWithDefaults()` fallbacks in the active processor startup paths with fail-closed, processor-local storage initialization
- validate repository/database wiring before constructing metrics, AI, DLQ, ML training, and severance processors so startup failures stop the Lambda instead of continuing with nil storage
- update federation-aggregator source routing to use configured table and deployed app/stage resource names instead of hard-coded `lesser-main` / bare `federation-aggregator` names

Refs #990.
Closes #997.
Closes #998.
Closes #999.
Partially addresses #1000; left open because this session had no live handler-level evidence for the underlying `apptheory: event workload failed` failure beyond the source-level hard-coded table/queue/function naming fixes.

## Init-path notes

- `metrics-processor`: builds repository storage from the injected TableTheory DB or a new Lambda-optimized client; fails closed on missing table/region, invalid DB/repos, client creation, or repository factory errors.
- `ai-processor`: initializes storage before `NewSimplifiedAIProcessor`, validates DB/repos/analyzer/saver, and returns construction errors instead of panicking on nil services.
- `ml-training-processor`: validates Lambda context/config/AWS services/DB before processor construction and fails closed on storage client setup errors.
- `dlq-processor`: initializes and validates TableTheory DB before constructing `dlq.NewProcessor`.
- `severance-processor`: initializes repository storage before building the service registry and only calls `services.WithStorage` with non-nil storage.
- `federation-aggregator`: removes default storage fallback warnings, honors configured table name, and derives queue/function names through deploy naming with app/stage inputs.

## Validation

- `go test ./cmd/metrics-processor ./cmd/ai-processor ./cmd/ml-training-processor ./cmd/dlq-processor ./cmd/severance-processor ./cmd/federation-aggregator`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`

## Deployment

No deploy, live AWS source mapping changes, processor re-enable, or backfill/reconciliation was performed. M0 containment remains Ops-owned; M2 guardrail/alarm gates and M3 re-enable/backfill gates remain intact.