### PR TITLE
[codex] inject federation aggregator queue url

### DIFF
--- a/cmd/federation-aggregator/main.go
+++ b/cmd/federation-aggregator/main.go
@@ -373,25 +373,20 @@ func (p *FederationAggregatorProcessor) triggerAggregation(ctx context.Context, 
 		return pkgErrors.WrapError(err, pkgErrors.CodeEventProcessingFailed, pkgErrors.CategoryLambda, "Failed to marshal aggregation event")
 	}
 
-	queueURL, err := p.federationAggregatorQueueURL()
-	if err != nil {
-		return err
-	}
-
-	sqsInput := &sqs.SendMessageInput{
-		QueueUrl:    &queueURL,
-		MessageBody: aws.String(string(eventPayload)),
-		MessageAttributes: map[string]sqstypes.MessageAttributeValue{
-			"AggregationType": {
-				DataType:    aws.String("String"),
-				StringValue: aws.String(event.Type),
-			},
-		},
-		DelaySeconds: 0, // Process immediately
-	}
-
 	var sqsErr error
-	if p.sqsClient != nil {
+	if queueURL, queueErr := p.federationAggregatorQueueURL(); queueErr == nil && p.sqsClient != nil {
+		sqsInput := &sqs.SendMessageInput{
+			QueueUrl:    &queueURL,
+			MessageBody: aws.String(string(eventPayload)),
+			MessageAttributes: map[string]sqstypes.MessageAttributeValue{
+				"AggregationType": {
+					DataType:    aws.String("String"),
+					StringValue: aws.String(event.Type),
+				},
+			},
+			DelaySeconds: 0, // Process immediately
+		}
+
 		var sqsResult *sqs.SendMessageOutput
 		sqsResult, sqsErr = p.sqsClient.SendMessage(ctx, sqsInput)
 		if sqsErr == nil {
@@ -400,6 +395,10 @@ func (p *FederationAggregatorProcessor) triggerAggregation(ctx context.Context, 
 				zap.String("type", event.Type))
 			return nil
 		}
+	} else if queueErr != nil {
+		sqsErr = queueErr
+	} else {
+		sqsErr = pkgErrors.NewAppError(pkgErrors.CodeInternal, pkgErrors.CategoryLambda, "SQS client not configured")
 	}
 
 	// If SQS fails, fallback to direct Lambda invocation
@@ -444,26 +443,10 @@ func (p *FederationAggregatorProcessor) triggerAggregation(ctx context.Context, 
 }
 
 func (p *FederationAggregatorProcessor) federationAggregatorQueueURL() (string, error) {
-	if p == nil || p.lambdaCtx == nil || p.lambdaCtx.Config == nil {
-		return "", pkgErrors.NewAppError(pkgErrors.CodeInternal, pkgErrors.CategoryLambda, "Lambda config not available")
+	if queueURL := strings.TrimSpace(os.Getenv("FEDERATION_AGGREGATOR_QUEUE_URL")); queueURL != "" {
+		return queueURL, nil
 	}
-
-	cfg := p.lambdaCtx.Config
-	region := strings.TrimSpace(cfg.Region)
-	accountID := strings.TrimSpace(cfg.AWSAccountID)
-	if region == "" {
-		return "", pkgErrors.NewAppError(pkgErrors.CodeInternal, pkgErrors.CategoryLambda, "AWS region not configured")
-	}
-	if accountID == "" {
-		return "", pkgErrors.NewAppError(pkgErrors.CodeInternal, pkgErrors.CategoryLambda, "AWS account ID not configured")
-	}
-
-	queueName := naming.ResourceNameWithApp(
-		os.Getenv("APP_NAME"),
-		"federation-aggregator-queue",
-		firstNonEmpty(cfg.Stage, cfg.Environment, os.Getenv("STAGE"), os.Getenv("ENVIRONMENT")),
-	)
-	return fmt.Sprintf("https://sqs.%s.amazonaws.com/%s/%s", region, accountID, queueName), nil
+	return "", pkgErrors.NewAppError(pkgErrors.CodeInternal, pkgErrors.CategoryLambda, "federation aggregator queue URL not configured")
 }
 
 func (p *FederationAggregatorProcessor) federationAggregatorFunctionName() string {

--- a/cmd/federation-aggregator/round12_federation_aggregator_test.go
+++ b/cmd/federation-aggregator/round12_federation_aggregator_test.go
@@ -62,12 +62,16 @@ func (f *fakeFederationActivityRepo) GetInstanceInfo(context.Context, string) (*
 }
 
 type fakeSQSClient struct {
-	sendCalls int
-	err       error
+	sendCalls    int
+	err          error
+	lastQueueURL string
 }
 
-func (f *fakeSQSClient) SendMessage(context.Context, *sqs.SendMessageInput, ...func(*sqs.Options)) (*sqs.SendMessageOutput, error) {
+func (f *fakeSQSClient) SendMessage(_ context.Context, input *sqs.SendMessageInput, _ ...func(*sqs.Options)) (*sqs.SendMessageOutput, error) {
 	f.sendCalls++
+	if input != nil && input.QueueUrl != nil {
+		f.lastQueueURL = *input.QueueUrl
+	}
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -329,9 +333,10 @@ func TestHandleAggregationEvent_FullPath_Round12(t *testing.T) {
 }
 
 func TestIsDomainIncluded_AndTriggerNextLevelAggregation_Round12(t *testing.T) {
+	t.Setenv("FEDERATION_AGGREGATOR_QUEUE_URL", "https://sqs.us-east-1.amazonaws.com/123/federation-aggregator-queue")
 	p := &FederationAggregatorProcessor{
 		logger:       zap.NewNop(),
-		lambdaCtx:    &common.LambdaContext{Config: &config.Config{Region: "us-east-1", AWSAccountID: "123"}},
+		lambdaCtx:    &common.LambdaContext{Config: &config.Config{Region: "us-east-1"}},
 		sqsClient:    &fakeSQSClient{},
 		lambdaClient: &fakeLambdaClient{},
 	}
@@ -437,15 +442,17 @@ func TestFederationAggregator_StoreAggregation_Round12(t *testing.T) {
 }
 
 func TestFederationAggregator_TriggerAggregation_Round12(t *testing.T) {
+	t.Setenv("FEDERATION_AGGREGATOR_QUEUE_URL", "https://sqs.us-east-1.amazonaws.com/123/federation-aggregator-queue")
 	p := &FederationAggregatorProcessor{
 		logger:       zap.NewNop(),
-		lambdaCtx:    &common.LambdaContext{Config: &config.Config{Region: "us-east-1", AWSAccountID: "123"}},
+		lambdaCtx:    &common.LambdaContext{Config: &config.Config{Region: "us-east-1"}},
 		sqsClient:    &fakeSQSClient{},
 		lambdaClient: &fakeLambdaClient{},
 	}
 
 	err := p.triggerAggregation(context.Background(), AggregationEvent{Type: "daily", StartTime: time.Now().Add(-24 * time.Hour), EndTime: time.Now()})
 	require.NoError(t, err)
+	require.Equal(t, "https://sqs.us-east-1.amazonaws.com/123/federation-aggregator-queue", p.sqsClient.(*fakeSQSClient).lastQueueURL)
 
 	p.sqsClient = &fakeSQSClient{err: errors.New("boom")}
 	p.lambdaClient = &fakeLambdaClient{result: &awslambda.InvokeOutput{StatusCode: 202}}
@@ -464,11 +471,11 @@ func TestFederationAggregator_TriggerAggregation_Round12(t *testing.T) {
 
 func TestFederationAggregator_UsesDeployedResourceNames_Round12(t *testing.T) {
 	t.Setenv("APP_NAME", "simulacrum")
+	t.Setenv("FEDERATION_AGGREGATOR_QUEUE_URL", "https://sqs.us-west-2.amazonaws.com/123456789012/simulacrum-live-federation-aggregator-queue")
 	p := &FederationAggregatorProcessor{
 		lambdaCtx: &common.LambdaContext{Config: &config.Config{
-			Region:       "us-west-2",
-			AWSAccountID: "123456789012",
-			Stage:        "live",
+			Region: "us-west-2",
+			Stage:  "live",
 		}},
 	}
 
@@ -482,6 +489,7 @@ func TestFederationAggregator_ResourceNameFallbacks_Round12(t *testing.T) {
 	t.Setenv("APP_NAME", "")
 	t.Setenv("STAGE", "")
 	t.Setenv("ENVIRONMENT", "")
+	t.Setenv("FEDERATION_AGGREGATOR_QUEUE_URL", "")
 
 	var nilProcessor *FederationAggregatorProcessor
 	_, err := nilProcessor.federationAggregatorQueueURL()
@@ -489,21 +497,51 @@ func TestFederationAggregator_ResourceNameFallbacks_Round12(t *testing.T) {
 	require.Equal(t, "lesser-dev-federation-aggregator", nilProcessor.federationAggregatorFunctionName())
 
 	p := &FederationAggregatorProcessor{lambdaCtx: &common.LambdaContext{Config: &config.Config{
-		Region:       "us-east-2",
-		AWSAccountID: "111122223333",
-		Environment:  "production",
+		Region:      "us-east-2",
+		Environment: "production",
 	}}}
+	require.Equal(t, "lesser-live-federation-aggregator", p.federationAggregatorFunctionName())
+
+	t.Setenv("FEDERATION_AGGREGATOR_QUEUE_URL", "https://sqs.us-east-2.amazonaws.com/111122223333/lesser-live-federation-aggregator-queue")
 	queueURL, err := p.federationAggregatorQueueURL()
 	require.NoError(t, err)
 	require.Equal(t, "https://sqs.us-east-2.amazonaws.com/111122223333/lesser-live-federation-aggregator-queue", queueURL)
-	require.Equal(t, "lesser-live-federation-aggregator", p.federationAggregatorFunctionName())
+}
 
-	p.lambdaCtx.Config.Region = ""
-	_, err = p.federationAggregatorQueueURL()
-	require.Error(t, err)
+func TestFederationAggregator_TriggerAggregationFallsBackWithoutQueueURL_Round12(t *testing.T) {
+	t.Setenv("FEDERATION_AGGREGATOR_QUEUE_URL", "")
+	t.Setenv("APP_NAME", "simulacrum")
+	t.Setenv("STAGE", "live")
 
-	p.lambdaCtx.Config.Region = "us-east-2"
-	p.lambdaCtx.Config.AWSAccountID = ""
+	lambdaClient := &fakeLambdaClient{result: &awslambda.InvokeOutput{StatusCode: 202}}
+	p := &FederationAggregatorProcessor{
+		logger:       zap.NewNop(),
+		lambdaCtx:    &common.LambdaContext{Config: &config.Config{Region: "us-east-1", Stage: "live"}},
+		sqsClient:    &fakeSQSClient{},
+		lambdaClient: lambdaClient,
+	}
+
+	err := p.triggerAggregation(context.Background(), AggregationEvent{Type: "daily", StartTime: time.Now().Add(-24 * time.Hour), EndTime: time.Now()})
+	require.NoError(t, err)
+	require.Equal(t, 0, p.sqsClient.(*fakeSQSClient).sendCalls)
+	require.Equal(t, 1, lambdaClient.invokeCalls)
+}
+
+func TestFederationAggregator_QueueURLDoesNotRequireAWSAccountID_Round12(t *testing.T) {
+	t.Setenv("FEDERATION_AGGREGATOR_QUEUE_URL", "https://sqs.us-east-1.amazonaws.com/111122223333/simulacrum-live-federation-aggregator-queue")
+	t.Setenv("AWS_ACCOUNT_ID", "")
+
+	p := &FederationAggregatorProcessor{
+		lambdaCtx: &common.LambdaContext{Config: &config.Config{
+			Region: "us-east-1",
+			Stage:  "live",
+		}},
+	}
+	queueURL, err := p.federationAggregatorQueueURL()
+	require.NoError(t, err)
+	require.Equal(t, "https://sqs.us-east-1.amazonaws.com/111122223333/simulacrum-live-federation-aggregator-queue", queueURL)
+
+	t.Setenv("FEDERATION_AGGREGATOR_QUEUE_URL", "")
 	_, err = p.federationAggregatorQueueURL()
 	require.Error(t, err)
 }

--- a/infra/cdk/constructs/lambda_functions.go
+++ b/infra/cdk/constructs/lambda_functions.go
@@ -438,4 +438,10 @@ func ApplyQueueEnvironmentVariables(functions *LambdaFunctions, queues map[strin
 		fn.AddEnvironment(jsii.String("FEDERATION_DELIVERY_QUEUE_URL"), queueURL(queues, "federation-delivery-queue"), nil)
 		fn.AddEnvironment(jsii.String("PUSH_NOTIFICATION_QUEUE_URL"), queueURL(queues, "push-delivery-queue"), nil)
 	}
+
+	functions.Must("federation-aggregator").AddEnvironment(
+		jsii.String("FEDERATION_AGGREGATOR_QUEUE_URL"),
+		queueURL(queues, "federation-aggregator-queue"),
+		nil,
+	)
 }

--- a/infra/cdk/constructs/lambda_functions_env_test.go
+++ b/infra/cdk/constructs/lambda_functions_env_test.go
@@ -118,6 +118,20 @@ func TestLambdaEnvironmentsIncludeBaselineAndInventoryVars(t *testing.T) {
 			}
 		}
 	}
+
+	federationAggregatorName := naming.ResourceName("federation-aggregator", environment)
+	federationAggregatorEnv, ok := envByName[federationAggregatorName]
+	if !ok {
+		t.Fatalf("environment not found for %s", federationAggregatorName)
+	}
+	for _, key := range []string{"APP_NAME", "STAGE", "DYNAMODB_TABLE", "FEDERATION_AGGREGATOR_QUEUE_URL"} {
+		if val := federationAggregatorEnv[key]; val == "" {
+			t.Fatalf("federation aggregator env var %s missing", key)
+		}
+	}
+	if _, present := federationAggregatorEnv["AWS_ACCOUNT_ID"]; present {
+		t.Fatalf("federation aggregator should not depend on AWS_ACCOUNT_ID in the synthesized env")
+	}
 }
 
 func collectLambdaEnvironments(t *testing.T, tpl map[string]any) map[string]map[string]string {


### PR DESCRIPTION
## Summary

- inject `FEDERATION_AGGREGATOR_QUEUE_URL` into the federation-aggregator Lambda from the CDK-created queue instead of requiring `AWS_ACCOUNT_ID` to manually construct the SQS URL
- make `triggerAggregation` fall back to direct app/stage-named Lambda invocation when the SQS queue URL is unavailable, preserving processing without an unset account-id dependency
- add runtime and CDK deployed-env-shape tests proving the aggregator does not require synthesized `AWS_ACCOUNT_ID` while preserving configured table/app-stage naming

Refs #990.
Closes #1000.

## Federation-trust audit

- Signing/verification: not touched; no HTTP Signature signing or inbound verification behavior changed.
- Actor object / key material: not touched.
- Delivery impact: limited to federation-aggregator's internal next-level aggregation trigger path; outbound ActivityPub delivery, retry, circuit breaker, and domain-block enforcement are unchanged.
- Failure posture: SQS URL absence no longer blocks the fallback Lambda trigger; no delivery errors are swallowed for ActivityPub delivery paths.

## Validation

- `go test ./cmd/federation-aggregator -count=1`
- `(cd infra/cdk && go test ./constructs -count=1)`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`

## Deployment

No deploy, live source mapping mutation, processor re-enable, or backfill/reconciliation was performed. This is code/test only per the M1.4 gate clarification.