### PR TITLE
deploy processor storm retry and alarm guardrails

### DIFF
--- a/cmd/metrics-processor/round12_metrics_processor_test.go
+++ b/cmd/metrics-processor/round12_metrics_processor_test.go
@@ -524,3 +524,58 @@ func TestInitializeMetricsStorage_CreatesReposAndStoresClient(t *testing.T) {
 	require.Equal(t, "us-east-1", gotRegion)
 	require.Equal(t, "test-table", gotTable)
 }
+
+func TestInitializeMetricsStorage_ValidationErrors(t *testing.T) {
+	originalNewRepositoryFactoryFn := newRepositoryFactoryFn
+	t.Cleanup(func() {
+		newRepositoryFactoryFn = originalNewRepositoryFactoryFn
+	})
+
+	_, err := initializeMetricsStorage(nil)
+	require.ErrorContains(t, err, "lambda context is nil")
+
+	_, err = initializeMetricsStorage(&common.LambdaContext{})
+	require.ErrorContains(t, err, "config is nil")
+
+	_, err = initializeMetricsStorage(&common.LambdaContext{
+		Config: &config.Config{},
+		Repos:  struct{}{},
+	})
+	require.ErrorContains(t, err, "invalid repository storage")
+
+	_, err = initializeMetricsStorage(&common.LambdaContext{
+		Config: &config.Config{Region: "us-east-1"},
+	})
+	require.ErrorContains(t, err, "dynamodb table name is required")
+
+	_, err = initializeMetricsStorage(&common.LambdaContext{
+		Config: &config.Config{DynamoTableName: "test-table"},
+	})
+	require.ErrorContains(t, err, "AWS region is required")
+
+	_, err = initializeMetricsStorage(&common.LambdaContext{
+		Config:   &config.Config{Region: "us-east-1", DynamoTableName: "test-table"},
+		DynamoDB: struct{}{},
+	})
+	require.ErrorContains(t, err, "invalid dynamodb client")
+
+	newRepositoryFactoryFn = func(dynamormCore.DB, string, *zap.Logger) (core.RepositoryStorage, error) {
+		return nil, errors.New("factory failed")
+	}
+	_, err = initializeMetricsStorage(&common.LambdaContext{
+		Config:   &config.Config{Region: "us-east-1", DynamoTableName: "test-table"},
+		DynamoDB: dynamormmocks.NewMockExtendedDB(),
+	})
+	require.ErrorContains(t, err, "repository initialization failed")
+}
+
+func TestHandleMetricsProcessorStreamRecordRequiresHandler(t *testing.T) {
+	originalHandler := handler
+	t.Cleanup(func() {
+		handler = originalHandler
+	})
+
+	handler = nil
+	err := handleMetricsProcessorStreamRecord(nil, events.DynamoDBEventRecord{})
+	require.ErrorContains(t, err, "handler not initialized")
+}

--- a/docs/specs/01-lambda-inventory-matrix.md
+++ b/docs/specs/01-lambda-inventory-matrix.md
@@ -38,40 +38,40 @@ The inventory set is enforced by:
 
 | Name | Type | Triggers | Required Env Vars | Role | Operational Defaults |
 | --- | --- | --- | --- | --- | --- |
-| activity-processor | processor-stream | Stream: table=main-table; start=TRIM_HORIZON; batch=25; window=5s; parallel=5; maxRetry=3; bisect=true; reportBatchItemFailures=true | — | basic | memory=1024MB; timeout=300s; logs=7d |
+| activity-processor | processor-stream | Stream: table=main-table; start=TRIM_HORIZON; batch=25; window=5s; parallel=5; maxRetry=3; maxAge=3600s; poisonQueue=activity-processor-stream-poison-queue; bisect=true; reportBatchItemFailures=true | — | basic | memory=1024MB; timeout=300s; logs=7d |
 | actor | api-http | HTTP: GET /users/{username} | — | encryption | memory=512MB; timeout=30s; logs=7d |
-| ai-processor | processor-stream | Stream: table=main-table; start=TRIM_HORIZON; batch=25; window=5s; parallel=2; maxRetry=3; bisect=true; reportBatchItemFailures=true | — | basic | memory=1024MB; timeout=300s; logs=7d |
+| ai-processor | processor-stream | Stream: table=main-table; start=TRIM_HORIZON; batch=25; window=5s; parallel=2; maxRetry=3; maxAge=3600s; poisonQueue=ai-processor-stream-poison-queue; bisect=true; reportBatchItemFailures=true | — | basic | memory=1024MB; timeout=300s; logs=7d |
 | api | api-http | HTTP: ANY /api/v1/{proxy+}<br>HTTP: ANY /api/v2/{proxy+}<br>HTTP: GET /.well-known/nodeinfo<br>HTTP: GET /robots.txt | — | encryption | memory=512MB; timeout=30s; logs=7d |
 | cms-scheduler | processor-scheduled | Schedule: expression=rate(1 minute) | — | basic | memory=512MB; timeout=300s; logs=7d |
 | collections | api-http | HTTP: GET /users/{username}/followers<br>HTTP: GET /users/{username}/following<br>HTTP: GET /users/{username}/liked | — | encryption | memory=512MB; timeout=30s; logs=7d |
-| cost-aggregator | processor-stream | Stream: table=main-table; start=LATEST; batch=10; window=2s; parallel=1; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
+| cost-aggregator | processor-stream | Stream: table=main-table; start=LATEST; batch=10; window=2s; parallel=1; maxRetry=3; maxAge=3600s; poisonQueue=cost-aggregator-stream-poison-queue; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
 | dlq-processor | hybrid | SQS: queue=enhanced-federation-queue; consume=dlq; batch=10; window=1s<br>SQS: queue=export-processor-queue; consume=dlq; batch=10; window=1s<br>SQS: queue=federation-aggregator-queue; consume=dlq; batch=10; window=1s<br>SQS: queue=federation-delivery-queue; consume=dlq; batch=10; window=1s<br>SQS: queue=import-processor-queue; consume=dlq; batch=10; window=1s<br>SQS: queue=media-processor-queue; consume=dlq; batch=10; window=1s<br>SQS: queue=notification-processor-queue; consume=dlq; batch=10; window=1s<br>SQS: queue=push-delivery-queue; consume=dlq; batch=10; window=1s<br>Schedule: expression=rate(15 minutes) | — | basic | memory=512MB; timeout=30s; logs=7d |
 | enhanced-federation-processor | processor-sqs | SQS: queue=enhanced-federation-queue; partialFailure=true | — | basic | memory=512MB; timeout=30s; logs=7d |
 | export-generator | processor-sqs | SQS: queue=export-processor-queue; partialFailure=true | — | basic | memory=512MB; timeout=30s; logs=7d |
 | federation-aggregator | hybrid | SQS: queue=federation-aggregator-queue; partialFailure=true<br>Schedule: expression=rate(1 hour) | — | basic | memory=512MB; timeout=30s; logs=7d |
 | federation-delivery | processor-sqs | SQS: queue=federation-delivery-queue; partialFailure=true | — | basic | memory=512MB; timeout=30s; logs=7d |
-| federation-timeseries | processor-stream | Stream: table=main-table; start=LATEST; batch=25; window=5s; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
-| federation-tracker | processor-stream | Stream: table=main-table; start=LATEST; batch=25; window=5s; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
+| federation-timeseries | processor-stream | Stream: table=main-table; start=LATEST; batch=25; window=5s; maxRetry=3; maxAge=3600s; poisonQueue=federation-timeseries-stream-poison-queue; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
+| federation-tracker | processor-stream | Stream: table=main-table; start=LATEST; batch=25; window=5s; maxRetry=3; maxAge=3600s; poisonQueue=federation-tracker-stream-poison-queue; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
 | graphql | api-http | HTTP: GET /api/graphql<br>HTTP: POST /api/graphql | — | encryption | memory=512MB; timeout=30s; logs=7d |
 | graphql-ws | api-ws | — | — | encryption | memory=512MB; timeout=30s; logs=7d |
 | import-processor | processor-sqs | SQS: queue=import-processor-queue; partialFailure=true | — | basic | memory=512MB; timeout=30s; logs=7d |
 | inbox | api-http | HTTP: POST /inbox<br>HTTP: GET /inbox<br>HTTP: GET /users/{username}/inbox<br>HTTP: POST /users/{username}/inbox | — | encryption | memory=512MB; timeout=30s; logs=7d |
 | media-processor | processor-sqs | SQS: queue=media-processor-queue; partialFailure=true | — | basic | memory=512MB; timeout=30s; logs=7d |
-| metrics-aggregator | processor-stream | Stream: table=main-table; start=LATEST; batch=25; window=5s; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
-| metrics-processor | processor-stream | Stream: table=main-table; start=LATEST; batch=25; window=5s; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
-| ml-training-processor | processor-stream | Stream: table=main-table; start=LATEST; batch=5; window=1s; parallel=1; maxRetry=3; bisect=true; reportBatchItemFailures=true | — | basic | memory=1024MB; timeout=900s; logs=7d |
-| moderation-processor | processor-stream | Stream: table=main-table; start=LATEST; batch=10; window=5s; parallel=2; maxRetry=3; bisect=true; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
-| note-processor | processor-stream | Stream: table=main-table; start=LATEST; batch=25; window=5s; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
+| metrics-aggregator | processor-stream | Stream: table=main-table; start=LATEST; batch=25; window=5s; maxRetry=3; maxAge=3600s; poisonQueue=metrics-aggregator-stream-poison-queue; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
+| metrics-processor | processor-stream | Stream: table=main-table; start=LATEST; batch=25; window=5s; maxRetry=3; maxAge=3600s; poisonQueue=metrics-processor-stream-poison-queue; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
+| ml-training-processor | processor-stream | Stream: table=main-table; start=LATEST; batch=5; window=1s; parallel=1; maxRetry=3; maxAge=3600s; poisonQueue=ml-training-processor-stream-poison-queue; bisect=true; reportBatchItemFailures=true | — | basic | memory=1024MB; timeout=900s; logs=7d |
+| moderation-processor | processor-stream | Stream: table=main-table; start=LATEST; batch=10; window=5s; parallel=2; maxRetry=3; maxAge=3600s; poisonQueue=moderation-processor-stream-poison-queue; bisect=true; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
+| note-processor | processor-stream | Stream: table=main-table; start=LATEST; batch=25; window=5s; maxRetry=3; maxAge=3600s; poisonQueue=note-processor-stream-poison-queue; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
 | notification-processor | processor-sqs | SQS: queue=notification-processor-queue; partialFailure=true | — | basic | memory=512MB; timeout=30s; logs=7d |
 | objects | api-http | HTTP: GET /objects/{id}<br>HTTP: GET /users/{username}/statuses/{id} | — | encryption | memory=512MB; timeout=30s; logs=7d |
 | outbox | api-http | HTTP: GET /users/{username}/outbox<br>HTTP: POST /users/{username}/outbox | — | encryption | memory=512MB; timeout=30s; logs=7d |
 | push-delivery | processor-sqs | SQS: queue=push-delivery-queue; partialFailure=true | VAPID_PUBLIC_KEY<br>VAPID_SUBJECT<br>VAPID_SECRET_ARN | basic | memory=512MB; timeout=30s; logs=7d |
-| report-trust-updater | processor-stream | Stream: table=main-table; start=LATEST; batch=25; window=5s; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
-| search-indexer | processor-stream | Stream: table=main-table; start=LATEST; batch=100; window=30s; parallel=5; maxRetry=3; bisect=true; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
-| severance-processor | processor-stream | Stream: table=main-table; start=LATEST; batch=10; window=5s; parallel=2; maxRetry=3; bisect=true; reportBatchItemFailures=true | — | basic | memory=1024MB; timeout=30s; logs=7d |
+| report-trust-updater | processor-stream | Stream: table=main-table; start=LATEST; batch=25; window=5s; maxRetry=3; maxAge=3600s; poisonQueue=report-trust-updater-stream-poison-queue; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
+| search-indexer | processor-stream | Stream: table=main-table; start=LATEST; batch=100; window=30s; parallel=5; maxRetry=3; maxAge=3600s; poisonQueue=search-indexer-stream-poison-queue; bisect=true; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
+| severance-processor | processor-stream | Stream: table=main-table; start=LATEST; batch=10; window=5s; parallel=2; maxRetry=3; maxAge=3600s; poisonQueue=severance-processor-stream-poison-queue; bisect=true; reportBatchItemFailures=true | — | basic | memory=1024MB; timeout=30s; logs=7d |
 | sse | api-http | — | — | encryption | memory=512MB; timeout=900s; logs=7d |
-| status-indexer | processor-stream | Stream: table=main-table; start=LATEST; batch=25; window=5s; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
-| stream-router | processor-stream | Stream: table=main-table; start=LATEST; batch=50; window=2s; parallel=5; maxRetry=3; bisect=true; reportBatchItemFailures=true | — | encryption | memory=512MB; timeout=30s; logs=7d |
+| status-indexer | processor-stream | Stream: table=main-table; start=LATEST; batch=25; window=5s; maxRetry=3; maxAge=3600s; poisonQueue=status-indexer-stream-poison-queue; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
+| stream-router | processor-stream | Stream: table=main-table; start=LATEST; batch=50; window=2s; parallel=5; maxRetry=3; maxAge=3600s; poisonQueue=stream-router-stream-poison-queue; bisect=true; reportBatchItemFailures=true | — | encryption | memory=512MB; timeout=30s; logs=7d |
 | streaming | api-ws | — | — | encryption | memory=512MB; timeout=30s; logs=7d |
 | trend-aggregator | processor-scheduled | Schedule: expression=cron(0 2 * * ? *) | — | basic | memory=512MB; timeout=30s; logs=7d |
 | webfinger | api-http | HTTP: GET /.well-known/webfinger | — | basic | memory=512MB; timeout=30s; logs=7d |

--- a/infra/cdk/cmd/generate-inventory/main.go
+++ b/infra/cdk/cmd/generate-inventory/main.go
@@ -252,6 +252,9 @@ func formatStreamTrigger(t inventory.StreamTrigger) string {
 	if t.MaxRecordAgeSeconds > 0 {
 		entries = append(entries, fmt.Sprintf("maxAge=%ds", t.MaxRecordAgeSeconds))
 	}
+	if t.PoisonRecordQueue != "" {
+		entries = append(entries, fmt.Sprintf("poisonQueue=%s", t.PoisonRecordQueue))
+	}
 	if t.EnableBisectOnError {
 		entries = append(entries, "bisect=true")
 	}

--- a/infra/cdk/constructs/stream_processors.go
+++ b/infra/cdk/constructs/stream_processors.go
@@ -12,13 +12,17 @@ import (
 	"github.com/aws/aws-cdk-go/awscdk/v2/awssqs"
 	"github.com/aws/constructs-go/constructs/v10"
 	"github.com/aws/jsii-runtime-go"
+	"github.com/equaltoai/lesser/pkg/deploy/naming"
 	apptheorycdk "github.com/theory-cloud/apptheory/cdk-go/apptheorycdk"
 )
 
 type StreamProcessorsProps struct {
-	Table     awsdynamodb.Table
-	Queues    map[string]QueuePair
-	Functions *LambdaFunctions
+	AppName       string
+	Environment   string
+	RemovalPolicy awscdk.RemovalPolicy
+	Table         awsdynamodb.Table
+	Queues        map[string]QueuePair
+	Functions     *LambdaFunctions
 }
 
 func CreateStreamProcessors(scope constructs.Construct, props *StreamProcessorsProps) {
@@ -35,18 +39,20 @@ func CreateStreamProcessors(scope constructs.Construct, props *StreamProcessorsP
 			validateStreamCapable(spec)
 			for idx, trig := range spec.StreamTriggers {
 				table := resolveStreamTable(spec, trig, props.Table)
-				eventSourceID := fmt.Sprintf("%sStreamMapping%d", sanitizeStreamMappingID(spec.Name), idx)
 				table.GrantStreamRead(handler)
+				poisonQueue := createStreamPoisonQueue(scope, props, handler, spec, trig, idx)
 
 				startPos := awslambda.StartingPosition_LATEST
 				if trig.StartingPosition == inventory.StreamStartTrimHorizon {
 					startPos = awslambda.StartingPosition_TRIM_HORIZON
 				}
 
-				eventSourceProps := &apptheorycdk.AppTheoryDynamoDBStreamMappingProps{
-					Consumer:         handler,
-					Table:            table,
+				// AppTheoryDynamoDBStreamMapping currently has no OnFailure destination prop.
+				// Keep the inventory-driven shape but use the AWS CDK DynamoEventSource so
+				// poison records are captured instead of being retried until stream expiry.
+				eventSourceProps := &awslambdaeventsources.DynamoEventSourceProps{
 					StartingPosition: startPos,
+					OnFailure:        awslambdaeventsources.NewSqsDlq(poisonQueue),
 				}
 
 				if trig.BatchSize > 0 {
@@ -71,7 +77,7 @@ func CreateStreamProcessors(scope constructs.Construct, props *StreamProcessorsP
 					eventSourceProps.ReportBatchItemFailures = jsii.Bool(true)
 				}
 
-				_ = apptheorycdk.NewAppTheoryDynamoDBStreamMapping(scope, jsii.String(eventSourceID), eventSourceProps)
+				handler.AddEventSource(awslambdaeventsources.NewDynamoEventSource(table, eventSourceProps))
 			}
 		}
 
@@ -88,6 +94,35 @@ func CreateStreamProcessors(scope constructs.Construct, props *StreamProcessorsP
 			}
 		}
 	}
+}
+
+func createStreamPoisonQueue(scope constructs.Construct, props *StreamProcessorsProps, handler awslambda.Function, spec inventory.LambdaSpec, trig inventory.StreamTrigger, idx int) awssqs.IQueue {
+	if strings.TrimSpace(trig.PoisonRecordQueue) == "" {
+		panic(fmt.Sprintf("lambda %s stream trigger %d requires a poison record queue", spec.Name, idx))
+	}
+
+	queueName := naming.ResourceNameWithApp(props.AppName, trig.PoisonRecordQueue, props.Environment)
+	removalPolicy := props.RemovalPolicy
+	if removalPolicy == "" {
+		removalPolicy = awscdk.RemovalPolicy_DESTROY
+	}
+
+	queue := apptheorycdk.NewAppTheoryQueue(scope, jsii.String(fmt.Sprintf("%sStreamPoisonQueue%d", sanitizeStreamMappingID(spec.Name), idx)), &apptheorycdk.AppTheoryQueueProps{
+		QueueName:         jsii.String(queueName),
+		EnableDlq:         jsii.Bool(false),
+		RetentionPeriod:   awscdk.Duration_Days(jsii.Number(14)),
+		RemovalPolicy:     removalPolicy,
+		VisibilityTimeout: awscdk.Duration_Minutes(jsii.Number(2)),
+	})
+	poisonQueue := queue.Queue()
+	appName := strings.TrimSpace(props.AppName)
+	if appName == "" {
+		appName = naming.DefaultAppName
+	}
+	awscdk.Tags_Of(poisonQueue).Add(jsii.String("app"), jsii.String(appName), nil)
+	awscdk.Tags_Of(poisonQueue).Add(jsii.String("stage"), jsii.String(string(naming.StageForEnvironment(props.Environment))), nil)
+	poisonQueue.GrantSendMessages(handler)
+	return poisonQueue
 }
 
 func validateStreamCapable(spec inventory.LambdaSpec) {

--- a/infra/cdk/constructs/trigger_wiring_test.go
+++ b/infra/cdk/constructs/trigger_wiring_test.go
@@ -21,9 +21,14 @@ import (
 )
 
 type eventSourceMapping struct {
-	FunctionName  string
-	SourceLogical string
-	SourceAttr    string
+	FunctionName               string
+	SourceLogical              string
+	SourceAttr                 string
+	DestinationLogical         string
+	MaximumRetryAttempts       float64
+	MaximumRecordAgeInSeconds  float64
+	BisectBatchOnFunctionError bool
+	ReportsBatchItemFailures   bool
 }
 
 type queueDetails struct {
@@ -96,9 +101,12 @@ func TestInventoryTriggersMaterializeResources(t *testing.T) {
 	ApplyQueueEnvironmentVariables(functions, queues)
 
 	CreateStreamProcessors(stack, &StreamProcessorsProps{
-		Table:     mainTable,
-		Queues:    queues,
-		Functions: functions,
+		AppName:       naming.DefaultAppName,
+		Environment:   environment,
+		RemovalPolicy: awscdk.RemovalPolicy_DESTROY,
+		Table:         mainTable,
+		Queues:        queues,
+		Functions:     functions,
 	})
 
 	app.Synth(nil)
@@ -118,6 +126,29 @@ func TestInventoryTriggersMaterializeResources(t *testing.T) {
 		if len(spec.StreamTriggers) > 0 {
 			if countMappingsBySourceAttr(mappings, fnName, "StreamArn") != len(spec.StreamTriggers) {
 				t.Fatalf("stream trigger mapping mismatch for %s", spec.Name)
+			}
+			for _, trig := range spec.StreamTriggers {
+				poisonName := naming.ResourceName(trig.PoisonRecordQueue, environment)
+				poisonQueue, ok := queuesMeta[poisonName]
+				if !ok {
+					t.Fatalf("stream poison queue %s not created for %s", poisonName, spec.Name)
+				}
+				mapping := requireStreamMapping(t, mappings, fnName)
+				if mapping.MaximumRetryAttempts != float64(trig.MaxRetryAttempts) {
+					t.Fatalf("%s retry attempts = %v, want %d", spec.Name, mapping.MaximumRetryAttempts, trig.MaxRetryAttempts)
+				}
+				if mapping.MaximumRecordAgeInSeconds != float64(trig.MaxRecordAgeSeconds) {
+					t.Fatalf("%s max record age = %v, want %d", spec.Name, mapping.MaximumRecordAgeInSeconds, trig.MaxRecordAgeSeconds)
+				}
+				if mapping.DestinationLogical != poisonQueue.LogicalID {
+					t.Fatalf("%s poison destination = %s, want %s", spec.Name, mapping.DestinationLogical, poisonQueue.LogicalID)
+				}
+				if mapping.BisectBatchOnFunctionError != trig.EnableBisectOnError {
+					t.Fatalf("%s bisect setting = %v, want %v", spec.Name, mapping.BisectBatchOnFunctionError, trig.EnableBisectOnError)
+				}
+				if mapping.ReportsBatchItemFailures != trig.ReportBatchItemFailures {
+					t.Fatalf("%s partial failure setting = %v, want %v", spec.Name, mapping.ReportsBatchItemFailures, trig.ReportBatchItemFailures)
+				}
 			}
 		}
 
@@ -280,9 +311,12 @@ func TestMissingQueuePanics(t *testing.T) {
 		}
 	}()
 	CreateStreamProcessors(stack, &StreamProcessorsProps{
-		Table:     mainTable,
-		Queues:    map[string]QueuePair{},
-		Functions: functions,
+		AppName:       naming.DefaultAppName,
+		Environment:   environment,
+		RemovalPolicy: awscdk.RemovalPolicy_DESTROY,
+		Table:         mainTable,
+		Queues:        map[string]QueuePair{},
+		Functions:     functions,
 	})
 }
 
@@ -387,12 +421,73 @@ func collectEventSourceMappings(t *testing.T, tpl map[string]any) []eventSourceM
 			continue
 		}
 		mappings = append(mappings, eventSourceMapping{
-			FunctionName:  fnName,
-			SourceLogical: srcLogical,
-			SourceAttr:    srcAttr,
+			FunctionName:               fnName,
+			SourceLogical:              srcLogical,
+			SourceAttr:                 srcAttr,
+			DestinationLogical:         extractEventSourceMappingDestinationLogical(props),
+			MaximumRetryAttempts:       numericProperty(props, "MaximumRetryAttempts"),
+			MaximumRecordAgeInSeconds:  numericProperty(props, "MaximumRecordAgeInSeconds"),
+			BisectBatchOnFunctionError: boolProperty(props, "BisectBatchOnFunctionError"),
+			ReportsBatchItemFailures:   containsStringAny(props["FunctionResponseTypes"], "ReportBatchItemFailures"),
 		})
 	}
 	return mappings
+}
+
+func requireStreamMapping(t *testing.T, mappings []eventSourceMapping, fnName string) eventSourceMapping {
+	t.Helper()
+	var found []eventSourceMapping
+	for _, m := range mappings {
+		if m.FunctionName == fnName && m.SourceAttr == "StreamArn" {
+			found = append(found, m)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("expected exactly one stream mapping for %s, got %d", fnName, len(found))
+	}
+	return found[0]
+}
+
+func extractEventSourceMappingDestinationLogical(props map[string]any) string {
+	cfg, ok := props["DestinationConfig"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	onFailure, ok := cfg["OnFailure"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	logical, _ := extractLogicalAndAttr(onFailure["Destination"])
+	return logical
+}
+
+func numericProperty(props map[string]any, key string) float64 {
+	switch v := props[key].(type) {
+	case float64:
+		return v
+	case int:
+		return float64(v)
+	default:
+		return 0
+	}
+}
+
+func boolProperty(props map[string]any, key string) bool {
+	v, _ := props[key].(bool)
+	return v
+}
+
+func containsStringAny(v any, needle string) bool {
+	items, ok := v.([]any)
+	if !ok {
+		return false
+	}
+	for _, item := range items {
+		if s, ok := item.(string); ok && s == needle {
+			return true
+		}
+	}
+	return false
 }
 
 func collectQueuesByName(t *testing.T, tpl map[string]any) map[string]queueDetails {

--- a/infra/cdk/inventory/lambdas.go
+++ b/infra/cdk/inventory/lambdas.go
@@ -27,11 +27,13 @@ var LambdaInventory = Inventory{
 			StreamTriggers: []StreamTrigger{
 				{
 					SourceTable:              "main-table", // replaced by stack DDB table at deploy time
+					PoisonRecordQueue:        "activity-processor-stream-poison-queue",
 					StartingPosition:         StreamStartTrimHorizon,
 					BatchSize:                25,
 					MaxBatchingWindowSeconds: 5,
 					ParallelizationFactor:    5,
 					MaxRetryAttempts:         3,
+					MaxRecordAgeSeconds:      3600,
 					EnableBisectOnError:      true,
 					ReportBatchItemFailures:  true,
 				},
@@ -56,11 +58,13 @@ var LambdaInventory = Inventory{
 			StreamTriggers: []StreamTrigger{
 				{
 					SourceTable:              "main-table",
+					PoisonRecordQueue:        "ai-processor-stream-poison-queue",
 					StartingPosition:         StreamStartTrimHorizon,
 					BatchSize:                25,
 					MaxBatchingWindowSeconds: 5,
 					ParallelizationFactor:    2,
 					MaxRetryAttempts:         3,
+					MaxRecordAgeSeconds:      3600,
 					EnableBisectOnError:      true,
 					ReportBatchItemFailures:  true,
 				},
@@ -117,10 +121,13 @@ var LambdaInventory = Inventory{
 			StreamTriggers: []StreamTrigger{
 				{
 					SourceTable:              "main-table",
+					PoisonRecordQueue:        "cost-aggregator-stream-poison-queue",
 					StartingPosition:         StreamStartLatest,
 					BatchSize:                10,
 					MaxBatchingWindowSeconds: 2,
 					ParallelizationFactor:    1,
+					MaxRetryAttempts:         3,
+					MaxRecordAgeSeconds:      3600,
 					ReportBatchItemFailures:  true,
 				},
 			},
@@ -185,9 +192,12 @@ var LambdaInventory = Inventory{
 			StreamTriggers: []StreamTrigger{
 				{
 					SourceTable:              "main-table",
+					PoisonRecordQueue:        "federation-timeseries-stream-poison-queue",
 					StartingPosition:         StreamStartLatest,
 					BatchSize:                25,
 					MaxBatchingWindowSeconds: 5,
+					MaxRetryAttempts:         3,
+					MaxRecordAgeSeconds:      3600,
 					ReportBatchItemFailures:  true,
 				},
 			},
@@ -199,9 +209,12 @@ var LambdaInventory = Inventory{
 			StreamTriggers: []StreamTrigger{
 				{
 					SourceTable:              "main-table",
+					PoisonRecordQueue:        "federation-tracker-stream-poison-queue",
 					StartingPosition:         StreamStartLatest,
 					BatchSize:                25,
 					MaxBatchingWindowSeconds: 5,
+					MaxRetryAttempts:         3,
+					MaxRecordAgeSeconds:      3600,
 					ReportBatchItemFailures:  true,
 				},
 			},
@@ -249,9 +262,12 @@ var LambdaInventory = Inventory{
 			StreamTriggers: []StreamTrigger{
 				{
 					SourceTable:              "main-table",
+					PoisonRecordQueue:        "metrics-aggregator-stream-poison-queue",
 					StartingPosition:         StreamStartLatest,
 					BatchSize:                25,
 					MaxBatchingWindowSeconds: 5,
+					MaxRetryAttempts:         3,
+					MaxRecordAgeSeconds:      3600,
 					ReportBatchItemFailures:  true,
 				},
 			},
@@ -263,9 +279,12 @@ var LambdaInventory = Inventory{
 			StreamTriggers: []StreamTrigger{
 				{
 					SourceTable:              "main-table",
+					PoisonRecordQueue:        "metrics-processor-stream-poison-queue",
 					StartingPosition:         StreamStartLatest,
 					BatchSize:                25,
 					MaxBatchingWindowSeconds: 5,
+					MaxRetryAttempts:         3,
+					MaxRecordAgeSeconds:      3600,
 					ReportBatchItemFailures:  true,
 				},
 			},
@@ -277,11 +296,13 @@ var LambdaInventory = Inventory{
 			StreamTriggers: []StreamTrigger{
 				{
 					SourceTable:              "main-table",
+					PoisonRecordQueue:        "ml-training-processor-stream-poison-queue",
 					StartingPosition:         StreamStartLatest,
 					BatchSize:                5,
 					MaxBatchingWindowSeconds: 1,
 					ParallelizationFactor:    1,
 					MaxRetryAttempts:         3,
+					MaxRecordAgeSeconds:      3600,
 					EnableBisectOnError:      true,
 					ReportBatchItemFailures:  true,
 				},
@@ -298,11 +319,13 @@ var LambdaInventory = Inventory{
 			StreamTriggers: []StreamTrigger{
 				{
 					SourceTable:              "main-table",
+					PoisonRecordQueue:        "moderation-processor-stream-poison-queue",
 					StartingPosition:         StreamStartLatest,
 					BatchSize:                10,
 					MaxBatchingWindowSeconds: 5,
 					ParallelizationFactor:    2,
 					MaxRetryAttempts:         3,
+					MaxRecordAgeSeconds:      3600,
 					EnableBisectOnError:      true,
 					ReportBatchItemFailures:  true,
 				},
@@ -315,9 +338,12 @@ var LambdaInventory = Inventory{
 			StreamTriggers: []StreamTrigger{
 				{
 					SourceTable:              "main-table",
+					PoisonRecordQueue:        "note-processor-stream-poison-queue",
 					StartingPosition:         StreamStartLatest,
 					BatchSize:                25,
 					MaxBatchingWindowSeconds: 5,
+					MaxRetryAttempts:         3,
+					MaxRecordAgeSeconds:      3600,
 					ReportBatchItemFailures:  true,
 				},
 			},
@@ -364,9 +390,12 @@ var LambdaInventory = Inventory{
 			StreamTriggers: []StreamTrigger{
 				{
 					SourceTable:              "main-table",
+					PoisonRecordQueue:        "report-trust-updater-stream-poison-queue",
 					StartingPosition:         StreamStartLatest,
 					BatchSize:                25,
 					MaxBatchingWindowSeconds: 5,
+					MaxRetryAttempts:         3,
+					MaxRecordAgeSeconds:      3600,
 					ReportBatchItemFailures:  true,
 				},
 			},
@@ -378,11 +407,13 @@ var LambdaInventory = Inventory{
 			StreamTriggers: []StreamTrigger{
 				{
 					SourceTable:              "main-table",
+					PoisonRecordQueue:        "search-indexer-stream-poison-queue",
 					StartingPosition:         StreamStartLatest,
 					BatchSize:                100,
 					MaxBatchingWindowSeconds: 30,
 					ParallelizationFactor:    5,
 					MaxRetryAttempts:         3,
+					MaxRecordAgeSeconds:      3600,
 					EnableBisectOnError:      true,
 					ReportBatchItemFailures:  true,
 				},
@@ -395,11 +426,13 @@ var LambdaInventory = Inventory{
 			StreamTriggers: []StreamTrigger{
 				{
 					SourceTable:              "main-table",
+					PoisonRecordQueue:        "severance-processor-stream-poison-queue",
 					StartingPosition:         StreamStartLatest,
 					BatchSize:                10,
 					MaxBatchingWindowSeconds: 5,
 					ParallelizationFactor:    2,
 					MaxRetryAttempts:         3,
+					MaxRecordAgeSeconds:      3600,
 					EnableBisectOnError:      true,
 					ReportBatchItemFailures:  true,
 				},
@@ -416,9 +449,12 @@ var LambdaInventory = Inventory{
 			StreamTriggers: []StreamTrigger{
 				{
 					SourceTable:              "main-table",
+					PoisonRecordQueue:        "status-indexer-stream-poison-queue",
 					StartingPosition:         StreamStartLatest,
 					BatchSize:                25,
 					MaxBatchingWindowSeconds: 5,
+					MaxRetryAttempts:         3,
+					MaxRecordAgeSeconds:      3600,
 					ReportBatchItemFailures:  true,
 				},
 			},
@@ -430,11 +466,13 @@ var LambdaInventory = Inventory{
 			StreamTriggers: []StreamTrigger{
 				{
 					SourceTable:              "main-table",
+					PoisonRecordQueue:        "stream-router-stream-poison-queue",
 					StartingPosition:         StreamStartLatest,
 					BatchSize:                50,
 					MaxBatchingWindowSeconds: 2,
 					ParallelizationFactor:    5,
 					MaxRetryAttempts:         3,
+					MaxRecordAgeSeconds:      3600,
 					EnableBisectOnError:      true,
 					ReportBatchItemFailures:  true,
 				},

--- a/infra/cdk/inventory/lambdas_test.go
+++ b/infra/cdk/inventory/lambdas_test.go
@@ -1,0 +1,25 @@
+package inventory
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStreamTriggersDeclareFiniteRetryAgeAndPoisonDestination(t *testing.T) {
+	for _, spec := range LambdaInventory.Lambdas {
+		for idx, trig := range spec.StreamTriggers {
+			if trig.MaxRetryAttempts < 0 {
+				t.Fatalf("%s stream trigger %d has negative retry attempts: %d", spec.Name, idx, trig.MaxRetryAttempts)
+			}
+			if trig.MaxRetryAttempts == 0 {
+				t.Fatalf("%s stream trigger %d must declare finite retry attempts", spec.Name, idx)
+			}
+			if trig.MaxRecordAgeSeconds < 60 {
+				t.Fatalf("%s stream trigger %d must declare finite max record age >= 60 seconds, got %d", spec.Name, idx, trig.MaxRecordAgeSeconds)
+			}
+			if strings.TrimSpace(trig.PoisonRecordQueue) == "" {
+				t.Fatalf("%s stream trigger %d must declare a poison record queue", spec.Name, idx)
+			}
+		}
+	}
+}

--- a/infra/cdk/inventory/types.go
+++ b/infra/cdk/inventory/types.go
@@ -55,6 +55,7 @@ const (
 type StreamTrigger struct {
 	SourceTable              string                 `json:"sourceTable,omitempty" yaml:"sourceTable,omitempty"`
 	StreamArn                string                 `json:"streamArn,omitempty" yaml:"streamArn,omitempty"`
+	PoisonRecordQueue        string                 `json:"poisonRecordQueue,omitempty" yaml:"poisonRecordQueue,omitempty"`
 	BatchSize                int                    `json:"batchSize,omitempty" yaml:"batchSize,omitempty"`
 	MaxBatchingWindowSeconds int                    `json:"maxBatchingWindowSeconds,omitempty" yaml:"maxBatchingWindowSeconds,omitempty"`
 	ParallelizationFactor    int                    `json:"parallelizationFactor,omitempty" yaml:"parallelizationFactor,omitempty"`

--- a/infra/cdk/stacks/critical_alarms.go
+++ b/infra/cdk/stacks/critical_alarms.go
@@ -1,0 +1,198 @@
+package stacks
+
+import (
+	"fmt"
+
+	"cdk/inventory"
+
+	"github.com/aws/aws-cdk-go/awscdk/v2"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awscloudwatch"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awscloudwatchactions"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awssns"
+	"github.com/aws/constructs-go/constructs/v10"
+	"github.com/aws/jsii-runtime-go"
+	"github.com/equaltoai/lesser/pkg/deploy/naming"
+)
+
+type CriticalAlarmsNestedStackProps struct {
+	awscdk.NestedStackProps
+	AppName     string
+	Environment string
+}
+
+type CriticalAlarmsNestedStack struct {
+	awscdk.NestedStack
+	AppName     string
+	Environment string
+}
+
+func (s *LesserApiStack) createCriticalAlarms() {
+	NewCriticalAlarmsNestedStack(s.Stack, "CriticalAlarms", &CriticalAlarmsNestedStackProps{
+		AppName:     s.AppName,
+		Environment: s.Environment,
+	})
+}
+
+func NewCriticalAlarmsNestedStack(scope constructs.Construct, id string, props *CriticalAlarmsNestedStackProps) *CriticalAlarmsNestedStack {
+	nested := awscdk.NewNestedStack(scope, jsii.String(id), &props.NestedStackProps)
+	stack := &CriticalAlarmsNestedStack{
+		NestedStack: nested,
+		AppName:     props.AppName,
+		Environment: props.Environment,
+	}
+
+	alertTopic := awssns.NewTopic(nested, jsii.String("CriticalAlertTopic"), &awssns.TopicProps{
+		TopicName:   jsii.String(naming.ResourceNameWithApp(stack.AppName, "critical-alerts", stack.Environment)),
+		DisplayName: jsii.String(fmt.Sprintf("%s %s critical processor alerts", stack.AppName, naming.StageForEnvironment(stack.Environment))),
+	})
+
+	stack.addCriticalLambdaAlarms(alertTopic)
+	stack.addCriticalQueueAlarms(alertTopic)
+	return stack
+}
+
+func (s *CriticalAlarmsNestedStack) addCriticalLambdaAlarms(alertTopic awssns.ITopic) {
+	thresholds := lambdaAlarmThresholdsFor(s.Environment)
+	for _, spec := range inventory.LambdaInventory.Lambdas {
+		functionName := lambdaPhysicalName(s.AppName, s.Environment, spec.Name)
+		constructPrefix := fmt.Sprintf("%sCritical", sanitizeConstructID(spec.Name))
+
+		invocationsMetric := awscloudwatch.NewMetric(&awscloudwatch.MetricProps{
+			Namespace:     jsii.String("AWS/Lambda"),
+			MetricName:    jsii.String("Invocations"),
+			DimensionsMap: &map[string]*string{"FunctionName": jsii.String(functionName)},
+			Statistic:     jsii.String("Sum"),
+			Period:        awscdk.Duration_Minutes(jsii.Number(5)),
+		})
+		errorsMetric := awscloudwatch.NewMetric(&awscloudwatch.MetricProps{
+			Namespace:     jsii.String("AWS/Lambda"),
+			MetricName:    jsii.String("Errors"),
+			DimensionsMap: &map[string]*string{"FunctionName": jsii.String(functionName)},
+			Statistic:     jsii.String("Sum"),
+			Period:        awscdk.Duration_Minutes(jsii.Number(5)),
+		})
+
+		awscloudwatch.NewAlarm(s.NestedStack, jsii.String(fmt.Sprintf("%sErrorRateAlarm", constructPrefix)), &awscloudwatch.AlarmProps{
+			AlarmName: jsii.String(fmt.Sprintf("%s-critical-error-rate", functionName)),
+			Metric: awscloudwatch.NewMathExpression(&awscloudwatch.MathExpressionProps{
+				Expression: jsii.String("(errors / invocations) * 100"),
+				UsingMetrics: &map[string]awscloudwatch.IMetric{
+					"errors":      errorsMetric,
+					"invocations": invocationsMetric,
+				},
+				Period: awscdk.Duration_Minutes(jsii.Number(5)),
+			}),
+			Threshold:          jsii.Number(thresholds.ErrorRatePercent),
+			EvaluationPeriods:  jsii.Number(2),
+			ComparisonOperator: awscloudwatch.ComparisonOperator_GREATER_THAN_THRESHOLD,
+			TreatMissingData:   awscloudwatch.TreatMissingData_NOT_BREACHING,
+		}).AddAlarmAction(awscloudwatchactions.NewSnsAction(alertTopic))
+
+		awscloudwatch.NewAlarm(s.NestedStack, jsii.String(fmt.Sprintf("%sErrorsAlarm", constructPrefix)), &awscloudwatch.AlarmProps{
+			AlarmName:          jsii.String(fmt.Sprintf("%s-critical-errors", functionName)),
+			Metric:             errorsMetric,
+			Threshold:          jsii.Number(1),
+			EvaluationPeriods:  jsii.Number(1),
+			ComparisonOperator: awscloudwatch.ComparisonOperator_GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+			TreatMissingData:   awscloudwatch.TreatMissingData_NOT_BREACHING,
+		}).AddAlarmAction(awscloudwatchactions.NewSnsAction(alertTopic))
+
+		if isStreamLambda(spec) {
+			iteratorAgeMetric := awscloudwatch.NewMetric(&awscloudwatch.MetricProps{
+				Namespace:     jsii.String("AWS/Lambda"),
+				MetricName:    jsii.String("IteratorAge"),
+				DimensionsMap: &map[string]*string{"FunctionName": jsii.String(functionName)},
+				Statistic:     jsii.String("Maximum"),
+				Period:        awscdk.Duration_Minutes(jsii.Number(5)),
+			})
+			awscloudwatch.NewAlarm(s.NestedStack, jsii.String(fmt.Sprintf("%sIteratorAgeAlarm", constructPrefix)), &awscloudwatch.AlarmProps{
+				AlarmName:          jsii.String(fmt.Sprintf("%s-critical-iterator-age", functionName)),
+				Metric:             iteratorAgeMetric,
+				Threshold:          jsii.Number(60000),
+				EvaluationPeriods:  jsii.Number(2),
+				ComparisonOperator: awscloudwatch.ComparisonOperator_GREATER_THAN_THRESHOLD,
+				TreatMissingData:   awscloudwatch.TreatMissingData_NOT_BREACHING,
+			}).AddAlarmAction(awscloudwatchactions.NewSnsAction(alertTopic))
+		}
+
+		if len(spec.ScheduleTriggers) > 0 {
+			awscloudwatch.NewAlarm(s.NestedStack, jsii.String(fmt.Sprintf("%sScheduledErrorsAlarm", constructPrefix)), &awscloudwatch.AlarmProps{
+				AlarmName:          jsii.String(fmt.Sprintf("%s-critical-scheduled-errors", functionName)),
+				Metric:             errorsMetric,
+				Threshold:          jsii.Number(1),
+				EvaluationPeriods:  jsii.Number(1),
+				ComparisonOperator: awscloudwatch.ComparisonOperator_GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+				TreatMissingData:   awscloudwatch.TreatMissingData_NOT_BREACHING,
+			}).AddAlarmAction(awscloudwatchactions.NewSnsAction(alertTopic))
+		}
+	}
+}
+
+func (s *CriticalAlarmsNestedStack) addCriticalQueueAlarms(alertTopic awssns.ITopic) {
+	for _, q := range deriveInventoryQueues() {
+		primaryName := queuePhysicalName(s.AppName, s.Environment, q.Logical)
+		addCriticalQueueAgeAlarm(s.NestedStack, alertTopic, s.Environment, primaryName, q.Logical)
+		addCriticalQueueDepthAlarm(s.NestedStack, alertTopic, primaryName, fmt.Sprintf("%sPrimary", q.Logical), sqsDepthThresholdFor(s.Environment))
+
+		dlqName := queuePhysicalName(s.AppName, s.Environment, q.DLQLogical)
+		addCriticalQueueDepthAlarm(s.NestedStack, alertTopic, dlqName, fmt.Sprintf("%sDLQ", q.Logical), 0)
+	}
+
+	for _, spec := range inventory.LambdaInventory.Lambdas {
+		for idx, trig := range spec.StreamTriggers {
+			poisonName := queuePhysicalName(s.AppName, s.Environment, trig.PoisonRecordQueue)
+			addCriticalQueueDepthAlarm(s.NestedStack, alertTopic, poisonName, fmt.Sprintf("%sStreamPoison%d", spec.Name, idx), 0)
+		}
+		for idx := range spec.ScheduleTriggers {
+			scheduleDLQ := queuePhysicalName(s.AppName, s.Environment, fmt.Sprintf("%s-schedule-%d-dlq", spec.Name, idx))
+			addCriticalQueueDepthAlarm(s.NestedStack, alertTopic, scheduleDLQ, fmt.Sprintf("%sScheduleDLQ%d", spec.Name, idx), 0)
+		}
+	}
+}
+
+func addCriticalQueueAgeAlarm(scope constructs.Construct, alertTopic awssns.ITopic, environment string, queueName string, logicalID string) {
+	ageOfOldest := awscloudwatch.NewMetric(&awscloudwatch.MetricProps{
+		Namespace:     jsii.String("AWS/SQS"),
+		MetricName:    jsii.String("ApproximateAgeOfOldestMessage"),
+		DimensionsMap: &map[string]*string{"QueueName": jsii.String(queueName)},
+		Statistic:     jsii.String("Maximum"),
+		Period:        awscdk.Duration_Minutes(jsii.Number(5)),
+	})
+	awscloudwatch.NewAlarm(scope, jsii.String(fmt.Sprintf("%sCriticalAgeAlarm", sanitizeConstructID(logicalID))), &awscloudwatch.AlarmProps{
+		AlarmName:          jsii.String(fmt.Sprintf("%s-critical-age", queueName)),
+		Metric:             ageOfOldest,
+		Threshold:          jsii.Number(sqsAgeThresholdSecondsFor(environment)),
+		EvaluationPeriods:  jsii.Number(2),
+		ComparisonOperator: awscloudwatch.ComparisonOperator_GREATER_THAN_THRESHOLD,
+		TreatMissingData:   awscloudwatch.TreatMissingData_NOT_BREACHING,
+	}).AddAlarmAction(awscloudwatchactions.NewSnsAction(alertTopic))
+}
+
+func addCriticalQueueDepthAlarm(scope constructs.Construct, alertTopic awssns.ITopic, queueName string, logicalID string, threshold float64) {
+	visibleMessages := awscloudwatch.NewMetric(&awscloudwatch.MetricProps{
+		Namespace:     jsii.String("AWS/SQS"),
+		MetricName:    jsii.String("ApproximateNumberOfMessagesVisible"),
+		DimensionsMap: &map[string]*string{"QueueName": jsii.String(queueName)},
+		Statistic:     jsii.String("Average"),
+		Period:        awscdk.Duration_Minutes(jsii.Number(5)),
+	})
+	awscloudwatch.NewAlarm(scope, jsii.String(fmt.Sprintf("%sCriticalDepthAlarm", sanitizeConstructID(logicalID))), &awscloudwatch.AlarmProps{
+		AlarmName:          jsii.String(fmt.Sprintf("%s-critical-depth", queueName)),
+		Metric:             visibleMessages,
+		Threshold:          jsii.Number(threshold),
+		EvaluationPeriods:  jsii.Number(1),
+		ComparisonOperator: awscloudwatch.ComparisonOperator_GREATER_THAN_THRESHOLD,
+		TreatMissingData:   awscloudwatch.TreatMissingData_NOT_BREACHING,
+	}).AddAlarmAction(awscloudwatchactions.NewSnsAction(alertTopic))
+}
+
+func sqsDepthThresholdFor(environment string) float64 {
+	switch naming.StageForEnvironment(environment) {
+	case naming.StageLive:
+		return 100
+	case naming.StageStaging:
+		return 250
+	default:
+		return 500
+	}
+}

--- a/infra/cdk/stacks/critical_alarms_test.go
+++ b/infra/cdk/stacks/critical_alarms_test.go
@@ -1,0 +1,125 @@
+package stacks
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"cdk/inventory"
+
+	"github.com/aws/aws-cdk-go/awscdk/v2"
+	"github.com/aws/jsii-runtime-go"
+	"github.com/equaltoai/lesser/pkg/deploy/naming"
+)
+
+func TestLesserApiStackSynthCreatesCriticalProcessorAlarms(t *testing.T) {
+	appName := "lesser"
+	environment := "development"
+	tpl := synthLesserApiStageTemplate(t, appName, environment)
+	alarms := collectAlarmNames(t, tpl)
+
+	for _, spec := range inventory.LambdaInventory.Lambdas {
+		physical := lambdaPhysicalName(appName, environment, spec.Name)
+		requireAlarm(t, alarms, fmt.Sprintf("%s-critical-error-rate", physical))
+		requireAlarm(t, alarms, fmt.Sprintf("%s-critical-errors", physical))
+		if isStreamLambda(spec) {
+			requireAlarm(t, alarms, fmt.Sprintf("%s-critical-iterator-age", physical))
+		}
+		if len(spec.ScheduleTriggers) > 0 {
+			requireAlarm(t, alarms, fmt.Sprintf("%s-critical-scheduled-errors", physical))
+		}
+	}
+
+	for _, q := range deriveInventoryQueues() {
+		primary := queuePhysicalName(appName, environment, q.Logical)
+		dlq := queuePhysicalName(appName, environment, q.DLQLogical)
+		requireAlarm(t, alarms, fmt.Sprintf("%s-critical-age", primary))
+		requireAlarm(t, alarms, fmt.Sprintf("%s-critical-depth", primary))
+		requireAlarm(t, alarms, fmt.Sprintf("%s-critical-depth", dlq))
+	}
+
+	for _, spec := range inventory.LambdaInventory.Lambdas {
+		for _, trig := range spec.StreamTriggers {
+			poison := queuePhysicalName(appName, environment, trig.PoisonRecordQueue)
+			requireAlarm(t, alarms, fmt.Sprintf("%s-critical-depth", poison))
+		}
+		for idx := range spec.ScheduleTriggers {
+			scheduleDLQ := queuePhysicalName(appName, environment, fmt.Sprintf("%s-schedule-%d-dlq", spec.Name, idx))
+			requireAlarm(t, alarms, fmt.Sprintf("%s-critical-depth", scheduleDLQ))
+		}
+	}
+}
+
+func synthLesserApiStageTemplate(t *testing.T, appName string, environment string) map[string]any {
+	t.Helper()
+
+	outdir := t.TempDir()
+	assetRoot := writePlaceholderLambdaAssets(t, t.TempDir())
+	app := awscdk.NewApp(&awscdk.AppProps{Outdir: jsii.String(outdir)})
+
+	NewLesserApiStack(app, "CriticalAlarmStageStack", &LesserApiStackProps{
+		StackProps: awscdk.StackProps{
+			Env: &awscdk.Environment{
+				Account: jsii.String("123456789012"),
+				Region:  jsii.String("us-east-1"),
+			},
+		},
+		Environment:      environment,
+		Domain:           naming.StageDomain(naming.StageForEnvironment(environment), "example.com"),
+		Config:           map[string]interface{}{"lambdaAssetRoot": assetRoot},
+		HostedZoneDomain: "example.com",
+		HostedZoneId:     "Z1",
+		AppName:          appName,
+		AccountID:        "123456789012",
+		Region:           "us-east-1",
+	})
+
+	app.Synth(nil)
+
+	templatePath := filepath.Join(outdir, "CriticalAlarmStageStack.template.json")
+	tpl := readTemplateFile(t, templatePath)
+	for _, nestedPath := range nestedTemplatePaths(t, outdir) {
+		mergeTemplateResources(t, tpl, readTemplateFile(t, nestedPath), filepath.Base(nestedPath))
+	}
+	return tpl
+}
+
+func nestedTemplatePaths(t *testing.T, outdir string) []string {
+	t.Helper()
+
+	paths, err := filepath.Glob(filepath.Join(outdir, "*.nested.template.json"))
+	if err != nil {
+		t.Fatalf("glob nested templates: %v", err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("expected critical alarms nested stack template")
+	}
+	return paths
+}
+
+func readTemplateFile(t *testing.T, templatePath string) map[string]any {
+	t.Helper()
+
+	data, err := os.ReadFile(templatePath)
+	if err != nil {
+		t.Fatalf("read template: %v", err)
+	}
+
+	var tpl map[string]any
+	if err := json.Unmarshal(data, &tpl); err != nil {
+		t.Fatalf("unmarshal template: %v", err)
+	}
+	return tpl
+}
+
+func mergeTemplateResources(t *testing.T, into map[string]any, from map[string]any, prefix string) {
+	t.Helper()
+
+	intoResources := mustResources(t, into)
+	fromResources := mustResources(t, from)
+	for logicalID, resource := range fromResources {
+		intoResources[prefix+"::"+logicalID] = resource
+	}
+}

--- a/infra/cdk/stacks/lesser_api_stack.go
+++ b/infra/cdk/stacks/lesser_api_stack.go
@@ -132,6 +132,9 @@ func NewLesserApiStack(scope constructs.Construct, id string, props *LesserApiSt
 	// Create stream processors
 	apiStack.createStreamProcessors()
 
+	// Create minimum critical operational alarms in the normal stage stack path
+	apiStack.createCriticalAlarms()
+
 	// Setup security
 	apiStack.setupSecurity()
 

--- a/infra/cdk/stacks/lesser_api_stack.go
+++ b/infra/cdk/stacks/lesser_api_stack.go
@@ -1037,9 +1037,12 @@ func (s *LesserApiStack) createAPIGateway(domain string) {
 func (s *LesserApiStack) createStreamProcessors() {
 	// Inventory-driven wiring for streams and SQS (requires queues/table/functions)
 	localconstructs.CreateStreamProcessors(s.Stack, &localconstructs.StreamProcessorsProps{
-		Table:     s.MainTable,
-		Queues:    s.Queues,
-		Functions: s.Functions,
+		AppName:       s.AppName,
+		Environment:   s.Environment,
+		RemovalPolicy: getRemovalPolicy(naming.IsLiveEnvironment(s.Environment)),
+		Table:         s.MainTable,
+		Queues:        s.Queues,
+		Functions:     s.Functions,
 	})
 }
 

--- a/infra/cdk/stacks/monitoring_stack.go
+++ b/infra/cdk/stacks/monitoring_stack.go
@@ -310,6 +310,15 @@ func (s *MonitoringStack) addLambdaMetrics(environment string, spec inventory.La
 		TreatMissingData:   awscloudwatch.TreatMissingData_NOT_BREACHING,
 	}).AddAlarmAction(awscloudwatchactions.NewSnsAction(s.AlertTopic))
 
+	awscloudwatch.NewAlarm(s.Stack, jsii.String(fmt.Sprintf("%sErrorsAlarm", sanitizeConstructID(spec.Name))), &awscloudwatch.AlarmProps{
+		AlarmName:          jsii.String(fmt.Sprintf("%s-errors", functionName)),
+		Metric:             errorsMetric,
+		Threshold:          jsii.Number(1),
+		EvaluationPeriods:  jsii.Number(1),
+		ComparisonOperator: awscloudwatch.ComparisonOperator_GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+		TreatMissingData:   awscloudwatch.TreatMissingData_NOT_BREACHING,
+	}).AddAlarmAction(awscloudwatchactions.NewSnsAction(s.AlertTopic))
+
 	awscloudwatch.NewAlarm(s.Stack, jsii.String(fmt.Sprintf("%sDurationAlarm", sanitizeConstructID(spec.Name))), &awscloudwatch.AlarmProps{
 		AlarmName:          jsii.String(fmt.Sprintf("%s-duration", functionName)),
 		Metric:             durationMetric,
@@ -412,6 +421,15 @@ func (s *MonitoringStack) addQueueMetrics(environment string, spec queueSpec) {
 		Metric:             ageOfOldest,
 		Threshold:          jsii.Number(sqsAgeThresholdSecondsFor(environment)),
 		EvaluationPeriods:  jsii.Number(2),
+		ComparisonOperator: awscloudwatch.ComparisonOperator_GREATER_THAN_THRESHOLD,
+		TreatMissingData:   awscloudwatch.TreatMissingData_NOT_BREACHING,
+	}).AddAlarmAction(awscloudwatchactions.NewSnsAction(s.AlertTopic))
+
+	awscloudwatch.NewAlarm(s.Stack, jsii.String(fmt.Sprintf("%sDepthAlarm", sanitizeConstructID(spec.Logical))), &awscloudwatch.AlarmProps{
+		AlarmName:          jsii.String(fmt.Sprintf("%s-depth", primaryName)),
+		Metric:             visibleMessages,
+		Threshold:          jsii.Number(sqsDepthThresholdFor(environment)),
+		EvaluationPeriods:  jsii.Number(1),
 		ComparisonOperator: awscloudwatch.ComparisonOperator_GREATER_THAN_THRESHOLD,
 		TreatMissingData:   awscloudwatch.TreatMissingData_NOT_BREACHING,
 	}).AddAlarmAction(awscloudwatchactions.NewSnsAction(s.AlertTopic))

--- a/infra/cdk/stacks/monitoring_stack_test.go
+++ b/infra/cdk/stacks/monitoring_stack_test.go
@@ -24,6 +24,7 @@ func TestMonitoringStackSynthCreatesInventoryLambdaAlarms(t *testing.T) {
 	for _, spec := range inventory.LambdaInventory.Lambdas {
 		physical := lambdaPhysicalName(appName, environment, spec.Name)
 		requireAlarm(t, alarms, fmt.Sprintf("%s-error-rate", physical))
+		requireAlarm(t, alarms, fmt.Sprintf("%s-errors", physical))
 		requireAlarm(t, alarms, fmt.Sprintf("%s-duration", physical))
 		requireAlarm(t, alarms, fmt.Sprintf("%s-throttles", physical))
 		if isStreamLambda(spec) {
@@ -80,6 +81,7 @@ func TestMonitoringStackSynthCreatesQueueAndTableAlarms(t *testing.T) {
 		primary := queuePhysicalName(appName, environment, q.Logical)
 		dlq := queuePhysicalName(appName, environment, q.DLQLogical)
 		requireAlarm(t, alarms, fmt.Sprintf("%s-age", primary))
+		requireAlarm(t, alarms, fmt.Sprintf("%s-depth", primary))
 		requireAlarm(t, alarms, fmt.Sprintf("%s-depth", dlq))
 	}
 

--- a/pkg/releaseassets/deploy_assembly.go
+++ b/pkg/releaseassets/deploy_assembly.go
@@ -84,6 +84,26 @@ var stageLookupParameterNames = map[string]struct{}{
 
 var cloudFormationLogicalIDPattern = regexp.MustCompile(`^[A-Za-z0-9]+$`)
 
+var stageReleaseParameters = []struct {
+	Name        string
+	Description string
+	WithDefault bool
+	Default     string
+}{
+	{Name: "AppSlug", Description: "app slug / stack prefix for this installation"},
+	{Name: "BaseDomain", Description: "base domain for this installation"},
+	{Name: "HostedZoneId", Description: "route53 hosted zone id for the base domain"},
+	{Name: "ReleaseAssetBucketName", Description: "shared release asset bucket used for deploy assembly uploads"},
+	{Name: "LesserHostUrl", Description: "managed Lesser host base URL", WithDefault: true},
+	{Name: "LesserHostAttestationsUrl", Description: "managed Lesser host attestations URL", WithDefault: true},
+	{Name: "LesserHostInstanceKeyArn", Description: "managed Lesser host instance key secret ARN", WithDefault: true},
+	{Name: "TranslationEnabled", Description: "per-install translation toggle", WithDefault: true},
+	{Name: "TipEnabled", Description: "per-install tips toggle", WithDefault: true},
+	{Name: "TipChainId", Description: "per-install tip chain id", WithDefault: true},
+	{Name: "TipContractAddress", Description: "per-install tip contract address", WithDefault: true},
+	{Name: "ApiCorsAllowedOrigins", Description: "per-install API browser CORS origins", WithDefault: true},
+}
+
 // DeployAssemblyDescriptor describes the published deploy assembly archive and
 // the outer executor contract.
 type DeployAssemblyDescriptor struct {
@@ -415,20 +435,52 @@ func synthesizeStageTemplate(repoRoot string, stage naming.Stage) ([]byte, []dep
 
 	stripCDKBootstrapValidation(template)
 	deleteStageLookupParameters(template)
-	addStringParameter(template, "AppSlug", "app slug / stack prefix for this installation", false, "")
-	addStringParameter(template, "BaseDomain", "base domain for this installation", false, "")
-	addStringParameter(template, "HostedZoneId", "route53 hosted zone id for the base domain", false, "")
-	addStringParameter(template, "ReleaseAssetBucketName", "shared release asset bucket used for deploy assembly uploads", false, "")
-	addStringParameter(template, "LesserHostUrl", "managed Lesser host base URL", true, "")
-	addStringParameter(template, "LesserHostAttestationsUrl", "managed Lesser host attestations URL", true, "")
-	addStringParameter(template, "LesserHostInstanceKeyArn", "managed Lesser host instance key secret ARN", true, "")
-	addStringParameter(template, "TranslationEnabled", "per-install translation toggle", true, "")
-	addStringParameter(template, "TipEnabled", "per-install tips toggle", true, "")
-	addStringParameter(template, "TipChainId", "per-install tip chain id", true, "")
-	addStringParameter(template, "TipContractAddress", "per-install tip contract address", true, "")
-	addStringParameter(template, "ApiCorsAllowedOrigins", "per-install API browser CORS origins", true, "")
+	addStageReleaseParameters(template)
 
-	replacements := orderedPlaceholderReplacements(map[string]string{
+	replacements := stageTemplateReplacements(stage)
+
+	transformed, err := transformTemplateValues(template, func(path []string) bool {
+		return len(path) == 3 && path[0] == "Parameters" && path[2] == "Default" && generatedParameterName(path[1])
+	}, replacements)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	replaceStageLookupRefs(transformed, stage)
+	injectNestedStackReleaseParameters(transformed)
+	if err := normalizeTemplateDependsOn(transformed); err != nil {
+		return nil, nil, err
+	}
+
+	templateBytes, err := marshalTemplateJSON(transformed)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	assets, err := collectDeployAssets(stackName, assetsManifest, func(sourcePath string, data []byte) ([]byte, error) {
+		if !isNestedTemplateAsset(sourcePath) {
+			return data, nil
+		}
+		transformedData, err := transformNestedStageTemplateAsset(data, stage, replacements)
+		if err != nil {
+			return nil, fmt.Errorf("transform nested deploy template %s: %w", filepath.Base(sourcePath), err)
+		}
+		return transformedData, nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return templateBytes, assets, nil
+}
+
+func addStageReleaseParameters(template map[string]any) {
+	for _, param := range stageReleaseParameters {
+		addStringParameter(template, param.Name, param.Description, param.WithDefault, param.Default)
+	}
+}
+
+func stageTemplateReplacements(stage naming.Stage) []placeholderReplacement {
+	return orderedPlaceholderReplacements(map[string]string{
 		stagePlaceholderDomain(stage):        stageDomainSub(stage),
 		"*." + stagePlaceholderDomain(stage): "*." + stageDomainSub(stage),
 		placeholderBaseDomain:                "${BaseDomain}",
@@ -446,29 +498,55 @@ func synthesizeStageTemplate(repoRoot string, stage naming.Stage) ([]byte, []dep
 		placeholderAPICORSAllowedOrigins:     "${ApiCorsAllowedOrigins}",
 		assetBucketPlaceholder():             "${ReleaseAssetBucketName}",
 	})
+}
+
+func transformNestedStageTemplateAsset(data []byte, stage naming.Stage, replacements []placeholderReplacement) ([]byte, error) {
+	var template map[string]any
+	if err := json.Unmarshal(data, &template); err != nil {
+		return nil, fmt.Errorf("parse nested template: %w", err)
+	}
+
+	stripCDKBootstrapValidation(template)
+	deleteStageLookupParameters(template)
+	addStageReleaseParameters(template)
 
 	transformed, err := transformTemplateValues(template, func(path []string) bool {
 		return len(path) == 3 && path[0] == "Parameters" && path[2] == "Default" && generatedParameterName(path[1])
 	}, replacements)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-
 	replaceStageLookupRefs(transformed, stage)
 	if err := normalizeTemplateDependsOn(transformed); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
+	return marshalTemplateJSON(transformed)
+}
 
-	templateBytes, err := marshalTemplateJSON(transformed)
-	if err != nil {
-		return nil, nil, err
+func injectNestedStackReleaseParameters(template map[string]any) {
+	resources, ok := template["Resources"].(map[string]any)
+	if !ok {
+		return
 	}
-
-	assets, err := collectDeployAssets(stackName, assetsManifest)
-	if err != nil {
-		return nil, nil, err
+	for _, raw := range resources {
+		resource, ok := raw.(map[string]any)
+		if !ok || resource["Type"] != "AWS::CloudFormation::Stack" {
+			continue
+		}
+		props, ok := resource["Properties"].(map[string]any)
+		if !ok {
+			props = map[string]any{}
+			resource["Properties"] = props
+		}
+		params, ok := props["Parameters"].(map[string]any)
+		if !ok {
+			params = map[string]any{}
+			props["Parameters"] = params
+		}
+		for _, param := range stageReleaseParameters {
+			params[param.Name] = map[string]any{"Ref": param.Name}
+		}
 	}
-	return templateBytes, assets, nil
 }
 
 func runCDKSynthJSON(repoRoot string, stackName string, contexts map[string]string) (map[string]any, cdkAssetsManifest, string, error) {
@@ -557,7 +635,7 @@ func absolutizeAssetPaths(synthDir string, manifest cdkAssetsManifest) cdkAssets
 	return manifest
 }
 
-func collectDeployAssets(stackName string, manifest cdkAssetsManifest) ([]deployAsset, error) {
+func collectDeployAssets(stackName string, manifest cdkAssetsManifest, transform func(sourcePath string, data []byte) ([]byte, error)) ([]deployAsset, error) {
 	assets := make([]deployAsset, 0, len(manifest.Files))
 	for _, fileAsset := range manifest.Files {
 		if strings.HasSuffix(fileAsset.Source.Path, stackName+".template.json") {
@@ -572,6 +650,12 @@ func collectDeployAssets(stackName string, manifest cdkAssetsManifest) ([]deploy
 		if err != nil {
 			return nil, err
 		}
+		if transform != nil {
+			data, err = transform(fileAsset.Source.Path, data)
+			if err != nil {
+				return nil, err
+			}
+		}
 
 		assets = append(assets, deployAsset{
 			ObjectKey:   objectKey,
@@ -584,6 +668,10 @@ func collectDeployAssets(stackName string, manifest cdkAssetsManifest) ([]deploy
 		return assets[i].ObjectKey < assets[j].ObjectKey
 	})
 	return assets, nil
+}
+
+func isNestedTemplateAsset(sourcePath string) bool {
+	return strings.HasSuffix(filepath.ToSlash(sourcePath), ".nested.template.json")
 }
 
 func firstObjectKey(destinations map[string]struct {

--- a/pkg/releaseassets/deploy_assembly_test.go
+++ b/pkg/releaseassets/deploy_assembly_test.go
@@ -67,7 +67,7 @@ func TestCollectDeployAssets_FileAndZip(t *testing.T) {
 	}
 	require.NoError(t, os.WriteFile(filepath.Join(root, "demo.template.json"), []byte("{}"), 0o644))
 
-	assets, err := collectDeployAssets("demo", manifest)
+	assets, err := collectDeployAssets("demo", manifest, nil)
 	require.NoError(t, err)
 	require.Len(t, assets, 2)
 	require.Equal(t, "assets/dir.zip", assets[0].ObjectKey)
@@ -95,7 +95,7 @@ func TestCollectDeployAssets_ErrorsWhenObjectKeyMissing(t *testing.T) {
 	}
 	require.NoError(t, os.WriteFile(filepath.Join(root, "asset.txt"), []byte("content"), 0o644))
 
-	_, err := collectDeployAssets("demo", manifest)
+	_, err := collectDeployAssets("demo", manifest, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "missing destination object key")
 }
@@ -240,6 +240,52 @@ func TestTemplateTransformHelpers(t *testing.T) {
 	require.Equal(t, map[string]any{
 		"Fn::Sub": "{{resolve:ssm:/${AppSlug}/shared/iam/lambda-encryption-role-arn}}",
 	}, props["Lookup"])
+}
+
+func TestTransformNestedStageTemplateAssetAddsReleaseParameters(t *testing.T) {
+	nested := map[string]any{
+		"Resources": map[string]any{
+			"Alarm": map[string]any{
+				"Type": "AWS::CloudWatch::Alarm",
+				"Properties": map[string]any{
+					"AlarmName":  placeholderAppSlug + "-dev-metrics-processor-critical-errors",
+					"MetricName": "Errors",
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(nested)
+	require.NoError(t, err)
+
+	out, err := transformNestedStageTemplateAsset(data, naming.StageDev, stageTemplateReplacements(naming.StageDev))
+	require.NoError(t, err)
+
+	var transformed map[string]any
+	require.NoError(t, json.Unmarshal(out, &transformed))
+	parameters := transformed["Parameters"].(map[string]any)
+	require.Contains(t, parameters, "AppSlug")
+
+	props := transformed["Resources"].(map[string]any)["Alarm"].(map[string]any)["Properties"].(map[string]any)
+	require.Equal(t, map[string]any{"Fn::Sub": "${AppSlug}-dev-metrics-processor-critical-errors"}, props["AlarmName"])
+}
+
+func TestInjectNestedStackReleaseParameters(t *testing.T) {
+	template := map[string]any{
+		"Resources": map[string]any{
+			"Nested": map[string]any{
+				"Type":       "AWS::CloudFormation::Stack",
+				"Properties": map[string]any{"TemplateURL": "https://example.invalid/nested.json"},
+			},
+			"Bucket": map[string]any{"Type": "AWS::S3::Bucket"},
+		},
+	}
+
+	injectNestedStackReleaseParameters(template)
+
+	nestedProps := template["Resources"].(map[string]any)["Nested"].(map[string]any)["Properties"].(map[string]any)
+	params := nestedProps["Parameters"].(map[string]any)
+	require.Equal(t, map[string]any{"Ref": "AppSlug"}, params["AppSlug"])
+	require.Equal(t, map[string]any{"Ref": "ReleaseAssetBucketName"}, params["ReleaseAssetBucketName"])
 }
 
 func TestNormalizeTemplateDependsOn(t *testing.T) {

--- a/pkg/releaseassets/deploy_assembly_test.go
+++ b/pkg/releaseassets/deploy_assembly_test.go
@@ -269,6 +269,27 @@ func TestTransformNestedStageTemplateAssetAddsReleaseParameters(t *testing.T) {
 	require.Equal(t, map[string]any{"Fn::Sub": "${AppSlug}-dev-metrics-processor-critical-errors"}, props["AlarmName"])
 }
 
+func TestTransformNestedStageTemplateAssetErrors(t *testing.T) {
+	_, err := transformNestedStageTemplateAsset([]byte("{"), naming.StageDev, stageTemplateReplacements(naming.StageDev))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parse nested template")
+
+	nested := map[string]any{
+		"Resources": map[string]any{
+			"BadDependsOn": map[string]any{
+				"Type":      "Custom::Example",
+				"DependsOn": map[string]any{"Fn::GetAtt": []any{"Other", "Arn"}},
+			},
+		},
+	}
+	data, err := json.Marshal(nested)
+	require.NoError(t, err)
+
+	_, err = transformNestedStageTemplateAsset(data, naming.StageDev, stageTemplateReplacements(naming.StageDev))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported intrinsic")
+}
+
 func TestInjectNestedStackReleaseParameters(t *testing.T) {
 	template := map[string]any{
 		"Resources": map[string]any{
@@ -286,6 +307,28 @@ func TestInjectNestedStackReleaseParameters(t *testing.T) {
 	params := nestedProps["Parameters"].(map[string]any)
 	require.Equal(t, map[string]any{"Ref": "AppSlug"}, params["AppSlug"])
 	require.Equal(t, map[string]any{"Ref": "ReleaseAssetBucketName"}, params["ReleaseAssetBucketName"])
+}
+
+func TestInjectNestedStackReleaseParametersHandlesMissingSections(t *testing.T) {
+	noResources := map[string]any{"Description": "empty"}
+	injectNestedStackReleaseParameters(noResources)
+	require.Equal(t, map[string]any{"Description": "empty"}, noResources)
+
+	template := map[string]any{
+		"Resources": map[string]any{
+			"Nested": map[string]any{
+				"Type": "AWS::CloudFormation::Stack",
+			},
+			"Malformed": "not-a-resource-map",
+		},
+	}
+
+	injectNestedStackReleaseParameters(template)
+
+	nested := template["Resources"].(map[string]any)["Nested"].(map[string]any)
+	props := nested["Properties"].(map[string]any)
+	params := props["Parameters"].(map[string]any)
+	require.Equal(t, map[string]any{"Ref": "BaseDomain"}, params["BaseDomain"])
 }
 
 func TestNormalizeTemplateDependsOn(t *testing.T) {


### PR DESCRIPTION
## Milestone
Project 34 M2 — deploy retry boundaries and minimum alarms.

Refs #991. Closes #1001. Closes #1002.

## Classification
Operational reliability / CDK infrastructure / framework-feedback.

## Surfaces affected
- DynamoDB stream event source mappings for inventory stream processors.
- Stage-stack SQS poison-record queues for stream processor discarded records.
- Stage-stack CloudWatch critical alarms through a nested stack in the normal `LesserApiStack` path.
- Monitoring stack parity for absolute Lambda errors and primary queue depth.
- Release deploy assembly nested-template transformation so managed consumers receive parameterized nested alarm templates.
- Generated Lambda inventory matrix.

## Specialist walks referenced
- Federation trust: not directly touched. No HTTP Signature signing/verification, actor key material, inbox/outbox semantics, or federation delivery signing paths changed.
- Contract / API: not touched. No `/api/v1/*`, GraphQL, OpenAPI, or ActivityPub actor-shape changes.
- Schema: not touched. No TableTheory model tags, PK/SK, GSI, or data-shape changes.
- Framework: AppTheory v1.6.0 gap surfaced. `AppTheoryDynamoDBStreamMappingProps` exposes retry/max-age/bisect/partial-failure but not `OnFailure`/destination config, so this PR uses AWS CDK `DynamoEventSource` only for DynamoDB stream mappings that require poison-record destinations, while continuing to use AppTheory queues and inventory-driven wiring.

## What changed
- Added `PoisonRecordQueue` to stream inventory and declared finite `MaxRetryAttempts`, finite `MaxRecordAgeSeconds`, and per-processor poison queues for every DynamoDB stream processor, including `metrics-processor`.
- Materialized stream poison queues and wired them as Lambda stream `OnFailure` destinations.
- Preserved existing bisect/partial-failure settings rather than broadening them to handlers that did not already opt in.
- Added critical alarms for Lambda error rate/absolute errors, stream iterator age, SQS queue age/depth, DLQ depth, stream poison queue depth, and scheduled processor failures.
- Put the alarm floor in a nested stack under the normal stage stack path to keep the parent stage template under CloudFormation's 500-resource limit (`lesser-dev` synth reports 467 parent resources).
- Updated release deploy assembly handling to transform and parameterize nested stack templates.
- Regenerated `docs/specs/01-lambda-inventory-matrix.md` and taught the generator to print stream poison queues.

## Consumer impact
Operators get bounded retry/record-age behavior and explicit poison destinations before any processor re-enable/backfill. Managed release consumers keep the same deploy assembly schema; nested alarm templates are packaged as transformed assets and receive the same release parameters as the parent stage template.

## Tasks
- [x] #1001 Add finite stream retry policy and poison-record destinations
- [x] #1002 Deploy critical alarms through the normal stage path

## Validation
- `gofmt -l .` (empty)
- `go test ./...`
- `go vet ./...`
- `go test ./pkg/releaseassets -count=1`
- `(cd infra/cdk && go test ./... -count=1)`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `(cd infra/cdk && CDK_DEFAULT_ACCOUNT=123456789012 CDK_DEFAULT_REGION=us-east-1 AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1 cdk synth lesser-dev --context app=lesser --context baseDomain=example.com --context hostedZoneId=Z1 --context stage=dev >/tmp/lesser-m2-cdk-synth.out)`
- `./lesser verify ci`

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
No sibling repo edits. Framework-feedback signal for AppTheory: add `OnFailure`/poison destination support to `AppTheoryDynamoDBStreamMappingProps` so lesser can return to the AppTheory stream-mapping construct without bypassing it for this operational guardrail.

## Phase gate
No processor re-enable, no backfill/reconciliation, no live mapping mutation, and no deploy performed by this PR.