### PR TITLE
fix processor bootstrap and lazy secrets

### DIFF
--- a/cmd/activity-processor/main.go
+++ b/cmd/activity-processor/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/federation"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	storageCore "github.com/equaltoai/lesser/pkg/storage/core"
 	"github.com/equaltoai/lesser/pkg/storage/factory"
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
@@ -80,16 +81,26 @@ func NewActivityProcessor(lambdaCtx *common.LambdaContext) *ActivityProcessor {
 	logger := lambdaCtx.Logger
 	cfg := lambdaCtx.Config
 
-	// Initialize storage independently to avoid import cycles
-	db, err := theorydb.GetClient(context.Background())
-	if err != nil {
-		logger.Fatal("failed to initialize DynamORM database", zap.Error(err))
-	}
+	var (
+		db    core.DB
+		repos storageCore.RepositoryStorage
+	)
+	if storage, ok := lambdaCtx.Repos.(storageCore.RepositoryStorage); ok && storage != nil {
+		repos = storage
+		db = storage.GetDB()
+	} else {
+		var err error
+		// Legacy unit-test fallback: production startup populates LambdaContext via
+		// pkg/lambdastorage before constructing the processor.
+		db, err = theorydb.GetClient(context.Background())
+		if err != nil {
+			logger.Fatal("failed to initialize DynamORM database", zap.Error(err))
+		}
 
-	// Initialize repository factory
-	repos, err := factory.NewRepositoryFactory(db, cfg.DynamoTableName, logger)
-	if err != nil {
-		logger.Fatal("Failed to create repository factory", zap.Error(err))
+		repos, err = factory.NewRepositoryFactory(db, cfg.DynamoTableName, logger)
+		if err != nil {
+			logger.Fatal("Failed to create repository factory", zap.Error(err))
+		}
 	}
 
 	// Extract domain from baseURL
@@ -1428,15 +1439,18 @@ func init() {
 	// Automatic dependency injection
 	cfg = lambdaCtx.Config
 	logger = lambdaCtx.Logger
-	if lambdaCtx.Repos != nil {
-		repos = lambdaCtx.Repos.(storageCore.RepositoryStorage)
-	}
-
-	// Initialize with processor-specific defaults
-	err := lambdaCtx.InitializeWithDefaults()
+	deps, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName:         "activity-processor",
+		RequireRepositories: true,
+		AllowEmptyRegion:    true,
+		NewDB: func(ctx context.Context, _ string) (core.DB, error) {
+			return theorydb.GetClient(ctx)
+		},
+	})
 	if err != nil {
-		logger.Warn("failed to initialize with defaults", zap.Error(err))
+		logger.Fatal("failed to initialize storage", zap.Error(err))
 	}
+	repos = deps.Repos
 
 	// Initialize processor
 	processor = NewActivityProcessor(lambdaCtx)

--- a/cmd/actor/legacy_init_defaults_test.go
+++ b/cmd/actor/legacy_init_defaults_test.go
@@ -1,0 +1,5 @@
+package main
+
+import "github.com/equaltoai/lesser/pkg/common"
+
+var initializeWithDefaultsFn = func(*common.LambdaContext) error { return nil }

--- a/cmd/actor/main.go
+++ b/cmd/actor/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/crawler"
 	"github.com/equaltoai/lesser/pkg/federation"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	securityheaders "github.com/equaltoai/lesser/pkg/security/headers"
 	"github.com/equaltoai/lesser/pkg/security/htmlsafe"
 	"github.com/equaltoai/lesser/pkg/storage"
@@ -51,7 +52,6 @@ var (
 
 var (
 	mustInitializeLambdaFn     = common.MustInitializeLambda
-	initializeWithDefaultsFn   = func(ctx *common.LambdaContext) error { return ctx.InitializeWithDefaults() }
 	lambdaStartFn              = lambda.Start
 	newHandlerFn               = NewHandler
 	newLambdaOptimizedClientFn = theorydb.NewLambdaOptimizedClient
@@ -129,45 +129,16 @@ func initializeActor() {
 		logger = zap.NewNop()
 	}
 
-	// Initialize with default options for API Lambda type (best-effort; some lambdas still do manual wiring).
-	if err := initializeWithDefaultsFn(lambdaCtx); err != nil {
-		logger.Warn("failed to initialize with defaults", zap.Error(err))
-	}
-
-	storage, ok := lambdaCtx.Repos.(core.RepositoryStorage)
-	if !ok || storage == nil {
-		logger.Warn("lambda context repository missing after initialization, attempting manual storage initialization")
-		initializeManualStorage()
-		storage, ok = lambdaCtx.Repos.(core.RepositoryStorage)
-	}
-	if !ok || storage == nil {
-		logger.Fatal("lambda context repository is not core.RepositoryStorage")
-	}
-	repos = storage
-}
-
-func initializeManualStorage() {
-	if lambdaCtx == nil {
-		logger.Fatal("manual storage initialization requires lambda context")
-	}
-
-	tableName := strings.TrimSpace(cfg.DynamoTableName)
-	if tableName == "" {
-		logger.Fatal("DYNAMODB_TABLE environment variable is required for actor lambda")
-	}
-
-	db, err := newLambdaOptimizedClientFn(context.Background(), cfg.Region)
+	deps, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName:          "actor",
+		RequireRepositories:  true,
+		NewDB:                newLambdaOptimizedClientFn,
+		NewRepositoryStorage: newRepositoryFactoryFn,
+	})
 	if err != nil {
-		logger.Fatal("failed to initialize DynamORM", zap.Error(err))
+		logger.Fatal("failed to initialize storage", zap.Error(err))
 	}
-
-	storage, err := newRepositoryFactoryFn(db, tableName, logger)
-	if err != nil {
-		logger.Fatal("failed to initialize repository factory", zap.Error(err))
-	}
-
-	lambdaCtx.DynamoDB = db
-	lambdaCtx.Repos = storage
+	repos = deps.Repos
 }
 
 // HandleActorProfile handles ActivityPub actor profile requests

--- a/cmd/ai-processor/main.go
+++ b/cmd/ai-processor/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/deploy/naming"
 	pkgErrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	aiService "github.com/equaltoai/lesser/pkg/services/ai"
 	storageCore "github.com/equaltoai/lesser/pkg/storage/core"
 	"github.com/equaltoai/lesser/pkg/storage/factory"
@@ -349,53 +350,16 @@ func initializeAIProcessor() error {
 }
 
 func initializeAIStorage(lambdaCtx *common.LambdaContext) (storageCore.RepositoryStorage, error) {
-	if lambdaCtx == nil {
-		return nil, fmt.Errorf("AI processor lambda context is nil")
-	}
-	if lambdaCtx.Config == nil {
-		return nil, fmt.Errorf("AI processor config is nil")
-	}
-
-	if lambdaCtx.Repos != nil {
-		repos, ok := lambdaCtx.Repos.(storageCore.RepositoryStorage)
-		if !ok || repos == nil {
-			return nil, fmt.Errorf("AI processor invalid repository storage")
-		}
-		return repos, nil
-	}
-
-	tableName := strings.TrimSpace(lambdaCtx.Config.DynamoTableName)
-	if tableName == "" {
-		return nil, fmt.Errorf("AI processor dynamodb table name is required")
-	}
-
-	region := strings.TrimSpace(lambdaCtx.Config.Region)
-	if region == "" {
-		return nil, fmt.Errorf("AI processor AWS region is required")
-	}
-
-	var db core.DB
-	if lambdaCtx.DynamoDB != nil {
-		var ok bool
-		db, ok = lambdaCtx.DynamoDB.(core.DB)
-		if !ok || db == nil {
-			return nil, fmt.Errorf("AI processor invalid dynamodb client")
-		}
-	} else {
-		var err error
-		db, err = newLambdaOptimizedClientFn(context.Background(), region)
-		if err != nil {
-			return nil, fmt.Errorf("AI processor storage client initialization failed: %w", err)
-		}
-		lambdaCtx.DynamoDB = db
-	}
-
-	repos, err := newRepositoryFactoryFn(db, tableName, logger)
+	deps, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName:          "AI processor",
+		RequireRepositories:  true,
+		NewDB:                newLambdaOptimizedClientFn,
+		NewRepositoryStorage: newRepositoryFactoryFn,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("AI processor repository initialization failed: %w", err)
+		return nil, err
 	}
-	lambdaCtx.Repos = repos
-	return repos, nil
+	return deps.Repos, nil
 }
 
 // NewSimplifiedAIProcessor creates a new AI processor instance with simplified Lambda context

--- a/cmd/api/handlers/agent_access_leases.go
+++ b/cmd/api/handlers/agent_access_leases.go
@@ -621,20 +621,7 @@ func (h *Handler) HandleExchangeAgentAccessLeaseTokenLift(ctx *apptheory.Context
 	}
 	accessTTL := remaining
 
-	if h.cfg == nil || (strings.TrimSpace(h.cfg.JWTSecret) == "" && strings.TrimSpace(h.cfg.JWTSecretARN) == "") {
-		return common.RespondInternalServerError(ctx)
-	}
-	oauthSvc := createOAuthService("", h.cfg, h.repos, h.logger)
-	accessToken, _, err := oauthSvc.GenerateTokensWithAccessTokenTTLAndClientContext(
-		ctx.Context(),
-		lease.Username,
-		agentAccessLeaseClientID,
-		"",
-		lease.Scopes,
-		accessTTL,
-		"",
-		"",
-	)
+	accessToken, err := h.mintAgentAccessLeaseToken(ctx, lease, accessTTL)
 	if err != nil {
 		return common.RespondInternalServerError(ctx)
 	}
@@ -665,6 +652,30 @@ func (h *Handler) HandleExchangeAgentAccessLeaseTokenLift(ctx *apptheory.Context
 			CreatedAt:   now.Unix(),
 		},
 	})
+}
+
+func (h *Handler) mintAgentAccessLeaseToken(ctx *apptheory.Context, lease *storageModels.AgentAccessLease, accessTTL time.Duration) (string, error) {
+	if h.cfg == nil || lease == nil || (strings.TrimSpace(h.cfg.JWTSecret) == "" && strings.TrimSpace(h.cfg.JWTSecretARN) == "") {
+		return "", errors.New("agent access lease token configuration unavailable")
+	}
+	oauthSvc, err := createOAuthService("", h.cfg, h.repos, h.logger)
+	if err != nil {
+		return "", err
+	}
+	accessToken, _, err := oauthSvc.GenerateTokensWithAccessTokenTTLAndClientContext(
+		ctx.Context(),
+		lease.Username,
+		agentAccessLeaseClientID,
+		"",
+		lease.Scopes,
+		accessTTL,
+		"",
+		"",
+	)
+	if err != nil {
+		return "", err
+	}
+	return accessToken, nil
 }
 
 func (h *Handler) handleCreateAgentAccessLeaseChallenge(ctx *apptheory.Context, action string) (*apptheory.Response, error) {

--- a/cmd/api/handlers/agent_access_leases.go
+++ b/cmd/api/handlers/agent_access_leases.go
@@ -621,10 +621,10 @@ func (h *Handler) HandleExchangeAgentAccessLeaseTokenLift(ctx *apptheory.Context
 	}
 	accessTTL := remaining
 
-	if h.cfg == nil || h.cfg.JWTSecret == "" {
+	if h.cfg == nil || (strings.TrimSpace(h.cfg.JWTSecret) == "" && strings.TrimSpace(h.cfg.JWTSecretARN) == "") {
 		return common.RespondInternalServerError(ctx)
 	}
-	oauthSvc := createOAuthService(h.cfg.JWTSecret, h.cfg, h.repos, h.logger)
+	oauthSvc := createOAuthService("", h.cfg, h.repos, h.logger)
 	accessToken, _, err := oauthSvc.GenerateTokensWithAccessTokenTTLAndClientContext(
 		ctx.Context(),
 		lease.Username,

--- a/cmd/api/handlers/apps.go
+++ b/cmd/api/handlers/apps.go
@@ -57,7 +57,11 @@ func (h *Handler) HandleAppVerifyCredentialsLift(ctx *apptheory.Context) (*appth
 	// Parse the token to get app credentials
 	// The token should be in the format "client_id:client_secret" base64 encoded
 	// or a valid OAuth access token
-	oauthSvc := createOAuthService(h.cfg.JWTSecret, h.cfg, h.repos, h.logger)
+	oauthSvc, err := createOAuthService(h.cfg.JWTSecret, h.cfg, h.repos, h.logger)
+	if err != nil {
+		h.logger.Error("failed to initialize OAuth service", zap.Error(err))
+		return common.RespondInternalServerError(ctx)
+	}
 
 	// First try to validate as an access token
 	claims := auth.ClaimsFromAppTheoryContext(ctx)

--- a/cmd/api/handlers/handler.go
+++ b/cmd/api/handlers/handler.go
@@ -203,7 +203,10 @@ func (h *Handler) authenticatedClaimsLift(ctx *apptheory.Context) (*auth.Claims,
 		return nil, apperrors.Unauthorized("authentication required")
 	}
 
-	oauthSvc := createOAuthService(h.cfg.JWTSecret, h.cfg, h.repos, h.logger)
+	oauthSvc, err := createOAuthService(h.cfg.JWTSecret, h.cfg, h.repos, h.logger)
+	if err != nil {
+		return nil, apperrors.InternalWithCause(err, "OAuth service unavailable")
+	}
 	claims, err := oauthSvc.ValidateAccessToken(token)
 	if err != nil {
 		return nil, err

--- a/cmd/api/handlers/helpers.go
+++ b/cmd/api/handlers/helpers.go
@@ -1126,23 +1126,31 @@ func (h *Handler) agentIdentitySemantics(ctx context.Context, agentUser *storage
 	return workflow.DeriveDroneIdentitySemantics(agentUser.Username, workflowState, soulBound, soulAgentID)
 }
 
-// createOAuthService creates an OAuth service with proper audit logger setup
-func createOAuthService(jwtSecret string, cfg *config.Config, repos core.RepositoryStorage, logger *zap.Logger) *auth.OAuthService {
+var resolveOAuthJWTSecretFn = func(cfg *config.Config) (string, error) {
+	return cfg.ResolveJWTSecret()
+}
+
+// createOAuthService creates an OAuth service with proper audit logger setup.
+// Auth paths fail closed when lazy JWT secret resolution fails or resolves empty.
+func createOAuthService(jwtSecret string, cfg *config.Config, repos core.RepositoryStorage, logger *zap.Logger) (*auth.OAuthService, error) {
 	secret := strings.TrimSpace(jwtSecret)
 	if secret == "" && cfg != nil {
-		resolved, err := cfg.ResolveJWTSecret()
+		resolved, err := resolveOAuthJWTSecretFn(cfg)
 		if err != nil {
 			if logger != nil {
 				logger.Error("failed to resolve JWT secret", zap.Error(err))
 			}
-		} else {
-			secret = resolved
+			return nil, fmt.Errorf("resolve JWT secret: %w", err)
 		}
+		secret = strings.TrimSpace(resolved)
+	}
+	if secret == "" {
+		return nil, errors.New("JWT secret is required")
 	}
 
 	// Create audit logger with default configuration
 	auditLogger := auth.NewAuditLogger(repos, logger, auth.DefaultAuditConfig())
-	return auth.NewOAuthService(secret, cfg, repos, auditLogger)
+	return auth.NewOAuthService(secret, cfg, repos, auditLogger), nil
 }
 
 // parsePaginationParams extracts common pagination parameters from a Lift context

--- a/cmd/api/handlers/helpers.go
+++ b/cmd/api/handlers/helpers.go
@@ -1128,9 +1128,21 @@ func (h *Handler) agentIdentitySemantics(ctx context.Context, agentUser *storage
 
 // createOAuthService creates an OAuth service with proper audit logger setup
 func createOAuthService(jwtSecret string, cfg *config.Config, repos core.RepositoryStorage, logger *zap.Logger) *auth.OAuthService {
+	secret := strings.TrimSpace(jwtSecret)
+	if secret == "" && cfg != nil {
+		resolved, err := cfg.ResolveJWTSecret()
+		if err != nil {
+			if logger != nil {
+				logger.Error("failed to resolve JWT secret", zap.Error(err))
+			}
+		} else {
+			secret = resolved
+		}
+	}
+
 	// Create audit logger with default configuration
 	auditLogger := auth.NewAuditLogger(repos, logger, auth.DefaultAuditConfig())
-	return auth.NewOAuthService(jwtSecret, cfg, repos, auditLogger)
+	return auth.NewOAuthService(secret, cfg, repos, auditLogger)
 }
 
 // parsePaginationParams extracts common pagination parameters from a Lift context

--- a/cmd/api/handlers/helpers_optional_auth_round12_test.go
+++ b/cmd/api/handlers/helpers_optional_auth_round12_test.go
@@ -42,7 +42,7 @@ func TestHandler_authenticateUserOptional(t *testing.T) {
 	})
 
 	t.Run("valid token returns username", func(t *testing.T) {
-		oauthSvc := createOAuthService(cfg.JWTSecret, cfg, nil, h.logger)
+		oauthSvc := mustCreateOAuthService(t, cfg.JWTSecret, cfg, nil, h.logger)
 		accessToken, _, err := oauthSvc.GenerateTokens(context.Background(), "alice", "client", "1.2.3.4", []string{auth.ScopeRead})
 		require.NoError(t, err)
 
@@ -57,7 +57,7 @@ func TestHandler_authenticateUserOptional(t *testing.T) {
 	})
 
 	t.Run("valid token without required scope returns insufficient scope", func(t *testing.T) {
-		oauthSvc := createOAuthService(cfg.JWTSecret, cfg, nil, h.logger)
+		oauthSvc := mustCreateOAuthService(t, cfg.JWTSecret, cfg, nil, h.logger)
 		accessToken, _, err := oauthSvc.GenerateTokens(context.Background(), "alice", "client", "1.2.3.4", []string{auth.ScopeRead})
 		require.NoError(t, err)
 
@@ -72,7 +72,7 @@ func TestHandler_authenticateUserOptional(t *testing.T) {
 	})
 
 	t.Run("valid token with required scope returns username", func(t *testing.T) {
-		oauthSvc := createOAuthService(cfg.JWTSecret, cfg, nil, h.logger)
+		oauthSvc := mustCreateOAuthService(t, cfg.JWTSecret, cfg, nil, h.logger)
 		accessToken, _, err := oauthSvc.GenerateTokens(context.Background(), "alice", "client", "1.2.3.4", []string{auth.ScopeRead, auth.ScopeWrite})
 		require.NoError(t, err)
 
@@ -147,7 +147,7 @@ func TestHandler_authenticateWithClaims(t *testing.T) {
 	})
 
 	t.Run("valid token returns claims", func(t *testing.T) {
-		oauthSvc := createOAuthService(cfg.JWTSecret, cfg, nil, h.logger)
+		oauthSvc := mustCreateOAuthService(t, cfg.JWTSecret, cfg, nil, h.logger)
 		accessToken, _, err := oauthSvc.GenerateTokens(context.Background(), "alice", "client", "1.2.3.4", []string{auth.ScopeRead, auth.ScopeWrite})
 		require.NoError(t, err)
 
@@ -163,7 +163,7 @@ func TestHandler_authenticateWithClaims(t *testing.T) {
 	})
 
 	t.Run("valid token without required scope returns insufficient scope", func(t *testing.T) {
-		oauthSvc := createOAuthService(cfg.JWTSecret, cfg, nil, h.logger)
+		oauthSvc := mustCreateOAuthService(t, cfg.JWTSecret, cfg, nil, h.logger)
 		accessToken, _, err := oauthSvc.GenerateTokens(context.Background(), "alice", "client", "1.2.3.4", []string{auth.ScopeRead})
 		require.NoError(t, err)
 

--- a/cmd/api/handlers/oauth.go
+++ b/cmd/api/handlers/oauth.go
@@ -111,9 +111,16 @@ func (h *Handler) initializeAuthorizeFlow(ctx *apptheory.Context) (*authorizeFlo
 		return nil, resp, err
 	}
 
+	oauthSvc, err := createOAuthService(h.cfg.JWTSecret, h.cfg, h.repos, h.logger)
+	if err != nil {
+		h.logger.Error("failed to initialize OAuth service", zap.Error(err))
+		resp, respErr := h.oauthErrorLift(ctx, "server_error", "OAuth service unavailable", req.redirectURI, req.state)
+		return nil, resp, respErr
+	}
+
 	flow := &authorizeFlow{
 		request:  req,
-		oauthSvc: createOAuthService(h.cfg.JWTSecret, h.cfg, h.repos, h.logger),
+		oauthSvc: oauthSvc,
 	}
 
 	if err := flow.oauthSvc.ValidateRedirectURI(ctx.Context(), req.clientID, req.redirectURI); err != nil {
@@ -683,7 +690,14 @@ func (h *Handler) HandleOAuthTokenLift(ctx *apptheory.Context) (*apptheory.Respo
 	}
 
 	// Initialize OAuth service
-	oauthSvc := createOAuthService(h.cfg.JWTSecret, h.cfg, h.repos, h.logger)
+	oauthSvc, err := createOAuthService(h.cfg.JWTSecret, h.cfg, h.repos, h.logger)
+	if err != nil {
+		h.logger.Error("failed to initialize OAuth service", zap.Error(err))
+		return apptheory.JSON(http.StatusInternalServerError, apimodels.OAuthErrorResponse{
+			Error:            "server_error",
+			ErrorDescription: "OAuth service unavailable",
+		})
+	}
 
 	switch req.grantType {
 	case oauthGrantTypeAuthorizationCode:

--- a/cmd/api/handlers/oauth_consent.go
+++ b/cmd/api/handlers/oauth_consent.go
@@ -189,7 +189,14 @@ func (h *Handler) handleConsentApproval(ctx *apptheory.Context, authState *stora
 	}
 
 	// Generate authorization code
-	oauthSvc := createOAuthService(h.cfg.JWTSecret, h.cfg, h.repos, h.logger)
+	oauthSvc, err := createOAuthService(h.cfg.JWTSecret, h.cfg, h.repos, h.logger)
+	if err != nil {
+		h.logger.Error("failed to initialize OAuth service", zap.Error(err))
+		return apptheory.JSON(http.StatusInternalServerError, map[string]string{
+			"error":             "server_error",
+			"error_description": "Failed to initialize OAuth service",
+		})
+	}
 	code, err := oauthSvc.GenerateAuthorizationCode()
 	if err != nil {
 		h.logger.Error("failed to generate authorization code", zap.Error(err))

--- a/cmd/api/handlers/oauth_device_verification_round12_test.go
+++ b/cmd/api/handlers/oauth_device_verification_round12_test.go
@@ -121,7 +121,7 @@ func TestOAuthDeviceConsentLiftRound12(t *testing.T) {
 
 	h, _, _ := round11NewHandler(t, cfgDevice, state)
 
-	oauthSvc := createOAuthService(cfgDevice.JWTSecret, cfgDevice, h.repos, h.logger)
+	oauthSvc := mustCreateOAuthService(t, cfgDevice.JWTSecret, cfgDevice, h.repos, h.logger)
 	accessToken, _, err := oauthSvc.GenerateTokens(context.Background(), "alice", "client-1", "", []string{auth.ScopeRead, auth.ScopeWrite})
 	require.NoError(t, err)
 

--- a/cmd/api/handlers/oauth_device_verification_round13_more_branches_test.go
+++ b/cmd/api/handlers/oauth_device_verification_round13_more_branches_test.go
@@ -107,7 +107,7 @@ func TestOAuthDeviceConsentLiftRound13_InvalidAction(t *testing.T) {
 
 	h, _, _ := round11NewHandler(t, cfg, state)
 
-	oauthSvc := createOAuthService(cfg.JWTSecret, cfg, h.repos, h.logger)
+	oauthSvc := mustCreateOAuthService(t, cfg.JWTSecret, cfg, h.repos, h.logger)
 	accessToken, _, err := oauthSvc.GenerateTokens(context.Background(), "alice", "client-1", "", []string{auth.ScopeRead})
 	require.NoError(t, err)
 
@@ -145,7 +145,7 @@ func TestOAuthDeviceConsentLiftRound13_UpdateErrorReturns500(t *testing.T) {
 
 	h, _, _ := round11NewHandler(t, cfg, state)
 
-	oauthSvc := createOAuthService(cfg.JWTSecret, cfg, h.repos, h.logger)
+	oauthSvc := mustCreateOAuthService(t, cfg.JWTSecret, cfg, h.repos, h.logger)
 	accessToken, _, err := oauthSvc.GenerateTokens(context.Background(), "alice", "client-1", "", []string{auth.ScopeRead})
 	require.NoError(t, err)
 

--- a/cmd/api/handlers/oauth_lazy_secret_failure_test.go
+++ b/cmd/api/handlers/oauth_lazy_secret_failure_test.go
@@ -1,0 +1,81 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/equaltoai/lesser/cmd/api/models"
+	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func withFailingOAuthSecretResolver(t testing.TB) {
+	t.Helper()
+	orig := resolveOAuthJWTSecretFn
+	resolveOAuthJWTSecretFn = func(*config.Config) (string, error) {
+		return "", errors.New("secrets manager unavailable")
+	}
+	t.Cleanup(func() { resolveOAuthJWTSecretFn = orig })
+}
+
+func TestCreateOAuthServiceFailsClosedWhenLazyJWTResolutionFails(t *testing.T) {
+	withFailingOAuthSecretResolver(t)
+
+	cfg := round11TestConfig()
+	cfg.JWTSecret = ""
+	cfg.JWTSecretARN = "arn:aws:secretsmanager:us-east-1:123456789012:secret:jwt"
+	h, _, _ := round11NewHandler(t, cfg)
+
+	oauthSvc, err := createOAuthService("", cfg, h.repos, h.logger)
+	require.ErrorContains(t, err, "resolve JWT secret")
+	require.Nil(t, oauthSvc)
+}
+
+func TestOAuthTokenEndpointFailsClosedWhenLazyJWTResolutionFails(t *testing.T) {
+	withFailingOAuthSecretResolver(t)
+
+	cfg := round11TestConfig()
+	cfg.JWTSecret = ""
+	cfg.JWTSecretARN = "arn:aws:secretsmanager:us-east-1:123456789012:secret:jwt"
+	h, _, _ := round11NewHandler(t, cfg)
+
+	ctx := round10NewLiftContextWithBodyBytes(
+		http.MethodPost,
+		"/oauth/token",
+		map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
+		nil,
+		[]byte("grant_type=refresh_token&refresh_token=rt&client_id=client"),
+	)
+
+	resp := requireStatus(t, http.StatusInternalServerError)(h.HandleOAuthTokenLift(ctx))
+	var body models.OAuthErrorResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Equal(t, "server_error", body.Error)
+}
+
+func TestAuthenticatedClaimsFailsClosedWhenLazyJWTResolutionFails(t *testing.T) {
+	withFailingOAuthSecretResolver(t)
+
+	cfg := round11TestConfig()
+	cfg.JWTSecret = ""
+	cfg.JWTSecretARN = "arn:aws:secretsmanager:us-east-1:123456789012:secret:jwt"
+	h, _, _ := round11NewHandler(t, cfg)
+
+	emptyKeyToken := round11SignAccessToken(t, "", "alice", []string{auth.ScopeRead})
+	ctx := round10NewLiftContextWithBodyBytes(
+		http.MethodGet,
+		"/api/v1/accounts/verify_credentials",
+		map[string]string{"Authorization": "Bearer " + emptyKeyToken},
+		nil,
+		nil,
+	)
+
+	claims, err := h.authenticatedClaimsLift(ctx)
+	require.Nil(t, claims)
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "OAuth service unavailable") || strings.Contains(err.Error(), "secrets manager unavailable"))
+}

--- a/cmd/api/handlers/oauth_revoke.go
+++ b/cmd/api/handlers/oauth_revoke.go
@@ -109,7 +109,11 @@ func (h *Handler) parseOAuthRevokeRequest(ctx *apptheory.Context) (*oauthRevokeR
 }
 
 func (h *Handler) revokeAccessTokenBestEffort(ctx context.Context, token string) {
-	oauthSvc := createOAuthService(h.cfg.JWTSecret, h.cfg, h.repos, h.logger)
+	oauthSvc, err := createOAuthService(h.cfg.JWTSecret, h.cfg, h.repos, h.logger)
+	if err != nil {
+		h.logger.Warn("failed to initialize OAuth service for access token revocation", zap.Error(err))
+		return
+	}
 	claims, err := oauthSvc.ValidateAccessToken(token)
 	if err != nil || claims == nil {
 		return
@@ -176,7 +180,12 @@ func (h *Handler) validateOAuthRevokeRefreshClient(ctx context.Context, stored *
 		return nil, nil
 	}
 
-	oauthSvc := createOAuthService(h.cfg.JWTSecret, h.cfg, h.repos, h.logger)
+	oauthSvc, err := createOAuthService(h.cfg.JWTSecret, h.cfg, h.repos, h.logger)
+	if err != nil {
+		h.logger.Error("failed to initialize OAuth service for refresh token revocation", zap.Error(err))
+		resp, _ := oauthRevokeError(http.StatusInternalServerError, "server_error", "OAuth service unavailable")
+		return nil, resp
+	}
 	if err := validateRefreshGrantClientSecret(ctx, oauthSvc, client, stored.ClientID, clientSecret); err != nil {
 		resp, _ := oauthRevokeError(http.StatusBadRequest, "invalid_client", "invalid client credentials")
 		return nil, resp

--- a/cmd/api/handlers/oauth_revoke_round22_test.go
+++ b/cmd/api/handlers/oauth_revoke_round22_test.go
@@ -74,7 +74,7 @@ func TestOAuthRevokeLift_Round22(t *testing.T) {
 		state := &round10QueryState{}
 		h, repos, _ := round11NewHandler(t, cfg, state)
 
-		oauthSvc := createOAuthService(cfg.JWTSecret, cfg, repos, h.logger)
+		oauthSvc := mustCreateOAuthService(t, cfg.JWTSecret, cfg, repos, h.logger)
 		access, _, err := oauthSvc.GenerateTokens(context.Background(), "alice", "client-1", "192.0.2.10", []string{auth.ScopeRead})
 		require.NoError(t, err)
 

--- a/cmd/api/handlers/oauth_service_test_helpers_test.go
+++ b/cmd/api/handlers/oauth_service_test_helpers_test.go
@@ -1,0 +1,18 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/config"
+	"github.com/equaltoai/lesser/pkg/storage/core"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func mustCreateOAuthService(t testing.TB, jwtSecret string, cfg *config.Config, repos core.RepositoryStorage, logger *zap.Logger) *auth.OAuthService {
+	t.Helper()
+	oauthSvc, err := createOAuthService(jwtSecret, cfg, repos, logger)
+	require.NoError(t, err)
+	return oauthSvc
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/cost"
 	"github.com/equaltoai/lesser/pkg/crawler"
 	"github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	"github.com/equaltoai/lesser/pkg/logging"
 	"github.com/equaltoai/lesser/pkg/observability"
 	browsercors "github.com/equaltoai/lesser/pkg/security/cors"
@@ -111,9 +112,12 @@ func init() {
 	// Use standardized Lambda initialization
 	lambdaCtx = common.MustInitializeLambda(lambdaConfig)
 
-	// Initialize with default options for API Lambda type
-	err := lambdaCtx.InitializeWithDefaults()
-	if err != nil {
+	if _, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName:          "api",
+		RequireRepositories:  true,
+		NewDB:                newLambdaOptimizedClient,
+		NewRepositoryStorage: newRepositoryFactory,
+	}); err != nil {
 		// Fallback to manual initialization for services requiring it
 		initializeManualServices()
 	} else {
@@ -272,6 +276,14 @@ func initializeManualServices() {
 
 // initializeAPISpecificServices initializes API-specific services
 func initializeAPISpecificServices() {
+	if authService == nil {
+		var err error
+		authService, err = newAuthService(cfg, repos)
+		if err != nil {
+			logger.Fatal("failed to initialize auth service", zap.Error(err))
+		}
+	}
+
 	// Validate VAPID keys in production environment
 	if err := apiHandlers.ValidateVAPIDKeysForProduction(context.Background(), cfg, repos, logger); err != nil {
 		logger.Fatal("VAPID keys validation failed in production", zap.Error(err))
@@ -352,15 +364,28 @@ func main() {
 }
 
 func newAPIOAuthService(serviceLogger *zap.Logger) *auth.OAuthService {
-	if cfg == nil || cfg.JWTSecret == "" {
+	if cfg == nil {
 		if serviceLogger != nil {
 			serviceLogger.Warn("JWT secret is not configured; API auth principal hook disabled")
 		}
 		return nil
 	}
+	if common.RunningUnitTests() && strings.TrimSpace(cfg.JWTSecret) == "" && strings.TrimSpace(cfg.JWTSecretARN) == "" {
+		if serviceLogger != nil {
+			serviceLogger.Warn("JWT secret is not configured; API auth principal hook disabled")
+		}
+		return nil
+	}
+	jwtSecret, err := cfg.ResolveJWTSecret()
+	if err != nil || jwtSecret == "" {
+		if serviceLogger != nil {
+			serviceLogger.Warn("JWT secret is not configured; API auth principal hook disabled", zap.Error(err))
+		}
+		return nil
+	}
 
 	auditLogger := auth.NewAuditLogger(repos, serviceLogger, auth.DefaultAuditConfig())
-	return auth.NewOAuthService(cfg.JWTSecret, cfg, repos, auditLogger)
+	return auth.NewOAuthService(jwtSecret, cfg, repos, auditLogger)
 }
 
 const (

--- a/cmd/cms-scheduler/legacy_init_defaults_test.go
+++ b/cmd/cms-scheduler/legacy_init_defaults_test.go
@@ -1,0 +1,5 @@
+package main
+
+import "github.com/equaltoai/lesser/pkg/common"
+
+var initializeWithDefaultsFn = func(*common.LambdaContext) error { return nil }

--- a/cmd/cms-scheduler/main.go
+++ b/cmd/cms-scheduler/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/deploy/naming"
 	pkgErrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	"github.com/equaltoai/lesser/pkg/services"
 	"github.com/equaltoai/lesser/pkg/services/cms"
 	storageCore "github.com/equaltoai/lesser/pkg/storage/core"
@@ -337,7 +338,6 @@ func init() {
 
 var (
 	mustInitializeLambdaFn     = common.MustInitializeLambda
-	initializeWithDefaultsFn   = func(ctx *common.LambdaContext) error { return ctx.InitializeWithDefaults() }
 	newLambdaOptimizedClientFn = theorydb.NewLambdaOptimizedClient
 	newRepositoryStorageFn     = func(db dynamormCore.DB, tableName string, logger *zap.Logger) (storageCore.RepositoryStorage, error) {
 		repos, err := factory.NewRepositoryFactory(db, tableName, logger)
@@ -360,19 +360,16 @@ func initializeCMSScheduler() {
 	cfg = lambdaCtx.Config
 	logger = lambdaCtx.Logger
 
-	if err := initializeWithDefaultsFn(lambdaCtx); err != nil {
-		logger.Warn("failed to initialize with defaults", zap.Error(err))
-	}
-
-	db, err := newLambdaOptimizedClientFn(context.Background(), cfg.Region)
+	deps, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName:          "cms-scheduler",
+		RequireRepositories:  true,
+		NewDB:                newLambdaOptimizedClientFn,
+		NewRepositoryStorage: newRepositoryStorageFn,
+	})
 	if err != nil {
-		logger.Fatal("failed to initialize DynamORM", zap.Error(err))
+		logger.Fatal("failed to initialize storage", zap.Error(err))
 	}
-
-	repos, err := newRepositoryStorageFn(db, cfg.DynamoTableName, logger)
-	if err != nil {
-		logger.Fatal("failed to initialize repositories", zap.Error(err))
-	}
+	repos := deps.Repos
 
 	serviceCfg := &services.ServiceConfig{
 		BaseURL:   fmt.Sprintf("https://%s", cfg.Domain),

--- a/cmd/collections/legacy_init_defaults_test.go
+++ b/cmd/collections/legacy_init_defaults_test.go
@@ -1,0 +1,5 @@
+package main
+
+import "github.com/equaltoai/lesser/pkg/common"
+
+var initializeWithDefaultsFn = func(*common.LambdaContext) error { return nil }

--- a/cmd/collections/main.go
+++ b/cmd/collections/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/crawler"
 	"github.com/equaltoai/lesser/pkg/federation"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/core"
 	"github.com/equaltoai/lesser/pkg/storage/factory"
@@ -36,7 +37,6 @@ var (
 
 var (
 	mustInitializeLambdaFn     = common.MustInitializeLambda
-	initializeWithDefaultsFn   = func(ctx *common.LambdaContext) error { return ctx.InitializeWithDefaults() }
 	lambdaStartFn              = lambda.Start
 	newCollectionsHandlerFn    = NewCollectionsHandler
 	newLambdaOptimizedClientFn = theorydb.NewLambdaOptimizedClient
@@ -66,45 +66,16 @@ func initializeCollections() {
 		logger = zap.NewNop()
 	}
 
-	// Initialize with default options for API Lambda type (best-effort; some lambdas still do manual wiring).
-	if err := initializeWithDefaultsFn(lambdaCtx); err != nil {
-		logger.Warn("failed to initialize with defaults", zap.Error(err))
-	}
-
-	storage, ok := lambdaCtx.Repos.(core.RepositoryStorage)
-	if !ok || storage == nil {
-		logger.Warn("lambda context repository missing after initialization, attempting manual storage initialization")
-		initializeManualStorage()
-		storage, ok = lambdaCtx.Repos.(core.RepositoryStorage)
-	}
-	if !ok || storage == nil {
-		logger.Fatal("lambda context repository is not core.RepositoryStorage")
-	}
-	repos = storage
-}
-
-func initializeManualStorage() {
-	if lambdaCtx == nil {
-		logger.Fatal("manual storage initialization requires lambda context")
-	}
-
-	tableName := strings.TrimSpace(cfg.DynamoTableName)
-	if tableName == "" {
-		logger.Fatal("DYNAMODB_TABLE environment variable is required for collections lambda")
-	}
-
-	db, err := newLambdaOptimizedClientFn(context.Background(), cfg.Region)
+	deps, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName:          "collections",
+		RequireRepositories:  true,
+		NewDB:                newLambdaOptimizedClientFn,
+		NewRepositoryStorage: newRepositoryFactoryFn,
+	})
 	if err != nil {
-		logger.Fatal("failed to initialize DynamORM", zap.Error(err))
+		logger.Fatal("failed to initialize storage", zap.Error(err))
 	}
-
-	storage, err := newRepositoryFactoryFn(db, tableName, logger)
-	if err != nil {
-		logger.Fatal("failed to initialize repository factory", zap.Error(err))
-	}
-
-	lambdaCtx.DynamoDB = db
-	lambdaCtx.Repos = storage
+	repos = deps.Repos
 }
 
 // Collection type constants

--- a/cmd/cost-aggregator/legacy_init_defaults_test.go
+++ b/cmd/cost-aggregator/legacy_init_defaults_test.go
@@ -1,0 +1,5 @@
+package main
+
+import "github.com/equaltoai/lesser/pkg/common"
+
+var initializeWithDefaultsFn = func(*common.LambdaContext) error { return nil }

--- a/cmd/cost-aggregator/main.go
+++ b/cmd/cost-aggregator/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/deploy/naming"
 	pkgErrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
 	"github.com/equaltoai/lesser/pkg/storage/theorydb"
@@ -121,7 +122,6 @@ func init() {
 
 var (
 	mustInitializeLambdaFn     = common.MustInitializeLambda
-	initializeWithDefaultsFn   = func(ctx *common.LambdaContext) error { return ctx.InitializeWithDefaults() }
 	newLambdaOptimizedClientFn = theorydb.NewLambdaOptimizedClient
 	newCostTrackingRepoFn      = func(db dynamormCore.DB, tableName string, logger *zap.Logger) costTrackingStore {
 		return repositories.NewTrackingRepository(db, tableName, logger, nil)
@@ -140,21 +140,18 @@ func initializeCostAggregator() {
 	cfg = lambdaCtx.Config
 	logger = lambdaCtx.Logger
 
-	// Initialize with processor-specific defaults
-	if err := initializeWithDefaultsFn(lambdaCtx); err != nil {
-		logger.Warn("failed to initialize with defaults", zap.Error(err))
-	}
-
 	// Function-specific initialization only
 	tableName := cfg.DynamoTableName
 
-	// Initialize storage independently to avoid import cycles
-	db, err := newLambdaOptimizedClientFn(context.Background(), cfg.Region)
+	deps, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName: "cost-aggregator",
+		NewDB:       newLambdaOptimizedClientFn,
+	})
 	if err != nil {
-		logger.Fatal("failed to initialize DynamORM", zap.Error(err))
+		logger.Fatal("failed to initialize storage", zap.Error(err))
 	}
 
-	costTrackingRepository := newCostTrackingRepoFn(db, tableName, logger)
+	costTrackingRepository := newCostTrackingRepoFn(deps.DB, tableName, logger)
 
 	var snsClient snsPublisher
 	var cloudWatchClient cloudWatchPutter
@@ -176,7 +173,7 @@ func initializeCostAggregator() {
 	}
 
 	processor = &CostAggregator{
-		db:                     db,
+		db:                     deps.DB,
 		tableName:              tableName,
 		logger:                 logger,
 		costTrackingRepository: costTrackingRepository,

--- a/cmd/dlq-processor/main.go
+++ b/cmd/dlq-processor/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/deploy/naming"
 	"github.com/equaltoai/lesser/pkg/dlq"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
 	"github.com/equaltoai/lesser/pkg/storage/theorydb"
@@ -228,36 +229,14 @@ func initializeDLQProcessor() error {
 }
 
 func initializeDLQStorage(lambdaCtx *common.LambdaContext) (core.DB, error) {
-	if lambdaCtx == nil {
-		return nil, fmt.Errorf("dlq-processor lambda context is nil")
-	}
-	if lambdaCtx.Config == nil {
-		return nil, fmt.Errorf("dlq-processor config is nil")
-	}
-	if lambdaCtx.DynamoDB != nil {
-		db, ok := lambdaCtx.DynamoDB.(core.DB)
-		if !ok || db == nil {
-			return nil, fmt.Errorf("dlq-processor invalid dynamodb client")
-		}
-		return db, nil
-	}
-
-	tableName := strings.TrimSpace(lambdaCtx.Config.DynamoTableName)
-	if tableName == "" {
-		return nil, fmt.Errorf("dlq-processor dynamodb table name is required")
-	}
-
-	region := strings.TrimSpace(lambdaCtx.Config.Region)
-	if region == "" {
-		return nil, fmt.Errorf("dlq-processor AWS region is required")
-	}
-
-	db, err := newLambdaOptimizedClientFn(context.Background(), region)
+	deps, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName: "dlq-processor",
+		NewDB:       newLambdaOptimizedClientFn,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("dlq-processor storage client initialization failed: %w", err)
+		return nil, err
 	}
-	lambdaCtx.DynamoDB = db
-	return db, nil
+	return deps.DB, nil
 }
 
 func main() {

--- a/cmd/federation-aggregator/main.go
+++ b/cmd/federation-aggregator/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/deploy/naming"
 	pkgErrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	"github.com/equaltoai/lesser/pkg/storage/core"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
@@ -223,12 +224,14 @@ func initializeFederationAggregator() error {
 		}
 	}
 
-	// Initialize DynamORM with Lambda optimizations
-	var err error
-	db, err = newLambdaOptimizedClientFn(context.Background(), cfg.Region)
+	deps, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName: "federation-aggregator",
+		NewDB:       newLambdaOptimizedClientFn,
+	})
 	if err != nil {
 		return err
 	}
+	db = deps.DB
 
 	processor = newProcessorFn(db, cfg.DynamoTableName, lambdaCtx)
 	federationAggregationTableName = cfg.DynamoTableName

--- a/cmd/federation-delivery/legacy_init_defaults_test.go
+++ b/cmd/federation-delivery/legacy_init_defaults_test.go
@@ -1,0 +1,5 @@
+package main
+
+import "github.com/equaltoai/lesser/pkg/common"
+
+var initializeWithDefaultsFn = func(*common.LambdaContext) error { return nil }

--- a/cmd/federation-delivery/main.go
+++ b/cmd/federation-delivery/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/deploy/naming"
 	pkgErrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/federation"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/core"
 	"github.com/equaltoai/lesser/pkg/storage/models"
@@ -132,13 +133,12 @@ var (
 )
 
 var (
-	runningUnitTestsFn       = common.RunningUnitTests
-	mustInitializeLambdaFn   = common.MustInitializeLambda
-	initializeWithDefaultsFn = func(ctx *common.LambdaContext) error { return ctx.InitializeWithDefaults() }
-	loadAWSConfigFn          = awsconfig.LoadDefaultConfig
-	newSQSClientFn           = sqs.NewFromConfig
-	newDeliveryServiceFn     = federation.NewDeliveryService
-	lambdaStartFn            = lambda.Start
+	runningUnitTestsFn     = common.RunningUnitTests
+	mustInitializeLambdaFn = common.MustInitializeLambda
+	loadAWSConfigFn        = awsconfig.LoadDefaultConfig
+	newSQSClientFn         = sqs.NewFromConfig
+	newDeliveryServiceFn   = federation.NewDeliveryService
+	lambdaStartFn          = lambda.Start
 
 	getSigningActorFn = func(ctx context.Context, storage core.RepositoryStorage, signingActorID string) (*activitypub.Actor, error) {
 		return storage.Account().GetActor(ctx, signingActorID)
@@ -189,13 +189,14 @@ func initializeFederationDelivery() error {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
-	repos = lambdaCtx.Repos.(core.RepositoryStorage)
-
-	// Initialize with processor-specific defaults
-	err := initializeWithDefaultsFn(lambdaCtx)
+	deps, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName:         "federation-delivery",
+		RequireRepositories: true,
+	})
 	if err != nil {
-		logger.Warn("failed to initialize with defaults", zap.Error(err))
+		return fmt.Errorf("failed to initialize storage: %w", err)
 	}
+	repos = deps.Repos
 
 	// Function-specific initialization only
 	// Initialize AWS SQS client config

--- a/cmd/federation-timeseries/legacy_init_defaults_test.go
+++ b/cmd/federation-timeseries/legacy_init_defaults_test.go
@@ -1,0 +1,5 @@
+package main
+
+import "github.com/equaltoai/lesser/pkg/common"
+
+var initializeWithDefaultsFn = func(*common.LambdaContext) error { return nil }

--- a/cmd/federation-timeseries/main.go
+++ b/cmd/federation-timeseries/main.go
@@ -16,8 +16,8 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/equaltoai/lesser/pkg/common"
-	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/deploy/naming"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/theorydb"
 	"github.com/equaltoai/lesser/pkg/storage/theorydb/stream"
@@ -274,16 +274,14 @@ func (tp *TimeseriesProcessor) storeMetrics(ctx context.Context, requestID strin
 
 var (
 	lambdaCtx *common.LambdaContext
-	cfg       *config.Config
 	logger    *zap.Logger
 	processor *TimeseriesProcessor
 )
 
 var (
-	mustInitializeLambdaFn   = common.MustInitializeLambda
-	initializeWithDefaultsFn = func(ctx *common.LambdaContext) error { return ctx.InitializeWithDefaults() }
-	dynamormGetClientFn      = theorydb.GetClient
-	lambdaStartFn            = lambda.Start
+	mustInitializeLambdaFn = common.MustInitializeLambda
+	dynamormGetClientFn    = theorydb.GetClient
+	lambdaStartFn          = lambda.Start
 )
 
 func initializeFederationTimeseries() {
@@ -294,25 +292,23 @@ func initializeFederationTimeseries() {
 	})
 
 	// Automatic dependency injection
-	cfg = lambdaCtx.Config
 	logger = lambdaCtx.Logger
 	if logger == nil {
 		logger = zap.NewNop()
 	}
-	// Initialize with processor-specific defaults
-	if err := initializeWithDefaultsFn(lambdaCtx); err != nil {
-		logger.Warn("failed to initialize with defaults", zap.Error(err))
-	}
-
-	// Function-specific initialization only
-	// Initialize storage independently to avoid import cycles
-	db, err := dynamormGetClientFn(context.Background())
+	deps, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName:      "federation-timeseries",
+		AllowEmptyRegion: true,
+		NewDB: func(ctx context.Context, _ string) (dynamormCore.DB, error) {
+			return dynamormGetClientFn(ctx)
+		},
+	})
 	if err != nil {
-		logger.Fatal("failed to initialize DynamORM database", zap.Error(err))
+		logger.Fatal("failed to initialize storage", zap.Error(err))
 	}
 
 	// Initialize processor
-	processor = NewTimeseriesProcessor(db, cfg.DynamoTableName, logger)
+	processor = NewTimeseriesProcessor(deps.DB, deps.TableName, logger)
 }
 
 func init() {

--- a/cmd/federation-tracker/legacy_init_defaults_test.go
+++ b/cmd/federation-tracker/legacy_init_defaults_test.go
@@ -1,0 +1,5 @@
+package main
+
+import "github.com/equaltoai/lesser/pkg/common"
+
+var initializeWithDefaultsFn = func(*common.LambdaContext) error { return nil }

--- a/cmd/federation-tracker/main.go
+++ b/cmd/federation-tracker/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/deploy/naming"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	"github.com/equaltoai/lesser/pkg/storage/core"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
@@ -47,7 +48,6 @@ type FederationTracker struct {
 
 var (
 	mustInitializeLambdaFn      = common.MustInitializeLambda
-	initializeWithDefaultsFn    = func(ctx *common.LambdaContext) error { return ctx.InitializeWithDefaults() }
 	newLambdaOptimizedClientFn  = theorydb.NewLambdaOptimizedClient
 	newFederationActivityRepoFn = func(db dynamormCore.DB, tableName string, logger *zap.Logger) federationActivityStore {
 		return repositories.NewFederationActivityRepository(db, tableName, logger, nil)
@@ -76,18 +76,17 @@ func initializeFederationTracker() {
 		repos = storage
 	}
 
-	// Initialize with processor-specific defaults
-	err := initializeWithDefaultsFn(lambdaCtx)
+	deps, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName: "federation-tracker",
+		NewDB:       newLambdaOptimizedClientFn,
+	})
 	if err != nil {
-		logger.Warn("failed to initialize with defaults", zap.Error(err))
+		logger.Fatal("failed to initialize storage", zap.Error(err))
 	}
 
 	// Function-specific initialization only
 	// Initialize DynamORM with Lambda optimizations
-	db, err = newLambdaOptimizedClientFn(context.Background(), cfg.Region)
-	if err != nil {
-		logger.Fatal("Failed to initialize DynamORM", zap.Error(err))
-	}
+	db = deps.DB
 
 	// Initialize repository
 	federationActivityRepository = newFederationActivityRepoFn(db, cfg.DynamoTableName, logger)

--- a/cmd/graphql-ws/legacy_init_defaults_test.go
+++ b/cmd/graphql-ws/legacy_init_defaults_test.go
@@ -1,0 +1,5 @@
+package main
+
+import "github.com/equaltoai/lesser/pkg/common"
+
+var initializeWithDefaultsFn = func(*common.LambdaContext) error { return nil }

--- a/cmd/graphql-ws/main.go
+++ b/cmd/graphql-ws/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	appconfig "github.com/equaltoai/lesser/pkg/config"
 	gqllimits "github.com/equaltoai/lesser/pkg/graphql/limits"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	"github.com/equaltoai/lesser/pkg/services"
 	"github.com/equaltoai/lesser/pkg/storage/core"
 	"github.com/equaltoai/lesser/pkg/storage/factory"
@@ -1106,6 +1107,10 @@ func (s *wsServer) executeSubscription(ctx context.Context, connectionID, subscr
 	}
 }
 
+// initializeManualServices is retained for legacy unit coverage of manual
+// bootstrap behavior; production startup now uses pkg/lambdastorage.
+//
+//nolint:unused
 func initializeManualServices() {
 	if logger == nil {
 		logger = zap.NewNop()
@@ -1193,14 +1198,29 @@ func initializeOAuth() {
 		logger.Fatal("graphql-ws initialization missing required configuration")
 	}
 
+	jwtSecret := resolveJWTSecretForGraphQLWS()
 	auditLogger := auth.NewAuditLogger(repos, logger, auth.DefaultAuditConfig())
-	oauth = auth.NewOAuthService(cfg.JWTSecret, cfg, repos, auditLogger)
+	oauth = auth.NewOAuthService(jwtSecret, cfg, repos, auditLogger)
+}
+
+func resolveJWTSecretForGraphQLWS() string {
+	if cfg == nil {
+		return ""
+	}
+	jwtSecret, err := cfg.ResolveJWTSecret()
+	if err != nil {
+		logger.Fatal("failed to resolve graphql-ws JWT secret", zap.Error(err))
+	}
+	if jwtSecret == "" {
+		logger.Fatal("JWT secret is not configured for graphql-ws")
+	}
+	return jwtSecret
 }
 
 func initializeResolver() (*graph.Resolver, *executor.Executor) {
 	serviceConfig := &services.ServiceConfig{
 		BaseURL:   cfg.BaseURL(),
-		JWTSecret: cfg.JWTSecret,
+		JWTSecret: resolveJWTSecretForGraphQLWS(),
 		Config:    cfg,
 	}
 
@@ -1347,7 +1367,6 @@ func resolveStreamQueue() streaming.StreamQueueService {
 
 var (
 	mustInitializeLambdaFn     = common.MustInitializeLambda
-	initializeWithDefaultsFn   = func(lambdaCtx *common.LambdaContext) error { return lambdaCtx.InitializeWithDefaults() }
 	newLambdaOptimizedClientFn = theorydb.NewLambdaOptimizedClient
 	newRepositoryFactoryFn     = func(db dynamormCore.DB, tableName string, logger *zap.Logger) (core.RepositoryStorage, error) {
 		return factory.NewRepositoryFactory(db, tableName, logger)
@@ -1370,20 +1389,23 @@ func initializeGraphQLWS() {
 
 	extractServices()
 
-	if err := initializeWithDefaultsFn(lambdaCtx); err != nil {
-		initializeManualServices()
-	} else {
-		extractServices()
+	deps, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName:          graphqlWSName,
+		RequireRepositories:  true,
+		NewDB:                newLambdaOptimizedClientFn,
+		NewRepositoryStorage: newRepositoryFactoryFn,
+	})
+	if err != nil {
+		logger.Fatal("failed to initialize storage", zap.Error(err))
 	}
+	repos = deps.Repos
+	extractServices()
 
-	if repos == nil {
-		initializeManualServices()
-		extractServices()
-	}
-
-	if cfg != nil && cfg.JWTSecret != "" && os.Getenv("JWT_SECRET") == "" {
-		if err := os.Setenv("JWT_SECRET", cfg.JWTSecret); err != nil {
-			logger.Warn("failed to propagate JWT secret to environment", zap.Error(err))
+	if cfg != nil && os.Getenv("JWT_SECRET") == "" {
+		if jwtSecret := resolveJWTSecretForGraphQLWS(); jwtSecret != "" {
+			if err := os.Setenv("JWT_SECRET", jwtSecret); err != nil {
+				logger.Warn("failed to propagate JWT secret to environment", zap.Error(err))
+			}
 		}
 	}
 

--- a/cmd/graphql/legacy_init_defaults_test.go
+++ b/cmd/graphql/legacy_init_defaults_test.go
@@ -1,0 +1,5 @@
+package main
+
+import "github.com/equaltoai/lesser/pkg/common"
+
+var initializeWithDefaultsFn = func(*common.LambdaContext) error { return nil }

--- a/cmd/graphql/main.go
+++ b/cmd/graphql/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/cost"
 	apperrors "github.com/equaltoai/lesser/pkg/errors"
 	gqllimits "github.com/equaltoai/lesser/pkg/graphql/limits"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	"github.com/equaltoai/lesser/pkg/mastodon"
 	"github.com/equaltoai/lesser/pkg/services"
 	"github.com/equaltoai/lesser/pkg/storage/core"
@@ -82,9 +83,8 @@ var (
 )
 
 var (
-	runningUnitTestsFn       = common.RunningUnitTests
-	mustInitializeLambdaFn   = common.MustInitializeLambda
-	initializeWithDefaultsFn = func(ctx *common.LambdaContext) error { return ctx.InitializeWithDefaults() }
+	runningUnitTestsFn     = common.RunningUnitTests
+	mustInitializeLambdaFn = common.MustInitializeLambda
 
 	extractStandardizedServicesFn       = extractStandardizedServices
 	initializeManualServicesFn          = initializeManualServices
@@ -132,8 +132,12 @@ func initializeGraphQL() {
 		RequestTimeout: 30 * time.Second,
 	})
 
-	// Initialize with default options for API Lambda type
-	if err := initializeWithDefaultsFn(lambdaCtx); err != nil {
+	if _, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName:          "graphql",
+		RequireRepositories:  true,
+		NewDB:                newLambdaOptimizedClientFn,
+		NewRepositoryStorage: newRepositoryFactoryFn,
+	}); err != nil {
 		// Fallback to manual initialization for services requiring it
 		initializeManualServicesFn()
 	} else {
@@ -275,7 +279,7 @@ func initializeGraphQLSpecificServices() {
 	// Create service registry with all dependencies
 	serviceConfig := &services.ServiceConfig{
 		BaseURL:   cfg.BaseURL(),
-		JWTSecret: cfg.JWTSecret,
+		JWTSecret: resolveJWTSecretForGraphQL(logger),
 		Config:    cfg,
 	}
 
@@ -977,7 +981,7 @@ func createAuthMiddlewareWithServices(authService *auth.AuthService, oauthServic
 }
 
 func newGraphQLAuthService(serviceLogger *zap.Logger) *auth.AuthService {
-	if cfg == nil || cfg.JWTSecret == "" || repos == nil {
+	if cfg == nil || repos == nil {
 		return nil
 	}
 
@@ -992,15 +996,39 @@ func newGraphQLAuthService(serviceLogger *zap.Logger) *auth.AuthService {
 }
 
 func newGraphQLOAuthService(serviceLogger *zap.Logger) *auth.OAuthService {
-	if cfg == nil || cfg.JWTSecret == "" {
+	if cfg == nil {
 		if serviceLogger != nil {
 			serviceLogger.Fatal("JWT secret is not configured; cannot initialize GraphQL auth middleware")
 		}
 		return nil
 	}
+	if common.RunningUnitTests() && strings.TrimSpace(cfg.JWTSecret) == "" && strings.TrimSpace(cfg.JWTSecretARN) == "" {
+		return nil
+	}
+	jwtSecret, err := cfg.ResolveJWTSecret()
+	if err != nil || jwtSecret == "" {
+		if serviceLogger != nil {
+			serviceLogger.Fatal("JWT secret is not configured; cannot initialize GraphQL auth middleware", zap.Error(err))
+		}
+		return nil
+	}
 
 	auditLogger := auth.NewAuditLogger(repos, serviceLogger, auth.DefaultAuditConfig())
-	return auth.NewOAuthService(cfg.JWTSecret, cfg, repos, auditLogger)
+	return auth.NewOAuthService(jwtSecret, cfg, repos, auditLogger)
+}
+
+func resolveJWTSecretForGraphQL(serviceLogger *zap.Logger) string {
+	if cfg == nil {
+		return ""
+	}
+	jwtSecret, err := cfg.ResolveJWTSecret()
+	if err != nil {
+		if serviceLogger != nil {
+			serviceLogger.Warn("failed to resolve GraphQL JWT secret", zap.Error(err))
+		}
+		return ""
+	}
+	return jwtSecret
 }
 
 func main() {

--- a/cmd/graphql/round12_graphql_test.go
+++ b/cmd/graphql/round12_graphql_test.go
@@ -203,6 +203,8 @@ func TestInitializeGraphQL_Branches_Round12(t *testing.T) {
 	originalExtract := extractStandardizedServicesFn
 	originalManual := initializeManualServicesFn
 	originalSpecific := initializeGraphQLSpecificServicesFn
+	originalNewClient := newLambdaOptimizedClientFn
+	originalNewFactory := newRepositoryFactoryFn
 	originalLambdaCtx := lambdaCtx
 	originalInitTime := initTime
 
@@ -213,6 +215,8 @@ func TestInitializeGraphQL_Branches_Round12(t *testing.T) {
 		extractStandardizedServicesFn = originalExtract
 		initializeManualServicesFn = originalManual
 		initializeGraphQLSpecificServicesFn = originalSpecific
+		newLambdaOptimizedClientFn = originalNewClient
+		newRepositoryFactoryFn = originalNewFactory
 		lambdaCtx = originalLambdaCtx
 		initTime = originalInitTime
 	})
@@ -227,13 +231,19 @@ func TestInitializeGraphQL_Branches_Round12(t *testing.T) {
 		require.Equal(t, 30*time.Second, cfg.RequestTimeout)
 		return &common.LambdaContext{
 			Logger: zap.NewNop(),
-			Config: &config.Config{},
+			Config: &config.Config{DynamoTableName: "tbl", Region: "us-east-1"},
 		}
 	}
 
 	t.Run("defaults_success_uses_standardized_extraction", func(t *testing.T) {
 		var extracted, manual, specific int
 		initializeWithDefaultsFn = func(*common.LambdaContext) error { return nil }
+		newLambdaOptimizedClientFn = func(context.Context, string) (dynamormCore.DB, error) {
+			return &tabletheory.LambdaDB{}, nil
+		}
+		newRepositoryFactoryFn = func(dynamormCore.DB, string, *zap.Logger) (storagecore.RepositoryStorage, error) {
+			return &testingmocks.MockRepositoryStorage{}, nil
+		}
 		extractStandardizedServicesFn = func() { extracted++ }
 		initializeManualServicesFn = func() { manual++ }
 		initializeGraphQLSpecificServicesFn = func() { specific++ }
@@ -250,6 +260,9 @@ func TestInitializeGraphQL_Branches_Round12(t *testing.T) {
 	t.Run("defaults_error_falls_back_to_manual_init", func(t *testing.T) {
 		var extracted, manual, specific int
 		initializeWithDefaultsFn = func(*common.LambdaContext) error { return errors.New("boom") }
+		newLambdaOptimizedClientFn = func(context.Context, string) (dynamormCore.DB, error) {
+			return nil, errors.New("boom")
+		}
 		extractStandardizedServicesFn = func() { extracted++ }
 		initializeManualServicesFn = func() { manual++ }
 		initializeGraphQLSpecificServicesFn = func() { specific++ }
@@ -264,6 +277,12 @@ func TestInitializeGraphQL_Branches_Round12(t *testing.T) {
 	t.Run("on_start_respects_running_unit_tests_flag", func(t *testing.T) {
 		mustInitCalls = 0
 		initializeWithDefaultsFn = func(*common.LambdaContext) error { return nil }
+		newLambdaOptimizedClientFn = func(context.Context, string) (dynamormCore.DB, error) {
+			return &tabletheory.LambdaDB{}, nil
+		}
+		newRepositoryFactoryFn = func(dynamormCore.DB, string, *zap.Logger) (storagecore.RepositoryStorage, error) {
+			return &testingmocks.MockRepositoryStorage{}, nil
+		}
 		extractStandardizedServicesFn = func() {}
 		initializeManualServicesFn = func() {}
 		initializeGraphQLSpecificServicesFn = func() {}

--- a/cmd/inbox/internal/routing/round10_test_helpers_test.go
+++ b/cmd/inbox/internal/routing/round10_test_helpers_test.go
@@ -94,6 +94,9 @@ func newInboxTestEnv(t *testing.T) *inboxTestEnv {
 	logger := zap.NewNop()
 
 	cfg := config.Get()
+	if strings.TrimSpace(cfg.JWTSecret) == "" {
+		cfg.JWTSecret = "dummy"
+	}
 	cfg.DynamoTableName = "test-table"
 	if cfg.Domain == "" {
 		cfg.Domain = "localhost"

--- a/cmd/init-deploy/main.go
+++ b/cmd/init-deploy/main.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"math/big"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -134,7 +135,7 @@ func runInitDeploy(ctx context.Context, args []string) error {
 	adminUsername := domain
 
 	// Initialize storage - use the deps Config
-	if err := common.ValidateRequiredParam("JWTSecret", lambdaCtx.Config.JWTSecret); err != nil {
+	if strings.TrimSpace(lambdaCtx.Config.JWTSecret) == "" && strings.TrimSpace(lambdaCtx.Config.JWTSecretARN) == "" {
 		jwtSecret, err := generateSecurePasswordFn(64)
 		if err != nil {
 			return pkgErrors.WrapError(err, pkgErrors.CodeInternal, pkgErrors.CategoryLambda, "Failed to generate JWT secret")

--- a/cmd/media-processor/main.go
+++ b/cmd/media-processor/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/deploy/naming"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	"github.com/equaltoai/lesser/pkg/media"
 	"github.com/equaltoai/lesser/pkg/monitoring"
 	"github.com/equaltoai/lesser/pkg/observability"
@@ -316,6 +317,10 @@ var (
 )
 
 func init() {
+	if common.RunningUnitTests() {
+		return
+	}
+
 	// Standardized Lambda initialization for processor functions
 	lambdaCtx = common.MustInitializeLambda(common.LambdaConfig{
 		ServiceName: "media-processor",
@@ -325,15 +330,15 @@ func init() {
 	// Automatic dependency injection
 	cfg = lambdaCtx.Config
 	logger = lambdaCtx.Logger
-	if lambdaCtx.Repos != nil {
-		repos = lambdaCtx.Repos.(storageCore.RepositoryStorage)
-	}
 
-	// Initialize with processor-specific defaults
-	err := lambdaCtx.InitializeWithDefaults()
+	deps, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName:         "media-processor",
+		RequireRepositories: true,
+	})
 	if err != nil {
-		logger.Warn("failed to initialize with defaults", zap.Error(err))
+		logger.Fatal("failed to initialize storage", zap.Error(err))
 	}
+	repos = deps.Repos
 
 	// Initialize processor with media-specific configuration
 	processor = NewMediaProcessor(lambdaCtx)

--- a/cmd/metrics-processor/main.go
+++ b/cmd/metrics-processor/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/deploy/naming"
 	appErrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	"github.com/equaltoai/lesser/pkg/storage/core"
 	"github.com/equaltoai/lesser/pkg/storage/factory"
 	"github.com/equaltoai/lesser/pkg/storage/models"
@@ -783,53 +784,16 @@ var (
 )
 
 func initializeMetricsStorage(lambdaCtx *common.LambdaContext) (core.RepositoryStorage, error) {
-	if lambdaCtx == nil {
-		return nil, fmt.Errorf("metrics-processor lambda context is nil")
-	}
-	if lambdaCtx.Config == nil {
-		return nil, fmt.Errorf("metrics-processor config is nil")
-	}
-
-	if lambdaCtx.Repos != nil {
-		repos, ok := lambdaCtx.Repos.(core.RepositoryStorage)
-		if !ok || repos == nil {
-			return nil, fmt.Errorf("metrics-processor invalid repository storage")
-		}
-		return repos, nil
-	}
-
-	tableName := strings.TrimSpace(lambdaCtx.Config.DynamoTableName)
-	if tableName == "" {
-		return nil, fmt.Errorf("metrics-processor dynamodb table name is required")
-	}
-
-	region := strings.TrimSpace(lambdaCtx.Config.Region)
-	if region == "" {
-		return nil, fmt.Errorf("metrics-processor AWS region is required")
-	}
-
-	var db dynamormCore.DB
-	if lambdaCtx.DynamoDB != nil {
-		var ok bool
-		db, ok = lambdaCtx.DynamoDB.(dynamormCore.DB)
-		if !ok || db == nil {
-			return nil, fmt.Errorf("metrics-processor invalid dynamodb client")
-		}
-	} else {
-		var err error
-		db, err = newLambdaOptimizedClientFn(context.Background(), region)
-		if err != nil {
-			return nil, fmt.Errorf("metrics-processor storage client initialization failed: %w", err)
-		}
-		lambdaCtx.DynamoDB = db
-	}
-
-	repos, err := newRepositoryFactoryFn(db, tableName, logger)
+	deps, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName:          "metrics-processor",
+		RequireRepositories:  true,
+		NewDB:                newLambdaOptimizedClientFn,
+		NewRepositoryStorage: newRepositoryFactoryFn,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("metrics-processor repository initialization failed: %w", err)
+		return nil, err
 	}
-	lambdaCtx.Repos = repos
-	return repos, nil
+	return deps.Repos, nil
 }
 
 func initializeMetricsProcessor() error {

--- a/cmd/ml-training-processor/main.go
+++ b/cmd/ml-training-processor/main.go
@@ -20,6 +20,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
 	"github.com/equaltoai/lesser/pkg/storage/theorydb"
@@ -125,36 +126,11 @@ func initializeMLTraining() error {
 }
 
 func initializeMLTrainingStorage(lambdaCtx *common.LambdaContext) error {
-	if lambdaCtx == nil {
-		return fmt.Errorf("ml-training-processor lambda context is nil")
-	}
-	if lambdaCtx.Config == nil {
-		return fmt.Errorf("ml-training-processor config is nil")
-	}
-	if lambdaCtx.DynamoDB != nil {
-		db, ok := lambdaCtx.DynamoDB.(core.DB)
-		if !ok || db == nil {
-			return fmt.Errorf("ml-training-processor invalid dynamodb client")
-		}
-		return nil
-	}
-
-	tableName := strings.TrimSpace(lambdaCtx.Config.DynamoTableName)
-	if tableName == "" {
-		return fmt.Errorf("ml-training-processor dynamodb table name is required")
-	}
-
-	region := strings.TrimSpace(lambdaCtx.Config.Region)
-	if region == "" {
-		return fmt.Errorf("ml-training-processor AWS region is required")
-	}
-
-	db, err := newLambdaOptimizedClientFn(context.Background(), region)
-	if err != nil {
-		return fmt.Errorf("ml-training-processor storage client initialization failed: %w", err)
-	}
-	lambdaCtx.DynamoDB = db
-	return nil
+	_, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName: "ml-training-processor",
+		NewDB:       newLambdaOptimizedClientFn,
+	})
+	return err
 }
 
 // NewMLTrainingProcessor creates a new ML training processor

--- a/cmd/moderation-processor/legacy_init_defaults_test.go
+++ b/cmd/moderation-processor/legacy_init_defaults_test.go
@@ -1,0 +1,5 @@
+package main
+
+import "github.com/equaltoai/lesser/pkg/common"
+
+var initializeWithDefaults = func(*common.LambdaContext) error { return nil }

--- a/cmd/moderation-processor/main.go
+++ b/cmd/moderation-processor/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/cost"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	"github.com/equaltoai/lesser/pkg/moderation"
 	"github.com/equaltoai/lesser/pkg/moderation/advanced"
 	notifpush "github.com/equaltoai/lesser/pkg/notifications"
@@ -49,7 +50,6 @@ var (
 	lambdaStart              = lambda.Start
 	mustInitializeLambda     = common.MustInitializeLambda
 	newLambdaOptimizedClient = theorydb.NewLambdaOptimizedClient
-	initializeWithDefaults   = (*common.LambdaContext).InitializeWithDefaults
 	lambdaCtx                *common.LambdaContext
 	db                       core.DB
 	consensusEngine          *moderation.ConsensusEngine
@@ -423,8 +423,8 @@ func parseCategoryFromString(s string) moderation.Category {
 }
 
 var (
-	cfg    *config.Config //nolint:unused // Reserved for dependency injection pattern
-	logger *zap.Logger
+	cfg    *config.Config                //nolint:unused // Reserved for dependency injection pattern
+	logger *zap.Logger                   //nolint:unused // Reserved for dependency injection pattern and legacy tests
 	repos  storageCore.RepositoryStorage //nolint:unused // Reserved for dependency injection pattern
 )
 
@@ -445,21 +445,16 @@ func initialize() {
 	// Automatic dependency injection
 	cfg = lambdaCtx.Config
 	logger = lambdaCtx.Logger
-	if lambdaCtx.Repos != nil {
-		repos = lambdaCtx.Repos.(storageCore.RepositoryStorage)
-	}
-
-	// Initialize with processor-specific defaults
-	err := initializeWithDefaults(lambdaCtx)
+	deps, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName:         "moderation-processor",
+		RequireRepositories: true,
+		NewDB:               newLambdaOptimizedClient,
+	})
 	if err != nil {
-		logger.Warn("failed to initialize with defaults", zap.Error(err))
+		lambdaCtx.Logger.Fatal("failed to initialize storage", zap.Error(err))
 	}
-
-	// Initialize DynamORM with Lambda optimizations
-	db, err = newLambdaOptimizedClient(context.Background(), lambdaCtx.Config.Region)
-	if err != nil {
-		lambdaCtx.Logger.Fatal("Failed to initialize DynamORM", zap.Error(err))
-	}
+	db = deps.DB
+	repos = deps.Repos
 
 	// Initialize repositories
 	moderationRepo = repositories.NewModerationRepository(db, lambdaCtx.Config.DynamoTableName, lambdaCtx.Logger)

--- a/cmd/note-processor/main.go
+++ b/cmd/note-processor/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
 	pkgErrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	"github.com/equaltoai/lesser/pkg/storage"
 	storageCore "github.com/equaltoai/lesser/pkg/storage/core"
 	storageInterfaces "github.com/equaltoai/lesser/pkg/storage/interfaces"
@@ -129,10 +130,20 @@ func NewNoteProcessor(lambdaCtx *common.LambdaContext) *NoteProcessor {
 	logger := lambdaCtx.Logger
 	cfg := lambdaCtx.Config
 
-	// Initialize storage independently to avoid import cycles
-	db, err := dynamormGetClientFn(context.Background())
-	if err != nil {
-		logger.Fatal("failed to initialize DynamORM database", zap.Error(err))
+	var db core.DB
+	if lambdaCtx.DynamoDB != nil {
+		if storageDB, ok := lambdaCtx.DynamoDB.(core.DB); ok && storageDB != nil {
+			db = storageDB
+		}
+	}
+	if db == nil {
+		var err error
+		// Legacy unit-test fallback: production startup populates LambdaContext via
+		// pkg/lambdastorage before constructing the processor.
+		db, err = dynamormGetClientFn(context.Background())
+		if err != nil {
+			logger.Fatal("failed to initialize DynamORM database", zap.Error(err))
+		}
 	}
 
 	// Initialize repositories
@@ -1380,15 +1391,18 @@ func init() {
 	// Automatic dependency injection
 	cfg = lambdaCtx.Config
 	logger = lambdaCtx.Logger
-	if lambdaCtx.Repos != nil {
-		repos = lambdaCtx.Repos.(storageCore.RepositoryStorage)
-	}
-
-	// Initialize with processor-specific defaults
-	err := lambdaCtx.InitializeWithDefaults()
+	deps, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName:         "note-processor",
+		RequireRepositories: true,
+		AllowEmptyRegion:    true,
+		NewDB: func(ctx context.Context, _ string) (core.DB, error) {
+			return dynamormGetClientFn(ctx)
+		},
+	})
 	if err != nil {
-		logger.Warn("failed to initialize with defaults", zap.Error(err))
+		logger.Fatal("failed to initialize storage", zap.Error(err))
 	}
+	repos = deps.Repos
 
 	// Initialize processor
 	processor = NewNoteProcessor(lambdaCtx)

--- a/cmd/notification-processor/legacy_init_defaults_test.go
+++ b/cmd/notification-processor/legacy_init_defaults_test.go
@@ -1,0 +1,5 @@
+package main
+
+import "github.com/equaltoai/lesser/pkg/common"
+
+var initializeWithDefaultsFn = func(*common.LambdaContext) error { return nil }

--- a/cmd/notification-processor/main.go
+++ b/cmd/notification-processor/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/deploy/naming"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
@@ -156,10 +157,20 @@ func NewNotificationProcessor(lambdaCtx *common.LambdaContext) *NotificationProc
 	logger := lambdaCtx.Logger
 	cfg := lambdaCtx.Config
 
-	// Initialize storage independently to avoid import cycles
-	db, err := dynamormGetClientFn(context.Background())
-	if err != nil {
-		lambdaCtx.Logger.Fatal("failed to initialize DynamORM database", zap.Error(err))
+	var db core.DB
+	if lambdaCtx.DynamoDB != nil {
+		if storageDB, ok := lambdaCtx.DynamoDB.(core.DB); ok && storageDB != nil {
+			db = storageDB
+		}
+	}
+	if db == nil {
+		var err error
+		// Legacy unit-test fallback: production startup populates LambdaContext via
+		// pkg/lambdastorage before constructing the processor.
+		db, err = dynamormGetClientFn(context.Background())
+		if err != nil {
+			lambdaCtx.Logger.Fatal("failed to initialize DynamORM database", zap.Error(err))
+		}
 	}
 	// Initialize repositories
 	notificationRepo := repositories.NewNotificationRepository(db, cfg.DynamoTableName, logger, nil)
@@ -813,7 +824,6 @@ func init() {
 
 var (
 	mustInitializeLambdaFn     = common.MustInitializeLambda
-	initializeWithDefaultsFn   = (*common.LambdaContext).InitializeWithDefaults
 	newNotificationProcessorFn = NewNotificationProcessor
 	dynamormGetClientFn        = theorydb.GetClient
 	streamerNewClientFn        = streamer.NewClient
@@ -835,11 +845,19 @@ func initializeNotificationProcessor() error {
 		},
 	})
 
-	// Automatic dependency injection handled by processor initialization
-
-	// Initialize with processor-specific defaults
-	if err := initializeWithDefaultsFn(lambdaCtx); err != nil {
-		lambdaCtx.Logger.Warn("failed to initialize with defaults", zap.Error(err))
+	if lambdaCtx.Config != nil {
+		if _, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+			ServiceName:         "notification-processor",
+			RequireRepositories: true,
+			AllowEmptyRegion:    true,
+			NewDB: func(ctx context.Context, _ string) (core.DB, error) {
+				return dynamormGetClientFn(ctx)
+			},
+		}); err != nil {
+			return fmt.Errorf("failed to initialize storage: %w", err)
+		}
+	} else if !common.RunningUnitTests() {
+		return fmt.Errorf("failed to initialize storage: config is nil")
 	}
 
 	processor = newNotificationProcessorFn(lambdaCtx)

--- a/cmd/objects/legacy_init_defaults_test.go
+++ b/cmd/objects/legacy_init_defaults_test.go
@@ -1,0 +1,5 @@
+package main
+
+import "github.com/equaltoai/lesser/pkg/common"
+
+var initializeWithDefaultsFn = func(*common.LambdaContext) error { return nil }

--- a/cmd/objects/main.go
+++ b/cmd/objects/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/crawler"
 	"github.com/equaltoai/lesser/pkg/federation"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	securityheaders "github.com/equaltoai/lesser/pkg/security/headers"
 	"github.com/equaltoai/lesser/pkg/security/htmlsafe"
 	"github.com/equaltoai/lesser/pkg/storage/core"
@@ -37,7 +38,6 @@ var (
 
 var (
 	mustInitializeLambdaFn     = common.MustInitializeLambda
-	initializeWithDefaultsFn   = func(ctx *common.LambdaContext) error { return ctx.InitializeWithDefaults() }
 	lambdaStartFn              = lambda.Start
 	newHandlerFn               = NewHandler
 	newLambdaOptimizedClientFn = theorydb.NewLambdaOptimizedClient
@@ -67,45 +67,16 @@ func initializeObjects() {
 		logger = zap.NewNop()
 	}
 
-	// Initialize with default options for API Lambda type (best-effort; some lambdas still do manual wiring).
-	if err := initializeWithDefaultsFn(lambdaCtx); err != nil {
-		logger.Warn("failed to initialize with defaults", zap.Error(err))
-	}
-
-	storage, ok := lambdaCtx.Repos.(core.RepositoryStorage)
-	if !ok || storage == nil {
-		logger.Warn("lambda context repository missing after initialization, attempting manual storage initialization")
-		initializeManualStorage()
-		storage, ok = lambdaCtx.Repos.(core.RepositoryStorage)
-	}
-	if !ok || storage == nil {
-		logger.Fatal("lambda context repository is not core.RepositoryStorage")
-	}
-	repos = storage
-}
-
-func initializeManualStorage() {
-	if lambdaCtx == nil {
-		logger.Fatal("manual storage initialization requires lambda context")
-	}
-
-	tableName := strings.TrimSpace(cfg.DynamoTableName)
-	if tableName == "" {
-		logger.Fatal("DYNAMODB_TABLE environment variable is required for objects lambda")
-	}
-
-	db, err := newLambdaOptimizedClientFn(context.Background(), cfg.Region)
+	deps, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName:          "objects",
+		RequireRepositories:  true,
+		NewDB:                newLambdaOptimizedClientFn,
+		NewRepositoryStorage: newRepositoryFactoryFn,
+	})
 	if err != nil {
-		logger.Fatal("failed to initialize DynamORM", zap.Error(err))
+		logger.Fatal("failed to initialize storage", zap.Error(err))
 	}
-
-	storage, err := newRepositoryFactoryFn(db, tableName, logger)
-	if err != nil {
-		logger.Fatal("failed to initialize repository factory", zap.Error(err))
-	}
-
-	lambdaCtx.DynamoDB = db
-	lambdaCtx.Repos = storage
+	repos = deps.Repos
 }
 
 // Handler handles ActivityPub federation object requests

--- a/cmd/outbox/main.go
+++ b/cmd/outbox/main.go
@@ -1101,12 +1101,16 @@ func (op *OutboxProcessor) validateJWTToken(tokenString string) (*auth.Claims, e
 	// Extract config with reflection or direct import for now
 	// This will be improved when config interface is standardized
 	cfg := op.lambdaCtx.Config
+	jwtSecret, err := cfg.ResolveJWTSecret()
+	if err != nil || strings.TrimSpace(jwtSecret) == "" {
+		return nil, invalidToken()
+	}
 
 	token, err := jwt.ParseWithClaims(tokenString, &auth.Claims{}, func(token *jwt.Token) (any, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, unexpectedJWTSigningMethod()
 		}
-		return []byte(cfg.JWTSecret), nil
+		return []byte(jwtSecret), nil
 	})
 	if err != nil {
 		return nil, jwtTokenParsingFailed(err)

--- a/cmd/severance-processor/main.go
+++ b/cmd/severance-processor/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/deploy/naming"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	"github.com/equaltoai/lesser/pkg/services"
 	severanceService "github.com/equaltoai/lesser/pkg/services/severance"
 	storageCore "github.com/equaltoai/lesser/pkg/storage/core"
@@ -91,53 +92,16 @@ func initializeSeveranceProcessor() error {
 }
 
 func initializeSeveranceStorage(lambdaCtx *common.LambdaContext) (storageCore.RepositoryStorage, error) {
-	if lambdaCtx == nil {
-		return nil, fmt.Errorf("severance-processor lambda context is nil")
-	}
-	if lambdaCtx.Config == nil {
-		return nil, fmt.Errorf("severance-processor config is nil")
-	}
-
-	if lambdaCtx.Repos != nil {
-		repos, ok := lambdaCtx.Repos.(storageCore.RepositoryStorage)
-		if !ok || repos == nil {
-			return nil, fmt.Errorf("severance-processor invalid repository storage")
-		}
-		return repos, nil
-	}
-
-	tableName := strings.TrimSpace(lambdaCtx.Config.DynamoTableName)
-	if tableName == "" {
-		return nil, fmt.Errorf("severance-processor dynamodb table name is required")
-	}
-
-	region := strings.TrimSpace(lambdaCtx.Config.Region)
-	if region == "" {
-		return nil, fmt.Errorf("severance-processor AWS region is required")
-	}
-
-	var db dynamormCore.DB
-	if lambdaCtx.DynamoDB != nil {
-		var ok bool
-		db, ok = lambdaCtx.DynamoDB.(dynamormCore.DB)
-		if !ok || db == nil {
-			return nil, fmt.Errorf("severance-processor invalid dynamodb client")
-		}
-	} else {
-		var err error
-		db, err = newLambdaOptimizedClientFn(context.Background(), region)
-		if err != nil {
-			return nil, fmt.Errorf("severance-processor storage client initialization failed: %w", err)
-		}
-		lambdaCtx.DynamoDB = db
-	}
-
-	repos, err := newRepositoryFactoryFn(db, tableName, logger)
+	deps, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName:          "severance-processor",
+		RequireRepositories:  true,
+		NewDB:                newLambdaOptimizedClientFn,
+		NewRepositoryStorage: newRepositoryFactoryFn,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("severance-processor repository initialization failed: %w", err)
+		return nil, err
 	}
-	lambdaCtx.Repos = repos
-	return repos, nil
+	return deps.Repos, nil
 }
 
 // SeveranceProcessor handles severance detection from DynamoDB streams

--- a/cmd/sse/legacy_init_defaults_test.go
+++ b/cmd/sse/legacy_init_defaults_test.go
@@ -1,0 +1,5 @@
+package main
+
+import "github.com/equaltoai/lesser/pkg/common"
+
+var initializeWithDefaultsFn = func(*common.LambdaContext) error { return nil }

--- a/cmd/sse/main.go
+++ b/cmd/sse/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
 	apperrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/core"
 	"github.com/equaltoai/lesser/pkg/storage/factory"
@@ -61,7 +62,6 @@ type streamEventLog interface {
 
 var (
 	mustInitializeLambdaFn     = common.MustInitializeLambda
-	initializeWithDefaultsFn   = func(ctx *common.LambdaContext) error { return ctx.InitializeWithDefaults() }
 	newLambdaOptimizedClientFn = theorydb.NewLambdaOptimizedClient
 	newRepositoryFactoryFn     = factory.NewRepositoryFactory
 	newAuthServiceFn           = func(cfg *config.Config, repos core.RepositoryStorage) (accessTokenValidator, error) {
@@ -104,36 +104,18 @@ func initializeSSE() {
 		logger = zap.NewNop()
 	}
 
-	// Best-effort standardized init (currently uses placeholders; SSE relies on manual wiring below).
-	if err := initializeWithDefaultsFn(lambdaCtx); err != nil {
-		logger.Debug("standardized initialization unavailable; using manual wiring", zap.Error(err))
-	}
-
-	// Manual repo + auth initialization (keeps this lambda standalone).
-	tableName := cfg.DynamoTableName
-	if err := common.ValidateRequiredParam("DYNAMODB_TABLE", tableName); err != nil {
-		logger.Fatal("DYNAMODB_TABLE environment variable is required", zap.Error(err))
-	}
-
-	var db dynamormCore.DB
-	if lambdaCtx.DynamoDB != nil {
-		if existing, ok := lambdaCtx.DynamoDB.(dynamormCore.DB); ok && existing != nil {
-			db = existing
-		}
-	}
-	if db == nil {
-		manualDB, err := newLambdaOptimizedClientFn(context.Background(), cfg.Region)
-		if err != nil {
-			logger.Fatal("failed to initialize DynamoDB client", zap.Error(err))
-		}
-		db = manualDB
-	}
-
-	var err error
-	repos, err = newRepositoryFactoryFn(db, tableName, logger)
+	deps, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName:         "sse",
+		RequireRepositories: true,
+		NewDB:               newLambdaOptimizedClientFn,
+		NewRepositoryStorage: func(db dynamormCore.DB, tableName string, logger *zap.Logger) (core.RepositoryStorage, error) {
+			return newRepositoryFactoryFn(db, tableName, logger)
+		},
+	})
 	if err != nil {
-		logger.Fatal("failed to create repository factory", zap.Error(err))
+		logger.Fatal("failed to initialize storage", zap.Error(err))
 	}
+	repos = deps.Repos
 
 	authService, err = newAuthServiceFn(cfg, repos)
 	if err != nil {
@@ -143,7 +125,7 @@ func initializeSSE() {
 	if cfg.StreamEventsTable == "" {
 		logger.Fatal("STREAM_EVENTS_TABLE_NAME environment variable is required")
 	}
-	eventLog = newStreamEventLogFn(db, 30*time.Minute)
+	eventLog = newStreamEventLogFn(deps.DB, 30*time.Minute)
 }
 
 func runSSE() {

--- a/cmd/stream-router/main.go
+++ b/cmd/stream-router/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	"github.com/equaltoai/lesser/pkg/mastodon"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
@@ -242,19 +243,11 @@ func init() {
 		LambdaType:  common.LambdaTypeProcessor, // Background processing
 	})
 
-	// Automatic dependency injection handled by handler initialization
-
-	// Initialize with processor-specific defaults
-	err := lambdaCtx.InitializeWithDefaults()
-	if err != nil {
-		lambdaCtx.Logger.Warn("failed to initialize with defaults", zap.Error(err))
-	}
-
-	// Ensure we have a Dynamo client even if the default bootstrap path failed
-	if lambdaCtx.DynamoDB == nil {
-		if manualErr := initializeManualServices(); manualErr != nil {
-			lambdaCtx.Logger.Fatal("failed to initialize manual services", zap.Error(manualErr))
-		}
+	if _, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName: "stream-router",
+		NewDB:       newLambdaOptimizedClient,
+	}); err != nil {
+		lambdaCtx.Logger.Fatal("failed to initialize storage", zap.Error(err))
 	}
 
 	// Stream router-specific initialization

--- a/cmd/streaming/legacy_init_defaults_test.go
+++ b/cmd/streaming/legacy_init_defaults_test.go
@@ -1,0 +1,5 @@
+package main
+
+import "github.com/equaltoai/lesser/pkg/common"
+
+var initializeWithDefaultsFn = func(*common.LambdaContext) error { return nil }

--- a/cmd/streaming/main.go
+++ b/cmd/streaming/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
 	pkgErrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	"github.com/equaltoai/lesser/pkg/services"
 	"github.com/equaltoai/lesser/pkg/storage/core"
 	"github.com/equaltoai/lesser/pkg/storage/factory"
@@ -103,7 +104,6 @@ var (
 	runningUnitTestsFn = common.RunningUnitTests
 
 	mustInitializeLambdaFn    = common.MustInitializeLambda
-	initializeWithDefaultsFn  = func(ctx *common.LambdaContext) error { return ctx.InitializeWithDefaults() }
 	ensureRepositoryFactoryFn = ensureRepositoryFactory
 	resolveDynamoClientFn     = resolveDynamoClient
 	newUserRepositoryFn       = repositories.NewUserRepository
@@ -181,10 +181,18 @@ func initializeStreaming() error {
 		logger = zap.NewNop()
 	}
 
-	// Initialize with API-specific defaults
-	if err := initializeWithDefaultsFn(lambdaCtx); err != nil {
-		logger.Warn("failed to initialize with defaults", zap.Error(err))
+	deps, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName:         "streaming",
+		RequireRepositories: true,
+		NewDB:               newLambdaOptimizedClientFn,
+		NewRepositoryStorage: func(db dynamormCore.DB, tableName string, logger *zap.Logger) (core.RepositoryStorage, error) {
+			return newRepositoryFactoryFn(db, tableName, logger)
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to initialize storage: %w", err)
 	}
+	repos = deps.Repos
 
 	if err := ensureRepositoryFactoryFn(); err != nil {
 		return err
@@ -386,20 +394,25 @@ func (sh *StreamingHandler) handleConnect(ctx context.Context, event events.APIG
 		// we'll extract the token and validate directly
 		// Create minimal audit logger for OAuth service
 		// Use storageFactory from the handler
-		auditLogger := auth.NewAuditLogger(sh.storageFactory, sh.logger, auth.DefaultAuditConfig())
-		authService := auth.NewOAuthService(sh.cfg.JWTSecret, sh.cfg, sh.storageFactory, auditLogger)
-		claims, err := authService.ValidateAccessToken(token)
-		if err != nil {
-			sh.logger.Warn("invalid token", zap.Error(err))
-			// Don't reject connection, allow anonymous access for public streams
+		jwtSecret, secretErr := sh.cfg.ResolveJWTSecret()
+		if secretErr != nil || strings.TrimSpace(jwtSecret) == "" {
+			sh.logger.Warn("failed to resolve JWT secret for streaming authentication", zap.Error(secretErr))
 		} else {
-			userID = claims.Subject
-			username = claims.Username
-			authSuccess = true
-			sh.logger.Info("user authenticated",
-				zap.String("userID", userID),
-				zap.String("username", username),
-				zap.Strings("scopes", claims.Scopes))
+			auditLogger := auth.NewAuditLogger(sh.storageFactory, sh.logger, auth.DefaultAuditConfig())
+			authService := auth.NewOAuthService(jwtSecret, sh.cfg, sh.storageFactory, auditLogger)
+			claims, err := authService.ValidateAccessToken(token)
+			if err != nil {
+				sh.logger.Warn("invalid token", zap.Error(err))
+				// Don't reject connection, allow anonymous access for public streams
+			} else {
+				userID = claims.Subject
+				username = claims.Username
+				authSuccess = true
+				sh.logger.Info("user authenticated",
+					zap.String("userID", userID),
+					zap.String("username", username),
+					zap.Strings("scopes", claims.Scopes))
+			}
 		}
 	} else {
 		sh.logger.Info("anonymous connection allowed")

--- a/cmd/webfinger/legacy_init_defaults_test.go
+++ b/cmd/webfinger/legacy_init_defaults_test.go
@@ -1,0 +1,5 @@
+package main
+
+import "github.com/equaltoai/lesser/pkg/common"
+
+var initializeWithDefaultsFn = func(*common.LambdaContext) error { return nil }

--- a/cmd/webfinger/main.go
+++ b/cmd/webfinger/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/crawler"
+	"github.com/equaltoai/lesser/pkg/lambdastorage"
 	"github.com/equaltoai/lesser/pkg/storage/core"
 	"github.com/equaltoai/lesser/pkg/storage/factory"
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
@@ -282,7 +283,6 @@ var (
 	repos     core.RepositoryStorage
 
 	mustInitializeLambdaFn     = common.MustInitializeLambda
-	initializeWithDefaultsFn   = (*common.LambdaContext).InitializeWithDefaults
 	lambdaStartFn              = lambda.Start
 	rsaGenerateKeyFn           = rsa.GenerateKey
 	timeNowFn                  = time.Now
@@ -321,45 +321,16 @@ func initializeWebFinger() {
 		logger = zap.NewNop()
 	}
 
-	// Initialize with default options for API Lambda type
-	if err := initializeWithDefaultsFn(lambdaCtx); err != nil {
-		logger.Warn("failed to initialize with defaults, some features may be limited", zap.Error(err))
-	}
-
-	storage, ok := lambdaCtx.Repos.(core.RepositoryStorage)
-	if !ok || storage == nil {
-		logger.Warn("lambda context repository missing after initialization, attempting manual storage initialization")
-		initializeManualStorage()
-		storage, ok = lambdaCtx.Repos.(core.RepositoryStorage)
-	}
-	if !ok || storage == nil {
-		logger.Fatal("lambda context repository is not core.RepositoryStorage")
-	}
-	repos = storage
-}
-
-func initializeManualStorage() {
-	if lambdaCtx == nil {
-		logger.Fatal("manual storage initialization requires lambda context")
-	}
-
-	tableName := strings.TrimSpace(cfg.DynamoTableName)
-	if tableName == "" {
-		logger.Fatal("DYNAMODB_TABLE environment variable is required for webfinger lambda")
-	}
-
-	db, err := newLambdaOptimizedClientFn(context.Background(), cfg.Region)
+	deps, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
+		ServiceName:          "webfinger",
+		RequireRepositories:  true,
+		NewDB:                newLambdaOptimizedClientFn,
+		NewRepositoryStorage: newRepositoryFactoryFn,
+	})
 	if err != nil {
-		logger.Fatal("failed to initialize DynamORM", zap.Error(err))
+		logger.Fatal("failed to initialize storage", zap.Error(err))
 	}
-
-	storage, err := newRepositoryFactoryFn(db, tableName, logger)
-	if err != nil {
-		logger.Fatal("failed to initialize repository factory", zap.Error(err))
-	}
-
-	lambdaCtx.DynamoDB = db
-	lambdaCtx.Repos = storage
+	repos = deps.Repos
 }
 
 func main() {

--- a/graph/agent_access_lease_resolvers.go
+++ b/graph/agent_access_lease_resolvers.go
@@ -442,10 +442,17 @@ func (r *mutationResolver) ExchangeAgentAccessLeaseToken(ctx context.Context, us
 		return nil, apperrors.Unauthorized("lease expired")
 	}
 	accessTTL := remaining
-	if r.Config == nil || r.Config.JWTSecret == "" {
-		return nil, apperrors.Internal("jwt secret not configured")
+	if r.Config == nil {
+		return nil, apperrors.Internal("jwt config not configured")
 	}
-	oauthSvc := auth.NewOAuthService(r.Config.JWTSecret, r.Config, r.Storage, nil)
+	jwtSecret, err := r.Config.ResolveJWTSecret()
+	if err == nil && strings.TrimSpace(jwtSecret) == "" {
+		err = errors.New("JWT secret is empty")
+	}
+	if err != nil {
+		return nil, apperrors.InternalWithCause(err, "jwt secret not configured")
+	}
+	oauthSvc := auth.NewOAuthService(jwtSecret, r.Config, r.Storage, nil)
 	accessToken, _, err := oauthSvc.GenerateTokensWithAccessTokenTTLAndClientContext(ctx, lease.Username, graphAgentAccessLeaseClientID, "", lease.Scopes, accessTTL, "", "")
 	if err != nil {
 		return nil, apperrors.InternalWithCause(err, "failed to mint lease access token")

--- a/graph/agent_resolvers_stubs.go
+++ b/graph/agent_resolvers_stubs.go
@@ -753,8 +753,8 @@ func (r *mutationResolver) DelegateToAgent(ctx context.Context, input model.Dele
 		return nil, err
 	}
 
-	if r.Config.JWTSecret == "" {
-		return nil, apperrors.Internal("jwt secret not configured")
+	if r.Config == nil {
+		return nil, apperrors.Internal("jwt config not configured")
 	}
 	bundle, err := auth.IssueAgentRuntimeTokens(ctx, r.Config, r.Storage, auth.AgentRuntimeTokenIssueParams{
 		Username:           agentUsername,

--- a/pkg/auth/agent_runtime.go
+++ b/pkg/auth/agent_runtime.go
@@ -117,7 +117,11 @@ func IssueAgentRuntimeTokens(ctx context.Context, cfg *config.Config, repos Stor
 
 	idleExpiry, absoluteExpiry := AgentRuntimeRefreshExpiries(now, params.RefreshIdleTTL, params.RefreshAbsoluteTTL)
 
-	oauthSvc := NewOAuthService(cfg.JWTSecret, cfg, repos, nil)
+	jwtSecret, err := cfg.ResolveJWTSecret()
+	if err != nil {
+		return nil, err
+	}
+	oauthSvc := NewOAuthService(jwtSecret, cfg, repos, nil)
 	accessToken, refreshToken, err := oauthSvc.GenerateTokensWithAccessTokenTTLAndClientContext(
 		ctx,
 		params.Username,

--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -43,9 +43,9 @@ func NewMiddleware() *Middleware {
 	if err != nil {
 		// JWT secret is required - no fallback to default
 		cfg := config.Get()
-		jwtSecret := cfg.JWTSecret
-		if jwtSecret == "" {
-			panic("JWT_SECRET environment variable is required")
+		jwtSecret, resolveErr := cfg.ResolveJWTSecret()
+		if resolveErr != nil || jwtSecret == "" {
+			panic("JWT secret configuration is required")
 		}
 
 		// Fallback for backward compatibility, but this won't work properly

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -57,7 +57,10 @@ type AuthService struct {
 
 // NewAuthService creates a comprehensive auth service
 func NewAuthService(cfg *config.Config, repos StorageProvider) (*AuthService, error) {
-	jwtSecret := cfg.JWTSecret
+	jwtSecret, err := cfg.ResolveJWTSecret()
+	if err != nil {
+		return nil, fmt.Errorf("resolve JWT secret: %w", err)
+	}
 	if jwtSecret == "" {
 		return nil, fmt.Errorf("JWT_SECRET is required")
 	}

--- a/pkg/common/lambda_helpers.go
+++ b/pkg/common/lambda_helpers.go
@@ -332,7 +332,13 @@ func (lambdaCtx *LambdaContext) InitializeServiceSpecificDependencies(options La
 	return nil
 }
 
-// InitializeWithDefaults initializes Lambda with default options for the Lambda type
+// InitializeWithDefaults initializes Lambda with default options for the Lambda type.
+//
+// Deprecated: production Lambda startup that depends on DynamoDB or repository
+// storage must use the product-level storage bootstrap in pkg/lambdastorage so
+// storage failures are explicit and typed. This helper remains for legacy
+// non-storage bootstrap tests and should not be reintroduced as a production
+// storage contract.
 func (lambdaCtx *LambdaContext) InitializeWithDefaults() error {
 	options := DefaultLambdaInitOptions(lambdaCtx.LambdaType)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -334,25 +334,19 @@ func loadConfig() *Config {
 		ReputationTableName:     getEnvOrDefault("REPUTATION_TABLE_NAME", "lesser-reputation"),
 		AWSAccountID:            getEnvOrDefault("AWS_ACCOUNT_ID", ""),
 
-		JWTSecret:            mustGetJWTSecret(),
-		JWTSecretARN:         getEnvOrDefault("JWT_SECRET_ARN", ""),
-		KMSKeyID:             getEnvOrDefault("KMS_KEY_ID", ""), // Optional - defaults to AWS managed key
-		ReputationPrivateKey: getEnvOrDefault("REPUTATION_PRIVATE_KEY", ""),
-		VAPIDPublicKey:       getEnvOrDefault("VAPID_PUBLIC_KEY", ""),
-		VAPIDSecretARN:       getEnvOrDefault("VAPID_SECRET_ARN", ""),
-		VAPIDSubject:         getEnvOrDefault("VAPID_SUBJECT", ""),
-		AdminUsername:        getEnvOrDefault("ADMIN_USERNAME", ""),
-		SystemActorPublicKey: getEnvOrDefault("SYSTEM_ACTOR_PUBLIC_KEY", ""),
-		InstanceAPIKey: getOptionalSecretFromEnvOrARN(
-			"INSTANCE_API_KEY",
-			"INSTANCE_API_KEY_ARN",
-		),
-		InstanceAPIKeyARN: strings.TrimSpace(getEnvOrDefault("INSTANCE_API_KEY_ARN", "")),
-		LesserHostURL:     strings.TrimRight(strings.TrimSpace(getEnvOrDefault("LESSER_HOST_URL", "")), "/"),
-		LesserHostInstanceKey: getOptionalSecretFromEnvOrARN(
-			"LESSER_HOST_INSTANCE_KEY",
-			"LESSER_HOST_INSTANCE_KEY_ARN",
-		),
+		JWTSecret:                 strings.TrimSpace(getEnvOrDefault("JWT_SECRET", "")),
+		JWTSecretARN:              strings.TrimSpace(getEnvOrDefault("JWT_SECRET_ARN", "")),
+		KMSKeyID:                  getEnvOrDefault("KMS_KEY_ID", ""), // Optional - defaults to AWS managed key
+		ReputationPrivateKey:      getEnvOrDefault("REPUTATION_PRIVATE_KEY", ""),
+		VAPIDPublicKey:            getEnvOrDefault("VAPID_PUBLIC_KEY", ""),
+		VAPIDSecretARN:            getEnvOrDefault("VAPID_SECRET_ARN", ""),
+		VAPIDSubject:              getEnvOrDefault("VAPID_SUBJECT", ""),
+		AdminUsername:             getEnvOrDefault("ADMIN_USERNAME", ""),
+		SystemActorPublicKey:      getEnvOrDefault("SYSTEM_ACTOR_PUBLIC_KEY", ""),
+		InstanceAPIKey:            strings.TrimSpace(getEnvOrDefault("INSTANCE_API_KEY", "")),
+		InstanceAPIKeyARN:         strings.TrimSpace(getEnvOrDefault("INSTANCE_API_KEY_ARN", "")),
+		LesserHostURL:             strings.TrimRight(strings.TrimSpace(getEnvOrDefault("LESSER_HOST_URL", "")), "/"),
+		LesserHostInstanceKey:     strings.TrimSpace(getEnvOrDefault("LESSER_HOST_INSTANCE_KEY", "")),
 		LesserHostInstanceKeyARN:  strings.TrimSpace(getEnvOrDefault("LESSER_HOST_INSTANCE_KEY_ARN", "")),
 		LesserHostAttestationsURL: strings.TrimRight(strings.TrimSpace(getEnvOrDefault("LESSER_HOST_ATTESTATIONS_URL", "")), "/"),
 
@@ -612,6 +606,26 @@ func (c *Config) ResolveInstanceAPIKey() (string, error) {
 	return resolveOptionalSecretValue(c.InstanceAPIKey, c.InstanceAPIKeyARN)
 }
 
+// ResolveJWTSecret returns the configured JWT signing secret, resolving the
+// optional Secrets Manager ARN lazily only for auth paths that need it.
+func (c *Config) ResolveJWTSecret() (string, error) {
+	if c == nil {
+		return "", nil
+	}
+	if secret := strings.TrimSpace(c.JWTSecret); secret != "" {
+		return secret, nil
+	}
+	arn := strings.TrimSpace(c.JWTSecretARN)
+	if arn == "" {
+		arn = "lesser/jwt-secret"
+	}
+	if isRunningTests() {
+		// Avoid reaching out to AWS Secrets Manager during unit tests.
+		return "dummy", nil
+	}
+	return resolveRequiredSecretValue(arn)
+}
+
 // ResolveLesserHostInstanceKey returns the configured lesser.host instance key,
 // resolving the optional Secrets Manager ARN lazily when needed.
 func (c *Config) ResolveLesserHostInstanceKey() (string, error) {
@@ -644,6 +658,7 @@ type optionalSecretLoader struct {
 
 var optionalSecretLoaders sync.Map
 
+//nolint:unused // retained for legacy callers and package-level secret-resolution tests
 func mustGetJWTSecret() string {
 	// Check for plain text secret (not recommended for production)
 	if secret := os.Getenv("JWT_SECRET"); secret != "" {
@@ -661,16 +676,12 @@ func mustGetJWTSecret() string {
 		arn = "lesser/jwt-secret"
 	}
 
-	// Load secret from AWS Secrets Manager (once)
-	jwtSecretLoader.once.Do(func() {
-		jwtSecretLoader.value, jwtSecretLoader.err = fetchSecretValue(arn)
-	})
-
-	if jwtSecretLoader.err != nil {
-		panic(fmt.Sprintf("Failed to resolve JWT secret from %s: %v", arn, jwtSecretLoader.err))
+	value, err := resolveRequiredSecretValue(arn)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to resolve JWT secret from %s: %v", arn, err))
 	}
 
-	return jwtSecretLoader.value
+	return value
 }
 
 func fetchSecretValue(arn string) (string, error) {
@@ -703,6 +714,7 @@ func fetchSecretValue(arn string) (string, error) {
 	return val, nil
 }
 
+//nolint:unused // retained for legacy callers and package-level secret-resolution tests
 func getOptionalSecretFromEnvOrARN(valueKey, arnKey string) string {
 	val, err := resolveOptionalSecretValue(os.Getenv(valueKey), os.Getenv(arnKey))
 	if err != nil {
@@ -743,6 +755,20 @@ func resolveOptionalSecretValue(value string, arn string) (string, error) {
 	loader.value = fetchedValue
 	loader.ready = true
 	return loader.value, nil
+}
+
+func resolveRequiredSecretValue(arn string) (string, error) {
+	arn = strings.TrimSpace(arn)
+	if arn == "" {
+		return "", errors.New("secret ARN is required")
+	}
+	jwtSecretLoader.once.Do(func() {
+		jwtSecretLoader.value, jwtSecretLoader.err = fetchSecretValue(arn)
+	})
+	if jwtSecretLoader.err != nil {
+		return "", jwtSecretLoader.err
+	}
+	return jwtSecretLoader.value, nil
 }
 
 func getEnvAsIntOrDefault(key string, defaultValue int) int {

--- a/pkg/config/config_secrets_test.go
+++ b/pkg/config/config_secrets_test.go
@@ -138,6 +138,58 @@ func TestConfigResolveInstanceAPIKey_ResolvesSecretARNOutsideTests(t *testing.T)
 	require.Equal(t, 1, callCount)
 }
 
+func TestConfigResolveJWTSecret_ResolvesSecretARNOutsideTests(t *testing.T) {
+	ResetForTests()
+
+	origLoad := loadDefaultAWSConfig
+	origNew := newSecretsManagerValueGetter
+	origArgs := os.Args
+	t.Cleanup(func() {
+		loadDefaultAWSConfig = origLoad
+		newSecretsManagerValueGetter = origNew
+		os.Args = origArgs
+		ResetForTests()
+	})
+
+	os.Args = []string{"app"}
+
+	loadDefaultAWSConfig = func(_ context.Context, _ ...func(*awsconfig.LoadOptions) error) (aws.Config, error) {
+		return aws.Config{Region: "us-east-1"}, nil
+	}
+
+	callCount := 0
+	secretString := `{"secret":"jwt-from-secrets-manager"}`
+	newSecretsManagerValueGetter = func(_ aws.Config) secretsManagerValueGetter {
+		callCount++
+		return stubSecretsManagerGetter{
+			output: &secretsmanager.GetSecretValueOutput{SecretString: &secretString},
+		}
+	}
+
+	cfg := &Config{
+		JWTSecretARN: "arn:aws:secretsmanager:us-east-1:123456789012:secret:jwt",
+	}
+
+	value, err := cfg.ResolveJWTSecret()
+	require.NoError(t, err)
+	require.Equal(t, "jwt-from-secrets-manager", value)
+
+	value, err = cfg.ResolveJWTSecret()
+	require.NoError(t, err)
+	require.Equal(t, "jwt-from-secrets-manager", value)
+	require.Equal(t, 1, callCount)
+}
+
+func TestConfigResolveJWTSecret_PlaintextPrecedence(t *testing.T) {
+	cfg := &Config{
+		JWTSecret:    "  plaintext  ",
+		JWTSecretARN: "arn:aws:secretsmanager:us-east-1:123456789012:secret:jwt",
+	}
+	value, err := cfg.ResolveJWTSecret()
+	require.NoError(t, err)
+	require.Equal(t, "plaintext", value)
+}
+
 func TestConfigResolveLesserHostInstanceKey_ReturnsFetchErrorsOutsideTests(t *testing.T) {
 	ResetForTests()
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -71,6 +71,26 @@ func TestConfig_InstanceAPIKey_ArnCapturedWhenValueMissing(t *testing.T) {
 	assert.Equal(t, "arn:aws:secretsmanager:us-east-1:123456789012:secret:instance-api-key", cfg.InstanceAPIKeyARN)
 }
 
+func TestConfig_GetDoesNotResolveSecretARNs(t *testing.T) {
+	SetupTestEnvironment(t)
+	t.Setenv("JWT_SECRET", "")
+	t.Setenv("JWT_SECRET_ARN", "arn:aws:secretsmanager:us-east-1:123456789012:secret:jwt")
+	t.Setenv("INSTANCE_API_KEY", "")
+	t.Setenv("INSTANCE_API_KEY_ARN", "arn:aws:secretsmanager:us-east-1:123456789012:secret:instance-api-key")
+	t.Setenv("LESSER_HOST_INSTANCE_KEY", "")
+	t.Setenv("LESSER_HOST_INSTANCE_KEY_ARN", "arn:aws:secretsmanager:us-east-1:123456789012:secret:lesser-host-key")
+
+	ResetForTests()
+	cfg := Get()
+
+	assert.Equal(t, "", cfg.JWTSecret)
+	assert.Equal(t, "arn:aws:secretsmanager:us-east-1:123456789012:secret:jwt", cfg.JWTSecretARN)
+	assert.Equal(t, "", cfg.InstanceAPIKey)
+	assert.Equal(t, "arn:aws:secretsmanager:us-east-1:123456789012:secret:instance-api-key", cfg.InstanceAPIKeyARN)
+	assert.Equal(t, "", cfg.LesserHostInstanceKey)
+	assert.Equal(t, "arn:aws:secretsmanager:us-east-1:123456789012:secret:lesser-host-key", cfg.LesserHostInstanceKeyARN)
+}
+
 func TestConfig_OAuthClientSecretRotationGracePeriod_DefaultsTo24Hours(t *testing.T) {
 	SetupTestEnvironment(t)
 	t.Setenv("OAUTH_CLIENT_SECRET_ROTATION_GRACE_PERIOD", "")

--- a/pkg/lambdastorage/bootstrap.go
+++ b/pkg/lambdastorage/bootstrap.go
@@ -1,0 +1,309 @@
+// Package lambdastorage provides explicit product-level storage bootstrap for
+// Lambda handlers that need TableTheory DB clients and repository storage.
+package lambdastorage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/config"
+	storagecore "github.com/equaltoai/lesser/pkg/storage/core"
+	"github.com/equaltoai/lesser/pkg/storage/factory"
+	"github.com/equaltoai/lesser/pkg/storage/theorydb"
+	dynamormcore "github.com/theory-cloud/tabletheory/pkg/core"
+	"go.uber.org/zap"
+)
+
+// NewDBFunc creates a Lambda-optimized TableTheory database client.
+type NewDBFunc func(context.Context, string) (dynamormcore.DB, error)
+
+// NewRepositoryStorageFunc creates repository storage over a TableTheory DB.
+type NewRepositoryStorageFunc func(dynamormcore.DB, string, *zap.Logger) (storagecore.RepositoryStorage, error)
+
+// Options controls explicit Lambda storage bootstrap.
+type Options struct {
+	// ServiceName is used in validation errors to make cold-start failures
+	// operator-readable without relying on ad-hoc processor text.
+	ServiceName string
+
+	// TableName overrides Config.DynamoTableName when a Lambda stores data in a
+	// non-main table. Empty uses Config.DynamoTableName.
+	TableName string
+
+	// RequireRepositories initializes and validates RepositoryStorage in addition
+	// to the TableTheory DB client.
+	RequireRepositories bool
+
+	// AllowEmptyRegion permits custom NewDB hooks that deliberately resolve AWS
+	// region from their own environment/config path.
+	AllowEmptyRegion bool
+
+	// NewDB and NewRepositoryStorage are injectable for tests. Production callers
+	// should leave them nil unless they already expose package-local hooks.
+	NewDB                NewDBFunc
+	NewRepositoryStorage NewRepositoryStorageFunc
+}
+
+// Dependencies are the typed storage dependencies produced by Initialize.
+type Dependencies struct {
+	Config    *config.Config
+	Logger    *zap.Logger
+	DB        dynamormcore.DB
+	Repos     storagecore.RepositoryStorage
+	TableName string
+}
+
+var runningUnitTestsFn = common.RunningUnitTests
+
+// Initialize ensures a LambdaContext has typed storage dependencies and writes
+// them back to LambdaContext for compatibility with existing handlers.
+func Initialize(ctx context.Context, lambdaCtx *common.LambdaContext, opts Options) (*Dependencies, error) {
+	serviceName := normalizeServiceName(opts.ServiceName)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if lambdaCtx == nil {
+		return nil, fmt.Errorf("%s storage bootstrap: lambda context is nil", serviceName)
+	}
+	if lambdaCtx.Config == nil {
+		return nil, fmt.Errorf("%s storage bootstrap: config is nil", serviceName)
+	}
+
+	logger := ensureLogger(lambdaCtx)
+	if deps, handled, err := existingRepositoryDependencies(lambdaCtx, opts, serviceName, logger); handled || err != nil {
+		return deps, err
+	}
+
+	tableName, err := tableNameFromConfig(lambdaCtx, opts, serviceName)
+	if err != nil {
+		return nil, err
+	}
+
+	if existingDB, ok := lambdaCtx.DynamoDB.(dynamormcore.DB); ok && existingDB != nil {
+		deps := &Dependencies{
+			Config:    lambdaCtx.Config,
+			Logger:    logger,
+			DB:        existingDB,
+			TableName: tableName,
+		}
+		if opts.RequireRepositories {
+			repos, err := resolveRepositoryStorage(lambdaCtx, opts, serviceName, existingDB, tableName, logger)
+			if err != nil {
+				return nil, err
+			}
+			deps.Repos = repos
+		}
+		return deps, nil
+	}
+
+	region, err := resolveRegion(lambdaCtx, opts, serviceName)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := resolveDB(ctx, lambdaCtx, opts, serviceName, region)
+	if err != nil {
+		return nil, err
+	}
+
+	deps := &Dependencies{
+		Config:    lambdaCtx.Config,
+		Logger:    logger,
+		DB:        db,
+		TableName: tableName,
+	}
+
+	if opts.RequireRepositories {
+		repos, err := resolveRepositoryStorage(lambdaCtx, opts, serviceName, db, tableName, logger)
+		if err != nil {
+			return nil, err
+		}
+		deps.Repos = repos
+	}
+
+	return deps, nil
+}
+
+func normalizeServiceName(serviceName string) string {
+	serviceName = strings.TrimSpace(serviceName)
+	if serviceName == "" {
+		return "lambda"
+	}
+	return serviceName
+}
+
+func ensureLogger(lambdaCtx *common.LambdaContext) *zap.Logger {
+	if lambdaCtx.Logger != nil {
+		return lambdaCtx.Logger
+	}
+	logger := zap.NewNop()
+	lambdaCtx.Logger = logger
+	return logger
+}
+
+func existingRepositoryDependencies(lambdaCtx *common.LambdaContext, opts Options, serviceName string, logger *zap.Logger) (*Dependencies, bool, error) {
+	if !opts.RequireRepositories || lambdaCtx.Repos == nil {
+		return nil, false, nil
+	}
+
+	repos, ok := lambdaCtx.Repos.(storagecore.RepositoryStorage)
+	if !ok || repos == nil {
+		return nil, true, fmt.Errorf("%s storage bootstrap: invalid repository storage", serviceName)
+	}
+
+	db := safeRepositoryDB(repos)
+	if db == nil {
+		if existingDB, ok := lambdaCtx.DynamoDB.(dynamormcore.DB); ok && existingDB != nil {
+			db = existingDB
+		}
+	}
+
+	if db != nil {
+		tableName, err := tableNameWithRepositoryFallback(lambdaCtx, opts, serviceName, repos)
+		if err != nil {
+			return nil, true, err
+		}
+		lambdaCtx.DynamoDB = db
+		lambdaCtx.Repos = repos
+		return &Dependencies{
+			Config:    lambdaCtx.Config,
+			Logger:    logger,
+			DB:        db,
+			Repos:     repos,
+			TableName: tableName,
+		}, true, nil
+	}
+
+	if !runningUnitTestsFn() {
+		return nil, false, nil
+	}
+
+	tableName := strings.TrimSpace(opts.TableName)
+	if tableName == "" {
+		tableName = strings.TrimSpace(safeRepositoryTableName(repos))
+	}
+	if tableName == "" {
+		tableName = strings.TrimSpace(lambdaCtx.Config.DynamoTableName)
+	}
+	lambdaCtx.Repos = repos
+	return &Dependencies{
+		Config:    lambdaCtx.Config,
+		Logger:    logger,
+		Repos:     repos,
+		TableName: tableName,
+	}, true, nil
+}
+
+func tableNameWithRepositoryFallback(lambdaCtx *common.LambdaContext, opts Options, serviceName string, repos storagecore.RepositoryStorage) (string, error) {
+	tableName := strings.TrimSpace(opts.TableName)
+	if tableName == "" {
+		tableName = strings.TrimSpace(safeRepositoryTableName(repos))
+	}
+	if tableName == "" {
+		tableName = strings.TrimSpace(lambdaCtx.Config.DynamoTableName)
+	}
+	if tableName == "" {
+		return "", fmt.Errorf("%s storage bootstrap: dynamodb table name is required", serviceName)
+	}
+	return tableName, nil
+}
+
+func tableNameFromConfig(lambdaCtx *common.LambdaContext, opts Options, serviceName string) (string, error) {
+	tableName := strings.TrimSpace(opts.TableName)
+	if tableName == "" {
+		tableName = strings.TrimSpace(lambdaCtx.Config.DynamoTableName)
+	}
+	if tableName == "" {
+		return "", fmt.Errorf("%s storage bootstrap: dynamodb table name is required", serviceName)
+	}
+	return tableName, nil
+}
+
+func resolveRegion(lambdaCtx *common.LambdaContext, opts Options, serviceName string) (string, error) {
+	region := strings.TrimSpace(lambdaCtx.Config.Region)
+	if region == "" && lambdaCtx.AWSServices != nil {
+		region = strings.TrimSpace(lambdaCtx.AWSServices.Config.Region)
+		if region != "" {
+			lambdaCtx.Config.Region = region
+		}
+	}
+	if region == "" && !opts.AllowEmptyRegion {
+		return "", fmt.Errorf("%s storage bootstrap: AWS region is required", serviceName)
+	}
+	return region, nil
+}
+
+func resolveDB(ctx context.Context, lambdaCtx *common.LambdaContext, opts Options, serviceName string, region string) (dynamormcore.DB, error) {
+	if lambdaCtx.DynamoDB != nil {
+		db, ok := lambdaCtx.DynamoDB.(dynamormcore.DB)
+		if !ok || db == nil {
+			return nil, fmt.Errorf("%s storage bootstrap: invalid dynamodb client", serviceName)
+		}
+		return db, nil
+	}
+
+	newDB := opts.NewDB
+	if newDB == nil {
+		newDB = theorydb.NewLambdaOptimizedClient
+	}
+
+	db, err := newDB(ctx, region)
+	if err != nil {
+		return nil, fmt.Errorf("%s storage bootstrap: storage client initialization failed: %w", serviceName, err)
+	}
+	if db == nil {
+		return nil, fmt.Errorf("%s storage bootstrap: storage client initialization returned nil", serviceName)
+	}
+	lambdaCtx.DynamoDB = db
+	return db, nil
+}
+
+func resolveRepositoryStorage(lambdaCtx *common.LambdaContext, opts Options, serviceName string, db dynamormcore.DB, tableName string, logger *zap.Logger) (storagecore.RepositoryStorage, error) {
+	if lambdaCtx.Repos != nil {
+		repos, ok := lambdaCtx.Repos.(storagecore.RepositoryStorage)
+		if !ok || repos == nil {
+			return nil, fmt.Errorf("%s storage bootstrap: invalid repository storage", serviceName)
+		}
+		if safeRepositoryDB(repos) == nil && !runningUnitTestsFn() {
+			return nil, fmt.Errorf("%s storage bootstrap: existing repository storage has no dynamodb client", serviceName)
+		}
+		return repos, nil
+	}
+
+	newRepos := opts.NewRepositoryStorage
+	if newRepos == nil {
+		newRepos = func(db dynamormcore.DB, tableName string, logger *zap.Logger) (storagecore.RepositoryStorage, error) {
+			return factory.NewRepositoryFactory(db, tableName, logger)
+		}
+	}
+
+	repos, err := newRepos(db, tableName, logger)
+	if err != nil {
+		return nil, fmt.Errorf("%s storage bootstrap: repository initialization failed: %w", serviceName, err)
+	}
+	if repos == nil {
+		return nil, fmt.Errorf("%s storage bootstrap: repository initialization returned nil", serviceName)
+	}
+	lambdaCtx.Repos = repos
+	return repos, nil
+}
+
+func safeRepositoryDB(repos storagecore.RepositoryStorage) (db dynamormcore.DB) {
+	defer func() {
+		if recover() != nil {
+			db = nil
+		}
+	}()
+	return repos.GetDB()
+}
+
+func safeRepositoryTableName(repos storagecore.RepositoryStorage) (tableName string) {
+	defer func() {
+		if recover() != nil {
+			tableName = ""
+		}
+	}()
+	return repos.GetTableName()
+}

--- a/pkg/lambdastorage/bootstrap_test.go
+++ b/pkg/lambdastorage/bootstrap_test.go
@@ -1,0 +1,337 @@
+package lambdastorage
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsinit "github.com/equaltoai/lesser/pkg/aws"
+	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/config"
+	storagecore "github.com/equaltoai/lesser/pkg/storage/core"
+	"github.com/stretchr/testify/require"
+	"github.com/theory-cloud/tabletheory"
+	dynamormcore "github.com/theory-cloud/tabletheory/pkg/core"
+	"go.uber.org/zap"
+)
+
+type stubRepositoryStorage struct {
+	storagecore.RepositoryStorage
+	db        dynamormcore.DB
+	tableName string
+}
+
+func (s *stubRepositoryStorage) GetDB() dynamormcore.DB { return s.db }
+func (s *stubRepositoryStorage) GetTableName() string   { return s.tableName }
+func (s *stubRepositoryStorage) GetLogger() *zap.Logger { return zap.NewNop() }
+
+type panicRepositoryStorage struct {
+	storagecore.RepositoryStorage
+}
+
+func (p *panicRepositoryStorage) GetDB() dynamormcore.DB { panic("db unavailable") }
+func (p *panicRepositoryStorage) GetTableName() string   { panic("table unavailable") }
+func (p *panicRepositoryStorage) GetLogger() *zap.Logger { return zap.NewNop() }
+
+func TestInitializeRequiresContextConfigAndTable(t *testing.T) {
+	_, err := Initialize(context.Background(), nil, Options{})
+	require.ErrorContains(t, err, "lambda storage bootstrap: lambda context is nil")
+
+	_, err = Initialize(context.Background(), &common.LambdaContext{}, Options{ServiceName: "unit"})
+	require.ErrorContains(t, err, "config is nil")
+
+	_, err = Initialize(context.Background(), &common.LambdaContext{Config: &config.Config{Region: "us-east-1"}}, Options{ServiceName: "unit"})
+	require.ErrorContains(t, err, "dynamodb table name is required")
+
+	_, err = Initialize(context.Background(), &common.LambdaContext{Config: &config.Config{DynamoTableName: "lesser-test"}}, Options{ServiceName: "unit"})
+	require.ErrorContains(t, err, "AWS region is required")
+}
+
+func TestInitializeCreatesDBAndRepositoryStorage(t *testing.T) {
+	db := &tabletheory.LambdaDB{}
+	repos := &stubRepositoryStorage{db: db, tableName: "lesser-test"}
+	ctx := &common.LambdaContext{
+		Config: &config.Config{DynamoTableName: "lesser-test", Region: "us-east-1"},
+		Logger: zap.NewNop(),
+	}
+
+	deps, err := Initialize(nil, ctx, Options{
+		ServiceName:         "unit-processor",
+		RequireRepositories: true,
+		NewDB: func(context.Context, string) (dynamormcore.DB, error) {
+			return db, nil
+		},
+		NewRepositoryStorage: func(gotDB dynamormcore.DB, tableName string, logger *zap.Logger) (storagecore.RepositoryStorage, error) {
+			require.Same(t, db, gotDB)
+			require.Equal(t, "lesser-test", tableName)
+			require.NotNil(t, logger)
+			return repos, nil
+		},
+	})
+	require.NoError(t, err)
+	require.Same(t, db, deps.DB)
+	require.Same(t, repos, deps.Repos)
+	require.Same(t, db, ctx.DynamoDB)
+	require.Same(t, repos, ctx.Repos)
+
+	ctx = &common.LambdaContext{
+		Config:   &config.Config{DynamoTableName: "lesser-test", Region: "us-east-1"},
+		DynamoDB: db,
+	}
+	_, err = Initialize(context.Background(), ctx, Options{
+		ServiceName:         "unit-processor",
+		RequireRepositories: true,
+		NewRepositoryStorage: func(dynamormcore.DB, string, *zap.Logger) (storagecore.RepositoryStorage, error) {
+			return nil, errors.New("repo boom")
+		},
+	})
+	require.ErrorContains(t, err, "repository initialization failed")
+}
+
+func TestInitializeReusesExistingTypedDependencies(t *testing.T) {
+	db := &tabletheory.LambdaDB{}
+	repos := &stubRepositoryStorage{db: db, tableName: "lesser-test"}
+	ctx := &common.LambdaContext{
+		Config:   &config.Config{DynamoTableName: "lesser-test", Region: "us-east-1"},
+		DynamoDB: db,
+		Repos:    repos,
+	}
+
+	deps, err := Initialize(context.Background(), ctx, Options{
+		ServiceName:         "unit-processor",
+		RequireRepositories: true,
+		NewDB: func(context.Context, string) (dynamormcore.DB, error) {
+			t.Fatal("NewDB should not be called when a typed DB already exists")
+			return nil, nil
+		},
+	})
+	require.NoError(t, err)
+	require.Same(t, db, deps.DB)
+	require.Same(t, repos, deps.Repos)
+}
+
+func TestInitializeValidatesExistingRepositories(t *testing.T) {
+	db := &tabletheory.LambdaDB{}
+	ctx := &common.LambdaContext{
+		Config: &config.Config{DynamoTableName: "lesser-test", Region: "us-east-1"},
+		Repos:  struct{}{},
+	}
+	_, err := Initialize(context.Background(), ctx, Options{
+		ServiceName:         "unit-processor",
+		RequireRepositories: true,
+	})
+	require.ErrorContains(t, err, "invalid repository storage")
+
+	ctx = &common.LambdaContext{
+		Config:   &config.Config{Region: "us-east-1"},
+		DynamoDB: db,
+		Repos:    &stubRepositoryStorage{db: db},
+	}
+	_, err = Initialize(context.Background(), ctx, Options{
+		ServiceName:         "unit-processor",
+		RequireRepositories: true,
+	})
+	require.ErrorContains(t, err, "dynamodb table name is required")
+}
+
+func TestInitializeHandlesRepositoryIntrospectionPanics(t *testing.T) {
+	db := &tabletheory.LambdaDB{}
+	repos := &panicRepositoryStorage{}
+	ctx := &common.LambdaContext{
+		Config:   &config.Config{DynamoTableName: "lesser-test", Region: "us-east-1"},
+		DynamoDB: db,
+		Repos:    repos,
+	}
+
+	deps, err := Initialize(context.Background(), ctx, Options{
+		ServiceName:         "unit-processor",
+		RequireRepositories: true,
+	})
+
+	require.NoError(t, err)
+	require.Same(t, db, deps.DB)
+	require.Same(t, repos, deps.Repos)
+	require.Equal(t, "lesser-test", deps.TableName)
+}
+
+func TestInitializeUsesExistingDBAndCreatesRepositories(t *testing.T) {
+	db := &tabletheory.LambdaDB{}
+	repos := &stubRepositoryStorage{db: db, tableName: "lesser-test"}
+	ctx := &common.LambdaContext{
+		Config:   &config.Config{DynamoTableName: "lesser-test", Region: "us-east-1"},
+		DynamoDB: db,
+	}
+
+	deps, err := Initialize(context.Background(), ctx, Options{
+		ServiceName:         "unit-processor",
+		RequireRepositories: true,
+		NewRepositoryStorage: func(gotDB dynamormcore.DB, tableName string, logger *zap.Logger) (storagecore.RepositoryStorage, error) {
+			require.Same(t, db, gotDB)
+			require.Equal(t, "lesser-test", tableName)
+			require.NotNil(t, logger)
+			return repos, nil
+		},
+	})
+
+	require.NoError(t, err)
+	require.Same(t, db, deps.DB)
+	require.Same(t, repos, deps.Repos)
+	require.Same(t, repos, ctx.Repos)
+}
+
+func TestInitializeUsesAWSServiceRegionAndTableOverride(t *testing.T) {
+	db := &tabletheory.LambdaDB{}
+	ctx := &common.LambdaContext{
+		Config:      &config.Config{DynamoTableName: "ignored"},
+		AWSServices: &awsinit.AWSServices{Config: aws.Config{Region: "us-west-2"}},
+	}
+
+	deps, err := Initialize(context.Background(), ctx, Options{
+		ServiceName: "unit-processor",
+		TableName:   "lesser-override",
+		NewDB: func(_ context.Context, region string) (dynamormcore.DB, error) {
+			require.Equal(t, "us-west-2", region)
+			return db, nil
+		},
+	})
+
+	require.NoError(t, err)
+	require.Same(t, db, deps.DB)
+	require.Equal(t, "lesser-override", deps.TableName)
+	require.Equal(t, "us-west-2", ctx.Config.Region)
+}
+
+func TestInitializeValidatesExistingDBAndRepositoryResults(t *testing.T) {
+	ctx := &common.LambdaContext{
+		Config:   &config.Config{DynamoTableName: "lesser-test", Region: "us-east-1"},
+		DynamoDB: "not-a-db",
+	}
+	_, err := Initialize(context.Background(), ctx, Options{ServiceName: "unit-processor"})
+	require.ErrorContains(t, err, "invalid dynamodb client")
+
+	db := &tabletheory.LambdaDB{}
+	ctx = &common.LambdaContext{Config: &config.Config{DynamoTableName: "lesser-test", Region: "us-east-1"}}
+	_, err = Initialize(context.Background(), ctx, Options{
+		ServiceName:         "unit-processor",
+		RequireRepositories: true,
+		NewDB: func(context.Context, string) (dynamormcore.DB, error) {
+			return db, nil
+		},
+		NewRepositoryStorage: func(dynamormcore.DB, string, *zap.Logger) (storagecore.RepositoryStorage, error) {
+			return nil, errors.New("repo boom")
+		},
+	})
+	require.ErrorContains(t, err, "repository initialization failed")
+
+	ctx = &common.LambdaContext{Config: &config.Config{DynamoTableName: "lesser-test", Region: "us-east-1"}}
+	_, err = Initialize(context.Background(), ctx, Options{
+		ServiceName:         "unit-processor",
+		RequireRepositories: true,
+		NewDB: func(context.Context, string) (dynamormcore.DB, error) {
+			return db, nil
+		},
+		NewRepositoryStorage: func(dynamormcore.DB, string, *zap.Logger) (storagecore.RepositoryStorage, error) {
+			return nil, nil
+		},
+	})
+	require.ErrorContains(t, err, "repository initialization returned nil")
+}
+
+func TestResolveRepositoryStorageExistingBranches(t *testing.T) {
+	db := &tabletheory.LambdaDB{}
+	ctx := &common.LambdaContext{Repos: struct{}{}}
+	_, err := resolveRepositoryStorage(ctx, Options{}, "unit-processor", db, "lesser-test", zap.NewNop())
+	require.ErrorContains(t, err, "invalid repository storage")
+
+	origRunningUnitTests := runningUnitTestsFn
+	runningUnitTestsFn = func() bool { return false }
+	t.Cleanup(func() { runningUnitTestsFn = origRunningUnitTests })
+
+	repos := &stubRepositoryStorage{tableName: "lesser-test"}
+	ctx = &common.LambdaContext{Repos: repos}
+	_, err = resolveRepositoryStorage(ctx, Options{}, "unit-processor", db, "lesser-test", zap.NewNop())
+	require.ErrorContains(t, err, "existing repository storage has no dynamodb client")
+
+	runningUnitTestsFn = func() bool { return true }
+	got, err := resolveRepositoryStorage(ctx, Options{}, "unit-processor", db, "lesser-test", zap.NewNop())
+	require.NoError(t, err)
+	require.Same(t, repos, got)
+}
+
+func TestInitializeRejectsExistingRepositoryWithoutDBOutsideTests(t *testing.T) {
+	origRunningUnitTests := runningUnitTestsFn
+	runningUnitTestsFn = func() bool { return false }
+	t.Cleanup(func() { runningUnitTestsFn = origRunningUnitTests })
+
+	db := &tabletheory.LambdaDB{}
+	ctx := &common.LambdaContext{
+		Config: &config.Config{DynamoTableName: "lesser-test", Region: "us-east-1"},
+		Repos:  &stubRepositoryStorage{tableName: "lesser-test"},
+	}
+
+	_, err := Initialize(context.Background(), ctx, Options{
+		ServiceName:         "unit-processor",
+		RequireRepositories: true,
+		NewDB: func(context.Context, string) (dynamormcore.DB, error) {
+			return db, nil
+		},
+	})
+	require.ErrorContains(t, err, "existing repository storage has no dynamodb client")
+}
+
+func TestInitializeAllowsTestRepositoryWithoutDB(t *testing.T) {
+	origRunningUnitTests := runningUnitTestsFn
+	runningUnitTestsFn = func() bool { return true }
+	t.Cleanup(func() { runningUnitTestsFn = origRunningUnitTests })
+
+	repos := &stubRepositoryStorage{tableName: "lesser-test"}
+	ctx := &common.LambdaContext{
+		Config: &config.Config{DynamoTableName: "lesser-test", Region: "us-east-1"},
+		Repos:  repos,
+	}
+
+	deps, err := Initialize(context.Background(), ctx, Options{
+		ServiceName:         "unit-processor",
+		RequireRepositories: true,
+		NewDB: func(context.Context, string) (dynamormcore.DB, error) {
+			t.Fatal("NewDB should not be called for unit-test repository compatibility")
+			return nil, nil
+		},
+	})
+
+	require.NoError(t, err)
+	require.Nil(t, deps.DB)
+	require.Same(t, repos, deps.Repos)
+	require.Equal(t, "lesser-test", deps.TableName)
+
+	ctx = &common.LambdaContext{
+		Config: &config.Config{Region: "us-east-1"},
+		Repos:  &stubRepositoryStorage{},
+	}
+	deps, err = Initialize(context.Background(), ctx, Options{
+		ServiceName:         "unit-processor",
+		RequireRepositories: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "", deps.TableName)
+}
+
+func TestInitializePropagatesCreationErrors(t *testing.T) {
+	ctx := &common.LambdaContext{Config: &config.Config{DynamoTableName: "lesser-test", Region: "us-east-1"}}
+	_, err := Initialize(context.Background(), ctx, Options{
+		ServiceName: "unit-processor",
+		NewDB: func(context.Context, string) (dynamormcore.DB, error) {
+			return nil, errors.New("boom")
+		},
+	})
+	require.ErrorContains(t, err, "storage client initialization failed")
+
+	_, err = Initialize(context.Background(), ctx, Options{
+		ServiceName: "unit-processor",
+		NewDB: func(context.Context, string) (dynamormcore.DB, error) {
+			return nil, nil
+		},
+	})
+	require.ErrorContains(t, err, "storage client initialization returned nil")
+}

--- a/pkg/services/authentication.go
+++ b/pkg/services/authentication.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/common"
@@ -47,9 +48,13 @@ func (a *authenticationService) AuthenticateUser(_ context.Context, token string
 	var oauthSvc *auth.OAuthService
 	switch r := a.repos.(type) {
 	case core.RepositoryStorage:
+		jwtSecret, err := a.jwtSigningSecret()
+		if err != nil {
+			return nil, NewInternalError("JWT secret configuration is required", err)
+		}
 		// Create a minimal audit logger for OAuth service
 		auditLogger := auth.NewAuditLogger(r, a.logger, auth.DefaultAuditConfig())
-		oauthSvc = auth.NewOAuthService(a.jwtSecret, a.config, r, auditLogger)
+		oauthSvc = auth.NewOAuthService(jwtSecret, a.config, r, auditLogger)
 	default:
 		// For legacy storage, we can't use the OAuth service directly
 		// Would need to implement a different validation approach
@@ -69,6 +74,27 @@ func (a *authenticationService) AuthenticateUser(_ context.Context, token string
 		ActorID:  actorID,
 		Claims:   claims,
 	}, nil
+}
+
+func (a *authenticationService) jwtSigningSecret() (string, error) {
+	if a == nil {
+		return "", fmt.Errorf("authentication service is nil")
+	}
+	if secret := strings.TrimSpace(a.jwtSecret); secret != "" {
+		return secret, nil
+	}
+	if a.config == nil {
+		return "", fmt.Errorf("config is nil")
+	}
+	secret, err := a.config.ResolveJWTSecret()
+	if err != nil {
+		return "", fmt.Errorf("resolve JWT secret: %w", err)
+	}
+	if strings.TrimSpace(secret) == "" {
+		return "", fmt.Errorf("JWT secret is empty")
+	}
+	a.jwtSecret = secret
+	return secret, nil
 }
 
 // ValidateScope checks if the user has the required scope

--- a/pkg/services/core_services_round27_coverage_test.go
+++ b/pkg/services/core_services_round27_coverage_test.go
@@ -988,6 +988,39 @@ func TestAuthenticationService_round27_coverage(t *testing.T) {
 	})
 }
 
+func TestAuthenticationServiceJWTSigningSecret_round27_coverage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil_service_returns_error", func(t *testing.T) {
+		var svc *authenticationService
+		secret, err := svc.jwtSigningSecret()
+		require.ErrorContains(t, err, "authentication service is nil")
+		assert.Empty(t, secret)
+	})
+
+	t.Run("plaintext_secret_is_trimmed_and_returned", func(t *testing.T) {
+		svc := &authenticationService{jwtSecret: "  local-secret  "}
+		secret, err := svc.jwtSigningSecret()
+		require.NoError(t, err)
+		assert.Equal(t, "local-secret", secret)
+	})
+
+	t.Run("missing_config_returns_error", func(t *testing.T) {
+		svc := &authenticationService{}
+		secret, err := svc.jwtSigningSecret()
+		require.ErrorContains(t, err, "config is nil")
+		assert.Empty(t, secret)
+	})
+
+	t.Run("lazy_resolution_caches_secret", func(t *testing.T) {
+		svc := &authenticationService{config: &config.Config{JWTSecretARN: "arn:aws:secretsmanager:us-east-1:123456789012:secret:jwt"}}
+		secret, err := svc.jwtSigningSecret()
+		require.NoError(t, err)
+		assert.Equal(t, "dummy", secret)
+		assert.Equal(t, "dummy", svc.jwtSecret)
+	})
+}
+
 func TestServiceFactory_round27_coverage(t *testing.T) {
 	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
 	t.Setenv("AWS_REGION", "us-east-1")

--- a/pkg/services/registry.go
+++ b/pkg/services/registry.go
@@ -71,7 +71,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/equaltoai/lesser/pkg/activitypub"
-	"github.com/equaltoai/lesser/pkg/common"
 	pkgconfig "github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/federation"
 	"github.com/equaltoai/lesser/pkg/federation/remotenotes"
@@ -265,24 +264,6 @@ func (r *Registry) validate() error {
 
 	if r.config == nil {
 		cfg := pkgconfig.Get()
-		jwtSecret := strings.TrimSpace(cfg.JWTSecret)
-		if jwtSecret == "" && common.RunningUnitTests() {
-			jwtSecret = strings.Repeat("x", 32)
-		}
-
-		if jwtSecret == "" {
-			r.logger.Fatal("JWT secret configuration is required")
-			panic("JWT secret configuration is required")
-		}
-
-		if err := validateJWTSecret(jwtSecret); err != nil {
-			if common.RunningUnitTests() {
-				jwtSecret = strings.Repeat("x", 32)
-			} else {
-				r.logger.Fatal("invalid JWT secret", zap.Error(err))
-				panic(fmt.Sprintf("invalid JWT secret: %v", err))
-			}
-		}
 
 		baseURL := cfg.BaseURL()
 		if strings.TrimSpace(baseURL) == "" {
@@ -291,9 +272,13 @@ func (r *Registry) validate() error {
 
 		r.config = &ServiceConfig{
 			BaseURL:   baseURL,
-			JWTSecret: jwtSecret,
+			JWTSecret: strings.TrimSpace(cfg.JWTSecret),
 			Config:    cfg,
 		}
+	}
+
+	if r.config != nil {
+		r.config.JWTSecret = strings.TrimSpace(r.config.JWTSecret)
 	}
 
 	return nil
@@ -2738,6 +2723,8 @@ func (r *Registry) getJobQueue() JobQueueServiceInterface {
 }
 
 // validateJWTSecret validates that the JWT secret meets security requirements
+//
+//nolint:unused // retained for legacy registry validation coverage; auth paths validate after lazy resolution
 func validateJWTSecret(secret string) error {
 	// Check minimum length (32 characters for 256-bit security)
 	if len(secret) < 32 {
@@ -2773,6 +2760,8 @@ func validateJWTSecret(secret string) error {
 }
 
 // isLowEntropy checks if a string has low entropy (e.g., all same character, sequential)
+//
+//nolint:unused
 func isLowEntropy(s string) bool {
 	if len(s) == 0 {
 		return true

--- a/tools/audit_gates/default_init_storage_test.go
+++ b/tools/audit_gates/default_init_storage_test.go
@@ -1,0 +1,11 @@
+package main
+
+import "testing"
+
+func TestNoDefaultInitStorageContinuation(t *testing.T) {
+	t.Chdir("../..")
+
+	if err := checkNoDefaultInitStorageContinuation(); err != nil {
+		t.Fatalf("default init storage continuation gate failed: %v", err)
+	}
+}

--- a/tools/audit_gates/main.go
+++ b/tools/audit_gates/main.go
@@ -122,12 +122,65 @@ func run(opts options) error {
 		problems = append(problems, err.Error())
 	}
 
+	if err := checkNoDefaultInitStorageContinuation(); err != nil {
+		problems = append(problems, err.Error())
+	}
+
 	if len(problems) > 0 {
 		return errors.New("audit gates failed:\n- " + strings.Join(problems, "\n- "))
 	}
 
 	fmt.Println("✓ audit gates passed")
 	return nil
+}
+
+func checkNoDefaultInitStorageContinuation() error {
+	matches, err := findDefaultInitStorageContinuationMatches("cmd")
+	if err != nil {
+		return err
+	}
+	if len(matches) > 0 {
+		return fmt.Errorf("production lambdas must use pkg/lambdastorage instead of continuing after common.InitializeWithDefaults failures:\n  %s", strings.Join(matches, "\n  "))
+	}
+	return nil
+}
+
+func findDefaultInitStorageContinuationMatches(root string) ([]string, error) {
+	forbidden := []string{
+		"failed to initialize with defaults",
+		"InitializeWithDefaults(",
+		"initializeWithDefaults",
+	}
+	var matches []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if strings.HasPrefix(path, ".git") || strings.Contains(path, string(filepath.Separator)+"testdata"+string(filepath.Separator)) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".go" || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		content, readErr := os.ReadFile(path) // #nosec G304 -- repo-local audit gate
+		if readErr != nil {
+			return readErr
+		}
+		for _, needle := range forbidden {
+			if bytes.Contains(content, []byte(needle)) {
+				matches = append(matches, fmt.Sprintf("%s contains %q", path, needle))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan lambda default-init usage: %w", err)
+	}
+	sort.Strings(matches)
+	return matches, nil
 }
 
 func dumpDynamoDBBaseline() error {


### PR DESCRIPTION
## Milestone
Project 34 M5 — durable prevention after the Sim processor storm, covering M5.1 (#1006) and M5.2 (#1007).

Fixes #1006.
Fixes #1007.

## Classification
operational-reliability / storage / auth / federation-trust-adjacent

## Surfaces affected
- Adds `pkg/lambdastorage` as explicit product storage bootstrap returning typed DB/repository/table dependencies and writing them back to `common.LambdaContext` for compatibility.
- Migrates storage-dependent Lambda startup away from `common.InitializeWithDefaults()` continuation into explicit bootstrap/fail-closed paths.
- Makes `config.Get()` side-effect-light for JWT, instance API key, and lesser-host instance key references; auth/trust paths resolve secrets explicitly and retain warm caching.
- Adds audit guardrails so production `cmd` code cannot reintroduce default-init failure logging followed by storage construction.

## Specialist walks referenced
- Federation trust: clean. HTTP Signature signing/verification, actor object shape, WebFinger response shape, inbox validation, delivery retry/circuit-breaker behavior, and domain-block enforcement are not changed. Federation-facing Lambdas only change cold-start storage/auth-secret wiring.
- Contract / API: no REST, GraphQL, ActivityPub object-shape, or OpenAPI/GraphQL schema changes.
- Schema: no DynamoDB PK/SK/GSI/TableTheory tag changes.
- Framework: no AppTheory/TableTheory patches.

## Consumer impact
- Operators: storage-dependent processors fail closed on explicit storage bootstrap errors instead of continuing after ambiguous default init failures.
- Operators: generic processor cold starts no longer fetch unrelated JWT/host secrets; Ops should verify post-deploy Secrets Manager/KMS rates against non-auth processor retry storms.
- Mastodon clients / remote AP peers: no observable API or federation contract change intended.

## Tasks
- [x] #1006 — Add explicit product storage bootstrap package.
- [x] #1007 — Make `config.Get()` side-effect-light with lazy secret resolution.

## Validation
- `go test ./...`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Ops verification after deploy
No deploy, source mapping, EventBridge, processor re-enable/disable, backfill, or live mutation was performed in this PR. After a separately authorized deploy/soak, compare Secrets Manager and KMS call rates for non-auth processors before/after the candidate; unrelated retry storms should no longer drive JWT/host secret fetches.

## Cross-repo coordination
None for this PR. Release/deploy sequencing remains with Project 34 / Arch and `deploy-instance` after merge.