### PR TITLE
docs: prepare processor storm recovery

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,7 +72,7 @@ internal/CI-only (except for building the `lesser` CLI itself).
 - Release-driven deploy contract: `docs/contracts/release-driven-deploy-contract.md`
 - CLI auth (device flow): `docs/cli/auth.md`
 - Configure: `docs/configuration.md`
-- Operate: `docs/monitoring.md`, `docs/security.md`, `docs/backup-recovery.md`, `docs/operations/runbook.md`, `docs/operations/processor-storm-runbook.md`
+- Operate: `docs/monitoring.md`, `docs/security.md`, `docs/backup-recovery.md`, `docs/operations/runbook.md`, `docs/operations/processor-storm-runbook.md`, `docs/operations/processor-storm-recovery-runbook.md`, `docs/operations/processor-storm-recovery-decisions.md`
 - Release notes: `docs/operations/release-notes.md`
 - Incident stewardship packets: `docs/operations/processor-storm-apptheory-stewardship-evidence.md`
 - Release checklist: `docs/release-checklist.md`

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -8,6 +8,8 @@ This directory contains the operator runbooks and workflows for deployed environ
 
 - Runbook: `docs/operations/runbook.md`
 - Processor storm containment: `docs/operations/processor-storm-runbook.md`
+- Processor storm recovery preparation: `docs/operations/processor-storm-recovery-runbook.md`
+- Processor storm M4 decisions: `docs/operations/processor-storm-recovery-decisions.md`
 - CloudWatch workflow: `docs/operations/cloudwatch-debugging.md`
 - Release notes: `docs/operations/release-notes.md`
 

--- a/docs/operations/processor-storm-recovery-decisions.md
+++ b/docs/operations/processor-storm-recovery-decisions.md
@@ -1,0 +1,105 @@
+# Processor storm M4 recovery decisions
+
+Date: 2026-05-18
+Issues: [#993](https://github.com/equaltoai/lesser/issues/993),
+[#1004](https://github.com/equaltoai/lesser/issues/1004),
+[#1005](https://github.com/equaltoai/lesser/issues/1005)
+
+This packet records the current Project 34 M4 recovery decisions for the dev-stage test instances after creator
+clarified that dev/test backfill or reconciliation may run when safety preconditions are satisfied. It is a decision
+record and dry-run evidence summary, not a production runbook receipt.
+
+## Boundary and authorization state
+
+Authorized for this packet:
+
+- prepare recovery/backfill tooling, runbooks, and decision records;
+- use AWS profiles `Sim` and `Theory` for dev-stage test evidence;
+- run read-only/dry-run previews;
+- perform dev-stage backfill or reconciliation only where the surface-specific safety preconditions are satisfied.
+
+Not authorized or not performed in this packet:
+
+- production resource access;
+- deploys;
+- source-mapping or EventBridge mutation;
+- processor re-enable/disable;
+- secret-value reads;
+- framework issue filing;
+- write-path backfill/reconciliation when M1/M2/M5 deployed-code prerequisites are not live.
+
+## Current dev-stage evidence
+
+Read-only snapshots were collected with `scripts/processor_storm_recovery_snapshot.sh`.
+
+| Instance | Profile | Account | Stage/domain | Snapshot window | Stack last updated | Prerequisite status |
+| --- | --- | ---: | --- | --- | --- | --- |
+| `simulacrum-dev` | `Sim` | `209468748504` | `dev.simulacrum.greater.website` | `2026-05-18T10:09:04Z`–`2026-05-18T11:09:04Z` | `2026-05-17T23:56:38Z` | M1/M2/M5 fixes not deployed; active errors remain |
+| `theory-dev` | `Theory` | `251050869245` | `dev.theory.greater.website` | `2026-05-18T10:13:18Z`–`2026-05-18T11:13:18Z` | `2026-05-17T23:56:33Z` | M1/M2/M5 fixes not deployed; active errors remain |
+
+The candidate source commit for eventual deploy remains `e0f7f35997d1da70f2a08fc5d1b007a76d4bd495`, which includes
+M1/M1.4/M2/M5 source-control fixes. Neither dev stack exposes a deployed Git SHA in the inspected metadata, but
+both stack update times predate the M1/M2/M5 merged main commits.
+
+### Processor health signals
+
+| Instance | Processor | Invocations | Errors | Throttles | Max iterator age |
+| --- | --- | ---: | ---: | ---: | ---: |
+| `simulacrum-dev` | `metrics-processor` | 255 | 255 | 0 | 108,485,363 ms |
+| `simulacrum-dev` | `ai-processor` | 1212 | 1212 | 0 | 21,063 ms |
+| `simulacrum-dev` | `ml-training-processor` | 1213 | 1213 | 0 | 19,672 ms |
+| `simulacrum-dev` | `severance-processor` | 1209 | 1209 | 0 | 22,424 ms |
+| `simulacrum-dev` | `dlq-processor` | 12 | 12 | 0 | n/a |
+| `simulacrum-dev` | `federation-aggregator` | 3 | 3 | 0 | n/a |
+| `theory-dev` | `metrics-processor` | 238 | 238 | 1 | 99,556,093 ms |
+| `theory-dev` | `ai-processor` | 8 | 8 | 0 | 5,579 ms |
+| `theory-dev` | `ml-training-processor` | 8 | 8 | 0 | 4,534 ms |
+| `theory-dev` | `severance-processor` | 8 | 8 | 0 | 8,319 ms |
+| `theory-dev` | `dlq-processor` | 12 | 12 | 0 | n/a |
+| `theory-dev` | `federation-aggregator` | 3 | 3 | 0 | n/a |
+
+All relevant DynamoDB stream mappings are still enabled with pre-M2 guardrail posture in the snapshots: no
+`OnFailure` destination, `maxAge=-1`, and some `retry=-1` mappings. This blocks write-path recovery for stream-derived
+surfaces because recovery writes could be immediately re-poisoned or obscured by the still-failing processors.
+
+SQS processor queues and DLQs in both snapshots had `visible=0`, `notVisible=0`, `delayed=0`, and
+`oldestAgeSeconds=0`. That supports a no-op DLQ decision for retained SQS messages at the snapshot time, but it is
+not proof that historical stream-only work was recovered.
+
+## Surface decisions
+
+| Surface | Current decision state | Source-of-truth inputs | Dry-run / preview evidence | Idempotency / rerun posture | Stop conditions | Residual rationale |
+| --- | --- | --- | --- | --- | --- | --- |
+| Metrics projections | **Deferred by prerequisite**; planned mode `backfill` or `reconcile` after fixes deploy | Source tables plus CloudWatch metrics / metric aggregate rows | Metrics processor is still 100% failing on both dev instances; stream mappings have no poison destination and unbounded age | Future recomputation must use idempotent upserts and never overwrite newer aggregate windows | Any metrics errors, iterator-age growth, poison/DLQ growth, or throttles after deploy | Cannot safely backfill now; exact stream-only history may later be accepted stale if source rows cannot reconstruct it |
+| AI analysis | **Deferred by prerequisite**; planned mode `backfill` for eligible content or `accept stale` for deleted/ineligible content | Analyzable notes/objects plus AI analysis rows | AI processor is still 100% failing on both dev instances | Future replay must skip deleted/private/blocked/superseded content and be batch bounded | AI errors, KMS/Secrets errors, queue/poison growth, or moderation-policy mismatch | Replaying before startup/lazy-secret fixes are live would amplify the active storm |
+| ML job state | **Deferred by prerequisite** for write reconciliation; read-only Bedrock/job-status planning allowed later | `MLJOB#*`, `MLPOLL#*`, model metadata rows, Bedrock job state | ML training processor is still 100% failing on both dev instances | Future reconciliation must preserve terminal Bedrock state and must not restart training without explicit cost/data authorization | Bedrock status mismatch, processor errors, throttles, or unexpected model-version changes | Local job rows cannot be trusted as sole source; remote Bedrock state must win during execution |
+| Severance state | **Deferred by prerequisite**; planned mode `reconcile` from current policy and relationship truth | Domain blocks, federation health, issue records, relationships, severance rows | Severance processor is still 100% failing on both dev instances | Future reconciliation must be monotonic with current moderation/federation policy and audited | Unexpected relationship-count deltas or severance processor errors | Historical stream-only severance gaps may be accepted stale if current source truth cannot reconstruct them |
+| DLQ processing | **Accepted no-op for retained SQS DLQ messages at snapshot time**; rerun snapshot before any later redrive | SQS queues/DLQs, DLQ repository records where present | All observed SQS queues/DLQs had zero visible, not-visible, delayed, and oldest-message age values | No purge/redrive was run; if messages appear later, group by source/error class and prove idempotency first | Any nonzero DLQ/poison depth without idempotency proof, duplicate writes, or repeated poison growth | Empty retained queues mean there was no safe SQS redrive work to perform now; stream-only loss remains separate |
+| Federation aggregation | **Deferred by prerequisite**; planned mode `backfill` or `reconcile` after routing/table fixes deploy | Persisted federation activity, route metrics, delivery outcomes, federation rollup rows | Federation aggregator still errors on scheduled/queue invocations; queues are empty at snapshot time | Future recompute must be oldest-to-newest and idempotent to avoid double-counting deliveries | Aggregator errors, queue growth, poison/DLQ growth, or mismatched source/aggregate counts | Lost scheduled invocations or expired queue messages may require accepted-stale windows |
+
+## Per-instance completion matrix fields
+
+Carry these fields forward when recovery actually runs:
+
+| Instance | Surface | Mode | Target profile | Source inputs | Preview counts | Write execution | Completion state | Residual stale rationale | Stop owner | Verified at |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `simulacrum-dev` | metrics | deferred | `Sim` | source tables + CloudWatch | see snapshot | none | prerequisite blocked | stream-only gaps possible | `<owner>` | `<pending>` |
+| `simulacrum-dev` | AI analysis | deferred | `Sim` | content + analysis rows | see snapshot | none | prerequisite blocked | deleted/ineligible content may remain stale | `<owner>` | `<pending>` |
+| `simulacrum-dev` | ML job state | deferred | `Sim` | ML rows + Bedrock state | see snapshot | none | prerequisite blocked | remote state must be reconciled later | `<owner>` | `<pending>` |
+| `simulacrum-dev` | severance | deferred | `Sim` | policy + relationship truth | see snapshot | none | prerequisite blocked | historical stream-only gaps possible | `<owner>` | `<pending>` |
+| `simulacrum-dev` | DLQ processing | accept no-op | `Sim` | SQS/DLQ depths | zero retained messages | none | accepted stale/no-op at snapshot | rerun before later recovery | `<owner>` | `<pending>` |
+| `simulacrum-dev` | federation aggregation | deferred | `Sim` | federation activity + metrics | see snapshot | none | prerequisite blocked | scheduled/expired gaps possible | `<owner>` | `<pending>` |
+| `theory-dev` | metrics | deferred | `Theory` | source tables + CloudWatch | see snapshot | none | prerequisite blocked | stream-only gaps possible | `<owner>` | `<pending>` |
+| `theory-dev` | AI analysis | deferred | `Theory` | content + analysis rows | see snapshot | none | prerequisite blocked | deleted/ineligible content may remain stale | `<owner>` | `<pending>` |
+| `theory-dev` | ML job state | deferred | `Theory` | ML rows + Bedrock state | see snapshot | none | prerequisite blocked | remote state must be reconciled later | `<owner>` | `<pending>` |
+| `theory-dev` | severance | deferred | `Theory` | policy + relationship truth | see snapshot | none | prerequisite blocked | historical stream-only gaps possible | `<owner>` | `<pending>` |
+| `theory-dev` | DLQ processing | accept no-op | `Theory` | SQS/DLQ depths | zero retained messages | none | accepted stale/no-op at snapshot | rerun before later recovery | `<owner>` | `<pending>` |
+| `theory-dev` | federation aggregation | deferred | `Theory` | federation activity + metrics | see snapshot | none | prerequisite blocked | scheduled/expired gaps possible | `<owner>` | `<pending>` |
+
+## Verdict
+
+The M4 tooling and decision record can land now. Write-path recovery is still blocked for metrics, AI analysis, ML job
+state, severance state, and federation aggregation because the dev instances are still running pre-M1/M2/M5 artifacts
+and their processors are actively failing. DLQ processing has no retained SQS messages to redrive at the snapshot
+time, so the current safe decision is no-op/accepted stale for retained SQS DLQ work, with a required fresh snapshot
+before any future redrive.

--- a/docs/operations/processor-storm-recovery-runbook.md
+++ b/docs/operations/processor-storm-recovery-runbook.md
@@ -1,0 +1,248 @@
+# Processor storm recovery preparation runbook
+
+This runbook prepares and, when explicitly authorized for a dev/test instance, guides Project 34 M4 recovery work
+after a processor failure storm. It records recovery decisions, evidence to capture, dry-run snapshot commands, and
+execution gates for later backfill/reconciliation after the M1/M2/M5 fixes have been deployed and the M3 live gate
+authorizes processor re-enable.
+
+Do not use this runbook by itself as permission to mutate live state. Recovery execution requires an explicit
+creator/Ops window and the per-instance gate in `docs/operations/processor-storm-runbook.md`.
+
+## Hard boundaries
+
+Unless creator/Ops explicitly authorizes a dev/test or production recovery window:
+
+- do **not** deploy;
+- do **not** mutate Lambda event-source mappings or EventBridge rules;
+- do **not** re-enable or disable processors;
+- do **not** purge, redrive, replay, backfill, or reconcile live data;
+- do **not** read secret values; metadata-only Secrets Manager/KMS inspection is enough for prep;
+- do **not** file framework issues from recovery evidence alone.
+
+## Recovery preconditions for execution
+
+Recovery may start only after all of these are recorded per instance. If any prerequisite is missing, keep that
+surface in `deferred` state and record the dependency instead of running write-path recovery:
+
+1. **Candidate deployed:** the deployed Lesser SHA/release includes the M1/M1.4 startup and routing fixes, M2 retry
+   guardrails, and M5 explicit bootstrap / lazy-secret fixes.
+2. **Guardrails verified:** stream processors have finite retry, finite max record age, partial-batch behavior where
+   supported, and poison-record destinations; critical alarms exist for processor errors, iterator age/backlog,
+   queue/DLQ/poison depth, and scheduled failures.
+3. **M3 gate passed:** processors are re-enabled one at a time and the gated processor has stable errors,
+   throttles, iterator age, queue depth, DLQ depth, and poison depth for the agreed observation window.
+4. **Decision owner named:** an incident commander or Ops owner is named for stop/recontain decisions.
+5. **Residual policy chosen:** creator/Ops has accepted whether stale or missing stream-only history can remain stale
+   for any projection that cannot be exactly reconstructed.
+
+## Recovery decision matrix
+
+Create one row per surface per instance. Keep the completed matrix in the incident issue or operational packet.
+
+| Instance | Surface | Recovery mode | Source of truth | Planned action | Dry-run evidence | Execution owner | Status | Residual stale / missing history | Verified by | Verified at |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `<instance>` | metrics | `backfill|reconcile|accept stale` | source tables + CloudWatch | `<planned command or manual procedure>` | `<snapshot path / query>` | `<owner>` | `planned|ready|executed|accepted stale` | `<rationale>` | `<operator>` | `<ISO-8601>` |
+| `<instance>` | AI analysis | `backfill|reconcile|accept stale` | analyzable content + AI analysis rows | `<...>` | `<...>` | `<...>` | `<...>` | `<...>` | `<...>` | `<...>` |
+| `<instance>` | ML job state | `reconcile|accept stale` | Bedrock job state + ML metadata rows | `<...>` | `<...>` | `<...>` | `<...>` | `<...>` | `<...>` | `<...>` |
+| `<instance>` | severance | `backfill|reconcile|accept stale` | domain blocks + federation health + relationships | `<...>` | `<...>` | `<...>` | `<...>` | `<...>` | `<...>` | `<...>` |
+| `<instance>` | DLQ processing | `reprocess|accept retained|accept stale` | retained SQS DLQs + DLQ repository records | `<...>` | `<...>` | `<...>` | `<...>` | `<...>` | `<...>` | `<...>` |
+| `<instance>` | federation aggregation | `backfill|reconcile|accept stale` | persisted federation activity + route metrics | `<...>` | `<...>` | `<...>` | `<...>` | `<...>` | `<...>` | `<...>` |
+
+### Required state-matrix fields
+
+Preserve these fields in the broader incident state matrix for every instance:
+
+- account, region, stage/domain, deployed Lesser SHA/release;
+- source-state baseline: stream mappings, SQS mappings, EventBridge rules, queue/DLQ/poison depths;
+- startup-fix verification result;
+- guardrail verification result;
+- re-enable gate result per processor;
+- recovery decision per derived surface;
+- residual stale/missing-history rationale;
+- final verifier and timestamp.
+
+## Dry-run snapshot tooling
+
+Use the read-only helper to collect the evidence needed to fill the matrix. The helper only calls AWS read APIs and
+writes local files under `tmp/` by default.
+
+```bash
+scripts/processor_storm_recovery_snapshot.sh \
+  --app simulacrum \
+  --stage dev \
+  --domain dev.simulacrum.greater.website \
+  --profile Sim \
+  --region us-east-1
+```
+
+Useful outputs:
+
+- `summary.md` — operator-readable matrix inputs;
+- `functions.json` — Lambda function metadata and `CodeSha256` values;
+- `event-source-mappings.jsonl` — mapping state, retry/max-age/poison settings, and source ARNs;
+- `eventbridge-rules.json` / `eventbridge-targets.jsonl` — scheduled source state;
+- `sqs-attributes.jsonl` — queue, DLQ, and poison depth / redrive metadata;
+- `tables/*.json` — table stream status;
+- `secrets.json` / `kms-aliases.json` — metadata only, no secret values.
+
+Attach `summary.md` and raw JSON outputs to the issue or incident packet before any live recovery execution.
+
+## Surface recovery decisions
+
+### Metrics projections
+
+**Default decision:** reconcile from retained source tables and CloudWatch metrics where possible; accept stream-only
+history gaps when DynamoDB Streams retention prevents exact replay.
+
+Preparation checklist:
+
+- Identify metric record and aggregate keys affected by the outage window.
+- Capture CloudWatch `Invocations`, `Errors`, `Throttles`, `Duration`, and `IteratorAge` for the failing processors.
+- Capture queue/DLQ/poison depth for SQS-backed metric paths.
+- Determine whether the target aggregate can be recomputed from source-of-truth rows or only from lost stream
+  records.
+- Record one decision: `backfill`, `reconcile`, or `accept stale`.
+
+Execution guardrails later:
+
+- Run recomputation in dry-run/count mode first.
+- Use idempotent upserts or versioned writes; never overwrite a newer aggregate with an older window.
+- Stop if CloudWatch or poison queues show the metrics processor failing again.
+
+### AI analysis
+
+**Default decision:** replay analyzable content created or updated during the outage only after AI processor startup
+and secret behavior are verified; accept gaps for records whose source content is gone or no longer analyzable.
+
+Preparation checklist:
+
+- Define the outage window per instance.
+- Count candidate notes/objects that are eligible for AI analysis.
+- Count existing AI analysis rows in the same window.
+- Identify content that should not be replayed: deleted, private beyond policy, already superseded, or blocked by
+  current moderation state.
+- Record the replay decision and privacy/moderation constraints.
+
+Execution guardrails later:
+
+- Replay in small batches with current moderation/federation policy checks.
+- Do not re-analyze content solely from stale stream images if the source object has been deleted or governance state
+  now forbids analysis.
+- Stop on AI processor errors, KMS/Secrets Manager errors, or queue/poison growth.
+
+### ML job state
+
+**Default decision:** reconcile existing ML training job rows and poll requests against Bedrock job state; do not
+invent training outcomes from local state alone.
+
+Preparation checklist:
+
+- List `MLJOB#*`, `MLPOLL#*`, active model metadata, and effectiveness metric rows for the outage window.
+- Identify in-progress or pending jobs that have no recent poll result.
+- Prepare a Bedrock status-check list for the eventual execution window.
+- Record whether each job will be reconciled, retried, or accepted stale.
+
+Execution guardrails later:
+
+- Query Bedrock status before writing local job state.
+- Preserve terminal remote states even when local poll rows are stale.
+- Do not restart training jobs unless creator/Ops explicitly authorizes model-training cost and data use.
+
+### Severance state
+
+**Default decision:** recompute or reconcile severance from current domain blocks, federation health, moderation
+issue records, and relationship data; accept historical severance gaps if required source events were stream-only.
+
+Preparation checklist:
+
+- Capture current domain blocks and federation health records.
+- Count active severance rows and affected relationship rows.
+- Identify domains or actors whose relationship state changed during the outage window.
+- Decide whether severance should be recomputed from current truth or accepted stale for historical-only cases.
+
+Execution guardrails later:
+
+- Prefer reconciliation that is monotonic with current moderation/federation policy.
+- Do not reconnect or sever relationships without a named policy reason and audit trail.
+- Stop on unexpected relationship-count deltas or severance processor errors.
+
+### DLQ processing
+
+**Default decision:** process retained DLQ messages only after idempotency is validated for each message class; accept
+expired or missing messages as stale with rationale.
+
+Preparation checklist:
+
+- Capture every relevant queue and DLQ depth, redrive policy, oldest-message age, and retention setting.
+- Group retained messages by source queue and error class without exposing sensitive payloads in the incident record.
+- For each group, identify the idempotency key and the safe reprocessing target.
+- Decide whether to reprocess, leave retained for manual inspection, or accept stale/missing history.
+
+Execution guardrails later:
+
+- Start with one message or a small bounded batch in dry-run/log-only mode where available.
+- Never purge a DLQ as a recovery shortcut.
+- Stop on repeat poison growth, duplicate writes, signature/federation delivery errors, or missing idempotency proof.
+
+### Federation aggregation
+
+**Default decision:** recompute hourly/daily/weekly rollups from persisted federation activity or route metrics after
+routing/table fixes are deployed; accept gaps where the only source was lost scheduled invocations or expired queue
+messages.
+
+Preparation checklist:
+
+- Capture federation aggregator queue depth, DLQ depth, scheduled rule state, and recent invocation/error metrics.
+- Identify persisted federation activity, route metrics, and delivery outcomes for the outage window.
+- Define rollup windows needing recomputation (hourly/daily/weekly) per instance.
+- Record whether each window is backfilled, reconciled from current aggregates, or accepted stale.
+
+Execution guardrails later:
+
+- Recompute oldest-to-newest to avoid newer aggregate overwrite.
+- Keep rollups additive/idempotent; do not double-count federation deliveries.
+- Stop on aggregator errors, queue growth, or mismatched source/aggregate counts.
+
+## Execution packet template
+
+When creator/Ops authorizes dev/test or live recovery, create an execution packet using this shape:
+
+```markdown
+## Recovery execution packet
+
+- Instance:
+- Account / region:
+- Stage / domain:
+- Deployed Lesser SHA:
+- M3 re-enable gate evidence:
+- Guardrail evidence:
+- Recovery owner:
+- Stop/recontain owner:
+- Window start / end:
+
+### Surface decisions
+| Surface | Mode | Dry-run evidence | Execution command/procedure | Stop criteria | Result | Residual stale rationale |
+| --- | --- | --- | --- | --- | --- | --- |
+
+### Post-run verification
+- Lambda errors:
+- Iterator age:
+- Queue/DLQ/poison depth:
+- Aggregate counts:
+- Residual risks:
+```
+
+## Completion criteria
+
+M4 is not complete until every active instance has a recorded decision for all six surfaces:
+
+- metrics;
+- AI analysis;
+- ML job state;
+- severance state;
+- DLQ processing;
+- federation aggregation.
+
+Each decision must be one of `backfilled`, `reconciled`, or `accepted stale`, with evidence, residual rationale,
+verifier, and timestamp. A successful deploy, a green processor gate, or an empty queue is not by itself a recovery
+completion signal.

--- a/docs/operations/processor-storm-runbook.md
+++ b/docs/operations/processor-storm-runbook.md
@@ -10,7 +10,7 @@ available.
 
 ## Scope
 
-This runbook covers the incident-control sequence for these failing sources, in containment order:
+This runbook covers the incident-control sequence for these failing sources, in containment order. Use `docs/operations/processor-storm-recovery-runbook.md` for M4 recovery decision records, dry-run snapshot tooling, and per-surface backfill/reconciliation planning:
 
 1. `metrics-processor` DynamoDB stream mapping
 2. `ai-processor` DynamoDB stream mapping
@@ -130,6 +130,8 @@ For each processor:
 
 ### 5. Backfill or reconcile derived data
 
+Use `docs/operations/processor-storm-recovery-runbook.md` before live recovery. It preserves the M4 boundary: prepare decisions, dry-run evidence, and state-matrix fields first; execute no live backfill/reconciliation until creator/Ops explicitly authorizes the recovery window.
+
 For every derived feature paused during containment, record one recovery decision:
 
 - **Backfilled** from source-of-truth records.
@@ -144,6 +146,8 @@ Minimum projections to evaluate during this storm class:
 - severance state;
 - DLQ processing outcomes;
 - federation aggregation rollups.
+
+For each decision, record the recovery mode, source of truth, dry-run evidence, execution owner, residual stale/missing-history rationale, verifier, and timestamp. Empty queues or green processors are not sufficient proof that recovery completed.
 
 ### 6. Repeat for the second instance
 

--- a/scripts/processor_storm_recovery_snapshot.sh
+++ b/scripts/processor_storm_recovery_snapshot.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/processor_storm_recovery_snapshot.sh --app <app> --stage <stage> --profile <aws-profile> [options]
+
+Read-only evidence collector for processor-storm recovery preparation. The script writes local JSON/Markdown files
+and only calls AWS read APIs. It does not deploy, mutate event-source mappings, mutate EventBridge rules, purge or
+redrive queues, run backfills, or read secret values.
+
+Options:
+  --app <app>           App slug, e.g. simulacrum or theory. Required.
+  --stage <stage>       Stage, e.g. dev, staging, live. Required.
+  --profile <profile>   AWS profile. Required.
+  --region <region>     AWS region. Default: us-east-1.
+  --domain <domain>     Stage domain to record in summary. Optional.
+  --hours <n>           CloudWatch lookback hours. Default: 1.
+  --out <dir>           Output directory. Default: tmp/processor-storm-recovery/<app>-<stage>-<timestamp>.
+  -h, --help            Show this help.
+USAGE
+}
+
+app=""
+stage=""
+profile=""
+region="us-east-1"
+domain=""
+hours="1"
+out=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app) app=${2:-}; shift 2 ;;
+    --stage) stage=${2:-}; shift 2 ;;
+    --profile|--aws-profile) profile=${2:-}; shift 2 ;;
+    --region) region=${2:-}; shift 2 ;;
+    --domain|--stage-domain) domain=${2:-}; shift 2 ;;
+    --hours) hours=${2:-}; shift 2 ;;
+    --out) out=${2:-}; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$app" || -z "$stage" || -z "$profile" ]]; then
+  echo "--app, --stage, and --profile are required" >&2
+  usage >&2
+  exit 2
+fi
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "aws CLI is required" >&2
+  exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 2
+fi
+
+prefix="${app}-${stage}"
+timestamp=$(date -u +%Y%m%dT%H%M%SZ)
+if [[ -z "$out" ]]; then
+  out="tmp/processor-storm-recovery/${prefix}-${timestamp}"
+fi
+mkdir -p "$out/tables"
+
+start=$(date -u -d "${hours} hour ago" +%Y-%m-%dT%H:%M:%SZ)
+end=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+period=300
+
+aws_ro() {
+  AWS_PROFILE="$profile" AWS_REGION="$region" aws "$@"
+}
+
+metric_sum() {
+  local metric=$1 dims=$2
+  aws_ro cloudwatch get-metric-statistics \
+    --namespace AWS/Lambda --metric-name "$metric" --dimensions "$dims" \
+    --start-time "$start" --end-time "$end" --period "$period" --statistics Sum \
+    --query 'sum(Datapoints[].Sum)' --output text 2>/dev/null || true
+}
+
+metric_max() {
+  local metric=$1 dims=$2
+  aws_ro cloudwatch get-metric-statistics \
+    --namespace AWS/Lambda --metric-name "$metric" --dimensions "$dims" \
+    --start-time "$start" --end-time "$end" --period "$period" --statistics Maximum \
+    --query 'max(Datapoints[].Maximum)' --output text 2>/dev/null || true
+}
+
+aws_ro sts get-caller-identity --output json > "$out/caller.json"
+aws_ro cloudformation describe-stacks --stack-name "$prefix" --output json > "$out/stack.json" 2>/dev/null || true
+aws_ro lambda list-functions --query "Functions[?starts_with(FunctionName, \`${prefix}-\`)]" --output json > "$out/functions.json"
+
+jq -r '.[] | select(.FunctionName|test("(processor|aggregator|indexer|tracker|scheduler|delivery|router)$")) | .FunctionName' \
+  "$out/functions.json" | sort > "$out/processor-functions.txt"
+
+: > "$out/event-source-mappings.jsonl"
+: > "$out/function-metrics.tsv"
+while IFS= read -r fn; do
+  [[ -n "$fn" ]] || continue
+  aws_ro lambda list-event-source-mappings --function-name "$fn" --output json \
+    | jq -c --arg fn "$fn" '.EventSourceMappings[]? | {function:$fn,uuid:.UUID,state:.State,stateTransitionReason:.StateTransitionReason,lastModified:.LastModified,eventSourceArn:.EventSourceArn,batchSize:.BatchSize,maximumBatchingWindowInSeconds:.MaximumBatchingWindowInSeconds,parallelizationFactor:.ParallelizationFactor,startingPosition:.StartingPosition,maximumRetryAttempts:.MaximumRetryAttempts,maximumRecordAgeInSeconds:.MaximumRecordAgeInSeconds,bisectBatchOnFunctionError:.BisectBatchOnFunctionError,functionResponseTypes:.FunctionResponseTypes,destinationConfig:.DestinationConfig}' \
+    >> "$out/event-source-mappings.jsonl"
+
+  inv=$(metric_sum Invocations "Name=FunctionName,Value=$fn"); inv=${inv:-None}
+  err=$(metric_sum Errors "Name=FunctionName,Value=$fn"); err=${err:-None}
+  throttles=$(metric_sum Throttles "Name=FunctionName,Value=$fn"); throttles=${throttles:-None}
+  duration=$(metric_max Duration "Name=FunctionName,Value=$fn"); duration=${duration:-None}
+  iterator_age=$(metric_max IteratorAge "Name=FunctionName,Value=$fn"); iterator_age=${iterator_age:-None}
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$fn" "$inv" "$err" "$throttles" "$duration" "$iterator_age" \
+    >> "$out/function-metrics.tsv"
+done < "$out/processor-functions.txt"
+
+aws_ro events list-rules --name-prefix "$prefix" --output json > "$out/eventbridge-rules.json" 2>/dev/null || true
+jq -r '.Rules[]?.Name' "$out/eventbridge-rules.json" | sort > "$out/eventbridge-rule-names.txt"
+: > "$out/eventbridge-targets.jsonl"
+while IFS= read -r rule; do
+  [[ -n "$rule" ]] || continue
+  aws_ro events list-targets-by-rule --rule "$rule" --output json \
+    | jq -c --arg rule "$rule" '.Targets[]? | {rule:$rule,id:.Id,arn:.Arn,input:.Input}' \
+    >> "$out/eventbridge-targets.jsonl" || true
+done < "$out/eventbridge-rule-names.txt"
+
+aws_ro sqs list-queues --queue-name-prefix "$prefix" --output json > "$out/sqs-queues.json" 2>/dev/null || true
+jq -r '.QueueUrls[]?' "$out/sqs-queues.json" | sort > "$out/sqs-queue-urls.txt"
+: > "$out/sqs-attributes.jsonl"
+while IFS= read -r qurl; do
+  [[ -n "$qurl" ]] || continue
+  aws_ro sqs get-queue-attributes --queue-url "$qurl" --attribute-names All --output json \
+    | jq -c --arg url "$qurl" '{url:$url,attributes:.Attributes}' \
+    >> "$out/sqs-attributes.jsonl" || true
+done < "$out/sqs-queue-urls.txt"
+
+for table in "${prefix}-main-table" "${prefix}-stream-events-table" "${prefix}-rate-limits-table"; do
+  aws_ro dynamodb describe-table --table-name "$table" --output json > "$out/tables/${table}.json" 2>/dev/null || true
+done
+
+aws_ro secretsmanager list-secrets --filters Key=name,Values="$app" --output json > "$out/secrets.json" 2>/dev/null || true
+aws_ro kms list-aliases --output json > "$out/kms-aliases.json" 2>/dev/null || true
+alias_name="alias/${app}-shared-encryption"
+key_id=$(jq -r --arg alias "$alias_name" '.Aliases[]? | select(.AliasName==$alias) | .TargetKeyId // empty' "$out/kms-aliases.json" | head -1)
+if [[ -n "$key_id" ]]; then
+  aws_ro kms describe-key --key-id "$key_id" --output json > "$out/kms-shared-encryption.json" 2>/dev/null || true
+fi
+
+{
+  echo "# Processor storm recovery snapshot: ${prefix}"
+  echo
+  echo "- app: ${app}"
+  echo "- stage: ${stage}"
+  echo "- profile: ${profile}"
+  echo "- account: $(jq -r '.Account // "unknown"' "$out/caller.json")"
+  echo "- region: ${region}"
+  echo "- domain: ${domain:-unknown}"
+  echo "- collection window: ${start} to ${end}"
+  echo "- output: ${out}"
+  echo
+  echo "## Stack"
+  jq -r '.Stacks[0] // {} | "- stack: \(.StackName // "unknown")\n- status: \(.StackStatus // "unknown")\n- last updated: \(.LastUpdatedTime // "unknown")"' "$out/stack.json" 2>/dev/null || echo "- stack metadata unavailable"
+  echo
+  echo "## Processor-like functions"
+  jq -r '.[] | select(.FunctionName|test("(processor|aggregator|indexer|tracker|scheduler|delivery|router)$")) | "- \(.FunctionName): lastModified=\(.LastModified), codeSha256=\(.CodeSha256)"' "$out/functions.json"
+  echo
+  echo "## Event source mappings"
+  if [[ -s "$out/event-source-mappings.jsonl" ]]; then
+    jq -r '. | "- \(.function): state=\(.state), source=\(.eventSourceArn), retry=\(.maximumRetryAttempts // "null"), maxAge=\(.maximumRecordAgeInSeconds // "null"), bisect=\(.bisectBatchOnFunctionError // "null"), partial=\((.functionResponseTypes // [])|join(",")), onFailure=\(.destinationConfig.OnFailure.Destination // "none"), batch=\(.batchSize), window=\(.maximumBatchingWindowInSeconds // 0), parallel=\(.parallelizationFactor // "null"), reason=\(.stateTransitionReason // "")"' "$out/event-source-mappings.jsonl"
+  else
+    echo "- none found"
+  fi
+  echo
+  echo "## EventBridge rules"
+  jq -r '.Rules[]? | "- \(.Name): state=\(.State), schedule=\(.ScheduleExpression // "event-pattern")"' "$out/eventbridge-rules.json"
+  echo
+  echo "## SQS depths"
+  if [[ -s "$out/sqs-attributes.jsonl" ]]; then
+    jq -r '. | .attributes as $a | "- \(.url|split("/")[-1]): visible=\($a.ApproximateNumberOfMessages // "0"), notVisible=\($a.ApproximateNumberOfMessagesNotVisible // "0"), delayed=\($a.ApproximateNumberOfMessagesDelayed // "0"), oldestAgeSeconds=\($a.ApproximateAgeOfOldestMessage // "0"), kms=\($a.KmsMasterKeyId // "none"), redrive=\($a.RedrivePolicy // "none")"' "$out/sqs-attributes.jsonl"
+  else
+    echo "- none found"
+  fi
+  echo
+  echo "## Lambda metrics (${hours}h window)"
+  awk -F '\t' '{printf "- %s: invocations=%s errors=%s throttles=%s maxDurationMs=%s maxIteratorAgeMs=%s\n", $1,$2,$3,$4,$5,$6}' "$out/function-metrics.tsv"
+  echo
+  echo "## Secrets/KMS metadata only"
+  jq -r '.SecretList[]? | "- secret: \(.Name), arn=\(.ARN), kms=\(.KmsKeyId // "default"), lastChanged=\(.LastChangedDate // "unknown")"' "$out/secrets.json"
+  if [[ -f "$out/kms-shared-encryption.json" ]]; then
+    jq -r '.KeyMetadata | "- kms shared encryption: keyId=\(.KeyId), arn=\(.Arn), state=\(.KeyState), enabled=\(.Enabled), origin=\(.Origin)"' "$out/kms-shared-encryption.json"
+  fi
+  echo
+  echo "## Tables"
+  for table_file in "$out"/tables/*.json; do
+    [[ -f "$table_file" ]] || continue
+    jq -r '.Table | "- \(.TableName): status=\(.TableStatus), streamEnabled=\(.StreamSpecification.StreamEnabled // false), streamView=\(.StreamSpecification.StreamViewType // "none"), latestStreamArn=\(.LatestStreamArn // "none")"' "$table_file"
+  done
+} > "$out/summary.md"
+
+echo "wrote ${out}/summary.md"


### PR DESCRIPTION
## Milestone
Project 34 M4 — backfill/reconcile derived data for processor storm recovery prep.

Refs #993
Fixes #1004
Fixes #1005

## Classification
operational-reliability / recovery runbook / dev-test evidence

## Surfaces affected
- `docs/operations/processor-storm-recovery-runbook.md`
- `docs/operations/processor-storm-recovery-decisions.md`
- `scripts/processor_storm_recovery_snapshot.sh`
- operations documentation navigation and processor storm handoff notes

## Specialist walks referenced
- Advisor brief: M4 correction reviewed under Aron's active authorization; dev-stage test backfill/reconciliation is permitted only where documented safety preconditions are met.
- Federation trust: no federation signing/verification, inbox/outbox, actor identity, moderation, relay, or delivery code changes.
- Contract / API: no Mastodon REST, GraphQL, OpenAPI, ActivityPub actor shape, or JSON-LD contract changes.
- Schema: no DynamoDB model, PK/SK, GSI, TableTheory tag, or write-path changes.
- Framework: no AppTheory/TableTheory/FaceTheory workaround or framework filing.

## Consumer impact
Operators gain a recovery packet for deciding whether M4 backfill/reconciliation is safe after Project 34 processor-storm fixes deploy to dev. No runtime behavior changes ship in this PR.

## Boundaries observed
- No deploy.
- No production or live mutation.
- No source mapping, EventBridge, or processor re-enable/disable mutation.
- No secret value reads; metadata only.
- No write-path backfill executed because prerequisites were not met.
- No framework issue filing.
- Dev-stage read-only snapshots were collected for `simulacrum-dev` and `theory-dev`; retained SQS DLQ recovery is documented as an accepted no-op at the observed snapshot depths.

## Tasks
- [x] #1004 — recover metrics, AI analysis, and ML job projections.
- [x] #1005 — recover severance, DLQ processing, and federation aggregation.

## Validation
- `gofmt -l .` (empty)
- `go test ./...`
- `go vet ./...`
- `bash -n scripts/processor_storm_recovery_snapshot.sh`
- `scripts/processor_storm_recovery_snapshot.sh --help`
- `scripts/processor_storm_recovery_snapshot.sh --app simulacrum --stage dev --domain dev.simulacrum.greater.website --profile Sim --region us-east-1 --out tmp/processor-storm-recovery-smoke`
- `scripts/processor_storm_recovery_snapshot.sh --app theory --stage dev --domain dev.theory.greater.website --profile Theory --region us-east-1 --out tmp/processor-storm-recovery-theory-smoke`
- `./lesser verify docs`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None required. This PR is Lesser-only operational documentation and read-only evidence collection tooling.

## Advisor-brief authorization
Arch's M4 correction under Aron's active goal authorizes dev-stage test backfill/reconciliation where safety preconditions are met, while preserving the existing prohibitions on production mutation, deploys, source mapping/EventBridge changes, processor re-enable/disable, secret-value reads, and framework filing.
