### PR TITLE
chore: update Theory Cloud pins

### DIFF
--- a/cmd/lesser/client_install_test.go
+++ b/cmd/lesser/client_install_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 const testFaceTheoryDependency = "https://github.com/theory-cloud/FaceTheory/releases/download/" +
-	"v3.1.2/theory-cloud-facetheory-3.1.2.tgz"
+	"v3.2.2/theory-cloud-facetheory-3.2.2.tgz"
 
 func testFaceTheoryPackageJSON(name string) string {
 	return `{"name":"` + name + `","version":"1.2.3","dependencies":{"@theory-cloud/facetheory":"` +

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -21,11 +21,11 @@ Current state:
 ## Theory Cloud framework baseline
 
 The current deployable baseline consumes the latest released Theory Cloud framework line that was evaluated on
-2026-05-16:
+2026-05-18:
 
-- AppTheory `v1.6.0` in the Go runtime and CDK app.
+- AppTheory `v1.7.0` in the Go runtime and CDK app.
 - TableTheory `v1.8.3` in the Go runtime.
-- FaceTheory `v3.1.2` as the recommended client-app dependency in `docs/guides/CLIENT_APP_GUIDE.md`.
+- FaceTheory `v3.2.2` as the recommended client-app dependency in `docs/guides/CLIENT_APP_GUIDE.md`.
 
 Deploy implications:
 

--- a/docs/guides/CLIENT_APP_GUIDE.md
+++ b/docs/guides/CLIENT_APP_GUIDE.md
@@ -74,7 +74,7 @@ Contract requirements:
   ```json
   {
     "dependencies": {
-      "@theory-cloud/facetheory": "https://github.com/theory-cloud/FaceTheory/releases/download/v3.1.2/theory-cloud-facetheory-3.1.2.tgz"
+      "@theory-cloud/facetheory": "https://github.com/theory-cloud/FaceTheory/releases/download/v3.2.2/theory-cloud-facetheory-3.2.2.tgz"
     }
   }
   ```

--- a/docs/planning/theory-cloud-framework-leverage-roadmap.md
+++ b/docs/planning/theory-cloud-framework-leverage-roadmap.md
@@ -1,7 +1,7 @@
 # Theory Cloud Framework Leverage Roadmap
 
-Status: Phase 4 docs closeout in progress; Phases 0 through 3b are merged to `main` (updated 2026-05-16)
-Current closeout branch: `codex/issue-975-framework-docs`
+Status: Phase 4 docs closeout in progress; Phases 0 through 3b are merged to `main`; framework pins refreshed on 2026-05-18
+Current maintenance focus: 2026-05-18 AppTheory / FaceTheory pin refresh.
 
 ## Reported need
 
@@ -14,7 +14,7 @@ moving to the next milestone. Aron additionally authorized work requested by Arc
 
 | Phase | Issue / PR | Status | Landed outcome |
 | --- | --- | --- | --- |
-| Phase 0 dependency/security baseline | #968 / #976 | Merged | AppTheory `v1.6.0`, TableTheory `v1.8.3`, FaceTheory `v3.1.2` guidance, auth UI dependency remediation, CDK asset-root canonicalization. |
+| Phase 0 dependency/security baseline + 2026-05-18 pin refresh | #968 / #976 + maintenance refresh | Merged / in progress | Initial AppTheory `v1.6.0` and FaceTheory `v3.1.2` guidance refreshed to AppTheory `v1.7.0`, TableTheory remains `v1.8.3`, FaceTheory guidance refreshed to `v3.2.2`; auth UI dependency remediation and CDK asset-root canonicalization remain intact. |
 | Phase 1a TableTheory Lambda client semantics | #969 / #977 | Merged | `NewLambdaOptimizedClient` now uses TableTheory Lambda-optimized timeout behavior with tests proving context/deadline handling. |
 | Phase 1b AppTheory invocation-context threading | #970 / #978 | Merged | Import-processor SQS handling now scopes TableTheory repository access to the AppTheory event context deadline via `WithLambdaTimeout`; the cold-start client remains initialized once and is rebound per invocation. |
 | Phase 2a strict route proof | #971 / #979 | Merged | WebFinger route registration uses AppTheory strict registration with route-parity tests. |
@@ -37,24 +37,24 @@ moving to the next milestone. Aron additionally authorized work requested by Arc
 
 ### Upstream framework facts verified
 
-- AppTheory latest stable release/tag: `v1.6.0`.
+- AppTheory latest stable release/tag: `v1.7.0`.
   - Relevant capabilities: AppSync Lambda resolver support, strict route registration helpers, multi-language CDK/jsii
     constructs including `AppTheoryFunction`, `AppTheoryFunctionAlarms`, `AppTheoryQueueProcessor`,
     `AppTheorySsrSite`, `AppTheoryPathRoutedFrontend`, and existing Rest API / queue / table constructs.
 - TableTheory latest stable release/tag: `v1.8.3`.
   - Relevant capabilities: Lambda timeout configuration and hardening, encrypted batch retry fixes, audit/security guard
     hardening, pointer `omitempty` preservation.
-- FaceTheory latest stable release: `v3.1.2`.
+- FaceTheory latest stable release: `v3.2.2`.
   - Relevant capabilities: dependency pin alignment and Svelte vulnerable peer range exclusions.
-- There is no newer stable framework release beyond the pins already applied on
-  `chore/framework-deps-2026-05-16`.
+- There is no newer stable framework release beyond the pins applied by the 2026-05-18 AppTheory / FaceTheory
+  refresh.
 
 ### What is definitely true in lesser today
 
-- `main` pins:
-  - root `go.mod`: AppTheory `v1.6.0`, TableTheory `v1.8.3`;
-  - `infra/cdk/go.mod`: AppTheory `v1.6.0`, AWS CDK Go `v2.254.0`, jsii runtime `v1.129.0`;
-  - FaceTheory client-install tests/docs: `v3.1.2` GitHub release asset;
+- post-refresh pins:
+  - root `go.mod`: AppTheory `v1.7.0`, TableTheory `v1.8.3`;
+  - `infra/cdk/go.mod`: AppTheory `v1.7.0`, AWS CDK Go `v2.254.0`, jsii runtime `v1.129.0`;
+  - FaceTheory client-install tests/docs: `v3.2.2` GitHub release asset;
   - auth UI: Astro `6.3.3`, Svelte `5.55.7`, devalue override `5.8.1`.
 - The baseline already fixed one CDK/jsii surfaced issue by canonicalizing `LambdaAssetRoot` to an absolute path
   before `Code_FromAsset`.
@@ -105,11 +105,11 @@ local adoption proceeds.
    - Verification: introduce a local registration wrapper and targeted route-registration test for one surface before
      expanding.
 3. **AppTheory CDK `AppTheoryFunction` / alarms may reduce custom Lambda construct drift.**
-   - Evidence: v1.6.0 publishes Go jsii bindings for `AppTheoryFunction` and `AppTheoryFunctionAlarms`; lesser still
+   - Evidence: v1.7.0 publishes Go jsii bindings for `AppTheoryFunction` and `AppTheoryFunctionAlarms`; lesser still
      creates functions directly with native AWS CDK.
    - Verification: synth a representative function behind tests and compare generated CloudFormation for function name,
      architecture, runtime, timeout, memory, role, env, asset path, DLQ, and permissions before broader migration.
-4. **FaceTheory v3.1.2 is best consumed as guidance/provenance, not a hard client-app gate inside lesser.**
+4. **FaceTheory v3.2.2 is best consumed as guidance/provenance, not a hard client-app gate inside lesser.**
    - Evidence: `lesser client install` validates that a FaceTheory dependency exists; enforcing an exact dependency URL
      would break local workspace/client development.
    - Verification: docs/tests are enough in lesser; any client-app enforcement belongs in client repos or a non-blocking
@@ -197,7 +197,7 @@ Dependency-maintenance, operational-reliability, framework-consumption, docs. Po
 - Strict AppTheory route registration is adopted for selected surfaces without OpenAPI/GraphQL/federation route drift.
 - CDK function construct adoption either lands with template-parity proof or produces a framework-feedback signal instead
   of a local workaround.
-- FaceTheory v3.1.2 guidance remains backward-compatible for client app authors.
+- FaceTheory v3.2.2 guidance remains backward-compatible for client app authors.
 
 ### Specialist routing
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -18,9 +18,9 @@ This checklist is for maintainers preparing a release/deployable build.
 ## Theory Cloud framework baseline
 
 - [ ] Confirm release notes name the pinned framework baseline:
-  - AppTheory `v1.6.0`
+  - AppTheory `v1.7.0`
   - TableTheory `v1.8.3`
-  - FaceTheory `v3.1.2` for client-app guidance
+  - FaceTheory `v3.2.2` for client-app guidance
 - [ ] Confirm auth UI dependency remediation remains intact (`cd auth-ui && corepack pnpm audit --prod` when touching
       `auth-ui/package.json` or `auth-ui/pnpm-lock.yaml`)
 - [ ] Confirm the auth UI CSP freshness gate passed before release asset build. It verifies the CloudFront CSP hash

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/shopspring/decimal v1.4.0
 	github.com/spruceid/siwe-go v0.2.1
 	github.com/stretchr/testify v1.11.1
-	github.com/theory-cloud/apptheory v1.6.0
+	github.com/theory-cloud/apptheory v1.7.0
 	github.com/theory-cloud/tabletheory v1.8.3
 	github.com/tyler-smith/go-bip32 v1.0.0
 	github.com/tyler-smith/go-bip39 v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -255,8 +255,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/supranational/blst v0.3.16 h1:bTDadT+3fK497EvLdWRQEjiGnUtzJ7jjIUMF0jqwYhE=
 github.com/supranational/blst v0.3.16/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
-github.com/theory-cloud/apptheory v1.6.0 h1:SgVMnqiO+XJBG0m8U44LFG/la5qTwHu6/3XgtPqbDzo=
-github.com/theory-cloud/apptheory v1.6.0/go.mod h1:IWDWb5NChOgaChceWniCEQF0PQ+ddMSca7hpv18ljFY=
+github.com/theory-cloud/apptheory v1.7.0 h1:CC0fmSi8GlCwu1jKMlamyr3R97+AZ/WquU7XgtkfQ14=
+github.com/theory-cloud/apptheory v1.7.0/go.mod h1:IWDWb5NChOgaChceWniCEQF0PQ+ddMSca7hpv18ljFY=
 github.com/theory-cloud/tabletheory v1.8.3 h1:LJeON7t8YTjKr8BXWV3GEe7qk69F6ElE4R2XBS1y9IY=
 github.com/theory-cloud/tabletheory v1.8.3/go.mod h1:YV1toSvmQE6J1YhIvQcEkbz5PKygDfrLrCgG+wRTZ3U=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=

--- a/infra/cdk/go.mod
+++ b/infra/cdk/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/constructs-go/constructs/v10 v10.6.0
 	github.com/aws/jsii-runtime-go v1.129.0
 	github.com/equaltoai/lesser v1.1.17
-	github.com/theory-cloud/apptheory v1.6.0
+	github.com/theory-cloud/apptheory v1.7.0
 )
 
 require (

--- a/infra/cdk/go.sum
+++ b/infra/cdk/go.sum
@@ -26,8 +26,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/theory-cloud/apptheory v1.6.0 h1:SgVMnqiO+XJBG0m8U44LFG/la5qTwHu6/3XgtPqbDzo=
-github.com/theory-cloud/apptheory v1.6.0/go.mod h1:IWDWb5NChOgaChceWniCEQF0PQ+ddMSca7hpv18ljFY=
+github.com/theory-cloud/apptheory v1.7.0 h1:CC0fmSi8GlCwu1jKMlamyr3R97+AZ/WquU7XgtkfQ14=
+github.com/theory-cloud/apptheory v1.7.0/go.mod h1:IWDWb5NChOgaChceWniCEQF0PQ+ddMSca7hpv18ljFY=
 github.com/yuin/goldmark v1.7.16 h1:n+CJdUxaFMiDUNnWC3dMWCIQJSkxH4uz3ZwQBkAlVNE=
 github.com/yuin/goldmark v1.7.16/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
## Milestone
Theory Cloud pin refresh — update AppTheory and FaceTheory guidance to the latest stable releases verified on 2026-05-18.

## Classification
Dependency-maintenance / framework-consumption / docs.

## Surfaces affected
- Root Go runtime dependency pin: AppTheory `v1.6.0` → `v1.7.0`
- CDK Go dependency pin: AppTheory `v1.6.0` → `v1.7.0`
- FaceTheory client-install guidance/test fixture: `v3.1.2` → `v3.2.2`
- Operator release/deployment docs for the framework baseline

## Specialist walks referenced
- Federation trust: not touched; no signing, inbox/outbox, delivery, relay, moderation-gate, or actor-identity behavior change.
- Contract / API: not touched; no Mastodon REST, GraphQL, ActivityPub actor object, JSON-LD, or error-shape change.
- Schema: not touched; no DynamoDB PK/SK/GSI/TableTheory tag/version change.
- Framework: idiomatic dependency pin refresh only; no local framework patch or workaround.

## Consumer impact
- Operators get an updated AppTheory runtime/CDK baseline once this lands and is released/deployed through the normal staged path.
- FaceTheory client app authors see the recommended release-asset URL updated to `v3.2.2`; `lesser client install` still only requires that `@theory-cloud/facetheory` is present, so local workspace development remains supported.
- Managed release artifact shape is unchanged.

## Tasks
- [x] Verify latest stable AppTheory and FaceTheory releases.
- [x] Bump root and CDK AppTheory pins to `v1.7.0`.
- [x] Refresh FaceTheory docs/test fixture to `v3.2.2`.
- [x] Run framework/dependency validation.

## Validation
- `go test ./cmd/lesser -run ClientInstall`
- `go test ./...`
- `go vet ./...`
- `(cd infra/cdk && go test ./...)`
- `(cd infra/cdk && go vet ./...)`
- `gofmt -l .` (empty)
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`
- `CDK_DEFAULT_ACCOUNT=000000000000 CDK_DEFAULT_REGION=us-east-1 cdk synth --context app=lesser --context stage=dev --context baseDomain=example.com --context hostedZoneId=Z000000000000000000000`

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
None required for this Lesser-only pin/guidance refresh. FaceTheory source code is not changed here.
