### PR TITLE
fix: default federation aggregation schedule

### DIFF
--- a/cmd/federation-aggregator/main.go
+++ b/cmd/federation-aggregator/main.go
@@ -279,20 +279,27 @@ func (p *FederationAggregatorProcessor) handleEventBridgeEvent(ctx context.Conte
 
 	// Parse the aggregation configuration from the event
 	var aggEvent AggregationEvent
-	if err := json.Unmarshal(event.Detail, &aggEvent); err != nil {
-		// Default to hourly aggregation for scheduled events
-		now := event.Time
-		if now.IsZero() {
-			now = time.Now()
-		}
-		aggEvent = AggregationEvent{
-			Type:      "hourly",
-			StartTime: now.Add(-1 * time.Hour).Truncate(time.Hour),
-			EndTime:   now.Truncate(time.Hour),
-		}
+	if err := json.Unmarshal(event.Detail, &aggEvent); err != nil || aggregationEventNeedsDefault(aggEvent) {
+		aggEvent = defaultScheduledAggregationEvent(event)
 	}
 
 	return p.handleAggregationEvent(ctx, aggEvent)
+}
+
+func aggregationEventNeedsDefault(event AggregationEvent) bool {
+	return strings.TrimSpace(event.Type) == "" || event.StartTime.IsZero() || event.EndTime.IsZero()
+}
+
+func defaultScheduledAggregationEvent(event events.EventBridgeEvent) AggregationEvent {
+	now := event.Time
+	if now.IsZero() {
+		now = time.Now()
+	}
+	return AggregationEvent{
+		Type:      "hourly",
+		StartTime: now.Add(-1 * time.Hour).Truncate(time.Hour),
+		EndTime:   now.Truncate(time.Hour),
+	}
 }
 
 // handleAggregationEvent processes federation aggregation events

--- a/cmd/federation-aggregator/round12_federation_aggregator_test.go
+++ b/cmd/federation-aggregator/round12_federation_aggregator_test.go
@@ -27,6 +27,7 @@ type fakeFederationActivityRepo struct {
 	recentCalls int
 	listCalls   int
 	infoCalls   int
+	recentSince time.Time
 
 	recent []*models.FederationActivity
 	list   []*models.FederationActivity
@@ -37,8 +38,9 @@ type fakeFederationActivityRepo struct {
 	infoErr   error
 }
 
-func (f *fakeFederationActivityRepo) GetRecentActivities(context.Context, time.Time, int) ([]*models.FederationActivity, error) {
+func (f *fakeFederationActivityRepo) GetRecentActivities(_ context.Context, since time.Time, _ int) ([]*models.FederationActivity, error) {
 	f.recentCalls++
+	f.recentSince = since
 	if f.recentErr != nil {
 		return nil, f.recentErr
 	}
@@ -278,10 +280,11 @@ func TestHandleEventBridgeEvent_DefaultsHourly_Round12(t *testing.T) {
 	db.On("Model", mock.Anything).Return(query)
 	query.On("Create").Return(nil)
 
+	repo := &fakeFederationActivityRepo{}
 	p := &FederationAggregatorProcessor{
 		db:                           db,
 		logger:                       zap.NewNop(),
-		federationActivityRepository: &fakeFederationActivityRepo{},
+		federationActivityRepository: repo,
 		lambdaCtx: &common.LambdaContext{
 			Config:      &config.Config{Region: "us-east-1", AWSAccountID: "123"},
 			Logger:      zap.NewNop(),
@@ -294,6 +297,28 @@ func TestHandleEventBridgeEvent_DefaultsHourly_Round12(t *testing.T) {
 		Detail: []byte("{not-json"),
 	}
 	require.NoError(t, p.handleEventBridgeEvent(context.Background(), event))
+	require.Equal(t, time.Date(2024, 1, 1, 11, 0, 0, 0, time.UTC), repo.recentSince)
+}
+
+func TestHandleEventBridgeEvent_DefaultsEmptyScheduledDetail_Round12(t *testing.T) {
+	repo := &fakeFederationActivityRepo{}
+	p := &FederationAggregatorProcessor{
+		logger:                       zap.NewNop(),
+		federationActivityRepository: repo,
+		lambdaCtx: &common.LambdaContext{
+			Config:      &config.Config{Region: "us-east-1", AWSAccountID: "123"},
+			Logger:      zap.NewNop(),
+			AWSServices: &awsInit.AWSServices{Config: aws.Config{Region: "us-east-1"}},
+		},
+	}
+
+	event := events.EventBridgeEvent{
+		Time:   time.Date(2024, 1, 1, 12, 34, 0, 0, time.UTC),
+		Detail: []byte("{}"),
+	}
+	require.NoError(t, p.handleEventBridgeEvent(context.Background(), event))
+	require.Equal(t, 1, repo.recentCalls)
+	require.Equal(t, time.Date(2024, 1, 1, 11, 0, 0, 0, time.UTC), repo.recentSince)
 }
 
 func TestHandleAggregationEvent_FullPath_Round12(t *testing.T) {


### PR DESCRIPTION
## Milestone
Project 34 re-enable follow-up — fix federation-aggregator scheduled EventBridge handling observed after re-enabling gated dev/test sources.

## Classification
Operational-reliability / async-processor / federation-adjacent aggregation.

## Surfaces affected
- `cmd/federation-aggregator` scheduled EventBridge path only.
- No HTTP Signature, actor identity, delivery signing, inbox verification, Mastodon REST, GraphQL, ActivityPub actor shape, or DynamoDB schema changes.

## Reported / observed symptom
After Aron authorized re-enabling all Project 34 gated dev/test sources, both `simulacrum-dev-federation-aggregator` and `theory-dev-federation-aggregator` failed scheduled EventBridge invocations. Logs showed normal scheduled events with empty aggregation detail producing zero-valued aggregation windows:

- `type=""`
- `start_time="0001-01-01T00:00:00Z"`
- `end_time="0001-01-01T00:00:00Z"`

## Root cause
`json.Unmarshal(event.Detail, &aggEvent)` succeeds for EventBridge scheduled detail `{}`, so the previous fallback only covered invalid JSON. Empty scheduled detail therefore reached storage with a zero-valued `AggregationEvent` instead of the intended default hourly window.

## Change
- Default scheduled events when detail is invalid **or incomplete** (`type`, `startTime`, or `endTime` missing/zero).
- Extract default-window helpers.
- Add regression coverage for empty scheduled detail `{}` and assert the hourly `since` window used by repository reads.

## Validation
- `go test ./cmd/federation-aggregator`
- `gofmt -l .` (empty)
- `go test ./...`
- `go vet ./...`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`

## Operational evidence
Re-enable artifacts are under `tmp/project34-reenable-20260518T165311Z/` locally. Final state verifier shows all gated sources enabled on `simulacrum-dev` and `theory-dev`; first post-enable metric window showed zero errors for metrics/ai/ml-training/severance/dlq and scheduled federation-aggregator failures that this PR addresses.

## Stage rollout plan
- [ ] Merged to main
- [ ] Deploy to dev/test instances
- [ ] Verify federation-aggregator scheduled invocation no longer fails with empty detail
- [ ] Confirm no new errors on gated processor set

## Cross-repo coordination
None.
