### PR TITLE
fix: bind indexer models to main table

### DIFF
--- a/cmd/search-indexer/main.go
+++ b/cmd/search-indexer/main.go
@@ -167,6 +167,50 @@ type IndexableContent struct {
 	CreatedAt time.Time
 }
 
+type searchIndexRecord struct {
+	PK          string   `theorydb:"pk"`
+	SK          string   `theorydb:"sk"`
+	Type        string   `json:"type"`
+	ContentID   string   `json:"content_id"`
+	ContentType string   `json:"content_type"`
+	Text        string   `json:"text"`
+	TextLower   string   `json:"text_lower"`
+	ActorID     string   `json:"actor_id"`
+	Tags        []string `json:"tags"`
+	Language    string   `json:"language"`
+	WordCount   int      `json:"word_count"`
+	CreatedAt   string   `json:"created_at"`
+	IndexedAt   string   `json:"indexed_at"`
+	TTL         int64    `theorydb:"ttl"`
+}
+
+func (searchIndexRecord) TableName() string { return models.MainTableName }
+
+type searchActorIndex struct {
+	PK        string `theorydb:"pk"`
+	SK        string `theorydb:"sk"`
+	Type      string `json:"type"`
+	ContentID string `json:"content_id"`
+	Text      string `json:"text"`
+	CreatedAt string `json:"created_at"`
+	TTL       int64  `theorydb:"ttl"`
+}
+
+func (searchActorIndex) TableName() string { return models.MainTableName }
+
+type searchTagIndex struct {
+	PK        string `theorydb:"pk"`
+	SK        string `theorydb:"sk"`
+	Type      string `json:"type"`
+	Tag       string `json:"tag"`
+	ContentID string `json:"content_id"`
+	ActorID   string `json:"actor_id"`
+	CreatedAt string `json:"created_at"`
+	TTL       int64  `theorydb:"ttl"`
+}
+
+func (searchTagIndex) TableName() string { return models.MainTableName }
+
 func (si *SearchIndexer) extractIndexableContent(record events.DynamoDBEventRecord) (*IndexableContent, error) {
 	var item struct {
 		PK          string   `theorydb:"pk"`
@@ -243,22 +287,7 @@ func (si *SearchIndexer) extractIndexableContent(record events.DynamoDBEventReco
 
 func (si *SearchIndexer) createSearchIndex(ctx context.Context, content *IndexableContent) error {
 	// Create search index record with full-text search capabilities
-	searchRecord := struct {
-		PK          string   `theorydb:"pk"`
-		SK          string   `theorydb:"sk"`
-		Type        string   `json:"type"`
-		ContentID   string   `json:"content_id"`
-		ContentType string   `json:"content_type"`
-		Text        string   `json:"text"`
-		TextLower   string   `json:"text_lower"` // For case-insensitive search
-		ActorID     string   `json:"actor_id"`
-		Tags        []string `json:"tags"`
-		Language    string   `json:"language"`
-		WordCount   int      `json:"word_count"`
-		CreatedAt   string   `json:"created_at"`
-		IndexedAt   string   `json:"indexed_at"`
-		TTL         int64    `theorydb:"ttl"`
-	}{
+	searchRecord := searchIndexRecord{
 		PK:          fmt.Sprintf("SEARCH#%s", content.Type),
 		SK:          fmt.Sprintf("CONTENT#%s#%s", content.CreatedAt.Format(common.DateFormat), content.ID),
 		Type:        "SearchIndex",
@@ -294,15 +323,7 @@ func (si *SearchIndexer) createSearchIndex(ctx context.Context, content *Indexab
 func (si *SearchIndexer) createAdditionalIndexes(ctx context.Context, content *IndexableContent) error {
 	// Create actor-specific index for searching user's content
 	if content.ActorID != "" {
-		actorIndex := struct {
-			PK        string `theorydb:"pk"`
-			SK        string `theorydb:"sk"`
-			Type      string `json:"type"`
-			ContentID string `json:"content_id"`
-			Text      string `json:"text"`
-			CreatedAt string `json:"created_at"`
-			TTL       int64  `theorydb:"ttl"`
-		}{
+		actorIndex := searchActorIndex{
 			PK:        fmt.Sprintf("SEARCH#ACTOR#%s", content.ActorID),
 			SK:        fmt.Sprintf("CONTENT#%s", content.ID),
 			Type:      "ActorSearchIndex",
@@ -320,16 +341,7 @@ func (si *SearchIndexer) createAdditionalIndexes(ctx context.Context, content *I
 	// Create tag-based indexes
 	for _, tag := range content.Tags {
 		if tag != "" {
-			tagIndex := struct {
-				PK        string `theorydb:"pk"`
-				SK        string `theorydb:"sk"`
-				Type      string `json:"type"`
-				Tag       string `json:"tag"`
-				ContentID string `json:"content_id"`
-				ActorID   string `json:"actor_id"`
-				CreatedAt string `json:"created_at"`
-				TTL       int64  `theorydb:"ttl"`
-			}{
+			tagIndex := searchTagIndex{
 				PK:        fmt.Sprintf("SEARCH#TAG#%s", strings.ToLower(tag)),
 				SK:        fmt.Sprintf("CONTENT#%s", content.ID),
 				Type:      "TagSearchIndex",

--- a/cmd/search-indexer/round12_search_indexer_test.go
+++ b/cmd/search-indexer/round12_search_indexer_test.go
@@ -18,6 +18,7 @@ import (
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	dynamormCore "github.com/theory-cloud/tabletheory/pkg/core"
 	dynamormmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
+	ttmodel "github.com/theory-cloud/tabletheory/pkg/model"
 	"go.uber.org/zap"
 )
 
@@ -62,6 +63,23 @@ func setField(out any, name string, value any) {
 	case reflect.Slice:
 		f.Set(reflect.ValueOf(value))
 	}
+}
+
+func requireSearchModelBindsToMainTable(t *testing.T, modelValue any) {
+	t.Helper()
+
+	registry := ttmodel.NewRegistry()
+	require.NoError(t, registry.Register(modelValue))
+	metadata, err := registry.GetMetadata(modelValue)
+	require.NoError(t, err)
+	require.Equal(t, models.MainTableName, metadata.TableName)
+	require.NotEqual(t, "s", metadata.TableName)
+}
+
+func TestSearchIndexerWriteModels_BindToMainTable_Round12(t *testing.T) {
+	requireSearchModelBindsToMainTable(t, &searchIndexRecord{})
+	requireSearchModelBindsToMainTable(t, &searchActorIndex{})
+	requireSearchModelBindsToMainTable(t, &searchTagIndex{})
 }
 
 func TestInitializeSearchIndexer_Round12(t *testing.T) {

--- a/cmd/status-indexer/main.go
+++ b/cmd/status-indexer/main.go
@@ -195,6 +195,61 @@ type statusDetails struct {
 	audienceObserved bool
 }
 
+type statusWordIndex struct {
+	PK        string `theorydb:"pk"`
+	SK        string `theorydb:"sk"`
+	GSI5PK    string `theorydb:"index:gsi5,pk"`
+	GSI5SK    string `theorydb:"index:gsi5,sk"`
+	StatusID  string `json:"status_id"`
+	Word      string `json:"word"`
+	IndexedAt string `json:"indexed_at"`
+	TTL       int64  `theorydb:"ttl"`
+}
+
+func (statusWordIndex) TableName() string { return models.MainTableName }
+
+type statusTagIndex struct {
+	PK        string `theorydb:"pk"`
+	SK        string `theorydb:"sk"`
+	GSI6PK    string `theorydb:"index:gsi6,pk"`
+	GSI6SK    string `theorydb:"index:gsi6,sk"`
+	StatusID  string `json:"status_id"`
+	Tag       string `json:"tag"`
+	IndexedAt string `json:"indexed_at"`
+	TTL       int64  `theorydb:"ttl"`
+}
+
+func (statusTagIndex) TableName() string { return models.MainTableName }
+
+type statusAuthorIndex struct {
+	PK        string `theorydb:"pk"`
+	SK        string `theorydb:"sk"`
+	GSI7PK    string `theorydb:"index:gsi7,pk"`
+	GSI7SK    string `theorydb:"index:gsi7,sk"`
+	StatusID  string `json:"status_id"`
+	AuthorID  string `json:"author_id"`
+	IndexedAt string `json:"indexed_at"`
+	TTL       int64  `theorydb:"ttl"`
+}
+
+func (statusAuthorIndex) TableName() string { return models.MainTableName }
+
+type statusTrendingHashtag struct {
+	PK            string    `theorydb:"pk"`
+	SK            string    `theorydb:"sk"`
+	GSI6PK        string    `theorydb:"index:gsi6,pk"`
+	GSI6SK        string    `theorydb:"index:gsi6,sk"`
+	Tag           string    `json:"tag"`
+	Date          string    `json:"date"`
+	Hour          string    `json:"hour"`
+	EngagementSum float64   `json:"engagement_sum"`
+	PostCount     int       `json:"post_count"`
+	LastUpdated   time.Time `json:"last_updated"`
+	TTL           int64     `theorydb:"ttl"`
+}
+
+func (statusTrendingHashtag) TableName() string { return models.MainTableName }
+
 // shouldProcessEvent checks if the event should be processed
 func (si *StatusIndexer) shouldProcessEvent(record events.DynamoDBEventRecord) bool {
 	return record.EventName == "INSERT" || record.EventName == "MODIFY"
@@ -462,16 +517,7 @@ func (si *StatusIndexer) processStatusEvent(ctx context.Context, statusID, conte
 
 // indexWord indexes a word for search using DynamORM
 func (si *StatusIndexer) indexWord(ctx context.Context, word, statusID string, published time.Time) error {
-	wordIndex := struct {
-		PK        string `theorydb:"pk"`
-		SK        string `theorydb:"sk"`
-		GSI5PK    string `theorydb:"index:gsi5,pk"`
-		GSI5SK    string `theorydb:"index:gsi5,sk"`
-		StatusID  string `json:"status_id"`
-		Word      string `json:"word"`
-		IndexedAt string `json:"indexed_at"`
-		TTL       int64  `theorydb:"ttl"`
-	}{
+	wordIndex := statusWordIndex{
 		PK:        fmt.Sprintf("WORD#%s#%s", word, statusID),
 		SK:        "INDEX",
 		GSI5PK:    fmt.Sprintf("WORD#%s", word),
@@ -487,16 +533,7 @@ func (si *StatusIndexer) indexWord(ctx context.Context, word, statusID string, p
 
 // indexHashtag indexes a hashtag for search using DynamORM
 func (si *StatusIndexer) indexHashtag(ctx context.Context, tag, statusID string, published time.Time) error {
-	tagIndex := struct {
-		PK        string `theorydb:"pk"`
-		SK        string `theorydb:"sk"`
-		GSI6PK    string `theorydb:"index:gsi6,pk"`
-		GSI6SK    string `theorydb:"index:gsi6,sk"`
-		StatusID  string `json:"status_id"`
-		Tag       string `json:"tag"`
-		IndexedAt string `json:"indexed_at"`
-		TTL       int64  `theorydb:"ttl"`
-	}{
+	tagIndex := statusTagIndex{
 		PK:        fmt.Sprintf("TAG#%s#%s", tag, statusID),
 		SK:        "INDEX",
 		GSI6PK:    fmt.Sprintf("TAG#%s", tag),
@@ -512,16 +549,7 @@ func (si *StatusIndexer) indexHashtag(ctx context.Context, tag, statusID string,
 
 // indexByAuthor indexes a status by author using DynamORM
 func (si *StatusIndexer) indexByAuthor(ctx context.Context, authorID, statusID string, published time.Time) error {
-	authorIndex := struct {
-		PK        string `theorydb:"pk"`
-		SK        string `theorydb:"sk"`
-		GSI7PK    string `theorydb:"index:gsi7,pk"`
-		GSI7SK    string `theorydb:"index:gsi7,sk"`
-		StatusID  string `json:"status_id"`
-		AuthorID  string `json:"author_id"`
-		IndexedAt string `json:"indexed_at"`
-		TTL       int64  `theorydb:"ttl"`
-	}{
+	authorIndex := statusAuthorIndex{
 		PK:        fmt.Sprintf("AUTHOR#%s#%s", authorID, statusID),
 		SK:        "INDEX",
 		GSI7PK:    fmt.Sprintf("AUTHOR#%s", authorID),
@@ -716,19 +744,7 @@ func (si *StatusIndexer) updateTrendingHashtag(ctx context.Context, tag string, 
 	date := time.Now().Format(common.DateFormat)
 	hour := time.Now().Format("2006-01-02-15") // Hour-level granularity
 
-	trendingHashtag := struct {
-		PK            string    `theorydb:"pk"`
-		SK            string    `theorydb:"sk"`
-		GSI6PK        string    `theorydb:"index:gsi6,pk"`
-		GSI6SK        string    `theorydb:"index:gsi6,sk"`
-		Tag           string    `json:"tag"`
-		Date          string    `json:"date"`
-		Hour          string    `json:"hour"`
-		EngagementSum float64   `json:"engagement_sum"`
-		PostCount     int       `json:"post_count"`
-		LastUpdated   time.Time `json:"last_updated"`
-		TTL           int64     `theorydb:"ttl"`
-	}{
+	trendingHashtag := statusTrendingHashtag{
 		PK:            fmt.Sprintf("TRENDING_TAG#%s#%s", tag, hour),
 		SK:            "METRICS",
 		GSI6PK:        fmt.Sprintf("TRENDING_TAGS#%s", date),
@@ -743,19 +759,7 @@ func (si *StatusIndexer) updateTrendingHashtag(ctx context.Context, tag string, 
 	}
 
 	// Try to get existing record first and update it
-	var existing struct {
-		PK            string    `theorydb:"pk"`
-		SK            string    `theorydb:"sk"`
-		GSI6PK        string    `theorydb:"index:gsi6,pk"`
-		GSI6SK        string    `theorydb:"index:gsi6,sk"`
-		Tag           string    `json:"tag"`
-		Date          string    `json:"date"`
-		Hour          string    `json:"hour"`
-		EngagementSum float64   `json:"engagement_sum"`
-		PostCount     int       `json:"post_count"`
-		LastUpdated   time.Time `json:"last_updated"`
-		TTL           int64     `theorydb:"ttl"`
-	}
+	var existing statusTrendingHashtag
 
 	err := si.db.WithContext(ctx).Model(&existing).
 		Where("PK", "=", trendingHashtag.PK).

--- a/cmd/status-indexer/round12_status_indexer_test.go
+++ b/cmd/status-indexer/round12_status_indexer_test.go
@@ -20,6 +20,7 @@ import (
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	dynamormCore "github.com/theory-cloud/tabletheory/pkg/core"
 	dynamormmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
+	ttmodel "github.com/theory-cloud/tabletheory/pkg/model"
 	"go.uber.org/zap"
 )
 
@@ -69,6 +70,24 @@ func newMockDB(t *testing.T) (*dynamormmocks.MockDB, *dynamormmocks.MockQuery) {
 	q.On("First", mock.Anything).Return(errors.New("not found"))
 
 	return db, q
+}
+
+func requireStatusModelBindsToMainTable(t *testing.T, modelValue any) {
+	t.Helper()
+
+	registry := ttmodel.NewRegistry()
+	require.NoError(t, registry.Register(modelValue))
+	metadata, err := registry.GetMetadata(modelValue)
+	require.NoError(t, err)
+	require.Equal(t, models.MainTableName, metadata.TableName)
+	require.NotEqual(t, "s", metadata.TableName)
+}
+
+func TestStatusIndexerSideIndexModels_BindToMainTable_Round12(t *testing.T) {
+	requireStatusModelBindsToMainTable(t, &statusWordIndex{})
+	requireStatusModelBindsToMainTable(t, &statusTagIndex{})
+	requireStatusModelBindsToMainTable(t, &statusAuthorIndex{})
+	requireStatusModelBindsToMainTable(t, &statusTrendingHashtag{})
 }
 
 func TestNewStatusIndexer_Round12(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replaces `cmd/status-indexer` anonymous TableTheory write models with named models that implement `TableName() string { return models.MainTableName }`.
- Covers the word, hashtag, author, and trending hashtag read/update/create side-index paths.
- Applies the same bounded fix to same-class `cmd/search-indexer` write models because the audit found the pattern there too and the change is trivial.
- Adds registry regression tests proving these write models bind to `models.MainTableName` and do not resolve to `"s"`.

## Root cause

TableTheory v1.8.3 resolves model table names from `TableName()` when present, otherwise from the Go type name. Anonymous structs have no useful type name and resolve to `"s"`, matching the observed DynamoDB validation error. These processors were using anonymous structs for production persistence writes.

## Schema / contract impact

- PK/SK patterns are unchanged.
- GSI population is unchanged; existing GSI5/GSI6/GSI7 tags are preserved.
- Attribute names, types, and TTL semantics are unchanged.
- No Mastodon REST, GraphQL, ActivityPub actor shape, or federation signing/verification contract changes.
- No deploy, live mutation, backfill, or TableTheory/framework filing is bundled.

## Validation

- `go test ./cmd/status-indexer`
- `go test ./cmd/search-indexer`
- `go test ./cmd/status-indexer ./cmd/search-indexer`
- `go test ./...`
- `git diff --check`
- `go build -o lesser ./cmd/lesser && ./lesser build lambdas && ./lesser verify ci`

## Arch acceptance notes

This is the bounded direct fix requested by Arch for the status-indexer table-binding issue. Side-index failure semantics remain warning-only in this patch.