### PR TITLE
feat: add agent-usable DM conversation reads

### DIFF
--- a/cmd/api/handlers/conversations.go
+++ b/cmd/api/handlers/conversations.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 
 	apimodels "github.com/equaltoai/lesser/cmd/api/models"
@@ -39,6 +41,40 @@ func (h *Handler) convertConversationToAPIWithPrefetch(ctx context.Context, conv
 	}
 
 	return apiConversation, nil
+}
+
+func (h *Handler) convertConversationWithMessagesToAPI(ctx context.Context, result *conversations.ConversationWithMessages, viewerUsername string) (apimodels.ConversationDetail, error) {
+	if result == nil || result.Conversation == nil {
+		return apimodels.ConversationDetail{Messages: []apimodels.Status{}}, nil
+	}
+
+	prefetch := h.loadConversationAPIPrefetch(ctx, []*storageModels.Conversation{result.Conversation}, viewerUsername)
+	apiConversation, err := h.convertConversationToAPIWithPrefetch(ctx, result.Conversation, viewerUsername, prefetch)
+	if err != nil {
+		return apimodels.ConversationDetail{}, err
+	}
+
+	detail := apimodels.ConversationDetail{
+		Conversation: apiConversation,
+		Messages:     []apimodels.Status{},
+	}
+	if result.Messages == nil {
+		return detail, nil
+	}
+
+	statusCtx := conversationAPIStatusContext(h, prefetch)
+	for _, message := range result.Messages.Items {
+		if message == nil {
+			continue
+		}
+		apiStatus, err := h.convertStorageStatusToAPIWithContext(statusCtx, message, viewerUsername)
+		if err != nil || apiStatus == nil {
+			continue
+		}
+		detail.Messages = append(detail.Messages, *apiStatus)
+	}
+
+	return detail, nil
 }
 
 // HandleGetConversationsLift retrieves all conversations for the authenticated user
@@ -95,6 +131,51 @@ func (h *Handler) HandleGetConversationsLift(ctx *apptheory.Context) (*apptheory
 	return resp, nil
 }
 
+// HandleGetConversationLift retrieves one conversation and recent viewer-visible messages.
+func (h *Handler) HandleGetConversationLift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	conversationID := ctx.Param("id")
+	if err := common.ValidateRequiredParam("conversation_id", conversationID); err != nil {
+		return common.RespondBadRequest(ctx, "missing conversation id")
+	}
+
+	username, err := h.authenticateUser(ctx, []string{auth.ScopeRead})
+	if err != nil {
+		if isInsufficientScopeError(err) {
+			return h.respondInsufficientScope(ctx)
+		}
+		return h.respondUnauthorized(ctx)
+	}
+
+	limit := h.parseConversationLimit(ctx)
+	maxID := queryValue(ctx, "max_id")
+
+	result, err := h.registry.Conversations().GetConversation(ctx.Context(), &conversations.GetConversationQuery{
+		ConversationID: conversationID,
+		ViewerID:       username,
+		Pagination: interfaces.PaginationOptions{
+			Limit:  limit,
+			Cursor: maxID,
+		},
+	})
+	if err != nil {
+		return h.respondConversationReadError(ctx, "failed to get conversation", err)
+	}
+
+	response, err := h.convertConversationWithMessagesToAPI(ctx.Context(), result, username)
+	if err != nil {
+		return common.RespondInternalServerError(ctx)
+	}
+
+	resp, err := okJSON(response)
+	if err != nil {
+		return nil, err
+	}
+	if result != nil && result.Messages != nil && result.Messages.HasMore && result.Messages.NextCursor != "" {
+		h.setConversationMessagesPaginationHeader(resp, "/api/v1/conversations/"+url.PathEscape(conversationID), result.Messages.NextCursor, limit)
+	}
+	return resp, nil
+}
+
 // parseConversationLimit parses the limit query parameter
 func (h *Handler) parseConversationLimit(ctx *apptheory.Context) int {
 	limitStr := queryValue(ctx, "limit")
@@ -116,6 +197,30 @@ func (h *Handler) setConversationPaginationHeader(resp *apptheory.Response, curs
 		nextURL += fmt.Sprintf("&limit=%d", limit)
 	}
 	setHeader(resp, "Link", fmt.Sprintf(`<%s>; rel="next"`, nextURL))
+}
+
+func (h *Handler) setConversationMessagesPaginationHeader(resp *apptheory.Response, path string, cursor string, limit int) {
+	if err := common.ValidateRequiredParam("cursor", cursor); err != nil {
+		return
+	}
+
+	nextURL := fmt.Sprintf("%s%s?max_id=%s", h.cfg.BaseURL(), path, url.QueryEscape(cursor))
+	if limit != 20 {
+		nextURL += fmt.Sprintf("&limit=%d", limit)
+	}
+	setHeader(resp, "Link", fmt.Sprintf(`<%s>; rel="next"`, nextURL))
+}
+
+func (h *Handler) respondConversationReadError(ctx *apptheory.Context, message string, err error) (*apptheory.Response, error) {
+	if errors.Is(err, conversations.ErrConversationNotFound) ||
+		errors.Is(err, conversations.ErrNotConversationParticipant) ||
+		strings.Contains(strings.ToLower(err.Error()), "not found") ||
+		strings.Contains(strings.ToLower(err.Error()), "not a participant") ||
+		strings.Contains(strings.ToLower(err.Error()), "access denied") {
+		return common.RespondNotFound(ctx, "conversation")
+	}
+	h.logger.Error(message, zap.Error(err))
+	return common.RespondInternalServerError(ctx)
 }
 
 // HandleDeleteConversationLift removes a conversation from the user's list

--- a/cmd/api/handlers/conversations.go
+++ b/cmd/api/handlers/conversations.go
@@ -55,8 +55,11 @@ func (h *Handler) convertConversationWithMessagesToAPI(ctx context.Context, resu
 	}
 
 	detail := apimodels.ConversationDetail{
-		Conversation: apiConversation,
-		Messages:     []apimodels.Status{},
+		ID:         apiConversation.ID,
+		Unread:     apiConversation.Unread,
+		Accounts:   apiConversation.Accounts,
+		LastStatus: apiConversation.LastStatus,
+		Messages:   []apimodels.Status{},
 	}
 	if result.Messages == nil {
 		return detail, nil
@@ -176,6 +179,51 @@ func (h *Handler) HandleGetConversationLift(ctx *apptheory.Context) (*apptheory.
 	return resp, nil
 }
 
+// HandleLookupConversationByCounterpartLift retrieves one 1:1 conversation by exact counterpart.
+func (h *Handler) HandleLookupConversationByCounterpartLift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	counterpart := queryValue(ctx, "counterpart")
+	if err := common.ValidateRequiredParam("counterpart", counterpart); err != nil {
+		return common.RespondBadRequest(ctx, "missing counterpart")
+	}
+
+	username, err := h.authenticateUser(ctx, []string{auth.ScopeRead})
+	if err != nil {
+		if isInsufficientScopeError(err) {
+			return h.respondInsufficientScope(ctx)
+		}
+		return h.respondUnauthorized(ctx)
+	}
+
+	limit := h.parseConversationLimit(ctx)
+	maxID := queryValue(ctx, "max_id")
+
+	result, err := h.registry.Conversations().LookupConversationByCounterpart(ctx.Context(), &conversations.LookupConversationByCounterpartQuery{
+		ViewerID:    username,
+		Counterpart: counterpart,
+		Pagination: interfaces.PaginationOptions{
+			Limit:  limit,
+			Cursor: maxID,
+		},
+	})
+	if err != nil {
+		return h.respondConversationReadError(ctx, "failed to lookup conversation by counterpart", err)
+	}
+
+	response, err := h.convertConversationWithMessagesToAPI(ctx.Context(), result, username)
+	if err != nil {
+		return common.RespondInternalServerError(ctx)
+	}
+
+	resp, err := okJSON(response)
+	if err != nil {
+		return nil, err
+	}
+	if result != nil && result.Messages != nil && result.Messages.HasMore && result.Messages.NextCursor != "" {
+		h.setConversationLookupPaginationHeader(resp, counterpart, result.Messages.NextCursor, limit)
+	}
+	return resp, nil
+}
+
 // parseConversationLimit parses the limit query parameter
 func (h *Handler) parseConversationLimit(ctx *apptheory.Context) int {
 	limitStr := queryValue(ctx, "limit")
@@ -211,9 +259,25 @@ func (h *Handler) setConversationMessagesPaginationHeader(resp *apptheory.Respon
 	setHeader(resp, "Link", fmt.Sprintf(`<%s>; rel="next"`, nextURL))
 }
 
+func (h *Handler) setConversationLookupPaginationHeader(resp *apptheory.Response, counterpart, cursor string, limit int) {
+	if err := common.ValidateRequiredParam("cursor", cursor); err != nil {
+		return
+	}
+
+	values := url.Values{}
+	values.Set("counterpart", counterpart)
+	values.Set("max_id", cursor)
+	if limit != 20 {
+		values.Set("limit", fmt.Sprintf("%d", limit))
+	}
+	nextURL := fmt.Sprintf("%s/api/v1/conversations/lookup?%s", h.cfg.BaseURL(), values.Encode())
+	setHeader(resp, "Link", fmt.Sprintf(`<%s>; rel="next"`, nextURL))
+}
+
 func (h *Handler) respondConversationReadError(ctx *apptheory.Context, message string, err error) (*apptheory.Response, error) {
 	if errors.Is(err, conversations.ErrConversationNotFound) ||
 		errors.Is(err, conversations.ErrNotConversationParticipant) ||
+		errors.Is(err, conversations.ErrConversationMustBeOneToOne) ||
 		strings.Contains(strings.ToLower(err.Error()), "not found") ||
 		strings.Contains(strings.ToLower(err.Error()), "not a participant") ||
 		strings.Contains(strings.ToLower(err.Error()), "access denied") {

--- a/cmd/api/handlers/conversations_get_round12_test.go
+++ b/cmd/api/handlers/conversations_get_round12_test.go
@@ -1,0 +1,121 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	apimodels "github.com/equaltoai/lesser/cmd/api/models"
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/services/conversations"
+	"github.com/equaltoai/lesser/pkg/storage/interfaces"
+	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleGetConversationLift_ReturnsExpandedConversation(t *testing.T) {
+	cfg := round10TestConfig()
+	now := time.Now().UTC()
+	state := &round10QueryState{
+		actorsByUser: map[string]storagemodels.Actor{
+			"bob": {
+				Username: "bob",
+				Actor: &activitypub.Actor{
+					BaseObject:        activitypub.BaseObject{ID: "https://example.com/users/bob", Type: "Person"},
+					PreferredUsername: "bob",
+					Name:              "Bob",
+				},
+			},
+		},
+	}
+	handler, _, _ := round11NewHandler(t, cfg, state)
+
+	handler.registry = &RegistryStub{
+		ConversationsSvc: &ConversationsServiceStub{
+			GetConversationFunc: func(_ context.Context, query *conversations.GetConversationQuery) (*conversations.ConversationWithMessages, error) {
+				require.Equal(t, "alice", query.ViewerID)
+				require.Equal(t, "conv-1", query.ConversationID)
+				require.Equal(t, 5, query.Pagination.Limit)
+				return &conversations.ConversationWithMessages{
+					Conversation: &storagemodels.Conversation{
+						ID:           "conv-1",
+						Participants: []string{"alice", "bob"},
+						LastStatusID: "status-2",
+						Unread:       true,
+					},
+					Messages: &interfaces.PaginatedResult[*storagemodels.Status]{
+						Items: []*storagemodels.Status{
+							{
+								StatusID:       "status-1",
+								AuthorID:       "https://example.com/users/bob",
+								AuthorUsername: "bob",
+								Content:        "hello alice",
+								Visibility:     conversations.VisibilityDirect,
+								ConversationID: "conv-1",
+								PublishedAt:    now.Add(-time.Minute),
+								CreatedAt:      now.Add(-time.Minute),
+								UpdatedAt:      now.Add(-time.Minute),
+							},
+						},
+						HasMore:    true,
+						NextCursor: "cursor-2",
+					},
+				}, nil
+			},
+		},
+	}
+
+	token := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{"read"})
+	ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/conversations/conv-1", map[string]string{
+		"Authorization": "Bearer " + token,
+	}, map[string]string{"limit": "5"}, nil)
+	require.NoError(t, err)
+	ctx.Params["id"] = "conv-1"
+
+	resp := requireStatus(t, http.StatusOK)(handler.HandleGetConversationLift(ctx))
+	require.Contains(t, resp.Headers["link"][0], "/api/v1/conversations/conv-1?max_id=cursor-2&limit=5")
+
+	var body apimodels.ConversationDetail
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Equal(t, "conv-1", body.ID)
+	require.True(t, body.Unread)
+	require.Len(t, body.Accounts, 1)
+	require.Equal(t, "bob", body.Accounts[0].Username)
+	require.Len(t, body.Messages, 1)
+	require.Equal(t, "status-1", body.Messages[0].ID)
+}
+
+func TestHandleGetConversationLift_DeniesUnavailableConversation(t *testing.T) {
+	cfg := round10TestConfig()
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "not found", err: conversations.ErrConversationNotFound},
+		{name: "not participant", err: conversations.ErrNotConversationParticipant},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, _, _ := round11NewHandler(t, cfg)
+			handler.registry = &RegistryStub{
+				ConversationsSvc: &ConversationsServiceStub{
+					GetConversationFunc: func(context.Context, *conversations.GetConversationQuery) (*conversations.ConversationWithMessages, error) {
+						return nil, tt.err
+					},
+				},
+			}
+
+			token := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{"read"})
+			ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/conversations/conv-hidden", map[string]string{
+				"Authorization": "Bearer " + token,
+			}, nil, nil)
+			require.NoError(t, err)
+			ctx.Params["id"] = "conv-hidden"
+
+			requireStatus(t, http.StatusNotFound)(handler.HandleGetConversationLift(ctx))
+		})
+	}
+}

--- a/cmd/api/handlers/conversations_get_round12_test.go
+++ b/cmd/api/handlers/conversations_get_round12_test.go
@@ -119,3 +119,102 @@ func TestHandleGetConversationLift_DeniesUnavailableConversation(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleLookupConversationByCounterpartLift_ReturnsExpandedConversation(t *testing.T) {
+	cfg := round10TestConfig()
+	now := time.Now().UTC()
+	handler, _, _ := round11NewHandler(t, cfg, &round10QueryState{
+		actorsByUser: map[string]storagemodels.Actor{
+			"ops": {
+				Username: "ops",
+				Actor: &activitypub.Actor{
+					BaseObject:        activitypub.BaseObject{ID: "https://example.com/users/ops", Type: "Person"},
+					PreferredUsername: "ops",
+					Name:              "Ops",
+				},
+			},
+		},
+	})
+
+	handler.registry = &RegistryStub{
+		ConversationsSvc: &ConversationsServiceStub{
+			LookupConversationByCounterpartFunc: func(_ context.Context, query *conversations.LookupConversationByCounterpartQuery) (*conversations.ConversationWithMessages, error) {
+				require.Equal(t, "alice", query.ViewerID)
+				require.Equal(t, "ops", query.Counterpart)
+				require.Equal(t, 2, query.Pagination.Limit)
+				return &conversations.ConversationWithMessages{
+					Conversation: &storagemodels.Conversation{
+						ID:           "conv-ops",
+						Participants: []string{"alice", "ops"},
+					},
+					Messages: &interfaces.PaginatedResult[*storagemodels.Status]{
+						Items: []*storagemodels.Status{
+							{
+								StatusID:       "status-ops",
+								AuthorID:       "https://example.com/users/ops",
+								AuthorUsername: "ops",
+								Content:        "ack",
+								Visibility:     conversations.VisibilityDirect,
+								ConversationID: "conv-ops",
+								PublishedAt:    now,
+								CreatedAt:      now,
+								UpdatedAt:      now,
+							},
+						},
+						HasMore:    true,
+						NextCursor: "cursor-ops",
+					},
+				}, nil
+			},
+		},
+	}
+
+	token := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{"read"})
+	ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/conversations/lookup", map[string]string{
+		"Authorization": "Bearer " + token,
+	}, map[string]string{"counterpart": "ops", "limit": "2"}, nil)
+	require.NoError(t, err)
+
+	resp := requireStatus(t, http.StatusOK)(handler.HandleLookupConversationByCounterpartLift(ctx))
+	require.Contains(t, resp.Headers["link"][0], "/api/v1/conversations/lookup?")
+	require.Contains(t, resp.Headers["link"][0], "counterpart=ops")
+	require.Contains(t, resp.Headers["link"][0], "max_id=cursor-ops")
+
+	var body apimodels.ConversationDetail
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Equal(t, "conv-ops", body.ID)
+	require.Len(t, body.Messages, 1)
+	require.Equal(t, "status-ops", body.Messages[0].ID)
+}
+
+func TestHandleLookupConversationByCounterpartLift_RequiresCounterpart(t *testing.T) {
+	cfg := round10TestConfig()
+	handler, _, _ := round11NewHandler(t, cfg)
+	token := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{"read"})
+	ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/conversations/lookup", map[string]string{
+		"Authorization": "Bearer " + token,
+	}, nil, nil)
+	require.NoError(t, err)
+
+	requireStatus(t, http.StatusBadRequest)(handler.HandleLookupConversationByCounterpartLift(ctx))
+}
+
+func TestHandleLookupConversationByCounterpartLift_NotFound(t *testing.T) {
+	cfg := round10TestConfig()
+	handler, _, _ := round11NewHandler(t, cfg)
+	handler.registry = &RegistryStub{
+		ConversationsSvc: &ConversationsServiceStub{
+			LookupConversationByCounterpartFunc: func(context.Context, *conversations.LookupConversationByCounterpartQuery) (*conversations.ConversationWithMessages, error) {
+				return nil, conversations.ErrConversationNotFound
+			},
+		},
+	}
+
+	token := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{"read"})
+	ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/conversations/lookup", map[string]string{
+		"Authorization": "Bearer " + token,
+	}, map[string]string{"counterpart": "missing"}, nil)
+	require.NoError(t, err)
+
+	requireStatus(t, http.StatusNotFound)(handler.HandleLookupConversationByCounterpartLift(ctx))
+}

--- a/cmd/api/handlers/service_registry.go
+++ b/cmd/api/handlers/service_registry.go
@@ -70,6 +70,7 @@ type AIService interface {
 // ConversationsService defines the subset of conversation-related operations used by the Lift API
 type ConversationsService interface {
 	DeleteConversation(ctx context.Context, cmd *conversations.DeleteConversationCommand) (*conversations.ConversationResult, error)
+	GetConversation(ctx context.Context, query *conversations.GetConversationQuery) (*conversations.ConversationWithMessages, error)
 	ListConversations(ctx context.Context, query *conversations.ListConversationsQuery) (*conversations.Result, error)
 	MarkConversationRead(ctx context.Context, cmd *conversations.MarkConversationReadCommand) (*conversations.ConversationResult, error)
 	SendDirectMessage(ctx context.Context, cmd *conversations.SendDirectMessageCommand) (*conversations.MessageResult, error)

--- a/cmd/api/handlers/service_registry.go
+++ b/cmd/api/handlers/service_registry.go
@@ -72,6 +72,7 @@ type ConversationsService interface {
 	DeleteConversation(ctx context.Context, cmd *conversations.DeleteConversationCommand) (*conversations.ConversationResult, error)
 	GetConversation(ctx context.Context, query *conversations.GetConversationQuery) (*conversations.ConversationWithMessages, error)
 	ListConversations(ctx context.Context, query *conversations.ListConversationsQuery) (*conversations.Result, error)
+	LookupConversationByCounterpart(ctx context.Context, query *conversations.LookupConversationByCounterpartQuery) (*conversations.ConversationWithMessages, error)
 	MarkConversationRead(ctx context.Context, cmd *conversations.MarkConversationReadCommand) (*conversations.ConversationResult, error)
 	SendDirectMessage(ctx context.Context, cmd *conversations.SendDirectMessageCommand) (*conversations.MessageResult, error)
 }

--- a/cmd/api/handlers/service_registry_stubs_test.go
+++ b/cmd/api/handlers/service_registry_stubs_test.go
@@ -248,6 +248,7 @@ func (s *AIServiceStub) QueueForAnalysis(ctx context.Context, cmd *ai.QueueAnaly
 
 type ConversationsServiceStub struct {
 	DeleteConversationFunc   func(ctx context.Context, cmd *conversations.DeleteConversationCommand) (*conversations.ConversationResult, error)
+	GetConversationFunc      func(ctx context.Context, query *conversations.GetConversationQuery) (*conversations.ConversationWithMessages, error)
 	ListConversationsFunc    func(ctx context.Context, query *conversations.ListConversationsQuery) (*conversations.Result, error)
 	MarkConversationReadFunc func(ctx context.Context, cmd *conversations.MarkConversationReadCommand) (*conversations.ConversationResult, error)
 	SendDirectMessageFunc    func(ctx context.Context, cmd *conversations.SendDirectMessageCommand) (*conversations.MessageResult, error)
@@ -260,6 +261,13 @@ func (s *ConversationsServiceStub) DeleteConversation(ctx context.Context, cmd *
 		return s.DeleteConversationFunc(ctx, cmd)
 	}
 	return nil, missingStub("ConversationsService.DeleteConversation")
+}
+
+func (s *ConversationsServiceStub) GetConversation(ctx context.Context, query *conversations.GetConversationQuery) (*conversations.ConversationWithMessages, error) {
+	if s != nil && s.GetConversationFunc != nil {
+		return s.GetConversationFunc(ctx, query)
+	}
+	return nil, missingStub("ConversationsService.GetConversation")
 }
 
 func (s *ConversationsServiceStub) ListConversations(ctx context.Context, query *conversations.ListConversationsQuery) (*conversations.Result, error) {

--- a/cmd/api/handlers/service_registry_stubs_test.go
+++ b/cmd/api/handlers/service_registry_stubs_test.go
@@ -247,11 +247,12 @@ func (s *AIServiceStub) QueueForAnalysis(ctx context.Context, cmd *ai.QueueAnaly
 }
 
 type ConversationsServiceStub struct {
-	DeleteConversationFunc   func(ctx context.Context, cmd *conversations.DeleteConversationCommand) (*conversations.ConversationResult, error)
-	GetConversationFunc      func(ctx context.Context, query *conversations.GetConversationQuery) (*conversations.ConversationWithMessages, error)
-	ListConversationsFunc    func(ctx context.Context, query *conversations.ListConversationsQuery) (*conversations.Result, error)
-	MarkConversationReadFunc func(ctx context.Context, cmd *conversations.MarkConversationReadCommand) (*conversations.ConversationResult, error)
-	SendDirectMessageFunc    func(ctx context.Context, cmd *conversations.SendDirectMessageCommand) (*conversations.MessageResult, error)
+	DeleteConversationFunc              func(ctx context.Context, cmd *conversations.DeleteConversationCommand) (*conversations.ConversationResult, error)
+	GetConversationFunc                 func(ctx context.Context, query *conversations.GetConversationQuery) (*conversations.ConversationWithMessages, error)
+	ListConversationsFunc               func(ctx context.Context, query *conversations.ListConversationsQuery) (*conversations.Result, error)
+	LookupConversationByCounterpartFunc func(ctx context.Context, query *conversations.LookupConversationByCounterpartQuery) (*conversations.ConversationWithMessages, error)
+	MarkConversationReadFunc            func(ctx context.Context, cmd *conversations.MarkConversationReadCommand) (*conversations.ConversationResult, error)
+	SendDirectMessageFunc               func(ctx context.Context, cmd *conversations.SendDirectMessageCommand) (*conversations.MessageResult, error)
 }
 
 var _ ConversationsService = (*ConversationsServiceStub)(nil)
@@ -275,6 +276,13 @@ func (s *ConversationsServiceStub) ListConversations(ctx context.Context, query 
 		return s.ListConversationsFunc(ctx, query)
 	}
 	return nil, missingStub("ConversationsService.ListConversations")
+}
+
+func (s *ConversationsServiceStub) LookupConversationByCounterpart(ctx context.Context, query *conversations.LookupConversationByCounterpartQuery) (*conversations.ConversationWithMessages, error) {
+	if s != nil && s.LookupConversationByCounterpartFunc != nil {
+		return s.LookupConversationByCounterpartFunc(ctx, query)
+	}
+	return nil, missingStub("ConversationsService.LookupConversationByCounterpart")
 }
 
 func (s *ConversationsServiceStub) MarkConversationRead(ctx context.Context, cmd *conversations.MarkConversationReadCommand) (*conversations.ConversationResult, error) {

--- a/cmd/api/models/conversation.go
+++ b/cmd/api/models/conversation.go
@@ -8,3 +8,10 @@ type Conversation struct {
 	Accounts   []Account `json:"accounts"`
 	LastStatus *Status   `json:"last_status,omitempty"`
 }
+
+// ConversationDetail represents a direct message conversation expanded with
+// the viewer-visible recent messages in that conversation.
+type ConversationDetail struct {
+	Conversation
+	Messages []Status `json:"messages"`
+}

--- a/cmd/api/models/conversation.go
+++ b/cmd/api/models/conversation.go
@@ -12,6 +12,9 @@ type Conversation struct {
 // ConversationDetail represents a direct message conversation expanded with
 // the viewer-visible recent messages in that conversation.
 type ConversationDetail struct {
-	Conversation
-	Messages []Status `json:"messages"`
+	ID         string    `json:"id"`
+	Unread     bool      `json:"unread"`
+	Accounts   []Account `json:"accounts"`
+	LastStatus *Status   `json:"last_status,omitempty"`
+	Messages   []Status  `json:"messages"`
 }

--- a/cmd/api/path_redaction_test.go
+++ b/cmd/api/path_redaction_test.go
@@ -71,3 +71,27 @@ func TestExtractRequestInfoSanitizesPrivateMintConversationPath(t *testing.T) {
 	require.NotContains(t, info.path, "raw-cursor")
 	require.Equal(t, info.method+" "+info.path, info.endpoint)
 }
+
+func TestExtractRequestInfoSanitizesConversationIDPath(t *testing.T) {
+	rawConversationID := "conv-agent-readable"
+	ctx := newTestAppTheoryContext(http.MethodGet, "/api/v1/conversations/"+rawConversationID+"?max_id=raw-cursor")
+
+	info := extractRequestInfo(ctx)
+	require.Equal(t, http.MethodGet, info.method)
+	require.Contains(t, info.path, "/api/v1/conversations/conversation-sha256:")
+	require.NotContains(t, info.path, rawConversationID)
+	require.NotContains(t, info.path, "raw-cursor")
+	require.Equal(t, info.method+" "+info.path, info.endpoint)
+}
+
+func TestExtractRequestInfoSanitizesConversationReadPath(t *testing.T) {
+	rawConversationID := "conv-read-path"
+	ctx := newTestAppTheoryContext(http.MethodPost, "/api/v1/conversations/"+rawConversationID+"/read")
+
+	info := extractRequestInfo(ctx)
+	require.Equal(t, http.MethodPost, info.method)
+	require.Contains(t, info.path, "/api/v1/conversations/conversation-sha256:")
+	require.Contains(t, info.path, "/read")
+	require.NotContains(t, info.path, rawConversationID)
+	require.Equal(t, info.method+" "+info.path, info.endpoint)
+}

--- a/cmd/api/path_redaction_test.go
+++ b/cmd/api/path_redaction_test.go
@@ -95,3 +95,13 @@ func TestExtractRequestInfoSanitizesConversationReadPath(t *testing.T) {
 	require.NotContains(t, info.path, rawConversationID)
 	require.Equal(t, info.method+" "+info.path, info.endpoint)
 }
+
+func TestExtractRequestInfoSanitizesConversationLookupQuery(t *testing.T) {
+	ctx := newTestAppTheoryContext(http.MethodGet, "/api/v1/conversations/lookup?counterpart=ops%40example.com&max_id=raw-cursor")
+
+	info := extractRequestInfo(ctx)
+	require.Equal(t, http.MethodGet, info.method)
+	require.Equal(t, "/api/v1/conversations/lookup", info.path)
+	require.NotContains(t, info.endpoint, "ops")
+	require.NotContains(t, info.endpoint, "raw-cursor")
+}

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -566,6 +566,7 @@ func configureRoutes(app *apptheory.App) {
 
 	// Conversation endpoints (Direct Messages) - always enabled for 100% Mastodon API compatibility
 	app.Get("/api/v1/conversations", apiHandler.HandleGetConversationsLift, requireRead)
+	app.Get("/api/v1/conversations/{id}", apiHandler.HandleGetConversationLift, requireRead)
 	app.Delete("/api/v1/conversations/{id}", apiHandler.HandleDeleteConversationLift, requireWrite)
 	app.Post("/api/v1/conversations/{id}/read", apiHandler.HandleMarkConversationReadLift, requireWrite)
 

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -566,6 +566,7 @@ func configureRoutes(app *apptheory.App) {
 
 	// Conversation endpoints (Direct Messages) - always enabled for 100% Mastodon API compatibility
 	app.Get("/api/v1/conversations", apiHandler.HandleGetConversationsLift, requireRead)
+	app.Get("/api/v1/conversations/lookup", apiHandler.HandleLookupConversationByCounterpartLift, requireRead)
 	app.Get("/api/v1/conversations/{id}", apiHandler.HandleGetConversationLift, requireRead)
 	app.Delete("/api/v1/conversations/{id}", apiHandler.HandleDeleteConversationLift, requireWrite)
 	app.Post("/api/v1/conversations/{id}/read", apiHandler.HandleMarkConversationReadLift, requireWrite)

--- a/cmd/api/testdata/routes_manifest.txt
+++ b/cmd/api/testdata/routes_manifest.txt
@@ -68,6 +68,7 @@ GET /api/v1/auth/webauthn/credentials
 GET /api/v1/blocks
 GET /api/v1/bookmarks
 GET /api/v1/conversations
+GET /api/v1/conversations/lookup
 GET /api/v1/conversations/{id}
 GET /api/v1/custom_emojis
 GET /api/v1/directory

--- a/cmd/api/testdata/routes_manifest.txt
+++ b/cmd/api/testdata/routes_manifest.txt
@@ -68,6 +68,7 @@ GET /api/v1/auth/webauthn/credentials
 GET /api/v1/blocks
 GET /api/v1/bookmarks
 GET /api/v1/conversations
+GET /api/v1/conversations/{id}
 GET /api/v1/custom_emojis
 GET /api/v1/directory
 GET /api/v1/domain_blocks

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -2120,6 +2120,31 @@ components:
             items:
                 $ref: '#/components/schemas/Conversation'
             type: array
+        ConversationDetail:
+            additionalProperties: false
+            properties:
+                accounts:
+                    items:
+                        $ref: '#/components/schemas/Account'
+                    type: array
+                id:
+                    type: string
+                last_status:
+                    anyOf:
+                        - $ref: '#/components/schemas/Status'
+                        - type: "null"
+                messages:
+                    items:
+                        $ref: '#/components/schemas/Status'
+                    type: array
+                unread:
+                    type: boolean
+            required:
+                - accounts
+                - id
+                - messages
+                - unread
+            type: object
         CreateAgentAccessLeaseRequest:
             additionalProperties: false
             properties:
@@ -13817,6 +13842,48 @@ paths:
             x-oauth-scopes:
                 - read
     /api/v1/conversations/{id}:
+        get:
+            operationId: get_api_v1_conversations_by_id
+            tags:
+                - conversations
+            security:
+                - bearerAuth: []
+            parameters:
+                - name: id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - $ref: '#/components/parameters/Limit'
+                - $ref: '#/components/parameters/MaxID'
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ConversationDetail'
+                    headers:
+                        Link:
+                            description: RFC 8288 pagination links for recent messages.
+                            schema:
+                                type: string
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "401":
+                    $ref: '#/components/responses/Unauthorized'
+                "403":
+                    $ref: '#/components/responses/Forbidden'
+                "404":
+                    $ref: '#/components/responses/NotFound'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+            x-lesser-handler: HandleGetConversationLift
+            x-lesser-lambda: api
+            x-lesser-routeSources:
+                - cmd/api/routes.go
+            x-oauth-scopes:
+                - read
         delete:
             operationId: delete_api_v1_conversations_by_id
             tags:
@@ -21149,4 +21216,3 @@ paths:
             x-lesser-lambda: objects
             x-lesser-routeSources:
                 - infra/cdk/inventory/lambdas.go:objects
-

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -2116,10 +2116,6 @@ components:
                 - id
                 - unread
             type: object
-        ConversationList:
-            items:
-                $ref: '#/components/schemas/Conversation'
-            type: array
         ConversationDetail:
             additionalProperties: false
             properties:
@@ -2145,6 +2141,10 @@ components:
                 - messages
                 - unread
             type: object
+        ConversationList:
+            items:
+                $ref: '#/components/schemas/Conversation'
+            type: array
         CreateAgentAccessLeaseRequest:
             additionalProperties: false
             properties:
@@ -13849,13 +13849,13 @@ paths:
             security:
                 - bearerAuth: []
             parameters:
+                - $ref: '#/components/parameters/Limit'
+                - $ref: '#/components/parameters/MaxID'
                 - name: id
                   in: path
                   required: true
                   schema:
                     type: string
-                - $ref: '#/components/parameters/Limit'
-                - $ref: '#/components/parameters/MaxID'
             responses:
                 "200":
                     description: OK
@@ -13957,6 +13957,51 @@ paths:
                 - cmd/api/routes.go
             x-oauth-scopes:
                 - write
+    /api/v1/conversations/lookup:
+        get:
+            operationId: get_api_v1_conversations_lookup
+            tags:
+                - conversations
+            security:
+                - bearerAuth: []
+            parameters:
+                - name: counterpart
+                  in: query
+                  required: true
+                  description: Exact 1:1 direct-message counterpart identifier. Accepts local username, acct value, or actor URL where resolvable.
+                  schema:
+                    type: string
+                    minLength: 1
+                - $ref: '#/components/parameters/Limit'
+                - $ref: '#/components/parameters/MaxID'
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ConversationDetail'
+                    headers:
+                        Link:
+                            description: RFC 8288 pagination links for recent messages.
+                            schema:
+                                type: string
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "401":
+                    $ref: '#/components/responses/Unauthorized'
+                "403":
+                    $ref: '#/components/responses/Forbidden'
+                "404":
+                    $ref: '#/components/responses/NotFound'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+            x-lesser-handler: HandleLookupConversationByCounterpartLift
+            x-lesser-lambda: api
+            x-lesser-routeSources:
+                - cmd/api/routes.go
+            x-oauth-scopes:
+                - read
     /api/v1/custom_emojis:
         get:
             operationId: get_api_v1_custom_emojis
@@ -21216,3 +21261,4 @@ paths:
             x-lesser-lambda: objects
             x-lesser-routeSources:
                 - infra/cdk/inventory/lambdas.go:objects
+

--- a/docs/specs/graphql_coverage.yaml
+++ b/docs/specs/graphql_coverage.yaml
@@ -68,6 +68,11 @@ exemptions:
             - /api/v1/souls/bound/me
             - /api/v1/souls/bound/me/mint-conversations
             - /api/v1/souls/bound/me/mint-conversations/{conversationId}
+    - id: agent_usable_dm_lookup
+      reason: Exact counterpart DM lookup is a REST-only agent primitive for resolving a compact conversation reference without scanning; GraphQL clients can use Query.conversation/Query.conversationMessages once they have the conversation id.
+      match:
+        exact:
+            - /api/v1/conversations/lookup
     - id: canonical_skill_authority
       reason: Canonical skill authority approval, exposure, assignment, effective-resolution, catalog, and bundle-publication APIs are REST-only for Project 21 M3/M4.
       match:
@@ -776,6 +781,17 @@ routes:
       status: covered
       graphql:
         - Query.conversations
+    - method: GET
+      path: /api/v1/conversations/lookup
+      policy: rest_only
+      exemptedBy: agent_usable_dm_lookup
+    - method: GET
+      path: /api/v1/conversations/{id}
+      policy: graphql_required
+      status: covered
+      graphql:
+        - Query.conversation
+        - Query.conversationMessages
     - method: DELETE
       path: /api/v1/conversations/{id}
       policy: graphql_required

--- a/pkg/logging/path_redaction.go
+++ b/pkg/logging/path_redaction.go
@@ -6,7 +6,11 @@ import (
 	"strings"
 )
 
-const privateConversationLogHashPrefix = "sha256:"
+const (
+	privateConversationLogHashPrefix = "sha256:"
+	routeSegmentAPI                  = "api"
+	routeSegmentV1                   = "v1"
+)
 
 // SanitizeLogPath normalizes private route path segments before generic
 // request/access logs and derived metrics persist them. It intentionally keeps
@@ -42,8 +46,8 @@ func splitLogPathSuffix(raw string) (path string, suffix string) {
 func sanitizeLesserSelfScopeMintConversationPath(path string) (string, bool) {
 	segments, leadingSlash := splitLogPathSegments(path)
 	if len(segments) != 7 ||
-		segments[0] != "api" ||
-		segments[1] != "v1" ||
+		segments[0] != routeSegmentAPI ||
+		segments[1] != routeSegmentV1 ||
 		segments[2] != "souls" ||
 		segments[3] != "bound" ||
 		segments[4] != "me" ||
@@ -59,8 +63,8 @@ func sanitizeLesserSelfScopeMintConversationPath(path string) (string, bool) {
 func sanitizeLesserSelfScopeMintConversationListPath(path string) (string, bool) {
 	segments, leadingSlash := splitLogPathSegments(path)
 	if len(segments) != 6 ||
-		segments[0] != "api" ||
-		segments[1] != "v1" ||
+		segments[0] != routeSegmentAPI ||
+		segments[1] != routeSegmentV1 ||
 		segments[2] != "souls" ||
 		segments[3] != "bound" ||
 		segments[4] != "me" ||
@@ -74,8 +78,8 @@ func sanitizeLesserSelfScopeMintConversationListPath(path string) (string, bool)
 func sanitizeAPIConversationPath(path string) (string, bool) {
 	segments, leadingSlash := splitLogPathSegments(path)
 	if len(segments) < 3 ||
-		segments[0] != "api" ||
-		segments[1] != "v1" ||
+		segments[0] != routeSegmentAPI ||
+		segments[1] != routeSegmentV1 ||
 		segments[2] != "conversations" {
 		return "", false
 	}
@@ -86,6 +90,9 @@ func sanitizeAPIConversationPath(path string) (string, bool) {
 	case 4:
 		if strings.TrimSpace(segments[3]) == "" {
 			return "", false
+		}
+		if segments[3] == "lookup" {
+			return joinLogPathSegments(segments, leadingSlash), true
 		}
 		segments[3] = "conversation-" + shortLogHash(segments[3])
 		return joinLogPathSegments(segments, leadingSlash), true

--- a/pkg/logging/path_redaction.go
+++ b/pkg/logging/path_redaction.go
@@ -24,6 +24,9 @@ func SanitizeLogPath(raw string) string {
 	if sanitized, ok := sanitizeLesserSelfScopeMintConversationListPath(path); ok {
 		return sanitized
 	}
+	if sanitized, ok := sanitizeAPIConversationPath(path); ok {
+		return sanitized
+	}
 	return trimmed
 }
 
@@ -66,6 +69,35 @@ func sanitizeLesserSelfScopeMintConversationListPath(path string) (string, bool)
 	}
 
 	return joinLogPathSegments(segments, leadingSlash), true
+}
+
+func sanitizeAPIConversationPath(path string) (string, bool) {
+	segments, leadingSlash := splitLogPathSegments(path)
+	if len(segments) < 3 ||
+		segments[0] != "api" ||
+		segments[1] != "v1" ||
+		segments[2] != "conversations" {
+		return "", false
+	}
+
+	switch len(segments) {
+	case 3:
+		return joinLogPathSegments(segments, leadingSlash), true
+	case 4:
+		if strings.TrimSpace(segments[3]) == "" {
+			return "", false
+		}
+		segments[3] = "conversation-" + shortLogHash(segments[3])
+		return joinLogPathSegments(segments, leadingSlash), true
+	case 5:
+		if strings.TrimSpace(segments[3]) == "" || segments[4] != "read" {
+			return "", false
+		}
+		segments[3] = "conversation-" + shortLogHash(segments[3])
+		return joinLogPathSegments(segments, leadingSlash), true
+	default:
+		return "", false
+	}
 }
 
 func splitLogPathSegments(path string) ([]string, bool) {

--- a/pkg/logging/path_redaction_test.go
+++ b/pkg/logging/path_redaction_test.go
@@ -56,6 +56,81 @@ func TestSanitizeLogPathHandlesPrivateMintConversationListRoute(t *testing.T) {
 	require.NotContains(t, got, "raw-cursor")
 }
 
+func TestSanitizeLogPathHandlesAPIConversationRoutes(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		in          string
+		rawSecret   string
+		want        string
+		wantPrefix  string
+		wantSuffix  string
+		mustNotLeak []string
+	}{
+		"list strips query": {
+			in:          "/api/v1/conversations?limit=20&max_id=raw-cursor",
+			want:        "/api/v1/conversations",
+			mustNotLeak: []string{"raw-cursor"},
+		},
+		"lookup strips counterpart query": {
+			in:          "/api/v1/conversations/lookup?counterpart=ops%40example.com&max_id=raw-cursor",
+			want:        "/api/v1/conversations/lookup",
+			mustNotLeak: []string{"ops", "raw-cursor"},
+		},
+		"conversation id redacted": {
+			in:          "/api/v1/conversations/conv-private-agent",
+			rawSecret:   "conv-private-agent",
+			wantPrefix:  "/api/v1/conversations/conversation-sha256:",
+			mustNotLeak: []string{"conv-private-agent"},
+		},
+		"conversation id redacted without leading slash": {
+			in:          "api/v1/conversations/conv-private-relative?max_id=raw-cursor",
+			rawSecret:   "conv-private-relative",
+			wantPrefix:  "api/v1/conversations/conversation-sha256:",
+			mustNotLeak: []string{"conv-private-relative", "raw-cursor"},
+		},
+		"read route id redacted": {
+			in:          "/api/v1/conversations/conv-private-read/read",
+			rawSecret:   "conv-private-read",
+			wantPrefix:  "/api/v1/conversations/conversation-sha256:",
+			wantSuffix:  "/read",
+			mustNotLeak: []string{"conv-private-read"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := SanitizeLogPath(tc.in)
+			if tc.want != "" {
+				require.Equal(t, tc.want, got)
+			}
+			if tc.wantPrefix != "" {
+				require.Truef(t, strings.HasPrefix(got, tc.wantPrefix), "expected sanitized prefix %q, got %q", tc.wantPrefix, got)
+			}
+			if tc.wantSuffix != "" {
+				require.Truef(t, strings.HasSuffix(got, tc.wantSuffix), "expected sanitized suffix %q, got %q", tc.wantSuffix, got)
+			}
+			if tc.rawSecret != "" {
+				require.NotContains(t, got, tc.rawSecret)
+			}
+			for _, forbidden := range tc.mustNotLeak {
+				require.NotContains(t, got, forbidden)
+			}
+		})
+	}
+}
+
+func TestSanitizeLogPathLeavesMalformedConversationRoutesUnchanged(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		"/api/v1/conversations/conv-private/read/extra",
+		"/api/v1/conversations/conv-private/write",
+	} {
+		require.Equal(t, path, SanitizeLogPath(path))
+	}
+}
+
 func TestSanitizeLogPathLeavesOtherRoutesUnchanged(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/conversations/service.go
+++ b/pkg/services/conversations/service.go
@@ -225,6 +225,14 @@ type GetConversationQuery struct {
 	Pagination     interfaces.PaginationOptions `json:"pagination"`
 }
 
+// LookupConversationByCounterpartQuery contains parameters for resolving a 1:1 DM
+// conversation by the exact viewer/counterpart participant pair.
+type LookupConversationByCounterpartQuery struct {
+	ViewerID    string                       `json:"viewer_id" validate:"required"`
+	Counterpart string                       `json:"counterpart" validate:"required"`
+	Pagination  interfaces.PaginationOptions `json:"pagination"`
+}
+
 // SendMessageCommand contains all data needed to send a message to an existing 1:1 conversation.
 type SendMessageCommand struct {
 	SenderID       string   `json:"sender_id" validate:"required"`
@@ -1887,6 +1895,154 @@ func (s *Service) GetConversation(ctx context.Context, query *GetConversationQue
 		Messages:     filteredMessagesResult,
 		Events:       []*streaming.Event{}, // No events for read operations
 	}, nil
+}
+
+// LookupConversationByCounterpart resolves a visible 1:1 DM conversation for the
+// authenticated viewer and one exact counterpart identifier.
+func (s *Service) LookupConversationByCounterpart(ctx context.Context, query *LookupConversationByCounterpartQuery) (*ConversationWithMessages, error) {
+	if query == nil {
+		return nil, errors.Join(ErrConversationValidationFailed, storage.ErrInvalidInput)
+	}
+
+	viewerID := strings.TrimSpace(query.ViewerID)
+	counterpart := normalizeConversationCounterpartLookupInput(query.Counterpart)
+	if viewerID == "" || counterpart == "" {
+		return nil, errors.Join(ErrConversationValidationFailed, ErrInvalidRecipient)
+	}
+
+	participants, participantRefs, err := s.lookupParticipantsForCounterpart(ctx, viewerID, counterpart)
+	if err != nil {
+		return nil, err
+	}
+
+	conversation, err := s.lookupDirectMessageConversationForSend(ctx, participants, participantRefs)
+	if err != nil {
+		if isNotFoundError(err) {
+			return nil, ErrConversationNotFound
+		}
+		return nil, errors.Join(ErrLookupExistingConversation, err)
+	}
+	if conversation == nil || strings.TrimSpace(conversation.ID) == "" {
+		return nil, ErrConversationNotFound
+	}
+	if !conversationIsOneToOne(conversation) {
+		return nil, ErrConversationMustBeOneToOne
+	}
+
+	return s.GetConversation(ctx, &GetConversationQuery{
+		ConversationID: conversation.ID,
+		ViewerID:       viewerID,
+		Pagination:     query.Pagination,
+	})
+}
+
+func normalizeConversationCounterpartLookupInput(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	trimmed = strings.TrimPrefix(trimmed, "acct:")
+	trimmed = strings.TrimPrefix(trimmed, "@")
+	return strings.TrimSpace(trimmed)
+}
+
+func (s *Service) lookupParticipantsForCounterpart(ctx context.Context, viewerID, counterpart string) ([]string, []models.ConversationParticipantRef, error) {
+	localDomain := normalizeDirectMessageMentionDomain(s.domainName)
+	username, domain := directMessageMentionHandleParts(counterpart)
+	normalizedDomain := normalizeDirectMessageMentionDomain(domain)
+
+	if strings.Contains(counterpart, "://") && normalizedDomain != "" && normalizedDomain != localDomain {
+		ref := models.NormalizeConversationParticipantRef(models.ConversationParticipantRef{
+			ParticipantType: models.ConversationParticipantTypeRemoteActor,
+			ParticipantID:   strings.TrimRight(strings.TrimSpace(counterpart), "/"),
+			Acct:            formatConversationLookupAcct(username, normalizedDomain),
+			Domain:          normalizedDomain,
+		})
+		return buildConversationLookupParticipants(viewerID, ref)
+	}
+
+	if normalizedDomain != "" && normalizedDomain != localDomain {
+		ref, err := s.resolveRemoteCounterpartForLookup(ctx, counterpart, username, normalizedDomain)
+		if err != nil {
+			return nil, nil, err
+		}
+		return buildConversationLookupParticipants(viewerID, *ref)
+	}
+
+	counterpartID := models.CanonicalConversationParticipantID(username)
+	if counterpartID == "" ||
+		models.CanonicalConversationParticipantID(viewerID) == counterpartID {
+		return nil, nil, ErrConversationNotFound
+	}
+
+	ref := models.NormalizeConversationParticipantRef(models.ConversationParticipantRef{
+		ParticipantType: models.ConversationParticipantTypeLocalUser,
+		ParticipantID:   counterpartID,
+	})
+	return buildConversationLookupParticipants(viewerID, ref)
+}
+
+func (s *Service) resolveRemoteCounterpartForLookup(ctx context.Context, counterpart, username, domain string) (*models.ConversationParticipantRef, error) {
+	resolver, ok := s.federation.(remoteActorResolver)
+	if !ok || resolver == nil {
+		return nil, ErrConversationNotFound
+	}
+
+	actor, err := resolver.ResolveActor(ctx, counterpart)
+	if err != nil || actor == nil || strings.TrimSpace(actor.ID) == "" {
+		return nil, ErrConversationNotFound
+	}
+
+	identity := federationActorIdentityForDirectMessage(actor, s.domainName)
+	if username == "" {
+		username = identity.username
+	}
+	if domain == "" {
+		domain = identity.domain
+	}
+	now := time.Now().UTC()
+	ref := models.NormalizeConversationParticipantRef(models.ConversationParticipantRef{
+		ParticipantType: models.ConversationParticipantTypeRemoteActor,
+		ParticipantID:   actor.ID,
+		Acct:            formatConversationLookupAcct(username, domain),
+		Domain:          domain,
+		ResolvedAt:      &now,
+	})
+	if ref.ParticipantID == "" {
+		return nil, ErrConversationNotFound
+	}
+	return &ref, nil
+}
+
+func buildConversationLookupParticipants(viewerID string, counterpartRef models.ConversationParticipantRef) ([]string, []models.ConversationParticipantRef, error) {
+	viewerRef := models.ConversationParticipantRef{
+		ParticipantType: models.ConversationParticipantTypeLocalUser,
+		ParticipantID:   viewerID,
+	}
+	refs := models.NormalizeConversationParticipantRefs([]models.ConversationParticipantRef{viewerRef, counterpartRef})
+	if len(refs) != 2 {
+		return nil, nil, ErrConversationNotFound
+	}
+	return models.ConversationParticipantIDsFromRefs(refs), refs, nil
+}
+
+func formatConversationLookupAcct(username, domain string) string {
+	username = strings.TrimSpace(strings.TrimPrefix(username, "@"))
+	domain = normalizeDirectMessageMentionDomain(domain)
+	if username == "" {
+		return ""
+	}
+	if domain == "" || strings.Contains(username, "@") {
+		return strings.ToLower(username)
+	}
+	return strings.ToLower(username + "@" + domain)
+}
+
+func conversationIsOneToOne(conversation *models.Conversation) bool {
+	if conversation == nil {
+		return false
+	}
+	if refs := models.NormalizeConversationParticipantRefs(conversation.ParticipantRefs); len(refs) > 0 {
+		return len(refs) == 2
+	}
+	return len(models.CanonicalConversationParticipants(conversation.Participants)) == 2
 }
 
 // Private helper methods

--- a/pkg/services/conversations/service.go
+++ b/pkg/services/conversations/service.go
@@ -1850,11 +1850,13 @@ func (s *Service) GetConversation(ctx context.Context, query *GetConversationQue
 
 	// Populate per-viewer unread state if available.
 	if state, err := s.conversationRepo.GetUserConversationState(ctx, query.ViewerID, query.ConversationID); err == nil && state != nil {
-		if state.DeletedAt != nil && !state.DeletedAt.IsZero() {
+		if (state.DeletedAt != nil && !state.DeletedAt.IsZero()) ||
+			state.Folder == models.UserConversationFolderHidden {
 			return nil, ErrConversationNotFound
 		}
 
 		conversation.Unread = state.Unread
+		conversation.ViewerState = userConversationStateFromContract(conversation, query.ViewerID, "", state)
 	}
 
 	// Get conversation messages (these are statuses with this conversation ID).

--- a/pkg/services/conversations/service_lookup_round53_test.go
+++ b/pkg/services/conversations/service_lookup_round53_test.go
@@ -1,0 +1,380 @@
+package conversations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/storage/interfaces"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_LookupConversationByCounterpart_LocalIdentifiers(t *testing.T) {
+	inputs := []string{
+		"ops",
+		"ops@example.com",
+		"@ops@example.com",
+		"acct:ops@example.com",
+		"https://example.com/users/ops",
+	}
+
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			service, conversationRepo, noteRepo, _, _, _ := createTestService()
+			ctx := context.Background()
+			conversation := createTestConversation("conv-lookup", []string{"alice", "ops"})
+			message := createTestMessage("msg-1", "ops", "conv-lookup", "ready")
+			message.AuthorUsername = "ops"
+			message.ToRecipients = []string{"https://example.com/users/alice"}
+			pagination := interfaces.PaginationOptions{Limit: 7}
+
+			conversationRepo.
+				On("GetConversationByParticipants", ctx, mock.MatchedBy(func(participants []string) bool {
+					return fmt.Sprint(participants) == "[alice ops]"
+				})).
+				Return(conversation, nil).
+				Once()
+			conversationRepo.On("GetConversation", ctx, "conv-lookup").Return(conversation, nil).Once()
+			conversationRepo.On("GetUserConversationState", ctx, "alice", "conv-lookup").Return(
+				testConversationStateContract("alice", "conv-lookup", func(state *interfaces.UserConversationStateContract) {
+					state.Folder = models.UserConversationFolderInbox
+				}), nil,
+			).Once()
+			noteRepo.On("GetConversationThread", ctx, "conv-lookup", pagination).Return(&interfaces.PaginatedResult[*models.Status]{
+				Items: []*models.Status{message},
+				Total: 1,
+			}, nil).Once()
+
+			result, err := service.LookupConversationByCounterpart(ctx, &LookupConversationByCounterpartQuery{
+				ViewerID:    "alice",
+				Counterpart: input,
+				Pagination:  pagination,
+			})
+			require.NoError(t, err)
+			require.Equal(t, "conv-lookup", result.Conversation.ID)
+			require.Len(t, result.Messages.Items, 1)
+			require.Equal(t, "msg-1", result.Messages.Items[0].StatusID)
+			conversationRepo.AssertExpectations(t)
+			noteRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestService_LookupConversationByCounterpart_RemoteActorURLUsesTypedLookup(t *testing.T) {
+	service, conversationRepo, noteRepo, _, _, _ := createTestService()
+	ctx := context.Background()
+	remoteActorID := "https://remote.example/users/Bob"
+	refs := models.NormalizeConversationParticipantRefs([]models.ConversationParticipantRef{
+		{ParticipantType: models.ConversationParticipantTypeLocalUser, ParticipantID: "alice"},
+		{ParticipantType: models.ConversationParticipantTypeRemoteActor, ParticipantID: remoteActorID, Acct: "bob@remote.example", Domain: "remote.example"},
+	})
+	conversation := createTestConversation("conv-remote", models.ConversationParticipantIDsFromRefs(refs))
+	conversation.ParticipantRefs = refs
+	message := createTestMessage("msg-remote", remoteActorID, "conv-remote", "federated hello")
+	message.AuthorUsername = "bob"
+	message.ToRecipients = []string{"https://example.com/users/alice"}
+	pagination := interfaces.PaginationOptions{Limit: 3}
+
+	conversationRepo.
+		On("GetConversationByParticipantRefs", ctx, mock.MatchedBy(func(got []models.ConversationParticipantRef) bool {
+			got = models.NormalizeConversationParticipantRefs(got)
+			return len(got) == 2 &&
+				got[0].ParticipantID == "alice" &&
+				got[1].ParticipantID == remoteActorID &&
+				got[1].ParticipantType == models.ConversationParticipantTypeRemoteActor &&
+				got[1].Acct == "bob@remote.example"
+		})).
+		Return(conversation, nil).
+		Once()
+	conversationRepo.On("GetConversation", ctx, "conv-remote").Return(conversation, nil).Once()
+	conversationRepo.On("GetUserConversationState", ctx, "alice", "conv-remote").Return(
+		testConversationStateContract("alice", "conv-remote", func(state *interfaces.UserConversationStateContract) {
+			state.Folder = models.UserConversationFolderInbox
+		}), nil,
+	).Once()
+	noteRepo.On("GetConversationThread", ctx, "conv-remote", pagination).Return(&interfaces.PaginatedResult[*models.Status]{
+		Items: []*models.Status{message},
+		Total: 1,
+	}, nil).Once()
+
+	result, err := service.LookupConversationByCounterpart(ctx, &LookupConversationByCounterpartQuery{
+		ViewerID:    "alice",
+		Counterpart: remoteActorID,
+		Pagination:  pagination,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "conv-remote", result.Conversation.ID)
+	require.Len(t, result.Messages.Items, 1)
+	conversationRepo.AssertExpectations(t)
+	noteRepo.AssertExpectations(t)
+}
+
+func TestService_LookupConversationByCounterpart_RemoteAcctResolvesActor(t *testing.T) {
+	service, conversationRepo, noteRepo, _, _, federation := createTestService()
+	ctx := context.Background()
+	remoteActorID := "https://remote.example/users/bob"
+	federation.actors = map[string]*activitypub.Actor{
+		"bob@remote.example": {
+			BaseObject:        activitypub.BaseObject{ID: remoteActorID, Type: activitypub.PersonType},
+			PreferredUsername: "bob",
+		},
+	}
+	refs := models.NormalizeConversationParticipantRefs([]models.ConversationParticipantRef{
+		{ParticipantType: models.ConversationParticipantTypeLocalUser, ParticipantID: "alice"},
+		{ParticipantType: models.ConversationParticipantTypeRemoteActor, ParticipantID: remoteActorID, Acct: "bob@remote.example", Domain: "remote.example"},
+	})
+	conversation := createTestConversation("conv-remote-acct", models.ConversationParticipantIDsFromRefs(refs))
+	conversation.ParticipantRefs = refs
+	message := createTestMessage("msg-remote-acct", remoteActorID, "conv-remote-acct", "resolved hello")
+	message.AuthorUsername = "bob"
+	message.ToRecipients = []string{"https://example.com/users/alice"}
+	pagination := interfaces.PaginationOptions{Limit: 4}
+
+	conversationRepo.
+		On("GetConversationByParticipantRefs", ctx, mock.MatchedBy(func(got []models.ConversationParticipantRef) bool {
+			got = models.NormalizeConversationParticipantRefs(got)
+			return len(got) == 2 &&
+				got[0].ParticipantID == "alice" &&
+				got[1].ParticipantID == remoteActorID &&
+				got[1].Acct == "bob@remote.example" &&
+				got[1].Domain == "remote.example" &&
+				got[1].ResolvedAt != nil
+		})).
+		Return(conversation, nil).
+		Once()
+	conversationRepo.On("GetConversation", ctx, "conv-remote-acct").Return(conversation, nil).Once()
+	conversationRepo.On("GetUserConversationState", ctx, "alice", "conv-remote-acct").Return(
+		testConversationStateContract("alice", "conv-remote-acct", func(state *interfaces.UserConversationStateContract) {
+			state.Folder = models.UserConversationFolderInbox
+		}), nil,
+	).Once()
+	noteRepo.On("GetConversationThread", ctx, "conv-remote-acct", pagination).Return(&interfaces.PaginatedResult[*models.Status]{
+		Items: []*models.Status{message},
+		Total: 1,
+	}, nil).Once()
+
+	result, err := service.LookupConversationByCounterpart(ctx, &LookupConversationByCounterpartQuery{
+		ViewerID:    "alice",
+		Counterpart: "bob@remote.example",
+		Pagination:  pagination,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "conv-remote-acct", result.Conversation.ID)
+	require.Len(t, result.Messages.Items, 1)
+	conversationRepo.AssertExpectations(t)
+	noteRepo.AssertExpectations(t)
+}
+
+func TestService_LookupConversationByCounterpart_RemoteAcctResolutionFailures(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(*Service, *mockFederationService)
+	}{
+		{
+			name: "without resolver",
+			setup: func(service *Service, _ *mockFederationService) {
+				service.federation = nil
+			},
+		},
+		{
+			name: "resolver error",
+			setup: func(_ *Service, federation *mockFederationService) {
+				federation.resolveErr = errors.New("resolve failed")
+			},
+		},
+		{
+			name: "empty actor id",
+			setup: func(_ *Service, federation *mockFederationService) {
+				federation.actors = map[string]*activitypub.Actor{
+					"bob@remote.example": {PreferredUsername: "bob"},
+				}
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			service, conversationRepo, noteRepo, _, _, federation := createTestService()
+			ctx := context.Background()
+			testCase.setup(service, federation)
+
+			result, err := service.LookupConversationByCounterpart(ctx, &LookupConversationByCounterpartQuery{
+				ViewerID:    "alice",
+				Counterpart: "bob@remote.example",
+			})
+			require.Nil(t, result)
+			require.ErrorIs(t, err, ErrConversationNotFound)
+			conversationRepo.AssertNotCalled(t, "GetConversationByParticipants")
+			conversationRepo.AssertNotCalled(t, "GetConversationByParticipantRefs")
+			noteRepo.AssertNotCalled(t, "GetConversationThread")
+		})
+	}
+}
+
+func TestService_LookupConversationByCounterpart_InvalidInputs(t *testing.T) {
+	service, conversationRepo, noteRepo, _, _, _ := createTestService()
+	ctx := context.Background()
+
+	result, err := service.LookupConversationByCounterpart(ctx, nil)
+	require.Nil(t, result)
+	require.Error(t, err)
+
+	result, err = service.LookupConversationByCounterpart(ctx, &LookupConversationByCounterpartQuery{ViewerID: "alice"})
+	require.Nil(t, result)
+	require.Error(t, err)
+
+	result, err = service.LookupConversationByCounterpart(ctx, &LookupConversationByCounterpartQuery{ViewerID: "alice", Counterpart: "@alice@example.com"})
+	require.Nil(t, result)
+	require.ErrorIs(t, err, ErrConversationNotFound)
+
+	conversationRepo.AssertNotCalled(t, "GetConversationByParticipants")
+	conversationRepo.AssertNotCalled(t, "GetConversationByParticipantRefs")
+	noteRepo.AssertNotCalled(t, "GetConversationThread")
+}
+
+func TestConversationCounterpartLookupHelpers(t *testing.T) {
+	require.Equal(t, "ops@example.com", normalizeConversationCounterpartLookupInput(" acct:@ops@example.com "))
+	require.Equal(t, "ops@example.com", formatConversationLookupAcct("@Ops", "Example.COM"))
+	require.Equal(t, "ops@example.com", formatConversationLookupAcct("Ops@Example.COM", "ignored.example"))
+	require.Empty(t, formatConversationLookupAcct("", "example.com"))
+
+	participants, refs, err := buildConversationLookupParticipants("alice", models.ConversationParticipantRef{
+		ParticipantType: models.ConversationParticipantTypeLocalUser,
+		ParticipantID:   "ops",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"alice", "ops"}, participants)
+	require.Len(t, refs, 2)
+
+	participants, refs, err = buildConversationLookupParticipants("alice", models.ConversationParticipantRef{
+		ParticipantType: models.ConversationParticipantTypeLocalUser,
+		ParticipantID:   "alice",
+	})
+	require.Nil(t, participants)
+	require.Nil(t, refs)
+	require.ErrorIs(t, err, ErrConversationNotFound)
+
+	require.False(t, conversationIsOneToOne(nil))
+	require.True(t, conversationIsOneToOne(createTestConversation("conv-local", []string{"alice", "ops"})))
+	require.False(t, conversationIsOneToOne(createTestConversation("conv-group", []string{"alice", "bob", "carol"})))
+
+	refConversation := createTestConversation("conv-refs", nil)
+	refConversation.ParticipantRefs = []models.ConversationParticipantRef{
+		{ParticipantType: models.ConversationParticipantTypeLocalUser, ParticipantID: "alice"},
+		{ParticipantType: models.ConversationParticipantTypeRemoteActor, ParticipantID: "https://remote.example/users/bob"},
+	}
+	require.True(t, conversationIsOneToOne(refConversation))
+	refConversation.ParticipantRefs = append(refConversation.ParticipantRefs,
+		models.ConversationParticipantRef{ParticipantType: models.ConversationParticipantTypeLocalUser, ParticipantID: "carol"})
+	require.False(t, conversationIsOneToOne(refConversation))
+}
+
+func TestService_LookupConversationByCounterpart_NotFound(t *testing.T) {
+	service, conversationRepo, noteRepo, _, _, _ := createTestService()
+	ctx := context.Background()
+
+	conversationRepo.On("GetConversationByParticipants", ctx, []string{"alice", "missing"}).Return(nil, storage.ErrNotFound).Once()
+
+	result, err := service.LookupConversationByCounterpart(ctx, &LookupConversationByCounterpartQuery{
+		ViewerID:    "alice",
+		Counterpart: "missing",
+	})
+	require.Nil(t, result)
+	require.ErrorIs(t, err, ErrConversationNotFound)
+	conversationRepo.AssertExpectations(t)
+	noteRepo.AssertNotCalled(t, "GetConversationThread")
+}
+
+func TestService_LookupConversationByCounterpart_RepositoryEdgeFailures(t *testing.T) {
+	cases := []struct {
+		name         string
+		conversation *models.Conversation
+		err          error
+		wantErr      error
+	}{
+		{
+			name:    "lookup error",
+			err:     errors.New("dynamodb unavailable"),
+			wantErr: ErrLookupExistingConversation,
+		},
+		{
+			name:    "nil conversation",
+			wantErr: ErrConversationNotFound,
+		},
+		{
+			name:         "empty id",
+			conversation: createTestConversation("", []string{"alice", "ops"}),
+			wantErr:      ErrConversationNotFound,
+		},
+		{
+			name:         "group conversation",
+			conversation: createTestConversation("conv-group", []string{"alice", "ops", "carol"}),
+			wantErr:      ErrConversationMustBeOneToOne,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			service, conversationRepo, noteRepo, _, _, _ := createTestService()
+			ctx := context.Background()
+			conversationRepo.On("GetConversationByParticipants", ctx, []string{"alice", "ops"}).
+				Return(testCase.conversation, testCase.err).
+				Once()
+
+			result, err := service.LookupConversationByCounterpart(ctx, &LookupConversationByCounterpartQuery{
+				ViewerID:    "alice",
+				Counterpart: "ops",
+			})
+			require.Nil(t, result)
+			require.ErrorIs(t, err, testCase.wantErr)
+			conversationRepo.AssertExpectations(t)
+			noteRepo.AssertNotCalled(t, "GetConversationThread")
+		})
+	}
+}
+
+func TestService_LookupConversationByCounterpart_ReloadDeniesNonParticipant(t *testing.T) {
+	service, conversationRepo, noteRepo, _, _, _ := createTestService()
+	ctx := context.Background()
+	conversation := createTestConversation("conv-other", []string{"bob", "ops"})
+
+	conversationRepo.On("GetConversationByParticipants", ctx, []string{"alice", "ops"}).Return(conversation, nil).Once()
+	conversationRepo.On("GetConversation", ctx, "conv-other").Return(conversation, nil).Once()
+
+	result, err := service.LookupConversationByCounterpart(ctx, &LookupConversationByCounterpartQuery{
+		ViewerID:    "alice",
+		Counterpart: "ops",
+	})
+	require.Nil(t, result)
+	require.ErrorIs(t, err, ErrNotConversationParticipant)
+	conversationRepo.AssertExpectations(t)
+	noteRepo.AssertNotCalled(t, "GetConversationThread")
+}
+
+func TestService_LookupConversationByCounterpart_RespectsHiddenViewerState(t *testing.T) {
+	service, conversationRepo, noteRepo, _, _, _ := createTestService()
+	ctx := context.Background()
+	conversation := createTestConversation("conv-hidden", []string{"alice", "ops"})
+
+	conversationRepo.On("GetConversationByParticipants", ctx, []string{"alice", "ops"}).Return(conversation, nil).Once()
+	conversationRepo.On("GetConversation", ctx, "conv-hidden").Return(conversation, nil).Once()
+	conversationRepo.On("GetUserConversationState", ctx, "alice", "conv-hidden").Return(
+		testConversationStateContract("alice", "conv-hidden", func(state *interfaces.UserConversationStateContract) {
+			state.Folder = models.UserConversationFolderHidden
+		}), nil,
+	).Once()
+
+	result, err := service.LookupConversationByCounterpart(ctx, &LookupConversationByCounterpartQuery{
+		ViewerID:    "alice",
+		Counterpart: "ops",
+	})
+	require.Nil(t, result)
+	require.ErrorIs(t, err, ErrConversationNotFound)
+	conversationRepo.AssertExpectations(t)
+	noteRepo.AssertNotCalled(t, "GetConversationThread")
+}

--- a/pkg/services/conversations/service_test.go
+++ b/pkg/services/conversations/service_test.go
@@ -1475,34 +1475,54 @@ func TestService_DeleteConversation_DeleteForMe(t *testing.T) {
 	conversationRepo.AssertExpectations(t)
 }
 
-func TestService_GetConversation_HidesDeletedConversation(t *testing.T) {
-	service, conversationRepo, noteRepo, _, _, _ := createTestService()
-
+func TestService_GetConversation_HidesDeletedOrHiddenConversation(t *testing.T) {
 	now := time.Now().UTC()
-	conversation := &models.Conversation{
-		ID:           "conv123",
-		Participants: []string{"sender123", "recipient456"},
-		CreatedAt:    now.Add(-time.Hour),
-		UpdatedAt:    now.Add(-time.Minute),
-	}
 	deletedAt := now.Add(-time.Second)
-	conversationRepo.On("GetConversation", mock.Anything, "conv123").Return(conversation, nil)
-	conversationRepo.
-		On("GetUserConversationState", mock.Anything, "sender123", "conv123").
-		Return(testConversationStateContract("sender123", "conv123", func(state *interfaces.UserConversationStateContract) {
-			state.DeletedAt = &deletedAt
-		}), nil)
 
-	_, err := service.GetConversation(context.Background(), &GetConversationQuery{
-		ConversationID: "conv123",
-		ViewerID:       "sender123",
-		Pagination:     interfaces.PaginationOptions{Limit: 10},
-	})
-	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrConversationNotFound)
+	tests := []struct {
+		name  string
+		apply func(*interfaces.UserConversationStateContract)
+	}{
+		{
+			name: "deleted",
+			apply: func(state *interfaces.UserConversationStateContract) {
+				state.DeletedAt = &deletedAt
+			},
+		},
+		{
+			name: "hidden folder",
+			apply: func(state *interfaces.UserConversationStateContract) {
+				state.Folder = models.UserConversationFolderHidden
+			},
+		},
+	}
 
-	conversationRepo.AssertExpectations(t)
-	noteRepo.AssertNotCalled(t, "GetConversationThread")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service, conversationRepo, noteRepo, _, _, _ := createTestService()
+			conversation := &models.Conversation{
+				ID:           "conv123",
+				Participants: []string{"sender123", "recipient456"},
+				CreatedAt:    now.Add(-time.Hour),
+				UpdatedAt:    now.Add(-time.Minute),
+			}
+			conversationRepo.On("GetConversation", mock.Anything, "conv123").Return(conversation, nil)
+			conversationRepo.
+				On("GetUserConversationState", mock.Anything, "sender123", "conv123").
+				Return(testConversationStateContract("sender123", "conv123", tt.apply), nil)
+
+			_, err := service.GetConversation(context.Background(), &GetConversationQuery{
+				ConversationID: "conv123",
+				ViewerID:       "sender123",
+				Pagination:     interfaces.PaginationOptions{Limit: 10},
+			})
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrConversationNotFound)
+
+			conversationRepo.AssertExpectations(t)
+			noteRepo.AssertNotCalled(t, "GetConversationThread")
+		})
+	}
 }
 
 func TestService_DeleteMessage_CreatesViewerTombstone(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements the Agent-Usable DM Access M0 primitives for issue #1019 and subissues #1020/#1021:

- add `GET /api/v1/conversations/{id}` to expand an authorized DM conversation with bounded messages and Link pagination
- add `GET /api/v1/conversations/lookup?counterpart=...` for exact 1:1 counterpart lookup without scans or new storage indexes
- enforce existing participant authorization, hidden/deleted viewer state, direct-message filtering, and tombstone filtering by reusing the conversations service read path
- redact private conversation IDs and lookup query values in route/path logging
- regenerate OpenAPI and update GraphQL coverage mapping/exemption docs

Closes #1019.
Closes #1020.
Closes #1021.

## Stewardship / contract notes

- Contract/API: additive REST endpoints only; existing Mastodon conversation list/delete/read behavior is unchanged. `docs/contracts/openapi.yaml` was regenerated and `docs/specs/graphql_coverage.yaml` was updated.
- Federation trust: no ActivityPub inbox/outbox, HTTP Signature, delivery, relay, or actor-shape changes.
- Schema: no PK/SK/GSI/TableTheory tag changes and no new storage/index/backfill.
- Frameworks: uses existing AppTheory/TableTheory patterns; no framework workaround or upstream feedback filing needed.
- Cross-repo handoff: `lesser-body` can consume these new REST primitives for agent DM access; no sibling repo code was edited.

## Validation

Full local hard gate passed:

```bash
gofmt -l .
git diff --check
go test ./...
go vet ./...
go build -o lesser ./cmd/lesser
./lesser build lambdas
./lesser verify ci
```

Additional focused validation during implementation:

```bash
go test ./pkg/services/conversations
./lesser verify openapi
./lesser verify graphql-coverage
```

`./lesser verify ci` completed lint, security, supply-chain, verify suite, strict contracts, and overall/pkg/cmd coverage gates (`pkg` coverage 90.001%, `cmd` coverage 90.012%).

## Rollout

No deploy performed. Standard lesser rollout remains dev → staging (where used) → live via `./lesser up` after PR review/merge.