### PR TITLE
feat: add canonical article routing

### DIFF
--- a/cmd/api/handlers/status_pins.go
+++ b/cmd/api/handlers/status_pins.go
@@ -69,6 +69,8 @@ func (h *Handler) HandlePinStatusLift(ctx *apptheory.Context) (*apptheory.Respon
 	switch obj := object.(type) {
 	case *activitypub.Note:
 		attributedTo = obj.AttributedTo
+	case *activitypub.Article:
+		attributedTo = obj.AttributedTo
 	case map[string]any:
 		if attr, ok := obj["attributedTo"].(string); ok {
 			attributedTo = attr

--- a/cmd/api/handlers/status_pins_round12_coverage_test.go
+++ b/cmd/api/handlers/status_pins_round12_coverage_test.go
@@ -21,7 +21,7 @@ func TestStatusPinsRound12_Coverage(t *testing.T) {
 	writeToken := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{auth.ScopeWrite})
 	headers := map[string]string{"Authorization": "Bearer " + writeToken}
 
-	t.Run("pin/unpin fallback id extraction + map object ownership", func(t *testing.T) {
+	t.Run("pin/unpin fallback id extraction + article ownership", func(t *testing.T) {
 		objectID := cfg.BaseURL() + "/objects/s1"
 		state := &round10QueryState{
 			actorsByUser: map[string]storagemodels.Actor{
@@ -31,7 +31,7 @@ func TestStatusPinsRound12_Coverage(t *testing.T) {
 				},
 			},
 			objectsByID: map[string]storagemodels.Object{
-				// Non-note type forces map[string]any path for attributedTo extraction.
+				// Article objects are returned as first-class ActivityPub Article values.
 				objectID: {ID: objectID, Type: "Article", Content: "hello", AttributedTo: cfg.ActorURL("alice")},
 			},
 		}

--- a/cmd/objects/main.go
+++ b/cmd/objects/main.go
@@ -1336,6 +1336,10 @@ func objectsActivityJSON(status int, value any) (*apptheory.Response, error) {
 	if err != nil {
 		return nil, err
 	}
+	body, err = objectsStripHiddenRecipientsJSON(body)
+	if err != nil {
+		return nil, err
+	}
 	return &apptheory.Response{
 		Status: status,
 		Headers: map[string][]string{
@@ -1343,4 +1347,29 @@ func objectsActivityJSON(status int, value any) (*apptheory.Response, error) {
 		},
 		Body: body,
 	}, nil
+}
+
+func objectsStripHiddenRecipientsJSON(body []byte) ([]byte, error) {
+	var decoded any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return nil, err
+	}
+
+	objectsStripHiddenRecipients(decoded)
+	return json.Marshal(decoded)
+}
+
+func objectsStripHiddenRecipients(value any) {
+	switch typed := value.(type) {
+	case map[string]any:
+		delete(typed, "bto")
+		delete(typed, "bcc")
+		for _, nested := range typed {
+			objectsStripHiddenRecipients(nested)
+		}
+	case []any:
+		for _, nested := range typed {
+			objectsStripHiddenRecipients(nested)
+		}
+	}
 }

--- a/cmd/objects/main.go
+++ b/cmd/objects/main.go
@@ -114,6 +114,7 @@ type objectsRouteInventoryEntry struct {
 func objectsRouteInventory() []objectsRouteInventoryEntry {
 	return []objectsRouteInventoryEntry{
 		{Method: http.MethodGet, Path: "/objects/:id"},
+		{Method: http.MethodGet, Path: "/articles/:slug"},
 		{Method: http.MethodGet, Path: "/users/:username/statuses/:id"},
 	}
 }
@@ -427,6 +428,12 @@ func (h *Handler) resolveObjectLookup(ctx *apptheory.Context) (string, string) {
 		return "", ""
 	}
 
+	slug := strings.TrimSpace(ctx.Param("slug"))
+	if slug != "" {
+		canonicalID := fmt.Sprintf("%s/articles/%s", cfg.BaseURL(), slug)
+		return canonicalID, canonicalID
+	}
+
 	objectID := strings.TrimSpace(ctx.Param("id"))
 	if objectID == "" {
 		return "", ""
@@ -476,6 +483,10 @@ func (h *Handler) extractObjectData(objInterface any) *objectData {
 		return h.extractNoteData(note)
 	}
 
+	if article, ok := objInterface.(*activitypub.Article); ok {
+		return h.extractArticleData(article)
+	}
+
 	// Handle generic object as map
 	if objMap, ok := objInterface.(map[string]any); ok {
 		return h.extractMapData(objMap)
@@ -509,6 +520,16 @@ func (h *Handler) extractNoteData(note *activitypub.Note) *objectData {
 		data.updated = *note.Updated
 	}
 
+	return data
+}
+
+func (h *Handler) extractArticleData(article *activitypub.Article) *objectData {
+	data := h.extractNoteData(&article.Note)
+	data.objectType = article.Type
+	if data.objectType == "" {
+		data.objectType = activitypub.ArticleType
+	}
+	data.name = article.Name
 	return data
 }
 

--- a/cmd/objects/round12_objects_test.go
+++ b/cmd/objects/round12_objects_test.go
@@ -417,7 +417,13 @@ func TestHandleGetObject_FetchResponses_Round12(t *testing.T) {
 	})
 
 	t.Run("activitypub json response", func(t *testing.T) {
-		objRepo := &fakeObjectRepo{obj: map[string]any{"id": "x", "type": "Note", "to": []any{activitypub.PublicAddress}}}
+		objRepo := &fakeObjectRepo{obj: map[string]any{
+			"id":   "x",
+			"type": "Note",
+			"to":   []any{activitypub.PublicAddress},
+			"bto":  []any{"https://remote.example/users/hidden"},
+			"bcc":  []any{"https://remote.example/users/also-hidden"},
+		}}
 		h := &Handler{
 			instanceRepo:           instanceRepo,
 			objectRepo:             objRepo,
@@ -435,6 +441,11 @@ func TestHandleGetObject_FetchResponses_Round12(t *testing.T) {
 		require.NotNil(t, resp)
 		require.Equal(t, 200, resp.Status)
 		require.Equal(t, []string{"application/activity+json"}, resp.Headers["content-type"])
+
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.NotContains(t, body, "bto")
+		require.NotContains(t, body, "bcc")
 	})
 
 	t.Run("canonical article route resolves article url and negotiates activitypub json", func(t *testing.T) {
@@ -448,6 +459,8 @@ func TestHandleGetObject_FetchResponses_Round12(t *testing.T) {
 					Published: &now,
 					Updated:   &now,
 					To:        []string{activitypub.PublicAddress},
+					BTo:       []string{"https://remote.example/users/hidden"},
+					BCC:       []string{"https://remote.example/users/also-hidden"},
 				},
 				Content:      "<p>Article body</p>",
 				AttributedTo: "https://example.com/users/alice",
@@ -489,6 +502,8 @@ func TestHandleGetObject_FetchResponses_Round12(t *testing.T) {
 		require.Equal(t, "A short summary", body["summary"])
 		require.Equal(t, "<p>Article body</p>", body["content"])
 		require.Equal(t, "https://example.com/users/alice", body["attributedTo"])
+		require.NotContains(t, body, "bto")
+		require.NotContains(t, body, "bcc")
 		require.NotEmpty(t, body["attachment"])
 		require.NotEmpty(t, body["tag"])
 	})
@@ -723,6 +738,15 @@ func TestExtractObjectData_Round12(t *testing.T) {
 	require.Equal(t, "article summary", data.summary)
 	require.Len(t, data.attachments, 1)
 	require.Len(t, data.tags, 1)
+
+	data = h.extractObjectData(&activitypub.Article{
+		Note: activitypub.Note{
+			BaseObject: activitypub.BaseObject{ID: "https://example.com/articles/untyped"},
+		},
+		Name: "Untyped Article",
+	})
+	require.Equal(t, activitypub.ArticleType, data.objectType)
+	require.Equal(t, "Untyped Article", data.name)
 }
 
 type extendedMockDB struct {
@@ -1295,6 +1319,8 @@ func TestObjectHelpers_UncoveredBranches_Round12(t *testing.T) {
 		Request: apptheory.Request{Headers: map[string][]string{"accept": {}}},
 	}, "accept"))
 	require.Equal(t, []string{"x"}, objectsAppendRecipients(nil, []string{"", "x"}))
+	_, err := objectsStripHiddenRecipientsJSON([]byte("{broken"))
+	require.Error(t, err)
 
 	ctx := &apptheory.Context{
 		Request: apptheory.Request{

--- a/cmd/objects/round12_objects_test.go
+++ b/cmd/objects/round12_objects_test.go
@@ -437,6 +437,131 @@ func TestHandleGetObject_FetchResponses_Round12(t *testing.T) {
 		require.Equal(t, []string{"application/activity+json"}, resp.Headers["content-type"])
 	})
 
+	t.Run("canonical article route resolves article url and negotiates activitypub json", func(t *testing.T) {
+		now := time.Date(2026, time.May, 19, 12, 0, 0, 0, time.UTC)
+		article := &activitypub.Article{
+			Note: activitypub.Note{
+				BaseObject: activitypub.BaseObject{
+					ID:        "https://example.com/articles/hello-world",
+					Type:      activitypub.ArticleType,
+					Summary:   "A short summary",
+					Published: &now,
+					Updated:   &now,
+					To:        []string{activitypub.PublicAddress},
+				},
+				Content:      "<p>Article body</p>",
+				AttributedTo: "https://example.com/users/alice",
+				Attachment: []activitypub.Attachment{
+					{Type: "Image", MediaType: "image/png", URL: "https://example.com/media/cover.png", Name: "cover"},
+				},
+				Tag: []activitypub.Tag{
+					{Type: "Hashtag", Href: "https://example.com/tags/cms", Name: "#cms"},
+				},
+			},
+			Name: "Hello World",
+		}
+
+		objRepo := &fakeObjectRepo{obj: article}
+		h := &Handler{
+			instanceRepo:           instanceRepo,
+			objectRepo:             objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method:  http.MethodGet,
+				Path:    "/articles/hello-world",
+				Headers: map[string][]string{"accept": {"application/activity+json"}},
+			},
+			Params: map[string]string{"slug": "hello-world"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusOK, resp.Status)
+		require.Equal(t, []string{"application/activity+json"}, resp.Headers["content-type"])
+		require.Equal(t, "https://example.com/articles/hello-world", objRepo.gotID)
+
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "https://example.com/articles/hello-world", body["id"])
+		require.Equal(t, activitypub.ArticleType, body["type"])
+		require.Equal(t, "Hello World", body["name"])
+		require.Equal(t, "A short summary", body["summary"])
+		require.Equal(t, "<p>Article body</p>", body["content"])
+		require.Equal(t, "https://example.com/users/alice", body["attributedTo"])
+		require.NotEmpty(t, body["attachment"])
+		require.NotEmpty(t, body["tag"])
+	})
+
+	t.Run("canonical article route returns html for public article", func(t *testing.T) {
+		now := time.Now().UTC()
+		article := &activitypub.Article{
+			Note: activitypub.Note{
+				BaseObject: activitypub.BaseObject{
+					ID:        "https://example.com/articles/hello-world",
+					Type:      activitypub.ArticleType,
+					Summary:   "A summary",
+					Published: &now,
+					To:        []string{activitypub.PublicAddress},
+				},
+				AttributedTo: "https://example.com/users/alice",
+			},
+			Name: "Hello World",
+		}
+
+		h := &Handler{
+			instanceRepo:           instanceRepo,
+			objectRepo:             &fakeObjectRepo{obj: article},
+			authorizedFetchService: &fakeAuthorizedFetch{enabled: true},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method:  http.MethodGet,
+				Path:    "/articles/hello-world",
+				Headers: map[string][]string{"accept": {"text/html"}},
+			},
+			Params: map[string]string{"slug": "hello-world"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusOK, resp.Status)
+		require.Equal(t, []string{"text/html; charset=utf-8"}, resp.Headers["content-type"])
+		require.Contains(t, string(resp.Body), "Hello World")
+		require.Contains(t, string(resp.Body), "A summary")
+	})
+
+	t.Run("canonical article route suppresses html for non-public article", func(t *testing.T) {
+		article := &activitypub.Article{
+			Note: activitypub.Note{
+				BaseObject: activitypub.BaseObject{
+					ID:   "https://example.com/articles/private-article",
+					Type: activitypub.ArticleType,
+					To:   []string{"https://example.com/users/alice/followers"},
+				},
+				Content:      "followers only",
+				AttributedTo: "https://example.com/users/alice",
+			},
+			Name: "Private Article",
+		}
+
+		h := &Handler{
+			instanceRepo:           instanceRepo,
+			objectRepo:             &fakeObjectRepo{obj: article},
+			authorizedFetchService: &fakeAuthorizedFetch{enabled: true},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method:  http.MethodGet,
+				Path:    "/articles/private-article",
+				Headers: map[string][]string{"accept": {"text/html"}},
+			},
+			Params: map[string]string{"slug": "private-article"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusNotFound, resp.Status)
+	})
+
 	t.Run("canonical status route resolves published status url", func(t *testing.T) {
 		now := time.Now().UTC()
 		note := &activitypub.Note{
@@ -568,6 +693,34 @@ func TestExtractObjectData_Round12(t *testing.T) {
 	require.Equal(t, "Article", data.objectType)
 	require.Equal(t, "Title", data.name)
 	require.True(t, data.sensitive)
+	require.Len(t, data.attachments, 1)
+	require.Len(t, data.tags, 1)
+
+	now = time.Now().UTC()
+	data = h.extractObjectData(&activitypub.Article{
+		Note: activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				Type:      activitypub.ArticleType,
+				ID:        "https://example.com/articles/1",
+				Summary:   "article summary",
+				Published: &now,
+				To:        []string{activitypub.PublicAddress},
+			},
+			Content:      "<p>article body</p>",
+			AttributedTo: "https://example.com/users/alice",
+			Attachment: []activitypub.Attachment{
+				{Type: "Image", URL: "https://example.com/cover.png"},
+			},
+			Tag: []activitypub.Tag{
+				{Type: "Hashtag", Name: "#cms", Href: "https://example.com/tags/cms"},
+			},
+		},
+		Name: "Article Title",
+	})
+	require.Equal(t, activitypub.ArticleType, data.objectType)
+	require.Equal(t, "Article Title", data.name)
+	require.Equal(t, "<p>article body</p>", data.content)
+	require.Equal(t, "article summary", data.summary)
 	require.Len(t, data.attachments, 1)
 	require.Len(t, data.tags, 1)
 }
@@ -865,6 +1018,58 @@ func TestHandleGetObject_PrivateVisibilityGate_Round29(t *testing.T) {
 		require.Equal(t, 1, relationships.calls)
 	})
 
+	t.Run("accepted follower can fetch followers-only article route", func(t *testing.T) {
+		actorID := "https://remote.example/users/bob"
+		authFetch := &fakeAuthorizedFetch{
+			enabled: true,
+			actor: &activitypub.Actor{
+				BaseObject:        activitypub.BaseObject{ID: actorID},
+				PreferredUsername: "bob",
+			},
+		}
+		relationships := &fakeRelationshipChecker{
+			following: map[string]bool{actorID + "|" + authorID: true},
+		}
+		article := &activitypub.Article{
+			Note: activitypub.Note{
+				BaseObject: activitypub.BaseObject{
+					ID:   "https://example.com/articles/private-article",
+					Type: activitypub.ArticleType,
+					To:   []string{followersCollection},
+				},
+				Content:      "followers only article",
+				AttributedTo: authorID,
+			},
+			Name: "Private Article",
+		}
+		objRepo := &fakeObjectRepo{obj: article}
+		h := &Handler{
+			instanceRepo:           instanceRepo,
+			objectRepo:             objRepo,
+			authorizedFetchService: authFetch,
+			relationshipRepo:       relationships,
+		}
+
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method: http.MethodGet,
+				Path:   "/articles/private-article",
+				Headers: map[string][]string{
+					"accept": {"application/activity+json"},
+					"host":   {"example.com"},
+				},
+			},
+			Params: map[string]string{"slug": "private-article"},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusOK, resp.Status)
+		require.Equal(t, "https://example.com/articles/private-article", objRepo.gotID)
+		require.Equal(t, []string{"application/activity+json"}, resp.Headers["content-type"])
+		require.Equal(t, 1, relationships.calls)
+	})
+
 	t.Run("explicitly addressed actor can fetch non-public object without follower lookup", func(t *testing.T) {
 		actorID := "https://remote.example/users/bob"
 		note := privateNote()
@@ -1078,7 +1283,18 @@ func TestObjectHelpers_UncoveredBranches_Round12(t *testing.T) {
 	require.True(t, h.parseDateTime(time.Now()).After(time.Time{}))
 	require.True(t, h.parseDateTime("not-a-time").IsZero())
 	require.Equal(t, "", h.generateWarningHTML(false, "cw"))
+	require.Contains(t, h.generateWarningHTML(true, "cw"), "cw")
 	require.Equal(t, "", h.generateUpdatedHTML(time.Time{}))
+	require.Contains(t, h.generateUpdatedHTML(time.Date(2026, time.May, 19, 12, 0, 0, 0, time.UTC)), "Updated")
+	require.Equal(t, "@", h.extractUsernameFromURL(""))
+	objectID, lookupID := h.resolveObjectLookup(nil)
+	require.Empty(t, objectID)
+	require.Empty(t, lookupID)
+	require.Empty(t, objectsHeaderValue(nil, "accept"))
+	require.Empty(t, objectsHeaderValue(&apptheory.Context{
+		Request: apptheory.Request{Headers: map[string][]string{"accept": {}}},
+	}, "accept"))
+	require.Equal(t, []string{"x"}, objectsAppendRecipients(nil, []string{"", "x"}))
 
 	ctx := &apptheory.Context{
 		Request: apptheory.Request{
@@ -1098,6 +1314,14 @@ func TestObjectHelpers_UncoveredBranches_Round12(t *testing.T) {
 	require.Equal(t, "https://example.com/objects/123?q=1", req.URL.String())
 	require.Equal(t, "example.com", req.Host)
 	require.Equal(t, "example.com", req.Header.Get("Host"))
+}
+
+func TestHandleTombstonedObject_NilRepoBranch_Round12(t *testing.T) {
+	h := &Handler{}
+	resp, handled, err := h.handleTombstonedObject(context.Background(), "lookup", "object", "req", false)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+	require.False(t, handled)
 }
 
 func TestObjectsSecurityHeaders_Round12(t *testing.T) {

--- a/cmd/objects/round13_routes_test.go
+++ b/cmd/objects/round13_routes_test.go
@@ -19,6 +19,7 @@ func TestObjectsStrictRouteInventoryParity_Round13(t *testing.T) {
 	require.NoError(t, json.Unmarshal(artifactBytes, &artifact))
 	require.Equal(t, []objectsRouteInventoryEntry{
 		{Method: http.MethodGet, Path: "/objects/:id"},
+		{Method: http.MethodGet, Path: "/articles/:slug"},
 		{Method: http.MethodGet, Path: "/users/:username/statuses/:id"},
 	}, artifact)
 	require.Equal(t, artifact, objectsRouteInventory())
@@ -28,6 +29,7 @@ func TestObjectsStrictRouteInventoryParity_Round13(t *testing.T) {
 	require.NoError(t, registerObjectsRoutes(app, func(ctx *apptheory.Context) (*apptheory.Response, error) {
 		params = append(params, map[string]string{
 			"id":       ctx.Param("id"),
+			"slug":     ctx.Param("slug"),
 			"username": ctx.Param("username"),
 		})
 		return &apptheory.Response{Status: http.StatusNoContent}, nil
@@ -38,28 +40,35 @@ func TestObjectsStrictRouteInventoryParity_Round13(t *testing.T) {
 		Path:   "/objects/note-1",
 	})
 	require.Equal(t, http.StatusNoContent, resp.Status)
-	require.Equal(t, map[string]string{"id": "note-1", "username": ""}, params[0])
+	require.Equal(t, map[string]string{"id": "note-1", "slug": "", "username": ""}, params[0])
+
+	resp = app.Serve(context.Background(), apptheory.Request{
+		Method: http.MethodGet,
+		Path:   "/articles/hello-world",
+	})
+	require.Equal(t, http.StatusNoContent, resp.Status)
+	require.Equal(t, map[string]string{"id": "", "slug": "hello-world", "username": ""}, params[1])
 
 	resp = app.Serve(context.Background(), apptheory.Request{
 		Method: http.MethodGet,
 		Path:   "/users/alice/statuses/note-2",
 	})
 	require.Equal(t, http.StatusNoContent, resp.Status)
-	require.Equal(t, map[string]string{"id": "note-2", "username": "alice"}, params[1])
+	require.Equal(t, map[string]string{"id": "note-2", "slug": "", "username": "alice"}, params[2])
 
 	resp = app.Serve(context.Background(), apptheory.Request{
 		Method: http.MethodPost,
 		Path:   "/objects/note-1",
 	})
 	require.Equal(t, http.StatusMethodNotAllowed, resp.Status)
-	require.Len(t, params, 2)
+	require.Len(t, params, 3)
 
 	resp = app.Serve(context.Background(), apptheory.Request{
 		Method: http.MethodGet,
 		Path:   "/users/alice/statuses",
 	})
 	require.Equal(t, http.StatusNotFound, resp.Status)
-	require.Len(t, params, 2)
+	require.Len(t, params, 3)
 }
 
 func TestRegisterObjectsRoutesStrictFailure_Round13(t *testing.T) {

--- a/cmd/objects/testdata/route_inventory.json
+++ b/cmd/objects/testdata/route_inventory.json
@@ -5,6 +5,10 @@
   },
   {
     "method": "GET",
+    "path": "/articles/:slug"
+  },
+  {
+    "method": "GET",
     "path": "/users/:username/statuses/:id"
   }
 ]

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -20003,6 +20003,29 @@ paths:
             x-lesser-lambda: api
             x-lesser-routeSources:
                 - cmd/api/routes.go
+    /articles/{slug}:
+        get:
+            operationId: get_articles_by_slug
+            tags:
+                - articles
+            parameters:
+                - name: slug
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "404":
+                    $ref: '#/components/responses/NotFound'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+            x-lesser-lambda: objects
+            x-lesser-routeSources:
+                - infra/cdk/inventory/lambdas.go:objects
     /auth/device:
         get:
             operationId: get_auth_device

--- a/docs/specs/01-lambda-inventory-matrix.md
+++ b/docs/specs/01-lambda-inventory-matrix.md
@@ -63,7 +63,7 @@ The inventory set is enforced by:
 | moderation-processor | processor-stream | Stream: table=main-table; start=LATEST; batch=10; window=5s; parallel=2; maxRetry=3; maxAge=3600s; poisonQueue=moderation-processor-stream-poison-queue; bisect=true; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
 | note-processor | processor-stream | Stream: table=main-table; start=LATEST; batch=25; window=5s; maxRetry=3; maxAge=3600s; poisonQueue=note-processor-stream-poison-queue; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |
 | notification-processor | processor-sqs | SQS: queue=notification-processor-queue; partialFailure=true | — | basic | memory=512MB; timeout=30s; logs=7d |
-| objects | api-http | HTTP: GET /objects/{id}<br>HTTP: GET /users/{username}/statuses/{id} | — | encryption | memory=512MB; timeout=30s; logs=7d |
+| objects | api-http | HTTP: GET /objects/{id}<br>HTTP: GET /articles/{slug}<br>HTTP: GET /users/{username}/statuses/{id} | — | encryption | memory=512MB; timeout=30s; logs=7d |
 | outbox | api-http | HTTP: GET /users/{username}/outbox<br>HTTP: POST /users/{username}/outbox | — | encryption | memory=512MB; timeout=30s; logs=7d |
 | push-delivery | processor-sqs | SQS: queue=push-delivery-queue; partialFailure=true | VAPID_PUBLIC_KEY<br>VAPID_SUBJECT<br>VAPID_SECRET_ARN | basic | memory=512MB; timeout=30s; logs=7d |
 | report-trust-updater | processor-stream | Stream: table=main-table; start=LATEST; batch=25; window=5s; maxRetry=3; maxAge=3600s; poisonQueue=report-trust-updater-stream-poison-queue; reportBatchItemFailures=true | — | basic | memory=512MB; timeout=30s; logs=7d |

--- a/graph/cms_helpers.go
+++ b/graph/cms_helpers.go
@@ -36,10 +36,6 @@ func cmsArticleID(domain, slug string) string {
 	return common.GenerateObjectID(domain, "articles", slug)
 }
 
-func cmsArticleObjectID(domain, objectID string) string {
-	return common.GenerateObjectID(domain, "objects", objectID)
-}
-
 func cmsCategoryID(domain, slug string) string {
 	return common.GenerateObjectID(domain, "categories", slug)
 }

--- a/graph/cms_resolvers_round12_test.go
+++ b/graph/cms_resolvers_round12_test.go
@@ -101,6 +101,7 @@ func TestRound12CMS_DraftLifecycle(t *testing.T) {
 	article, err := mut.PublishDraft(ctx, draft.ID)
 	require.NoError(t, err)
 	require.NotNil(t, article)
+	require.Equal(t, "https://localhost/articles/updated-draft", article.ID)
 	require.NotEmpty(t, article.ID)
 }
 
@@ -559,6 +560,7 @@ func TestRound12CMS_SeriesMutationRejectsCrossTenantSeries(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, article)
+	require.Equal(t, "https://tenant-b.example/articles/tenant-b-article", article.ID)
 
 	order := 1
 	_, err = mut.AddArticleToSeries(aliceCtx, tenantASeries.ID, article.ID, &order)
@@ -592,6 +594,7 @@ func TestRound12CMS_ArticleWritesRejectCrossTenantArticle(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, tenantAArticle)
+	require.Equal(t, "https://tenant-a.example/articles/tenant-a-article", tenantAArticle.ID)
 
 	revision := &models.Revision{
 		ID:           "tenant-a-rev-1",
@@ -623,6 +626,43 @@ func TestRound12CMS_ArticleWritesRejectCrossTenantArticle(t *testing.T) {
 	storedArticle, err := storage.Article().GetArticle(context.Background(), tenantAArticle.ID)
 	require.NoError(t, err)
 	require.Equal(t, "Tenant A Article", storedArticle.Name)
+}
+
+func TestRound12CMS_ArticleCreateCanonicalIDSlugCollisionsAreTenantScoped(t *testing.T) {
+	resolver, _ := newRound12GraphResolver(t)
+	mut := resolver.Mutation()
+	aliceCtx := round12AuthContext("alice")
+
+	cfg := resolver.Registry.GetConfig()
+	require.NotNil(t, cfg)
+
+	slug := "shared-slug"
+	cfg.BaseURL = "https://tenant-a.example"
+	tenantAArticle, err := mut.CreateArticle(aliceCtx, model.CreateArticleInput{
+		Slug:    &slug,
+		Title:   "Tenant A Article",
+		Content: "tenant a body",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, tenantAArticle)
+	require.Equal(t, "https://tenant-a.example/articles/shared-slug", tenantAArticle.ID)
+
+	_, err = mut.CreateArticle(aliceCtx, model.CreateArticleInput{
+		Slug:    &slug,
+		Title:   "Tenant A Duplicate",
+		Content: "duplicate",
+	})
+	require.Error(t, err)
+
+	cfg.BaseURL = "https://tenant-b.example"
+	tenantBArticle, err := mut.CreateArticle(aliceCtx, model.CreateArticleInput{
+		Slug:    &slug,
+		Title:   "Tenant B Article",
+		Content: "tenant b body",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, tenantBArticle)
+	require.Equal(t, "https://tenant-b.example/articles/shared-slug", tenantBArticle.ID)
 }
 
 func TestRound12CMS_HelperBranches(t *testing.T) {

--- a/graph/mutation_resolvers_cms.go
+++ b/graph/mutation_resolvers_cms.go
@@ -279,9 +279,10 @@ func (r *mutationResolver) CreateArticle(ctx context.Context, input model.Create
 
 	article := &models.Article{
 		Object: models.Object{
-			ID:           cmsArticleObjectID(domain, uuid.NewString()),
+			ID:           cmsArticleID(domain, slug),
 			Type:         "Article",
 			Name:         input.Title,
+			Summary:      derefString(input.Excerpt),
 			Content:      input.Content,
 			AttributedTo: cmsLocalActorID(domain, username),
 			Published:    now,

--- a/infra/cdk/inventory/lambdas.go
+++ b/infra/cdk/inventory/lambdas.go
@@ -362,6 +362,7 @@ var LambdaInventory = Inventory{
 			Role: RoleClassEncryption,
 			HTTPRoutes: []HTTPRoute{
 				{Method: "GET", Path: "/objects/{id}"},
+				{Method: "GET", Path: "/articles/{slug}"},
 				{Method: "GET", Path: "/users/{username}/statuses/{id}"},
 			},
 		},

--- a/pkg/services/cms/article_service.go
+++ b/pkg/services/cms/article_service.go
@@ -233,6 +233,22 @@ func (s *ArticleService) UpdateArticle(ctx context.Context, article *models.Arti
 
 	slug := strings.TrimSpace(article.Slug)
 	article.Slug = slug
+	if existing != nil {
+		if canonicalSlug, ok := cmsArticleSlugFromCanonicalID(existing.ID); ok {
+			requestedSlug := slug
+			if requestedSlug == "" {
+				requestedSlug = strings.TrimSpace(existing.Slug)
+			}
+			if requestedSlug == "" {
+				requestedSlug = canonicalSlug
+			}
+			if requestedSlug != canonicalSlug {
+				return apperrors.ValidationFailed("slug", "published article slug is immutable")
+			}
+			article.Slug = requestedSlug
+			slug = requestedSlug
+		}
+	}
 
 	slugCreated := false
 	if slug != "" {

--- a/pkg/services/cms/article_service_round31_more_coverage_test.go
+++ b/pkg/services/cms/article_service_round31_more_coverage_test.go
@@ -64,6 +64,58 @@ func TestArticleService_UpdateArticle_AllowsBlankSlugAndSetsUpdatedFields(t *tes
 	require.False(t, article.Updated.IsZero())
 }
 
+func TestArticleService_UpdateArticle_RejectsCanonicalPublishedSlugChange(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db, q := newCMSMockDB(t)
+	q.On("Create").Return(nil).Maybe()
+	q.On("Delete").Return(nil).Maybe()
+
+	repo := &fakeArticleRepo{
+		db:       db,
+		articles: map[string]*models.Article{},
+	}
+	articleID := "https://example.com/articles/original-slug"
+	repo.articles[articleID] = &models.Article{
+		Object: models.Object{
+			ID:           articleID,
+			Type:         activitypub.ArticleType,
+			Published:    time.Now(),
+			AttributedTo: "https://example.com/users/alice",
+			Content:      "before",
+		},
+		Slug: "original-slug",
+	}
+
+	svc := NewArticleService(repo, fakeActorRepo{err: errors.New("no actor")}, nil, nil, nil, &fakeFederation{}, zap.NewNop())
+
+	err := svc.UpdateArticle(ctx, &models.Article{
+		Object: models.Object{
+			ID:           articleID,
+			Type:         activitypub.ArticleType,
+			Published:    time.Now(),
+			AttributedTo: "https://example.com/users/alice",
+			Content:      "after",
+		},
+		Slug: "renamed-slug",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "immutable")
+
+	err = svc.UpdateArticle(ctx, &models.Article{
+		Object: models.Object{
+			ID:           articleID,
+			Type:         activitypub.ArticleType,
+			Published:    time.Now(),
+			AttributedTo: "https://example.com/users/alice",
+			Content:      "after",
+		},
+		Slug: "original-slug",
+	})
+	require.NoError(t, err)
+}
+
 func TestArticleService_DeleteArticle_ValidatesInput(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/services/cms/draft_service.go
+++ b/pkg/services/cms/draft_service.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/common"
-	apperrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"go.uber.org/zap"
 )
@@ -33,10 +32,6 @@ type articleDraftPublisher interface {
 	GetArticleBySlug(ctx context.Context, slug string) (*models.Article, error)
 	CreateArticle(ctx context.Context, article *models.Article) error
 	UpdateArticle(ctx context.Context, article *models.Article) error
-}
-
-type tenantArticleDraftPublisher interface {
-	GetArticleByTenantSlug(ctx context.Context, tenant string, slug string) (*models.Article, error)
 }
 
 // DraftService handles business logic for drafts
@@ -314,56 +309,12 @@ func (s *DraftService) publishDraftCreateNewArticle(ctx context.Context, authorI
 	}
 
 	if err := s.articleService.CreateArticle(ctx, article); err != nil {
-		if apperrors.HasCode(err, apperrors.CodeAlreadyExists) {
-			existing, getErr := s.resolveExistingArticleBySlug(ctx, domain, slug)
-			if getErr == nil && existing != nil {
-				if strings.TrimSpace(existing.AttributedTo) != common.GenerateActorID(domain, authorID) {
-					s.markDraftFailed(ctx, authorID, draft, draftID, err)
-					return nil, err
-				}
-
-				s.deleteDraftAfterPublish(ctx, draft, authorID, draftID, strings.TrimSpace(existing.ID))
-				return existing, nil
-			}
-		}
-
 		s.markDraftFailed(ctx, authorID, draft, draftID, err)
 		return nil, err
 	}
 
 	s.deleteDraftAfterPublish(ctx, draft, authorID, draftID, objectID)
 	return article, nil
-}
-
-func (s *DraftService) resolveExistingArticleBySlug(ctx context.Context, domain string, slug string) (*models.Article, error) {
-	slug = strings.TrimSpace(slug)
-	if slug == "" {
-		return nil, stdErrors.New("slug is required")
-	}
-
-	if s.articleService != nil {
-		var (
-			article *models.Article
-			err     error
-		)
-		if tenantGetter, ok := s.articleService.(tenantArticleDraftPublisher); ok {
-			article, err = tenantGetter.GetArticleByTenantSlug(ctx, domain, slug)
-		} else {
-			article, err = s.articleService.GetArticleBySlug(ctx, slug)
-		}
-		if err == nil {
-			return article, nil
-		}
-		if err != nil && !apperrors.HasCode(err, apperrors.CodeNotFound) {
-			return nil, err
-		}
-	}
-
-	legacyID := common.GenerateObjectID(domain, "articles", slug)
-	if strings.TrimSpace(legacyID) == "" {
-		return nil, apperrors.ItemNotFoundWithID("article slug", slug)
-	}
-	return s.articleService.GetArticle(ctx, legacyID)
 }
 
 func (s *DraftService) deleteDraftAfterPublish(ctx context.Context, draft *models.Draft, authorID, draftID, objectID string) {

--- a/pkg/services/cms/draft_service.go
+++ b/pkg/services/cms/draft_service.go
@@ -10,7 +10,6 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	apperrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/storage/models"
-	"github.com/google/uuid"
 	"go.uber.org/zap"
 )
 
@@ -216,7 +215,7 @@ func (s *DraftService) resolveArticleDraftTarget(domain string, draft *models.Dr
 	}
 
 	if objectID == "" {
-		objectID = common.GenerateObjectID(domain, "objects", uuid.NewString())
+		objectID = common.GenerateObjectID(domain, "articles", slug)
 	}
 
 	if !strings.HasPrefix(objectID, "https://"+domain+"/") && !strings.HasPrefix(objectID, "http://"+domain+"/") {

--- a/pkg/services/cms/draft_service_round31_even_more_coverage_test.go
+++ b/pkg/services/cms/draft_service_round31_even_more_coverage_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
-	"github.com/equaltoai/lesser/pkg/common"
 	apperrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/require"
@@ -34,27 +33,6 @@ func (s *memArticleServiceGetErr) CreateArticle(ctx context.Context, article *mo
 }
 
 func (s *memArticleServiceGetErr) UpdateArticle(ctx context.Context, article *models.Article) error {
-	return s.base.UpdateArticle(ctx, article)
-}
-
-type memArticleServiceSlugErr struct {
-	base      *memArticleService
-	slugError error
-}
-
-func (s *memArticleServiceSlugErr) GetArticle(ctx context.Context, articleID string) (*models.Article, error) {
-	return s.base.GetArticle(ctx, articleID)
-}
-
-func (s *memArticleServiceSlugErr) GetArticleBySlug(ctx context.Context, slug string) (*models.Article, error) {
-	return nil, s.slugError
-}
-
-func (s *memArticleServiceSlugErr) CreateArticle(ctx context.Context, article *models.Article) error {
-	return s.base.CreateArticle(ctx, article)
-}
-
-func (s *memArticleServiceSlugErr) UpdateArticle(ctx context.Context, article *models.Article) error {
 	return s.base.UpdateArticle(ctx, article)
 }
 
@@ -142,44 +120,4 @@ func TestDraftServicePublishDraft_UpdatesExistingArticleAndDeletesDraft(t *testi
 	_, err = repo.GetDraft(context.Background(), draft.AuthorID, draft.ID)
 	require.Error(t, err)
 	require.True(t, apperrors.HasCode(err, apperrors.CodeNotFound))
-}
-
-func TestDraftServiceResolveExistingArticleBySlug_LegacyFallback(t *testing.T) {
-	t.Parallel()
-
-	articles := newMemArticleService()
-	svc := &DraftService{
-		articleService: articles,
-	}
-
-	slug := "legacy-article"
-	legacyID := common.GenerateObjectID("example.com", "articles", slug)
-	articles.items[legacyID] = &models.Article{
-		Object: models.Object{
-			ID:           legacyID,
-			Type:         activitypub.ArticleType,
-			AttributedTo: "https://example.com/users/alice",
-		},
-		Slug: slug,
-	}
-
-	got, err := svc.resolveExistingArticleBySlug(context.Background(), "example.com", slug)
-	require.NoError(t, err)
-	require.NotNil(t, got)
-	require.Equal(t, legacyID, got.ID)
-}
-
-func TestDraftServiceResolveExistingArticleBySlug_PropagatesUnexpectedGetBySlugError(t *testing.T) {
-	t.Parallel()
-
-	articles := &memArticleServiceSlugErr{
-		base:      newMemArticleService(),
-		slugError: errors.New("unexpected slug error"),
-	}
-	svc := &DraftService{
-		articleService: articles,
-	}
-
-	_, err := svc.resolveExistingArticleBySlug(context.Background(), "example.com", "slug")
-	require.Error(t, err)
 }

--- a/pkg/services/cms/draft_service_round31_more_coverage_test.go
+++ b/pkg/services/cms/draft_service_round31_more_coverage_test.go
@@ -189,6 +189,17 @@ func TestDraftServiceResolveArticleDraftTarget_ValidatesSlugAndObjectID(t *testi
 	require.NoError(t, err)
 	require.Equal(t, validObjectID, objectID)
 	require.Equal(t, "hello", slug)
+
+	objectID, slug, err = svc.resolveArticleDraftTarget("example.com", &models.Draft{Title: "Hello World"})
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/articles/hello-world", objectID)
+	require.Equal(t, "hello-world", slug)
+
+	validLegacyObjectID := "https://example.com/objects/legacy"
+	objectID, slug, err = svc.resolveArticleDraftTarget("example.com", &models.Draft{Title: "Legacy", ObjectID: &validLegacyObjectID})
+	require.NoError(t, err)
+	require.Equal(t, validLegacyObjectID, objectID)
+	require.Equal(t, "legacy", slug)
 }
 
 func TestDraftServicePublishDraft_UpdateExistingArticlePermissionDeniedMarksFailed(t *testing.T) {

--- a/pkg/services/cms/draft_service_test.go
+++ b/pkg/services/cms/draft_service_test.go
@@ -276,7 +276,7 @@ func TestDraftServicePublishDraftCreatesArticleAndDeletesDraft(t *testing.T) {
 	require.True(t, apperrors.HasCode(err, apperrors.CodeNotFound))
 }
 
-func TestDraftServicePublishDraftAlreadyExistsSameAuthor(t *testing.T) {
+func TestDraftServicePublishDraftAlreadyExistsSameAuthorMarksFailed(t *testing.T) {
 	t.Parallel()
 
 	repo := newMemDraftRepo()
@@ -314,13 +314,17 @@ func TestDraftServicePublishDraftAlreadyExistsSameAuthor(t *testing.T) {
 	require.NoError(t, repo.CreateDraft(context.Background(), draft))
 
 	article, err := svc.PublishDraft(context.Background(), draft.AuthorID, draft.ID)
-	require.NoError(t, err)
-	require.NotNil(t, article)
-	require.Equal(t, existing.ID, article.ID)
-
-	_, err = repo.GetDraft(context.Background(), draft.AuthorID, draft.ID)
 	require.Error(t, err)
-	require.True(t, apperrors.HasCode(err, apperrors.CodeNotFound))
+	require.Nil(t, article)
+	require.True(t, apperrors.HasCode(err, apperrors.CodeAlreadyExists))
+
+	after, getErr := repo.GetDraft(context.Background(), draft.AuthorID, draft.ID)
+	require.NoError(t, getErr)
+	require.Equal(t, "failed", after.Status)
+
+	stored, getExistingErr := articles.GetArticle(context.Background(), existing.ID)
+	require.NoError(t, getExistingErr)
+	require.Equal(t, "Existing", stored.Name)
 }
 
 func TestDraftServicePublishDraftAlreadyExistsDifferentAuthorMarksFailed(t *testing.T) {

--- a/pkg/services/cms/draft_service_test.go
+++ b/pkg/services/cms/draft_service_test.go
@@ -266,7 +266,7 @@ func TestDraftServicePublishDraftCreatesArticleAndDeletesDraft(t *testing.T) {
 	article, err := svc.PublishDraft(context.Background(), draft.AuthorID, draft.ID)
 	require.NoError(t, err)
 	require.NotNil(t, article)
-	require.True(t, strings.HasPrefix(article.ID, "https://example.com/objects/"))
+	require.Equal(t, "https://example.com/articles/hello-world", article.ID)
 	require.Equal(t, "hello-world", article.Slug)
 	require.Equal(t, "https://example.com/users/alice", article.AttributedTo)
 	require.Equal(t, activitypub.ArticleType, article.Type)
@@ -396,6 +396,6 @@ func TestCMSSmokeDraftLifecycle(t *testing.T) {
 
 	article, err := svc.PublishDraft(context.Background(), draft.AuthorID, draft.ID)
 	require.NoError(t, err)
-	require.True(t, strings.HasPrefix(article.ID, "https://example.com/objects/"))
+	require.Equal(t, "https://example.com/articles/smoke-test", article.ID)
 	require.Equal(t, "smoke-test", article.Slug)
 }

--- a/pkg/services/cms/slug_indexes.go
+++ b/pkg/services/cms/slug_indexes.go
@@ -32,6 +32,25 @@ func cmsTenantFromID(value string) string {
 	return cmsNormalizeTenant(cmsHostFromURL(value))
 }
 
+func cmsArticleSlugFromCanonicalID(value string) (string, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", false
+	}
+
+	parsed, err := neturl.Parse(value)
+	if err != nil || strings.TrimSpace(parsed.Host) == "" {
+		return "", false
+	}
+
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) != 2 || parts[0] != "articles" || strings.TrimSpace(parts[1]) == "" {
+		return "", false
+	}
+
+	return strings.TrimSpace(parts[1]), true
+}
+
 func cmsEnsureSlugIndex(ctx context.Context, db core.DB, pk string, slug string, targetID string, itemType string) (bool, error) {
 	idx := &models.CMSSlugIndex{
 		PK:       pk,

--- a/pkg/storage/repositories/object_repository.go
+++ b/pkg/storage/repositories/object_repository.go
@@ -610,37 +610,15 @@ func (r *ObjectRepository) TombstoneObject(ctx context.Context, objectID string,
 func (r *ObjectRepository) modelToActivityPubObject(objModel *models.Object) (any, error) {
 	switch objModel.Type {
 	case activitypub.NoteType:
-		note := &activitypub.Note{
-			BaseObject: activitypub.BaseObject{
-				ID:        objModel.ID,
-				Type:      objModel.Type,
-				Published: &objModel.Published,
-				Updated:   &objModel.Updated,
-				To:        objModel.To,
-				CC:        objModel.CC,
-				Sensitive: objModel.Sensitive,
-			},
-			Content:      objModel.Content,
-			AttributedTo: objModel.AttributedTo,
-		}
+		return objectModelToActivityPubNote(objModel), nil
 
-		// Set InReplyTo if present
-		if objModel.InReplyTo != nil {
-			note.InReplyTo = *objModel.InReplyTo
-		}
-
-		// Parse complex fields from JSON
-		if objModel.AttachmentJSON != "" {
-			_ = json.Unmarshal([]byte(objModel.AttachmentJSON), &note.Attachment)
-		}
-		if objModel.TagJSON != "" {
-			_ = json.Unmarshal([]byte(objModel.TagJSON), &note.Tag)
-		}
-		if objModel.ContextJSON != "" {
-			_ = json.Unmarshal([]byte(objModel.ContextJSON), &note.Context)
-		}
-
-		return note, nil
+	case activitypub.ArticleType:
+		note := objectModelToActivityPubNote(objModel)
+		note.Type = activitypub.ArticleType
+		return &activitypub.Article{
+			Note: *note,
+			Name: objModel.Name,
+		}, nil
 
 	default:
 		// Return as generic map for other types
@@ -662,6 +640,41 @@ func (r *ObjectRepository) modelToActivityPubObject(objModel *models.Object) (an
 
 		return result, nil
 	}
+}
+
+func objectModelToActivityPubNote(objModel *models.Object) *activitypub.Note {
+	note := &activitypub.Note{
+		BaseObject: activitypub.BaseObject{
+			ID:        objModel.ID,
+			Type:      objModel.Type,
+			Published: &objModel.Published,
+			Updated:   &objModel.Updated,
+			To:        objModel.To,
+			CC:        objModel.CC,
+			BTo:       objModel.BTo,
+			BCC:       objModel.BCC,
+			Summary:   objModel.Summary,
+			Sensitive: objModel.Sensitive,
+		},
+		Content:      objModel.Content,
+		AttributedTo: objModel.AttributedTo,
+	}
+
+	if objModel.InReplyTo != nil {
+		note.InReplyTo = *objModel.InReplyTo
+	}
+
+	if objModel.AttachmentJSON != "" {
+		_ = json.Unmarshal([]byte(objModel.AttachmentJSON), &note.Attachment)
+	}
+	if objModel.TagJSON != "" {
+		_ = json.Unmarshal([]byte(objModel.TagJSON), &note.Tag)
+	}
+	if objModel.ContextJSON != "" {
+		_ = json.Unmarshal([]byte(objModel.ContextJSON), &note.Context)
+	}
+
+	return note
 }
 
 // CreateUpdateHistory creates a new update history entry for an object

--- a/pkg/storage/repositories/object_repository.go
+++ b/pkg/storage/repositories/object_repository.go
@@ -613,12 +613,7 @@ func (r *ObjectRepository) modelToActivityPubObject(objModel *models.Object) (an
 		return objectModelToActivityPubNote(objModel), nil
 
 	case activitypub.ArticleType:
-		note := objectModelToActivityPubNote(objModel)
-		note.Type = activitypub.ArticleType
-		return &activitypub.Article{
-			Note: *note,
-			Name: objModel.Name,
-		}, nil
+		return objectModelToActivityPubArticle(objModel), nil
 
 	default:
 		// Return as generic map for other types
@@ -651,9 +646,6 @@ func objectModelToActivityPubNote(objModel *models.Object) *activitypub.Note {
 			Updated:   &objModel.Updated,
 			To:        objModel.To,
 			CC:        objModel.CC,
-			BTo:       objModel.BTo,
-			BCC:       objModel.BCC,
-			Summary:   objModel.Summary,
 			Sensitive: objModel.Sensitive,
 		},
 		Content:      objModel.Content,
@@ -675,6 +667,17 @@ func objectModelToActivityPubNote(objModel *models.Object) *activitypub.Note {
 	}
 
 	return note
+}
+
+func objectModelToActivityPubArticle(objModel *models.Object) *activitypub.Article {
+	note := objectModelToActivityPubNote(objModel)
+	note.Type = activitypub.ArticleType
+	note.Summary = objModel.Summary
+
+	return &activitypub.Article{
+		Note: *note,
+		Name: objModel.Name,
+	}
 }
 
 // CreateUpdateHistory creates a new update history entry for an object

--- a/pkg/storage/repositories/object_repository_additional_coverage_test.go
+++ b/pkg/storage/repositories/object_repository_additional_coverage_test.go
@@ -726,7 +726,7 @@ func TestObjectRepository_TombstoneObject_UsesMapBranch(t *testing.T) {
 	mockQuery := new(mocks.MockQuery)
 	mockQuery.On("First", mock.AnythingOfType("*models.Object")).Run(func(args mock.Arguments) {
 		obj := args.Get(0).(*models.Object)
-		*obj = *models.NewObject("note-1", "Article", "alice")
+		*obj = *models.NewObject("note-1", "Page", "alice")
 	}).Return(nil).Once()
 	setupPermissiveObjectRepoMocks(mockDB, mockQuery, baseTime)
 

--- a/pkg/storage/repositories/object_repository_helpers_test.go
+++ b/pkg/storage/repositories/object_repository_helpers_test.go
@@ -210,6 +210,44 @@ func TestModelToActivityPubObject_NoteType(t *testing.T) {
 	}
 }
 
+func TestModelToActivityPubObject_ArticleType(t *testing.T) {
+	repo := NewObjectRepository(nil, "test-table", "example.com", zap.NewNop())
+
+	baseTime := time.Date(2024, 12, 27, 10, 0, 0, 0, time.UTC)
+	updatedTime := time.Date(2024, 12, 27, 12, 0, 0, 0, time.UTC)
+	result, err := repo.modelToActivityPubObject(&models.Object{
+		ID:             "https://example.com/articles/article-123",
+		Type:           activitypub.ArticleType,
+		Name:           "Article Title",
+		Summary:        "Article summary",
+		Published:      baseTime,
+		Updated:        updatedTime,
+		To:             []string{activitypub.PublicAddress},
+		CC:             []string{"https://example.com/users/alice/followers"},
+		Content:        "Article body content",
+		AttributedTo:   "https://example.com/users/alice",
+		AttachmentJSON: `[{"type":"Image","url":"https://example.com/cover.jpg","mediaType":"image/jpeg","name":"cover"}]`,
+		TagJSON:        `[{"type":"Hashtag","href":"https://example.com/tags/cms","name":"#cms"}]`,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	article, ok := result.(*activitypub.Article)
+	require.True(t, ok, "expected *activitypub.Article, got %T", result)
+	require.Equal(t, "https://example.com/articles/article-123", article.ID)
+	require.Equal(t, activitypub.ArticleType, article.Type)
+	require.Equal(t, "Article Title", article.Name)
+	require.Equal(t, "Article summary", article.Summary)
+	require.Equal(t, "Article body content", article.Content)
+	require.Equal(t, "https://example.com/users/alice", article.AttributedTo)
+	require.Equal(t, baseTime, *article.Published)
+	require.Equal(t, updatedTime, *article.Updated)
+	require.Equal(t, []string{activitypub.PublicAddress}, article.To)
+	require.Equal(t, []string{"https://example.com/users/alice/followers"}, article.CC)
+	require.Len(t, article.Attachment, 1)
+	require.Len(t, article.Tag, 1)
+}
+
 // ============================================================================
 // 2) modelToActivityPubObject Tests - Default Conversion Branch
 // ============================================================================
@@ -226,30 +264,6 @@ func TestModelToActivityPubObject_DefaultBranch(t *testing.T) {
 		model    *models.Object
 		checkMap func(t *testing.T, result map[string]any)
 	}{
-		{
-			name: "Article type returns map with core fields",
-			model: &models.Object{
-				ID:           "https://example.com/objects/article-123",
-				Type:         "Article",
-				Published:    baseTime,
-				Updated:      updatedTime,
-				Content:      "Article body content",
-				AttributedTo: "https://example.com/users/alice",
-			},
-			checkMap: func(t *testing.T, result map[string]any) {
-				assert.Equal(t, "https://example.com/objects/article-123", result["id"])
-				assert.Equal(t, "Article", result["type"])
-				assert.Equal(t, "https://example.com/users/alice", result["attributedTo"])
-				assert.Equal(t, "Article body content", result["content"])
-				assert.Equal(t, baseTime, result["published"])
-				assert.Equal(t, updatedTime, result["updated"])
-				// To and CC should NOT be present when nil
-				_, hasTo := result["to"]
-				_, hasCC := result["cc"]
-				assert.False(t, hasTo, "to should not be present when nil")
-				assert.False(t, hasCC, "cc should not be present when nil")
-			},
-		},
 		{
 			name: "Tombstone type returns map",
 			model: &models.Object{

--- a/pkg/storage/repositories/object_repository_helpers_test.go
+++ b/pkg/storage/repositories/object_repository_helpers_test.go
@@ -63,6 +63,34 @@ func TestModelToActivityPubObject_NoteType(t *testing.T) {
 			},
 		},
 		{
+			name: "note omits summary and hidden recipients from readback shape",
+			model: &models.Object{
+				ID:           "https://example.com/objects/hidden-note",
+				Type:         activitypub.NoteType,
+				Published:    baseTime,
+				Updated:      updatedTime,
+				To:           []string{activitypub.PublicAddress},
+				BTo:          []string{"https://remote.example/users/hidden"},
+				BCC:          []string{"https://remote.example/users/also-hidden"},
+				Summary:      "note summary should not be emitted by repository readback",
+				Content:      "Hidden addressing must stay private",
+				AttributedTo: "https://example.com/users/alice",
+			},
+			checkNote: func(t *testing.T, note *activitypub.Note) {
+				assert.Empty(t, note.BTo)
+				assert.Empty(t, note.BCC)
+				assert.Empty(t, note.Summary)
+
+				bodyBytes, err := json.Marshal(note)
+				require.NoError(t, err)
+				var body map[string]any
+				require.NoError(t, json.Unmarshal(bodyBytes, &body))
+				assert.NotContains(t, body, "bto")
+				assert.NotContains(t, body, "bcc")
+				assert.NotContains(t, body, "summary")
+			},
+		},
+		{
 			name: "note with InReplyTo pointer set",
 			model: &models.Object{
 				ID:           "https://example.com/objects/reply-456",
@@ -224,6 +252,8 @@ func TestModelToActivityPubObject_ArticleType(t *testing.T) {
 		Updated:        updatedTime,
 		To:             []string{activitypub.PublicAddress},
 		CC:             []string{"https://example.com/users/alice/followers"},
+		BTo:            []string{"https://remote.example/users/hidden"},
+		BCC:            []string{"https://remote.example/users/also-hidden"},
 		Content:        "Article body content",
 		AttributedTo:   "https://example.com/users/alice",
 		AttachmentJSON: `[{"type":"Image","url":"https://example.com/cover.jpg","mediaType":"image/jpeg","name":"cover"}]`,
@@ -244,8 +274,18 @@ func TestModelToActivityPubObject_ArticleType(t *testing.T) {
 	require.Equal(t, updatedTime, *article.Updated)
 	require.Equal(t, []string{activitypub.PublicAddress}, article.To)
 	require.Equal(t, []string{"https://example.com/users/alice/followers"}, article.CC)
+	require.Empty(t, article.BTo)
+	require.Empty(t, article.BCC)
 	require.Len(t, article.Attachment, 1)
 	require.Len(t, article.Tag, 1)
+
+	bodyBytes, err := json.Marshal(article)
+	require.NoError(t, err)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(bodyBytes, &body))
+	require.Equal(t, "Article summary", body["summary"])
+	require.NotContains(t, body, "bto")
+	require.NotContains(t, body, "bcc")
 }
 
 // ============================================================================


### PR DESCRIPTION
## Milestone
Project 36 M1 — canonical Article identity, routing, and readback.

## Classification
Contract-stability / federation-trust-adjacent / operational route inventory. Additive ActivityPub object route and Article ID semantics; no HTTP Signature, inbox/outbox, actor-key, delivery, TableTheory tag, PK/SK, or GSI changes.

## Surfaces affected
- CMS Article create and draft publish ID construction.
- CMS Article update slug immutability for published canonical `/articles/:slug` identities.
- Objects Lambda readback/content negotiation for `GET /articles/{slug}`.
- ActivityPub Article storage readback shape.
- Route inventory, CDK lambda inventory, generated lambda inventory matrix, and OpenAPI contract.

## Specialist walks referenced
- Federation trust: additive object fetch route only; existing public-address/authorized-fetch/follower gates are preserved and tested for Articles.
- Contract / API: additive `GET /articles/{slug}` route; generated `docs/contracts/openapi.yaml` updated. Existing `/objects/{id}` and `/users/{username}/statuses/{id}` remain mapped to the objects Lambda.
- Schema: no TableTheory tags, PK/SK construction, GSI definitions, or model attributes changed. New Article IDs still persist through existing object rows.
- Framework: idiomatic AppTheory strict route registration and existing TableTheory repository path; no framework patches.

## Consumer impact
- New published Articles use `https://<domain>/articles/<slug>` as the canonical ActivityPub ID, public URL, and GraphQL `Article.id`.
- Direct create and draft publish share the same canonical constructor.
- Legacy `/objects/<uuid>` Article IDs remain fetchable through the unchanged `/objects/{id}` route; this PR does not migrate, rewrite, or duplicate existing Article identities.
- Published canonical Article slugs are immutable for the MVP to avoid creating a second ActivityPub identity.
- Draft publish now fails and marks the draft failed when the final slug is already claimed in the same tenant/domain; it no longer returns an existing same-author Article.
- Browser HTML and unsigned/public fetch paths continue to hide non-public Articles.

## Tasks
- [x] #1029 — M1 parent: canonical Article routing/readback
- [x] #1030 — canonical `/articles/:slug` IDs for new Articles
- [x] #1031 — draft publish defaults use Article canonical IDs
- [x] #1032 — add `GET /articles/:slug` route
- [x] #1033 — Article readback/content negotiation
- [x] #1034 — non-public fetch boundaries

Closes #1029
Closes #1030
Closes #1031
Closes #1032
Closes #1033
Closes #1034

## Validation
- `go test ./cmd/objects ./pkg/services/cms ./pkg/storage/repositories ./graph`
- `go test ./cmd/api/handlers`
- `gofmt -l .` (empty)
- `git diff --check`
- `go test ./...`
- `go vet ./...`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci` (passed after review fixes)
- `cd infra/cdk && CDK_DEFAULT_ACCOUNT=123456789012 CDK_DEFAULT_REGION=us-east-1 cdk synth lesser-dev --context app=lesser --context baseDomain=example.com --context hostedZoneId=Z1234567890 --context stage=dev` (passed with existing CDK deprecation warnings)

## Route inventory / API mapping
- `cmd/objects` strict inventory now includes `GET /articles/:slug`.
- `infra/cdk/inventory/lambdas.go` maps `GET /articles/{slug}` to the objects Lambda.
- `docs/specs/01-lambda-inventory-matrix.md` regenerated.
- `docs/contracts/openapi.yaml` regenerated and includes `GET /articles/{slug}`.
- `/objects/{id}` and `/users/{username}/statuses/{id}` remain registered and tested, so the new route does not shadow legacy object or status routes.

## Content negotiation and non-public boundaries
- ActivityPub JSON readback for Articles returns first-class `Article` objects with title/name, summary, content, attribution, tags, and attachments.
- HTML readback uses the existing safe object HTML path; this PR intentionally does not implement the M3 renderer/sanitizer.
- Tests cover public Article JSON/HTML, HTML suppression for non-public Articles, and authorized-follower JSON fetch for followers-only Articles.
- Review-fix regression coverage verifies stored Notes and Articles do not serialize hidden `bto`/`bcc` recipients in ActivityPub JSON readback.

## M2 deferral note
Generic Article deletion/tombstoning branch coverage is explicitly deferred to M2; M1 remains bounded to Article identity/routing/readback and does not change delete/tombstone semantics.

## Protocol risk / review note
M0 called object IDs, readback, and content negotiation Protocol Counsel-sensitive. This PR keeps the change additive and limited to newly published Articles, but it does affect canonical ActivityPub object identity for new Article creates/publishes. I recommend Arch route this to Protocol Counsel before merge.

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
No sibling-repo code changes. Notify client/consumer stewards if they cache Article IDs or route assumptions, but the public contract change is additive.