### PR TITLE
feat: harden Article federation

### DIFF
--- a/cmd/inbox/internal/routing/inbox.go
+++ b/cmd/inbox/internal/routing/inbox.go
@@ -2414,9 +2414,20 @@ func (ih *InboxHandler) processRemoteCreateActivity(ctx context.Context, activit
 	// Sanitize the object content to prevent XSS
 	common.SanitizeActivityPubObjectDefault(objMap)
 
-	// Store the object if it's a Note
-	if objType, _ := objMap["type"].(string); objType == activitypub.NoteType {
+	// Store the object if it's a Note. Remote Article ingestion is explicitly
+	// unsupported for the Blog/CMS MVP; do not materialize it as a disguised
+	// status or silently route it through the Note path.
+	objType, _ := objMap["type"].(string)
+	switch strings.TrimSpace(objType) {
+	case activitypub.NoteType:
 		return ih.processRemoteCreateNote(ctx, activity, targetActor, objMap)
+	case activitypub.ArticleType:
+		ih.logUnsupportedRemoteArticle(ctx, activity, objMap, "create")
+	default:
+		log.Info("ignoring unsupported remote create object type",
+			zap.String("activity_id", activity.ID),
+			zap.String("actor", activity.Actor),
+			zap.String("object_type", objType))
 	}
 
 	return nil
@@ -2473,6 +2484,19 @@ func (ih *InboxHandler) processRemoteCreateNote(ctx context.Context, activity *a
 	}
 
 	return ih.finishRemoteCreateDeliverySideEffects(ctx, activity, targetActor, &note, status, directConversation, createDirectConversation, directInfo)
+}
+
+func (ih *InboxHandler) logUnsupportedRemoteArticle(ctx context.Context, activity *activitypub.Activity, objMap map[string]any, operation string) {
+	objectID := ""
+	if objMap != nil {
+		objectID, _ = objMap["id"].(string)
+	}
+
+	common.WithContext(ctx).Info("ignoring unsupported remote Article activity",
+		zap.String("operation", operation),
+		zap.String("activity_id", activity.ID),
+		zap.String("actor", activity.Actor),
+		zap.String("object_id", objectID))
 }
 
 func (ih *InboxHandler) prepareDirectCreateState(
@@ -3331,16 +3355,18 @@ func (ih *InboxHandler) processRemoteUpdateActivity(ctx context.Context, activit
 	// Sanitize the object content to prevent XSS
 	common.SanitizeActivityPubObjectDefault(objMap)
 
-	// Store edit history before updating
-	if err := ih.storeEditHistory(ctx, objectID, existingObject, activity.Actor); err != nil {
-		log.Error("failed to store edit history",
-			zap.String("object_id", objectID),
-			zap.Error(err))
-		// Continue even if history storage fails
-	}
-
 	// Update the object if it's a Note
-	if objType, _ := objMap["type"].(string); objType == activitypub.NoteType {
+	objType, _ := objMap["type"].(string)
+	switch strings.TrimSpace(objType) {
+	case activitypub.NoteType:
+		// Store edit history before updating supported Note objects.
+		if err := ih.storeEditHistory(ctx, objectID, existingObject, activity.Actor); err != nil {
+			log.Error("failed to store edit history",
+				zap.String("object_id", objectID),
+				zap.Error(err))
+			// Continue even if history storage fails
+		}
+
 		// Convert to Note object
 		objJSON, err := json.Marshal(objMap)
 		if err != nil {
@@ -3374,6 +3400,14 @@ func (ih *InboxHandler) processRemoteUpdateActivity(ctx context.Context, activit
 		log.Info("successfully updated remote note",
 			zap.String("object_id", objectID),
 			zap.String("updated_by", activity.Actor))
+	case activitypub.ArticleType:
+		ih.logUnsupportedRemoteArticle(ctx, activity, objMap, "update")
+	default:
+		log.Info("ignoring unsupported remote update object type",
+			zap.String("activity_id", activity.ID),
+			zap.String("actor", activity.Actor),
+			zap.String("object_id", objectID),
+			zap.String("object_type", objType))
 	}
 
 	return nil
@@ -3429,7 +3463,7 @@ func (ih *InboxHandler) processRemoteDeleteActivity(ctx context.Context, activit
 	}
 
 	// Create tombstone (soft delete) instead of hard delete
-	if err := ih.createDeleteTombstone(ctx, objectID, activity, originalObject); err != nil {
+	if err := ih.createDeleteTombstone(ctx, objectID, activity, originalObject, existingObject); err != nil {
 		log.Error("failed to create tombstone",
 			zap.String("object_id", objectID),
 			zap.Error(err))
@@ -4594,6 +4628,8 @@ func (ih *InboxHandler) verifyUpdateAuthorization(_ context.Context, activity *a
 		if attr, ok := objMap["attributedTo"].(string); ok {
 			objectOwner = attr
 		}
+	} else if article, ok := existingObject.(*activitypub.Article); ok {
+		objectOwner = article.AttributedTo
 	} else if note, ok := existingObject.(*activitypub.Note); ok {
 		objectOwner = note.AttributedTo
 	}
@@ -4675,9 +4711,22 @@ func (ih *InboxHandler) extractDeleteTarget(activity *activitypub.Activity) (str
 			objectID = id
 			originalObject = obj
 		}
+	case *activitypub.Article:
+		objectID = obj.ID
+		originalObject = map[string]any{"id": obj.ID, "type": activitypub.ArticleType}
+	case *activitypub.Note:
+		objectID = obj.ID
+		objectType := obj.Type
+		if strings.TrimSpace(objectType) == "" {
+			objectType = activitypub.NoteType
+		}
+		originalObject = map[string]any{"id": obj.ID, "type": objectType}
 	case *activitypub.BaseObject:
 		// Object is typed
 		objectID = obj.ID
+		if strings.TrimSpace(obj.Type) != "" {
+			originalObject = map[string]any{"id": obj.ID, "type": obj.Type}
+		}
 	default:
 		return "", nil, unsupportedDeleteObjectError()
 	}
@@ -4694,6 +4743,8 @@ func (ih *InboxHandler) verifyDeleteAuthorization(_ context.Context, activity *a
 		if attr, ok := objMap["attributedTo"].(string); ok {
 			objectOwner = attr
 		}
+	} else if article, ok := existingObject.(*activitypub.Article); ok {
+		objectOwner = article.AttributedTo
 	} else if note, ok := existingObject.(*activitypub.Note); ok {
 		objectOwner = note.AttributedTo
 	}
@@ -4843,8 +4894,44 @@ func (ih *InboxHandler) cascadeDeleteNotifications(ctx context.Context, objectID
 	return nil
 }
 
+func activityPubObjectFormerType(existingObject any) string {
+	switch obj := existingObject.(type) {
+	case map[string]any:
+		objectType, _ := obj["type"].(string)
+		return strings.TrimSpace(objectType)
+	case *activitypub.Article:
+		if obj == nil {
+			return ""
+		}
+		if strings.TrimSpace(obj.Type) != "" {
+			return strings.TrimSpace(obj.Type)
+		}
+		return activitypub.ArticleType
+	case *activitypub.Note:
+		if obj == nil {
+			return ""
+		}
+		if strings.TrimSpace(obj.Type) != "" {
+			return strings.TrimSpace(obj.Type)
+		}
+		return activitypub.NoteType
+	case *activitypub.BaseObject:
+		if obj == nil {
+			return ""
+		}
+		return strings.TrimSpace(obj.Type)
+	case *models.Object:
+		if obj == nil {
+			return ""
+		}
+		return strings.TrimSpace(obj.Type)
+	default:
+		return ""
+	}
+}
+
 // createDeleteTombstone creates a tombstone for the deleted object
-func (ih *InboxHandler) createDeleteTombstone(ctx context.Context, objectID string, deleteActivity *activitypub.Activity, originalObject map[string]any) error {
+func (ih *InboxHandler) createDeleteTombstone(ctx context.Context, objectID string, deleteActivity *activitypub.Activity, originalObject map[string]any, existingObject any) error {
 	log := common.WithContext(ctx)
 
 	// Determine the original object type
@@ -4853,6 +4940,9 @@ func (ih *InboxHandler) createDeleteTombstone(ctx context.Context, objectID stri
 		if objType, ok := originalObject["type"].(string); ok {
 			formerType = objType
 		}
+	}
+	if common.ValidateRequiredParam("formerType", formerType) != nil {
+		formerType = activityPubObjectFormerType(existingObject)
 	}
 	if common.ValidateRequiredParam("formerType", formerType) != nil {
 		formerType = activitypub.NoteType // Default assumption

--- a/cmd/inbox/internal/routing/more_branches_round10_coverage_test.go
+++ b/cmd/inbox/internal/routing/more_branches_round10_coverage_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -223,6 +224,9 @@ func TestInboxHandler_Round10_HelperCoverageExpansion(t *testing.T) {
 
 		updateActivity.Actor = owner
 		require.NoError(t, env.handler.verifyUpdateAuthorization(context.Background(), updateActivity, note))
+		require.NoError(t, env.handler.verifyUpdateAuthorization(context.Background(), updateActivity, &activitypub.Article{
+			Note: activitypub.Note{AttributedTo: owner},
+		}))
 
 		deleteActivity := &activitypub.Activity{Actor: other}
 		require.Error(t, env.handler.verifyDeleteAuthorization(context.Background(), deleteActivity, map[string]any{}))
@@ -230,6 +234,9 @@ func TestInboxHandler_Round10_HelperCoverageExpansion(t *testing.T) {
 
 		deleteActivity.Actor = owner
 		require.NoError(t, env.handler.verifyDeleteAuthorization(context.Background(), deleteActivity, note))
+		require.NoError(t, env.handler.verifyDeleteAuthorization(context.Background(), deleteActivity, &activitypub.Article{
+			Note: activitypub.Note{AttributedTo: owner},
+		}))
 	})
 
 	t.Run("extractDeleteTarget branches", func(t *testing.T) {
@@ -249,8 +256,45 @@ func TestInboxHandler_Round10_HelperCoverageExpansion(t *testing.T) {
 		require.Equal(t, "https://example.com/objects/3", objectID)
 		require.Nil(t, original)
 
+		objectID, original, err = env.handler.extractDeleteTarget(&activitypub.Activity{Object: &activitypub.BaseObject{ID: "https://example.com/objects/4", Type: activitypub.TombstoneType}})
+		require.NoError(t, err)
+		require.Equal(t, "https://example.com/objects/4", objectID)
+		require.Equal(t, activitypub.TombstoneType, original["type"])
+
+		objectID, original, err = env.handler.extractDeleteTarget(&activitypub.Activity{Object: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{ID: "https://example.com/objects/5"},
+		}})
+		require.NoError(t, err)
+		require.Equal(t, "https://example.com/objects/5", objectID)
+		require.Equal(t, activitypub.NoteType, original["type"])
+
+		objectID, original, err = env.handler.extractDeleteTarget(&activitypub.Activity{Object: &activitypub.Article{
+			Note: activitypub.Note{BaseObject: activitypub.BaseObject{ID: "https://example.com/articles/6"}},
+		}})
+		require.NoError(t, err)
+		require.Equal(t, "https://example.com/articles/6", objectID)
+		require.Equal(t, activitypub.ArticleType, original["type"])
+
 		_, _, err = env.handler.extractDeleteTarget(&activitypub.Activity{Object: 123})
 		require.Error(t, err)
+	})
+
+	t.Run("activityPubObjectFormerType branches", func(t *testing.T) {
+		require.Equal(t, activitypub.ArticleType, activityPubObjectFormerType(map[string]any{"type": activitypub.ArticleType}))
+		require.Equal(t, activitypub.ArticleType, activityPubObjectFormerType(&activitypub.Article{}))
+		require.Equal(t, activitypub.NoteType, activityPubObjectFormerType(&activitypub.Note{}))
+		require.Equal(t, activitypub.TombstoneType, activityPubObjectFormerType(&activitypub.BaseObject{Type: activitypub.TombstoneType}))
+		require.Equal(t, activitypub.ArticleType, activityPubObjectFormerType(&models.Object{Type: activitypub.ArticleType}))
+		require.Empty(t, activityPubObjectFormerType(123))
+
+		var nilArticle *activitypub.Article
+		var nilNote *activitypub.Note
+		var nilBase *activitypub.BaseObject
+		var nilModel *models.Object
+		require.Empty(t, activityPubObjectFormerType(nilArticle))
+		require.Empty(t, activityPubObjectFormerType(nilNote))
+		require.Empty(t, activityPubObjectFormerType(nilBase))
+		require.Empty(t, activityPubObjectFormerType(nilModel))
 	})
 
 	t.Run("extractCollectionType branches", func(t *testing.T) {

--- a/cmd/inbox/internal/routing/pipeline_more_round10_coverage_test.go
+++ b/cmd/inbox/internal/routing/pipeline_more_round10_coverage_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
+	"github.com/equaltoai/lesser/pkg/testing/inmemory"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -325,6 +326,36 @@ func TestInboxHandler_Round10_RemoteCreateUpdateDelete_ErrorBranches(t *testing.
 		require.NoError(t, env.handler.processRemoteCreateActivity(ctx, create, env.local))
 	})
 
+	t.Run("create remote article is explicit unsupported no-op", func(t *testing.T) {
+		objectRepo := inmemory.NewObjectRepository()
+		statusRepo := &recordingStatusRepository{}
+		handler := *env.handler
+		handler.objectRepository = objectRepo
+		handler.statusRepository = statusRepo
+
+		articleID := "https://remote.example/articles/protocol-article"
+		create := &activitypub.Activity{
+			BaseObject: activitypub.BaseObject{Type: activitypub.CreateType, ID: env.cfg.BaseURL() + "/activities/create-remote-article"},
+			Actor:      env.remoteActorID,
+			Object: map[string]any{
+				"@context":     []any{"https://www.w3.org/ns/activitystreams"},
+				"id":           articleID,
+				"type":         activitypub.ArticleType,
+				"name":         "Remote Article",
+				"summary":      "not ingested during M2",
+				"content":      "<p>remote long form</p>",
+				"attributedTo": env.remoteActorID,
+				"to":           []any{activitypub.PublicAddress},
+			},
+		}
+
+		require.NoError(t, handler.processRemoteCreateActivity(ctx, create, env.local))
+		_, err := objectRepo.GetObject(ctx, articleID)
+		require.ErrorIs(t, err, storage.ErrNotFound)
+		require.Empty(t, statusRepo.created)
+		require.Empty(t, statusRepo.updated)
+	})
+
 	t.Run("create note materializes canonical status", func(t *testing.T) {
 		statusRepo := &recordingStatusRepository{}
 		env.handler.statusRepository = statusRepo
@@ -413,6 +444,53 @@ func TestInboxHandler_Round10_RemoteCreateUpdateDelete_ErrorBranches(t *testing.
 			},
 		}
 		require.NoError(t, env.handler.processRemoteUpdateActivity(ctx, update, env.local))
+	})
+
+	t.Run("update remote article is explicit unsupported no-op", func(t *testing.T) {
+		objectRepo := inmemory.NewObjectRepository()
+		statusRepo := &recordingStatusRepository{}
+		handler := *env.handler
+		handler.objectRepository = objectRepo
+		handler.statusRepository = statusRepo
+
+		published := time.Date(2026, time.May, 19, 13, 30, 0, 0, time.UTC)
+		articleID := "https://remote.example/articles/update-protocol-article"
+		article := &activitypub.Article{
+			Note: activitypub.Note{
+				BaseObject: activitypub.BaseObject{
+					ID:        articleID,
+					Type:      activitypub.ArticleType,
+					Published: &published,
+					To:        []string{activitypub.PublicAddress},
+				},
+				AttributedTo: env.remoteActorID,
+				Content:      "<p>before</p>",
+			},
+			Name: "Remote Article",
+		}
+		require.NoError(t, objectRepo.CreateObject(ctx, article))
+
+		update := &activitypub.Activity{
+			BaseObject: activitypub.BaseObject{Type: activitypub.UpdateType, ID: env.cfg.BaseURL() + "/activities/update-remote-article"},
+			Actor:      env.remoteActorID,
+			Object: map[string]any{
+				"id":           articleID,
+				"type":         activitypub.ArticleType,
+				"name":         "Remote Article Updated",
+				"content":      "<p>after</p>",
+				"attributedTo": env.remoteActorID,
+			},
+		}
+
+		require.NoError(t, handler.processRemoteUpdateActivity(ctx, update, env.local))
+		got, err := objectRepo.GetObject(ctx, articleID)
+		require.NoError(t, err)
+		gotArticle, ok := got.(*activitypub.Article)
+		require.True(t, ok)
+		require.Equal(t, "Remote Article", gotArticle.Name)
+		require.Equal(t, "<p>before</p>", gotArticle.Content)
+		require.Empty(t, statusRepo.created)
+		require.Empty(t, statusRepo.updated)
 	})
 
 	t.Run("update note refreshes canonical status", func(t *testing.T) {
@@ -573,6 +651,46 @@ func TestInboxHandler_Round10_RemoteCreateUpdateDelete_ErrorBranches(t *testing.
 			Object:     &activitypub.BaseObject{ID: env.cfg.BaseURL() + "/objects/1"},
 		}
 		require.NoError(t, env.handler.processRemoteDeleteActivity(ctx, del, env.local))
+	})
+
+	t.Run("delete stored article creates article tombstone", func(t *testing.T) {
+		objectRepo := inmemory.NewObjectRepository()
+		statusRepo := &recordingStatusRepository{}
+		handler := *env.handler
+		handler.objectRepository = objectRepo
+		handler.statusRepository = statusRepo
+
+		published := time.Date(2026, time.May, 19, 14, 0, 0, 0, time.UTC)
+		articleID := "https://remote.example/articles/delete-protocol-article"
+		article := &activitypub.Article{
+			Note: activitypub.Note{
+				BaseObject: activitypub.BaseObject{
+					ID:        articleID,
+					Type:      activitypub.ArticleType,
+					Published: &published,
+					To:        []string{activitypub.PublicAddress},
+				},
+				AttributedTo: env.remoteActorID,
+				Content:      "<p>before delete</p>",
+			},
+			Name: "Remote Article",
+		}
+		require.NoError(t, objectRepo.CreateObject(ctx, article))
+
+		del := &activitypub.Activity{
+			BaseObject: activitypub.BaseObject{Type: activitypub.DeleteType, ID: env.cfg.BaseURL() + "/activities/delete-remote-article"},
+			Actor:      env.remoteActorID,
+			Object:     articleID,
+		}
+
+		require.NoError(t, handler.processRemoteDeleteActivity(ctx, del, env.local))
+		tombstoned, err := objectRepo.IsTombstoned(ctx, articleID)
+		require.NoError(t, err)
+		require.True(t, tombstoned)
+		tombstone, err := objectRepo.GetTombstone(ctx, articleID)
+		require.NoError(t, err)
+		require.Equal(t, activitypub.ArticleType, tombstone.FormerType)
+		require.Equal(t, env.remoteActorID, tombstone.DeletedBy)
 	})
 
 	t.Run("delete note tombstones canonical status", func(t *testing.T) {

--- a/cmd/objects/main.go
+++ b/cmd/objects/main.go
@@ -252,6 +252,10 @@ func (h *Handler) HandleGetObject(ctx *apptheory.Context) (*apptheory.Response, 
 		zap.String("request_id", requestID),
 	)
 
+	if tombstoneResp, handled, tombErr := h.handleTombstonedObject(runCtx, lookupID, objectID, requestID, wantsHTML); handled {
+		return tombstoneResp, tombErr
+	}
+
 	// Get the object from storage
 	objInterface, err := h.objectRepo.GetObject(runCtx, lookupID)
 	if err != nil {

--- a/cmd/objects/round12_objects_test.go
+++ b/cmd/objects/round12_objects_test.go
@@ -683,6 +683,132 @@ func TestHandleGetObject_FetchResponses_Round12(t *testing.T) {
 		require.Equal(t, "https://example.com/users/alice/statuses/123", body["id"])
 		require.Equal(t, activitypub.NoteType, body["formerType"])
 	})
+
+	t.Run("canonical article route returns article tombstone when deleted", func(t *testing.T) {
+		deletedAt := time.Date(2026, time.May, 19, 14, 30, 0, 0, time.UTC)
+		articleID := "https://example.com/articles/deleted-article"
+		objRepo := &fakeObjectRepo{
+			err:        errors.New("not found"),
+			tombstoned: true,
+			tombstone: &storageModels.Tombstone{
+				ID:         articleID,
+				FormerType: activitypub.ArticleType,
+				Deleted:    deletedAt,
+				DeletedBy:  "https://example.com/users/alice",
+			},
+		}
+		h := &Handler{
+			instanceRepo:           instanceRepo,
+			objectRepo:             objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method:  http.MethodGet,
+				Path:    "/articles/deleted-article",
+				Headers: map[string][]string{"accept": {"application/activity+json"}},
+			},
+			Params: map[string]string{"slug": "deleted-article"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusGone, resp.Status)
+		require.Equal(t, []string{"application/activity+json"}, resp.Headers["content-type"])
+		require.Equal(t, articleID, objRepo.gotID)
+
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "Tombstone", body["type"])
+		require.Equal(t, articleID, body["id"])
+		require.Equal(t, activitypub.ArticleType, body["formerType"])
+		require.Equal(t, deletedAt.Format(time.RFC3339), body["deleted"])
+	})
+
+	t.Run("canonical article tombstone wins over stale object row", func(t *testing.T) {
+		deletedAt := time.Date(2026, time.May, 19, 14, 35, 0, 0, time.UTC)
+		articleID := "https://example.com/articles/stale-deleted-article"
+		objRepo := &fakeObjectRepo{
+			obj: &activitypub.Article{
+				Note: activitypub.Note{
+					BaseObject: activitypub.BaseObject{
+						ID:   articleID,
+						Type: activitypub.ArticleType,
+						To:   []string{activitypub.PublicAddress},
+					},
+					Content:      "<p>stale row</p>",
+					AttributedTo: "https://example.com/users/alice",
+				},
+				Name: "Stale Deleted Article",
+			},
+			tombstoned: true,
+			tombstone: &storageModels.Tombstone{
+				ID:         articleID,
+				FormerType: activitypub.ArticleType,
+				Deleted:    deletedAt,
+				DeletedBy:  "https://example.com/users/alice",
+			},
+		}
+		h := &Handler{
+			instanceRepo:           instanceRepo,
+			objectRepo:             objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method:  http.MethodGet,
+				Path:    "/articles/stale-deleted-article",
+				Headers: map[string][]string{"accept": {"application/activity+json"}},
+			},
+			Params: map[string]string{"slug": "stale-deleted-article"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusGone, resp.Status)
+
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "Tombstone", body["type"])
+		require.Equal(t, articleID, body["id"])
+		require.Equal(t, activitypub.ArticleType, body["formerType"])
+	})
+
+	t.Run("legacy object article route returns article tombstone when deleted", func(t *testing.T) {
+		deletedAt := time.Date(2026, time.May, 19, 14, 45, 0, 0, time.UTC)
+		legacyID := "https://example.com/objects/legacy-article-id"
+		objRepo := &fakeObjectRepo{
+			err:        errors.New("not found"),
+			tombstoned: true,
+			tombstone: &storageModels.Tombstone{
+				ID:         legacyID,
+				FormerType: activitypub.ArticleType,
+				Deleted:    deletedAt,
+				DeletedBy:  "https://example.com/users/alice",
+			},
+		}
+		h := &Handler{
+			instanceRepo:           instanceRepo,
+			objectRepo:             objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method:  http.MethodGet,
+				Path:    "/objects/legacy-article-id",
+				Headers: map[string][]string{"accept": {"application/activity+json"}},
+			},
+			Params: map[string]string{"id": "legacy-article-id"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusGone, resp.Status)
+		require.Equal(t, legacyID, objRepo.gotID)
+
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "Tombstone", body["type"])
+		require.Equal(t, legacyID, body["id"])
+		require.Equal(t, activitypub.ArticleType, body["formerType"])
+	})
 }
 
 func TestExtractObjectData_Round12(t *testing.T) {
@@ -930,6 +1056,65 @@ func TestNewHandler_MainAndInit_Round12(t *testing.T) {
 		require.Equal(t, 200, lambdaResp.StatusCode)
 		require.Equal(t, "https://example.com/users/alice/statuses/123", fakeRepo.gotID)
 		require.Equal(t, "application/activity+json", lambdaResp.Headers["content-type"])
+	})
+
+	t.Run("build app serves canonical article federation probe", func(t *testing.T) {
+		now := time.Date(2026, time.May, 19, 15, 0, 0, 0, time.UTC)
+		article := &activitypub.Article{
+			Note: activitypub.Note{
+				BaseObject: activitypub.BaseObject{
+					ID:        "https://example.com/articles/probe-article",
+					Type:      activitypub.ArticleType,
+					Summary:   "Probe summary",
+					Published: &now,
+					Updated:   &now,
+					To:        []string{activitypub.PublicAddress},
+				},
+				Content:      "<p>probe body</p>",
+				AttributedTo: "https://example.com/users/alice",
+			},
+			Name: "Probe Article",
+		}
+		fakeRepo := &fakeObjectRepo{obj: article}
+		app := buildApp(&Handler{
+			objectRepo:             fakeRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
+			instanceRepo:           &fakeInstanceRepo{state: &storageModels.InstanceState{Locked: false}},
+		}, zap.NewNop())
+
+		event := events.APIGatewayV2HTTPRequest{
+			Version:  "2.0",
+			RouteKey: "GET /articles/probe-article",
+			RawPath:  "/articles/probe-article",
+			Headers:  map[string]string{"accept": "application/activity+json"},
+			RequestContext: events.APIGatewayV2HTTPRequestContext{
+				RequestID: "req-article-probe",
+				HTTP: events.APIGatewayV2HTTPRequestContextHTTPDescription{
+					Method: "GET",
+					Path:   "/articles/probe-article",
+				},
+			},
+		}
+
+		raw, err := json.Marshal(event)
+		require.NoError(t, err)
+
+		resp, err := app.HandleLambda(context.Background(), raw)
+		require.NoError(t, err)
+		lambdaResp, ok := resp.(events.APIGatewayV2HTTPResponse)
+		require.True(t, ok)
+		require.Equal(t, http.StatusOK, lambdaResp.StatusCode)
+		require.Equal(t, "https://example.com/articles/probe-article", fakeRepo.gotID)
+		require.Equal(t, "application/activity+json", lambdaResp.Headers["content-type"])
+
+		var body map[string]any
+		require.NoError(t, json.Unmarshal([]byte(lambdaResp.Body), &body))
+		require.Equal(t, "https://example.com/articles/probe-article", body["id"])
+		require.Equal(t, activitypub.ArticleType, body["type"])
+		require.Equal(t, "Probe Article", body["name"])
+		require.Equal(t, "Probe summary", body["summary"])
+		require.Equal(t, "<p>probe body</p>", body["content"])
+		t.Logf("article federation probe url=%s type=%s content_type=%s", body["id"], body["type"], lambdaResp.Headers["content-type"])
 	})
 }
 

--- a/docs/architecture/cms/fediverse-first-blog-cms-contract.md
+++ b/docs/architecture/cms/fediverse-first-blog-cms-contract.md
@@ -92,6 +92,37 @@ Compatibility rules:
 3. If a browser-facing `/articles/<slug>` alias is introduced for a legacy Article, it is non-authoritative unless the stored object ID is also `/articles/<slug>`.
 4. A future migration must not create duplicate ActivityPub objects for the same published content. Legacy migration/alias behavior is deferred to M7.
 
+## M2 federation hardening decisions
+
+M2 fixes the protocol behavior for Article federation without starting renderer,
+sanitizer, UI, RSS, comments, newsletter, or remote-long-form-ingest work.
+
+- Outbound Article `Create` and `Update` activities embed an ActivityPub
+  `Article` object. The embedded object ID is the stored Article ID:
+  canonical `https://<domain>/articles/<slug>` for new Articles and legacy
+  `https://<domain>/objects/<uuid>` for existing Articles. `Update` preserves
+  the same Article ID.
+- Article delivery uses the same public/private policy as Note delivery:
+  public-addressed Article activities fan out to followers and explicit
+  recipients; non-public Article activities use recipient delivery without
+  public follower fanout. Object-level hidden recipients (`bto`/`bcc`) are not
+  serialized in embedded Article federation payloads or readback responses.
+- Article `Delete` activities reference the Article object ID directly. Deleting
+  a canonical Article creates an enhanced Tombstone with `formerType: "Article"`
+  so `GET /articles/<slug>` returns an ActivityPub Tombstone with HTTP 410.
+  Legacy Article IDs under `/objects/<uuid>` keep the same delete/tombstone
+  behavior and are not rewritten.
+- Inbound remote `Article` `Create` and `Update` activities are explicitly
+  unsupported in the MVP. After normal inbox authentication/signature handling,
+  lesser logs the unsupported Article operation and performs a no-op: it does
+  not materialize the remote Article as a disguised status, does not add it to
+  timelines, and does not create notifications. Inbound `Delete` for a locally
+  stored Article can tombstone that object with `formerType: "Article"`; unknown
+  remote Article deletes remain idempotent no-ops.
+- Release validation should include a focused fetch probe against a canonical
+  Article URL with `Accept: application/activity+json` and confirm the response
+  is an ActivityPub `Article` at the canonical URL, with no `bto`/`bcc` fields.
+
 ## Renderer authority contract
 
 ### Source and output model

--- a/pkg/services/cms/article_service.go
+++ b/pkg/services/cms/article_service.go
@@ -33,6 +33,10 @@ type articleServiceRepository interface {
 	DeleteArticle(ctx context.Context, articleID string) error
 }
 
+type transactWriteDB interface {
+	TransactWrite(ctx context.Context, fn func(dynamormcore.TransactionBuilder) error) error
+}
+
 type actorRepository interface {
 	GetActor(ctx context.Context, username string) (*activitypub.Actor, error)
 }
@@ -308,10 +312,7 @@ func (s *ArticleService) DeleteArticle(ctx context.Context, article *models.Arti
 		return errors.New("article id is required")
 	}
 
-	if err := s.articleRepo.DeleteArticle(ctx, strings.TrimSpace(article.ID)); err != nil {
-		return err
-	}
-	if err := s.createArticleTombstone(ctx, article); err != nil {
+	if err := s.deleteArticleAndCreateTombstone(ctx, article); err != nil {
 		return err
 	}
 
@@ -323,10 +324,49 @@ func (s *ArticleService) DeleteArticle(ctx context.Context, article *models.Arti
 	return nil
 }
 
-func (s *ArticleService) createArticleTombstone(ctx context.Context, article *models.Article) error {
+func (s *ArticleService) deleteArticleAndCreateTombstone(ctx context.Context, article *models.Article) error {
+	tombstone, err := s.buildArticleTombstone(article)
+	if err != nil {
+		return err
+	}
+
+	db := s.articleRepo.GetDB()
+	if db == nil {
+		return errors.New("article repository db is required for tombstone")
+	}
+
+	if txDB, ok := db.(transactWriteDB); ok {
+		deleteModel := *article
+		if err := deleteModel.UpdateKeys(); err != nil {
+			return fmt.Errorf("prepare article delete keys: %w", err)
+		}
+
+		if err := txDB.TransactWrite(ctx, func(tx dynamormcore.TransactionBuilder) error {
+			tx.Create(tombstone).Delete(&deleteModel)
+			return nil
+		}); err != nil {
+			s.logger.Error("failed to transactionally delete article with tombstone",
+				zap.String("article_id", tombstone.ID),
+				zap.String("former_type", tombstone.FormerType),
+				zap.Error(err))
+			return err
+		}
+		return nil
+	}
+
+	// Production TableTheory DBs expose TransactWrite above. This fallback keeps
+	// minimal core.DB test doubles functional while preserving the previous write
+	// order for implementations that cannot express a multi-item transaction.
+	if err := s.articleRepo.DeleteArticle(ctx, tombstone.ID); err != nil {
+		return err
+	}
+	return s.persistArticleTombstone(ctx, tombstone)
+}
+
+func (s *ArticleService) buildArticleTombstone(article *models.Article) (*models.Tombstone, error) {
 	objectID := strings.TrimSpace(article.ID)
 	if objectID == "" {
-		return errors.New("article id is required")
+		return nil, errors.New("article id is required")
 	}
 
 	formerType := strings.TrimSpace(article.Type)
@@ -348,7 +388,15 @@ func (s *ArticleService) createArticleTombstone(ctx context.Context, article *mo
 		Deleted:    time.Now(),
 	}
 	if err := tombstone.BeforeCreate(); err != nil {
-		return fmt.Errorf("prepare article tombstone: %w", err)
+		return nil, fmt.Errorf("prepare article tombstone: %w", err)
+	}
+
+	return tombstone, nil
+}
+
+func (s *ArticleService) persistArticleTombstone(ctx context.Context, tombstone *models.Tombstone) error {
+	if tombstone == nil {
+		return errors.New("article tombstone is required")
 	}
 
 	db := s.articleRepo.GetDB()
@@ -357,8 +405,8 @@ func (s *ArticleService) createArticleTombstone(ctx context.Context, article *mo
 	}
 	if err := db.WithContext(ctx).Model(tombstone).Create(); err != nil {
 		s.logger.Error("failed to create article tombstone",
-			zap.String("article_id", objectID),
-			zap.String("former_type", formerType),
+			zap.String("article_id", tombstone.ID),
+			zap.String("former_type", tombstone.FormerType),
 			zap.Error(err))
 		return err
 	}

--- a/pkg/services/cms/article_service.go
+++ b/pkg/services/cms/article_service.go
@@ -311,11 +311,57 @@ func (s *ArticleService) DeleteArticle(ctx context.Context, article *models.Arti
 	if err := s.articleRepo.DeleteArticle(ctx, strings.TrimSpace(article.ID)); err != nil {
 		return err
 	}
+	if err := s.createArticleTombstone(ctx, article); err != nil {
+		return err
+	}
 
 	s.deleteCMSArticleIndexes(ctx, article)
 	s.updateCMSArticleCountsBestEffort(ctx, article, nil)
 
 	go s.federateArticleDeletion(context.Background(), article)
+
+	return nil
+}
+
+func (s *ArticleService) createArticleTombstone(ctx context.Context, article *models.Article) error {
+	objectID := strings.TrimSpace(article.ID)
+	if objectID == "" {
+		return errors.New("article id is required")
+	}
+
+	formerType := strings.TrimSpace(article.Type)
+	if formerType == "" {
+		formerType = activitypub.ArticleType
+	}
+
+	deletedBy := strings.TrimSpace(article.AttributedTo)
+	summary := "Article was deleted"
+	if deletedBy != "" {
+		summary = fmt.Sprintf("Object deleted by %s", deletedBy)
+	}
+
+	tombstone := &models.Tombstone{
+		ID:         objectID,
+		FormerType: formerType,
+		DeletedBy:  deletedBy,
+		Summary:    summary,
+		Deleted:    time.Now(),
+	}
+	if err := tombstone.BeforeCreate(); err != nil {
+		return fmt.Errorf("prepare article tombstone: %w", err)
+	}
+
+	db := s.articleRepo.GetDB()
+	if db == nil {
+		return errors.New("article repository db is required for tombstone")
+	}
+	if err := db.WithContext(ctx).Model(tombstone).Create(); err != nil {
+		s.logger.Error("failed to create article tombstone",
+			zap.String("article_id", objectID),
+			zap.String("former_type", formerType),
+			zap.Error(err))
+		return err
+	}
 
 	return nil
 }

--- a/pkg/services/cms/article_service_round25_coverage_test.go
+++ b/pkg/services/cms/article_service_round25_coverage_test.go
@@ -2,7 +2,9 @@ package cms
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -16,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	dynamormcore "github.com/theory-cloud/tabletheory/pkg/core"
 	dynamormerrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	dynamormMocks "github.com/theory-cloud/tabletheory/pkg/mocks"
 	"go.uber.org/zap"
 )
 
@@ -93,16 +96,36 @@ type fakeFederation struct {
 	followerCalls  atomic.Int32
 	recipientCalls atomic.Int32
 	err            error
+
+	mu                  sync.Mutex
+	followerActivities  []*activitypub.Activity
+	recipientActivities []*activitypub.Activity
 }
 
-func (f *fakeFederation) DeliverToFollowers(_ context.Context, _ *activitypub.Activity, _ *activitypub.Actor) error {
+func (f *fakeFederation) DeliverToFollowers(_ context.Context, activity *activitypub.Activity, _ *activitypub.Actor) error {
 	f.followerCalls.Add(1)
+	f.mu.Lock()
+	f.followerActivities = append(f.followerActivities, activity)
+	f.mu.Unlock()
 	return f.err
 }
 
-func (f *fakeFederation) DeliverToRecipients(_ context.Context, _ *activitypub.Activity, _ *activitypub.Actor) error {
+func (f *fakeFederation) DeliverToRecipients(_ context.Context, activity *activitypub.Activity, _ *activitypub.Actor) error {
 	f.recipientCalls.Add(1)
+	f.mu.Lock()
+	f.recipientActivities = append(f.recipientActivities, activity)
+	f.mu.Unlock()
 	return f.err
+}
+
+func (f *fakeFederation) recipientActivity(t *testing.T, index int) *activitypub.Activity {
+	t.Helper()
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	require.Less(t, index, len(f.recipientActivities))
+	return f.recipientActivities[index]
 }
 
 type fakeRevisionCreator struct {
@@ -284,6 +307,7 @@ func TestArticleService_Round25_CreateUpdateDeleteArticle(t *testing.T) {
 	t.Run("delete removes article and indexes", func(t *testing.T) {
 		db, q := newCMSMockDB(t)
 		repo.db = db
+		q.On("Create").Return(nil).Once()
 		q.On("Delete").Return(nil).Maybe()
 
 		repo.articles["a6"] = &models.Article{Object: models.Object{ID: "a6", Published: time.Now(), AttributedTo: "https://example.com/users/alice"}, Slug: "slug"}
@@ -357,4 +381,215 @@ func TestArticleService_Round25_federationHelpersAndUsernameExtraction(t *testin
 	assert.Equal(t, "alice", extractUsernameFromActorID("https://example.com/users/alice"))
 	assert.Equal(t, "", extractUsernameFromActorID(""))
 	assert.Equal(t, "alice", extractUsernameFromActorID("alice"))
+}
+
+func TestArticleService_M2OutboundArticleFederationPayloads(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db, q := newCMSMockDB(t)
+	q.On("Create").Return(nil).Maybe()
+	q.On("Delete").Return(nil).Maybe()
+	q.On("First", mock.Anything).Return(nil).Maybe()
+
+	actor := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{ID: "https://example.com/users/alice", Type: activitypub.PersonType},
+	}
+	fed := &fakeFederation{}
+	svc := NewArticleService(
+		&fakeArticleRepo{db: db, articles: map[string]*models.Article{}},
+		fakeActorRepo{actor: actor},
+		nil,
+		nil,
+		nil,
+		fed,
+		zap.NewNop(),
+	)
+
+	published := time.Date(2026, time.May, 19, 12, 0, 0, 0, time.UTC)
+	publicArticle := &models.Article{
+		Object: models.Object{
+			ID:           "https://example.com/articles/federation-probe",
+			Type:         activitypub.ArticleType,
+			Name:         "Federation Probe",
+			Summary:      "Protocol-level Article summary",
+			Content:      "<p>hello article federation</p>",
+			Published:    published,
+			Updated:      published,
+			AttributedTo: "https://example.com/users/alice",
+			To:           []string{activitypub.PublicAddress},
+			CC:           []string{"https://example.com/users/alice/followers"},
+			BTo:          []string{"https://remote.example/users/hidden"},
+			BCC:          []string{"https://remote.example/users/also-hidden"},
+		},
+		Slug: "federation-probe",
+	}
+
+	svc.federateArticleWriteActivity(ctx, publicArticle, activitypub.CreateType, "create")
+	require.Equal(t, int32(1), fed.followerCalls.Load())
+	require.Equal(t, int32(1), fed.recipientCalls.Load())
+	assertArticleWriteActivity(t, fed.recipientActivity(t, 0), activitypub.CreateType, publicArticle.ID)
+
+	updateFed := &fakeFederation{}
+	svc.federation = updateFed
+	updatedArticle := *publicArticle
+	updatedArticle.Content = "<p>updated body, same Article identity</p>"
+	svc.federateArticleWriteActivity(ctx, &updatedArticle, activitypub.UpdateType, "update")
+	require.Equal(t, int32(1), updateFed.followerCalls.Load())
+	require.Equal(t, int32(1), updateFed.recipientCalls.Load())
+	assertArticleWriteActivity(t, updateFed.recipientActivity(t, 0), activitypub.UpdateType, publicArticle.ID)
+
+	privateFed := &fakeFederation{}
+	svc.federation = privateFed
+	privateArticle := &models.Article{
+		Object: models.Object{
+			ID:           "https://example.com/articles/followers-only",
+			Type:         activitypub.ArticleType,
+			Name:         "Followers Only",
+			Content:      "<p>private article</p>",
+			Published:    published,
+			Updated:      published,
+			AttributedTo: "https://example.com/users/alice",
+			To:           []string{"https://example.com/users/alice/followers"},
+		},
+		Slug: "followers-only",
+	}
+
+	svc.federateArticleWriteActivity(ctx, privateArticle, activitypub.CreateType, "create")
+	require.Equal(t, int32(0), privateFed.followerCalls.Load())
+	require.Equal(t, int32(1), privateFed.recipientCalls.Load())
+	privateActivity := privateFed.recipientActivity(t, 0)
+	assertArticleWriteActivity(t, privateActivity, activitypub.CreateType, privateArticle.ID)
+	assert.NotContains(t, privateActivity.To, activitypub.PublicAddress)
+	assert.NotContains(t, privateActivity.CC, activitypub.PublicAddress)
+}
+
+func TestArticleService_M2ArticleDeleteFederationAndTombstone(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db, q := newCMSMockDB(t)
+	q.On("Delete").Return(nil).Maybe()
+	q.On("First", mock.Anything).Return(nil).Maybe()
+
+	actor := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{ID: "https://example.com/users/alice", Type: activitypub.PersonType},
+	}
+	fed := &fakeFederation{}
+	repo := &fakeArticleRepo{
+		db:       db,
+		articles: map[string]*models.Article{},
+	}
+	svc := NewArticleService(repo, fakeActorRepo{actor: actor}, nil, nil, nil, fed, zap.NewNop())
+
+	published := time.Date(2026, time.May, 19, 12, 30, 0, 0, time.UTC)
+	canonicalArticle := &models.Article{
+		Object: models.Object{
+			ID:           "https://example.com/articles/delete-me",
+			Type:         activitypub.ArticleType,
+			Name:         "Delete Me",
+			Content:      "<p>delete me</p>",
+			Published:    published,
+			Updated:      published,
+			AttributedTo: "https://example.com/users/alice",
+			To:           []string{activitypub.PublicAddress},
+			CC:           []string{"https://example.com/users/alice/followers"},
+		},
+		Slug: "delete-me",
+	}
+
+	svc.federateArticleDeletion(ctx, canonicalArticle)
+	require.Equal(t, int32(1), fed.followerCalls.Load())
+	require.Equal(t, int32(1), fed.recipientCalls.Load())
+	deleteActivity := fed.recipientActivity(t, 0)
+	require.Equal(t, activitypub.DeleteType, deleteActivity.Type)
+	require.Equal(t, canonicalArticle.ID, deleteActivity.Object)
+	require.Equal(t, canonicalArticle.To, deleteActivity.To)
+	require.Equal(t, canonicalArticle.CC, deleteActivity.CC)
+
+	legacyFed := &fakeFederation{}
+	svc.federation = legacyFed
+	legacyArticle := &models.Article{
+		Object: models.Object{
+			ID:           "https://example.com/objects/legacy-article-id",
+			Type:         activitypub.ArticleType,
+			Name:         "Legacy Article",
+			Content:      "<p>legacy delete</p>",
+			Published:    published,
+			Updated:      published,
+			AttributedTo: "https://example.com/users/alice",
+			To:           []string{activitypub.PublicAddress},
+		},
+		Slug: "legacy-article",
+	}
+
+	svc.federateArticleDeletion(ctx, legacyArticle)
+	require.Equal(t, int32(1), legacyFed.followerCalls.Load())
+	require.Equal(t, int32(1), legacyFed.recipientCalls.Load())
+	require.Equal(t, legacyArticle.ID, legacyFed.recipientActivity(t, 0).Object)
+
+	tombstoneDB := new(dynamormMocks.MockDB)
+	tombstoneQuery := new(dynamormMocks.MockQuery)
+	tombstoneDB.On("WithContext", mock.Anything).Return(tombstoneDB).Maybe()
+	var capturedTombstone *models.Tombstone
+	tombstoneDB.On("Model", mock.MatchedBy(func(model any) bool {
+		tombstone, ok := model.(*models.Tombstone)
+		if ok {
+			capturedTombstone = tombstone
+		}
+		return ok
+	})).Return(tombstoneQuery).Once()
+	tombstoneDB.On("Model", mock.Anything).Return(tombstoneQuery).Maybe()
+	tombstoneQuery.On("Create").Return(nil).Once()
+	tombstoneQuery.On("Delete").Return(nil).Maybe()
+
+	tombstoneRepo := &fakeArticleRepo{
+		db: tombstoneDB,
+		articles: map[string]*models.Article{
+			canonicalArticle.ID: canonicalArticle,
+		},
+	}
+	tombstoneSvc := NewArticleService(tombstoneRepo, fakeActorRepo{err: errors.New("no actor")}, nil, nil, nil, &fakeFederation{}, zap.NewNop())
+	require.NoError(t, tombstoneSvc.DeleteArticle(ctx, canonicalArticle))
+	require.NotNil(t, capturedTombstone)
+	require.Equal(t, canonicalArticle.ID, capturedTombstone.ID)
+	require.Equal(t, activitypub.ArticleType, capturedTombstone.FormerType)
+	require.Equal(t, "https://example.com/users/alice", capturedTombstone.DeletedBy)
+	require.Equal(t, "Tombstone", capturedTombstone.Type)
+	require.Equal(t, "OBJECT#"+canonicalArticle.ID, capturedTombstone.PK)
+	require.Equal(t, "TOMBSTONE", capturedTombstone.SK)
+}
+
+func assertArticleWriteActivity(t *testing.T, activity *activitypub.Activity, activityType string, articleID string) {
+	t.Helper()
+
+	require.NotNil(t, activity)
+	require.Equal(t, activityType, activity.Type)
+	require.Equal(t, "https://example.com/users/alice", activity.Actor)
+	require.NotEmpty(t, activity.ID)
+	require.NotNil(t, activity.Published)
+	require.Empty(t, activity.BTo)
+	require.Empty(t, activity.BCC)
+
+	article, ok := activity.Object.(*activitypub.Article)
+	require.True(t, ok, "expected *activitypub.Article, got %T", activity.Object)
+	require.Equal(t, activitypub.ArticleType, article.Type)
+	require.Equal(t, articleID, article.ID)
+	require.Equal(t, "https://example.com/users/alice", article.AttributedTo)
+	require.NotEmpty(t, article.Name)
+	require.Empty(t, article.BTo)
+	require.Empty(t, article.BCC)
+
+	raw, err := json.Marshal(activity)
+	require.NoError(t, err)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(raw, &body))
+	require.NotContains(t, body, "bto")
+	require.NotContains(t, body, "bcc")
+	obj, ok := body["object"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, activitypub.ArticleType, obj["type"])
+	require.Equal(t, articleID, obj["id"])
+	require.NotContains(t, obj, "bto")
+	require.NotContains(t, obj, "bcc")
 }

--- a/pkg/services/cms/article_service_round25_coverage_test.go
+++ b/pkg/services/cms/article_service_round25_coverage_test.go
@@ -629,6 +629,79 @@ func TestArticleService_DeleteArticle_UsesTransactionalTombstoneWhenAvailable(t 
 	db.AssertExpectations(t)
 }
 
+func TestArticleService_DeleteArticle_TombstoneErrorBranches(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	article := &models.Article{
+		Object: models.Object{
+			ID:           "https://example.com/articles/tombstone-errors",
+			Published:    time.Date(2026, time.May, 20, 1, 0, 0, 0, time.UTC),
+			AttributedTo: "https://example.com/users/alice",
+		},
+		Slug: "tombstone-errors",
+	}
+
+	t.Run("requires db for tombstone persistence", func(t *testing.T) {
+		repo := &fakeArticleRepo{
+			articles: map[string]*models.Article{
+				article.ID: article,
+			},
+		}
+		svc := NewArticleService(repo, fakeActorRepo{err: errors.New("no actor")}, nil, nil, nil, &fakeFederation{}, zap.NewNop())
+
+		err := svc.DeleteArticle(ctx, article)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "article repository db is required")
+		require.Empty(t, repo.deletedIDs)
+	})
+
+	t.Run("returns transaction failure", func(t *testing.T) {
+		db := new(dynamormMocks.MockExtendedDB)
+		db.On("TransactWrite", mock.Anything, mock.Anything).Return(errors.New("tx failed")).Once()
+
+		repo := &fakeArticleRepo{
+			db: db,
+			articles: map[string]*models.Article{
+				article.ID: article,
+			},
+		}
+		svc := NewArticleService(repo, fakeActorRepo{err: errors.New("no actor")}, nil, nil, nil, &fakeFederation{}, zap.NewNop())
+
+		err := svc.DeleteArticle(ctx, article)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "tx failed")
+		require.Empty(t, repo.deletedIDs)
+		db.AssertExpectations(t)
+	})
+
+	t.Run("build defaults missing former type and actor", func(t *testing.T) {
+		db, _ := newCMSMockDB(t)
+		svc := NewArticleService(&fakeArticleRepo{db: db}, fakeActorRepo{}, nil, nil, nil, &fakeFederation{}, zap.NewNop())
+
+		tombstone, err := svc.buildArticleTombstone(&models.Article{
+			Object: models.Object{ID: "https://example.com/articles/default-type"},
+		})
+		require.NoError(t, err)
+		require.Equal(t, activitypub.ArticleType, tombstone.FormerType)
+		require.Empty(t, tombstone.DeletedBy)
+		require.Equal(t, "Article was deleted", tombstone.Summary)
+		require.Equal(t, "Tombstone", tombstone.Type)
+		require.Equal(t, "OBJECT#https://example.com/articles/default-type", tombstone.PK)
+		require.Equal(t, "TOMBSTONE", tombstone.SK)
+		require.NotZero(t, tombstone.TTL)
+	})
+
+	t.Run("persist requires tombstone", func(t *testing.T) {
+		db, _ := newCMSMockDB(t)
+		svc := NewArticleService(&fakeArticleRepo{db: db}, fakeActorRepo{}, nil, nil, nil, &fakeFederation{}, zap.NewNop())
+
+		err := svc.persistArticleTombstone(ctx, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "article tombstone is required")
+	})
+}
+
 func assertArticleWriteActivity(t *testing.T, activity *activitypub.Activity, activityType string, articleID string) {
 	t.Helper()
 

--- a/pkg/services/cms/article_service_round25_coverage_test.go
+++ b/pkg/services/cms/article_service_round25_coverage_test.go
@@ -560,6 +560,75 @@ func TestArticleService_M2ArticleDeleteFederationAndTombstone(t *testing.T) {
 	require.Equal(t, "TOMBSTONE", capturedTombstone.SK)
 }
 
+func TestArticleService_DeleteArticle_UsesTransactionalTombstoneWhenAvailable(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := new(dynamormMocks.MockExtendedDB)
+	q := new(dynamormMocks.MockQuery)
+	builder := new(dynamormMocks.MockTransactionBuilder)
+	db.TransactWriteBuilder = builder
+
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.Anything).Return(q).Maybe()
+	q.On("Delete").Return(nil).Maybe()
+
+	var capturedTombstone *models.Tombstone
+	builder.On("Create", mock.MatchedBy(func(model any) bool {
+		tombstone, ok := model.(*models.Tombstone)
+		if ok {
+			capturedTombstone = tombstone
+		}
+		return ok
+	}), mock.Anything).Return(builder).Once()
+
+	var capturedDelete *models.Article
+	builder.On("Delete", mock.MatchedBy(func(model any) bool {
+		article, ok := model.(*models.Article)
+		if ok {
+			capturedDelete = article
+		}
+		return ok
+	}), mock.Anything).Return(builder).Once()
+	builder.On("Execute").Return(nil).Once()
+	db.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
+
+	article := &models.Article{
+		Object: models.Object{
+			ID:           "https://example.com/articles/tx-delete",
+			Type:         activitypub.ArticleType,
+			Name:         "Transactional Delete",
+			Published:    time.Date(2026, time.May, 20, 0, 0, 0, 0, time.UTC),
+			AttributedTo: "https://example.com/users/alice",
+			To:           []string{activitypub.PublicAddress},
+		},
+		Slug: "tx-delete",
+	}
+	repo := &fakeArticleRepo{
+		db: db,
+		articles: map[string]*models.Article{
+			article.ID: article,
+		},
+	}
+	svc := NewArticleService(repo, fakeActorRepo{err: errors.New("no actor")}, nil, nil, nil, &fakeFederation{}, zap.NewNop())
+
+	require.NoError(t, svc.DeleteArticle(ctx, article))
+	require.NotNil(t, capturedTombstone)
+	require.Equal(t, article.ID, capturedTombstone.ID)
+	require.Equal(t, "OBJECT#"+article.ID, capturedTombstone.PK)
+	require.Equal(t, "TOMBSTONE", capturedTombstone.SK)
+	require.Equal(t, "Tombstone", capturedTombstone.Type)
+	require.Equal(t, activitypub.ArticleType, capturedTombstone.FormerType)
+	require.NotZero(t, capturedTombstone.TTL)
+	require.NotNil(t, capturedDelete)
+	require.Equal(t, "object#"+article.ID, capturedDelete.PK)
+	require.Equal(t, "object#"+article.ID, capturedDelete.SK)
+	require.Empty(t, repo.deletedIDs)
+
+	builder.AssertExpectations(t)
+	db.AssertExpectations(t)
+}
+
 func assertArticleWriteActivity(t *testing.T, activity *activitypub.Activity, activityType string, articleID string) {
 	t.Helper()
 

--- a/pkg/storage/repositories/object_repository.go
+++ b/pkg/storage/repositories/object_repository.go
@@ -555,55 +555,78 @@ func (r *ObjectRepository) TombstoneObject(ctx context.Context, objectID string,
 		return ErrorHandler.HandleGetError(err, EntityObject, objectID)
 	}
 
-	// Get the object ID from the result
-	var objID string
-	if objMap, ok := existingObj.(map[string]any); ok {
-		if id, ok := objMap["id"].(string); ok {
-			objID = id
-		}
-	} else if note, ok := existingObj.(*activitypub.Note); ok {
-		objID = note.ID
-	}
+	objID, formerType := tombstoneSourceIdentity(existingObj)
 
 	if err := common.ValidateRequiredParam("object ID", objID); err != nil {
 		return ErrorHandler.HandleCreateError(err, EntityObject, "extract_id")
 	}
-
-	// Create a tombstone object
-	tombstone := models.NewObject(objectID, "Tombstone", deletedBy)
-	tombstone.Content = fmt.Sprintf("Object %s was deleted", objectID)
-	tombstone.Published = time.Now()
-	tombstone.Updated = time.Now()
-
-	// Set tombstone-specific fields
-	tombstone.AttributedTo = deletedBy
-
-	// Update GSI keys
-	tombstone.UpdateGSIKeys()
-
-	// Delete the original object and create tombstone in a transaction-like manner
-	// First delete the original
-	if err := r.DeleteObject(ctx, objectID); err != nil {
-		r.logger.Error("failed to delete original object for tombstoning",
-			zap.String("object_id", objectID),
-			zap.Error(err))
-		return ErrorHandler.HandleDeleteError(err, EntityObject, objectID)
+	if formerType == "" {
+		formerType = "Object"
 	}
 
-	// Then create the tombstone using BaseRepository
-	if err := r.Create(ctx, tombstone); err != nil {
+	if err := r.DeleteObject(ctx, objID); err != nil {
+		r.logger.Error("failed to delete original object for tombstoning",
+			zap.String("object_id", objID),
+			zap.Error(err))
+		return ErrorHandler.HandleDeleteError(err, EntityObject, objID)
+	}
+
+	tombstone := &models.Tombstone{
+		ID:         objID,
+		FormerType: formerType,
+		DeletedBy:  deletedBy,
+		Summary:    fmt.Sprintf("Object deleted by %s", deletedBy),
+		Deleted:    time.Now(),
+	}
+	if err := r.CreateTombstone(ctx, tombstone); err != nil {
 		r.logger.Error("failed to create tombstone",
-			zap.String("object_id", objectID),
+			zap.String("object_id", objID),
+			zap.String("former_type", formerType),
 			zap.String("deleted_by", deletedBy),
 			zap.Error(err))
 		return ErrorHandler.HandleCreateError(err, EntityObject, "tombstone")
 	}
 
 	r.logger.Info("tombstoned object",
-		zap.String("object_id", objectID),
+		zap.String("object_id", objID),
+		zap.String("former_type", formerType),
 		zap.String("deleted_by", deletedBy))
 
 	return nil
+}
+
+func tombstoneSourceIdentity(existingObj any) (string, string) {
+	switch obj := existingObj.(type) {
+	case map[string]any:
+		id, _ := obj["id"].(string)
+		objectType, _ := obj["type"].(string)
+		return strings.TrimSpace(id), strings.TrimSpace(objectType)
+	case *activitypub.Article:
+		if obj == nil {
+			return "", ""
+		}
+		objectType := strings.TrimSpace(obj.Type)
+		if objectType == "" {
+			objectType = activitypub.ArticleType
+		}
+		return strings.TrimSpace(obj.ID), objectType
+	case *activitypub.Note:
+		if obj == nil {
+			return "", ""
+		}
+		objectType := strings.TrimSpace(obj.Type)
+		if objectType == "" {
+			objectType = activitypub.NoteType
+		}
+		return strings.TrimSpace(obj.ID), objectType
+	case *activitypub.BaseObject:
+		if obj == nil {
+			return "", ""
+		}
+		return strings.TrimSpace(obj.ID), strings.TrimSpace(obj.Type)
+	default:
+		return "", ""
+	}
 }
 
 // modelToActivityPubObject converts a model to the appropriate ActivityPub object

--- a/pkg/storage/repositories/object_repository.go
+++ b/pkg/storage/repositories/object_repository.go
@@ -2346,6 +2346,13 @@ func (r *ObjectRepository) parseMentionsFromJSONString(tags string) []string {
 
 // CreateTombstone creates a tombstone for a deleted object
 func (r *ObjectRepository) CreateTombstone(ctx context.Context, tombstone *models.Tombstone) error {
+	if tombstone == nil {
+		return ErrorHandler.HandleCreateError(storage.ErrInvalidInput, EntityObject, "tombstone")
+	}
+	if err := tombstone.BeforeCreate(); err != nil {
+		return ErrorHandler.HandleCreateError(err, EntityObject, "tombstone")
+	}
+
 	if err := r.db.WithContext(ctx).Model(tombstone).Create(); err != nil {
 		r.logger.Error("failed to create tombstone",
 			zap.String("object_id", tombstone.ID),

--- a/pkg/storage/repositories/object_repository_additional_coverage_test.go
+++ b/pkg/storage/repositories/object_repository_additional_coverage_test.go
@@ -735,6 +735,39 @@ func TestObjectRepository_TombstoneObject_UsesMapBranch(t *testing.T) {
 	require.NoError(t, repo.TombstoneObject(ctx, "note-1", "alice"))
 }
 
+func TestObjectRepository_TombstoneObject_ArticleType(t *testing.T) {
+	ctx := context.Background()
+	baseTime := time.Date(2026, 5, 19, 13, 0, 0, 0, time.UTC)
+	articleID := "https://example.com/articles/tombstone-article"
+
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+	mockQuery.On("First", mock.AnythingOfType("*models.Object")).Run(func(args mock.Arguments) {
+		obj := args.Get(0).(*models.Object)
+		*obj = *models.NewObject(articleID, activitypub.ArticleType, "https://example.com/users/alice")
+		obj.Name = "Tombstone Article"
+		obj.Summary = "Article tombstone summary"
+	}).Return(nil).Once()
+	setupPermissiveObjectRepoMocks(mockDB, mockQuery, baseTime)
+
+	repo := NewObjectRepository(mockDB, "test-table", "example.com", zap.NewNop())
+
+	require.NoError(t, repo.TombstoneObject(ctx, articleID, "https://example.com/users/alice"))
+
+	gotID, formerType := tombstoneSourceIdentity(&activitypub.Article{
+		Note: activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:   articleID,
+				Type: activitypub.ArticleType,
+			},
+			AttributedTo: "https://example.com/users/alice",
+		},
+		Name: "Tombstone Article",
+	})
+	require.Equal(t, articleID, gotID)
+	require.Equal(t, activitypub.ArticleType, formerType)
+}
+
 func TestObjectRepository_CountQuotes_ErrorBranch(t *testing.T) {
 	ctx := context.Background()
 	baseTime := time.Date(2025, 1, 16, 17, 18, 19, 0, time.UTC)

--- a/pkg/storage/repositories/object_repository_additional_coverage_test.go
+++ b/pkg/storage/repositories/object_repository_additional_coverage_test.go
@@ -742,6 +742,14 @@ func TestObjectRepository_TombstoneObject_ArticleType(t *testing.T) {
 
 	mockDB := new(mocks.MockDB)
 	mockQuery := new(mocks.MockQuery)
+	var capturedTombstone *models.Tombstone
+	mockDB.On("Model", mock.MatchedBy(func(model any) bool {
+		tombstone, ok := model.(*models.Tombstone)
+		if ok {
+			capturedTombstone = tombstone
+		}
+		return ok
+	})).Return(mockQuery).Once()
 	mockQuery.On("First", mock.AnythingOfType("*models.Object")).Run(func(args mock.Arguments) {
 		obj := args.Get(0).(*models.Object)
 		*obj = *models.NewObject(articleID, activitypub.ArticleType, "https://example.com/users/alice")
@@ -753,6 +761,12 @@ func TestObjectRepository_TombstoneObject_ArticleType(t *testing.T) {
 	repo := NewObjectRepository(mockDB, "test-table", "example.com", zap.NewNop())
 
 	require.NoError(t, repo.TombstoneObject(ctx, articleID, "https://example.com/users/alice"))
+	require.NotNil(t, capturedTombstone)
+	require.Equal(t, "OBJECT#"+articleID, capturedTombstone.PK)
+	require.Equal(t, "TOMBSTONE", capturedTombstone.SK)
+	require.Equal(t, "Tombstone", capturedTombstone.Type)
+	require.Equal(t, activitypub.ArticleType, capturedTombstone.FormerType)
+	require.NotZero(t, capturedTombstone.TTL)
 
 	gotID, formerType := tombstoneSourceIdentity(&activitypub.Article{
 		Note: activitypub.Note{

--- a/pkg/transformations/transformers_activitypub.go
+++ b/pkg/transformations/transformers_activitypub.go
@@ -279,6 +279,11 @@ func StorageArticleToActivityPub(article *storagemodels.Article) (*activitypub.A
 
 	// Ensure type is correct
 	apArticle.Type = activitypub.ArticleType
+	// Hidden recipients are delivery metadata, not object readback or embedded
+	// federation payload data. Article delivery resolves recipients from the
+	// Activity addressing envelope; do not leak object-level bto/bcc fields.
+	apArticle.BTo = nil
+	apArticle.BCC = nil
 
 	return apArticle, nil
 }


### PR DESCRIPTION
## Summary

Closes #1035.
Closes #1036.
Closes #1037.
Closes #1038.
Closes #1039.

Project 36 M2 federation/protocol hardening for Blog/CMS Articles:

- covers outbound Article `Create`/`Update` payloads as first-class ActivityPub `Article` objects, preserving canonical or legacy Article IDs
- makes Article `Delete` activities reference the Article object ID and writes enhanced `Tombstone` rows with `formerType: "Article"`
- makes tombstone readback deterministic for `/articles/:slug` and legacy `/objects/:id` when a Tombstone row exists
- documents and tests the MVP inbound remote Article behavior: signed/authenticated `Article` `Create`/`Update` is an explicit no-op, not a disguised status ingest
- adds a canonical Article ActivityPub fetch probe test suitable for release validation

## Stewardship audits

- Federation trust: no change to inbound HTTP Signature enforcement or outbound signing. Article delivery continues through existing federation delivery services; hidden object-level `bto`/`bcc` is stripped from embedded Article payloads.
- API compatibility: no Mastodon REST or GraphQL contract changes; ActivityPub shape is the intended first-class `Article` object shape from the Project 36 contract.
- Schema integrity: no TableTheory tag, PK/SK format, or GSI definition changes. The implementation reuses the existing `models.Tombstone` schema (`PK=OBJECT#<id>`, `SK=TOMBSTONE`, existing GSI1/GSI2 behavior).
- Scope guard: no renderer/sanitizer, UI, RSS, comments, search, newsletter, or migration work.

Protocol Counsel review remains required before merge-clear because this touches Article Delete/Tombstone and inbound remote Article behavior.

## Validation

- `gofmt -l .`
- `git diff --check`
- `go test ./...`
- `go vet ./...`
- `go build -o lesser ./cmd/lesser`
- `./lesser build lambdas`
- `./lesser verify ci`