### PR TITLE
feat: harden cms authoring attribution

### DIFF
--- a/docs/architecture/cms/fediverse-first-blog-cms-contract.md
+++ b/docs/architecture/cms/fediverse-first-blog-cms-contract.md
@@ -188,6 +188,25 @@ Before an MCP-generated draft can be published, the draft/revision metadata must
 
 The metadata may reuse lesser's existing `AgentPostAttribution` vocabulary where it fits, but M4 owns the storage/API shape needed for CMS drafts and revisions. M0 does not add new fields.
 
+### M4 implemented attribution fields
+
+M4 stores and exposes the minimum attribution fields needed for MCP-first draft review without changing the ActivityPub Article object shape:
+
+- `Draft.generatedBy` / storage `generatedBy`: the agent actor or delegated local actor that generated or materially transformed the draft. Agent-authenticated draft create, update, and autosave paths populate this when it is absent.
+- `Draft.reviewedBy` / storage `reviewedBy`: the human actor that reviewed or edited a generated draft through the authenticated CMS workflow.
+- `Article.generatedBy`, `Article.reviewedBy`, and `Article.publishedBy` / storage `generatedBy`, `reviewedBy`, and `publishedBy`: attribution copied from the draft at publish time plus the publisher actor that performed publication or post-publish update.
+- `Revision.generatedBy`, `Revision.reviewedBy`, and `Revision.publishedBy` / storage `generatedBy`, `reviewedBy`, and `publishedBy`: the attribution snapshot recorded with each Article revision, alongside existing `changedBy`, `changeType`, `changeSummary`, and metadata JSON.
+
+`Article.attributedTo` remains the publisher/owner ActivityPub actor and is the only author identity serialized into the federated Article in M4. Generator and reviewer attribution are additive GraphQL/storage metadata for audit and UI review surfaces; M4 does not introduce a new ActivityPub extension, JSON-LD context, Mastodon REST field, or OpenAPI change. Future federation-visible agent attribution still requires the blocking protocol review gate above.
+
+### M4 schedule and rollback availability
+
+Schedule/cancel and restore are backend MVP capabilities, not rich editor UI work:
+
+- `scheduleDraft` and `cancelScheduledDraft` are available only when the CMS long-form, draft-system, and scheduled-publishing gates are enabled. Any UI exposure must remain hidden unless those gates are enabled and the authenticated author owns the draft.
+- `restoreRevision` is available only when the CMS long-form, revision-history, and author-permission gates pass. UI controls must stay hidden unless revision history is enabled and the user can mutate the Article.
+- “Rollback” in M4 means restoring local Article state from a recorded revision. It is not a federated recall mechanism: ActivityPub activities already delivered to remote peers cannot be recalled, and any post-restore federation follows the normal Article update path.
+
 ### Review gate
 
 An agent-generated draft cannot auto-publish in the MVP. Publication requires an explicit reviewer/publisher action through lesser's authenticated CMS workflow.

--- a/docs/contracts/graphql-schema.graphql
+++ b/docs/contracts/graphql-schema.graphql
@@ -2374,6 +2374,10 @@ type Article {
   editorNotes: String
   reviewStatus: String
 
+  generatedBy: Actor
+  reviewedBy: Actor
+  publishedBy: Actor
+
   publishedAt: Time!
   createdAt: Time!
   updatedAt: Time!
@@ -2404,6 +2408,9 @@ type Draft {
   scheduledAt: Time
   objectId: ID
 
+  generatedBy: Actor
+  reviewedBy: Actor
+
   autosaveVersion: Int!
   lastSavedAt: Time!
 
@@ -2431,6 +2438,9 @@ type Revision {
   changedBy: Actor!
   changeSummary: String
   changeType: ChangeType!
+  generatedBy: Actor
+  reviewedBy: Actor
+  publishedBy: Actor
   createdAt: Time!
 }
 

--- a/graph/cms_converters.go
+++ b/graph/cms_converters.go
@@ -60,6 +60,8 @@ func (r *Resolver) convertCMSDraft(ctx context.Context, draft *models.Draft) *mo
 		Status:          status,
 		ScheduledAt:     scheduledAt,
 		ObjectID:        objectID,
+		GeneratedBy:     r.resolveActorByID(ctx, draft.GeneratedBy),
+		ReviewedBy:      r.resolveActorByID(ctx, draft.ReviewedBy),
 		AutosaveVersion: draft.AutosaveVersion,
 		LastSavedAt:     model.Time(draft.LastSavedAt),
 		CreatedAt:       model.Time(draft.CreatedAt),
@@ -101,6 +103,9 @@ func (r *Resolver) convertCMSRevision(ctx context.Context, revision *models.Revi
 		ChangedBy:     changedBy,
 		ChangeSummary: changeSummary,
 		ChangeType:    changeType,
+		GeneratedBy:   r.resolveActorByID(ctx, revision.GeneratedBy),
+		ReviewedBy:    r.resolveActorByID(ctx, revision.ReviewedBy),
+		PublishedBy:   r.resolveActorByID(ctx, revision.PublishedBy),
 		CreatedAt:     model.Time(revision.CreatedAt),
 	}
 }
@@ -233,6 +238,10 @@ func (r *Resolver) convertCMSArticle(ctx context.Context, article *models.Articl
 
 		EditorNotes:  cmsOptionalString(strings.TrimSpace(article.EditorNotes)),
 		ReviewStatus: cmsOptionalString(strings.TrimSpace(article.ReviewStatus)),
+
+		GeneratedBy: r.resolveActorByID(ctx, article.GeneratedBy),
+		ReviewedBy:  r.resolveActorByID(ctx, article.ReviewedBy),
+		PublishedBy: r.resolveActorByID(ctx, article.PublishedBy),
 
 		PublishedAt: model.Time(article.Published),
 		CreatedAt:   model.Time(article.CreatedAt),

--- a/graph/cms_m4_attribution_test.go
+++ b/graph/cms_m4_attribution_test.go
@@ -1,0 +1,103 @@
+package graph
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/config"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestM4CMSConvertersExposeAuthoringAttribution(t *testing.T) {
+	t.Parallel()
+
+	resolver := &Resolver{Config: &config.Config{Domain: "example.com"}}
+	ctx := context.Background()
+
+	article := resolver.convertCMSArticle(ctx, &models.Article{
+		Object: models.Object{
+			ID:           "https://example.com/articles/hello",
+			Type:         activitypub.ArticleType,
+			Name:         "Hello",
+			Content:      "content",
+			AttributedTo: "https://example.com/users/alice",
+			Published:    time.Now(),
+			Updated:      time.Now(),
+			CreatedAt:    time.Now(),
+		},
+		Slug:          "hello",
+		ContentFormat: "markdown",
+		GeneratedBy:   "https://example.com/users/agent-0",
+		ReviewedBy:    "https://example.com/users/alice",
+		PublishedBy:   "https://example.com/users/alice",
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	}, false)
+	require.NotNil(t, article.GeneratedBy)
+	require.Equal(t, "https://example.com/users/agent-0", article.GeneratedBy.ID)
+	require.NotNil(t, article.ReviewedBy)
+	require.Equal(t, "https://example.com/users/alice", article.ReviewedBy.ID)
+	require.NotNil(t, article.PublishedBy)
+	require.Equal(t, "https://example.com/users/alice", article.PublishedBy.ID)
+
+	draft := resolver.convertCMSDraft(ctx, &models.Draft{
+		ID:            "draft-1",
+		AuthorID:      "alice",
+		ContentType:   activitypub.ArticleType,
+		Content:       "content",
+		ContentFormat: "markdown",
+		Status:        "draft",
+		LastSavedAt:   time.Now(),
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+		GeneratedBy:   "https://example.com/users/agent-0",
+		ReviewedBy:    "https://example.com/users/alice",
+	})
+	require.NotNil(t, draft.GeneratedBy)
+	require.Equal(t, "https://example.com/users/agent-0", draft.GeneratedBy.ID)
+	require.NotNil(t, draft.ReviewedBy)
+	require.Equal(t, "https://example.com/users/alice", draft.ReviewedBy.ID)
+
+	revision := resolver.convertCMSRevision(ctx, &models.Revision{
+		ID:          "rev-1",
+		ObjectID:    "https://example.com/articles/hello",
+		Version:     1,
+		Content:     "content",
+		ChangedBy:   "https://example.com/users/alice",
+		ChangeType:  "update",
+		GeneratedBy: "https://example.com/users/agent-0",
+		ReviewedBy:  "https://example.com/users/alice",
+		PublishedBy: "https://example.com/users/alice",
+		CreatedAt:   time.Now(),
+	})
+	require.NotNil(t, revision.GeneratedBy)
+	require.Equal(t, "https://example.com/users/agent-0", revision.GeneratedBy.ID)
+	require.NotNil(t, revision.ReviewedBy)
+	require.Equal(t, "https://example.com/users/alice", revision.ReviewedBy.ID)
+	require.NotNil(t, revision.PublishedBy)
+	require.Equal(t, "https://example.com/users/alice", revision.PublishedBy.ID)
+}
+
+func TestM4DraftRequestAttributionUsesAgentAndHumanReviewContext(t *testing.T) {
+	t.Parallel()
+
+	mut := &mutationResolver{Resolver: &Resolver{Config: &config.Config{Domain: "example.com"}}}
+	draft := &models.Draft{}
+
+	agentCtx := auth.WithClaims(context.Background(), &auth.Claims{
+		Username: "agent-0",
+		IsAgent:  true,
+	})
+	mut.cmsApplyDraftRequestAttribution(agentCtx, "agent-0", draft, false)
+	require.Equal(t, "https://localhost/users/agent-0", draft.GeneratedBy)
+	require.Empty(t, draft.ReviewedBy)
+
+	humanCtx := auth.WithClaims(context.Background(), &auth.Claims{Username: "alice"})
+	mut.cmsApplyDraftRequestAttribution(humanCtx, "alice", draft, true)
+	require.Equal(t, "https://localhost/users/agent-0", draft.GeneratedBy)
+	require.Equal(t, "https://localhost/users/alice", draft.ReviewedBy)
+}

--- a/graph/generated.go
+++ b/graph/generated.go
@@ -829,11 +829,14 @@ type ComplexityRoot struct {
 		EditorNotes        func(childComplexity int) int
 		Excerpt            func(childComplexity int) int
 		FeaturedImage      func(childComplexity int) int
+		GeneratedBy        func(childComplexity int) int
 		ID                 func(childComplexity int) int
 		OGImage            func(childComplexity int) int
 		PublishedAt        func(childComplexity int) int
+		PublishedBy        func(childComplexity int) int
 		ReadingTimeMinutes func(childComplexity int) int
 		ReviewStatus       func(childComplexity int) int
+		ReviewedBy         func(childComplexity int) int
 		SEODescription     func(childComplexity int) int
 		SEOTitle           func(childComplexity int) int
 		Series             func(childComplexity int) int
@@ -1139,9 +1142,11 @@ type ComplexityRoot struct {
 		ContentFormat   func(childComplexity int) int
 		ContentType     func(childComplexity int) int
 		CreatedAt       func(childComplexity int) int
+		GeneratedBy     func(childComplexity int) int
 		ID              func(childComplexity int) int
 		LastSavedAt     func(childComplexity int) int
 		ObjectID        func(childComplexity int) int
+		ReviewedBy      func(childComplexity int) int
 		ScheduledAt     func(childComplexity int) int
 		Slug            func(childComplexity int) int
 		Status          func(childComplexity int) int
@@ -2736,9 +2741,12 @@ type ComplexityRoot struct {
 		ChangedBy     func(childComplexity int) int
 		Content       func(childComplexity int) int
 		CreatedAt     func(childComplexity int) int
+		GeneratedBy   func(childComplexity int) int
 		ID            func(childComplexity int) int
 		MetadataJSON  func(childComplexity int) int
 		ObjectID      func(childComplexity int) int
+		PublishedBy   func(childComplexity int) int
+		ReviewedBy    func(childComplexity int) int
 		Version       func(childComplexity int) int
 	}
 
@@ -7345,6 +7353,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Article.FeaturedImage(childComplexity), true
 
+	case "Article.generatedBy":
+		if e.complexity.Article.GeneratedBy == nil {
+			break
+		}
+
+		return e.complexity.Article.GeneratedBy(childComplexity), true
+
 	case "Article.id":
 		if e.complexity.Article.ID == nil {
 			break
@@ -7366,6 +7381,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Article.PublishedAt(childComplexity), true
 
+	case "Article.publishedBy":
+		if e.complexity.Article.PublishedBy == nil {
+			break
+		}
+
+		return e.complexity.Article.PublishedBy(childComplexity), true
+
 	case "Article.readingTimeMinutes":
 		if e.complexity.Article.ReadingTimeMinutes == nil {
 			break
@@ -7379,6 +7401,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Article.ReviewStatus(childComplexity), true
+
+	case "Article.reviewedBy":
+		if e.complexity.Article.ReviewedBy == nil {
+			break
+		}
+
+		return e.complexity.Article.ReviewedBy(childComplexity), true
 
 	case "Article.seoDescription":
 		if e.complexity.Article.SEODescription == nil {
@@ -8738,6 +8767,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Draft.CreatedAt(childComplexity), true
 
+	case "Draft.generatedBy":
+		if e.complexity.Draft.GeneratedBy == nil {
+			break
+		}
+
+		return e.complexity.Draft.GeneratedBy(childComplexity), true
+
 	case "Draft.id":
 		if e.complexity.Draft.ID == nil {
 			break
@@ -8758,6 +8794,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Draft.ObjectID(childComplexity), true
+
+	case "Draft.reviewedBy":
+		if e.complexity.Draft.ReviewedBy == nil {
+			break
+		}
+
+		return e.complexity.Draft.ReviewedBy(childComplexity), true
 
 	case "Draft.scheduledAt":
 		if e.complexity.Draft.ScheduledAt == nil {
@@ -18356,6 +18399,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Revision.CreatedAt(childComplexity), true
 
+	case "Revision.generatedBy":
+		if e.complexity.Revision.GeneratedBy == nil {
+			break
+		}
+
+		return e.complexity.Revision.GeneratedBy(childComplexity), true
+
 	case "Revision.id":
 		if e.complexity.Revision.ID == nil {
 			break
@@ -18376,6 +18426,20 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Revision.ObjectID(childComplexity), true
+
+	case "Revision.publishedBy":
+		if e.complexity.Revision.PublishedBy == nil {
+			break
+		}
+
+		return e.complexity.Revision.PublishedBy(childComplexity), true
+
+	case "Revision.reviewedBy":
+		if e.complexity.Revision.ReviewedBy == nil {
+			break
+		}
+
+		return e.complexity.Revision.ReviewedBy(childComplexity), true
 
 	case "Revision.version":
 		if e.complexity.Revision.Version == nil {
@@ -50301,6 +50365,267 @@ func (ec *executionContext) fieldContext_Article_reviewStatus(_ context.Context,
 	return fc, nil
 }
 
+func (ec *executionContext) _Article_generatedBy(ctx context.Context, field graphql.CollectedField, obj *model.Article) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Article_generatedBy(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.GeneratedBy, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*activitypub.Actor)
+	fc.Result = res
+	return ec.marshalOActor2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋpkgᚋactivitypubᚐActor(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Article_generatedBy(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Article",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Actor_id(ctx, field)
+			case "username":
+				return ec.fieldContext_Actor_username(ctx, field)
+			case "domain":
+				return ec.fieldContext_Actor_domain(ctx, field)
+			case "displayName":
+				return ec.fieldContext_Actor_displayName(ctx, field)
+			case "summary":
+				return ec.fieldContext_Actor_summary(ctx, field)
+			case "avatar":
+				return ec.fieldContext_Actor_avatar(ctx, field)
+			case "header":
+				return ec.fieldContext_Actor_header(ctx, field)
+			case "followers":
+				return ec.fieldContext_Actor_followers(ctx, field)
+			case "following":
+				return ec.fieldContext_Actor_following(ctx, field)
+			case "statusesCount":
+				return ec.fieldContext_Actor_statusesCount(ctx, field)
+			case "bot":
+				return ec.fieldContext_Actor_bot(ctx, field)
+			case "locked":
+				return ec.fieldContext_Actor_locked(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Actor_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Actor_updatedAt(ctx, field)
+			case "fields":
+				return ec.fieldContext_Actor_fields(ctx, field)
+			case "isAgent":
+				return ec.fieldContext_Actor_isAgent(ctx, field)
+			case "agentInfo":
+				return ec.fieldContext_Actor_agentInfo(ctx, field)
+			case "tipAddress":
+				return ec.fieldContext_Actor_tipAddress(ctx, field)
+			case "tipChainId":
+				return ec.fieldContext_Actor_tipChainId(ctx, field)
+			case "trustScore":
+				return ec.fieldContext_Actor_trustScore(ctx, field)
+			case "reputation":
+				return ec.fieldContext_Actor_reputation(ctx, field)
+			case "vouches":
+				return ec.fieldContext_Actor_vouches(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Actor", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Article_reviewedBy(ctx context.Context, field graphql.CollectedField, obj *model.Article) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Article_reviewedBy(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ReviewedBy, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*activitypub.Actor)
+	fc.Result = res
+	return ec.marshalOActor2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋpkgᚋactivitypubᚐActor(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Article_reviewedBy(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Article",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Actor_id(ctx, field)
+			case "username":
+				return ec.fieldContext_Actor_username(ctx, field)
+			case "domain":
+				return ec.fieldContext_Actor_domain(ctx, field)
+			case "displayName":
+				return ec.fieldContext_Actor_displayName(ctx, field)
+			case "summary":
+				return ec.fieldContext_Actor_summary(ctx, field)
+			case "avatar":
+				return ec.fieldContext_Actor_avatar(ctx, field)
+			case "header":
+				return ec.fieldContext_Actor_header(ctx, field)
+			case "followers":
+				return ec.fieldContext_Actor_followers(ctx, field)
+			case "following":
+				return ec.fieldContext_Actor_following(ctx, field)
+			case "statusesCount":
+				return ec.fieldContext_Actor_statusesCount(ctx, field)
+			case "bot":
+				return ec.fieldContext_Actor_bot(ctx, field)
+			case "locked":
+				return ec.fieldContext_Actor_locked(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Actor_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Actor_updatedAt(ctx, field)
+			case "fields":
+				return ec.fieldContext_Actor_fields(ctx, field)
+			case "isAgent":
+				return ec.fieldContext_Actor_isAgent(ctx, field)
+			case "agentInfo":
+				return ec.fieldContext_Actor_agentInfo(ctx, field)
+			case "tipAddress":
+				return ec.fieldContext_Actor_tipAddress(ctx, field)
+			case "tipChainId":
+				return ec.fieldContext_Actor_tipChainId(ctx, field)
+			case "trustScore":
+				return ec.fieldContext_Actor_trustScore(ctx, field)
+			case "reputation":
+				return ec.fieldContext_Actor_reputation(ctx, field)
+			case "vouches":
+				return ec.fieldContext_Actor_vouches(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Actor", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Article_publishedBy(ctx context.Context, field graphql.CollectedField, obj *model.Article) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Article_publishedBy(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PublishedBy, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*activitypub.Actor)
+	fc.Result = res
+	return ec.marshalOActor2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋpkgᚋactivitypubᚐActor(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Article_publishedBy(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Article",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Actor_id(ctx, field)
+			case "username":
+				return ec.fieldContext_Actor_username(ctx, field)
+			case "domain":
+				return ec.fieldContext_Actor_domain(ctx, field)
+			case "displayName":
+				return ec.fieldContext_Actor_displayName(ctx, field)
+			case "summary":
+				return ec.fieldContext_Actor_summary(ctx, field)
+			case "avatar":
+				return ec.fieldContext_Actor_avatar(ctx, field)
+			case "header":
+				return ec.fieldContext_Actor_header(ctx, field)
+			case "followers":
+				return ec.fieldContext_Actor_followers(ctx, field)
+			case "following":
+				return ec.fieldContext_Actor_following(ctx, field)
+			case "statusesCount":
+				return ec.fieldContext_Actor_statusesCount(ctx, field)
+			case "bot":
+				return ec.fieldContext_Actor_bot(ctx, field)
+			case "locked":
+				return ec.fieldContext_Actor_locked(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Actor_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Actor_updatedAt(ctx, field)
+			case "fields":
+				return ec.fieldContext_Actor_fields(ctx, field)
+			case "isAgent":
+				return ec.fieldContext_Actor_isAgent(ctx, field)
+			case "agentInfo":
+				return ec.fieldContext_Actor_agentInfo(ctx, field)
+			case "tipAddress":
+				return ec.fieldContext_Actor_tipAddress(ctx, field)
+			case "tipChainId":
+				return ec.fieldContext_Actor_tipChainId(ctx, field)
+			case "trustScore":
+				return ec.fieldContext_Actor_trustScore(ctx, field)
+			case "reputation":
+				return ec.fieldContext_Actor_reputation(ctx, field)
+			case "vouches":
+				return ec.fieldContext_Actor_vouches(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Actor", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Article_publishedAt(ctx context.Context, field graphql.CollectedField, obj *model.Article) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Article_publishedAt(ctx, field)
 	if err != nil {
@@ -50662,6 +50987,12 @@ func (ec *executionContext) fieldContext_ArticleEdge_node(_ context.Context, fie
 				return ec.fieldContext_Article_editorNotes(ctx, field)
 			case "reviewStatus":
 				return ec.fieldContext_Article_reviewStatus(ctx, field)
+			case "generatedBy":
+				return ec.fieldContext_Article_generatedBy(ctx, field)
+			case "reviewedBy":
+				return ec.fieldContext_Article_reviewedBy(ctx, field)
+			case "publishedBy":
+				return ec.fieldContext_Article_publishedBy(ctx, field)
 			case "publishedAt":
 				return ec.fieldContext_Article_publishedAt(ctx, field)
 			case "createdAt":
@@ -59349,6 +59680,180 @@ func (ec *executionContext) fieldContext_Draft_objectId(_ context.Context, field
 	return fc, nil
 }
 
+func (ec *executionContext) _Draft_generatedBy(ctx context.Context, field graphql.CollectedField, obj *model.Draft) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Draft_generatedBy(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.GeneratedBy, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*activitypub.Actor)
+	fc.Result = res
+	return ec.marshalOActor2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋpkgᚋactivitypubᚐActor(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Draft_generatedBy(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Draft",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Actor_id(ctx, field)
+			case "username":
+				return ec.fieldContext_Actor_username(ctx, field)
+			case "domain":
+				return ec.fieldContext_Actor_domain(ctx, field)
+			case "displayName":
+				return ec.fieldContext_Actor_displayName(ctx, field)
+			case "summary":
+				return ec.fieldContext_Actor_summary(ctx, field)
+			case "avatar":
+				return ec.fieldContext_Actor_avatar(ctx, field)
+			case "header":
+				return ec.fieldContext_Actor_header(ctx, field)
+			case "followers":
+				return ec.fieldContext_Actor_followers(ctx, field)
+			case "following":
+				return ec.fieldContext_Actor_following(ctx, field)
+			case "statusesCount":
+				return ec.fieldContext_Actor_statusesCount(ctx, field)
+			case "bot":
+				return ec.fieldContext_Actor_bot(ctx, field)
+			case "locked":
+				return ec.fieldContext_Actor_locked(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Actor_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Actor_updatedAt(ctx, field)
+			case "fields":
+				return ec.fieldContext_Actor_fields(ctx, field)
+			case "isAgent":
+				return ec.fieldContext_Actor_isAgent(ctx, field)
+			case "agentInfo":
+				return ec.fieldContext_Actor_agentInfo(ctx, field)
+			case "tipAddress":
+				return ec.fieldContext_Actor_tipAddress(ctx, field)
+			case "tipChainId":
+				return ec.fieldContext_Actor_tipChainId(ctx, field)
+			case "trustScore":
+				return ec.fieldContext_Actor_trustScore(ctx, field)
+			case "reputation":
+				return ec.fieldContext_Actor_reputation(ctx, field)
+			case "vouches":
+				return ec.fieldContext_Actor_vouches(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Actor", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Draft_reviewedBy(ctx context.Context, field graphql.CollectedField, obj *model.Draft) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Draft_reviewedBy(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ReviewedBy, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*activitypub.Actor)
+	fc.Result = res
+	return ec.marshalOActor2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋpkgᚋactivitypubᚐActor(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Draft_reviewedBy(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Draft",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Actor_id(ctx, field)
+			case "username":
+				return ec.fieldContext_Actor_username(ctx, field)
+			case "domain":
+				return ec.fieldContext_Actor_domain(ctx, field)
+			case "displayName":
+				return ec.fieldContext_Actor_displayName(ctx, field)
+			case "summary":
+				return ec.fieldContext_Actor_summary(ctx, field)
+			case "avatar":
+				return ec.fieldContext_Actor_avatar(ctx, field)
+			case "header":
+				return ec.fieldContext_Actor_header(ctx, field)
+			case "followers":
+				return ec.fieldContext_Actor_followers(ctx, field)
+			case "following":
+				return ec.fieldContext_Actor_following(ctx, field)
+			case "statusesCount":
+				return ec.fieldContext_Actor_statusesCount(ctx, field)
+			case "bot":
+				return ec.fieldContext_Actor_bot(ctx, field)
+			case "locked":
+				return ec.fieldContext_Actor_locked(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Actor_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Actor_updatedAt(ctx, field)
+			case "fields":
+				return ec.fieldContext_Actor_fields(ctx, field)
+			case "isAgent":
+				return ec.fieldContext_Actor_isAgent(ctx, field)
+			case "agentInfo":
+				return ec.fieldContext_Actor_agentInfo(ctx, field)
+			case "tipAddress":
+				return ec.fieldContext_Actor_tipAddress(ctx, field)
+			case "tipChainId":
+				return ec.fieldContext_Actor_tipChainId(ctx, field)
+			case "trustScore":
+				return ec.fieldContext_Actor_trustScore(ctx, field)
+			case "reputation":
+				return ec.fieldContext_Actor_reputation(ctx, field)
+			case "vouches":
+				return ec.fieldContext_Actor_vouches(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Actor", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Draft_autosaveVersion(ctx context.Context, field graphql.CollectedField, obj *model.Draft) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Draft_autosaveVersion(ctx, field)
 	if err != nil {
@@ -59732,6 +60237,10 @@ func (ec *executionContext) fieldContext_DraftEdge_node(_ context.Context, field
 				return ec.fieldContext_Draft_scheduledAt(ctx, field)
 			case "objectId":
 				return ec.fieldContext_Draft_objectId(ctx, field)
+			case "generatedBy":
+				return ec.fieldContext_Draft_generatedBy(ctx, field)
+			case "reviewedBy":
+				return ec.fieldContext_Draft_reviewedBy(ctx, field)
 			case "autosaveVersion":
 				return ec.fieldContext_Draft_autosaveVersion(ctx, field)
 			case "lastSavedAt":
@@ -91128,6 +91637,10 @@ func (ec *executionContext) fieldContext_Mutation_createDraft(ctx context.Contex
 				return ec.fieldContext_Draft_scheduledAt(ctx, field)
 			case "objectId":
 				return ec.fieldContext_Draft_objectId(ctx, field)
+			case "generatedBy":
+				return ec.fieldContext_Draft_generatedBy(ctx, field)
+			case "reviewedBy":
+				return ec.fieldContext_Draft_reviewedBy(ctx, field)
 			case "autosaveVersion":
 				return ec.fieldContext_Draft_autosaveVersion(ctx, field)
 			case "lastSavedAt":
@@ -91213,6 +91726,10 @@ func (ec *executionContext) fieldContext_Mutation_updateDraft(ctx context.Contex
 				return ec.fieldContext_Draft_scheduledAt(ctx, field)
 			case "objectId":
 				return ec.fieldContext_Draft_objectId(ctx, field)
+			case "generatedBy":
+				return ec.fieldContext_Draft_generatedBy(ctx, field)
+			case "reviewedBy":
+				return ec.fieldContext_Draft_reviewedBy(ctx, field)
 			case "autosaveVersion":
 				return ec.fieldContext_Draft_autosaveVersion(ctx, field)
 			case "lastSavedAt":
@@ -91298,6 +91815,10 @@ func (ec *executionContext) fieldContext_Mutation_autosaveDraft(ctx context.Cont
 				return ec.fieldContext_Draft_scheduledAt(ctx, field)
 			case "objectId":
 				return ec.fieldContext_Draft_objectId(ctx, field)
+			case "generatedBy":
+				return ec.fieldContext_Draft_generatedBy(ctx, field)
+			case "reviewedBy":
+				return ec.fieldContext_Draft_reviewedBy(ctx, field)
 			case "autosaveVersion":
 				return ec.fieldContext_Draft_autosaveVersion(ctx, field)
 			case "lastSavedAt":
@@ -91460,6 +91981,12 @@ func (ec *executionContext) fieldContext_Mutation_publishDraft(ctx context.Conte
 				return ec.fieldContext_Article_editorNotes(ctx, field)
 			case "reviewStatus":
 				return ec.fieldContext_Article_reviewStatus(ctx, field)
+			case "generatedBy":
+				return ec.fieldContext_Article_generatedBy(ctx, field)
+			case "reviewedBy":
+				return ec.fieldContext_Article_reviewedBy(ctx, field)
+			case "publishedBy":
+				return ec.fieldContext_Article_publishedBy(ctx, field)
 			case "publishedAt":
 				return ec.fieldContext_Article_publishedAt(ctx, field)
 			case "createdAt":
@@ -91543,6 +92070,10 @@ func (ec *executionContext) fieldContext_Mutation_scheduleDraft(ctx context.Cont
 				return ec.fieldContext_Draft_scheduledAt(ctx, field)
 			case "objectId":
 				return ec.fieldContext_Draft_objectId(ctx, field)
+			case "generatedBy":
+				return ec.fieldContext_Draft_generatedBy(ctx, field)
+			case "reviewedBy":
+				return ec.fieldContext_Draft_reviewedBy(ctx, field)
 			case "autosaveVersion":
 				return ec.fieldContext_Draft_autosaveVersion(ctx, field)
 			case "lastSavedAt":
@@ -91628,6 +92159,10 @@ func (ec *executionContext) fieldContext_Mutation_cancelScheduledDraft(ctx conte
 				return ec.fieldContext_Draft_scheduledAt(ctx, field)
 			case "objectId":
 				return ec.fieldContext_Draft_objectId(ctx, field)
+			case "generatedBy":
+				return ec.fieldContext_Draft_generatedBy(ctx, field)
+			case "reviewedBy":
+				return ec.fieldContext_Draft_reviewedBy(ctx, field)
 			case "autosaveVersion":
 				return ec.fieldContext_Draft_autosaveVersion(ctx, field)
 			case "lastSavedAt":
@@ -91735,6 +92270,12 @@ func (ec *executionContext) fieldContext_Mutation_createArticle(ctx context.Cont
 				return ec.fieldContext_Article_editorNotes(ctx, field)
 			case "reviewStatus":
 				return ec.fieldContext_Article_reviewStatus(ctx, field)
+			case "generatedBy":
+				return ec.fieldContext_Article_generatedBy(ctx, field)
+			case "reviewedBy":
+				return ec.fieldContext_Article_reviewedBy(ctx, field)
+			case "publishedBy":
+				return ec.fieldContext_Article_publishedBy(ctx, field)
 			case "publishedAt":
 				return ec.fieldContext_Article_publishedAt(ctx, field)
 			case "createdAt":
@@ -91840,6 +92381,12 @@ func (ec *executionContext) fieldContext_Mutation_updateArticle(ctx context.Cont
 				return ec.fieldContext_Article_editorNotes(ctx, field)
 			case "reviewStatus":
 				return ec.fieldContext_Article_reviewStatus(ctx, field)
+			case "generatedBy":
+				return ec.fieldContext_Article_generatedBy(ctx, field)
+			case "reviewedBy":
+				return ec.fieldContext_Article_reviewedBy(ctx, field)
+			case "publishedBy":
+				return ec.fieldContext_Article_publishedBy(ctx, field)
 			case "publishedAt":
 				return ec.fieldContext_Article_publishedAt(ctx, field)
 			case "createdAt":
@@ -92000,6 +92547,12 @@ func (ec *executionContext) fieldContext_Mutation_restoreRevision(ctx context.Co
 				return ec.fieldContext_Article_editorNotes(ctx, field)
 			case "reviewStatus":
 				return ec.fieldContext_Article_reviewStatus(ctx, field)
+			case "generatedBy":
+				return ec.fieldContext_Article_generatedBy(ctx, field)
+			case "reviewedBy":
+				return ec.fieldContext_Article_reviewedBy(ctx, field)
+			case "publishedBy":
+				return ec.fieldContext_Article_publishedBy(ctx, field)
 			case "publishedAt":
 				return ec.fieldContext_Article_publishedAt(ctx, field)
 			case "createdAt":
@@ -92758,6 +93311,12 @@ func (ec *executionContext) fieldContext_Mutation_addArticleToCategory(ctx conte
 				return ec.fieldContext_Article_editorNotes(ctx, field)
 			case "reviewStatus":
 				return ec.fieldContext_Article_reviewStatus(ctx, field)
+			case "generatedBy":
+				return ec.fieldContext_Article_generatedBy(ctx, field)
+			case "reviewedBy":
+				return ec.fieldContext_Article_reviewedBy(ctx, field)
+			case "publishedBy":
+				return ec.fieldContext_Article_publishedBy(ctx, field)
 			case "publishedAt":
 				return ec.fieldContext_Article_publishedAt(ctx, field)
 			case "createdAt":
@@ -92863,6 +93422,12 @@ func (ec *executionContext) fieldContext_Mutation_removeArticleFromCategory(ctx 
 				return ec.fieldContext_Article_editorNotes(ctx, field)
 			case "reviewStatus":
 				return ec.fieldContext_Article_reviewStatus(ctx, field)
+			case "generatedBy":
+				return ec.fieldContext_Article_generatedBy(ctx, field)
+			case "reviewedBy":
+				return ec.fieldContext_Article_reviewedBy(ctx, field)
+			case "publishedBy":
+				return ec.fieldContext_Article_publishedBy(ctx, field)
 			case "publishedAt":
 				return ec.fieldContext_Article_publishedAt(ctx, field)
 			case "createdAt":
@@ -111812,6 +112377,10 @@ func (ec *executionContext) fieldContext_Query_draft(ctx context.Context, field 
 				return ec.fieldContext_Draft_scheduledAt(ctx, field)
 			case "objectId":
 				return ec.fieldContext_Draft_objectId(ctx, field)
+			case "generatedBy":
+				return ec.fieldContext_Draft_generatedBy(ctx, field)
+			case "reviewedBy":
+				return ec.fieldContext_Draft_reviewedBy(ctx, field)
 			case "autosaveVersion":
 				return ec.fieldContext_Draft_autosaveVersion(ctx, field)
 			case "lastSavedAt":
@@ -112016,6 +112585,12 @@ func (ec *executionContext) fieldContext_Query_revision(ctx context.Context, fie
 				return ec.fieldContext_Revision_changeSummary(ctx, field)
 			case "changeType":
 				return ec.fieldContext_Revision_changeType(ctx, field)
+			case "generatedBy":
+				return ec.fieldContext_Revision_generatedBy(ctx, field)
+			case "reviewedBy":
+				return ec.fieldContext_Revision_reviewedBy(ctx, field)
+			case "publishedBy":
+				return ec.fieldContext_Revision_publishedBy(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Revision_createdAt(ctx, field)
 			}
@@ -112114,6 +112689,12 @@ func (ec *executionContext) fieldContext_Query_article(ctx context.Context, fiel
 				return ec.fieldContext_Article_editorNotes(ctx, field)
 			case "reviewStatus":
 				return ec.fieldContext_Article_reviewStatus(ctx, field)
+			case "generatedBy":
+				return ec.fieldContext_Article_generatedBy(ctx, field)
+			case "reviewedBy":
+				return ec.fieldContext_Article_reviewedBy(ctx, field)
+			case "publishedBy":
+				return ec.fieldContext_Article_publishedBy(ctx, field)
 			case "publishedAt":
 				return ec.fieldContext_Article_publishedAt(ctx, field)
 			case "createdAt":
@@ -112216,6 +112797,12 @@ func (ec *executionContext) fieldContext_Query_articleBySlug(ctx context.Context
 				return ec.fieldContext_Article_editorNotes(ctx, field)
 			case "reviewStatus":
 				return ec.fieldContext_Article_reviewStatus(ctx, field)
+			case "generatedBy":
+				return ec.fieldContext_Article_generatedBy(ctx, field)
+			case "reviewedBy":
+				return ec.fieldContext_Article_reviewedBy(ctx, field)
+			case "publishedBy":
+				return ec.fieldContext_Article_publishedBy(ctx, field)
 			case "publishedAt":
 				return ec.fieldContext_Article_publishedAt(ctx, field)
 			case "createdAt":
@@ -122550,6 +123137,267 @@ func (ec *executionContext) fieldContext_Revision_changeType(_ context.Context, 
 	return fc, nil
 }
 
+func (ec *executionContext) _Revision_generatedBy(ctx context.Context, field graphql.CollectedField, obj *model.Revision) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Revision_generatedBy(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.GeneratedBy, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*activitypub.Actor)
+	fc.Result = res
+	return ec.marshalOActor2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋpkgᚋactivitypubᚐActor(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Revision_generatedBy(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Revision",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Actor_id(ctx, field)
+			case "username":
+				return ec.fieldContext_Actor_username(ctx, field)
+			case "domain":
+				return ec.fieldContext_Actor_domain(ctx, field)
+			case "displayName":
+				return ec.fieldContext_Actor_displayName(ctx, field)
+			case "summary":
+				return ec.fieldContext_Actor_summary(ctx, field)
+			case "avatar":
+				return ec.fieldContext_Actor_avatar(ctx, field)
+			case "header":
+				return ec.fieldContext_Actor_header(ctx, field)
+			case "followers":
+				return ec.fieldContext_Actor_followers(ctx, field)
+			case "following":
+				return ec.fieldContext_Actor_following(ctx, field)
+			case "statusesCount":
+				return ec.fieldContext_Actor_statusesCount(ctx, field)
+			case "bot":
+				return ec.fieldContext_Actor_bot(ctx, field)
+			case "locked":
+				return ec.fieldContext_Actor_locked(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Actor_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Actor_updatedAt(ctx, field)
+			case "fields":
+				return ec.fieldContext_Actor_fields(ctx, field)
+			case "isAgent":
+				return ec.fieldContext_Actor_isAgent(ctx, field)
+			case "agentInfo":
+				return ec.fieldContext_Actor_agentInfo(ctx, field)
+			case "tipAddress":
+				return ec.fieldContext_Actor_tipAddress(ctx, field)
+			case "tipChainId":
+				return ec.fieldContext_Actor_tipChainId(ctx, field)
+			case "trustScore":
+				return ec.fieldContext_Actor_trustScore(ctx, field)
+			case "reputation":
+				return ec.fieldContext_Actor_reputation(ctx, field)
+			case "vouches":
+				return ec.fieldContext_Actor_vouches(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Actor", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Revision_reviewedBy(ctx context.Context, field graphql.CollectedField, obj *model.Revision) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Revision_reviewedBy(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ReviewedBy, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*activitypub.Actor)
+	fc.Result = res
+	return ec.marshalOActor2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋpkgᚋactivitypubᚐActor(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Revision_reviewedBy(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Revision",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Actor_id(ctx, field)
+			case "username":
+				return ec.fieldContext_Actor_username(ctx, field)
+			case "domain":
+				return ec.fieldContext_Actor_domain(ctx, field)
+			case "displayName":
+				return ec.fieldContext_Actor_displayName(ctx, field)
+			case "summary":
+				return ec.fieldContext_Actor_summary(ctx, field)
+			case "avatar":
+				return ec.fieldContext_Actor_avatar(ctx, field)
+			case "header":
+				return ec.fieldContext_Actor_header(ctx, field)
+			case "followers":
+				return ec.fieldContext_Actor_followers(ctx, field)
+			case "following":
+				return ec.fieldContext_Actor_following(ctx, field)
+			case "statusesCount":
+				return ec.fieldContext_Actor_statusesCount(ctx, field)
+			case "bot":
+				return ec.fieldContext_Actor_bot(ctx, field)
+			case "locked":
+				return ec.fieldContext_Actor_locked(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Actor_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Actor_updatedAt(ctx, field)
+			case "fields":
+				return ec.fieldContext_Actor_fields(ctx, field)
+			case "isAgent":
+				return ec.fieldContext_Actor_isAgent(ctx, field)
+			case "agentInfo":
+				return ec.fieldContext_Actor_agentInfo(ctx, field)
+			case "tipAddress":
+				return ec.fieldContext_Actor_tipAddress(ctx, field)
+			case "tipChainId":
+				return ec.fieldContext_Actor_tipChainId(ctx, field)
+			case "trustScore":
+				return ec.fieldContext_Actor_trustScore(ctx, field)
+			case "reputation":
+				return ec.fieldContext_Actor_reputation(ctx, field)
+			case "vouches":
+				return ec.fieldContext_Actor_vouches(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Actor", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Revision_publishedBy(ctx context.Context, field graphql.CollectedField, obj *model.Revision) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Revision_publishedBy(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PublishedBy, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*activitypub.Actor)
+	fc.Result = res
+	return ec.marshalOActor2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋpkgᚋactivitypubᚐActor(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Revision_publishedBy(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Revision",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Actor_id(ctx, field)
+			case "username":
+				return ec.fieldContext_Actor_username(ctx, field)
+			case "domain":
+				return ec.fieldContext_Actor_domain(ctx, field)
+			case "displayName":
+				return ec.fieldContext_Actor_displayName(ctx, field)
+			case "summary":
+				return ec.fieldContext_Actor_summary(ctx, field)
+			case "avatar":
+				return ec.fieldContext_Actor_avatar(ctx, field)
+			case "header":
+				return ec.fieldContext_Actor_header(ctx, field)
+			case "followers":
+				return ec.fieldContext_Actor_followers(ctx, field)
+			case "following":
+				return ec.fieldContext_Actor_following(ctx, field)
+			case "statusesCount":
+				return ec.fieldContext_Actor_statusesCount(ctx, field)
+			case "bot":
+				return ec.fieldContext_Actor_bot(ctx, field)
+			case "locked":
+				return ec.fieldContext_Actor_locked(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Actor_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Actor_updatedAt(ctx, field)
+			case "fields":
+				return ec.fieldContext_Actor_fields(ctx, field)
+			case "isAgent":
+				return ec.fieldContext_Actor_isAgent(ctx, field)
+			case "agentInfo":
+				return ec.fieldContext_Actor_agentInfo(ctx, field)
+			case "tipAddress":
+				return ec.fieldContext_Actor_tipAddress(ctx, field)
+			case "tipChainId":
+				return ec.fieldContext_Actor_tipChainId(ctx, field)
+			case "trustScore":
+				return ec.fieldContext_Actor_trustScore(ctx, field)
+			case "reputation":
+				return ec.fieldContext_Actor_reputation(ctx, field)
+			case "vouches":
+				return ec.fieldContext_Actor_vouches(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Actor", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Revision_createdAt(ctx context.Context, field graphql.CollectedField, obj *model.Revision) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Revision_createdAt(ctx, field)
 	if err != nil {
@@ -122797,6 +123645,12 @@ func (ec *executionContext) fieldContext_RevisionEdge_node(_ context.Context, fi
 				return ec.fieldContext_Revision_changeSummary(ctx, field)
 			case "changeType":
 				return ec.fieldContext_Revision_changeType(ctx, field)
+			case "generatedBy":
+				return ec.fieldContext_Revision_generatedBy(ctx, field)
+			case "reviewedBy":
+				return ec.fieldContext_Revision_reviewedBy(ctx, field)
+			case "publishedBy":
+				return ec.fieldContext_Revision_publishedBy(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Revision_createdAt(ctx, field)
 			}
@@ -152277,6 +153131,12 @@ func (ec *executionContext) _Article(ctx context.Context, sel ast.SelectionSet, 
 			out.Values[i] = ec._Article_editorNotes(ctx, field, obj)
 		case "reviewStatus":
 			out.Values[i] = ec._Article_reviewStatus(ctx, field, obj)
+		case "generatedBy":
+			out.Values[i] = ec._Article_generatedBy(ctx, field, obj)
+		case "reviewedBy":
+			out.Values[i] = ec._Article_reviewedBy(ctx, field, obj)
+		case "publishedBy":
+			out.Values[i] = ec._Article_publishedBy(ctx, field, obj)
 		case "publishedAt":
 			out.Values[i] = ec._Article_publishedAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -154543,6 +155403,10 @@ func (ec *executionContext) _Draft(ctx context.Context, sel ast.SelectionSet, ob
 			out.Values[i] = ec._Draft_scheduledAt(ctx, field, obj)
 		case "objectId":
 			out.Values[i] = ec._Draft_objectId(ctx, field, obj)
+		case "generatedBy":
+			out.Values[i] = ec._Draft_generatedBy(ctx, field, obj)
+		case "reviewedBy":
+			out.Values[i] = ec._Draft_reviewedBy(ctx, field, obj)
 		case "autosaveVersion":
 			out.Values[i] = ec._Draft_autosaveVersion(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -168760,6 +169624,12 @@ func (ec *executionContext) _Revision(ctx context.Context, sel ast.SelectionSet,
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "generatedBy":
+			out.Values[i] = ec._Revision_generatedBy(ctx, field, obj)
+		case "reviewedBy":
+			out.Values[i] = ec._Revision_reviewedBy(ctx, field, obj)
+		case "publishedBy":
+			out.Values[i] = ec._Revision_publishedBy(ctx, field, obj)
 		case "createdAt":
 			out.Values[i] = ec._Revision_createdAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/graph/model/cms.go
+++ b/graph/model/cms.go
@@ -98,6 +98,10 @@ type Article struct {
 	EditorNotes  *string `json:"editorNotes"`
 	ReviewStatus *string `json:"reviewStatus"`
 
+	GeneratedBy *activitypub.Actor `json:"generatedBy"`
+	ReviewedBy  *activitypub.Actor `json:"reviewedBy"`
+	PublishedBy *activitypub.Actor `json:"publishedBy"`
+
 	PublishedAt Time `json:"publishedAt"`
 	CreatedAt   Time `json:"createdAt"`
 	UpdatedAt   Time `json:"updatedAt"`
@@ -131,6 +135,9 @@ type Draft struct {
 	ScheduledAt *Time       `json:"scheduledAt"`
 	ObjectID    *string     `json:"objectId"`
 
+	GeneratedBy *activitypub.Actor `json:"generatedBy"`
+	ReviewedBy  *activitypub.Actor `json:"reviewedBy"`
+
 	AutosaveVersion int  `json:"autosaveVersion"`
 	LastSavedAt     Time `json:"lastSavedAt"`
 
@@ -161,6 +168,9 @@ type Revision struct {
 	ChangedBy     *activitypub.Actor `json:"changedBy"`
 	ChangeSummary *string            `json:"changeSummary"`
 	ChangeType    ChangeType         `json:"changeType"`
+	GeneratedBy   *activitypub.Actor `json:"generatedBy"`
+	ReviewedBy    *activitypub.Actor `json:"reviewedBy"`
+	PublishedBy   *activitypub.Actor `json:"publishedBy"`
 	CreatedAt     Time               `json:"createdAt"`
 }
 

--- a/graph/mutation_resolvers_cms.go
+++ b/graph/mutation_resolvers_cms.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/equaltoai/lesser/graph/model"
+	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/google/uuid"
 	dynamormerrors "github.com/theory-cloud/tabletheory/pkg/errors"
@@ -58,6 +59,7 @@ func (r *mutationResolver) CreateDraft(ctx context.Context, input model.CreateDr
 		ContentFormat: cmsContentFormatToStorage(input.ContentFormat),
 		Status:        cmsDraftStatusToStorage(model.DraftStatusDraft),
 	}
+	r.cmsApplyDraftRequestAttribution(ctx, username, draft, false)
 
 	if err := draftSvc.CreateDraft(ctx, draft); err != nil {
 		return nil, err
@@ -98,6 +100,7 @@ func (r *mutationResolver) UpdateDraft(ctx context.Context, id string, input mod
 	if input.ContentFormat != nil {
 		draft.ContentFormat = cmsContentFormatToStorage(*input.ContentFormat)
 	}
+	r.cmsApplyDraftRequestAttribution(ctx, username, draft, true)
 
 	if err := draftSvc.UpdateDraft(ctx, username, draft); err != nil {
 		return nil, err
@@ -127,11 +130,35 @@ func (r *mutationResolver) AutosaveDraft(ctx context.Context, id string, content
 	}
 
 	draft.Content = content
+	r.cmsApplyDraftRequestAttribution(ctx, username, draft, true)
 	if err := draftSvc.Autosave(ctx, username, draft); err != nil {
 		return nil, err
 	}
 
 	return r.convertCMSDraft(ctx, draft), nil
+}
+
+func (r *mutationResolver) cmsApplyDraftRequestAttribution(ctx context.Context, username string, draft *models.Draft, reviewWrite bool) {
+	if draft == nil {
+		return
+	}
+
+	username = strings.TrimSpace(username)
+	actorID := cmsLocalActorID(r.getDomain(), username)
+	if actorID == "" {
+		return
+	}
+
+	if claims, ok := auth.GetClaims(ctx); ok && claims != nil && claims.IsAgent {
+		if strings.TrimSpace(draft.GeneratedBy) == "" {
+			draft.GeneratedBy = actorID
+		}
+		return
+	}
+
+	if reviewWrite && strings.TrimSpace(draft.GeneratedBy) != "" && !strings.EqualFold(strings.TrimSpace(draft.GeneratedBy), actorID) {
+		draft.ReviewedBy = actorID
+	}
 }
 
 func (r *mutationResolver) DeleteDraft(ctx context.Context, id string) (bool, error) {

--- a/graph/phase1.graphql
+++ b/graph/phase1.graphql
@@ -62,6 +62,10 @@ type Article {
   editorNotes: String
   reviewStatus: String
 
+  generatedBy: Actor
+  reviewedBy: Actor
+  publishedBy: Actor
+
   publishedAt: Time!
   createdAt: Time!
   updatedAt: Time!
@@ -92,6 +96,9 @@ type Draft {
   scheduledAt: Time
   objectId: ID
 
+  generatedBy: Actor
+  reviewedBy: Actor
+
   autosaveVersion: Int!
   lastSavedAt: Time!
 
@@ -119,6 +126,9 @@ type Revision {
   changedBy: Actor!
   changeSummary: String
   changeType: ChangeType!
+  generatedBy: Actor
+  reviewedBy: Actor
+  publishedBy: Actor
   createdAt: Time!
 }
 

--- a/pkg/services/cms/article_service.go
+++ b/pkg/services/cms/article_service.go
@@ -100,6 +100,7 @@ func (s *ArticleService) CreateArticle(ctx context.Context, article *models.Arti
 		article.CreatedAt = time.Now()
 	}
 	article.UpdatedAt = time.Now()
+	cmsNormalizeArticleAttribution(article, nil)
 
 	if err := validateArticleRenderable(article); err != nil {
 		return err
@@ -252,6 +253,7 @@ func (s *ArticleService) UpdateArticle(ctx context.Context, article *models.Arti
 	}
 
 	existing, _ := s.articleRepo.GetArticle(ctx, strings.TrimSpace(article.ID))
+	cmsNormalizeArticleAttribution(article, existing)
 
 	slug := strings.TrimSpace(article.Slug)
 	article.Slug = slug

--- a/pkg/services/cms/attribution.go
+++ b/pkg/services/cms/attribution.go
@@ -1,0 +1,74 @@
+package cms
+
+import (
+	"strings"
+
+	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+)
+
+func cmsNormalizeAttributionActorID(value string) string {
+	return strings.TrimSpace(value)
+}
+
+func cmsDefaultLocalAttributionActorID(domain string, username string) string {
+	username = strings.TrimSpace(username)
+	domain = strings.TrimSpace(domain)
+	if username == "" || domain == "" {
+		return ""
+	}
+	return common.GenerateActorID(domain, username)
+}
+
+func cmsNormalizeDraftAttribution(draft *models.Draft) {
+	if draft == nil {
+		return
+	}
+	draft.GeneratedBy = cmsNormalizeAttributionActorID(draft.GeneratedBy)
+	draft.ReviewedBy = cmsNormalizeAttributionActorID(draft.ReviewedBy)
+}
+
+func cmsNormalizeArticleAttribution(article *models.Article, existing *models.Article) {
+	if article == nil {
+		return
+	}
+
+	article.GeneratedBy = cmsNormalizeAttributionActorID(article.GeneratedBy)
+	article.ReviewedBy = cmsNormalizeAttributionActorID(article.ReviewedBy)
+	article.PublishedBy = cmsNormalizeAttributionActorID(article.PublishedBy)
+
+	if existing != nil {
+		if article.GeneratedBy == "" {
+			article.GeneratedBy = cmsNormalizeAttributionActorID(existing.GeneratedBy)
+		}
+		if article.ReviewedBy == "" {
+			article.ReviewedBy = cmsNormalizeAttributionActorID(existing.ReviewedBy)
+		}
+		if article.PublishedBy == "" {
+			article.PublishedBy = cmsNormalizeAttributionActorID(existing.PublishedBy)
+		}
+	}
+
+	if article.PublishedBy == "" {
+		article.PublishedBy = cmsNormalizeAttributionActorID(article.AttributedTo)
+	}
+}
+
+func cmsApplyDraftAttributionToArticle(article *models.Article, draft *models.Draft, domain string, publisherUsername string, preserveExisting bool) {
+	if article == nil || draft == nil {
+		return
+	}
+
+	cmsNormalizeDraftAttribution(draft)
+	if draft.GeneratedBy != "" || !preserveExisting {
+		article.GeneratedBy = draft.GeneratedBy
+	}
+	if draft.ReviewedBy != "" || !preserveExisting {
+		article.ReviewedBy = draft.ReviewedBy
+	}
+
+	publishedBy := cmsDefaultLocalAttributionActorID(domain, publisherUsername)
+	if publishedBy != "" {
+		article.PublishedBy = publishedBy
+	}
+}

--- a/pkg/services/cms/draft_service.go
+++ b/pkg/services/cms/draft_service.go
@@ -60,6 +60,7 @@ func (s *DraftService) CreateDraft(ctx context.Context, draft *models.Draft) err
 	if err := validateArticleDraftRenderable(draft); err != nil {
 		return err
 	}
+	cmsNormalizeDraftAttribution(draft)
 
 	s.logger.Info("creating draft", zap.String("title", draft.Title))
 
@@ -114,6 +115,7 @@ func (s *DraftService) UpdateDraft(ctx context.Context, authorID string, draft *
 	if err := validateArticleDraftRenderable(draft); err != nil {
 		return err
 	}
+	cmsNormalizeDraftAttribution(draft)
 	now := time.Now()
 	draft.UpdatedAt = now
 	draft.LastSavedAt = now
@@ -128,6 +130,7 @@ func (s *DraftService) Autosave(ctx context.Context, authorID string, draft *mod
 	if err := validateArticleDraftRenderable(draft); err != nil {
 		return err
 	}
+	cmsNormalizeDraftAttribution(draft)
 	s.logger.Debug("autosaving draft", zap.String("id", draft.ID))
 	now := time.Now()
 	draft.LastSavedAt = now
@@ -319,6 +322,7 @@ func (s *DraftService) publishDraftUpdateExistingArticle(ctx context.Context, au
 		return nil, err
 	}
 
+	article = cmsCloneArticleForDraftMutation(article)
 	if title := strings.TrimSpace(draft.Title); title != "" {
 		article.Name = title
 	}
@@ -329,6 +333,7 @@ func (s *DraftService) publishDraftUpdateExistingArticle(ctx context.Context, au
 	if format := strings.TrimSpace(draft.ContentFormat); format != "" {
 		article.ContentFormat = format
 	}
+	cmsApplyDraftAttributionToArticle(article, draft, domain, authorID, true)
 	article.UpdatedAt = now
 	article.Updated = now
 
@@ -339,6 +344,36 @@ func (s *DraftService) publishDraftUpdateExistingArticle(ctx context.Context, au
 
 	s.deleteDraftAfterPublish(ctx, draft, authorID, draftID, objectID)
 	return article, nil
+}
+
+func cmsCloneArticleForDraftMutation(article *models.Article) *models.Article {
+	if article == nil {
+		return nil
+	}
+	cp := *article
+	cp.To = append([]string{}, article.To...)
+	cp.CC = append([]string{}, article.CC...)
+	cp.BTo = append([]string{}, article.BTo...)
+	cp.BCC = append([]string{}, article.BCC...)
+	cp.CategoryIDs = append([]string{}, article.CategoryIDs...)
+	cp.TableOfContents = append([]models.TOCEntry{}, article.TableOfContents...)
+	if article.InReplyTo != nil {
+		v := *article.InReplyTo
+		cp.InReplyTo = &v
+	}
+	if article.SeriesID != nil {
+		v := *article.SeriesID
+		cp.SeriesID = &v
+	}
+	if article.SeriesOrder != nil {
+		v := *article.SeriesOrder
+		cp.SeriesOrder = &v
+	}
+	if article.FeaturedImage != nil {
+		v := *article.FeaturedImage
+		cp.FeaturedImage = &v
+	}
+	return &cp
 }
 
 func (s *DraftService) publishDraftCreateNewArticle(ctx context.Context, authorID, draftID, domain, objectID, slug string, draft *models.Draft, now time.Time) (*models.Article, error) {
@@ -358,6 +393,7 @@ func (s *DraftService) publishDraftCreateNewArticle(ctx context.Context, authorI
 		CreatedAt:     now,
 		UpdatedAt:     now,
 	}
+	cmsApplyDraftAttributionToArticle(article, draft, domain, authorID, false)
 
 	if err := s.articleService.CreateArticle(ctx, article); err != nil {
 		s.markDraftFailed(ctx, authorID, draft, draftID, err)

--- a/pkg/services/cms/m4_authoring_workflow_test.go
+++ b/pkg/services/cms/m4_authoring_workflow_test.go
@@ -1,0 +1,189 @@
+package cms
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestM4DraftPublishCreatesCanonicalArticleWithAttribution(t *testing.T) {
+	t.Parallel()
+
+	repo := newMemDraftRepo()
+	articles := newMemArticleService()
+	svc := &DraftService{
+		draftRepo:      repo,
+		articleService: articles,
+		domain:         "example.com",
+		logger:         zap.NewNop(),
+	}
+
+	draft := &models.Draft{
+		ID:            "draft-1",
+		AuthorID:      "alice",
+		ContentType:   activitypub.ArticleType,
+		Title:         "Agent Draft",
+		Slug:          "agent-draft",
+		Content:       "# Agent Draft\n\nBody.",
+		ContentFormat: "markdown",
+		Status:        draftStatusDraft,
+		GeneratedBy:   " https://example.com/users/agent-0 ",
+		ReviewedBy:    " https://example.com/users/alice ",
+	}
+	require.NoError(t, repo.CreateDraft(context.Background(), draft))
+
+	article, err := svc.PublishDraft(context.Background(), "alice", "draft-1")
+	require.NoError(t, err)
+	require.NotNil(t, article)
+	require.Equal(t, "https://example.com/articles/agent-draft", article.ID)
+	require.Equal(t, "agent-draft", article.Slug)
+	require.Equal(t, "https://example.com/users/agent-0", article.GeneratedBy)
+	require.Equal(t, "https://example.com/users/alice", article.ReviewedBy)
+	require.Equal(t, "https://example.com/users/alice", article.PublishedBy)
+}
+
+func TestM4DraftPublishRejectsCanonicalArticleSlugChangeSafely(t *testing.T) {
+	t.Parallel()
+
+	db, q := newCMSMockDB(t)
+	q.On("Create").Return(nil).Maybe()
+	q.On("Delete").Return(nil).Maybe()
+
+	articleID := "https://example.com/articles/original"
+	articleRepo := &fakeArticleRepo{
+		db: db,
+		articles: map[string]*models.Article{
+			articleID: {
+				Object: models.Object{
+					ID:           articleID,
+					Type:         activitypub.ArticleType,
+					Name:         "Original",
+					Content:      "before",
+					AttributedTo: "https://example.com/users/alice",
+					Published:    time.Now(),
+				},
+				Slug:          "original",
+				ContentFormat: "markdown",
+			},
+		},
+	}
+	articleSvc := NewArticleService(articleRepo, fakeActorRepo{err: errors.New("no actor")}, nil, nil, nil, &fakeFederation{}, zap.NewNop())
+	draftRepo := newMemDraftRepo()
+	draftSvc := &DraftService{
+		draftRepo:      draftRepo,
+		articleService: articleSvc,
+		domain:         "example.com",
+		logger:         zap.NewNop(),
+	}
+
+	draft := &models.Draft{
+		ID:            "draft-1",
+		AuthorID:      "alice",
+		ObjectID:      &articleID,
+		ContentType:   activitypub.ArticleType,
+		Title:         "Original renamed",
+		Slug:          "renamed",
+		Content:       "after",
+		ContentFormat: "markdown",
+		Status:        draftStatusDraft,
+	}
+	require.NoError(t, draftRepo.CreateDraft(context.Background(), draft))
+
+	article, err := draftSvc.PublishDraft(context.Background(), "alice", "draft-1")
+	require.Error(t, err)
+	require.Nil(t, article)
+	require.Contains(t, err.Error(), "immutable")
+
+	afterDraft, getErr := draftRepo.GetDraft(context.Background(), "alice", "draft-1")
+	require.NoError(t, getErr)
+	require.Equal(t, draftStatusFailed, afterDraft.Status)
+
+	stored, getArticleErr := articleRepo.GetArticle(context.Background(), articleID)
+	require.NoError(t, getArticleErr)
+	require.Equal(t, "Original", stored.Name)
+	require.Equal(t, "before", stored.Content)
+	require.Equal(t, "original", stored.Slug)
+}
+
+func TestM4ArticleUpdateRecordsRevisionAttributionAndFederatesUpdate(t *testing.T) {
+	t.Parallel()
+
+	db, q := newCMSMockDB(t)
+	q.On("Create").Return(nil).Maybe()
+	q.On("Delete").Return(nil).Maybe()
+
+	articleID := "https://example.com/articles/hello"
+	published := time.Now().Add(-time.Hour)
+	existing := &models.Article{
+		Object: models.Object{
+			ID:           articleID,
+			Type:         activitypub.ArticleType,
+			Name:         "Before",
+			Content:      "# Before\n\nBody.",
+			AttributedTo: "https://example.com/users/alice",
+			Published:    published,
+			Updated:      published,
+			To:           []string{activitypub.PublicAddress},
+		},
+		Slug:          "hello",
+		ContentFormat: "markdown",
+		GeneratedBy:   "https://example.com/users/agent-0",
+		ReviewedBy:    "https://example.com/users/alice",
+		PublishedBy:   "https://example.com/users/alice",
+		CreatedAt:     published,
+		UpdatedAt:     published,
+	}
+
+	articleRepo := &fakeArticleRepo{
+		db:       db,
+		articles: map[string]*models.Article{articleID: existing},
+	}
+	revisionRepo := newMemRevisionRepo()
+	revisionSvc := NewRevisionService(revisionRepo, articleRepo, nil, nil, 0, zap.NewNop())
+	fed := &fakeFederation{}
+	actor := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://example.com/users/alice",
+			Type: "Person",
+		},
+		PreferredUsername: "alice",
+		Inbox:             "https://example.com/users/alice/inbox",
+		Outbox:            "https://example.com/users/alice/outbox",
+	}
+	svc := NewArticleService(articleRepo, fakeActorRepo{actor: actor}, nil, nil, revisionSvc, fed, zap.NewNop())
+
+	updated := cloneArticle(existing)
+	updated.Name = "After"
+	updated.Content = "# After\n\nBody."
+	updated.UpdatedAt = time.Now()
+	updated.Updated = updated.UpdatedAt
+
+	ctx := context.WithValue(context.Background(), common.ContextKeyClaims, fakeClaims{username: "alice"})
+	require.NoError(t, svc.UpdateArticle(ctx, updated))
+
+	require.Len(t, revisionRepo.created, 1)
+	rev := revisionRepo.created[0]
+	require.Equal(t, articleID, rev.ObjectID)
+	require.Equal(t, "alice", rev.ChangedBy)
+	require.Equal(t, revisionChangeTypeUpdate, rev.ChangeType)
+	require.Equal(t, "https://example.com/users/agent-0", rev.GeneratedBy)
+	require.Equal(t, "https://example.com/users/alice", rev.ReviewedBy)
+	require.Equal(t, "https://example.com/users/alice", rev.PublishedBy)
+	require.Contains(t, rev.MetadataJSON, `"generatedBy":"https://example.com/users/agent-0"`)
+	require.Contains(t, rev.MetadataJSON, `"reviewedBy":"https://example.com/users/alice"`)
+	require.Contains(t, rev.MetadataJSON, `"publishedBy":"https://example.com/users/alice"`)
+
+	assert.Eventually(t, func() bool {
+		fed.mu.Lock()
+		defer fed.mu.Unlock()
+		return len(fed.recipientActivities) > 0 && fed.recipientActivities[0].Type == activitypub.UpdateType
+	}, 2*time.Second, 10*time.Millisecond)
+}

--- a/pkg/services/cms/revision_service.go
+++ b/pkg/services/cms/revision_service.go
@@ -36,6 +36,9 @@ type articleRevisionMetadata struct {
 	Name          string                `json:"name,omitempty"`
 	Summary       string                `json:"summary,omitempty"`
 	AttributedTo  string                `json:"attributedTo,omitempty"`
+	GeneratedBy   string                `json:"generatedBy,omitempty"`
+	ReviewedBy    string                `json:"reviewedBy,omitempty"`
+	PublishedBy   string                `json:"publishedBy,omitempty"`
 	Subtitle      string                `json:"subtitle,omitempty"`
 	Excerpt       string                `json:"excerpt,omitempty"`
 	ContentFormat string                `json:"contentFormat,omitempty"`
@@ -171,6 +174,9 @@ func (s *RevisionService) createRevision(ctx context.Context, article *models.Ar
 		MetadataJSON: metadata,
 		ChangedBy:    changedBy,
 		ChangeType:   revisionChangeTypeUpdate,
+		GeneratedBy:  strings.TrimSpace(article.GeneratedBy),
+		ReviewedBy:   strings.TrimSpace(article.ReviewedBy),
+		PublishedBy:  strings.TrimSpace(article.PublishedBy),
 		CreatedAt:    time.Now(),
 	}
 	if normalized := strings.ToLower(strings.TrimSpace(changeType)); normalized != "" {
@@ -231,6 +237,9 @@ func (s *RevisionService) buildRevisionMetadata(article *models.Article) (string
 		Name:               article.Name,
 		Summary:            article.Summary,
 		AttributedTo:       article.AttributedTo,
+		GeneratedBy:        article.GeneratedBy,
+		ReviewedBy:         article.ReviewedBy,
+		PublishedBy:        article.PublishedBy,
 		Subtitle:           article.Subtitle,
 		Excerpt:            article.Excerpt,
 		ContentFormat:      article.ContentFormat,
@@ -377,6 +386,9 @@ func (s *RevisionService) applyRevisionMetadataJSON(article *models.Article, met
 	if strings.TrimSpace(metadata.AttributedTo) != "" {
 		article.AttributedTo = metadata.AttributedTo
 	}
+	article.GeneratedBy = metadata.GeneratedBy
+	article.ReviewedBy = metadata.ReviewedBy
+	article.PublishedBy = metadata.PublishedBy
 	article.Subtitle = metadata.Subtitle
 	article.Excerpt = metadata.Excerpt
 	article.ContentFormat = metadata.ContentFormat

--- a/pkg/storage/models/article.go
+++ b/pkg/storage/models/article.go
@@ -37,6 +37,11 @@ type Article struct {
 	EditorNotes  string `theorydb:"attr:editorNotes" json:"editor_notes,omitempty"`
 	ReviewStatus string `theorydb:"attr:reviewStatus" json:"review_status,omitempty"`
 
+	// Authoring attribution
+	GeneratedBy string `theorydb:"attr:generatedBy,omitempty" json:"generated_by,omitempty"`
+	ReviewedBy  string `theorydb:"attr:reviewedBy,omitempty" json:"reviewed_by,omitempty"`
+	PublishedBy string `theorydb:"attr:publishedBy,omitempty" json:"published_by,omitempty"`
+
 	// Timestamps
 	CreatedAt time.Time `theorydb:"attr:createdAt" json:"created_at"`
 	UpdatedAt time.Time `theorydb:"attr:updatedAt" json:"updated_at"`

--- a/pkg/storage/models/draft.go
+++ b/pkg/storage/models/draft.go
@@ -41,6 +41,10 @@ type Draft struct {
 	// Metadata snapshot (full object metadata for preview)
 	MetadataJSON string `theorydb:"attr:metadataJSON" json:"metadata_json,omitempty"`
 
+	// Authoring attribution
+	GeneratedBy string `theorydb:"attr:generatedBy,omitempty" json:"generated_by,omitempty"`
+	ReviewedBy  string `theorydb:"attr:reviewedBy,omitempty" json:"reviewed_by,omitempty"`
+
 	// Autosave tracking
 	AutosaveVersion int       `theorydb:"attr:autosaveVersion" json:"autosave_version"`
 	LastSavedAt     time.Time `theorydb:"attr:lastSavedAt" json:"last_saved_at"`

--- a/pkg/storage/models/revision.go
+++ b/pkg/storage/models/revision.go
@@ -25,6 +25,9 @@ type Revision struct {
 	ChangeSummary string `theorydb:"attr:changeSummary" json:"change_summary,omitempty"` // Optional commit message
 	ChangedBy     string `theorydb:"attr:changedBy" json:"changed_by"`
 	ChangeType    string `theorydb:"attr:changeType" json:"change_type"` // create, update, restore
+	GeneratedBy   string `theorydb:"attr:generatedBy,omitempty" json:"generated_by,omitempty"`
+	ReviewedBy    string `theorydb:"attr:reviewedBy,omitempty" json:"reviewed_by,omitempty"`
+	PublishedBy   string `theorydb:"attr:publishedBy,omitempty" json:"published_by,omitempty"`
 
 	// Timestamps
 	CreatedAt time.Time `theorydb:"attr:createdAt" json:"created_at"`


### PR DESCRIPTION
## Milestone
Project 36 M4 — Authoring workflow, attribution, revision, and permissions.

Closes #1045.
Closes #1046.
Closes #1047.
Closes #1048.
Closes #1049.

## Classification
Contract-stability, schema/data-integrity, federation-trust-adjacent test coverage, operational-reliability.

## Surfaces affected
- CMS draft publish/update flows in `pkg/services/cms`.
- CMS Article/Draft/Revision storage models.
- GraphQL CMS schema/model/converters/resolvers.
- Generated GraphQL contract at `docs/contracts/graphql-schema.graphql`.
- CMS contract fence documentation.

## What changed
- Added optional authoring attribution fields:
  - Draft: `generatedBy`, `reviewedBy`.
  - Article: `generatedBy`, `reviewedBy`, `publishedBy`.
  - Revision: `generatedBy`, `reviewedBy`, `publishedBy`.
- Agent-authenticated draft writes populate generator attribution; human review writes on generated drafts populate reviewer attribution.
- Draft publish copies attribution to the canonical Article and records the publisher actor.
- Article revision snapshots preserve generated/reviewed/published attribution in fields and metadata JSON.
- Draft publish/update now clones the existing Article before mutation so canonical slug immutability failures do not leak partial changes into stored Article state.
- M4 docs make schedule/cancel/restore backend availability and UI gating explicit.

## Specialist walks referenced
- Federation trust: outbound signing, inbound verification, actor object shape, delivery retries, circuit breaker, relay, and block enforcement are unchanged. Update-after-publish still federates an ActivityPub `Update`; focused coverage asserts that path.
- Contract / API: GraphQL fields are additive nullable fields only. No Mastodon REST/OpenAPI changes. No ActivityPub actor/object JSON-LD shape changes; `Article.attributedTo` remains the federated author identity.
- Schema: storage changes are additive, non-indexed optional attributes on existing Article/Draft/Revision items. No PK/SK/GSI, TTL, or `version` tag changes. Existing rows deserialize with empty attribution fields.
- Framework: no AppTheory/TableTheory workaround or local framework patch.

## Consumer impact
- Mastodon clients: no impact; no `/api/v1/*` or OpenAPI changes.
- Remote ActivityPub peers: no serialized ActivityPub shape change; generated/reviewed/published attribution remains local GraphQL/storage metadata in M4.
- Sibling repos: `lesser-body` and future UI consumers may optionally read the new GraphQL/storage attribution metadata. `greater`/`sim` can hide schedule/restore controls unless the documented feature gates pass.
- Operators: no migration required for existing rows; new fields are optional.

## Tasks
- [x] #1046 Harden Article draft publish and update workflows.
- [x] #1047 Record attribution and revision metadata for agent-generated drafts.
- [x] #1048 Test slug alias/immutability and permissions.
- [x] #1049 Gate schedule and rollback before UI exposure.

## Validation
- `go build -o lesser ./cmd/lesser`
- `./lesser schema`
- `go test ./pkg/services/cms ./graph`
- `git diff --check`
- `gofmt -l .` (empty)
- `go test ./...`
- `go vet ./...`
- `./lesser build lambdas`
- `./lesser verify ci` (passed; overall coverage 87.659%, pkg 90.013%, cmd 90.008%)

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
No blocking coordination required before merge. Optional downstream consumers can adopt the new additive GraphQL fields when ready.

## Advisor-brief authorization
Arch assignment from `arch@lessersoul.ai` requested Project 36 M4 (#1045-#1049) under Aron's standing authorization for Arch-directed milestones in this thread.
