### PR TITLE
feat: expose article draft preview contract

### DIFF
--- a/docs/architecture/cms/fediverse-first-blog-cms-contract.md
+++ b/docs/architecture/cms/fediverse-first-blog-cms-contract.md
@@ -145,6 +145,25 @@ Canonical output policy:
 3. Table of contents, word count, reading time, link normalization, media embedding, and unsafe-content handling belong to the same server-side rendering boundary.
 4. Renderer output must be deterministic for the same source, metadata, and media inputs so preview/review/public/federated views can be compared.
 
+### Draft preview API contract
+
+M4.5 exposes the canonical Article preview renderer to body and other authenticated GraphQL consumers through:
+
+```graphql
+draftPreview(id: ID!): DraftPreview!
+```
+
+The resolver uses the same draft ownership/authentication rules as `draft(id:)`: CMS long-form and the draft system must be enabled, the caller must be authenticated, and the draft is loaded for the caller's own author ID. It then renders the draft through `DraftService.PreviewDraft` / `RenderDraftPreview`, which delegates to lesser's canonical Article publication renderer/sanitizer. Consumers must not re-render Markdown/HTML locally or use raw draft content as a public preview.
+
+`DraftPreview` is intentionally small and stable for MCP consumers:
+
+- `renderedHtml`: sanitized server-rendered Article HTML, present only when rendering succeeds;
+- `sourceFormat`: the normalized or stored source format used for rendering;
+- `sourceBytes` and `renderedBytes`: byte counts body can use for `preview_chars` and `max_output_bytes` controls;
+- `errors`: deterministic user-facing renderer errors for unsupported format, invalid UTF-8, source-size, and rendered-size failures.
+
+Authorization/storage lookup failures remain GraphQL errors, matching `draft(id:)`; content rendering failures return a `DraftPreview` with `success: false`, no `renderedHtml`, and a populated `errors` list so body can present review-safe feedback without exposing raw draft source.
+
 ### Unsafe content behavior
 
 Unsafe input must never be forwarded to ActivityPub peers or public HTML pages unsanitized.

--- a/docs/contracts/graphql-schema.graphql
+++ b/docs/contracts/graphql-schema.graphql
@@ -2429,6 +2429,16 @@ type DraftConnection {
   totalCount: Int!
 }
 
+type DraftPreview {
+  draftId: ID!
+  success: Boolean!
+  renderedHtml: String
+  sourceFormat: String!
+  sourceBytes: Int!
+  renderedBytes: Int!
+  errors: [String!]!
+}
+
 type Revision {
   id: ID!
   objectId: ID!
@@ -2527,6 +2537,7 @@ type PublicationMember {
 extend type Query {
   # Draft operations
   draft(id: ID!): Draft
+  draftPreview(id: ID!): DraftPreview!
   myDrafts(contentType: ObjectType, status: DraftStatus, first: Int, after: Cursor): DraftConnection!
 
   # Revision history

--- a/graph/cms_converters.go
+++ b/graph/cms_converters.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/equaltoai/lesser/graph/model"
+	"github.com/equaltoai/lesser/pkg/cmsrender"
 	"github.com/equaltoai/lesser/pkg/storage/core"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 )
@@ -66,6 +67,44 @@ func (r *Resolver) convertCMSDraft(ctx context.Context, draft *models.Draft) *mo
 		LastSavedAt:     model.Time(draft.LastSavedAt),
 		CreatedAt:       model.Time(draft.CreatedAt),
 		UpdatedAt:       model.Time(draft.UpdatedAt),
+	}
+}
+
+func (r *Resolver) convertCMSDraftPreview(draft *models.Draft, rendered cmsrender.RenderedArticleContent, renderErr error) *model.DraftPreview {
+	if draft == nil {
+		return nil
+	}
+
+	sourceFormat := strings.TrimSpace(draft.ContentFormat)
+	sourceBytes := len(draft.Content)
+	renderedBytes := 0
+	var renderedHTML *string
+	errorsList := []string{}
+
+	if renderErr == nil {
+		if strings.TrimSpace(rendered.SourceFormat) != "" {
+			sourceFormat = rendered.SourceFormat
+		}
+		sourceBytes = rendered.SourceBytes
+		renderedBytes = rendered.RenderedBytes
+		html := rendered.HTML
+		renderedHTML = &html
+	} else {
+		errorsList = append(errorsList, renderErr.Error())
+	}
+
+	if sourceFormat == "" {
+		sourceFormat = cmsrender.FormatMarkdown
+	}
+
+	return &model.DraftPreview{
+		DraftID:       draft.ID,
+		Success:       renderErr == nil,
+		RenderedHTML:  renderedHTML,
+		SourceFormat:  sourceFormat,
+		SourceBytes:   sourceBytes,
+		RenderedBytes: renderedBytes,
+		Errors:        errorsList,
 	}
 }
 

--- a/graph/cms_draft_preview_contract_test.go
+++ b/graph/cms_draft_preview_contract_test.go
@@ -1,0 +1,119 @@
+package graph
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/graph/model"
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/cmsrender"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestM45DraftPreviewReturnsCanonicalRenderedHTML(t *testing.T) {
+	resolver, _ := newRound12GraphResolver(t)
+	ctx := round12AuthContext("alice")
+	mut := resolver.Mutation()
+	qry := resolver.Query()
+
+	title := "Preview Me"
+	content := "# Preview Me\n\n<script>alert('x')</script>\n\n[ok](https://example.com) [bad](javascript:alert(1))"
+	draft, err := mut.CreateDraft(ctx, model.CreateDraftInput{
+		ContentType:   model.ObjectTypeArticle,
+		Title:         &title,
+		Content:       content,
+		ContentFormat: model.ContentFormatMarkdown,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, draft)
+
+	preview, err := qry.DraftPreview(ctx, draft.ID)
+	require.NoError(t, err)
+	require.NotNil(t, preview)
+	require.True(t, preview.Success)
+	require.Empty(t, preview.Errors)
+	require.Equal(t, draft.ID, preview.DraftID)
+	require.Equal(t, cmsrender.FormatMarkdown, preview.SourceFormat)
+	require.Equal(t, len(content), preview.SourceBytes)
+	require.NotNil(t, preview.RenderedHTML)
+	require.Equal(t, len(*preview.RenderedHTML), preview.RenderedBytes)
+	require.Contains(t, *preview.RenderedHTML, `<h1 id="preview-me">Preview Me</h1>`)
+	require.Contains(t, *preview.RenderedHTML, `href="https://example.com"`)
+	require.NotContains(t, *preview.RenderedHTML, "<script")
+	require.NotContains(t, *preview.RenderedHTML, "javascript:")
+
+	unauthorized, err := qry.DraftPreview(round12AuthContext("bob"), draft.ID)
+	require.Error(t, err)
+	require.Nil(t, unauthorized)
+}
+
+func TestM45DraftPreviewReturnsDeterministicRenderErrors(t *testing.T) {
+	resolver, storage := newRound12GraphResolver(t)
+	qry := resolver.Query()
+	ctx := context.Background()
+
+	cases := []struct {
+		name      string
+		format    string
+		content   string
+		wantError string
+	}{
+		{
+			name:      "unsupported format",
+			format:    "plaintext",
+			content:   "hello",
+			wantError: "unsupported article content format",
+		},
+		{
+			name:      "invalid utf8",
+			format:    cmsrender.FormatMarkdown,
+			content:   string([]byte{0xff, 0xfe, 0xfd}),
+			wantError: "valid UTF-8",
+		},
+		{
+			name:      "source size",
+			format:    cmsrender.FormatMarkdown,
+			content:   strings.Repeat("a", cmsrender.MaxArticleSourceBytes+1),
+			wantError: "maximum source size",
+		},
+		{
+			name:      "rendered size",
+			format:    cmsrender.FormatMarkdown,
+			content:   strings.Repeat("<", cmsrender.MaxArticleSourceBytes),
+			wantError: "maximum output size",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			draftID := "preview-" + strings.ReplaceAll(tc.name, " ", "-")
+			draft := &models.Draft{
+				ID:            draftID,
+				AuthorID:      "alice",
+				ContentType:   activitypub.ArticleType,
+				Content:       tc.content,
+				ContentFormat: tc.format,
+				Status:        "draft",
+				LastSavedAt:   time.Now(),
+				CreatedAt:     time.Now(),
+				UpdatedAt:     time.Now(),
+			}
+			require.NoError(t, storage.Draft().CreateDraft(ctx, draft))
+
+			preview, err := qry.DraftPreview(round12AuthContext("alice"), draftID)
+			require.NoError(t, err)
+			require.NotNil(t, preview)
+			require.False(t, preview.Success)
+			require.Nil(t, preview.RenderedHTML)
+			require.Equal(t, draftID, preview.DraftID)
+			require.Equal(t, tc.format, preview.SourceFormat)
+			require.Equal(t, len(tc.content), preview.SourceBytes)
+			require.Zero(t, preview.RenderedBytes)
+			require.Len(t, preview.Errors, 1)
+			require.Contains(t, preview.Errors[0], tc.wantError)
+		})
+	}
+}

--- a/graph/generated.go
+++ b/graph/generated.go
@@ -1165,6 +1165,16 @@ type ComplexityRoot struct {
 		Node   func(childComplexity int) int
 	}
 
+	DraftPreview struct {
+		DraftID       func(childComplexity int) int
+		Errors        func(childComplexity int) int
+		RenderedBytes func(childComplexity int) int
+		RenderedHTML  func(childComplexity int) int
+		SourceBytes   func(childComplexity int) int
+		SourceFormat  func(childComplexity int) int
+		Success       func(childComplexity int) int
+	}
+
 	Driver struct {
 		Cost           func(childComplexity int) int
 		Domain         func(childComplexity int) int
@@ -2463,6 +2473,7 @@ type ComplexityRoot struct {
 		CustomEmojis              func(childComplexity int) int
 		DomainBlocks              func(childComplexity int, first *int, after *model.Cursor) int
 		Draft                     func(childComplexity int, id string) int
+		DraftPreview              func(childComplexity int, id string) int
 		DroneWorkflow             func(childComplexity int, username string) int
 		Endorsements              func(childComplexity int) int
 		ExplainObject             func(childComplexity int, id string) int
@@ -3604,6 +3615,7 @@ type QueryResolver interface {
 	SeveredRelationships(ctx context.Context, instance *string, first *int, after *string) (*model.SeveredRelationshipConnection, error)
 	AffectedRelationships(ctx context.Context, severedRelationshipID string) (*model.AffectedRelationshipConnection, error)
 	Draft(ctx context.Context, id string) (*model.Draft, error)
+	DraftPreview(ctx context.Context, id string) (*model.DraftPreview, error)
 	MyDrafts(ctx context.Context, contentType *model.ObjectType, status *model.DraftStatus, first *int, after *model.Cursor) (*model.DraftConnection, error)
 	Revisions(ctx context.Context, objectID string, first *int, after *model.Cursor) (*model.RevisionConnection, error)
 	Revision(ctx context.Context, objectID string, version int) (*model.Revision, error)
@@ -8871,6 +8883,55 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.DraftEdge.Node(childComplexity), true
+
+	case "DraftPreview.draftId":
+		if e.complexity.DraftPreview.DraftID == nil {
+			break
+		}
+
+		return e.complexity.DraftPreview.DraftID(childComplexity), true
+
+	case "DraftPreview.errors":
+		if e.complexity.DraftPreview.Errors == nil {
+			break
+		}
+
+		return e.complexity.DraftPreview.Errors(childComplexity), true
+
+	case "DraftPreview.renderedBytes":
+		if e.complexity.DraftPreview.RenderedBytes == nil {
+			break
+		}
+
+		return e.complexity.DraftPreview.RenderedBytes(childComplexity), true
+
+	case "DraftPreview.renderedHtml":
+		if e.complexity.DraftPreview.RenderedHTML == nil {
+			break
+		}
+
+		return e.complexity.DraftPreview.RenderedHTML(childComplexity), true
+
+	case "DraftPreview.sourceBytes":
+		if e.complexity.DraftPreview.SourceBytes == nil {
+			break
+		}
+
+		return e.complexity.DraftPreview.SourceBytes(childComplexity), true
+
+	case "DraftPreview.sourceFormat":
+		if e.complexity.DraftPreview.SourceFormat == nil {
+			break
+		}
+
+		return e.complexity.DraftPreview.SourceFormat(childComplexity), true
+
+	case "DraftPreview.success":
+		if e.complexity.DraftPreview.Success == nil {
+			break
+		}
+
+		return e.complexity.DraftPreview.Success(childComplexity), true
 
 	case "Driver.cost":
 		if e.complexity.Driver.Cost == nil {
@@ -16478,6 +16539,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.Draft(childComplexity, args["id"].(string)), true
+
+	case "Query.draftPreview":
+		if e.complexity.Query.DraftPreview == nil {
+			break
+		}
+
+		args, err := ec.field_Query_draftPreview_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.DraftPreview(childComplexity, args["id"].(string)), true
 
 	case "Query.droneWorkflow":
 		if e.complexity.Query.DroneWorkflow == nil {
@@ -24099,6 +24172,17 @@ func (ec *executionContext) field_Query_domainBlocks_args(ctx context.Context, r
 		return nil, err
 	}
 	args["after"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_draftPreview_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "id", ec.unmarshalNID2string)
+	if err != nil {
+		return nil, err
+	}
+	args["id"] = arg0
 	return args, nil
 }
 
@@ -60295,6 +60379,311 @@ func (ec *executionContext) fieldContext_DraftEdge_cursor(_ context.Context, fie
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Cursor does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DraftPreview_draftId(ctx context.Context, field graphql.CollectedField, obj *model.DraftPreview) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DraftPreview_draftId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DraftID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DraftPreview_draftId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DraftPreview",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DraftPreview_success(ctx context.Context, field graphql.CollectedField, obj *model.DraftPreview) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DraftPreview_success(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Success, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DraftPreview_success(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DraftPreview",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DraftPreview_renderedHtml(ctx context.Context, field graphql.CollectedField, obj *model.DraftPreview) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DraftPreview_renderedHtml(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RenderedHTML, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DraftPreview_renderedHtml(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DraftPreview",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DraftPreview_sourceFormat(ctx context.Context, field graphql.CollectedField, obj *model.DraftPreview) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DraftPreview_sourceFormat(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SourceFormat, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DraftPreview_sourceFormat(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DraftPreview",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DraftPreview_sourceBytes(ctx context.Context, field graphql.CollectedField, obj *model.DraftPreview) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DraftPreview_sourceBytes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SourceBytes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DraftPreview_sourceBytes(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DraftPreview",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DraftPreview_renderedBytes(ctx context.Context, field graphql.CollectedField, obj *model.DraftPreview) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DraftPreview_renderedBytes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RenderedBytes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DraftPreview_renderedBytes(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DraftPreview",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DraftPreview_errors(ctx context.Context, field graphql.CollectedField, obj *model.DraftPreview) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DraftPreview_errors(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Errors, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DraftPreview_errors(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DraftPreview",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -112407,6 +112796,77 @@ func (ec *executionContext) fieldContext_Query_draft(ctx context.Context, field 
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_draftPreview(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_draftPreview(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().DraftPreview(rctx, fc.Args["id"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.DraftPreview)
+	fc.Result = res
+	return ec.marshalNDraftPreview2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐDraftPreview(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_draftPreview(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "draftId":
+				return ec.fieldContext_DraftPreview_draftId(ctx, field)
+			case "success":
+				return ec.fieldContext_DraftPreview_success(ctx, field)
+			case "renderedHtml":
+				return ec.fieldContext_DraftPreview_renderedHtml(ctx, field)
+			case "sourceFormat":
+				return ec.fieldContext_DraftPreview_sourceFormat(ctx, field)
+			case "sourceBytes":
+				return ec.fieldContext_DraftPreview_sourceBytes(ctx, field)
+			case "renderedBytes":
+				return ec.fieldContext_DraftPreview_renderedBytes(ctx, field)
+			case "errors":
+				return ec.fieldContext_DraftPreview_errors(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DraftPreview", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_draftPreview_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_myDrafts(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_myDrafts(ctx, field)
 	if err != nil {
@@ -155543,6 +156003,72 @@ func (ec *executionContext) _DraftEdge(ctx context.Context, sel ast.SelectionSet
 	return out
 }
 
+var draftPreviewImplementors = []string{"DraftPreview"}
+
+func (ec *executionContext) _DraftPreview(ctx context.Context, sel ast.SelectionSet, obj *model.DraftPreview) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, draftPreviewImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DraftPreview")
+		case "draftId":
+			out.Values[i] = ec._DraftPreview_draftId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "success":
+			out.Values[i] = ec._DraftPreview_success(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "renderedHtml":
+			out.Values[i] = ec._DraftPreview_renderedHtml(ctx, field, obj)
+		case "sourceFormat":
+			out.Values[i] = ec._DraftPreview_sourceFormat(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "sourceBytes":
+			out.Values[i] = ec._DraftPreview_sourceBytes(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "renderedBytes":
+			out.Values[i] = ec._DraftPreview_renderedBytes(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "errors":
+			out.Values[i] = ec._DraftPreview_errors(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var driverImplementors = []string{"Driver"}
 
 func (ec *executionContext) _Driver(ctx context.Context, sel ast.SelectionSet, obj *cost.Driver) graphql.Marshaler {
@@ -166847,6 +167373,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "draftPreview":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_draftPreview(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "myDrafts":
 			field := field
 
@@ -177128,6 +177676,20 @@ func (ec *executionContext) marshalNDraftEdge2ᚖgithubᚗcomᚋequaltoaiᚋless
 		return graphql.Null
 	}
 	return ec._DraftEdge(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNDraftPreview2githubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐDraftPreview(ctx context.Context, sel ast.SelectionSet, v model.DraftPreview) graphql.Marshaler {
+	return ec._DraftPreview(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNDraftPreview2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐDraftPreview(ctx context.Context, sel ast.SelectionSet, v *model.DraftPreview) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._DraftPreview(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNDraftStatus2githubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐDraftStatus(ctx context.Context, v any) (model.DraftStatus, error) {

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -1157,6 +1157,16 @@ type DomainBlockPage struct {
 	TotalCount int      `json:"totalCount"`
 }
 
+type DraftPreview struct {
+	DraftID       string   `json:"draftId"`
+	Success       bool     `json:"success"`
+	RenderedHTML  *string  `json:"renderedHtml,omitempty"`
+	SourceFormat  string   `json:"sourceFormat"`
+	SourceBytes   int      `json:"sourceBytes"`
+	RenderedBytes int      `json:"renderedBytes"`
+	Errors        []string `json:"errors"`
+}
+
 type DroneWorkflowMutationPayload struct {
 	Agent    *Agent                `json:"agent"`
 	Workflow *AgentWorkflowSurface `json:"workflow"`

--- a/graph/phase1.graphql
+++ b/graph/phase1.graphql
@@ -117,6 +117,16 @@ type DraftConnection {
   totalCount: Int!
 }
 
+type DraftPreview {
+  draftId: ID!
+  success: Boolean!
+  renderedHtml: String
+  sourceFormat: String!
+  sourceBytes: Int!
+  renderedBytes: Int!
+  errors: [String!]!
+}
+
 type Revision {
   id: ID!
   objectId: ID!
@@ -215,6 +225,7 @@ type PublicationMember {
 extend type Query {
   # Draft operations
   draft(id: ID!): Draft
+  draftPreview(id: ID!): DraftPreview!
   myDrafts(contentType: ObjectType, status: DraftStatus, first: Int, after: Cursor): DraftConnection!
 
   # Revision history

--- a/graph/query_resolvers_cms.go
+++ b/graph/query_resolvers_cms.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/equaltoai/lesser/graph/model"
+	"github.com/equaltoai/lesser/pkg/services/cms"
 	storagecore "github.com/equaltoai/lesser/pkg/storage/core"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	dynamormcore "github.com/theory-cloud/tabletheory/pkg/core"
@@ -295,6 +296,30 @@ func (r *queryResolver) Draft(ctx context.Context, id string) (*model.Draft, err
 	}
 
 	return r.convertCMSDraft(ctx, draft), nil
+}
+
+func (r *queryResolver) DraftPreview(ctx context.Context, id string) (*model.DraftPreview, error) {
+	if err := r.requireCMSDraftsEnabled(); err != nil {
+		return nil, err
+	}
+
+	username, err := r.requireAuth(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	drafts := r.Registry.Drafts()
+	if drafts == nil {
+		return nil, errors.New("draft service is not available")
+	}
+
+	draft, err := drafts.GetDraft(ctx, username, strings.TrimSpace(id))
+	if err != nil {
+		return nil, err
+	}
+
+	rendered, renderErr := cms.RenderDraftPreview(draft)
+	return r.convertCMSDraftPreview(draft, rendered, renderErr), nil
 }
 
 func (r *queryResolver) MyDrafts(ctx context.Context, contentType *model.ObjectType, status *model.DraftStatus, first *int, after *model.Cursor) (*model.DraftConnection, error) {


### PR DESCRIPTION
## Milestone
Project 36 M4.5 — expose Article draft preview API contract for body.

Closes #1059.

## Classification
Contract-stability and cross-repo unblocker for lesser-body #265.

## Surfaces affected
- GraphQL CMS schema/model/resolver.
- Generated GraphQL contract at `docs/contracts/graphql-schema.graphql`.
- CMS contract fence documentation.
- GraphQL resolver tests for the body-consumable preview contract.

## What changed
- Added `draftPreview(id: ID!): DraftPreview!` to the CMS GraphQL surface.
- Added `DraftPreview` fields:
  - `draftId`
  - `success`
  - `renderedHtml`
  - `sourceFormat`
  - `sourceBytes`
  - `renderedBytes`
  - `errors`
- The resolver follows `draft(id:)` ownership/auth rules and loads the draft for the authenticated author.
- The preview is rendered through lesser’s canonical Article renderer/sanitizer via `RenderDraftPreview`; body does not need to render Markdown/HTML locally or consume raw draft content.
- Renderer failures return a stable `DraftPreview` payload with `success: false`, no `renderedHtml`, and user-facing errors.

## Specialist walks referenced
- Federation trust: no HTTP Signature, inbox/outbox, delivery, actor object, relay, moderation, or key changes.
- Contract / API: additive GraphQL query/type only. No Mastodon REST/OpenAPI changes and no ActivityPub actor/object/JSON-LD shape changes.
- Schema: no DynamoDB model, PK/SK/GSI, TTL, or TableTheory tag change.
- Framework: no AppTheory/TableTheory workaround or local framework patch.

## Consumer impact
- lesser-body #265 can call `/api/graphql` for a review-safe Article draft preview instead of locally rendering or returning raw draft content.
- Existing GraphQL clients are unaffected; the change is additive.
- Mastodon clients and remote ActivityPub peers are unaffected.

## Validation
- `./lesser gqlgen`
- `./lesser schema`
- `go test ./graph -run 'TestM45DraftPreview'`
- `go test ./graph`
- `go test ./pkg/services/cms`
- `git diff --check`
- `gofmt -l .` (empty)
- `go build -o lesser ./cmd/lesser`
- `go test ./...`
- `go vet ./...`
- `./lesser build lambdas`
- `./lesser verify ci` (passed; overall coverage 87.659%, pkg 90.013%, cmd 90.010%)

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
This unblocks lesser-body #265. Body can adopt the additive `draftPreview` GraphQL operation after this merges.

## Advisor-brief authorization
Arch dependency assignment from `arch@lessersoul.ai` requested #1059 under Aron's standing authorization for Arch-directed work in this thread.
