### PR TITLE
feat: add cms operational readiness

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,7 +72,7 @@ internal/CI-only (except for building the `lesser` CLI itself).
 - Release-driven deploy contract: `docs/contracts/release-driven-deploy-contract.md`
 - CLI auth (device flow): `docs/cli/auth.md`
 - Configure: `docs/configuration.md`
-- Operate: `docs/monitoring.md`, `docs/security.md`, `docs/backup-recovery.md`, `docs/operations/runbook.md`, `docs/operations/processor-storm-runbook.md`, `docs/operations/processor-storm-recovery-runbook.md`, `docs/operations/processor-storm-recovery-decisions.md`
+- Operate: `docs/monitoring.md`, `docs/security.md`, `docs/backup-recovery.md`, `docs/operations/runbook.md`, `docs/operations/cms-blog-launch-runbook.md`, `docs/operations/processor-storm-runbook.md`, `docs/operations/processor-storm-recovery-runbook.md`, `docs/operations/processor-storm-recovery-decisions.md`
 - Release notes: `docs/operations/release-notes.md`
 - Incident stewardship packets: `docs/operations/processor-storm-apptheory-stewardship-evidence.md`
 - Release checklist: `docs/release-checklist.md`

--- a/docs/architecture/cms/fediverse-first-blog-cms-contract.md
+++ b/docs/architecture/cms/fediverse-first-blog-cms-contract.md
@@ -237,6 +237,61 @@ Revision rules:
 3. The publish revision records who approved and who published.
 4. Later Article updates continue to preserve attribution/review history.
 
+## M7 operational limits, migration, and observability
+
+M7 closes the launch-readiness gap for storage limits, legacy Article migration planning, renderer/federation
+observability, and the first Theory Cloud Blog launch runbook.
+
+### Body storage decision
+
+The MVP stores Article/Draft source bodies in DynamoDB and does **not** introduce S3 body offload. The renderer
+contract's limits are the launch guardrail:
+
+- source body limit: **256 KiB** before rendering;
+- rendered/sanitized HTML limit: **512 KiB** after rendering;
+- no silent truncation;
+- deterministic user-facing failures for unsupported formats, invalid UTF-8, source overflow, and rendered-output overflow.
+
+S3 body storage is deferred until real launch usage shows posts exceeding the 256 KiB source limit or DynamoDB item-size
+pressure from Article body plus metadata/media fields.
+
+### Legacy Article dry-run plan
+
+Legacy Articles whose stored ID is `https://<domain>/objects/<uuid>` keep that ID as their canonical ActivityPub object
+identity for the MVP. M7 adds a pure dry-run planner, `cms.PlanLegacyArticleMigration`, that:
+
+1. identifies legacy Article rows under `/objects/<uuid>` with a non-empty slug;
+2. proposes a non-authoritative `https://<domain>/articles/<slug>` browser alias;
+3. keeps `proposedCanonicalID` equal to the stored legacy ID, avoiding duplicate ActivityPub objects;
+4. reports conflicts when multiple legacy Articles propose the same tenant+slug alias or when a canonical
+   `/articles/<slug>` Article already occupies it.
+
+No alias/backfill apply path ships in M7. Any future apply-capable migration remains gated by DevOps review and must not
+rewrite remote-visible Article identity without Protocol Counsel review.
+
+### Renderer and federation observability
+
+Renderer failures emit structured, EMF-compatible logs without raw Article/Draft content:
+
+- `cms_article_render_failure`
+- `cms_draft_render_failure`
+- metric: `Lesser/CMS ArticleRenderFailure`
+
+Article federation emits attempt/outcome logs:
+
+- `cms_article_federation_attempt`
+- `cms_article_federation_outcome`
+- metric: `Lesser/CMS ArticleFederationFailure`
+
+The critical alarm stack includes alarms for `ArticleRenderFailure` and `ArticleFederationFailure` with
+`Stage=<dev|staging|live>, Status=failure` dimensions. This keeps Blog/CMS launch failures visible in normal operator
+paths instead of requiring bespoke log spelunking.
+
+### Launch runbook
+
+The operator launch checklist lives at `docs/operations/cms-blog-launch-runbook.md`. It covers publish probe,
+federation fetch, UI smoke, observability checks, rollback, and known residuals.
+
 ## MVP non-goals
 
 The MVP does not include:
@@ -282,7 +337,8 @@ Security review is required for the M3 sanitizer boundary before public HTML or 
 - **M2 federation hardening** ([#1035](https://github.com/equaltoai/lesser/issues/1035)): Article Create/Update/Delete payloads, Tombstone behavior, inbound remote Articles, and peer fetch probes need explicit tests before live federation.
 - **M3 renderer/sanitizer** ([#1040](https://github.com/equaltoai/lesser/issues/1040)): sanitizer strictness may remove author-intended markup; unsafe HTML handling and media/embed policy must be tested before public launch.
 - **M4 authoring/attribution** ([#1045](https://github.com/equaltoai/lesser/issues/1045)): current models do not yet carry all generated-draft attribution/review metadata required above.
-- **M7 operational/migration** ([#1050](https://github.com/equaltoai/lesser/issues/1050)): legacy `/objects/<uuid>` migration/aliases, body-size strategy, renderer observability, and launch runbook remain launch-readiness risks.
+- **Post-M7 alias application**: legacy `/objects/<uuid>` dry-run planning is explicit, but no apply-capable alias
+  migration ships in the launch path. Applying aliases/backfills remains a later DevOps/Protocol Counsel-gated change.
 
 ## Release-note text for the eventual implementation release
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -59,7 +59,21 @@ AWS_PROFILE=<profile> aws logs filter-log-events \
 
 - 4xx/5xx spikes correlated with deploys or client releases
 
+### CMS Blog/Article launch signals
+
+- CloudWatch Logs messages:
+  - `cms_article_render_failure`
+  - `cms_draft_render_failure`
+  - `cms_article_federation_outcome`
+- CloudWatch EMF namespace `Lesser/CMS`:
+  - `ArticleRenderFailure` (`Stage`, `Status=failure`)
+  - `ArticleFederationFailure` (`Stage`, `Status=failure`)
+- Both failure metrics are wired into the per-stage critical alarm stack. During launch soak, treat one live failure
+  as actionable and inspect structured fields such as `Operation`, `article_id`/`draft_id`, `failure_stage`,
+  `activity_type`, `error_kind`, and `source_bytes`.
+
 ## Deep dive
 
 - Runbook: `docs/operations/runbook.md`
+- CMS Blog launch runbook: `docs/operations/cms-blog-launch-runbook.md`
 - CloudWatch workflow: `docs/operations/cloudwatch-debugging.md`

--- a/docs/operations/cms-blog-launch-runbook.md
+++ b/docs/operations/cms-blog-launch-runbook.md
@@ -1,0 +1,157 @@
+# CMS Blog Launch Runbook
+
+This runbook is for the first Theory Cloud Blog/CMS launch on a Lesser instance. It covers the MCP-first,
+fediverse-first MVP only: canonical Article publishing, server-side rendering/sanitization, draft review,
+federation readback, and operational rollback.
+
+## Preconditions
+
+- Deploy through the canonical path:
+
+  ```bash
+  go build -o lesser ./cmd/lesser
+  ./lesser build lambdas
+  ./lesser up --app <app> --base-domain <domain> --aws-profile <profile> --stage dev
+  ```
+
+- The instance may be locked immediately after deploy. Confirm and unlock through setup before publish probes:
+
+  ```bash
+  curl -s "https://dev.<domain>/setup/status" | jq .
+  ```
+
+- Enable only the CMS gates required for the MVP: long-form CMS, drafts, revisions if used, and scheduled
+  publishing only when explicitly exercised.
+- Do not expand launch validation into rich editor, Simulacrum retrofit, newsletter, comments, search, RSS,
+  timeline/trending, or general document hosting. Those remain outside Project 36's cutline.
+
+## Storage limits and body strategy
+
+The MVP stores Article source in DynamoDB as the Article/Draft `content` field. There is **no S3 body offload**
+for the launch path.
+
+Current deterministic limits:
+
+- Article source: **256 KiB** before rendering (`cmsrender.MaxArticleSourceBytes`).
+- Rendered/sanitized HTML: **512 KiB** after rendering (`cmsrender.MaxArticleRenderedHTMLBytes`).
+- Supported source formats: Markdown and HTML-as-sanitizer-input.
+- Unsupported formats, invalid UTF-8, source-size overflow, and rendered-size overflow fail deterministically.
+- Lesser never silently truncates source or rendered output.
+
+Escalate a follow-up body-storage design only if real launch drafts need more than 256 KiB of source or
+operators observe DynamoDB item-size pressure from Article metadata/media growth.
+
+## Legacy `/objects/<uuid>` dry-run and alias policy
+
+Existing Article objects under `https://<domain>/objects/<uuid>` remain their own ActivityPub object identity.
+The launch path must not rewrite them into `/articles/<slug>` IDs.
+
+Dry-run policy:
+
+1. Identify local Article rows whose stored ID is `https://<domain>/objects/<uuid>` and whose Article slug is non-empty.
+2. Propose the non-authoritative browser alias `https://<domain>/articles/<slug>`.
+3. Keep `proposedCanonicalID` equal to the stored legacy `/objects/<uuid>` ID.
+4. Report conflicts before any alias/backfill write:
+   - more than one legacy Article proposes the same tenant+slug alias;
+   - a canonical `https://<domain>/articles/<slug>` Article already occupies that tenant+slug.
+5. Do not introduce duplicate canonical ActivityPub IDs.
+
+The dry-run planner is `cms.PlanLegacyArticleMigration`. It is pure/read-only and should be wired to operator
+tooling before any apply-capable alias migration exists.
+
+## Publish probe
+
+Use the authenticated GraphQL path so the probe exercises the same authoring contract used by MCP consumers:
+
+1. Create an Article draft.
+2. Call `draftPreview(id: ID!)` and confirm:
+   - `success: true`;
+   - `renderedHtml` is sanitized server output;
+   - `sourceBytes` and `renderedBytes` are present.
+3. Publish the draft.
+4. Confirm the returned `Article.id` is:
+
+   ```text
+   https://<domain>/articles/<slug>
+   ```
+
+5. Confirm the slug is immutable on post-publish update; title/body/metadata updates should preserve the same ID.
+
+## Federation fetch probe
+
+Fetch the published Article as a remote peer would:
+
+```bash
+curl -i \
+  -H 'Accept: application/activity+json' \
+  "https://<domain>/articles/<slug>"
+```
+
+Expected:
+
+- HTTP 200 for a live Article.
+- `type` is `Article`.
+- `id` is exactly `https://<domain>/articles/<slug>`.
+- `content` is sanitized HTML from lesser's renderer.
+- `bto` and `bcc` are absent.
+
+For a deleted Article, expect HTTP 410 with an ActivityPub Tombstone for the same Article ID.
+
+## UI smoke
+
+In a browser:
+
+1. Open `https://<domain>/articles/<slug>`.
+2. Confirm the article body matches the GraphQL draft preview semantically.
+3. Confirm unsafe HTML is not rendered as executable content.
+4. Confirm public chrome/templates do not reveal draft-only fields, raw source, private tokens, or hidden recipients.
+
+If GraphQL is used for the smoke path, `articleBySlug(slug: "<slug>")` must return the same `id` as the
+browser and ActivityPub fetch path.
+
+## Observability checks
+
+Article renderer and federation failures are normal ops-path signals, not optional ad hoc logs.
+
+CloudWatch Logs message filters:
+
+```text
+cms_article_render_failure
+cms_draft_render_failure
+cms_article_federation_attempt
+cms_article_federation_outcome
+```
+
+CloudWatch EMF namespace:
+
+```text
+Lesser/CMS
+```
+
+Critical metrics:
+
+- `ArticleRenderFailure` with dimensions `Stage=<dev|staging|live>, Status=failure`.
+- `ArticleFederationFailure` with dimensions `Stage=<dev|staging|live>, Status=failure`.
+
+The per-stage critical alarm stack creates alarms for both metrics and sends them to the critical alert topic.
+Treat a single production failure as actionable during launch soak: inspect the structured fields
+`Operation`, `article_id` or `draft_id`, `failure_stage`, `activity_type`, `error_kind`, and `source_bytes`.
+Logs intentionally do **not** include raw draft/article content.
+
+## Rollback and residuals
+
+Rollback code through the normal release path:
+
+1. Revert the offending commit or check out the prior reviewed release.
+2. Rebuild and redeploy with `./lesser up` through dev, staging if used, then live.
+3. Preserve the bootstrap mnemonic at `~/.lesser/<app>/<domain>/bootstrap.json`.
+
+Known residuals:
+
+- ActivityPub activities already delivered to remote peers cannot be recalled by rollback.
+- Legacy `/objects/<uuid>` Articles remain canonical legacy objects; `/articles/<slug>` aliases are planned by dry-run
+  and are not applied in the launch path.
+- RSS/Atom, comments, newsletter delivery, rich editor, Simulacrum retrofit, timeline/trending coupling, and general
+  document hosting remain non-goals.
+- If sanitized output removes author-intended markup, adjust the renderer policy in a reviewed follow-up rather than
+  bypassing the sanitizer.

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -101,6 +101,15 @@ destination are deployed.
 - Check the federation delivery queue depth (queue URL from `state.json`).
 - Validate `/.well-known/webfinger` routing and that your stage domain resolves correctly.
 
+### CMS Blog launch or Article federation failure
+
+Use the focused launch runbook in `docs/operations/cms-blog-launch-runbook.md`.
+
+- Tail `api`, `graphql`, and `federation-delivery` logs.
+- Search for `cms_article_render_failure`, `cms_draft_render_failure`, and `cms_article_federation_outcome`.
+- Check `Lesser/CMS` metrics `ArticleRenderFailure` and `ArticleFederationFailure`.
+- Do not bypass the server-side renderer/sanitizer or federation signing path to clear a launch blocker.
+
 ## Recovery
 
 Start with `docs/backup-recovery.md` and use table/bucket names from `state.json` (or CDK outputs), not hard-coded examples.

--- a/infra/cdk/stacks/critical_alarms.go
+++ b/infra/cdk/stacks/critical_alarms.go
@@ -48,6 +48,7 @@ func NewCriticalAlarmsNestedStack(scope constructs.Construct, id string, props *
 
 	stack.addCriticalLambdaAlarms(alertTopic)
 	stack.addCriticalQueueAlarms(alertTopic)
+	stack.addCriticalCMSArticleAlarms(alertTopic)
 	return stack
 }
 
@@ -147,6 +148,47 @@ func (s *CriticalAlarmsNestedStack) addCriticalQueueAlarms(alertTopic awssns.ITo
 			scheduleDLQ := queuePhysicalName(s.AppName, s.Environment, fmt.Sprintf("%s-schedule-%d-dlq", spec.Name, idx))
 			addCriticalQueueDepthAlarm(s.NestedStack, alertTopic, scheduleDLQ, fmt.Sprintf("%sScheduleDLQ%d", spec.Name, idx), 0)
 		}
+	}
+}
+
+func (s *CriticalAlarmsNestedStack) addCriticalCMSArticleAlarms(alertTopic awssns.ITopic) {
+	stage := naming.StageForEnvironment(s.Environment)
+	dimensions := &map[string]*string{
+		"Stage":  jsii.String(string(stage)),
+		"Status": jsii.String("failure"),
+	}
+
+	for _, spec := range []struct {
+		ConstructID string
+		MetricName  string
+		Resource    string
+	}{
+		{
+			ConstructID: "CMSArticleRenderFailureAlarm",
+			MetricName:  "ArticleRenderFailure",
+			Resource:    "cms-article-render-failure",
+		},
+		{
+			ConstructID: "CMSArticleFederationFailureAlarm",
+			MetricName:  "ArticleFederationFailure",
+			Resource:    "cms-article-federation-failure",
+		},
+	} {
+		metric := awscloudwatch.NewMetric(&awscloudwatch.MetricProps{
+			Namespace:     jsii.String("Lesser/CMS"),
+			MetricName:    jsii.String(spec.MetricName),
+			DimensionsMap: dimensions,
+			Statistic:     jsii.String("Sum"),
+			Period:        awscdk.Duration_Minutes(jsii.Number(5)),
+		})
+		awscloudwatch.NewAlarm(s.NestedStack, jsii.String(spec.ConstructID), &awscloudwatch.AlarmProps{
+			AlarmName:          jsii.String(fmt.Sprintf("%s-critical", naming.ResourceNameWithApp(s.AppName, spec.Resource, string(stage)))),
+			Metric:             metric,
+			Threshold:          jsii.Number(1),
+			EvaluationPeriods:  jsii.Number(1),
+			ComparisonOperator: awscloudwatch.ComparisonOperator_GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+			TreatMissingData:   awscloudwatch.TreatMissingData_NOT_BREACHING,
+		}).AddAlarmAction(awscloudwatchactions.NewSnsAction(alertTopic))
 	}
 }
 

--- a/infra/cdk/stacks/critical_alarms_test.go
+++ b/infra/cdk/stacks/critical_alarms_test.go
@@ -50,6 +50,9 @@ func TestLesserApiStackSynthCreatesCriticalProcessorAlarms(t *testing.T) {
 			requireAlarm(t, alarms, fmt.Sprintf("%s-critical-depth", scheduleDLQ))
 		}
 	}
+
+	requireAlarm(t, alarms, fmt.Sprintf("%s-critical", naming.ResourceNameWithApp(appName, "cms-article-render-failure", environment)))
+	requireAlarm(t, alarms, fmt.Sprintf("%s-critical", naming.ResourceNameWithApp(appName, "cms-article-federation-failure", environment)))
 }
 
 func synthLesserApiStageTemplate(t *testing.T, appName string, environment string) map[string]any {

--- a/pkg/services/cms/article_service.go
+++ b/pkg/services/cms/article_service.go
@@ -103,6 +103,7 @@ func (s *ArticleService) CreateArticle(ctx context.Context, article *models.Arti
 	cmsNormalizeArticleAttribution(article, nil)
 
 	if err := validateArticleRenderable(article); err != nil {
+		logCMSArticleRenderFailure(s.logger, "create_article", article, err)
 		return err
 	}
 
@@ -301,6 +302,7 @@ func (s *ArticleService) UpdateArticle(ctx context.Context, article *models.Arti
 	}
 
 	if err := validateArticleRenderable(article); err != nil {
+		logCMSArticleRenderFailure(s.logger, "update_article", article, err)
 		return err
 	}
 
@@ -534,12 +536,15 @@ func (s *ArticleService) federateArticleUpdate(ctx context.Context, article *mod
 }
 
 func (s *ArticleService) federateArticleWriteActivity(ctx context.Context, article *models.Article, activityType string, label string) {
+	logCMSArticleFederationAttempt(s.logger, label, activityType, article)
+
 	apArticle, err := transformations.StorageArticleToActivityPub(article)
 	if err != nil {
 		s.logger.Error("failed to convert article to AP for federation",
 			zap.String("label", label),
-			zap.String("article_id", article.ID),
+			zap.String("article_id", cmsArticleID(article)),
 			zap.Error(err))
+		logCMSArticleFederationFailure(s.logger, label, cmsFederationFailureStageTransform, activityType, "", article, err)
 		return
 	}
 
@@ -550,6 +555,7 @@ func (s *ArticleService) federateArticleWriteActivity(ctx context.Context, artic
 			zap.String("label", label),
 			zap.String("actor_id", article.AttributedTo),
 			zap.Error(err))
+		logCMSArticleFederationFailure(s.logger, label, cmsFederationFailureStageActor, activityType, "", article, err)
 		return
 	}
 
@@ -573,20 +579,25 @@ func (s *ArticleService) federateArticleWriteActivity(ctx context.Context, artic
 			zap.String("label", label),
 			zap.String("activity_id", activityID),
 			zap.Error(err))
+		logCMSArticleFederationFailure(s.logger, label, cmsFederationFailureStageDelivery, activityType, activityID, article, err)
 	} else {
 		s.logger.Info("successfully federated article activity",
 			zap.String("label", label),
 			zap.String("article_id", article.ID),
 			zap.String("activity_id", activityID))
+		logCMSArticleFederationSuccess(s.logger, label, activityType, activityID, article)
 	}
 }
 func (s *ArticleService) federateArticleDeletion(ctx context.Context, article *models.Article) {
+	logCMSArticleFederationAttempt(s.logger, "delete", activitypub.DeleteType, article)
+
 	username := extractUsernameFromActorID(article.AttributedTo)
 	apActor, err := s.actorRepo.GetActor(ctx, username)
 	if err != nil {
 		s.logger.Error("failed to get actor for article delete federation",
 			zap.String("actor_id", article.AttributedTo),
 			zap.Error(err))
+		logCMSArticleFederationFailure(s.logger, "delete", cmsFederationFailureStageActor, activitypub.DeleteType, "", article, err)
 		return
 	}
 
@@ -618,23 +629,30 @@ func (s *ArticleService) federateArticleDeletion(ctx context.Context, article *m
 		s.logger.Error("failed to deliver article delete activity",
 			zap.String("activity_id", activityID),
 			zap.Error(err))
+		logCMSArticleFederationFailure(s.logger, "delete", cmsFederationFailureStageDelivery, activitypub.DeleteType, activityID, article, err)
 	} else {
 		s.logger.Info("successfully federated article delete",
 			zap.String("article_id", article.ID),
 			zap.String("activity_id", activityID))
+		logCMSArticleFederationSuccess(s.logger, "delete", activitypub.DeleteType, activityID, article)
 	}
 }
 
 func (s *ArticleService) deliverFederatedArticleActivity(ctx context.Context, activity *activitypub.Activity, actor *activitypub.Actor) error {
+	var followerErr error
 	if articleActivityHasPublicAddressing(activity) {
 		if err := s.federation.DeliverToFollowers(ctx, activity, actor); err != nil {
+			followerErr = err
 			s.logger.Error("failed to deliver article activity to followers",
 				zap.String("activity_id", activity.ID),
 				zap.Error(err))
 		}
 	}
 
-	return s.federation.DeliverToRecipients(ctx, activity, actor)
+	if err := s.federation.DeliverToRecipients(ctx, activity, actor); err != nil {
+		return err
+	}
+	return followerErr
 }
 
 func articleActivityHasPublicAddressing(activity *activitypub.Activity) bool {

--- a/pkg/services/cms/draft_service.go
+++ b/pkg/services/cms/draft_service.go
@@ -58,6 +58,7 @@ func NewDraftService(draftRepo draftRepository, articleService *ArticleService, 
 // CreateDraft creates a new draft
 func (s *DraftService) CreateDraft(ctx context.Context, draft *models.Draft) error {
 	if err := validateArticleDraftRenderable(draft); err != nil {
+		logCMSDraftRenderFailure(s.logger, "create_draft", draft, err)
 		return err
 	}
 	cmsNormalizeDraftAttribution(draft)
@@ -113,6 +114,7 @@ func (s *DraftService) UpdateDraft(ctx context.Context, authorID string, draft *
 		return err
 	}
 	if err := validateArticleDraftRenderable(draft); err != nil {
+		logCMSDraftRenderFailure(s.logger, "update_draft", draft, err)
 		return err
 	}
 	cmsNormalizeDraftAttribution(draft)
@@ -128,6 +130,7 @@ func (s *DraftService) Autosave(ctx context.Context, authorID string, draft *mod
 		return err
 	}
 	if err := validateArticleDraftRenderable(draft); err != nil {
+		logCMSDraftRenderFailure(s.logger, "autosave_draft", draft, err)
 		return err
 	}
 	cmsNormalizeDraftAttribution(draft)
@@ -150,7 +153,12 @@ func (s *DraftService) PreviewDraft(ctx context.Context, authorID, draftID strin
 	if err != nil {
 		return cmsrender.RenderedArticleContent{}, err
 	}
-	return RenderDraftPreview(draft)
+	rendered, err := RenderDraftPreview(draft)
+	if err != nil {
+		logCMSDraftRenderFailure(s.logger, "preview_draft", draft, err)
+		return cmsrender.RenderedArticleContent{}, err
+	}
+	return rendered, nil
 }
 
 // RenderDraftPreview renders draft source through the canonical Article renderer.

--- a/pkg/services/cms/legacy_article_migration.go
+++ b/pkg/services/cms/legacy_article_migration.go
@@ -1,0 +1,241 @@
+package cms
+
+import (
+	neturl "net/url"
+	"sort"
+	"strings"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+)
+
+// Legacy Article migration skip and conflict reason codes.
+const (
+	LegacyArticleSkipNil               = "nil_article"
+	LegacyArticleSkipNotArticle        = "not_article"
+	LegacyArticleSkipMissingID         = "missing_id"
+	LegacyArticleSkipAlreadyCanonical  = "already_canonical_article"
+	LegacyArticleSkipNotLegacyObjectID = "not_legacy_objects_id"
+	LegacyArticleSkipMissingSlug       = "missing_slug"
+	LegacyArticleConflictDuplicate     = "duplicate_legacy_alias"
+	LegacyArticleConflictOccupied      = "canonical_alias_occupied"
+)
+
+// LegacyArticleMigrationPlan is the dry-run output for deciding how legacy
+// Article IDs under /objects/<uuid> could be exposed through non-authoritative
+// /articles/<slug> aliases without rewriting ActivityPub object identity.
+type LegacyArticleMigrationPlan struct {
+	Candidates []LegacyArticleMigrationCandidate
+	Conflicts  []LegacyArticleMigrationConflict
+	Skipped    []LegacyArticleMigrationSkipped
+}
+
+// LegacyArticleMigrationCandidate maps one legacy Article to its proposed
+// browser alias. ProposedCanonicalID intentionally remains the stored legacy
+// Article ID for the MVP so the dry-run never creates a second ActivityPub
+// object identity for existing content.
+type LegacyArticleMigrationCandidate struct {
+	ArticleID           string
+	Tenant              string
+	Slug                string
+	ProposedCanonicalID string
+	ProposedAliasURL    string
+}
+
+// LegacyArticleMigrationConflict describes a mapping that cannot be applied
+// without creating duplicate alias/canonical identity ambiguity.
+type LegacyArticleMigrationConflict struct {
+	Tenant     string
+	Slug       string
+	AliasURL   string
+	ArticleIDs []string
+	Reason     string
+}
+
+// LegacyArticleMigrationSkipped describes an Article row that is not a legacy
+// /objects/<uuid> Article migration candidate.
+type LegacyArticleMigrationSkipped struct {
+	ArticleID string
+	Reason    string
+}
+
+// PlanLegacyArticleMigration performs a pure dry-run over Article rows. It
+// identifies legacy /objects/<uuid> Articles, proposes non-authoritative
+// /articles/<slug> aliases, and reports conflicts before any write path exists.
+func PlanLegacyArticleMigration(articles []*models.Article, defaultDomain string) LegacyArticleMigrationPlan {
+	defaultDomain = cmsNormalizeTenant(defaultDomain)
+	plan := LegacyArticleMigrationPlan{}
+
+	canonicalByAlias := map[string]string{}
+	for _, article := range articles {
+		if article == nil {
+			continue
+		}
+		tenant, slug, ok := legacyArticleCanonicalSlug(article.ID)
+		if !ok {
+			continue
+		}
+		canonicalByAlias[legacyArticleAliasKey(tenant, slug)] = strings.TrimSpace(article.ID)
+	}
+
+	candidatesByAlias := map[string][]LegacyArticleMigrationCandidate{}
+	for _, article := range articles {
+		candidate, skipped, ok := legacyArticleMigrationCandidateFor(article, defaultDomain)
+		if !ok {
+			plan.Skipped = append(plan.Skipped, skipped)
+			continue
+		}
+		plan.Candidates = append(plan.Candidates, candidate)
+		key := legacyArticleAliasKey(candidate.Tenant, candidate.Slug)
+		candidatesByAlias[key] = append(candidatesByAlias[key], candidate)
+	}
+
+	for key, candidates := range candidatesByAlias {
+		parts := strings.SplitN(key, "\x00", 2)
+		tenant, slug := "", ""
+		if len(parts) == 2 {
+			tenant, slug = parts[0], parts[1]
+		}
+		aliasURL := ""
+		if len(candidates) > 0 {
+			aliasURL = candidates[0].ProposedAliasURL
+		}
+
+		if canonicalID := canonicalByAlias[key]; canonicalID != "" {
+			articleIDs := []string{canonicalID}
+			for _, candidate := range candidates {
+				articleIDs = append(articleIDs, candidate.ArticleID)
+			}
+			plan.Conflicts = append(plan.Conflicts, LegacyArticleMigrationConflict{
+				Tenant:     tenant,
+				Slug:       slug,
+				AliasURL:   aliasURL,
+				ArticleIDs: sortedUniqueStrings(articleIDs),
+				Reason:     LegacyArticleConflictOccupied,
+			})
+		}
+
+		if len(candidates) > 1 {
+			articleIDs := make([]string, 0, len(candidates))
+			for _, candidate := range candidates {
+				articleIDs = append(articleIDs, candidate.ArticleID)
+			}
+			plan.Conflicts = append(plan.Conflicts, LegacyArticleMigrationConflict{
+				Tenant:     tenant,
+				Slug:       slug,
+				AliasURL:   aliasURL,
+				ArticleIDs: sortedUniqueStrings(articleIDs),
+				Reason:     LegacyArticleConflictDuplicate,
+			})
+		}
+	}
+
+	sort.Slice(plan.Candidates, func(i, j int) bool {
+		if plan.Candidates[i].Tenant == plan.Candidates[j].Tenant {
+			return plan.Candidates[i].Slug < plan.Candidates[j].Slug
+		}
+		return plan.Candidates[i].Tenant < plan.Candidates[j].Tenant
+	})
+	sort.Slice(plan.Conflicts, func(i, j int) bool {
+		if plan.Conflicts[i].Tenant == plan.Conflicts[j].Tenant {
+			if plan.Conflicts[i].Slug == plan.Conflicts[j].Slug {
+				return plan.Conflicts[i].Reason < plan.Conflicts[j].Reason
+			}
+			return plan.Conflicts[i].Slug < plan.Conflicts[j].Slug
+		}
+		return plan.Conflicts[i].Tenant < plan.Conflicts[j].Tenant
+	})
+	return plan
+}
+
+func legacyArticleMigrationCandidateFor(article *models.Article, defaultDomain string) (
+	LegacyArticleMigrationCandidate,
+	LegacyArticleMigrationSkipped,
+	bool,
+) {
+	if article == nil {
+		return LegacyArticleMigrationCandidate{}, LegacyArticleMigrationSkipped{Reason: LegacyArticleSkipNil}, false
+	}
+
+	articleID := strings.TrimSpace(article.ID)
+	if articleID == "" {
+		return LegacyArticleMigrationCandidate{}, LegacyArticleMigrationSkipped{Reason: LegacyArticleSkipMissingID}, false
+	}
+	if article.Type != "" && !strings.EqualFold(strings.TrimSpace(article.Type), activitypub.ArticleType) {
+		return LegacyArticleMigrationCandidate{}, LegacyArticleMigrationSkipped{ArticleID: articleID, Reason: LegacyArticleSkipNotArticle}, false
+	}
+	if _, _, ok := legacyArticleCanonicalSlug(articleID); ok {
+		return LegacyArticleMigrationCandidate{}, LegacyArticleMigrationSkipped{ArticleID: articleID, Reason: LegacyArticleSkipAlreadyCanonical}, false
+	}
+
+	tenant, ok := legacyArticleObjectTenant(articleID)
+	if !ok {
+		return LegacyArticleMigrationCandidate{}, LegacyArticleMigrationSkipped{ArticleID: articleID, Reason: LegacyArticleSkipNotLegacyObjectID}, false
+	}
+	if tenant == "" {
+		tenant = defaultDomain
+	}
+	if tenant == "" {
+		return LegacyArticleMigrationCandidate{}, LegacyArticleMigrationSkipped{ArticleID: articleID, Reason: LegacyArticleSkipNotLegacyObjectID}, false
+	}
+
+	slug := common.Slugify(article.Slug)
+	if slug == "" {
+		return LegacyArticleMigrationCandidate{}, LegacyArticleMigrationSkipped{ArticleID: articleID, Reason: LegacyArticleSkipMissingSlug}, false
+	}
+
+	return LegacyArticleMigrationCandidate{
+		ArticleID:           articleID,
+		Tenant:              tenant,
+		Slug:                slug,
+		ProposedCanonicalID: articleID,
+		ProposedAliasURL:    common.GenerateObjectID(tenant, "articles", slug),
+	}, LegacyArticleMigrationSkipped{}, true
+}
+
+func legacyArticleObjectTenant(articleID string) (string, bool) {
+	parsed, err := neturl.Parse(strings.TrimSpace(articleID))
+	if err != nil || strings.TrimSpace(parsed.Host) == "" {
+		return "", false
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) != 2 || parts[0] != "objects" || strings.TrimSpace(parts[1]) == "" {
+		return "", false
+	}
+	return cmsNormalizeTenant(parsed.Host), true
+}
+
+func legacyArticleCanonicalSlug(articleID string) (tenant string, slug string, ok bool) {
+	parsed, err := neturl.Parse(strings.TrimSpace(articleID))
+	if err != nil || strings.TrimSpace(parsed.Host) == "" {
+		return "", "", false
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) != 2 || parts[0] != "articles" || strings.TrimSpace(parts[1]) == "" {
+		return "", "", false
+	}
+	return cmsNormalizeTenant(parsed.Host), strings.TrimSpace(parts[1]), true
+}
+
+func legacyArticleAliasKey(tenant string, slug string) string {
+	return cmsNormalizeTenant(tenant) + "\x00" + strings.ToLower(strings.TrimSpace(slug))
+}
+
+func sortedUniqueStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/pkg/services/cms/m7_operational_readiness_test.go
+++ b/pkg/services/cms/m7_operational_readiness_test.go
@@ -1,0 +1,204 @@
+package cms
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/cmsrender"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestM7ArticleRenderFailureEmitsOperationalMetricLog(t *testing.T) {
+	t.Setenv("STAGE", "dev")
+
+	core, observed := observer.New(zap.DebugLevel)
+	svc := NewArticleService(
+		&fakeArticleRepo{articles: map[string]*models.Article{}},
+		fakeActorRepo{err: errors.New("no actor")},
+		nil,
+		nil,
+		nil,
+		&fakeFederation{},
+		zap.New(core),
+	)
+
+	err := svc.CreateArticle(context.Background(), &models.Article{
+		Object: models.Object{
+			ID:      "https://example.com/articles/too-large",
+			Type:    activitypub.ArticleType,
+			Name:    "Too Large",
+			Content: string(make([]byte, cmsrender.MaxArticleSourceBytes+1)),
+		},
+		Slug:          "too-large",
+		ContentFormat: "markdown",
+	})
+	require.ErrorIs(t, err, cmsrender.ErrArticleContentTooLarge)
+
+	entries := observed.FilterMessage(cmsLogArticleRenderFailure).All()
+	require.Len(t, entries, 1)
+	fields := entries[0].ContextMap()
+	require.Equal(t, "dev", fields["Stage"])
+	require.Equal(t, "create_article", fields["Operation"])
+	require.Equal(t, cmsMetricStatusFailure, fields["Status"])
+	require.Equal(t, float64(1), fields[cmsMetricArticleRenderFailure])
+	require.Equal(t, "source_too_large", fields["error_kind"])
+	require.Equal(t, "https://example.com/articles/too-large", fields["article_id"])
+	require.Equal(t, int64(cmsrender.MaxArticleSourceBytes+1), fields["source_bytes"])
+	require.NotContains(t, fields, "content")
+}
+
+func TestM7DraftPreviewRenderFailureEmitsOperationalMetricLog(t *testing.T) {
+	t.Setenv("STAGE", "dev")
+
+	core, observed := observer.New(zap.DebugLevel)
+	repo := newMemDraftRepo()
+	require.NoError(t, repo.CreateDraft(context.Background(), &models.Draft{
+		ID:            "draft-1",
+		AuthorID:      "alice",
+		Title:         "Preview",
+		ContentType:   activitypub.ArticleType,
+		Content:       "draft body",
+		ContentFormat: "asciidoc",
+	}))
+
+	svc := NewDraftService(repo, nil, "example.com", false, zap.New(core))
+	_, err := svc.PreviewDraft(context.Background(), "alice", "draft-1")
+	require.ErrorIs(t, err, cmsrender.ErrUnsupportedContentFormat)
+
+	entries := observed.FilterMessage(cmsLogDraftRenderFailure).All()
+	require.Len(t, entries, 1)
+	fields := entries[0].ContextMap()
+	require.Equal(t, "preview_draft", fields["Operation"])
+	require.Equal(t, float64(1), fields[cmsMetricArticleRenderFailure])
+	require.Equal(t, "unsupported_content_format", fields["error_kind"])
+	require.Equal(t, "draft-1", fields["draft_id"])
+	require.Equal(t, "asciidoc", fields["content_format"])
+	require.Equal(t, int64(len("draft body")), fields["source_bytes"])
+	require.NotContains(t, fields, "content")
+}
+
+func TestM7ArticleFederationFailureEmitsOperationalMetricLog(t *testing.T) {
+	t.Setenv("STAGE", "dev")
+
+	core, observed := observer.New(zap.DebugLevel)
+	svc := NewArticleService(
+		&fakeArticleRepo{articles: map[string]*models.Article{}},
+		fakeActorRepo{err: errors.New("actor lookup failed")},
+		nil,
+		nil,
+		nil,
+		&fakeFederation{},
+		zap.New(core),
+	)
+
+	article := &models.Article{
+		Object: models.Object{
+			ID:           "https://example.com/articles/fed",
+			Type:         activitypub.ArticleType,
+			Name:         "Federation",
+			Content:      "hello",
+			Published:    time.Now(),
+			AttributedTo: "https://example.com/users/alice",
+			To:           []string{activitypub.PublicAddress},
+		},
+		Slug:          "fed",
+		ContentFormat: "markdown",
+	}
+
+	svc.federateArticleWriteActivity(context.Background(), article, activitypub.CreateType, "create")
+
+	attempts := observed.FilterMessage(cmsLogArticleFederationAttempt).All()
+	require.Len(t, attempts, 1)
+	require.Equal(t, float64(1), attempts[0].ContextMap()[cmsMetricArticleFederationAttempt])
+
+	failures := observed.FilterMessage(cmsLogArticleFederationOutcome).All()
+	require.Len(t, failures, 1)
+	fields := failures[0].ContextMap()
+	require.Equal(t, "create", fields["Operation"])
+	require.Equal(t, cmsMetricStatusFailure, fields["Status"])
+	require.Equal(t, cmsFederationFailureStageActor, fields["failure_stage"])
+	require.Equal(t, activitypub.CreateType, fields["activity_type"])
+	require.Equal(t, float64(1), fields[cmsMetricArticleFederationFailure])
+	require.Equal(t, "https://example.com/articles/fed", fields["article_id"])
+	require.NotContains(t, fields, "content")
+}
+
+func TestM7LegacyArticleMigrationPlanIdentifiesLegacyAliases(t *testing.T) {
+	plan := PlanLegacyArticleMigration([]*models.Article{
+		{
+			Object: models.Object{
+				ID:   "https://example.com/objects/abc123",
+				Type: activitypub.ArticleType,
+			},
+			Slug: "Launch Post",
+		},
+	}, "example.com")
+
+	require.Empty(t, plan.Conflicts)
+	require.Empty(t, plan.Skipped)
+	require.Len(t, plan.Candidates, 1)
+	candidate := plan.Candidates[0]
+	require.Equal(t, "https://example.com/objects/abc123", candidate.ArticleID)
+	require.Equal(t, "example.com", candidate.Tenant)
+	require.Equal(t, "launch-post", candidate.Slug)
+	require.Equal(t, candidate.ArticleID, candidate.ProposedCanonicalID)
+	require.Equal(t, "https://example.com/articles/launch-post", candidate.ProposedAliasURL)
+}
+
+func TestM7LegacyArticleMigrationPlanDetectsDuplicateAndCanonicalConflicts(t *testing.T) {
+	plan := PlanLegacyArticleMigration([]*models.Article{
+		{
+			Object: models.Object{ID: "https://example.com/objects/one", Type: activitypub.ArticleType},
+			Slug:   "same",
+		},
+		{
+			Object: models.Object{ID: "https://example.com/objects/two", Type: activitypub.ArticleType},
+			Slug:   "same",
+		},
+		{
+			Object: models.Object{ID: "https://example.com/articles/same", Type: activitypub.ArticleType},
+			Slug:   "same",
+		},
+	}, "example.com")
+
+	require.Len(t, plan.Candidates, 2)
+	require.Len(t, plan.Conflicts, 2)
+	reasons := []string{plan.Conflicts[0].Reason, plan.Conflicts[1].Reason}
+	require.Contains(t, reasons, LegacyArticleConflictDuplicate)
+	require.Contains(t, reasons, LegacyArticleConflictOccupied)
+	for _, conflict := range plan.Conflicts {
+		require.Equal(t, "https://example.com/articles/same", conflict.AliasURL)
+		require.Equal(t, "same", conflict.Slug)
+	}
+}
+
+func TestM7LegacyArticleMigrationPlanSkipsNonCandidates(t *testing.T) {
+	plan := PlanLegacyArticleMigration([]*models.Article{
+		nil,
+		{Object: models.Object{ID: "", Type: activitypub.ArticleType}, Slug: "missing-id"},
+		{Object: models.Object{ID: "https://example.com/objects/note", Type: activitypub.NoteType}, Slug: "note"},
+		{Object: models.Object{ID: "https://example.com/articles/canonical", Type: activitypub.ArticleType}, Slug: "canonical"},
+		{Object: models.Object{ID: "https://example.com/objects/no-slug", Type: activitypub.ArticleType}},
+		{Object: models.Object{ID: "https://example.com/users/alice/statuses/1", Type: activitypub.ArticleType}, Slug: "status"},
+	}, "example.com")
+
+	require.Empty(t, plan.Candidates)
+	require.Empty(t, plan.Conflicts)
+	require.Len(t, plan.Skipped, 6)
+	reasons := make([]string, 0, len(plan.Skipped))
+	for _, skipped := range plan.Skipped {
+		reasons = append(reasons, skipped.Reason)
+	}
+	require.Contains(t, reasons, LegacyArticleSkipNil)
+	require.Contains(t, reasons, LegacyArticleSkipMissingID)
+	require.Contains(t, reasons, LegacyArticleSkipNotArticle)
+	require.Contains(t, reasons, LegacyArticleSkipAlreadyCanonical)
+	require.Contains(t, reasons, LegacyArticleSkipMissingSlug)
+	require.Contains(t, reasons, LegacyArticleSkipNotLegacyObjectID)
+}

--- a/pkg/services/cms/observability.go
+++ b/pkg/services/cms/observability.go
@@ -1,0 +1,189 @@
+package cms
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/cmsrender"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"go.uber.org/zap"
+)
+
+const (
+	cmsMetricNamespace                 = "Lesser/CMS"
+	cmsMetricArticleRenderFailure      = "ArticleRenderFailure"
+	cmsMetricArticleFederationAttempt  = "ArticleFederationAttempt"
+	cmsMetricArticleFederationSuccess  = "ArticleFederationSuccess"
+	cmsMetricArticleFederationFailure  = "ArticleFederationFailure"
+	cmsMetricStatusAttempt             = "attempt"
+	cmsMetricStatusSuccess             = "success"
+	cmsMetricStatusFailure             = "failure"
+	cmsMetricUnknownStage              = "unknown"
+	cmsLogArticleRenderFailure         = "cms_article_render_failure"
+	cmsLogDraftRenderFailure           = "cms_draft_render_failure"
+	cmsLogArticleFederationAttempt     = "cms_article_federation_attempt"
+	cmsLogArticleFederationOutcome     = "cms_article_federation_outcome"
+	cmsFederationFailureStageTransform = "transform"
+	cmsFederationFailureStageActor     = "actor_lookup"
+	cmsFederationFailureStageDelivery  = "delivery"
+)
+
+func cmsLogger(logger *zap.Logger) *zap.Logger {
+	if logger == nil {
+		return zap.NewNop()
+	}
+	return logger
+}
+
+func cmsMetricStage() string {
+	for _, key := range []string{"STAGE", "ENVIRONMENT"} {
+		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+			return value
+		}
+	}
+	return cmsMetricUnknownStage
+}
+
+func cmsMetricFields(metricName string, operation string, status string) []zap.Field {
+	stage := cmsMetricStage()
+	return []zap.Field{
+		zap.Any("_aws", map[string]interface{}{
+			"Timestamp": time.Now().UnixMilli(),
+			"CloudWatchMetrics": []map[string]interface{}{
+				{
+					"Namespace": cmsMetricNamespace,
+					"Dimensions": [][]string{
+						{"Stage", "Status"},
+						{"Stage", "Operation", "Status"},
+					},
+					"Metrics": []map[string]string{
+						{"Name": metricName, "Unit": "Count"},
+					},
+				},
+			},
+		}),
+		zap.String("Stage", stage),
+		zap.String("Operation", strings.TrimSpace(operation)),
+		zap.String("Status", strings.TrimSpace(status)),
+		zap.Float64(metricName, 1),
+	}
+}
+
+func logCMSArticleRenderFailure(logger *zap.Logger, operation string, article *models.Article, err error) {
+	fields := cmsMetricFields(cmsMetricArticleRenderFailure, operation, cmsMetricStatusFailure)
+	fields = append(fields, cmsArticleFields(article)...)
+	fields = append(fields, renderErrorFields(err)...)
+	cmsLogger(logger).Error(cmsLogArticleRenderFailure, fields...)
+}
+
+func logCMSDraftRenderFailure(logger *zap.Logger, operation string, draft *models.Draft, err error) {
+	fields := cmsMetricFields(cmsMetricArticleRenderFailure, operation, cmsMetricStatusFailure)
+	fields = append(fields, cmsDraftFields(draft)...)
+	fields = append(fields, renderErrorFields(err)...)
+	cmsLogger(logger).Error(cmsLogDraftRenderFailure, fields...)
+}
+
+func logCMSArticleFederationAttempt(logger *zap.Logger, operation string, activityType string, article *models.Article) {
+	fields := cmsMetricFields(cmsMetricArticleFederationAttempt, operation, cmsMetricStatusAttempt)
+	fields = append(fields, cmsArticleFields(article)...)
+	fields = append(fields, zap.String("activity_type", strings.TrimSpace(activityType)))
+	cmsLogger(logger).Info(cmsLogArticleFederationAttempt, fields...)
+}
+
+func logCMSArticleFederationSuccess(logger *zap.Logger, operation string, activityType string, activityID string, article *models.Article) {
+	fields := cmsMetricFields(cmsMetricArticleFederationSuccess, operation, cmsMetricStatusSuccess)
+	fields = append(fields, cmsArticleFields(article)...)
+	fields = append(fields,
+		zap.String("activity_type", strings.TrimSpace(activityType)),
+		zap.String("activity_id", strings.TrimSpace(activityID)),
+	)
+	cmsLogger(logger).Info(cmsLogArticleFederationOutcome, fields...)
+}
+
+func logCMSArticleFederationFailure(
+	logger *zap.Logger,
+	operation string,
+	failureStage string,
+	activityType string,
+	activityID string,
+	article *models.Article,
+	err error,
+) {
+	fields := cmsMetricFields(cmsMetricArticleFederationFailure, operation, cmsMetricStatusFailure)
+	fields = append(fields, cmsArticleFields(article)...)
+	fields = append(fields,
+		zap.String("failure_stage", strings.TrimSpace(failureStage)),
+		zap.String("activity_type", strings.TrimSpace(activityType)),
+		zap.String("activity_id", strings.TrimSpace(activityID)),
+		zap.Error(err),
+	)
+	cmsLogger(logger).Error(cmsLogArticleFederationOutcome, fields...)
+}
+
+func cmsArticleFields(article *models.Article) []zap.Field {
+	if article == nil {
+		return []zap.Field{
+			zap.String("article_id", ""),
+			zap.String("slug", ""),
+			zap.String("content_format", ""),
+			zap.Int("source_bytes", 0),
+		}
+	}
+	return []zap.Field{
+		zap.String("article_id", cmsArticleID(article)),
+		zap.String("slug", strings.TrimSpace(article.Slug)),
+		zap.String("content_format", strings.TrimSpace(article.ContentFormat)),
+		zap.Int("source_bytes", len(article.Content)),
+	}
+}
+
+func cmsArticleID(article *models.Article) string {
+	if article == nil {
+		return ""
+	}
+	return strings.TrimSpace(article.ID)
+}
+
+func cmsDraftFields(draft *models.Draft) []zap.Field {
+	if draft == nil {
+		return []zap.Field{
+			zap.String("draft_id", ""),
+			zap.String("content_type", ""),
+			zap.String("content_format", ""),
+			zap.Int("source_bytes", 0),
+		}
+	}
+	return []zap.Field{
+		zap.String("draft_id", strings.TrimSpace(draft.ID)),
+		zap.String("content_type", strings.TrimSpace(draft.ContentType)),
+		zap.String("content_format", strings.TrimSpace(draft.ContentFormat)),
+		zap.Int("source_bytes", len(draft.Content)),
+	}
+}
+
+func renderErrorFields(err error) []zap.Field {
+	return []zap.Field{
+		zap.String("error_kind", renderErrorKind(err)),
+		zap.Error(err),
+	}
+}
+
+func renderErrorKind(err error) string {
+	if err == nil {
+		return ""
+	}
+	switch {
+	case errors.Is(err, cmsrender.ErrUnsupportedContentFormat):
+		return "unsupported_content_format"
+	case errors.Is(err, cmsrender.ErrArticleContentTooLarge):
+		return "source_too_large"
+	case errors.Is(err, cmsrender.ErrArticleRenderedContentTooLarge):
+		return "rendered_too_large"
+	case strings.Contains(strings.ToLower(err.Error()), "valid utf-8"):
+		return "invalid_utf8"
+	default:
+		return "render_error"
+	}
+}


### PR DESCRIPTION
## Summary
- Documents the Project 36 M7 Article body-size strategy: keep Article/Draft source in DynamoDB for the MVP, enforce existing 256 KiB source and 512 KiB rendered HTML limits, and defer S3 body offload until observed need.
- Adds a pure legacy Article migration dry-run planner that identifies /objects/<uuid> Articles, proposes non-authoritative /articles/<slug> aliases, and reports duplicate/canonical alias conflicts without rewriting ActivityPub IDs.
- Adds CMS Article renderer/federation observability with EMF-compatible logs and critical CloudWatch alarms for ArticleRenderFailure and ArticleFederationFailure.
- Adds the first Theory Cloud CMS Blog launch runbook covering publish probe, federation fetch, UI smoke, observability, rollback, and known residuals.

## Federation-trust audit
- Signing impact: none. This does not change HTTP Signature signing or key material.
- Verification impact: none. Inbound verification remains unchanged.
- Actor/object shape impact: none. Article IDs and ActivityPub object serialization are unchanged.
- Delivery impact: delivery calls are unchanged, but Article federation now emits attempt/success/failure metrics; follower fanout errors now mark the Article federation outcome as failed instead of logging an apparent success.
- Governance/moderation impact: none.

## Contract/schema impact
- No Mastodon REST/OpenAPI change.
- No GraphQL schema change.
- No DynamoDB PK/SK/GSI/TableTheory tag change.
- No apply-capable legacy alias migration; M7 is dry-run planning only.

## Validation
- git diff --check
- go build -o lesser ./cmd/lesser
- go test ./pkg/services/cms
- cd infra/cdk && go test ./stacks
- go test ./...
- go vet ./...
- ./lesser build lambdas
- ./lesser verify ci (overall 87.659%, pkg 90.008%, cmd 90.010%)

Closes #1050
Closes #1051
Closes #1052
Closes #1053
Closes #1054
