### PR TITLE
test(cli): add error-path coverage for seedAgentManagedDefaultsFromEn…

### DIFF
--- a/cmd/lesser/instance_feature_config_sync_test.go
+++ b/cmd/lesser/instance_feature_config_sync_test.go
@@ -1108,3 +1108,19 @@ func TestEnsureAndApplyManagedProvisioningConfig_ReturnsErrorWhenSetAgentFails(t
 	})
 	require.Error(t, err)
 }
+
+func TestSeedAgentManagedDefaultsFromEnvOnce_ReturnsErrorWhenEnsureFails(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	// Override First for AgentInstanceConfig to return a non-NotFound error.
+	q.On("First", mock.AnythingOfType("*models.AgentInstanceConfig")).Return(errors.New("ensure failed")).Once()
+	setupMockInstanceRepoDB(db, q)
+	setupMockFirstForFeatureConfigs(q)
+
+	t.Setenv("ALLOW_AGENTS", "true")
+
+	instanceRepo := repositories.NewInstanceRepository(db, "test-table", zap.NewNop())
+	require.Error(t, seedAgentManagedDefaultsFromEnvOnce(ctx, instanceRepo, "dev", "test-table"))
+}


### PR DESCRIPTION
…vOnce

Covers the EnsureAgentInstanceConfig failure path, bringing the function from 86.7% to 93.3% coverage. The remaining uncovered return (GetAgentInstanceConfig error after EnsureAgentInstanceConfig succeeds) is unreachable due to cache.