### PR TITLE
fix: CSR-038/043/051/052 identity canonicalization hardening (M1.3)

### DIFF
--- a/cmd/actor/main.go
+++ b/cmd/actor/main.go
@@ -419,7 +419,14 @@ func (h *Handler) convertAppTheoryRequest(ctx *apptheory.Context) (*http.Request
 	// instance domain before using it for signature verification. This prevents
 	// forwarded-host spoofing where an attacker could inject a host header that
 	// matches their own signing key rather than the instance's expected host.
-	if err := common.ValidateRequestOriginDomain(ctx.Request.Headers, cfg.Domain); err != nil {
+	//
+	// When cfg is nil (unit tests without Lambda init), the domain is empty and
+	// ValidateRequestOriginDomain returns nil (no-op), preserving existing test behavior.
+	domain := ""
+	if cfg != nil {
+		domain = cfg.Domain
+	}
+	if err := common.ValidateRequestOriginDomain(ctx.Request.Headers, domain); err != nil {
 		return nil, fmt.Errorf("origin domain validation failed: %w", err)
 	}
 

--- a/cmd/actor/main.go
+++ b/cmd/actor/main.go
@@ -415,6 +415,14 @@ func (h *Handler) convertAppTheoryRequest(ctx *apptheory.Context) (*http.Request
 		return nil, errors.New("nil context")
 	}
 
+	// Validate that the origin reconstructed from forwarded headers matches the
+	// instance domain before using it for signature verification. This prevents
+	// forwarded-host spoofing where an attacker could inject a host header that
+	// matches their own signing key rather than the instance's expected host.
+	if err := common.ValidateRequestOriginDomain(ctx.Request.Headers, cfg.Domain); err != nil {
+		return nil, fmt.Errorf("origin domain validation failed: %w", err)
+	}
+
 	u := common.RequestURLFromHeaders(ctx.Request.Headers, ctx.Request.Path, ctx.Request.Query)
 
 	// Create request with context (no body for GET requests)

--- a/cmd/api/handlers/notification_actor_fallback.go
+++ b/cmd/api/handlers/notification_actor_fallback.go
@@ -24,12 +24,16 @@ func (h *Handler) fallbackNotificationActor(actorID string) *activitypub.Actor {
 	}
 
 	baseURL := ""
+	localDomain := ""
 	if h != nil && h.cfg != nil {
 		baseURL = strings.TrimSuffix(strings.TrimSpace(h.cfg.BaseURL()), "/")
+		localDomain = strings.TrimSpace(h.cfg.Domain)
 	}
 
 	actor := &activitypub.Actor{
-		BaseObject: activitypub.BaseObject{Type: activitypub.PersonType},
+		BaseObject:        activitypub.BaseObject{Type: activitypub.PersonType},
+		PreferredUsername: username,
+		Name:              username,
 	}
 
 	if strings.Contains(actorID, "://") {
@@ -39,7 +43,18 @@ func (h *Handler) fallbackNotificationActor(actorID string) *activitypub.Actor {
 		}
 		actor.ID = actorID
 		actor.URL = actorID
-	} else if baseURL != "" && username != "" {
+		// For foreign-domain URLs, surface the domain in the actor name to
+		// prevent the extracted username from being mistaken for a local user.
+		if localDomain != "" && username != "" {
+			actorDomain := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+			if actorDomain != "" && !strings.EqualFold(actorDomain, localDomain) {
+				actor.Name = username + "@" + actorDomain
+			}
+		}
+	} else if baseURL != "" && username != "" && !hasRemoteDomainIndicator(actorID, localDomain) {
+		// Create local URLs for bare usernames and local-domain handles.
+		// Remote user@domain and email-like identifiers with foreign domains
+		// are rejected from local URL creation and fall through to opaque IDs.
 		actor.ID = fmt.Sprintf("%s/users/%s", baseURL, username)
 		actor.URL = fmt.Sprintf("%s/@%s", baseURL, username)
 		actor.Inbox = fmt.Sprintf("%s/users/%s/inbox", baseURL, username)
@@ -48,9 +63,6 @@ func (h *Handler) fallbackNotificationActor(actorID string) *activitypub.Actor {
 		// Non-URL identifiers (email addresses, opaque ids) must not be used as URLs.
 		actor.ID = actorID
 	}
-
-	actor.PreferredUsername = username
-	actor.Name = username
 
 	return actor
 }
@@ -124,4 +136,21 @@ func sanitizedNotificationActorUsername(username string) string {
 		return ""
 	}
 	return username
+}
+
+// hasRemoteDomainIndicator returns true when the actorID has a domain indicator
+// (@ sign after optional leading @) that points to a non-local domain. This
+// prevents email-like and user@remote.domain actor IDs from being assigned
+// local instance endpoints. (CSR-051)
+func hasRemoteDomainIndicator(actorID, localDomain string) bool {
+	cleaned := strings.TrimPrefix(strings.TrimSpace(actorID), "@")
+	at := strings.LastIndex(cleaned, "@")
+	if at == -1 {
+		return false // no domain indicator at all
+	}
+	if strings.TrimSpace(localDomain) == "" {
+		return false // can't determine — allow local URL creation
+	}
+	domainPart := strings.TrimSpace(cleaned[at+1:])
+	return !strings.EqualFold(domainPart, strings.TrimSpace(localDomain))
 }

--- a/cmd/api/handlers/notification_actor_fallback_round38_security_test.go
+++ b/cmd/api/handlers/notification_actor_fallback_round38_security_test.go
@@ -1,0 +1,126 @@
+package handlers
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFallbackNotificationActor_ForeignDomainSurfaced verifies that
+// the REST handler's fallbackNotificationActor surfaces foreign domains
+// in the actor display name. (CSR-051 regression probe)
+func TestFallbackNotificationActor_ForeignDomainSurfaced(t *testing.T) {
+	cfg := &config.Config{
+		Domain: "lesser.example",
+	}
+	h := &Handler{cfg: cfg}
+
+	tests := []struct {
+		name         string
+		actorID      string
+		wantID       string
+		wantURL      string
+		domainInName bool
+		wantNil      bool
+	}{
+		{
+			name:         "foreign URL actor surfaces domain in name",
+			actorID:      "https://evil.example/users/admin",
+			wantID:       "https://evil.example/users/admin",
+			wantURL:      "https://evil.example/users/admin",
+			domainInName: true,
+		},
+		{
+			name:    "local bare username creates local URLs",
+			actorID: "alice",
+			wantURL: "https://lesser.example/@alice",
+		},
+		{
+			name:    "email-like address treated as opaque",
+			actorID: "admin@evil.example",
+			wantID:  "admin@evil.example",
+			// No wantURL — opaque IDs have no URL.
+		},
+		{
+			name:    "URL with userinfo is rejected",
+			actorID: "https://evil@lesser.example/users/admin",
+			wantNil: true,
+		},
+		{
+			name:    "URL with query string is rejected",
+			actorID: "https://evil.example/users/admin?evil=true",
+			wantNil: true,
+		},
+		{
+			name:    "URL with fragment is rejected",
+			actorID: "https://evil.example/users/admin#evil",
+			wantNil: true,
+		},
+		{
+			name:    "URL with non-http scheme is rejected",
+			actorID: "javascript://evil.example/users/admin",
+			wantNil: true,
+		},
+		{
+			name:    "actorID with control characters is rejected",
+			actorID: "admin\x00evil",
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actor := h.fallbackNotificationActor(tt.actorID)
+			if tt.wantNil {
+				assert.Nil(t, actor, "expected nil for %q", tt.actorID)
+				return
+			}
+			require.NotNil(t, actor, "unexpected nil for %q", tt.actorID)
+
+			if tt.wantID != "" {
+				assert.Equal(t, tt.wantID, actor.ID)
+			}
+			if tt.wantURL != "" {
+				assert.Equal(t, tt.wantURL, actor.URL)
+			}
+			if tt.domainInName {
+				assert.True(t, strings.Contains(actor.Name, "@"),
+					"actor name for foreign URL should contain @domain, got %q", actor.Name)
+			}
+		})
+	}
+}
+
+// TestValidNotificationFallbackActorURL_RejectsDangerousSchemes verifies
+// that only http/https schemes are accepted for actor URLs used as
+// notification fallback actor IDs. (CSR-051 regression probe)
+func TestValidNotificationFallbackActorURL_RejectsDangerousSchemes(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		ok   bool
+	}{
+		{name: "https ok", url: "https://evil.example/users/admin", ok: true},
+		{name: "http ok", url: "http://evil.example/users/admin", ok: true},
+		{name: "javascript rejected", url: "javascript:alert(1)", ok: false},
+		{name: "data rejected", url: "data:text/html,<script>alert(1)</script>", ok: false},
+		{name: "ftp rejected", url: "ftp://evil.example/users/admin", ok: false},
+		{name: "empty host rejected", url: "https:///users/admin", ok: false},
+		{name: "userinfo rejected", url: "https://evil@evil.example/users/admin", ok: false},
+		{name: "query rejected", url: "https://evil.example/users/admin?q=1", ok: false},
+		{name: "fragment rejected", url: "https://evil.example/users/admin#x", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := url.Parse(tt.url)
+			require.NoError(t, err, "url.Parse should not error for %q", tt.url)
+			got := validNotificationFallbackActorURL(parsed)
+			assert.Equal(t, tt.ok, got, "validNotificationFallbackActorURL(%q) = %v, want %v", tt.url, got, tt.ok)
+		})
+	}
+}

--- a/cmd/api/handlers/notification_actor_fallback_test.go
+++ b/cmd/api/handlers/notification_actor_fallback_test.go
@@ -48,7 +48,9 @@ func TestFallbackNotificationActor(t *testing.T) {
 		require.Equal(t, "https://remote.example/users/bob", actor.ID)
 		require.Equal(t, "https://remote.example/users/bob", actor.URL)
 		require.Equal(t, "bob", actor.PreferredUsername)
-		require.Equal(t, "bob", actor.Name)
+		// CSR-051: foreign-domain URLs now surface the domain in Name
+		// to prevent the extracted username from being mistaken for a local user.
+		require.Equal(t, "bob@remote.example", actor.Name)
 	})
 
 	t.Run("url_parse_error_is_rejected", func(t *testing.T) {

--- a/cmd/objects/main.go
+++ b/cmd/objects/main.go
@@ -882,7 +882,14 @@ func (h *Handler) convertAppTheoryRequest(ctx *apptheory.Context) (*http.Request
 	// instance domain before using it for signature verification. This prevents
 	// forwarded-host spoofing where an attacker could inject a host header that
 	// matches their own signing key rather than the instance's expected host.
-	if err := common.ValidateRequestOriginDomain(ctx.Request.Headers, cfg.Domain); err != nil {
+	//
+	// When cfg is nil (unit tests without Lambda init), the domain is empty and
+	// ValidateRequestOriginDomain returns nil (no-op), preserving existing test behavior.
+	domain := ""
+	if cfg != nil {
+		domain = cfg.Domain
+	}
+	if err := common.ValidateRequestOriginDomain(ctx.Request.Headers, domain); err != nil {
 		return nil, fmt.Errorf("origin domain validation failed: %w", err)
 	}
 

--- a/cmd/objects/main.go
+++ b/cmd/objects/main.go
@@ -878,6 +878,14 @@ func (h *Handler) convertAppTheoryRequest(ctx *apptheory.Context) (*http.Request
 		return nil, errors.New("nil context")
 	}
 
+	// Validate that the origin reconstructed from forwarded headers matches the
+	// instance domain before using it for signature verification. This prevents
+	// forwarded-host spoofing where an attacker could inject a host header that
+	// matches their own signing key rather than the instance's expected host.
+	if err := common.ValidateRequestOriginDomain(ctx.Request.Headers, cfg.Domain); err != nil {
+		return nil, fmt.Errorf("origin domain validation failed: %w", err)
+	}
+
 	u := common.RequestURLFromHeaders(ctx.Request.Headers, ctx.Request.Path, ctx.Request.Query)
 
 	// Create request with context (no body for GET requests)

--- a/graph/notification_actor_round38_security_test.go
+++ b/graph/notification_actor_round38_security_test.go
@@ -1,0 +1,293 @@
+package graph
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/config"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoadNotificationActor_RejectsRemoteIdentityAsLocal verifies that
+// loadNotificationActor does not resolve a remote actor ID as a local
+// account. (CSR-038 regression probe)
+func TestLoadNotificationActor_RejectsRemoteIdentityAsLocal(t *testing.T) {
+	// A nil resolver without storage or accounts service should never
+	// resolve a remote actor ID to a local account.
+	r := &Resolver{
+		Config: &config.Config{Domain: "lesser.example"},
+	}
+
+	tests := []struct {
+		name    string
+		actorID string
+	}{
+		{
+			name:    "remote URL with foreign domain",
+			actorID: "https://evil.example/users/admin",
+		},
+		{
+			name:    "remote user@domain",
+			actorID: "admin@evil.example",
+		},
+		{
+			name:    "remote URL with @ prefix and foreign domain",
+			actorID: "https://evil.example/@admin",
+		},
+		{
+			name:    "remote user@domain with acct prefix",
+			actorID: "acct:admin@evil.example",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			notif := &models.Notification{
+				ActorID: tt.actorID,
+			}
+			actor := r.loadNotificationActor(context.Background(), notif)
+			// With no storage backend and a remote actorID, the result must
+			// be nil — we must never treat a remote identity as a local user.
+			assert.Nil(t, actor, "remote actor ID %q must not be resolved as a local actor", tt.actorID)
+		})
+	}
+}
+
+// TestLocalUsernameForLookup_RemoteDomainsNotLocal verifies that
+// localUsernameForLookup correctly rejects remote domains.
+// (CSR-038 regression probe)
+func TestLocalUsernameForLookup_RemoteDomainsNotLocal(t *testing.T) {
+	r := &Resolver{
+		Config: &config.Config{Domain: "lesser.example"},
+	}
+
+	tests := []struct {
+		name     string
+		actorID  string
+		wantUser string // empty means should return empty
+	}{
+		{
+			name:     "local user@domain extracts username",
+			actorID:  "alice@lesser.example",
+			wantUser: "alice",
+		},
+		{
+			name:     "remote user@domain returns empty",
+			actorID:  "alice@evil.example",
+			wantUser: "",
+		},
+		{
+			name:     "local URL returns username",
+			actorID:  "https://lesser.example/users/alice",
+			wantUser: "alice",
+		},
+		{
+			name:     "remote URL returns empty",
+			actorID:  "https://evil.example/users/alice",
+			wantUser: "",
+		},
+		{
+			name:     "bare username returns as-is",
+			actorID:  "alice",
+			wantUser: "alice",
+		},
+		{
+			name:     "username with @ prefix returns as-is",
+			actorID:  "@alice",
+			wantUser: "alice",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := r.localUsernameForLookup(tt.actorID)
+			if tt.wantUser == "" {
+				assert.Empty(t, got, "expected empty for %q", tt.actorID)
+			} else {
+				assert.Equal(t, tt.wantUser, got)
+			}
+		})
+	}
+}
+
+// TestExtractDomainFromActorURL verifies the helper extracts domain
+// correctly from various URL formats. (CSR-051 regression probe)
+func TestExtractDomainFromActorURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		rawURL string
+		want   string
+	}{
+		{name: "standard URL", rawURL: "https://evil.example/users/admin", want: "evil.example"},
+		{name: "URL with port", rawURL: "https://evil.example:8443/users/admin", want: "evil.example"},
+		{name: "empty", rawURL: "", want: ""},
+		{name: "not a URL", rawURL: "admin@evil.example", want: ""},
+		{name: "whitespace only", rawURL: "   ", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractDomainFromActorURL(tt.rawURL)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestFallbackNotificationActor_ForeignDomainSurfaced verifies that
+// the fallbackNotificationActor surfaces foreign domains in the actor
+// name when the actorID is a URL with a domain different from local.
+// (CSR-051 regression probe)
+func TestFallbackNotificationActor_ForeignDomainSurfaced(t *testing.T) {
+	r := &Resolver{
+		Config: &config.Config{
+			Domain: "lesser.example",
+		},
+	}
+
+	tests := []struct {
+		name         string
+		actorID      string
+		wantID       string
+		wantName     string
+		domainInName bool // whether name should contain @domain
+	}{
+		{
+			name:         "foreign URL actor gets domain in name",
+			actorID:      "https://evil.example/users/admin",
+			wantID:       "https://evil.example/users/admin",
+			domainInName: true,
+		},
+		{
+			name:         "local bare username does not get domain",
+			actorID:      "alice",
+			wantName:     "alice",
+			domainInName: false,
+		},
+		{
+			name:         "email-like address treated as opaque id",
+			actorID:      "admin@evil.example",
+			wantID:       "admin@evil.example",
+			domainInName: false,
+			// Opaque IDs don't get local URL endpoints.
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			notif := &models.Notification{
+				ActorID: tt.actorID,
+			}
+			actor := r.fallbackNotificationActor(notif)
+			require.NotNil(t, actor, "fallbackNotificationActor returned nil for %q", tt.actorID)
+
+			if tt.wantID != "" {
+				assert.Equal(t, tt.wantID, actor.ID)
+			}
+			if tt.wantName != "" {
+				assert.Equal(t, tt.wantName, actor.Name)
+			}
+			if tt.domainInName {
+				assert.True(t, strings.Contains(actor.Name, "@"),
+					"actor name for foreign URL %q should contain @domain, got %q", tt.actorID, actor.Name)
+			}
+		})
+	}
+}
+
+// TestFallbackNotificationActor_UsernameValidation verifies that
+// bare actor IDs are validated as ActivityPub usernames before being
+// used for local account lookups. (CSR-038 regression probe)
+func TestFallbackNotificationActor_UsernameValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		actorID string
+		valid   bool
+	}{
+		{name: "valid username", actorID: "alice", valid: true},
+		{name: "valid with underscore", actorID: "alice_wonder", valid: true},
+		{name: "valid with digits", actorID: "user123", valid: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := common.ValidateActivityPubUsername(strings.TrimPrefix(tt.actorID, "@"))
+			if tt.valid {
+				assert.NoError(t, err, "expected valid username %q", tt.actorID)
+			} else {
+				assert.Error(t, err, "expected invalid username %q", tt.actorID)
+			}
+		})
+	}
+}
+
+// TestConvertNotificationToGraphQL_CommunicationActorUsesEmailPlaceholder
+// verifies that communication notification actors are resolved through the
+// communication-specific path which handles email-style identifiers safely.
+// (CSR-051 regression probe)
+func TestConvertNotificationToGraphQL_CommunicationActorUsesEmailPlaceholder(t *testing.T) {
+	r := &Resolver{
+		Config: &config.Config{Domain: "lesser.example"},
+	}
+
+	// Communication notifications should use communicationNotificationActor
+	// which produces email-safe placeholders with no URL endpoints.
+	notif := &models.Notification{
+		ID:      "notif-1",
+		Type:    "communication:email",
+		ActorID: "sender@evil.example",
+		Data: map[string]interface{}{
+			"messageId": "msg-1",
+			"channel":   "email",
+			"from": map[string]interface{}{
+				"address":      "sender@evil.example",
+				"displayName":  "Evil Sender",
+				"soulAgentId":  "soul-1",
+			},
+		},
+	}
+
+	result := r.convertNotificationToGraphQL(context.Background(), notif)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Account)
+
+	// Email-placeholder actors must never have URL endpoints.
+	assert.Empty(t, result.Account.URL,
+		"email-placeholder actor must not have URL")
+	assert.Empty(t, result.Account.Inbox,
+		"email-placeholder actor must not have Inbox")
+	assert.Empty(t, result.Account.Outbox,
+		"email-placeholder actor must not have Outbox")
+
+	// The actor ID should be the email address.
+	assert.Equal(t, "sender@evil.example", result.Account.ID)
+}
+
+// TestBuildPlaceholderActor_ForeignDomainNotAssignedLocalEndpoints verifies
+// that buildPlaceholderActor does not assign local endpoints for foreign
+// domain URLs. (CSR-038 regression probe)
+func TestBuildPlaceholderActor_ForeignDomainNotAssignedLocalEndpoints(t *testing.T) {
+	r := &Resolver{
+		Config: &config.Config{Domain: "lesser.example"},
+	}
+
+	// A remote URL must be used as-is, without local endpoints.
+	actor := r.buildPlaceholderActor("https://evil.example/users/admin", "lesser.example")
+	require.NotNil(t, actor)
+
+	assert.Equal(t, "https://evil.example/users/admin", actor.ID)
+	assert.Empty(t, actor.Inbox, "foreign domain must not get local inbox")
+	assert.Empty(t, actor.Outbox, "foreign domain must not get local outbox")
+
+	// A bare username should get local endpoints.
+	localActor := r.buildPlaceholderActor("alice", "lesser.example")
+	require.NotNil(t, localActor)
+	assert.Contains(t, localActor.ID, "lesser.example")
+}
+
+// Ensure activitypub import is used (avoid unused import for test-only additions).
+var _ = activitypub.BaseObject{}

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -391,6 +391,9 @@ func (r *Resolver) loadNotificationActor(ctx context.Context, notif *models.Noti
 		return nil
 	}
 
+	if r.Registry == nil {
+		return nil
+	}
 	accountsService := r.Registry.Accounts()
 	if accountsService == nil {
 		return nil
@@ -406,8 +409,22 @@ func (r *Resolver) loadNotificationActor(ctx context.Context, notif *models.Noti
 	}
 
 	localUsername := r.localUsernameForLookup(actorID)
-	if localUsername == "" && !strings.Contains(actorID, "://") && !strings.Contains(strings.TrimPrefix(actorID, "@"), "@") {
-		localUsername = strings.TrimPrefix(actorID, "@")
+	if localUsername == "" {
+		// If the actorID has domain indicators (URL scheme or user@domain) and
+		// localUsernameForLookup ruled it out, this is a remote identity that must
+		// not be resolved through a local account lookup. Reject rather than
+		// silently mistaking a remote actor for a local one.
+		if strings.Contains(actorID, "://") || strings.Contains(strings.TrimPrefix(actorID, "@"), "@") {
+			return nil
+		}
+		// Bare actor IDs (no URL scheme, no @-domain) are valid only when they
+		// pass ActivityPub username validation. Unvalidated bare strings must not
+		// become local account lookup keys.
+		bareName := strings.TrimPrefix(actorID, "@")
+		if err := common.ValidateActivityPubUsername(bareName); err != nil {
+			return nil
+		}
+		localUsername = bareName
 	}
 	if localUsername == "" {
 		return nil
@@ -455,8 +472,10 @@ func (r *Resolver) fallbackNotificationActor(notif *models.Notification) *activi
 
 	username := extractUsernameFromActorIdentifier(rawID)
 	baseURL := ""
+	localDomain := ""
 	if r.Config != nil {
 		baseURL = strings.TrimSuffix(r.Config.BaseURL(), "/")
+		localDomain = strings.TrimSpace(r.Config.Domain)
 	}
 
 	actor := &activitypub.Actor{
@@ -470,7 +489,17 @@ func (r *Resolver) fallbackNotificationActor(notif *models.Notification) *activi
 	if strings.Contains(rawID, "://") {
 		actor.ID = rawID
 		actor.URL = rawID
-	} else if baseURL != "" && username != "" {
+		// For foreign-domain URLs, surface the domain in the actor name to
+		// prevent the extracted username from being mistaken for a local user.
+		if localDomain != "" && username != "" {
+			if actorDomain := extractDomainFromActorURL(rawID); actorDomain != "" && !strings.EqualFold(actorDomain, localDomain) {
+				actor.Name = username + "@" + actorDomain
+			}
+		}
+	} else if baseURL != "" && username != "" && !hasRemoteDomainIndicator(rawID, localDomain) {
+		// Create local URLs for bare usernames and local-domain handles.
+		// Remote user@domain and email-like identifiers with foreign domains
+		// are rejected from local URL creation and fall through to opaque IDs.
 		actor.ID = fmt.Sprintf("%s/users/%s", baseURL, username)
 		actor.URL = fmt.Sprintf("%s/@%s", baseURL, username)
 		actor.Inbox = fmt.Sprintf("%s/users/%s/inbox", baseURL, username)
@@ -490,6 +519,37 @@ func (r *Resolver) fallbackNotificationActor(notif *models.Notification) *activi
 	}
 
 	return actor
+}
+
+// extractDomainFromActorURL returns the hostname portion of an ActivityPub actor
+// URL in lowercase, or "" if the URL cannot be parsed.
+func extractDomainFromActorURL(rawURL string) string {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return ""
+	}
+	parsed, err := neturl.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+}
+
+// hasRemoteDomainIndicator returns true when the actorID has a domain indicator
+// (@ sign after optional leading @) that points to a non-local domain. This
+// prevents email-like and user@remote.domain actor IDs from being assigned
+// local instance endpoints. (CSR-051)
+func hasRemoteDomainIndicator(actorID, localDomain string) bool {
+	cleaned := strings.TrimPrefix(strings.TrimSpace(actorID), "@")
+	at := strings.LastIndex(cleaned, "@")
+	if at == -1 {
+		return false // no domain indicator at all
+	}
+	if strings.TrimSpace(localDomain) == "" {
+		return false // can't determine
+	}
+	domainPart := strings.TrimSpace(cleaned[at+1:])
+	return !strings.EqualFold(domainPart, strings.TrimSpace(localDomain))
 }
 
 func extractUsernameFromActorIdentifier(actorID string) string {

--- a/pkg/common/origin.go
+++ b/pkg/common/origin.go
@@ -178,32 +178,48 @@ func headerMapValue(headers map[string][]string, key string) string {
 	return ""
 }
 
-// ValidateRequestOriginDomain checks that the origin reconstructed from forwarded
-// headers matches the expected instance domain. This prevents forwarded-host spoofing
-// in federation-facing endpoints (actor, objects, inbox) where the reconstructed
-// origin feeds into ActivityPub HTTP Signature verification.
+// requestOriginHost returns the host from the request using the same reconstruction
+// semantics as RequestURLFromHeaders: forwarded headers take priority, then the
+// Host header is used as a safe fallback (same as RequestURLFromHeaders does at
+// lines 30–38). This ensures domain-binding validation (ValidateRequestOriginDomain)
+// and URL reconstruction (RequestURLFromHeaders) agree on which host to use.
+func requestOriginHost(headers map[string][]string) string {
+	// Forwarded headers first — matches OriginURLFromHeaders priority.
+	if origin := OriginURLFromHeaders(headers); origin != "" {
+		u, err := url.Parse(origin)
+		if err == nil && u != nil {
+			if host := strings.ToLower(strings.TrimSpace(u.Hostname())); host != "" {
+				return host
+			}
+		}
+	}
+	// Host header fallback — matches RequestURLFromHeaders lines 33–35.
+	if host, ok := normalizeForwardedHost(headerMapValue(headers, HostHeader)); ok {
+		u, err := url.Parse(SchemeHTTPS + "://" + host)
+		if err == nil && u != nil {
+			return strings.ToLower(strings.TrimSpace(u.Hostname()))
+		}
+	}
+	return ""
+}
+
+// ValidateRequestOriginDomain checks that the request origin host matches the
+// expected instance domain. Uses the same host reconstruction as
+// RequestURLFromHeaders (forwarded headers → Host header fallback) so that
+// Host-only requests reach existing auth/visibility gates rather than being
+// rejected early with a 400.
 //
 // Returns nil when validation passes or when localDomain is empty (caller cannot
-// bind without a known domain). Returns an error when the origin host differs from
-// the expected local domain.
+// bind without a known domain). Returns an error when the origin host cannot be
+// determined or differs from the expected local domain.
 func ValidateRequestOriginDomain(headers map[string][]string, localDomain string) error {
 	if strings.TrimSpace(localDomain) == "" {
 		return nil
 	}
 
-	origin := OriginURLFromHeaders(headers)
-	if origin == "" {
-		return errors.New("origin domain validation failed: no origin from forwarded headers")
-	}
-
-	u, err := url.Parse(origin)
-	if err != nil {
-		return fmt.Errorf("origin domain validation failed: invalid origin URL: %w", err)
-	}
-
-	originHost := strings.ToLower(strings.TrimSpace(u.Hostname()))
+	originHost := requestOriginHost(headers)
 	if originHost == "" {
-		return errors.New("origin domain validation failed: missing origin host")
+		return errors.New("origin domain validation failed: no origin host determinable")
 	}
 
 	expectedHost := strings.ToLower(strings.TrimSpace(localDomain))

--- a/pkg/common/origin.go
+++ b/pkg/common/origin.go
@@ -1,6 +1,8 @@
 package common // nolint:revive // "common" package name is acceptable for shared utilities
 
 import (
+	"errors"
+	"fmt"
 	"net"
 	"net/url"
 	"strconv"
@@ -174,4 +176,40 @@ func headerMapValue(headers map[string][]string, key string) string {
 		return strings.TrimSpace(values[0])
 	}
 	return ""
+}
+
+// ValidateRequestOriginDomain checks that the origin reconstructed from forwarded
+// headers matches the expected instance domain. This prevents forwarded-host spoofing
+// in federation-facing endpoints (actor, objects, inbox) where the reconstructed
+// origin feeds into ActivityPub HTTP Signature verification.
+//
+// Returns nil when validation passes or when localDomain is empty (caller cannot
+// bind without a known domain). Returns an error when the origin host differs from
+// the expected local domain.
+func ValidateRequestOriginDomain(headers map[string][]string, localDomain string) error {
+	if strings.TrimSpace(localDomain) == "" {
+		return nil
+	}
+
+	origin := OriginURLFromHeaders(headers)
+	if origin == "" {
+		return errors.New("origin domain validation failed: no origin from forwarded headers")
+	}
+
+	u, err := url.Parse(origin)
+	if err != nil {
+		return fmt.Errorf("origin domain validation failed: invalid origin URL: %w", err)
+	}
+
+	originHost := strings.ToLower(strings.TrimSpace(u.Hostname()))
+	if originHost == "" {
+		return errors.New("origin domain validation failed: missing origin host")
+	}
+
+	expectedHost := strings.ToLower(strings.TrimSpace(localDomain))
+	if originHost != expectedHost {
+		return fmt.Errorf("origin host %q does not match instance host %q", originHost, expectedHost)
+	}
+
+	return nil
 }

--- a/pkg/common/origin_round38_security_test.go
+++ b/pkg/common/origin_round38_security_test.go
@@ -72,12 +72,36 @@ func TestValidateRequestOriginDomain_BindsToInstanceDomain(t *testing.T) {
 			wantErr:     true, // normalizeForwardedHost rejects userinfo, so no origin
 		},
 		{
-			name: "no forwarded headers produces error",
+			name: "Host header matches (no forwarded headers)",
+			headers: map[string][]string{
+				"host": {"lesser.example"},
+			},
+			localDomain: "lesser.example",
+			wantErr:     false,
+		},
+		{
+			name: "Host header mismatches (no forwarded headers)",
 			headers: map[string][]string{
 				"host": {"internal.execute-api.us-east-1.amazonaws.com"},
 			},
 			localDomain: "lesser.example",
 			wantErr:     true,
+			errContains: "does not match instance host",
+		},
+		{
+			name: "Host header with port matches (no forwarded headers)",
+			headers: map[string][]string{
+				"host": {"lesser.example:8443"},
+			},
+			localDomain: "lesser.example",
+			wantErr:     false,
+		},
+		{
+			name:        "no host determinable (neither forwarded nor Host headers)",
+			headers:     map[string][]string{},
+			localDomain: "lesser.example",
+			wantErr:     true,
+			errContains: "no origin host determinable",
 		},
 		{
 			name: "case-insensitive domain comparison",

--- a/pkg/common/origin_round38_security_test.go
+++ b/pkg/common/origin_round38_security_test.go
@@ -1,0 +1,159 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateRequestOriginDomain_BindsToInstanceDomain verifies that
+// forwarded-host origin validation correctly binds the reconstructed
+// origin to the expected instance domain. (CSR-043 regression probe)
+func TestValidateRequestOriginDomain_BindsToInstanceDomain(t *testing.T) {
+	tests := []struct {
+		name        string
+		headers     map[string][]string
+		localDomain string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "lesser forwarded host matches",
+			headers: map[string][]string{
+				"x-lesser-forwarded-host":  {"lesser.example"},
+				"x-lesser-forwarded-proto": {"https"},
+			},
+			localDomain: "lesser.example",
+			wantErr:     false,
+		},
+		{
+			name: "forwarded header host matches",
+			headers: map[string][]string{
+				"forwarded": {"for=198.51.100.22;proto=https;host=lesser.example"},
+			},
+			localDomain: "lesser.example",
+			wantErr:     false,
+		},
+		{
+			name: "x-forwarded-host matches",
+			headers: map[string][]string{
+				"x-forwarded-host":  {"lesser.example"},
+				"x-forwarded-proto": {"https"},
+			},
+			localDomain: "lesser.example",
+			wantErr:     false,
+		},
+		{
+			name: "mismatched domain is rejected",
+			headers: map[string][]string{
+				"x-lesser-forwarded-host":  {"evil.example"},
+				"x-lesser-forwarded-proto": {"https"},
+			},
+			localDomain: "lesser.example",
+			wantErr:     true,
+			errContains: "does not match instance host",
+		},
+		{
+			name: "empty local domain skips validation",
+			headers: map[string][]string{
+				"x-lesser-forwarded-host":  {"evil.example"},
+				"x-lesser-forwarded-proto": {"https"},
+			},
+			localDomain: "",
+			wantErr:     false,
+		},
+		{
+			name: "spoiler forwarded host with userinfo is ignored",
+			headers: map[string][]string{
+				"x-lesser-forwarded-host": {"evil@lesser.example"},
+			},
+			localDomain: "lesser.example",
+			wantErr:     true, // normalizeForwardedHost rejects userinfo, so no origin
+		},
+		{
+			name: "no forwarded headers produces error",
+			headers: map[string][]string{
+				"host": {"internal.execute-api.us-east-1.amazonaws.com"},
+			},
+			localDomain: "lesser.example",
+			wantErr:     true,
+		},
+		{
+			name: "case-insensitive domain comparison",
+			headers: map[string][]string{
+				"x-lesser-forwarded-host":  {"Lesser.Example"},
+				"x-lesser-forwarded-proto": {"https"},
+			},
+			localDomain: "lesser.example",
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateRequestOriginDomain(tt.headers, tt.localDomain)
+			if tt.wantErr {
+				require.Error(t, err, "expected error for %s", tt.name)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				assert.NoError(t, err, "unexpected error for %s: %v", tt.name, err)
+			}
+		})
+	}
+}
+
+// TestValidateRequestOriginDomain_RejectsMalformedHosts verifies that
+// malformed forwarded host values are rejected rather than trusted.
+// (CSR-043 regression probe)
+func TestValidateRequestOriginDomain_RejectsMalformedHosts(t *testing.T) {
+	malformedTests := []struct {
+		name    string
+		headers map[string][]string
+	}{
+		{
+			name: "host with path",
+			headers: map[string][]string{
+				"x-lesser-forwarded-host":  {"lesser.example/evil"},
+				"x-lesser-forwarded-proto": {"https"},
+			},
+		},
+		{
+			name: "host with query",
+			headers: map[string][]string{
+				"x-lesser-forwarded-host":  {"lesser.example?evil=true"},
+				"x-lesser-forwarded-proto": {"https"},
+			},
+		},
+		{
+			name: "host with fragment",
+			headers: map[string][]string{
+				"x-lesser-forwarded-host":  {"lesser.example#evil"},
+				"x-lesser-forwarded-proto": {"https"},
+			},
+		},
+		{
+			name: "host with control characters",
+			headers: map[string][]string{
+				"x-lesser-forwarded-host":  {"lesser.example\r\nEvil: header"},
+				"x-lesser-forwarded-proto": {"https"},
+			},
+		},
+		{
+			name: "host with spaces",
+			headers: map[string][]string{
+				"x-lesser-forwarded-host":  {"lesser.example evil.example"},
+				"x-lesser-forwarded-proto": {"https"},
+			},
+		},
+	}
+
+	for _, tt := range malformedTests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateRequestOriginDomain(tt.headers, "lesser.example")
+			require.Error(t, err, "malformed forwarded host %q must be rejected", tt.name)
+		})
+	}
+}

--- a/pkg/services/accounts/service.go
+++ b/pkg/services/accounts/service.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	neturl "net/url"
 	"reflect"
 	"strings"
 	"time"
@@ -253,8 +254,19 @@ func (s *Service) normalizeUsername(username string) string {
 	trimmed = strings.TrimPrefix(trimmed, "@")
 	trimmed = strings.TrimSuffix(trimmed, "/")
 
+	remoteDomain := ""
 	if strings.HasPrefix(trimmed, "https://") || strings.HasPrefix(trimmed, "http://") {
 		urlWithoutScheme := strings.TrimSuffix(trimmed, "/")
+
+		// Extract the remote domain before stripping the URL structure so we
+		// can reconstruct user@domain for remote actors. Without this step,
+		// https://remote.example/users/admin would normalize to "admin" and
+		// collide with a same-named local account. (CSR-052)
+		parsed, parseErr := neturl.Parse(urlWithoutScheme)
+		if parseErr == nil && parsed != nil && strings.TrimSpace(parsed.Hostname()) != "" && !s.isLocalDomain(parsed.Hostname()) {
+			remoteDomain = strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+		}
+
 		if idx := strings.Index(urlWithoutScheme, "/users/"); idx != -1 && idx+7 < len(urlWithoutScheme) {
 			trimmed = urlWithoutScheme[idx+7:]
 		} else if idx := strings.LastIndex(urlWithoutScheme, "/@"); idx != -1 && idx+2 < len(urlWithoutScheme) {
@@ -266,6 +278,11 @@ func (s *Service) normalizeUsername(username string) string {
 			}
 		}
 		trimmed = strings.TrimPrefix(trimmed, "@")
+	}
+
+	// Reconstruct user@domain for remote actors when the URL had a foreign host.
+	if remoteDomain != "" && !strings.Contains(trimmed, "@") {
+		trimmed = fmt.Sprintf("%s@%s", trimmed, remoteDomain)
 	}
 
 	if at := strings.LastIndex(trimmed, "@"); at != -1 {

--- a/pkg/services/accounts/service_round38_security_test.go
+++ b/pkg/services/accounts/service_round38_security_test.go
@@ -1,0 +1,135 @@
+package accounts
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+// TestNormalizeUsername_PreservesRemoteDomainForURLActors verifies that
+// the accounts service's normalizeUsername preserves remote domains for
+// URL-format actor identifiers, preventing a same-named remote actor
+// from being resolved as a local account. (CSR-052 regression probe)
+func TestNormalizeUsername_PreservesRemoteDomainForURLActors(t *testing.T) {
+	svc := NewService(nil, nil, nil, nil, nil, zap.NewNop(), "lesser.example")
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		// Remote URL actors must preserve the domain.
+		{
+			name:     "remote users URL",
+			input:    "https://evil.example/users/admin",
+			expected: "admin@evil.example",
+		},
+		{
+			name:     "remote URL with @ prefix",
+			input:    "https://evil.example/@admin",
+			expected: "admin@evil.example",
+		},
+		{
+			name:     "remote URL with actors path",
+			input:    "https://remote.social/actors/admin",
+			expected: "admin@remote.social",
+		},
+		{
+			name:     "remote URL with trailing slash",
+			input:    "https://evil.example/users/admin/",
+			expected: "admin@evil.example",
+		},
+
+		// Local URL actors should NOT preserve the domain (it's local).
+		{
+			name:     "local users URL drops domain",
+			input:    "https://lesser.example/users/alice",
+			expected: "alice",
+		},
+		{
+			name:     "local URL with @ prefix drops domain",
+			input:    "https://lesser.example/@alice",
+			expected: "alice",
+		},
+
+		// Handle (user@domain) format.
+		{
+			name:     "remote handle preserves domain",
+			input:    "Alice@Evil.Example",
+			expected: "alice@evil.example",
+		},
+		{
+			name:     "local handle drops domain",
+			input:    "alice@lesser.example",
+			expected: "alice",
+		},
+
+		// Bare usernames (no domain indicator).
+		{
+			name:     "bare username unchanged",
+			input:    "alice",
+			expected: "alice",
+		},
+		{
+			name:     "bare username with @ prefix",
+			input:    "@alice",
+			expected: "alice",
+		},
+
+		// Edge cases.
+		{
+			name:     "acct prefix with remote handle",
+			input:    "acct:admin@evil.example",
+			expected: "admin@evil.example",
+		},
+		{
+			name:     "empty string",
+			input:    "   ",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := svc.normalizeUsername(tt.input)
+			assert.Equal(t, tt.expected, got,
+				"normalizeUsername(%q) = %q, want %q", tt.input, got, tt.expected)
+
+			// Additional assertion: remote URLs must never normalize to a
+			// bare username (no @ sign) when the domain is not local.
+			if strings.HasPrefix(tt.input, "https://") || strings.HasPrefix(tt.input, "http://") {
+				if strings.Contains(tt.expected, "@") {
+					// Remote domain preserved — correct.
+				} else if tt.expected != "" {
+					// The result is a bare username. It must only happen for
+					// local-domain URLs.
+					assert.True(t,
+						strings.Contains(strings.ToLower(tt.input), "lesser.example"),
+						"URL input %q normalized to bare username %q but domain is not local",
+						tt.input, tt.expected)
+				}
+			}
+		})
+	}
+}
+
+// TestNormalizeUsername_RemoteDomainCannotCollideWithLocal verifies that
+// a remote actor URL with the same username as a local account produces
+// a different normalized form (user@domain vs user), preventing
+// identity collision. (CSR-052 regression probe)
+func TestNormalizeUsername_RemoteDomainCannotCollideWithLocal(t *testing.T) {
+	svc := NewService(nil, nil, nil, nil, nil, zap.NewNop(), "lesser.example")
+
+	// Same username, different domains.
+	localResult := svc.normalizeUsername("admin@lesser.example")
+	remoteResult := svc.normalizeUsername("https://evil.example/users/admin")
+
+	assert.Equal(t, "admin", localResult,
+		"local user@domain should resolve to bare username")
+	assert.Equal(t, "admin@evil.example", remoteResult,
+		"remote URL must preserve domain to prevent collision")
+	assert.NotEqual(t, localResult, remoteResult,
+		"local and remote actors with same username must have different normalized forms")
+}


### PR DESCRIPTION
## Summary

Fixes four Codex Security Remediation May 2026 findings under M1.3 (Identity Canonicalization):

- **CSR-038** (medium) — Tightened `loadNotificationActor` to reject remote actor IDs as local accounts. Added nil-safety for Registry. Added domain-aware name formatting in `fallbackNotificationActor`.
- **CSR-043** (medium) — Added `ValidateRequestOriginDomain` in `pkg/common/origin.go` and wired it into `cmd/actor` and `cmd/objects` signature verification paths, matching the inbox's existing `validateInboundSignatureHost`.
- **CSR-051** (low) — Both REST and GraphQL `fallbackNotificationActor` now surface foreign domains in `actor.Name` for URL-format actor IDs. Added `hasRemoteDomainIndicator` helper so local `user@domain` handles still get local URLs while remote ones become opaque.
- **CSR-052** (low) — Fixed accounts `Service.normalizeUsername` to preserve remote domains for URL-format actor identifiers, matching `AccountRepository.normalizeUsername` behavior. Without this, `https://evil.example/users/admin` normalizes to `admin` and collides with a local account.

### Per-CSR Disposition

| CSR | Severity | Disposition | Evidence |
|-----|----------|-------------|----------|
| CSR-038 | medium | **fix** | Tightened `loadNotificationActor`, added `ValidateActivityPubUsername` gate, added nil-safety |
| CSR-043 | medium | **fix** | Added `ValidateRequestOriginDomain` + wired into actor/objects handlers |
| CSR-051 | low | **fix** | Foreign domain surfaced in actor name; `hasRemoteDomainIndicator` for user@domain guard |
| CSR-052 | low | **fix** | `Service.normalizeUsername` now preserves remote domains for URL actor IDs |

### Behavior Change Callout

- **CSR-051**: Foreign-domain URL actor IDs now display `user@remote.example` in `actor.Name` instead of just `user`. `actor.PreferredUsername` remains unchanged. This is a deliberate security tightening — the previous behavior could make a remote `https://evil.example/users/admin` notification look identical to a local `admin` notification.
- **CSR-051**: Email-like actor IDs with non-local domains (e.g. `admin@evil.example`) no longer get local instance URL endpoints. They are treated as opaque IDs.

### Test Plan

- [x] `pkg/common`: `TestValidateRequestOriginDomain_BindsToInstanceDomain`, `TestValidateRequestOriginDomain_RejectsMalformedHosts`
- [x] `pkg/services/accounts`: `TestNormalizeUsername_PreservesRemoteDomainForURLActors`, `TestNormalizeUsername_RemoteDomainCannotCollideWithLocal`
- [x] `graph`: `TestLoadNotificationActor_RejectsRemoteIdentityAsLocal`, `TestLocalUsernameForLookup_RemoteDomainsNotLocal`, `TestFallbackNotificationActor_ForeignDomainSurfaced`, `TestBuildPlaceholderActor_ForeignDomainNotAssignedLocalEndpoints`, `TestConvertNotificationToGraphQL_CommunicationActorUsesEmailPlaceholder`
- [x] `cmd/api/handlers`: `TestFallbackNotificationActor_ForeignDomainSurfaced`, `TestValidNotificationFallbackActorURL_RejectsDangerousSchemes`
- [x] Existing tests updated to reflect deliberate security tightening
- [x] Full `go build ./...` passes

### Validation

```
go build ./...                         # PASS
go test ./pkg/common/...               # PASS (0.366s)
go test ./pkg/services/accounts/...    # PASS (0.718s)
go test ./graph/... -run "TestFallback|TestExtract|TestNotification|TestLoad|TestLocal|TestBuild|TestConvert"  # PASS
go test ./cmd/api/handlers/... -run "TestFallback|TestValid"  # PASS
```

Full `./lesser verify ci` was not run locally due to time constraints (~30 min). Focused package tests all pass.

### Deferred Work

None. All four CSR findings have concrete fixes with regression tests.

Closes #1073