### PR TITLE
fix: enforce tombstone visibility boundaries for non-public objects (M2.1, CSR-030/040/050/053)

### DIFF
--- a/cmd/objects/main.go
+++ b/cmd/objects/main.go
@@ -440,11 +440,24 @@ func (h *Handler) handleTombstonedObject(ctx context.Context, lookupID, objectID
 }
 
 // handleTombstonedObjectVisible wraps handleTombstonedObject with visibility
-// enforcement. When the tombstone carries a non-empty AttributedTo, the
-// handler treats the original object as non-public and requires authorized-fetch
-// verification before returning the tombstone. Without an attributedTo the
-// tombstone is treated as public and returned unconditionally (backward
-// compatibility with tombstones created before the AttributedTo field was added).
+// enforcement. Visibility decisions are driven by the tombstone's IsPublic
+// field, which records whether the original object was publicly addressed
+// (To/CC contained https://www.w3.org/ns/activitystreams#Public).
+//
+// Public tombstones (IsPublic=true) are returned unconditionally — the original
+// object was public, so revealing its deletion is not a leak.
+//
+// Non-public tombstones (IsPublic=false) require authorized-fetch verification
+// with a verified actor matching the tombstone AttributedTo. This is a stricter
+// posture than live objects: for deleted non-public objects only the original
+// author can see the tombstone; followers and explicit recipients are not
+// granted access because the content is gone and the tombstone serves only to
+// signal deletion to the author's own federation peers.
+//
+// Legacy tombstones (IsPublic=false, AttributedTo="") were created before
+// visibility context was stored. They are treated conservatively: hidden when
+// authorized fetch is enabled without verification; shown otherwise (backward
+// compatibility).
 func (h *Handler) handleTombstonedObjectVisible(
 	ctx context.Context,
 	lookupID, objectID, requestID string,
@@ -468,10 +481,9 @@ func (h *Handler) handleTombstonedObjectVisible(
 			zap.String("request_id", requestID),
 			zap.Error(err),
 		)
-		// Even without tombstone details, if the object is tombstoned and
-		// authorized fetch is enabled, verify the requestor before returning
-		// a generic "deleted" response. This prevents leaking the existence
-		// of a deleted non-public object to unauthenticated requestors.
+		// Without tombstone details we cannot determine visibility. When
+		// authorized fetch is enabled, err on the side of hiding to avoid
+		// leaking a potentially non-public deletion.
 		if authorizedFetchEnabled && verifiedFetchActor == nil {
 			logger.Debug("suppressing tombstone response for unauthorized viewer",
 				zap.String("object_id", objectID),
@@ -482,13 +494,23 @@ func (h *Handler) handleTombstonedObjectVisible(
 		return objectsJSONError(http.StatusGone, fmt.Sprintf("object %s deleted", objectID)), true, nil
 	}
 
-	// If the tombstone carries an AttributedTo, the original object was
-	// attributed to a specific actor and must be treated as potentially
-	// non-public. Only allow the tombstone to be returned if authorized
-	// fetch is not enabled, or if the requestor is verified.
+	// Public tombstone: original object was publicly addressed. Return
+	// unconditionally — revealing that a public object was deleted is not
+	// a visibility leak.
+	if tombstone.IsPublic {
+		return h.handleTombstonedObject(ctx, lookupID, objectID, requestID, wantsHTML)
+	}
+
+	// Non-public tombstone: the original object's addressing did not include
+	// the public collection, so its deletion metadata must be gated.
+	//
+	// When the tombstone carries an AttributedTo, only the verified author
+	// may see it. When authorized fetch is globally disabled, even unsigned
+	// requests are hidden — consistent with live non-public object behavior
+	// (see TestHandleGetObject_PrivateVisibilityGate_Round29).
 	if strings.TrimSpace(tombstone.AttributedTo) != "" {
-		if authorizedFetchEnabled && verifiedFetchActor == nil {
-			logger.Debug("suppressing tombstone response for attributed object without authorization",
+		if !authorizedFetchEnabled {
+			logger.Debug("suppressing non-public tombstone when authorized fetch is disabled",
 				zap.String("object_id", objectID),
 				zap.String("attributed_to", tombstone.AttributedTo),
 				zap.String("request_id", requestID),
@@ -496,18 +518,40 @@ func (h *Handler) handleTombstonedObjectVisible(
 			return nil, false, nil
 		}
 
-		if verifiedFetchActor != nil {
-			actorID := objectsActorID(verifiedFetchActor)
-			if !objectsActorIdentifiersMatch(actorID, tombstone.AttributedTo) {
-				logger.Debug("suppressing tombstone response for non-author verified fetch",
-					zap.String("object_id", objectID),
-					zap.String("attributed_to", tombstone.AttributedTo),
-					zap.String("verified_actor_id", actorID),
-					zap.String("request_id", requestID),
-				)
-				return nil, false, nil
-			}
+		if verifiedFetchActor == nil {
+			logger.Debug("suppressing non-public tombstone for unverified viewer",
+				zap.String("object_id", objectID),
+				zap.String("attributed_to", tombstone.AttributedTo),
+				zap.String("request_id", requestID),
+			)
+			return nil, false, nil
 		}
+
+		actorID := objectsActorID(verifiedFetchActor)
+		if !objectsActorIdentifiersMatch(actorID, tombstone.AttributedTo) {
+			logger.Debug("suppressing non-public tombstone for non-author verified fetch",
+				zap.String("object_id", objectID),
+				zap.String("attributed_to", tombstone.AttributedTo),
+				zap.String("verified_actor_id", actorID),
+				zap.String("request_id", requestID),
+			)
+			return nil, false, nil
+		}
+
+		// Verified actor is the original author — allow the tombstone.
+		return h.handleTombstonedObject(ctx, lookupID, objectID, requestID, wantsHTML)
+	}
+
+	// Legacy tombstone: IsPublic is false (zero value) and AttributedTo is
+	// empty. These tombstones were created before visibility context was
+	// stored. When authorized fetch is enabled without verification, hide
+	// conservatively; otherwise show (backward compatibility).
+	if authorizedFetchEnabled && verifiedFetchActor == nil {
+		logger.Debug("suppressing legacy tombstone for unauthorized viewer",
+			zap.String("object_id", objectID),
+			zap.String("request_id", requestID),
+		)
+		return nil, false, nil
 	}
 
 	return h.handleTombstonedObject(ctx, lookupID, objectID, requestID, wantsHTML)

--- a/cmd/objects/main.go
+++ b/cmd/objects/main.go
@@ -254,7 +254,14 @@ func (h *Handler) HandleGetObject(ctx *apptheory.Context) (*apptheory.Response, 
 		zap.String("request_id", requestID),
 	)
 
-	if tombstoneResp, handled, tombErr := h.handleTombstonedObject(runCtx, lookupID, objectID, requestID, wantsHTML); handled {
+	// Try tombstone first (pre-fetch) with visibility enforcement.
+	// A tombstone carries AttributedTo; if non-empty the original object was
+	// attributed to a specific actor and its tombstone must not be returned
+	// before verifying authorized-fetch credentials.
+	if tombstoneResp, handled, tombErr := h.handleTombstonedObjectVisible(
+		runCtx, lookupID, objectID, requestID, wantsHTML,
+		authorizedFetchEnabled, verifiedFetchActor,
+	); handled {
 		return tombstoneResp, tombErr
 	}
 
@@ -262,7 +269,10 @@ func (h *Handler) HandleGetObject(ctx *apptheory.Context) (*apptheory.Response, 
 	objInterface, err := h.objectRepo.GetObject(runCtx, lookupID)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
-			if tombstoneResp, handled, tombErr := h.handleTombstonedObject(runCtx, lookupID, objectID, requestID, wantsHTML); handled {
+			if tombstoneResp, handled, tombErr := h.handleTombstonedObjectVisible(
+				runCtx, lookupID, objectID, requestID, wantsHTML,
+				authorizedFetchEnabled, verifiedFetchActor,
+			); handled {
 				return tombstoneResp, tombErr
 			}
 			logger.Debug("object not found",
@@ -427,6 +437,80 @@ func (h *Handler) handleTombstonedObject(ctx context.Context, lookupID, objectID
 		Deleted:    tombstone.Deleted.Format(time.RFC3339),
 	})
 	return resp, true, err
+}
+
+// handleTombstonedObjectVisible wraps handleTombstonedObject with visibility
+// enforcement. When the tombstone carries a non-empty AttributedTo, the
+// handler treats the original object as non-public and requires authorized-fetch
+// verification before returning the tombstone. Without an attributedTo the
+// tombstone is treated as public and returned unconditionally (backward
+// compatibility with tombstones created before the AttributedTo field was added).
+func (h *Handler) handleTombstonedObjectVisible(
+	ctx context.Context,
+	lookupID, objectID, requestID string,
+	wantsHTML bool,
+	authorizedFetchEnabled bool,
+	verifiedFetchActor *activitypub.Actor,
+) (*apptheory.Response, bool, error) {
+	if h.objectRepo == nil {
+		return nil, false, nil
+	}
+
+	tombstoned, err := h.objectRepo.IsTombstoned(ctx, lookupID)
+	if err != nil || !tombstoned {
+		return nil, false, nil
+	}
+
+	tombstone, err := h.objectRepo.GetTombstone(ctx, lookupID)
+	if err != nil {
+		logger.Warn("failed to load tombstone details for visibility check",
+			zap.String("object_id", objectID),
+			zap.String("request_id", requestID),
+			zap.Error(err),
+		)
+		// Even without tombstone details, if the object is tombstoned and
+		// authorized fetch is enabled, verify the requestor before returning
+		// a generic "deleted" response. This prevents leaking the existence
+		// of a deleted non-public object to unauthenticated requestors.
+		if authorizedFetchEnabled && verifiedFetchActor == nil {
+			logger.Debug("suppressing tombstone response for unauthorized viewer",
+				zap.String("object_id", objectID),
+				zap.String("request_id", requestID),
+			)
+			return nil, false, nil
+		}
+		return objectsJSONError(http.StatusGone, fmt.Sprintf("object %s deleted", objectID)), true, nil
+	}
+
+	// If the tombstone carries an AttributedTo, the original object was
+	// attributed to a specific actor and must be treated as potentially
+	// non-public. Only allow the tombstone to be returned if authorized
+	// fetch is not enabled, or if the requestor is verified.
+	if strings.TrimSpace(tombstone.AttributedTo) != "" {
+		if authorizedFetchEnabled && verifiedFetchActor == nil {
+			logger.Debug("suppressing tombstone response for attributed object without authorization",
+				zap.String("object_id", objectID),
+				zap.String("attributed_to", tombstone.AttributedTo),
+				zap.String("request_id", requestID),
+			)
+			return nil, false, nil
+		}
+
+		if verifiedFetchActor != nil {
+			actorID := objectsActorID(verifiedFetchActor)
+			if !objectsActorIdentifiersMatch(actorID, tombstone.AttributedTo) {
+				logger.Debug("suppressing tombstone response for non-author verified fetch",
+					zap.String("object_id", objectID),
+					zap.String("attributed_to", tombstone.AttributedTo),
+					zap.String("verified_actor_id", actorID),
+					zap.String("request_id", requestID),
+				)
+				return nil, false, nil
+			}
+		}
+	}
+
+	return h.handleTombstonedObject(ctx, lookupID, objectID, requestID, wantsHTML)
 }
 
 func (h *Handler) resolveObjectLookup(ctx *apptheory.Context) (string, string) {

--- a/cmd/objects/round12_objects_test.go
+++ b/cmd/objects/round12_objects_test.go
@@ -1561,297 +1561,297 @@ func TestObjectsSecurityHeaders_Round12(t *testing.T) {
 	require.Contains(t, resp.Headers["content-security-policy"][0], "script-src 'none'")
 }
 
-	// TestTombstoneVisibility_Round38 verifies tombstone visibility is governed by
-	// the IsPublic field, which records whether the original object was publicly
-	// addressed. Non-public tombstones are gated behind authorized fetch and
-	// author verification; public tombstones are returned unconditionally.
-	// This is consistent with live-object visibility semantics (see
-	// TestHandleGetObject_PrivateVisibilityGate_Round29). CSR-030 regression coverage.
-	func TestTombstoneVisibility_Round38(t *testing.T) {
-		origCfg := cfg
-		origLogger := logger
-		t.Cleanup(func() {
-			cfg = origCfg
-			logger = origLogger
-		})
+// TestTombstoneVisibility_Round38 verifies tombstone visibility is governed by
+// the IsPublic field, which records whether the original object was publicly
+// addressed. Non-public tombstones are gated behind authorized fetch and
+// author verification; public tombstones are returned unconditionally.
+// This is consistent with live-object visibility semantics (see
+// TestHandleGetObject_PrivateVisibilityGate_Round29). CSR-030 regression coverage.
+func TestTombstoneVisibility_Round38(t *testing.T) {
+	origCfg := cfg
+	origLogger := logger
+	t.Cleanup(func() {
+		cfg = origCfg
+		logger = origLogger
+	})
 
-		cfg = &config.Config{Domain: "example.com"}
-		logger = zap.NewNop()
+	cfg = &config.Config{Domain: "example.com"}
+	logger = zap.NewNop()
 
-		instanceRepo := &fakeInstanceRepo{
-			state: &storageModels.InstanceState{Locked: false},
-		}
-
-		deletedAt := time.Date(2026, time.May, 22, 10, 0, 0, 0, time.UTC)
-
-		t.Run("non-public attributed tombstone hidden when auth enabled and no signature", func(t *testing.T) {
-			objID := "https://example.com/users/alice/statuses/private-deleted"
-			objRepo := &fakeObjectRepo{
-				err:        errors.New("not found"),
-				tombstoned: true,
-				tombstone: &storageModels.Tombstone{
-					ID:           objID,
-					FormerType:   activitypub.NoteType,
-					Deleted:      deletedAt,
-					DeletedBy:    "https://example.com/users/alice",
-					AttributedTo: "https://example.com/users/alice",
-					IsPublic:     false,
-				},
-			}
-			h := &Handler{
-				instanceRepo: instanceRepo,
-				objectRepo:   objRepo,
-				authorizedFetchService: &fakeAuthorizedFetch{
-					enabled:   true,
-					verifyErr: errors.New("missing signature"),
-				},
-			}
-			resp, err := h.HandleGetObject(&apptheory.Context{
-				Request: apptheory.Request{
-					Method: http.MethodGet,
-					Path:   "/users/alice/statuses/private-deleted",
-					Headers: map[string][]string{
-						"accept": {"application/activity+json"},
-						"host":   {"example.com"},
-					},
-				},
-				Params: map[string]string{"username": "alice", "id": "private-deleted"},
-			})
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.Equal(t, http.StatusUnauthorized, resp.Status)
-		})
-
-		t.Run("non-public attributed tombstone hidden when authorized fetch is globally disabled", func(t *testing.T) {
-			// CSR-030 fix: non-public (IsPublic=false) attributed tombstone
-			// must NOT be returned to unsigned/public fetch even when authorized
-			// fetch is globally disabled. Consistent with
-			// TestHandleGetObject_PrivateVisibilityGate_Round29.
-			objID := "https://example.com/users/alice/statuses/private-deleted"
-			objRepo := &fakeObjectRepo{
-				err:        errors.New("not found"),
-				tombstoned: true,
-				tombstone: &storageModels.Tombstone{
-					ID:           objID,
-					FormerType:   activitypub.NoteType,
-					Deleted:      deletedAt,
-					DeletedBy:    "https://example.com/users/alice",
-					AttributedTo: "https://example.com/users/alice",
-					IsPublic:     false,
-				},
-			}
-			h := &Handler{
-				instanceRepo:           instanceRepo,
-				objectRepo:             objRepo,
-				authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
-			}
-			resp, err := h.HandleGetObject(&apptheory.Context{
-				Request: apptheory.Request{
-					Method:  http.MethodGet,
-					Path:    "/users/alice/statuses/private-deleted",
-					Headers: map[string][]string{"accept": {"application/activity+json"}},
-				},
-				Params: map[string]string{"username": "alice", "id": "private-deleted"},
-			})
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.Equal(t, http.StatusNotFound, resp.Status)
-		})
-
-		t.Run("public tombstone visible when authorized fetch is globally disabled", func(t *testing.T) {
-			// Publicly-addressed (IsPublic=true) tombstone is safe to show
-			// unconditionally. The original object was public.
-			objID := "https://example.com/users/alice/statuses/public-deleted"
-			objRepo := &fakeObjectRepo{
-				err:        errors.New("not found"),
-				tombstoned: true,
-				tombstone: &storageModels.Tombstone{
-					ID:           objID,
-					FormerType:   activitypub.NoteType,
-					Deleted:      deletedAt,
-					DeletedBy:    "https://example.com/users/alice",
-					AttributedTo: "https://example.com/users/alice",
-					IsPublic:     true,
-				},
-			}
-			h := &Handler{
-				instanceRepo:           instanceRepo,
-				objectRepo:             objRepo,
-				authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
-			}
-			resp, err := h.HandleGetObject(&apptheory.Context{
-				Request: apptheory.Request{
-					Method:  http.MethodGet,
-					Path:    "/users/alice/statuses/public-deleted",
-					Headers: map[string][]string{"accept": {"application/activity+json"}},
-				},
-				Params: map[string]string{"username": "alice", "id": "public-deleted"},
-			})
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.Equal(t, http.StatusGone, resp.Status)
-
-			var body map[string]any
-			require.NoError(t, json.Unmarshal(resp.Body, &body))
-			require.Equal(t, "Tombstone", body["type"])
-		})
-
-		t.Run("public tombstone visible when auth enabled and verified non-author requests", func(t *testing.T) {
-			// Public tombstone visible even to verified non-author.
-			objID := "https://example.com/users/alice/statuses/public-deleted"
-			objRepo := &fakeObjectRepo{
-				err:        errors.New("not found"),
-				tombstoned: true,
-				tombstone: &storageModels.Tombstone{
-					ID:           objID,
-					FormerType:   activitypub.NoteType,
-					Deleted:      deletedAt,
-					DeletedBy:    "https://example.com/users/alice",
-					AttributedTo: "https://example.com/users/alice",
-					IsPublic:     true,
-				},
-			}
-			h := &Handler{
-				instanceRepo: instanceRepo,
-				objectRepo:   objRepo,
-				authorizedFetchService: &fakeAuthorizedFetch{
-					enabled: true,
-					actor: &activitypub.Actor{
-						BaseObject: activitypub.BaseObject{ID: "https://example.com/users/bob"},
-					},
-				},
-			}
-			resp, err := h.HandleGetObject(&apptheory.Context{
-				Request: apptheory.Request{
-					Method: http.MethodGet,
-					Path:   "/users/alice/statuses/public-deleted",
-					Headers: map[string][]string{
-						"accept": {"application/activity+json"},
-						"host":   {"example.com"},
-					},
-				},
-				Params: map[string]string{"username": "alice", "id": "public-deleted"},
-			})
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.Equal(t, http.StatusGone, resp.Status)
-		})
-
-		t.Run("non-public tombstone shown when verified actor matches author", func(t *testing.T) {
-			objID := "https://example.com/users/alice/statuses/private-deleted"
-			objRepo := &fakeObjectRepo{
-				err:        errors.New("not found"),
-				tombstoned: true,
-				tombstone: &storageModels.Tombstone{
-					ID:           objID,
-					FormerType:   activitypub.NoteType,
-					Deleted:      deletedAt,
-					DeletedBy:    "https://example.com/users/alice",
-					AttributedTo: "https://example.com/users/alice",
-					IsPublic:     false,
-				},
-			}
-			h := &Handler{
-				instanceRepo: instanceRepo,
-				objectRepo:   objRepo,
-				authorizedFetchService: &fakeAuthorizedFetch{
-					enabled: true,
-					actor: &activitypub.Actor{
-						BaseObject: activitypub.BaseObject{
-							ID: "https://example.com/users/alice",
-						},
-					},
-				},
-			}
-			resp, err := h.HandleGetObject(&apptheory.Context{
-				Request: apptheory.Request{
-					Method: http.MethodGet,
-					Path:   "/users/alice/statuses/private-deleted",
-					Headers: map[string][]string{
-						"accept": {"application/activity+json"},
-						"host":   {"example.com"},
-					},
-				},
-				Params: map[string]string{"username": "alice", "id": "private-deleted"},
-			})
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.Equal(t, http.StatusGone, resp.Status)
-		})
-
-		t.Run("non-public tombstone hidden when verified actor does not match author", func(t *testing.T) {
-			objID := "https://example.com/users/alice/statuses/private-deleted"
-			objRepo := &fakeObjectRepo{
-				err:        errors.New("not found"),
-				tombstoned: true,
-				tombstone: &storageModels.Tombstone{
-					ID:           objID,
-					FormerType:   activitypub.NoteType,
-					Deleted:      deletedAt,
-					DeletedBy:    "https://example.com/users/alice",
-					AttributedTo: "https://example.com/users/alice",
-					IsPublic:     false,
-				},
-			}
-			h := &Handler{
-				instanceRepo: instanceRepo,
-				objectRepo:   objRepo,
-				authorizedFetchService: &fakeAuthorizedFetch{
-					enabled: true,
-					actor: &activitypub.Actor{
-						BaseObject: activitypub.BaseObject{
-							ID: "https://example.com/users/bob",
-						},
-					},
-				},
-			}
-			resp, err := h.HandleGetObject(&apptheory.Context{
-				Request: apptheory.Request{
-					Method: http.MethodGet,
-					Path:   "/users/alice/statuses/private-deleted",
-					Headers: map[string][]string{
-						"accept": {"application/activity+json"},
-						"host":   {"example.com"},
-					},
-				},
-				Params: map[string]string{"username": "alice", "id": "private-deleted"},
-			})
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.Equal(t, http.StatusNotFound, resp.Status)
-		})
-
-		t.Run("legacy tombstone without IsPublic or AttributedTo visible when auth disabled", func(t *testing.T) {
-			// Legacy tombstone (IsPublic=false zero-value, AttributedTo empty):
-			// backward compatible when authorized fetch is disabled.
-			objID := "https://example.com/objects/legacy-deleted"
-			objRepo := &fakeObjectRepo{
-				err:        errors.New("not found"),
-				tombstoned: true,
-				tombstone: &storageModels.Tombstone{
-					ID:           objID,
-					FormerType:   activitypub.NoteType,
-					Deleted:      deletedAt,
-					DeletedBy:    "https://example.com/users/alice",
-					AttributedTo: "",
-					IsPublic:     false,
-				},
-			}
-			h := &Handler{
-				instanceRepo:           instanceRepo,
-				objectRepo:             objRepo,
-				authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
-			}
-			resp, err := h.HandleGetObject(&apptheory.Context{
-				Request: apptheory.Request{
-					Method:  http.MethodGet,
-					Path:    "/objects/legacy-deleted",
-					Headers: map[string][]string{"accept": {"application/activity+json"}},
-				},
-				Params: map[string]string{"id": "legacy-deleted"},
-			})
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.Equal(t, http.StatusGone, resp.Status)
-		})
+	instanceRepo := &fakeInstanceRepo{
+		state: &storageModels.InstanceState{Locked: false},
 	}
+
+	deletedAt := time.Date(2026, time.May, 22, 10, 0, 0, 0, time.UTC)
+
+	t.Run("non-public attributed tombstone hidden when auth enabled and no signature", func(t *testing.T) {
+		objID := "https://example.com/users/alice/statuses/private-deleted"
+		objRepo := &fakeObjectRepo{
+			err:        errors.New("not found"),
+			tombstoned: true,
+			tombstone: &storageModels.Tombstone{
+				ID:           objID,
+				FormerType:   activitypub.NoteType,
+				Deleted:      deletedAt,
+				DeletedBy:    "https://example.com/users/alice",
+				AttributedTo: "https://example.com/users/alice",
+				IsPublic:     false,
+			},
+		}
+		h := &Handler{
+			instanceRepo: instanceRepo,
+			objectRepo:   objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{
+				enabled:   true,
+				verifyErr: errors.New("missing signature"),
+			},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method: http.MethodGet,
+				Path:   "/users/alice/statuses/private-deleted",
+				Headers: map[string][]string{
+					"accept": {"application/activity+json"},
+					"host":   {"example.com"},
+				},
+			},
+			Params: map[string]string{"username": "alice", "id": "private-deleted"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusUnauthorized, resp.Status)
+	})
+
+	t.Run("non-public attributed tombstone hidden when authorized fetch is globally disabled", func(t *testing.T) {
+		// CSR-030 fix: non-public (IsPublic=false) attributed tombstone
+		// must NOT be returned to unsigned/public fetch even when authorized
+		// fetch is globally disabled. Consistent with
+		// TestHandleGetObject_PrivateVisibilityGate_Round29.
+		objID := "https://example.com/users/alice/statuses/private-deleted"
+		objRepo := &fakeObjectRepo{
+			err:        errors.New("not found"),
+			tombstoned: true,
+			tombstone: &storageModels.Tombstone{
+				ID:           objID,
+				FormerType:   activitypub.NoteType,
+				Deleted:      deletedAt,
+				DeletedBy:    "https://example.com/users/alice",
+				AttributedTo: "https://example.com/users/alice",
+				IsPublic:     false,
+			},
+		}
+		h := &Handler{
+			instanceRepo:           instanceRepo,
+			objectRepo:             objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method:  http.MethodGet,
+				Path:    "/users/alice/statuses/private-deleted",
+				Headers: map[string][]string{"accept": {"application/activity+json"}},
+			},
+			Params: map[string]string{"username": "alice", "id": "private-deleted"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusNotFound, resp.Status)
+	})
+
+	t.Run("public tombstone visible when authorized fetch is globally disabled", func(t *testing.T) {
+		// Publicly-addressed (IsPublic=true) tombstone is safe to show
+		// unconditionally. The original object was public.
+		objID := "https://example.com/users/alice/statuses/public-deleted"
+		objRepo := &fakeObjectRepo{
+			err:        errors.New("not found"),
+			tombstoned: true,
+			tombstone: &storageModels.Tombstone{
+				ID:           objID,
+				FormerType:   activitypub.NoteType,
+				Deleted:      deletedAt,
+				DeletedBy:    "https://example.com/users/alice",
+				AttributedTo: "https://example.com/users/alice",
+				IsPublic:     true,
+			},
+		}
+		h := &Handler{
+			instanceRepo:           instanceRepo,
+			objectRepo:             objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method:  http.MethodGet,
+				Path:    "/users/alice/statuses/public-deleted",
+				Headers: map[string][]string{"accept": {"application/activity+json"}},
+			},
+			Params: map[string]string{"username": "alice", "id": "public-deleted"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusGone, resp.Status)
+
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "Tombstone", body["type"])
+	})
+
+	t.Run("public tombstone visible when auth enabled and verified non-author requests", func(t *testing.T) {
+		// Public tombstone visible even to verified non-author.
+		objID := "https://example.com/users/alice/statuses/public-deleted"
+		objRepo := &fakeObjectRepo{
+			err:        errors.New("not found"),
+			tombstoned: true,
+			tombstone: &storageModels.Tombstone{
+				ID:           objID,
+				FormerType:   activitypub.NoteType,
+				Deleted:      deletedAt,
+				DeletedBy:    "https://example.com/users/alice",
+				AttributedTo: "https://example.com/users/alice",
+				IsPublic:     true,
+			},
+		}
+		h := &Handler{
+			instanceRepo: instanceRepo,
+			objectRepo:   objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{
+				enabled: true,
+				actor: &activitypub.Actor{
+					BaseObject: activitypub.BaseObject{ID: "https://example.com/users/bob"},
+				},
+			},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method: http.MethodGet,
+				Path:   "/users/alice/statuses/public-deleted",
+				Headers: map[string][]string{
+					"accept": {"application/activity+json"},
+					"host":   {"example.com"},
+				},
+			},
+			Params: map[string]string{"username": "alice", "id": "public-deleted"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusGone, resp.Status)
+	})
+
+	t.Run("non-public tombstone shown when verified actor matches author", func(t *testing.T) {
+		objID := "https://example.com/users/alice/statuses/private-deleted"
+		objRepo := &fakeObjectRepo{
+			err:        errors.New("not found"),
+			tombstoned: true,
+			tombstone: &storageModels.Tombstone{
+				ID:           objID,
+				FormerType:   activitypub.NoteType,
+				Deleted:      deletedAt,
+				DeletedBy:    "https://example.com/users/alice",
+				AttributedTo: "https://example.com/users/alice",
+				IsPublic:     false,
+			},
+		}
+		h := &Handler{
+			instanceRepo: instanceRepo,
+			objectRepo:   objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{
+				enabled: true,
+				actor: &activitypub.Actor{
+					BaseObject: activitypub.BaseObject{
+						ID: "https://example.com/users/alice",
+					},
+				},
+			},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method: http.MethodGet,
+				Path:   "/users/alice/statuses/private-deleted",
+				Headers: map[string][]string{
+					"accept": {"application/activity+json"},
+					"host":   {"example.com"},
+				},
+			},
+			Params: map[string]string{"username": "alice", "id": "private-deleted"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusGone, resp.Status)
+	})
+
+	t.Run("non-public tombstone hidden when verified actor does not match author", func(t *testing.T) {
+		objID := "https://example.com/users/alice/statuses/private-deleted"
+		objRepo := &fakeObjectRepo{
+			err:        errors.New("not found"),
+			tombstoned: true,
+			tombstone: &storageModels.Tombstone{
+				ID:           objID,
+				FormerType:   activitypub.NoteType,
+				Deleted:      deletedAt,
+				DeletedBy:    "https://example.com/users/alice",
+				AttributedTo: "https://example.com/users/alice",
+				IsPublic:     false,
+			},
+		}
+		h := &Handler{
+			instanceRepo: instanceRepo,
+			objectRepo:   objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{
+				enabled: true,
+				actor: &activitypub.Actor{
+					BaseObject: activitypub.BaseObject{
+						ID: "https://example.com/users/bob",
+					},
+				},
+			},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method: http.MethodGet,
+				Path:   "/users/alice/statuses/private-deleted",
+				Headers: map[string][]string{
+					"accept": {"application/activity+json"},
+					"host":   {"example.com"},
+				},
+			},
+			Params: map[string]string{"username": "alice", "id": "private-deleted"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusNotFound, resp.Status)
+	})
+
+	t.Run("legacy tombstone without IsPublic or AttributedTo visible when auth disabled", func(t *testing.T) {
+		// Legacy tombstone (IsPublic=false zero-value, AttributedTo empty):
+		// backward compatible when authorized fetch is disabled.
+		objID := "https://example.com/objects/legacy-deleted"
+		objRepo := &fakeObjectRepo{
+			err:        errors.New("not found"),
+			tombstoned: true,
+			tombstone: &storageModels.Tombstone{
+				ID:           objID,
+				FormerType:   activitypub.NoteType,
+				Deleted:      deletedAt,
+				DeletedBy:    "https://example.com/users/alice",
+				AttributedTo: "",
+				IsPublic:     false,
+			},
+		}
+		h := &Handler{
+			instanceRepo:           instanceRepo,
+			objectRepo:             objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method:  http.MethodGet,
+				Path:    "/objects/legacy-deleted",
+				Headers: map[string][]string{"accept": {"application/activity+json"}},
+			},
+			Params: map[string]string{"id": "legacy-deleted"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusGone, resp.Status)
+	})
+}

--- a/cmd/objects/round12_objects_test.go
+++ b/cmd/objects/round12_objects_test.go
@@ -1561,221 +1561,297 @@ func TestObjectsSecurityHeaders_Round12(t *testing.T) {
 	require.Contains(t, resp.Headers["content-security-policy"][0], "script-src 'none'")
 }
 
-// TestTombstoneVisibility_Round38 verifies that tombstone responses for objects
-// with a non-empty AttributedTo field are not returned to unauthorized viewers
-// when authorized fetch is enabled. CSR-030 regression coverage.
-func TestTombstoneVisibility_Round38(t *testing.T) {
-	origCfg := cfg
-	origLogger := logger
-	t.Cleanup(func() {
-		cfg = origCfg
-		logger = origLogger
-	})
+	// TestTombstoneVisibility_Round38 verifies tombstone visibility is governed by
+	// the IsPublic field, which records whether the original object was publicly
+	// addressed. Non-public tombstones are gated behind authorized fetch and
+	// author verification; public tombstones are returned unconditionally.
+	// This is consistent with live-object visibility semantics (see
+	// TestHandleGetObject_PrivateVisibilityGate_Round29). CSR-030 regression coverage.
+	func TestTombstoneVisibility_Round38(t *testing.T) {
+		origCfg := cfg
+		origLogger := logger
+		t.Cleanup(func() {
+			cfg = origCfg
+			logger = origLogger
+		})
 
-	cfg = &config.Config{Domain: "example.com"}
-	logger = zap.NewNop()
+		cfg = &config.Config{Domain: "example.com"}
+		logger = zap.NewNop()
 
-	instanceRepo := &fakeInstanceRepo{
-		state: &storageModels.InstanceState{Locked: false},
+		instanceRepo := &fakeInstanceRepo{
+			state: &storageModels.InstanceState{Locked: false},
+		}
+
+		deletedAt := time.Date(2026, time.May, 22, 10, 0, 0, 0, time.UTC)
+
+		t.Run("non-public attributed tombstone hidden when auth enabled and no signature", func(t *testing.T) {
+			objID := "https://example.com/users/alice/statuses/private-deleted"
+			objRepo := &fakeObjectRepo{
+				err:        errors.New("not found"),
+				tombstoned: true,
+				tombstone: &storageModels.Tombstone{
+					ID:           objID,
+					FormerType:   activitypub.NoteType,
+					Deleted:      deletedAt,
+					DeletedBy:    "https://example.com/users/alice",
+					AttributedTo: "https://example.com/users/alice",
+					IsPublic:     false,
+				},
+			}
+			h := &Handler{
+				instanceRepo: instanceRepo,
+				objectRepo:   objRepo,
+				authorizedFetchService: &fakeAuthorizedFetch{
+					enabled:   true,
+					verifyErr: errors.New("missing signature"),
+				},
+			}
+			resp, err := h.HandleGetObject(&apptheory.Context{
+				Request: apptheory.Request{
+					Method: http.MethodGet,
+					Path:   "/users/alice/statuses/private-deleted",
+					Headers: map[string][]string{
+						"accept": {"application/activity+json"},
+						"host":   {"example.com"},
+					},
+				},
+				Params: map[string]string{"username": "alice", "id": "private-deleted"},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.Equal(t, http.StatusUnauthorized, resp.Status)
+		})
+
+		t.Run("non-public attributed tombstone hidden when authorized fetch is globally disabled", func(t *testing.T) {
+			// CSR-030 fix: non-public (IsPublic=false) attributed tombstone
+			// must NOT be returned to unsigned/public fetch even when authorized
+			// fetch is globally disabled. Consistent with
+			// TestHandleGetObject_PrivateVisibilityGate_Round29.
+			objID := "https://example.com/users/alice/statuses/private-deleted"
+			objRepo := &fakeObjectRepo{
+				err:        errors.New("not found"),
+				tombstoned: true,
+				tombstone: &storageModels.Tombstone{
+					ID:           objID,
+					FormerType:   activitypub.NoteType,
+					Deleted:      deletedAt,
+					DeletedBy:    "https://example.com/users/alice",
+					AttributedTo: "https://example.com/users/alice",
+					IsPublic:     false,
+				},
+			}
+			h := &Handler{
+				instanceRepo:           instanceRepo,
+				objectRepo:             objRepo,
+				authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
+			}
+			resp, err := h.HandleGetObject(&apptheory.Context{
+				Request: apptheory.Request{
+					Method:  http.MethodGet,
+					Path:    "/users/alice/statuses/private-deleted",
+					Headers: map[string][]string{"accept": {"application/activity+json"}},
+				},
+				Params: map[string]string{"username": "alice", "id": "private-deleted"},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.Equal(t, http.StatusNotFound, resp.Status)
+		})
+
+		t.Run("public tombstone visible when authorized fetch is globally disabled", func(t *testing.T) {
+			// Publicly-addressed (IsPublic=true) tombstone is safe to show
+			// unconditionally. The original object was public.
+			objID := "https://example.com/users/alice/statuses/public-deleted"
+			objRepo := &fakeObjectRepo{
+				err:        errors.New("not found"),
+				tombstoned: true,
+				tombstone: &storageModels.Tombstone{
+					ID:           objID,
+					FormerType:   activitypub.NoteType,
+					Deleted:      deletedAt,
+					DeletedBy:    "https://example.com/users/alice",
+					AttributedTo: "https://example.com/users/alice",
+					IsPublic:     true,
+				},
+			}
+			h := &Handler{
+				instanceRepo:           instanceRepo,
+				objectRepo:             objRepo,
+				authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
+			}
+			resp, err := h.HandleGetObject(&apptheory.Context{
+				Request: apptheory.Request{
+					Method:  http.MethodGet,
+					Path:    "/users/alice/statuses/public-deleted",
+					Headers: map[string][]string{"accept": {"application/activity+json"}},
+				},
+				Params: map[string]string{"username": "alice", "id": "public-deleted"},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.Equal(t, http.StatusGone, resp.Status)
+
+			var body map[string]any
+			require.NoError(t, json.Unmarshal(resp.Body, &body))
+			require.Equal(t, "Tombstone", body["type"])
+		})
+
+		t.Run("public tombstone visible when auth enabled and verified non-author requests", func(t *testing.T) {
+			// Public tombstone visible even to verified non-author.
+			objID := "https://example.com/users/alice/statuses/public-deleted"
+			objRepo := &fakeObjectRepo{
+				err:        errors.New("not found"),
+				tombstoned: true,
+				tombstone: &storageModels.Tombstone{
+					ID:           objID,
+					FormerType:   activitypub.NoteType,
+					Deleted:      deletedAt,
+					DeletedBy:    "https://example.com/users/alice",
+					AttributedTo: "https://example.com/users/alice",
+					IsPublic:     true,
+				},
+			}
+			h := &Handler{
+				instanceRepo: instanceRepo,
+				objectRepo:   objRepo,
+				authorizedFetchService: &fakeAuthorizedFetch{
+					enabled: true,
+					actor: &activitypub.Actor{
+						BaseObject: activitypub.BaseObject{ID: "https://example.com/users/bob"},
+					},
+				},
+			}
+			resp, err := h.HandleGetObject(&apptheory.Context{
+				Request: apptheory.Request{
+					Method: http.MethodGet,
+					Path:   "/users/alice/statuses/public-deleted",
+					Headers: map[string][]string{
+						"accept": {"application/activity+json"},
+						"host":   {"example.com"},
+					},
+				},
+				Params: map[string]string{"username": "alice", "id": "public-deleted"},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.Equal(t, http.StatusGone, resp.Status)
+		})
+
+		t.Run("non-public tombstone shown when verified actor matches author", func(t *testing.T) {
+			objID := "https://example.com/users/alice/statuses/private-deleted"
+			objRepo := &fakeObjectRepo{
+				err:        errors.New("not found"),
+				tombstoned: true,
+				tombstone: &storageModels.Tombstone{
+					ID:           objID,
+					FormerType:   activitypub.NoteType,
+					Deleted:      deletedAt,
+					DeletedBy:    "https://example.com/users/alice",
+					AttributedTo: "https://example.com/users/alice",
+					IsPublic:     false,
+				},
+			}
+			h := &Handler{
+				instanceRepo: instanceRepo,
+				objectRepo:   objRepo,
+				authorizedFetchService: &fakeAuthorizedFetch{
+					enabled: true,
+					actor: &activitypub.Actor{
+						BaseObject: activitypub.BaseObject{
+							ID: "https://example.com/users/alice",
+						},
+					},
+				},
+			}
+			resp, err := h.HandleGetObject(&apptheory.Context{
+				Request: apptheory.Request{
+					Method: http.MethodGet,
+					Path:   "/users/alice/statuses/private-deleted",
+					Headers: map[string][]string{
+						"accept": {"application/activity+json"},
+						"host":   {"example.com"},
+					},
+				},
+				Params: map[string]string{"username": "alice", "id": "private-deleted"},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.Equal(t, http.StatusGone, resp.Status)
+		})
+
+		t.Run("non-public tombstone hidden when verified actor does not match author", func(t *testing.T) {
+			objID := "https://example.com/users/alice/statuses/private-deleted"
+			objRepo := &fakeObjectRepo{
+				err:        errors.New("not found"),
+				tombstoned: true,
+				tombstone: &storageModels.Tombstone{
+					ID:           objID,
+					FormerType:   activitypub.NoteType,
+					Deleted:      deletedAt,
+					DeletedBy:    "https://example.com/users/alice",
+					AttributedTo: "https://example.com/users/alice",
+					IsPublic:     false,
+				},
+			}
+			h := &Handler{
+				instanceRepo: instanceRepo,
+				objectRepo:   objRepo,
+				authorizedFetchService: &fakeAuthorizedFetch{
+					enabled: true,
+					actor: &activitypub.Actor{
+						BaseObject: activitypub.BaseObject{
+							ID: "https://example.com/users/bob",
+						},
+					},
+				},
+			}
+			resp, err := h.HandleGetObject(&apptheory.Context{
+				Request: apptheory.Request{
+					Method: http.MethodGet,
+					Path:   "/users/alice/statuses/private-deleted",
+					Headers: map[string][]string{
+						"accept": {"application/activity+json"},
+						"host":   {"example.com"},
+					},
+				},
+				Params: map[string]string{"username": "alice", "id": "private-deleted"},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.Equal(t, http.StatusNotFound, resp.Status)
+		})
+
+		t.Run("legacy tombstone without IsPublic or AttributedTo visible when auth disabled", func(t *testing.T) {
+			// Legacy tombstone (IsPublic=false zero-value, AttributedTo empty):
+			// backward compatible when authorized fetch is disabled.
+			objID := "https://example.com/objects/legacy-deleted"
+			objRepo := &fakeObjectRepo{
+				err:        errors.New("not found"),
+				tombstoned: true,
+				tombstone: &storageModels.Tombstone{
+					ID:           objID,
+					FormerType:   activitypub.NoteType,
+					Deleted:      deletedAt,
+					DeletedBy:    "https://example.com/users/alice",
+					AttributedTo: "",
+					IsPublic:     false,
+				},
+			}
+			h := &Handler{
+				instanceRepo:           instanceRepo,
+				objectRepo:             objRepo,
+				authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
+			}
+			resp, err := h.HandleGetObject(&apptheory.Context{
+				Request: apptheory.Request{
+					Method:  http.MethodGet,
+					Path:    "/objects/legacy-deleted",
+					Headers: map[string][]string{"accept": {"application/activity+json"}},
+				},
+				Params: map[string]string{"id": "legacy-deleted"},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.Equal(t, http.StatusGone, resp.Status)
+		})
 	}
-
-	deletedAt := time.Date(2026, time.May, 22, 10, 0, 0, 0, time.UTC)
-
-	t.Run("tombstone with attributedTo hidden when verified actor missing with authorized fetch", func(t *testing.T) {
-		// When authorized fetch is enabled and verification returns "missing signature",
-		// the handler returns 401 before reaching the tombstone path.
-		// This is the normal enforcement: unverified requestors cannot see any
-		// ActivityPub objects (including tombstones) at all.
-		objID := "https://example.com/users/alice/statuses/private-deleted"
-		objRepo := &fakeObjectRepo{
-			err:        errors.New("not found"),
-			tombstoned: true,
-			tombstone: &storageModels.Tombstone{
-				ID:           objID,
-				FormerType:   activitypub.NoteType,
-				Deleted:      deletedAt,
-				DeletedBy:    "https://example.com/users/alice",
-				AttributedTo: "https://example.com/users/alice",
-			},
-		}
-		h := &Handler{
-			instanceRepo: instanceRepo,
-			objectRepo:   objRepo,
-			authorizedFetchService: &fakeAuthorizedFetch{
-				enabled:   true,
-				verifyErr: errors.New("missing signature"),
-			},
-		}
-		resp, err := h.HandleGetObject(&apptheory.Context{
-			Request: apptheory.Request{
-				Method: http.MethodGet,
-				Path:   "/users/alice/statuses/private-deleted",
-				Headers: map[string][]string{
-					"accept": {"application/activity+json"},
-					"host":   {"example.com"},
-				},
-			},
-			Params: map[string]string{"username": "alice", "id": "private-deleted"},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		// Authorized fetch is enabled, no valid signature → 401 rather than
-		// leaking the tombstone through the authorized-fetch gate.
-		require.Equal(t, http.StatusUnauthorized, resp.Status)
-	})
-
-	t.Run("tombstone with attributedTo shown when authorized fetch disabled", func(t *testing.T) {
-		objID := "https://example.com/users/alice/statuses/private-deleted"
-		objRepo := &fakeObjectRepo{
-			err:        errors.New("not found"),
-			tombstoned: true,
-			tombstone: &storageModels.Tombstone{
-				ID:           objID,
-				FormerType:   activitypub.NoteType,
-				Deleted:      deletedAt,
-				DeletedBy:    "https://example.com/users/alice",
-				AttributedTo: "https://example.com/users/alice",
-			},
-		}
-		h := &Handler{
-			instanceRepo:           instanceRepo,
-			objectRepo:             objRepo,
-			authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
-		}
-		resp, err := h.HandleGetObject(&apptheory.Context{
-			Request: apptheory.Request{
-				Method:  http.MethodGet,
-				Path:    "/users/alice/statuses/private-deleted",
-				Headers: map[string][]string{"accept": {"application/activity+json"}},
-			},
-			Params: map[string]string{"username": "alice", "id": "private-deleted"},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		// Authorized fetch is not enabled → even attributed tombstones are public.
-		require.Equal(t, http.StatusGone, resp.Status)
-
-		var body map[string]any
-		require.NoError(t, json.Unmarshal(resp.Body, &body))
-		require.Equal(t, "Tombstone", body["type"])
-	})
-
-	t.Run("tombstone without attributedTo visible regardless of auth state", func(t *testing.T) {
-		// Legacy tombstone with empty AttributedTo: backward compatible.
-		// These tombstones were created before the AttributedTo field existed,
-		// so the handler cannot determine the original author. When authorized
-		// fetch is disabled they remain publicly visible.
-		objID := "https://example.com/objects/legacy-deleted"
-		objRepo := &fakeObjectRepo{
-			err:        errors.New("not found"),
-			tombstoned: true,
-			tombstone: &storageModels.Tombstone{
-				ID:           objID,
-				FormerType:   activitypub.NoteType,
-				Deleted:      deletedAt,
-				DeletedBy:    "https://example.com/users/alice",
-				AttributedTo: "", // legacy tombstone without attributedTo
-			},
-		}
-		h := &Handler{
-			instanceRepo:           instanceRepo,
-			objectRepo:             objRepo,
-			authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
-		}
-		resp, err := h.HandleGetObject(&apptheory.Context{
-			Request: apptheory.Request{
-				Method:  http.MethodGet,
-				Path:    "/objects/legacy-deleted",
-				Headers: map[string][]string{"accept": {"application/activity+json"}},
-			},
-			Params: map[string]string{"id": "legacy-deleted"},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		require.Equal(t, http.StatusGone, resp.Status)
-	})
-
-	t.Run("tombstone with attributedTo shown when verified actor matches author", func(t *testing.T) {
-		objID := "https://example.com/users/alice/statuses/private-deleted"
-		objRepo := &fakeObjectRepo{
-			err:        errors.New("not found"),
-			tombstoned: true,
-			tombstone: &storageModels.Tombstone{
-				ID:           objID,
-				FormerType:   activitypub.NoteType,
-				Deleted:      deletedAt,
-				DeletedBy:    "https://example.com/users/alice",
-				AttributedTo: "https://example.com/users/alice",
-			},
-		}
-		h := &Handler{
-			instanceRepo: instanceRepo,
-			objectRepo:   objRepo,
-			authorizedFetchService: &fakeAuthorizedFetch{
-				enabled: true,
-				actor: &activitypub.Actor{
-					BaseObject: activitypub.BaseObject{
-						ID: "https://example.com/users/alice",
-					},
-				},
-			},
-		}
-		resp, err := h.HandleGetObject(&apptheory.Context{
-			Request: apptheory.Request{
-				Method: http.MethodGet,
-				Path:   "/users/alice/statuses/private-deleted",
-				Headers: map[string][]string{
-					"accept": {"application/activity+json"},
-					"host":   {"example.com"},
-				},
-			},
-			Params: map[string]string{"username": "alice", "id": "private-deleted"},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		// Author with verified signed fetch → tombstone allowed.
-		require.Equal(t, http.StatusGone, resp.Status)
-	})
-
-	t.Run("tombstone with attributedTo hidden when verified actor does not match author", func(t *testing.T) {
-		objID := "https://example.com/users/alice/statuses/private-deleted"
-		objRepo := &fakeObjectRepo{
-			err:        errors.New("not found"),
-			tombstoned: true,
-			tombstone: &storageModels.Tombstone{
-				ID:           objID,
-				FormerType:   activitypub.NoteType,
-				Deleted:      deletedAt,
-				DeletedBy:    "https://example.com/users/alice",
-				AttributedTo: "https://example.com/users/alice",
-			},
-		}
-		h := &Handler{
-			instanceRepo: instanceRepo,
-			objectRepo:   objRepo,
-			authorizedFetchService: &fakeAuthorizedFetch{
-				enabled: true,
-				actor: &activitypub.Actor{
-					BaseObject: activitypub.BaseObject{
-						ID: "https://example.com/users/bob", // different actor
-					},
-				},
-			},
-		}
-		resp, err := h.HandleGetObject(&apptheory.Context{
-			Request: apptheory.Request{
-				Method: http.MethodGet,
-				Path:   "/users/alice/statuses/private-deleted",
-				Headers: map[string][]string{
-					"accept": {"application/activity+json"},
-					"host":   {"example.com"},
-				},
-			},
-			Params: map[string]string{"username": "alice", "id": "private-deleted"},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		// Verified actor does not match the attributed author → tombstone hidden.
-		require.Equal(t, http.StatusNotFound, resp.Status)
-	})
-}

--- a/cmd/objects/round12_objects_test.go
+++ b/cmd/objects/round12_objects_test.go
@@ -1560,3 +1560,222 @@ func TestObjectsSecurityHeaders_Round12(t *testing.T) {
 	require.NotEmpty(t, resp.Headers["content-security-policy"])
 	require.Contains(t, resp.Headers["content-security-policy"][0], "script-src 'none'")
 }
+
+// TestTombstoneVisibility_Round38 verifies that tombstone responses for objects
+// with a non-empty AttributedTo field are not returned to unauthorized viewers
+// when authorized fetch is enabled. CSR-030 regression coverage.
+func TestTombstoneVisibility_Round38(t *testing.T) {
+	origCfg := cfg
+	origLogger := logger
+	t.Cleanup(func() {
+		cfg = origCfg
+		logger = origLogger
+	})
+
+	cfg = &config.Config{Domain: "example.com"}
+	logger = zap.NewNop()
+
+	instanceRepo := &fakeInstanceRepo{
+		state: &storageModels.InstanceState{Locked: false},
+	}
+
+	deletedAt := time.Date(2026, time.May, 22, 10, 0, 0, 0, time.UTC)
+
+	t.Run("tombstone with attributedTo hidden when verified actor missing with authorized fetch", func(t *testing.T) {
+		// When authorized fetch is enabled and verification returns "missing signature",
+		// the handler returns 401 before reaching the tombstone path.
+		// This is the normal enforcement: unverified requestors cannot see any
+		// ActivityPub objects (including tombstones) at all.
+		objID := "https://example.com/users/alice/statuses/private-deleted"
+		objRepo := &fakeObjectRepo{
+			err:        errors.New("not found"),
+			tombstoned: true,
+			tombstone: &storageModels.Tombstone{
+				ID:           objID,
+				FormerType:   activitypub.NoteType,
+				Deleted:      deletedAt,
+				DeletedBy:    "https://example.com/users/alice",
+				AttributedTo: "https://example.com/users/alice",
+			},
+		}
+		h := &Handler{
+			instanceRepo: instanceRepo,
+			objectRepo:   objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{
+				enabled:   true,
+				verifyErr: errors.New("missing signature"),
+			},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method: http.MethodGet,
+				Path:   "/users/alice/statuses/private-deleted",
+				Headers: map[string][]string{
+					"accept": {"application/activity+json"},
+					"host":   {"example.com"},
+				},
+			},
+			Params: map[string]string{"username": "alice", "id": "private-deleted"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		// Authorized fetch is enabled, no valid signature → 401 rather than
+		// leaking the tombstone through the authorized-fetch gate.
+		require.Equal(t, http.StatusUnauthorized, resp.Status)
+	})
+
+	t.Run("tombstone with attributedTo shown when authorized fetch disabled", func(t *testing.T) {
+		objID := "https://example.com/users/alice/statuses/private-deleted"
+		objRepo := &fakeObjectRepo{
+			err:        errors.New("not found"),
+			tombstoned: true,
+			tombstone: &storageModels.Tombstone{
+				ID:           objID,
+				FormerType:   activitypub.NoteType,
+				Deleted:      deletedAt,
+				DeletedBy:    "https://example.com/users/alice",
+				AttributedTo: "https://example.com/users/alice",
+			},
+		}
+		h := &Handler{
+			instanceRepo:           instanceRepo,
+			objectRepo:             objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method:  http.MethodGet,
+				Path:    "/users/alice/statuses/private-deleted",
+				Headers: map[string][]string{"accept": {"application/activity+json"}},
+			},
+			Params: map[string]string{"username": "alice", "id": "private-deleted"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		// Authorized fetch is not enabled → even attributed tombstones are public.
+		require.Equal(t, http.StatusGone, resp.Status)
+
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "Tombstone", body["type"])
+	})
+
+	t.Run("tombstone without attributedTo visible regardless of auth state", func(t *testing.T) {
+		// Legacy tombstone with empty AttributedTo: backward compatible.
+		// These tombstones were created before the AttributedTo field existed,
+		// so the handler cannot determine the original author. When authorized
+		// fetch is disabled they remain publicly visible.
+		objID := "https://example.com/objects/legacy-deleted"
+		objRepo := &fakeObjectRepo{
+			err:        errors.New("not found"),
+			tombstoned: true,
+			tombstone: &storageModels.Tombstone{
+				ID:           objID,
+				FormerType:   activitypub.NoteType,
+				Deleted:      deletedAt,
+				DeletedBy:    "https://example.com/users/alice",
+				AttributedTo: "", // legacy tombstone without attributedTo
+			},
+		}
+		h := &Handler{
+			instanceRepo:           instanceRepo,
+			objectRepo:             objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method:  http.MethodGet,
+				Path:    "/objects/legacy-deleted",
+				Headers: map[string][]string{"accept": {"application/activity+json"}},
+			},
+			Params: map[string]string{"id": "legacy-deleted"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusGone, resp.Status)
+	})
+
+	t.Run("tombstone with attributedTo shown when verified actor matches author", func(t *testing.T) {
+		objID := "https://example.com/users/alice/statuses/private-deleted"
+		objRepo := &fakeObjectRepo{
+			err:        errors.New("not found"),
+			tombstoned: true,
+			tombstone: &storageModels.Tombstone{
+				ID:           objID,
+				FormerType:   activitypub.NoteType,
+				Deleted:      deletedAt,
+				DeletedBy:    "https://example.com/users/alice",
+				AttributedTo: "https://example.com/users/alice",
+			},
+		}
+		h := &Handler{
+			instanceRepo: instanceRepo,
+			objectRepo:   objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{
+				enabled: true,
+				actor: &activitypub.Actor{
+					BaseObject: activitypub.BaseObject{
+						ID: "https://example.com/users/alice",
+					},
+				},
+			},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method: http.MethodGet,
+				Path:   "/users/alice/statuses/private-deleted",
+				Headers: map[string][]string{
+					"accept": {"application/activity+json"},
+					"host":   {"example.com"},
+				},
+			},
+			Params: map[string]string{"username": "alice", "id": "private-deleted"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		// Author with verified signed fetch → tombstone allowed.
+		require.Equal(t, http.StatusGone, resp.Status)
+	})
+
+	t.Run("tombstone with attributedTo hidden when verified actor does not match author", func(t *testing.T) {
+		objID := "https://example.com/users/alice/statuses/private-deleted"
+		objRepo := &fakeObjectRepo{
+			err:        errors.New("not found"),
+			tombstoned: true,
+			tombstone: &storageModels.Tombstone{
+				ID:           objID,
+				FormerType:   activitypub.NoteType,
+				Deleted:      deletedAt,
+				DeletedBy:    "https://example.com/users/alice",
+				AttributedTo: "https://example.com/users/alice",
+			},
+		}
+		h := &Handler{
+			instanceRepo: instanceRepo,
+			objectRepo:   objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{
+				enabled: true,
+				actor: &activitypub.Actor{
+					BaseObject: activitypub.BaseObject{
+						ID: "https://example.com/users/bob", // different actor
+					},
+				},
+			},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method: http.MethodGet,
+				Path:   "/users/alice/statuses/private-deleted",
+				Headers: map[string][]string{
+					"accept": {"application/activity+json"},
+					"host":   {"example.com"},
+				},
+			},
+			Params: map[string]string{"username": "alice", "id": "private-deleted"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		// Verified actor does not match the attributed author → tombstone hidden.
+		require.Equal(t, http.StatusNotFound, resp.Status)
+	})
+}

--- a/cmd/objects/round12_objects_test.go
+++ b/cmd/objects/round12_objects_test.go
@@ -1854,4 +1854,87 @@ func TestTombstoneVisibility_Round38(t *testing.T) {
 		require.NotNil(t, resp)
 		require.Equal(t, http.StatusGone, resp.Status)
 	})
+
+	t.Run("public tombstone with HTML Accept returns text response", func(t *testing.T) {
+		// When the client requests text/html, authorized fetch is not
+		// enforced and the tombstone handler returns a plain-text 410
+		// rather than an ActivityPub JSON tombstone payload.
+		objID := "https://example.com/users/alice/statuses/public-deleted"
+		objRepo := &fakeObjectRepo{
+			err:        errors.New("not found"),
+			tombstoned: true,
+			tombstone: &storageModels.Tombstone{
+				ID:           objID,
+				FormerType:   activitypub.NoteType,
+				Deleted:      deletedAt,
+				DeletedBy:    "https://example.com/users/alice",
+				AttributedTo: "https://example.com/users/alice",
+				IsPublic:     true,
+			},
+		}
+		h := &Handler{
+			instanceRepo:           instanceRepo,
+			objectRepo:             objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{enabled: true},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method: http.MethodGet,
+				Path:   "/users/alice/statuses/public-deleted",
+				Headers: map[string][]string{
+					"accept": {"text/html, application/activity+json"},
+					"host":   {"example.com"},
+				},
+			},
+			Params: map[string]string{"username": "alice", "id": "public-deleted"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusGone, resp.Status)
+		// wantsHTML path returns a plain-text deletion message, not JSON.
+		require.Contains(t, string(resp.Body), "deleted")
+	})
+
+	t.Run("tombstoned object with missing metadata returns 410 when auth disabled", func(t *testing.T) {
+		// IsTombstoned=true but GetTombstone returns an error because
+		// the tombstone metadata row is missing. With authorized fetch
+		// disabled the error fallthrough returns 410 Gone (safe because
+		// auth is off — we are not leaking visibility metadata).
+		objID := "https://example.com/objects/broken-tombstone"
+		objRepo := &fakeObjectRepo{
+			err:        errors.New("not found"),
+			tombstoned: true,
+			tombstone:  nil, // nil → GetTombstone returns "not found"
+		}
+		h := &Handler{
+			instanceRepo:           instanceRepo,
+			objectRepo:             objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method:  http.MethodGet,
+				Path:    objID,
+				Headers: map[string][]string{"accept": {"application/activity+json"}},
+			},
+			Params: map[string]string{"id": "broken-tombstone"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusGone, resp.Status)
+		require.Contains(t, string(resp.Body), "deleted")
+	})
+}
+
+// TestHandleTombstonedObjectVisible_NilRepoBranch_Round38 verifies the
+// nil-object-repo defensive guard in handleTombstonedObjectVisible returns
+// unhandled (handled=false) without panicking.
+func TestHandleTombstonedObjectVisible_NilRepoBranch_Round38(t *testing.T) {
+	h := &Handler{}
+	resp, handled, err := h.handleTombstonedObjectVisible(
+		context.Background(), "lookup", "object", "req", false, false, nil,
+	)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+	require.False(t, handled)
 }

--- a/pkg/services/notes/service.go
+++ b/pkg/services/notes/service.go
@@ -567,10 +567,36 @@ func (s *Service) replaceLocalNoteObjectProjectionWithTombstone(ctx context.Cont
 	}
 
 	attributedTo := ""
+	isPublic := false
 	if status != nil && status.Note != nil {
 		attributedTo = strings.TrimSpace(status.Note.AttributedTo)
+		// Preserve the original object's public-addressing state so the tombstone
+		// handler can apply visibility semantics consistent with live objects.
+		// A tombstone for a publicly-addressed object can be shown to anyone;
+		// a tombstone for a non-public object must be gated behind authorized
+		// fetch (same as the live-object visibility path in cmd/objects).
+		isPublic = noteIsPubliclyAddressed(status.Note)
 	}
-	return s.objectRepo.ReplaceObjectWithTombstone(ctx, objectID, activitypub.NoteType, s.localActorID(deleterID), attributedTo)
+	return s.objectRepo.ReplaceObjectWithTombstone(ctx, objectID, activitypub.NoteType, s.localActorID(deleterID), attributedTo, isPublic)
+}
+
+// noteIsPubliclyAddressed returns true when the note's To or CC recipients
+// contain the ActivityPub public addressing constant.
+func noteIsPubliclyAddressed(note *activitypub.Note) bool {
+	if note == nil {
+		return false
+	}
+	for _, recipient := range note.To {
+		if strings.TrimSpace(recipient) == activitypub.PublicAddress {
+			return true
+		}
+	}
+	for _, recipient := range note.CC {
+		if strings.TrimSpace(recipient) == activitypub.PublicAddress {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Service) localActorID(username string) string {

--- a/pkg/services/notes/service.go
+++ b/pkg/services/notes/service.go
@@ -565,7 +565,12 @@ func (s *Service) replaceLocalNoteObjectProjectionWithTombstone(ctx context.Cont
 	if objectID == "" {
 		return nil
 	}
-	return s.objectRepo.ReplaceObjectWithTombstone(ctx, objectID, activitypub.NoteType, s.localActorID(deleterID))
+
+	attributedTo := ""
+	if status != nil && status.Note != nil {
+		attributedTo = strings.TrimSpace(status.Note.AttributedTo)
+	}
+	return s.objectRepo.ReplaceObjectWithTombstone(ctx, objectID, activitypub.NoteType, s.localActorID(deleterID), attributedTo)
 }
 
 func (s *Service) localActorID(username string) string {

--- a/pkg/services/notes/service_round15_mainline_test.go
+++ b/pkg/services/notes/service_round15_mainline_test.go
@@ -1543,7 +1543,7 @@ func TestService_round15_local_note_object_projection_lifecycle(t *testing.T) {
 	accountRepo := &stubAccountRepo{domain: "example.com"}
 	objectRepo.On("CreateObject", mock.Anything, mock.Anything).Return(nil).Once()
 	objectRepo.On("UpdateObjectWithHistory", mock.Anything, mock.Anything, "https://example.com/users/alice").Return(nil).Once()
-	objectRepo.On("ReplaceObjectWithTombstone", mock.Anything, mock.Anything, activitypub.NoteType, "https://example.com/users/alice", "https://example.com/users/alice").Return(nil).Once()
+	objectRepo.On("ReplaceObjectWithTombstone", mock.Anything, mock.Anything, activitypub.NoteType, "https://example.com/users/alice", "https://example.com/users/alice", true).Return(nil).Once()
 	service := NewService(
 		statusRepo,
 		accountRepo,
@@ -1604,7 +1604,7 @@ func TestService_round15_local_note_object_projection_lifecycle(t *testing.T) {
 		StatusID:  created.Note.StatusID,
 		DeleterID: "alice",
 	}))
-	objectRepo.AssertCalled(t, "ReplaceObjectWithTombstone", mock.Anything, objectID, activitypub.NoteType, "https://example.com/users/alice", "https://example.com/users/alice")
+	objectRepo.AssertCalled(t, "ReplaceObjectWithTombstone", mock.Anything, objectID, activitypub.NoteType, "https://example.com/users/alice", "https://example.com/users/alice", true)
 	objectRepo.AssertExpectations(t)
 }
 

--- a/pkg/services/notes/service_round15_mainline_test.go
+++ b/pkg/services/notes/service_round15_mainline_test.go
@@ -1543,7 +1543,7 @@ func TestService_round15_local_note_object_projection_lifecycle(t *testing.T) {
 	accountRepo := &stubAccountRepo{domain: "example.com"}
 	objectRepo.On("CreateObject", mock.Anything, mock.Anything).Return(nil).Once()
 	objectRepo.On("UpdateObjectWithHistory", mock.Anything, mock.Anything, "https://example.com/users/alice").Return(nil).Once()
-	objectRepo.On("ReplaceObjectWithTombstone", mock.Anything, mock.Anything, activitypub.NoteType, "https://example.com/users/alice").Return(nil).Once()
+	objectRepo.On("ReplaceObjectWithTombstone", mock.Anything, mock.Anything, activitypub.NoteType, "https://example.com/users/alice", "https://example.com/users/alice").Return(nil).Once()
 	service := NewService(
 		statusRepo,
 		accountRepo,
@@ -1604,7 +1604,7 @@ func TestService_round15_local_note_object_projection_lifecycle(t *testing.T) {
 		StatusID:  created.Note.StatusID,
 		DeleterID: "alice",
 	}))
-	objectRepo.AssertCalled(t, "ReplaceObjectWithTombstone", mock.Anything, objectID, activitypub.NoteType, "https://example.com/users/alice")
+	objectRepo.AssertCalled(t, "ReplaceObjectWithTombstone", mock.Anything, objectID, activitypub.NoteType, "https://example.com/users/alice", "https://example.com/users/alice")
 	objectRepo.AssertExpectations(t)
 }
 

--- a/pkg/storage/interfaces/object.go
+++ b/pkg/storage/interfaces/object.go
@@ -82,8 +82,10 @@ type ObjectRepository interface {
 	// CleanupExpiredTombstones removes tombstones that have exceeded their TTL
 	CleanupExpiredTombstones(ctx context.Context, batchSize int) (int, error)
 
-	// ReplaceObjectWithTombstone atomically replaces an object with a tombstone
-	ReplaceObjectWithTombstone(ctx context.Context, objectID, formerType, deletedBy string) error
+	// ReplaceObjectWithTombstone atomically replaces an object with a tombstone.
+	// attributedTo is the original object's author actor ID; it is stored on the
+	// tombstone so that the tombstone handler can enforce visibility boundaries.
+	ReplaceObjectWithTombstone(ctx context.Context, objectID, formerType, deletedBy, attributedTo string) error
 
 	// ===== Update History Operations =====
 

--- a/pkg/storage/interfaces/object.go
+++ b/pkg/storage/interfaces/object.go
@@ -85,7 +85,10 @@ type ObjectRepository interface {
 	// ReplaceObjectWithTombstone atomically replaces an object with a tombstone.
 	// attributedTo is the original object's author actor ID; it is stored on the
 	// tombstone so that the tombstone handler can enforce visibility boundaries.
-	ReplaceObjectWithTombstone(ctx context.Context, objectID, formerType, deletedBy, attributedTo string) error
+	// isPublic records whether the original object was publicly addressed (To/CC
+	// contained https://www.w3.org/ns/activitystreams#Public), which determines
+	// whether the tombstone is visible without authorized-fetch verification.
+	ReplaceObjectWithTombstone(ctx context.Context, objectID, formerType, deletedBy, attributedTo string, isPublic bool) error
 
 	// ===== Update History Operations =====
 

--- a/pkg/storage/models/tombstone.go
+++ b/pkg/storage/models/tombstone.go
@@ -22,15 +22,15 @@ type Tombstone struct {
 	GSI2SK string `theorydb:"index:gsi2,sk,attr:gsi2SK,omitempty" json:"gsi2SK"` // DELETED#{timestamp}
 
 	// Core fields from legacy
-	ID           string    `theorydb:"attr:id" json:"id"`                             // Original object ID
-	Type         string    `theorydb:"attr:type" json:"type"`                         // Always "Tombstone"
-	FormerType   string    `theorydb:"attr:formerType" json:"formerType"`             // Original object type
-	Deleted      time.Time `theorydb:"attr:deleted" json:"deleted"`                   // When it was deleted
-	DeletedBy    string    `theorydb:"attr:deletedBy" json:"deletedBy"`               // Actor who deleted it
+	ID           string    `theorydb:"attr:id" json:"id"`                                         // Original object ID
+	Type         string    `theorydb:"attr:type" json:"type"`                                     // Always "Tombstone"
+	FormerType   string    `theorydb:"attr:formerType" json:"formerType"`                         // Original object type
+	Deleted      time.Time `theorydb:"attr:deleted" json:"deleted"`                               // When it was deleted
+	DeletedBy    string    `theorydb:"attr:deletedBy" json:"deletedBy"`                           // Actor who deleted it
 	AttributedTo string    `theorydb:"attr:attributedTo,omitempty" json:"attributedTo,omitempty"` // Original object's author actor ID
-	IsPublic     bool      `theorydb:"attr:isPublic" json:"isPublic"`                          // Whether the original object was publicly addressed
-	Summary      string    `theorydb:"attr:summary" json:"summary,omitempty"`         // Optional deletion reason
-	CreatedAt    time.Time `theorydb:"attr:createdAt" json:"CreatedAt"`               // When the tombstone was created
+	IsPublic     bool      `theorydb:"attr:isPublic" json:"isPublic"`                             // Whether the original object was publicly addressed
+	Summary      string    `theorydb:"attr:summary" json:"summary,omitempty"`                     // Optional deletion reason
+	CreatedAt    time.Time `theorydb:"attr:createdAt" json:"CreatedAt"`                           // When the tombstone was created
 
 	// TTL field for automatic cleanup after 30 days
 	TTL int64 `theorydb:"ttl,attr:ttl" json:"ttl"`

--- a/pkg/storage/models/tombstone.go
+++ b/pkg/storage/models/tombstone.go
@@ -28,6 +28,7 @@ type Tombstone struct {
 	Deleted      time.Time `theorydb:"attr:deleted" json:"deleted"`                   // When it was deleted
 	DeletedBy    string    `theorydb:"attr:deletedBy" json:"deletedBy"`               // Actor who deleted it
 	AttributedTo string    `theorydb:"attr:attributedTo,omitempty" json:"attributedTo,omitempty"` // Original object's author actor ID
+	IsPublic     bool      `theorydb:"attr:isPublic" json:"isPublic"`                          // Whether the original object was publicly addressed
 	Summary      string    `theorydb:"attr:summary" json:"summary,omitempty"`         // Optional deletion reason
 	CreatedAt    time.Time `theorydb:"attr:createdAt" json:"CreatedAt"`               // When the tombstone was created
 

--- a/pkg/storage/models/tombstone.go
+++ b/pkg/storage/models/tombstone.go
@@ -22,13 +22,14 @@ type Tombstone struct {
 	GSI2SK string `theorydb:"index:gsi2,sk,attr:gsi2SK,omitempty" json:"gsi2SK"` // DELETED#{timestamp}
 
 	// Core fields from legacy
-	ID         string    `theorydb:"attr:id" json:"id"`                     // Original object ID
-	Type       string    `theorydb:"attr:type" json:"type"`                 // Always "Tombstone"
-	FormerType string    `theorydb:"attr:formerType" json:"formerType"`     // Original object type
-	Deleted    time.Time `theorydb:"attr:deleted" json:"deleted"`           // When it was deleted
-	DeletedBy  string    `theorydb:"attr:deletedBy" json:"deletedBy"`       // Actor who deleted it
-	Summary    string    `theorydb:"attr:summary" json:"summary,omitempty"` // Optional deletion reason
-	CreatedAt  time.Time `theorydb:"attr:createdAt" json:"CreatedAt"`       // When the tombstone was created
+	ID           string    `theorydb:"attr:id" json:"id"`                             // Original object ID
+	Type         string    `theorydb:"attr:type" json:"type"`                         // Always "Tombstone"
+	FormerType   string    `theorydb:"attr:formerType" json:"formerType"`             // Original object type
+	Deleted      time.Time `theorydb:"attr:deleted" json:"deleted"`                   // When it was deleted
+	DeletedBy    string    `theorydb:"attr:deletedBy" json:"deletedBy"`               // Actor who deleted it
+	AttributedTo string    `theorydb:"attr:attributedTo,omitempty" json:"attributedTo,omitempty"` // Original object's author actor ID
+	Summary      string    `theorydb:"attr:summary" json:"summary,omitempty"`         // Optional deletion reason
+	CreatedAt    time.Time `theorydb:"attr:createdAt" json:"CreatedAt"`               // When the tombstone was created
 
 	// TTL field for automatic cleanup after 30 days
 	TTL int64 `theorydb:"ttl,attr:ttl" json:"ttl"`

--- a/pkg/storage/repositories/object_repository.go
+++ b/pkg/storage/repositories/object_repository.go
@@ -2498,14 +2498,15 @@ func (r *ObjectRepository) GetObjectHistory(ctx context.Context, objectID string
 }
 
 // ReplaceObjectWithTombstone atomically replaces an object with a tombstone
-func (r *ObjectRepository) ReplaceObjectWithTombstone(ctx context.Context, objectID, formerType, deletedBy string) error {
+func (r *ObjectRepository) ReplaceObjectWithTombstone(ctx context.Context, objectID, formerType, deletedBy, attributedTo string) error {
 	// Create tombstone
 	tombstone := &models.Tombstone{
-		ID:         objectID,
-		FormerType: formerType,
-		DeletedBy:  deletedBy,
-		Summary:    fmt.Sprintf("Object deleted by %s", deletedBy),
-		Deleted:    time.Now(),
+		ID:           objectID,
+		FormerType:   formerType,
+		DeletedBy:    deletedBy,
+		AttributedTo: strings.TrimSpace(attributedTo),
+		Summary:      fmt.Sprintf("Object deleted by %s", deletedBy),
+		Deleted:      time.Now(),
 	}
 
 	// First delete the original object

--- a/pkg/storage/repositories/object_repository.go
+++ b/pkg/storage/repositories/object_repository.go
@@ -2498,13 +2498,14 @@ func (r *ObjectRepository) GetObjectHistory(ctx context.Context, objectID string
 }
 
 // ReplaceObjectWithTombstone atomically replaces an object with a tombstone
-func (r *ObjectRepository) ReplaceObjectWithTombstone(ctx context.Context, objectID, formerType, deletedBy, attributedTo string) error {
+func (r *ObjectRepository) ReplaceObjectWithTombstone(ctx context.Context, objectID, formerType, deletedBy, attributedTo string, isPublic bool) error {
 	// Create tombstone
 	tombstone := &models.Tombstone{
 		ID:           objectID,
 		FormerType:   formerType,
 		DeletedBy:    deletedBy,
 		AttributedTo: strings.TrimSpace(attributedTo),
+		IsPublic:     isPublic,
 		Summary:      fmt.Sprintf("Object deleted by %s", deletedBy),
 		Deleted:      time.Now(),
 	}

--- a/pkg/storage/repositories/object_repository_additional_coverage_test.go
+++ b/pkg/storage/repositories/object_repository_additional_coverage_test.go
@@ -812,7 +812,7 @@ func TestObjectRepository_ReplaceObjectWithTombstone_WarnsOnDeleteError(t *testi
 
 	repo := NewObjectRepository(mockDB, "test-table", "example.com", zap.NewNop())
 
-	require.NoError(t, repo.ReplaceObjectWithTombstone(ctx, "note-1", activitypub.NoteType, "alice"))
+	require.NoError(t, repo.ReplaceObjectWithTombstone(ctx, "note-1", activitypub.NoteType, "alice", "alice"))
 }
 
 func TestObjectRepository_ErrorPathCoveragePush(t *testing.T) {

--- a/pkg/storage/repositories/object_repository_additional_coverage_test.go
+++ b/pkg/storage/repositories/object_repository_additional_coverage_test.go
@@ -812,7 +812,7 @@ func TestObjectRepository_ReplaceObjectWithTombstone_WarnsOnDeleteError(t *testi
 
 	repo := NewObjectRepository(mockDB, "test-table", "example.com", zap.NewNop())
 
-	require.NoError(t, repo.ReplaceObjectWithTombstone(ctx, "note-1", activitypub.NoteType, "alice", "alice"))
+	require.NoError(t, repo.ReplaceObjectWithTombstone(ctx, "note-1", activitypub.NoteType, "alice", "alice", true))
 }
 
 func TestObjectRepository_ErrorPathCoveragePush(t *testing.T) {

--- a/pkg/storage/repositories/object_repository_coverage_sweep_test.go
+++ b/pkg/storage/repositories/object_repository_coverage_sweep_test.go
@@ -366,5 +366,5 @@ func TestObjectRepository_CoverageSweep(t *testing.T) {
 
 	_, err = repo.GetObjectHistory(ctx, note.ID)
 	require.NoError(t, err)
-	require.NoError(t, repo.ReplaceObjectWithTombstone(ctx, note.ID, activitypub.NoteType, "alice"))
+	require.NoError(t, repo.ReplaceObjectWithTombstone(ctx, note.ID, activitypub.NoteType, "alice", note.AttributedTo))
 }

--- a/pkg/storage/repositories/object_repository_coverage_sweep_test.go
+++ b/pkg/storage/repositories/object_repository_coverage_sweep_test.go
@@ -366,5 +366,5 @@ func TestObjectRepository_CoverageSweep(t *testing.T) {
 
 	_, err = repo.GetObjectHistory(ctx, note.ID)
 	require.NoError(t, err)
-	require.NoError(t, repo.ReplaceObjectWithTombstone(ctx, note.ID, activitypub.NoteType, "alice", note.AttributedTo))
+	require.NoError(t, repo.ReplaceObjectWithTombstone(ctx, note.ID, activitypub.NoteType, "alice", note.AttributedTo, true))
 }

--- a/pkg/testing/inmemory/object_repository.go
+++ b/pkg/testing/inmemory/object_repository.go
@@ -542,7 +542,7 @@ func (r *ObjectRepository) CleanupExpiredTombstones(_ context.Context, batchSize
 }
 
 // ReplaceObjectWithTombstone atomically replaces an object with a tombstone
-func (r *ObjectRepository) ReplaceObjectWithTombstone(_ context.Context, objectID, formerType, deletedBy string) error {
+func (r *ObjectRepository) ReplaceObjectWithTombstone(_ context.Context, objectID, formerType, deletedBy, attributedTo string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -559,10 +559,11 @@ func (r *ObjectRepository) ReplaceObjectWithTombstone(_ context.Context, objectI
 
 	// Create tombstone
 	tombstone := &models.Tombstone{
-		ID:         objectID,
-		FormerType: formerType,
-		DeletedBy:  deletedBy,
-		Deleted:    time.Now(),
+		ID:           objectID,
+		FormerType:   formerType,
+		DeletedBy:    deletedBy,
+		AttributedTo: attributedTo,
+		Deleted:      time.Now(),
 	}
 
 	r.tombstones[objectID] = tombstone

--- a/pkg/testing/inmemory/object_repository.go
+++ b/pkg/testing/inmemory/object_repository.go
@@ -542,7 +542,7 @@ func (r *ObjectRepository) CleanupExpiredTombstones(_ context.Context, batchSize
 }
 
 // ReplaceObjectWithTombstone atomically replaces an object with a tombstone
-func (r *ObjectRepository) ReplaceObjectWithTombstone(_ context.Context, objectID, formerType, deletedBy, attributedTo string) error {
+func (r *ObjectRepository) ReplaceObjectWithTombstone(_ context.Context, objectID, formerType, deletedBy, attributedTo string, isPublic bool) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -563,6 +563,7 @@ func (r *ObjectRepository) ReplaceObjectWithTombstone(_ context.Context, objectI
 		FormerType:   formerType,
 		DeletedBy:    deletedBy,
 		AttributedTo: attributedTo,
+		IsPublic:     isPublic,
 		Deleted:      time.Now(),
 	}
 

--- a/pkg/testing/mocks/object_repository_mock.go
+++ b/pkg/testing/mocks/object_repository_mock.go
@@ -171,8 +171,8 @@ func (m *MockObjectRepository) CleanupExpiredTombstones(ctx context.Context, bat
 }
 
 // ReplaceObjectWithTombstone mocks the ReplaceObjectWithTombstone method
-func (m *MockObjectRepository) ReplaceObjectWithTombstone(ctx context.Context, objectID, formerType, deletedBy string) error {
-	args := m.Called(ctx, objectID, formerType, deletedBy)
+func (m *MockObjectRepository) ReplaceObjectWithTombstone(ctx context.Context, objectID, formerType, deletedBy, attributedTo string) error {
+	args := m.Called(ctx, objectID, formerType, deletedBy, attributedTo)
 	return args.Error(0)
 }
 

--- a/pkg/testing/mocks/object_repository_mock.go
+++ b/pkg/testing/mocks/object_repository_mock.go
@@ -171,8 +171,8 @@ func (m *MockObjectRepository) CleanupExpiredTombstones(ctx context.Context, bat
 }
 
 // ReplaceObjectWithTombstone mocks the ReplaceObjectWithTombstone method
-func (m *MockObjectRepository) ReplaceObjectWithTombstone(ctx context.Context, objectID, formerType, deletedBy, attributedTo string) error {
-	args := m.Called(ctx, objectID, formerType, deletedBy, attributedTo)
+func (m *MockObjectRepository) ReplaceObjectWithTombstone(ctx context.Context, objectID, formerType, deletedBy, attributedTo string, isPublic bool) error {
+	args := m.Called(ctx, objectID, formerType, deletedBy, attributedTo, isPublic)
 	return args.Error(0)
 }
 


### PR DESCRIPTION
## Summary

- **CSR-030 (fixed):** Tombstone responses now carry enough original visibility context to avoid leaking non-public deletion metadata. New tombstones store both the original `AttributedTo` actor and whether the original note was publicly addressed (`IsPublic`). Public tombstones can still return `410 Gone`; non-public tombstones are hidden from unsigned/public fetch even when authorized fetch is globally disabled, and are only returned to the verified original author when authorized fetch is enabled.
- **CSR-040 (stale/false-positive):** Notification get uses user-scoped `GetUserNotification` plus `notificationObjectVisibleToViewer` / `notificationSnapshotVisibleToViewer` visibility enforcement. No bypass path found in current code.
- **CSR-050 (stale/false-positive):** Notification list uses the same conversion and visibility checks as single-notification get through `convertNotificationViewToAPI`. No bypass path found in current code.
- **CSR-053 (stale/false-positive):** Hashtag indexing is public-only at production entry points via `isPublicHashtagVisibility`; analytics `RecordHashtagUsage` is trends-only and not public hashtag timeline exposure.

## Changes

- `pkg/storage/models/tombstone.go` — add `AttributedTo` and `IsPublic` tombstone metadata.
- `pkg/storage/interfaces/object.go`, `pkg/storage/repositories/object_repository.go`, `pkg/testing/*` — update `ReplaceObjectWithTombstone` signature and storage/mocks/in-memory behavior.
- `pkg/services/notes/service.go` — preserve original note public-addressing state when replacing the local note projection with a tombstone.
- `cmd/objects/main.go` — gate tombstone responses through `handleTombstonedObjectVisible` before returning `410 Gone`.
- `cmd/objects/round12_objects_test.go` — add CSR-030 regression coverage for public, non-public, author-verified, non-author, auth-disabled, and legacy tombstone cases.

## Validation

Steward validation:

```bash
go test ./cmd/objects/... ./pkg/services/notes/... ./pkg/storage/models/... ./pkg/storage/repositories/... -count=1
go test ./cmd/api/handlers ./pkg/services/notifications ./pkg/storage/repositories -run 'Notification|Hashtag|Visibility|Tombstone|ReplaceObjectWithTombstone|GetUserNotification|GetUserNotifications' -count=1
go test ./cmd/objects -run 'TestHandleGetObject_PrivateVisibilityGate_Round29|TestTombstoneVisibility_Round38' -count=1
```

Arch local validation at `19c2a3f656bb5800800e654d0ace2677eb427df1`:

```bash
gofmt -l <changed Go files>
go test ./cmd/objects/... ./pkg/services/notes/... ./pkg/storage/models/... ./pkg/storage/repositories/... -count=1
go test ./cmd/api/handlers ./pkg/services/notifications ./pkg/storage/repositories -run 'Notification|Hashtag|Visibility|Tombstone|ReplaceObjectWithTombstone|GetUserNotification|GetUserNotifications' -count=1
go test ./cmd/objects -run 'TestHandleGetObject_PrivateVisibilityGate_Round29|TestTombstoneVisibility_Round38' -count=1
go vet ./cmd/objects/... ./pkg/services/notes/... ./pkg/storage/models/... ./pkg/storage/repositories/...
```

Closes #1074

🤖 Generated with [Claude Code](https://claude.com/claude-code)