### PR TITLE
fix: bound public resource and cost-amplification paths (CSR-031, CSR-034, CSR-039)

### DIFF
--- a/cmd/ai-processor/main.go
+++ b/cmd/ai-processor/main.go
@@ -310,7 +310,7 @@ var (
 		if lambdaCtx == nil || lambdaCtx.AWSServices == nil {
 			return nil, fmt.Errorf("AI processor AWS services are not initialized")
 		}
-		return ai.NewAIService(lambdaCtx.AWSServices.Config, ai.DefaultAIConfig()), nil
+		return ai.NewAIService(lambdaCtx.AWSServices.Config, ai.DefaultConfig()), nil
 	}
 	newAnalysisSaverFn = func(repos storageCore.RepositoryStorage, _ core.DB, logger *zap.Logger) analysisSaver {
 		return aiService.NewService(repos, nil, logger)

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -382,8 +382,12 @@ func configureRoutes(app *apptheory.App) {
 	app.Delete("/api/v1/vouches/{vouch_id}", apiHandler.HandleRevokeVouchLift, requireAuth)
 
 	// Canonical skill authority (Lesser-exclusive additive API)
-	app.Get("/api/v1/skills", apiHandler.HandleListSkillsLift, optionalAuth)
-	app.Get("/api/v1/skills/catalog", apiHandler.HandleListSkillCatalogLift, optionalAuth)
+	app.Get("/api/v1/skills", ratelimit.ApplyRateLimit(
+		apiHandler.HandleListSkillsLift,
+		30, 5*time.Minute, logger), optionalAuth)
+	app.Get("/api/v1/skills/catalog", ratelimit.ApplyRateLimit(
+		apiHandler.HandleListSkillCatalogLift,
+		30, 5*time.Minute, logger), optionalAuth)
 	app.Get("/api/v1/skills/resolve", apiHandler.HandleResolveEffectiveSkillsLift, requireRead)
 	app.Get("/api/v1/skills/{skillId}", apiHandler.HandleGetSkillLift, optionalAuth)
 	app.Get("/api/v1/skills/{skillId}/revisions", apiHandler.HandleListSkillRevisionsLift, optionalAuth)
@@ -566,7 +570,9 @@ func configureRoutes(app *apptheory.App) {
 
 	// Conversation endpoints (Direct Messages) - always enabled for 100% Mastodon API compatibility
 	app.Get("/api/v1/conversations", apiHandler.HandleGetConversationsLift, requireRead)
-	app.Get("/api/v1/conversations/lookup", apiHandler.HandleLookupConversationByCounterpartLift, requireRead)
+	app.Get("/api/v1/conversations/lookup", ratelimit.ApplyRateLimit(
+		apiHandler.HandleLookupConversationByCounterpartLift,
+		30, 5*time.Minute, logger), requireRead)
 	app.Get("/api/v1/conversations/{id}", apiHandler.HandleGetConversationLift, requireRead)
 	app.Delete("/api/v1/conversations/{id}", apiHandler.HandleDeleteConversationLift, requireWrite)
 	app.Post("/api/v1/conversations/{id}/read", apiHandler.HandleMarkConversationReadLift, requireWrite)

--- a/cmd/api/routes_auth_options_test.go
+++ b/cmd/api/routes_auth_options_test.go
@@ -62,6 +62,18 @@ func TestConfigureRoutes_AuthOptions(t *testing.T) {
 	require.Equal(t, routeAuthState{authRequired: true}, routes["POST /api/v1/trust/previews"])
 	require.Equal(t, routeAuthState{}, routes["POST /api/v1/notifications/deliver"])
 	require.Equal(t, routeAuthState{}, routes["POST /api/v1/agents/{username}/access-leases/{leaseID}/token"])
+
+	// Rate-limited conversation lookup (CSR-031 regression): authenticated read
+	// access with rate limiting to prevent unbound remote actor fetches.
+	require.Equal(t, routeAuthState{
+		authRequired:   true,
+		requiredScopes: []string{"read"},
+	}, routes["GET /api/v1/conversations/lookup"])
+
+	// Rate-limited public skill catalog (CSR-039 regression): optional auth
+	// with rate limiting to prevent unbound catalog scans.
+	require.Equal(t, routeAuthState{optionalAuth: true}, routes["GET /api/v1/skills/catalog"])
+	require.Equal(t, routeAuthState{optionalAuth: true}, routes["GET /api/v1/skills"])
 }
 
 func configuredRouteAuthStates(t *testing.T, app *apptheory.App) map[string]routeAuthState {

--- a/cmd/api/routes_auth_options_test.go
+++ b/cmd/api/routes_auth_options_test.go
@@ -70,8 +70,11 @@ func TestConfigureRoutes_AuthOptions(t *testing.T) {
 		requiredScopes: []string{"read"},
 	}, routes["GET /api/v1/conversations/lookup"])
 
-	// Rate-limited public skill catalog (CSR-039 regression): optional auth
-	// with rate limiting to prevent unbound catalog scans.
+	// Public skill catalog routes (CSR-039 route registration coverage): these
+	// routes are registered with optional auth and rate limiting at the route
+	// level. The scan-bound enforcement lives in pkg/services/skills.ListCatalog
+	// (maxCatalogScanRevisions cap). This assertion confirms correct route wiring
+	// and auth posture, not rate-limit functionality.
 	require.Equal(t, routeAuthState{optionalAuth: true}, routes["GET /api/v1/skills/catalog"])
 	require.Equal(t, routeAuthState{optionalAuth: true}, routes["GET /api/v1/skills"])
 }

--- a/cmd/graphql/main.go
+++ b/cmd/graphql/main.go
@@ -252,7 +252,7 @@ func initializeGraphQLSpecificServices() {
 	// Initialize AI service (optional)
 	var aiService *ai.AIService
 	if !cfg.DisableAI {
-		aiConfig := &ai.AIConfig{
+		aiConfig := &ai.Config{
 			ToxicityThreshold:   0.7,
 			NSFWThreshold:       0.8,
 			SpamThreshold:       0.75,

--- a/cmd/status-indexer/main.go
+++ b/cmd/status-indexer/main.go
@@ -70,7 +70,7 @@ var (
 	processor              *StatusIndexer
 	mustInitializeLambdaFn = common.MustInitializeLambda
 	loadAWSConfigFn        = awsconfig.LoadDefaultConfig
-	newAIServiceFn         = func(cfg aws.Config, aiConfig *ai.AIConfig) embeddingGenerator { return ai.NewAIService(cfg, aiConfig) }
+	newAIServiceFn         = func(cfg aws.Config, aiConfig *ai.Config) embeddingGenerator { return ai.NewAIService(cfg, aiConfig) }
 	newStatusIndexerFn     = NewStatusIndexer
 	newLambdaClientFn      = theorydb.NewLambdaOptimizedClient
 	lambdaStartFn          = lambda.Start
@@ -825,7 +825,7 @@ func main() {
 	}
 
 	// Initialize AI service
-	aiConfig := &ai.AIConfig{
+	aiConfig := &ai.Config{
 		NSFWThreshold:       0.8,
 		ToxicityThreshold:   0.7,
 		SpamThreshold:       0.6,

--- a/cmd/status-indexer/round12_status_indexer_test.go
+++ b/cmd/status-indexer/round12_status_indexer_test.go
@@ -547,7 +547,7 @@ func TestStatusIndexer_Main_WiresLambdaStart_Round12(t *testing.T) {
 	loadAWSConfigFn = func(context.Context, ...func(*awsconfig.LoadOptions) error) (aws.Config, error) {
 		return aws.Config{}, nil
 	}
-	newAIServiceFn = func(aws.Config, *ai.AIConfig) embeddingGenerator { return nil }
+	newAIServiceFn = func(aws.Config, *ai.Config) embeddingGenerator { return nil }
 	newStatusIndexerFn = func(db dynamormCore.DB, tableName, domain string, _ embeddingGenerator, logger *zap.Logger) *StatusIndexer {
 		return &StatusIndexer{db: db, tableName: tableName, domain: domain, logger: logger, likeRepo: &fakeLikeCounter{}}
 	}
@@ -613,7 +613,7 @@ func TestStatusIndexer_Main_FallsBackToManualDynamoClient_Round12(t *testing.T) 
 	loadAWSConfigFn = func(context.Context, ...func(*awsconfig.LoadOptions) error) (aws.Config, error) {
 		return aws.Config{}, nil
 	}
-	newAIServiceFn = func(aws.Config, *ai.AIConfig) embeddingGenerator { return nil }
+	newAIServiceFn = func(aws.Config, *ai.Config) embeddingGenerator { return nil }
 	newLambdaClientFn = func(context.Context, string) (dynamormCore.DB, error) { return mockDB, nil }
 
 	var gotDB dynamormCore.DB

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -13990,6 +13990,21 @@ paths:
                             description: RFC 8288 pagination links for recent messages.
                             schema:
                                 type: string
+                        X-RateLimit-Limit:
+                            description: Request limit per window.
+                            schema:
+                                type: integer
+                                format: int32
+                        X-RateLimit-Remaining:
+                            description: Requests remaining in the current window.
+                            schema:
+                                type: integer
+                                format: int32
+                        X-RateLimit-Reset:
+                            description: Unix timestamp (seconds) when the current window resets.
+                            schema:
+                                type: integer
+                                format: int64
                 "400":
                     $ref: '#/components/responses/BadRequest'
                 "401":
@@ -13998,6 +14013,8 @@ paths:
                     $ref: '#/components/responses/Forbidden'
                 "404":
                     $ref: '#/components/responses/NotFound'
+                "429":
+                    $ref: '#/components/responses/TooManyRequests'
                 "500":
                     $ref: '#/components/responses/InternalServerError'
             x-lesser-handler: HandleLookupConversationByCounterpartLift
@@ -16546,8 +16563,26 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/SkillListResponse'
+                    headers:
+                        X-RateLimit-Limit:
+                            description: Request limit per window.
+                            schema:
+                                type: integer
+                                format: int32
+                        X-RateLimit-Remaining:
+                            description: Requests remaining in the current window.
+                            schema:
+                                type: integer
+                                format: int32
+                        X-RateLimit-Reset:
+                            description: Unix timestamp (seconds) when the current window resets.
+                            schema:
+                                type: integer
+                                format: int64
                 "400":
                     $ref: '#/components/responses/BadRequest'
+                "429":
+                    $ref: '#/components/responses/TooManyRequests'
                 "500":
                     $ref: '#/components/responses/InternalServerError'
             x-lesser-handler: HandleListSkillsLift
@@ -16715,8 +16750,26 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/SkillCatalogResponse'
+                    headers:
+                        X-RateLimit-Limit:
+                            description: Request limit per window.
+                            schema:
+                                type: integer
+                                format: int32
+                        X-RateLimit-Remaining:
+                            description: Requests remaining in the current window.
+                            schema:
+                                type: integer
+                                format: int32
+                        X-RateLimit-Reset:
+                            description: Unix timestamp (seconds) when the current window resets.
+                            schema:
+                                type: integer
+                                format: int64
                 "400":
                     $ref: '#/components/responses/BadRequest'
+                "429":
+                    $ref: '#/components/responses/TooManyRequests'
                 "500":
                     $ref: '#/components/responses/InternalServerError'
             x-lesser-handler: HandleListSkillCatalogLift

--- a/pkg/ai/config.go
+++ b/pkg/ai/config.go
@@ -52,17 +52,18 @@ var SignalWeights = map[string]float64{
 // DefaultAIConfig returns a sensible default configuration
 func DefaultAIConfig() *AIConfig {
 	return &AIConfig{
-		NSFWThreshold:       0.8,
-		ToxicityThreshold:   0.7,
-		SpamThreshold:       0.75,
-		AIContentThreshold:  0.85,
-		EnablePIIDetection:  true,
-		EnableAIDetection:   true,
-		EnableImageAnalysis: true,
-		BedrockModelID:      "anthropic.claude-v2",
-		ToxicityModelARN:    "", // Custom model if available
-		S3Bucket:            "lesser-media-analysis",
-		AIQueueURL:          "", // Set from environment
+		NSFWThreshold:         0.8,
+		ToxicityThreshold:     0.7,
+		SpamThreshold:         0.75,
+		AIContentThreshold:    0.85,
+		EnablePIIDetection:    true,
+		EnableAIDetection:     true,
+		EnableImageAnalysis:   true,
+		BedrockModelID:        "anthropic.claude-v2",
+		ToxicityModelARN:      "", // Custom model if available
+		S3Bucket:              "lesser-media-analysis",
+		AIQueueURL:            "", // Set from environment
+		MaxImageDownloadBytes: defaultMaxImageDownloadBytes,
 	}
 }
 

--- a/pkg/ai/config.go
+++ b/pkg/ai/config.go
@@ -49,9 +49,9 @@ var SignalWeights = map[string]float64{
 	"harassment":    0.25, // High weight for harassment
 }
 
-// DefaultAIConfig returns a sensible default configuration
-func DefaultAIConfig() *AIConfig {
-	return &AIConfig{
+// DefaultConfig returns a sensible default configuration
+func DefaultConfig() *Config {
+	return &Config{
 		NSFWThreshold:         0.8,
 		ToxicityThreshold:     0.7,
 		SpamThreshold:         0.75,

--- a/pkg/ai/config_test.go
+++ b/pkg/ai/config_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDefaultAIConfig(t *testing.T) {
-	cfg := DefaultAIConfig()
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
 	require.NotNil(t, cfg)
 	require.True(t, cfg.EnablePIIDetection)
 	require.True(t, cfg.EnableAIDetection)

--- a/pkg/ai/errors.go
+++ b/pkg/ai/errors.go
@@ -38,6 +38,9 @@ var (
 	// ErrImageDownloadHTTP is returned when image download fails with HTTP error
 	ErrImageDownloadHTTP = errors.NetworkError("image download", stdErrors.New("image download failed"))
 
+	// ErrImageDownloadTooLarge is returned when the downloaded image exceeds the configured size limit
+	ErrImageDownloadTooLarge = stdErrors.New("downloaded image exceeds size limit for AI analysis")
+
 	// ErrInvalidEmbeddingResponse is returned when embedding response format is invalid
 	ErrInvalidEmbeddingResponse = errors.ParsingFailed("embedding response", stdErrors.New("embedding response parsing failed"))
 

--- a/pkg/ai/service.go
+++ b/pkg/ai/service.go
@@ -121,14 +121,11 @@ func RedactPIIFromAnalysis(analysis *AIAnalysis) *AIAnalysis {
 	return &redacted
 }
 
-// AIConfig contains configuration for AI service features and thresholds
-//
 // defaultMaxImageDownloadBytes caps remote image downloads at 10 MiB
 // to prevent cost amplification via unbounded media downloads.
-//
-//nolint:revive // AI prefix clarifies this is AI-specific config
 const defaultMaxImageDownloadBytes = 10 * 1024 * 1024 // 10 MiB
 
+// AIConfig contains configuration for AI service features and thresholds.
 type AIConfig struct {
 	// Thresholds for auto-moderation
 	NSFWThreshold      float64

--- a/pkg/ai/service.go
+++ b/pkg/ai/service.go
@@ -74,7 +74,7 @@ type AIService struct {
 	sqsClient   SQSClient
 	httpClient  HTTPClient
 	logger      *zap.Logger
-	config      *AIConfig
+	config      *Config
 }
 
 // RedactPIIFromAnalysis returns a response-safe copy of an AI analysis with raw
@@ -125,8 +125,8 @@ func RedactPIIFromAnalysis(analysis *AIAnalysis) *AIAnalysis {
 // to prevent cost amplification via unbounded media downloads.
 const defaultMaxImageDownloadBytes = 10 * 1024 * 1024 // 10 MiB
 
-// AIConfig contains configuration for AI service features and thresholds.
-type AIConfig struct {
+// Config contains configuration for AI service features and thresholds.
+type Config struct {
 	// Thresholds for auto-moderation
 	NSFWThreshold      float64
 	ToxicityThreshold  float64
@@ -154,7 +154,7 @@ type AIConfig struct {
 }
 
 // NewAIService creates a new AI service instance
-func NewAIService(cfg aws.Config, aiConfig *AIConfig) *AIService {
+func NewAIService(cfg aws.Config, aiConfig *Config) *AIService {
 	logger := zap.L().Named("ai")
 	return &AIService{
 		comprehend:  comprehend.NewFromConfig(cfg),
@@ -169,7 +169,7 @@ func NewAIService(cfg aws.Config, aiConfig *AIConfig) *AIService {
 }
 
 // NewAIServiceWithSQS creates a new AI service instance with custom SQS client
-func NewAIServiceWithSQS(cfg aws.Config, aiConfig *AIConfig, sqsClient SQSClient) *AIService {
+func NewAIServiceWithSQS(cfg aws.Config, aiConfig *Config, sqsClient SQSClient) *AIService {
 	logger := zap.L().Named("ai")
 	return &AIService{
 		comprehend:  comprehend.NewFromConfig(cfg),

--- a/pkg/ai/service.go
+++ b/pkg/ai/service.go
@@ -123,7 +123,12 @@ func RedactPIIFromAnalysis(analysis *AIAnalysis) *AIAnalysis {
 
 // AIConfig contains configuration for AI service features and thresholds
 //
+// defaultMaxImageDownloadBytes caps remote image downloads at 10 MiB
+// to prevent cost amplification via unbounded media downloads.
+//
 //nolint:revive // AI prefix clarifies this is AI-specific config
+const defaultMaxImageDownloadBytes = 10 * 1024 * 1024 // 10 MiB
+
 type AIConfig struct {
 	// Thresholds for auto-moderation
 	NSFWThreshold      float64
@@ -145,6 +150,10 @@ type AIConfig struct {
 
 	// SQS queue URL for AI processing
 	AIQueueURL string
+
+	// MaxImageDownloadBytes caps the size of remote images downloaded for AI analysis.
+	// When zero, defaultMaxImageDownloadBytes is used.
+	MaxImageDownloadBytes int64
 }
 
 // NewAIService creates a new AI service instance
@@ -1099,17 +1108,34 @@ func (s *AIService) uploadImageToS3(ctx context.Context, imageURL string) (strin
 		return "", fmt.Errorf("%w: HTTP %d", ErrImageDownloadHTTP, resp.StatusCode)
 	}
 
+	// Enforce download size bound to prevent cost amplification.
+	maxBytes := s.config.MaxImageDownloadBytes
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxImageDownloadBytes
+	}
+	if resp.ContentLength > maxBytes {
+		s.logger.Warn("refusing oversized image download",
+			zap.String("url", imageURL),
+			zap.Int64("content_length", resp.ContentLength),
+			zap.Int64("max_bytes", maxBytes))
+		return "", fmt.Errorf("%w: Content-Length %d exceeds limit %d", ErrImageDownloadTooLarge, resp.ContentLength, maxBytes)
+	}
+
 	// Generate unique S3 key for the image
 	imageID := generateID("ai-image")
 	contentType := resp.Header.Get("Content-Type")
 	fileExt := s.getFileExtensionFromContentType(contentType)
 	s3Key := fmt.Sprintf("ai-analysis/%s%s", imageID, fileExt)
 
+	// Wrap body with a size-limited reader as defense-in-depth against
+	// servers that omit or misrepresent Content-Length.
+	limitedBody := io.LimitReader(resp.Body, maxBytes)
+
 	// Upload to S3
 	_, err = s.s3Client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:      aws.String(s.config.S3Bucket),
 		Key:         aws.String(s3Key),
-		Body:        io.Reader(resp.Body),
+		Body:        io.Reader(limitedBody),
 		ContentType: aws.String(contentType),
 		// Set appropriate metadata
 		Metadata: map[string]string{

--- a/pkg/ai/service_helpers_test.go
+++ b/pkg/ai/service_helpers_test.go
@@ -41,7 +41,7 @@ func TestRedactPIIFromAnalysis(t *testing.T) {
 func TestCalculateOverallRisk(t *testing.T) {
 	// Create a minimal AIService for testing - no AWS clients needed for pure helpers
 	service := &AIService{
-		config: &AIConfig{
+		config: &Config{
 			NSFWThreshold:     0.8,
 			ToxicityThreshold: 0.7,
 			SpamThreshold:     0.6,
@@ -161,7 +161,7 @@ func TestCalculateOverallRisk(t *testing.T) {
 
 func TestCalculateConfidence(t *testing.T) {
 	service := &AIService{
-		config: &AIConfig{},
+		config: &Config{},
 	}
 
 	tests := []struct {
@@ -243,14 +243,14 @@ func TestCalculateConfidence(t *testing.T) {
 func TestDetermineModerationAction(t *testing.T) {
 	tests := []struct {
 		name           string
-		config         *AIConfig
+		config         *Config
 		analysis       *AIAnalysis
 		expectedAction string
 	}{
 		// NSFW override path
 		{
 			name: "NSFW override triggers ActionRemove",
-			config: &AIConfig{
+			config: &Config{
 				NSFWThreshold:     0.7,
 				ToxicityThreshold: 0.8,
 				SpamThreshold:     0.8,
@@ -266,7 +266,7 @@ func TestDetermineModerationAction(t *testing.T) {
 		},
 		{
 			name: "NSFW below threshold does not trigger remove",
-			config: &AIConfig{
+			config: &Config{
 				NSFWThreshold:     0.9,
 				ToxicityThreshold: 0.8,
 				SpamThreshold:     0.8,
@@ -283,7 +283,7 @@ func TestDetermineModerationAction(t *testing.T) {
 		// Toxicity triggers ActionHide
 		{
 			name: "toxicity triggers ActionHide",
-			config: &AIConfig{
+			config: &Config{
 				NSFWThreshold:     0.9,
 				ToxicityThreshold: 0.6,
 				SpamThreshold:     0.8,
@@ -298,7 +298,7 @@ func TestDetermineModerationAction(t *testing.T) {
 		},
 		{
 			name: "toxicity below threshold uses risk fallback",
-			config: &AIConfig{
+			config: &Config{
 				NSFWThreshold:     0.9,
 				ToxicityThreshold: 0.8,
 				SpamThreshold:     0.8,
@@ -314,7 +314,7 @@ func TestDetermineModerationAction(t *testing.T) {
 		// Spam triggers ActionShadowBan
 		{
 			name: "spam triggers ActionShadowBan",
-			config: &AIConfig{
+			config: &Config{
 				NSFWThreshold:     0.9,
 				ToxicityThreshold: 0.8,
 				SpamThreshold:     0.5,
@@ -330,7 +330,7 @@ func TestDetermineModerationAction(t *testing.T) {
 		// Risk-based actions (fallback)
 		{
 			name: "risk > 0.9 triggers ActionRemove",
-			config: &AIConfig{
+			config: &Config{
 				NSFWThreshold:     0.9,
 				ToxicityThreshold: 0.9,
 				SpamThreshold:     0.9,
@@ -342,7 +342,7 @@ func TestDetermineModerationAction(t *testing.T) {
 		},
 		{
 			name: "risk > 0.7 triggers ActionHide",
-			config: &AIConfig{
+			config: &Config{
 				NSFWThreshold:     0.9,
 				ToxicityThreshold: 0.9,
 				SpamThreshold:     0.9,
@@ -354,7 +354,7 @@ func TestDetermineModerationAction(t *testing.T) {
 		},
 		{
 			name: "risk > 0.5 triggers ActionFlag",
-			config: &AIConfig{
+			config: &Config{
 				NSFWThreshold:     0.9,
 				ToxicityThreshold: 0.9,
 				SpamThreshold:     0.9,
@@ -366,7 +366,7 @@ func TestDetermineModerationAction(t *testing.T) {
 		},
 		{
 			name: "risk > 0.3 triggers ActionReview",
-			config: &AIConfig{
+			config: &Config{
 				NSFWThreshold:     0.9,
 				ToxicityThreshold: 0.9,
 				SpamThreshold:     0.9,
@@ -378,7 +378,7 @@ func TestDetermineModerationAction(t *testing.T) {
 		},
 		{
 			name: "risk <= 0.3 triggers ActionNone",
-			config: &AIConfig{
+			config: &Config{
 				NSFWThreshold:     0.9,
 				ToxicityThreshold: 0.9,
 				SpamThreshold:     0.9,
@@ -391,7 +391,7 @@ func TestDetermineModerationAction(t *testing.T) {
 		// Edge cases
 		{
 			name: "exactly at risk boundary 0.3",
-			config: &AIConfig{
+			config: &Config{
 				NSFWThreshold:     0.9,
 				ToxicityThreshold: 0.9,
 				SpamThreshold:     0.9,
@@ -403,7 +403,7 @@ func TestDetermineModerationAction(t *testing.T) {
 		},
 		{
 			name: "zero risk",
-			config: &AIConfig{
+			config: &Config{
 				NSFWThreshold:     0.9,
 				ToxicityThreshold: 0.9,
 				SpamThreshold:     0.9,
@@ -432,7 +432,7 @@ func TestDetermineModerationAction(t *testing.T) {
 
 func TestCalculateRepetition(t *testing.T) {
 	service := &AIService{
-		config: &AIConfig{},
+		config: &Config{},
 	}
 
 	tests := []struct {
@@ -501,7 +501,7 @@ func TestCalculateRepetition(t *testing.T) {
 
 func TestAnalyzeTopicConsistency(t *testing.T) {
 	service := &AIService{
-		config: &AIConfig{},
+		config: &Config{},
 	}
 
 	tests := []struct {
@@ -815,7 +815,7 @@ func TestMaxFloat64(t *testing.T) {
 // Test fallbackAIDetection which is a pure helper that doesn't use AWS
 func TestFallbackAIDetection(t *testing.T) {
 	service := &AIService{
-		config: &AIConfig{},
+		config: &Config{},
 	}
 
 	tests := []struct {
@@ -891,7 +891,7 @@ func TestFallbackAIDetection(t *testing.T) {
 // Test getFileExtensionFromContentType
 func TestGetFileExtensionFromContentType(t *testing.T) {
 	service := &AIService{
-		config: &AIConfig{},
+		config: &Config{},
 	}
 
 	tests := []struct {

--- a/pkg/ai/service_round20_coverage_test.go
+++ b/pkg/ai/service_round20_coverage_test.go
@@ -639,6 +639,81 @@ func TestAIService_Round20_UploadImageToS3_Paths(t *testing.T) {
 	})
 }
 
+func TestAIService_Round20_UploadImageToS3_ContentLengthBound(t *testing.T) {
+	t.Run("content_length_exceeds_default_limit", func(t *testing.T) {
+		svc := &AIService{
+			config: &AIConfig{
+				S3Bucket:              "bucket",
+				MaxImageDownloadBytes: 0, // use default 10 MiB
+			},
+			httpClient: &round20HTTPClient{
+				respByURL: map[string]*http.Response{
+					"https://example.com/big/": {
+						StatusCode:    http.StatusOK,
+						ContentLength: defaultMaxImageDownloadBytes + 1,
+						Header:        http.Header{"Content-Type": []string{"image/jpeg"}},
+						Body:          io.NopCloser(strings.NewReader("img")),
+					},
+				},
+			},
+			s3Client: &round20S3{},
+			logger:   zap.NewNop(),
+		}
+
+		_, err := svc.uploadImageToS3(context.Background(), "https://example.com/big/")
+		require.ErrorIs(t, err, ErrImageDownloadTooLarge)
+	})
+
+	t.Run("content_length_exceeds_custom_limit", func(t *testing.T) {
+		svc := &AIService{
+			config: &AIConfig{
+				S3Bucket:              "bucket",
+				MaxImageDownloadBytes: 1024, // 1 KiB
+			},
+			httpClient: &round20HTTPClient{
+				respByURL: map[string]*http.Response{
+					"https://example.com/oversized/": {
+						StatusCode:    http.StatusOK,
+						ContentLength: 2048,
+						Header:        http.Header{"Content-Type": []string{"image/jpeg"}},
+						Body:          io.NopCloser(strings.NewReader("img")),
+					},
+				},
+			},
+			s3Client: &round20S3{},
+			logger:   zap.NewNop(),
+		}
+
+		_, err := svc.uploadImageToS3(context.Background(), "https://example.com/oversized/")
+		require.ErrorIs(t, err, ErrImageDownloadTooLarge)
+	})
+
+	t.Run("content_length_within_limit_succeeds", func(t *testing.T) {
+		svc := &AIService{
+			config: &AIConfig{
+				S3Bucket:              "bucket",
+				MaxImageDownloadBytes: 1024,
+			},
+			httpClient: &round20HTTPClient{
+				respByURL: map[string]*http.Response{
+					"https://example.com/small/": {
+						StatusCode:    http.StatusOK,
+						ContentLength: 512,
+						Header:        http.Header{"Content-Type": []string{"image/jpeg"}},
+						Body:          io.NopCloser(strings.NewReader("smallimg")),
+					},
+				},
+			},
+			s3Client: &round20S3{},
+			logger:   zap.NewNop(),
+		}
+
+		key, err := svc.uploadImageToS3(context.Background(), "https://example.com/small/")
+		require.NoError(t, err)
+		require.NotEmpty(t, key)
+	})
+}
+
 func TestAIService_Round20_AnalyzeContent_ExerciseTopLevel(t *testing.T) {
 	aiModelID := "anthropic.claude-v2"
 	body, err := json.Marshal(map[string]any{"completion": `{"ai_generated_probability":0.1,"pattern_consistency":0.2,"style_deviation":0.3,"semantic_coherence":0.4,"suspicious_patterns":[]}`})

--- a/pkg/ai/service_round20_coverage_test.go
+++ b/pkg/ai/service_round20_coverage_test.go
@@ -307,7 +307,7 @@ func TestAIService_Round20_AnalyzeText_ComprehendPaths(t *testing.T) {
 		svc := &AIService{
 			comprehend: comprehendClient,
 			logger:     zap.NewNop(),
-			config: &AIConfig{
+			config: &Config{
 				EnablePIIDetection: true,
 				ToxicityModelARN:   "arn:aws:comprehend:toxicity",
 			},
@@ -348,7 +348,7 @@ func TestAIService_Round20_AnalyzeText_ComprehendPaths(t *testing.T) {
 		svc := &AIService{
 			comprehend: comprehendClient,
 			logger:     zap.NewNop(),
-			config: &AIConfig{
+			config: &Config{
 				EnablePIIDetection: false,
 				ToxicityModelARN:   "",
 			},
@@ -364,7 +364,7 @@ func TestAIService_Round20_AnalyzeText_ComprehendPaths(t *testing.T) {
 
 func TestAIService_Round20_ImageAnalysis_Paths(t *testing.T) {
 	t.Run("analyzeImage_returns_empty_when_rekognition_nil", func(t *testing.T) {
-		svc := &AIService{config: &AIConfig{S3Bucket: "bucket"}}
+		svc := &AIService{config: &Config{S3Bucket: "bucket"}}
 		analysis, err := svc.analyzeImage(context.Background(), "ignored", "key")
 		require.NoError(t, err)
 		require.NotNil(t, analysis)
@@ -416,7 +416,7 @@ func TestAIService_Round20_ImageAnalysis_Paths(t *testing.T) {
 			comprehend:  textClient,
 			rekognition: rekognitionClient,
 			logger:      zap.NewNop(),
-			config: &AIConfig{
+			config: &Config{
 				S3Bucket: "bucket",
 			},
 		}
@@ -446,7 +446,7 @@ func TestAIService_Round20_ImageAnalysis_Paths(t *testing.T) {
 			detectTextErr:             errors.New("texterr"),
 			recognizeCelebritiesErr:   errors.New("celeberr"),
 		}
-		svc := &AIService{rekognition: rekognitionClient, config: &AIConfig{S3Bucket: "bucket"}}
+		svc := &AIService{rekognition: rekognitionClient, config: &Config{S3Bucket: "bucket"}}
 
 		analysis, err := svc.analyzeImage(context.Background(), "ignored", "key")
 		require.NoError(t, err)
@@ -473,7 +473,7 @@ func TestAIService_Round20_DetectAIContent_GenerateEmbedding_AndRequests(t *test
 		svc := &AIService{
 			bedrock: bedrockClient,
 			logger:  zap.NewNop(),
-			config: &AIConfig{
+			config: &Config{
 				BedrockModelID: aiModelID,
 			},
 		}
@@ -508,7 +508,7 @@ func TestAIService_Round20_DetectAIContent_GenerateEmbedding_AndRequests(t *test
 		svc := &AIService{
 			bedrock: bedrockClient,
 			logger:  zap.NewNop(),
-			config: &AIConfig{
+			config: &Config{
 				BedrockModelID: aiModelID,
 			},
 		}
@@ -529,7 +529,7 @@ func TestAIService_Round20_DetectAIContent_GenerateEmbedding_AndRequests(t *test
 			},
 		}
 
-		svc := &AIService{bedrock: bedrockClient, config: &AIConfig{}}
+		svc := &AIService{bedrock: bedrockClient, config: &Config{}}
 		_, err := svc.GenerateEmbedding(context.Background(), "hello")
 		require.Error(t, err)
 
@@ -544,7 +544,7 @@ func TestAIService_Round20_DetectAIContent_GenerateEmbedding_AndRequests(t *test
 		svc := &AIService{
 			sqsClient: sqsClient,
 			logger:    zap.NewNop(),
-			config:    &AIConfig{AIQueueURL: ""},
+			config:    &Config{AIQueueURL: ""},
 		}
 		reqID, err := svc.QueueAnalysisRequest(context.Background(), "obj", "note", false)
 		require.NoError(t, err)
@@ -569,7 +569,7 @@ func TestAIService_Round20_DetectAIContent_GenerateEmbedding_AndRequests(t *test
 
 func TestAIService_Round20_UploadImageToS3_Paths(t *testing.T) {
 	t.Run("existing_key_short_circuit", func(t *testing.T) {
-		svc := &AIService{config: &AIConfig{S3Bucket: "bucket"}}
+		svc := &AIService{config: &Config{S3Bucket: "bucket"}}
 		key, err := svc.uploadImageToS3(context.Background(), "https://bucket.s3.us-east-1.amazonaws.com/media/images/photo.jpg")
 		require.NoError(t, err)
 		require.Equal(t, "media/images/photo.jpg", key)
@@ -577,7 +577,7 @@ func TestAIService_Round20_UploadImageToS3_Paths(t *testing.T) {
 
 	t.Run("invalid_url_parse_scheme_local_network_and_download_errors", func(t *testing.T) {
 		svc := &AIService{
-			config:     &AIConfig{S3Bucket: "bucket"},
+			config:     &Config{S3Bucket: "bucket"},
 			httpClient: &round20HTTPClient{errByURL: map[string]error{"https://example.com/": errors.New("dial")}},
 			s3Client:   &round20S3{},
 			logger:     zap.NewNop(),
@@ -616,7 +616,7 @@ func TestAIService_Round20_UploadImageToS3_Paths(t *testing.T) {
 		}
 		s3Client := &round20S3{putObjectErr: errors.New("s3 down")}
 		svc := &AIService{
-			config:     &AIConfig{S3Bucket: "bucket"},
+			config:     &Config{S3Bucket: "bucket"},
 			httpClient: httpClient,
 			s3Client:   s3Client,
 			logger:     zap.NewNop(),
@@ -642,7 +642,7 @@ func TestAIService_Round20_UploadImageToS3_Paths(t *testing.T) {
 func TestAIService_Round20_UploadImageToS3_ContentLengthBound(t *testing.T) {
 	t.Run("content_length_exceeds_default_limit", func(t *testing.T) {
 		svc := &AIService{
-			config: &AIConfig{
+			config: &Config{
 				S3Bucket:              "bucket",
 				MaxImageDownloadBytes: 0, // use default 10 MiB
 			},
@@ -666,7 +666,7 @@ func TestAIService_Round20_UploadImageToS3_ContentLengthBound(t *testing.T) {
 
 	t.Run("content_length_exceeds_custom_limit", func(t *testing.T) {
 		svc := &AIService{
-			config: &AIConfig{
+			config: &Config{
 				S3Bucket:              "bucket",
 				MaxImageDownloadBytes: 1024, // 1 KiB
 			},
@@ -690,7 +690,7 @@ func TestAIService_Round20_UploadImageToS3_ContentLengthBound(t *testing.T) {
 
 	t.Run("content_length_within_limit_succeeds", func(t *testing.T) {
 		svc := &AIService{
-			config: &AIConfig{
+			config: &Config{
 				S3Bucket:              "bucket",
 				MaxImageDownloadBytes: 1024,
 			},
@@ -750,7 +750,7 @@ func TestAIService_Round20_AnalyzeContent_ExerciseTopLevel(t *testing.T) {
 		bedrock:   bedrockClient,
 		sqsClient: sqsClient,
 		logger:    zap.NewNop(),
-		config: &AIConfig{
+		config: &Config{
 			EnablePIIDetection:  false,
 			EnableAIDetection:   true,
 			EnableImageAnalysis: true,

--- a/pkg/services/skills/service.go
+++ b/pkg/services/skills/service.go
@@ -72,6 +72,11 @@ const (
 	skillBundleBase64        = "base64"
 	defaultCatalogListLimit  = 25
 	maxCatalogListLimit      = 100
+	// maxCatalogScanRevisions caps the number of raw approved revisions a single
+	// ListCatalog request may inspect before returning a cursor. This bounds
+	// per-request storage work when many approved revisions are hidden (non-public
+	// exposure) and prevents unbound catalog scans (CSR-039).
+	maxCatalogScanRevisions = 300
 )
 
 // CatalogFilter constrains approved skill catalog listing.
@@ -320,6 +325,7 @@ func (s *Service) ListCatalog(ctx context.Context, viewer Viewer, filter Catalog
 	exposure := strings.ToLower(strings.TrimSpace(filter.Exposure))
 	out := make([]CatalogEntry, 0, limit)
 	nextCursor := ""
+	rawRevisionsInspected := 0
 
 	for len(out) < limit {
 		revisions, rawNextCursor, err := s.repo.ListSkillRevisionsByStatus(ctx, models.SkillRevisionStatusApproved, limit, cursor)
@@ -330,6 +336,7 @@ func (s *Service) ListCatalog(ctx context.Context, viewer Viewer, filter Catalog
 			return out, "", nil
 		}
 
+		rawRevisionsInspected += len(revisions)
 		rawNextCursor = strings.TrimSpace(rawNextCursor)
 		for index, revision := range revisions {
 			entry, ok := s.catalogEntryForRevision(ctx, viewer, exposure, revision)
@@ -343,6 +350,16 @@ func (s *Service) ListCatalog(ctx context.Context, viewer Viewer, filter Catalog
 			if len(out) >= limit {
 				return out, catalogCursorAfterVisibleLimit(index, len(revisions), rawNextCursor, nextCursor), nil
 			}
+		}
+
+		// Enforce per-request scan cap (CSR-039): if we have inspected the maximum
+		// allowed raw revisions without filling the visible page, return a cursor
+		// so the caller may continue rather than scanning indefinitely.
+		if rawRevisionsInspected >= maxCatalogScanRevisions {
+			if len(out) == 0 {
+				return out, rawNextCursor, nil
+			}
+			return out, nextCursor, nil
 		}
 
 		nextRawCursor, ok := advanceCatalogRawCursor(cursor, rawNextCursor)

--- a/pkg/services/skills/service.go
+++ b/pkg/services/skills/service.go
@@ -353,11 +353,13 @@ func (s *Service) ListCatalog(ctx context.Context, viewer Viewer, filter Catalog
 		}
 
 		// Enforce per-request scan cap (CSR-039): if we have inspected the maximum
-		// allowed raw revisions without filling the visible page, return a cursor
-		// so the caller may continue rather than scanning indefinitely.
+		// allowed raw revisions without filling the visible page, stop scanning.
+		// When no visible entries were found (e.g. all revisions are hidden from
+		// the viewer), return no continuation cursor — rawNextCursor may reference
+		// non-public revision identifiers and must never leak to public callers.
 		if rawRevisionsInspected >= maxCatalogScanRevisions {
 			if len(out) == 0 {
-				return out, rawNextCursor, nil
+				return out, "", nil
 			}
 			return out, nextCursor, nil
 		}

--- a/pkg/services/skills/service_test.go
+++ b/pkg/services/skills/service_test.go
@@ -888,9 +888,12 @@ func TestServiceListCatalogScansAreBounded(t *testing.T) {
 		repo.listRevisionsByStatusCallCount, maxExpectedCalls)
 
 	// Because all visible revisions are past the scan cap, the public viewer
-	// should see zero entries and receive a continuation cursor.
+	// should see zero entries and must NOT receive a continuation cursor that
+	// leaks hidden/non-public skill or revision identifiers.
 	require.Empty(t, catalog, "expected no visible entries when all public revisions are beyond scan cap")
-	require.NotEmpty(t, cursor, "expected a continuation cursor when scan cap is hit with no visible entries")
+	require.Empty(t, cursor, "expected no continuation cursor when scan cap is hit with no visible entries (cursor would leak hidden IDs)")
+	require.NotContains(t, cursor, "SKILL#hidden", "public cursor must not reveal hidden skill identifiers")
+	require.NotContains(t, cursor, "hidden-", "public cursor must not reveal hidden skill identifiers")
 
 	t.Logf("hidden=%d public=%d calls=%d cap=%d maxCalls=%d cursor=%q",
 		hiddenCount, publicCount, repo.listRevisionsByStatusCallCount,
@@ -936,10 +939,96 @@ func TestServiceListCatalogScansAreBoundedWithLimit100(t *testing.T) {
 	require.LessOrEqual(t, repo.listRevisionsByStatusCallCount, maxExpectedCalls,
 		"ListCatalog made %d calls at limit 100; expected at most %d",
 		repo.listRevisionsByStatusCallCount, maxExpectedCalls)
-	require.Empty(t, catalog)
-	require.NotEmpty(t, cursor)
+	require.Empty(t, catalog, "expected no visible entries when all revisions are hidden")
+	require.Empty(t, cursor, "expected no continuation cursor when scan cap is hit with no visible entries (cursor would leak hidden IDs)")
+	require.NotContains(t, cursor, "SKILL#hidden", "public cursor must not reveal hidden skill identifiers")
+	require.NotContains(t, cursor, "hidden-", "public cursor must not reveal hidden skill identifiers")
 
 	t.Logf("limit=100 calls=%d maxCalls=%d", repo.listRevisionsByStatusCallCount, maxExpectedCalls)
+}
+
+// TestServiceListCatalogPartialCursorDoesNotLeakHiddenIDs proves that when
+// ListCatalog returns a continuation cursor after filling a partial visible
+// page (i.e., some visible entries found before the scan cap), the cursor
+// references only visible revisions and never leaks hidden/private IDs.
+func TestServiceListCatalogPartialCursorDoesNotLeakHiddenIDs(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeSkillRepo()
+	svc := NewService(repo)
+
+	// Seed public revisions with IDs that sort before the hidden batch so they
+	// appear first in the repo's cursor-ordered listing.
+	const publicCount = 3
+	for i := 0; i < publicCount; i++ {
+		skillID := fmt.Sprintf("aaaa-public-%03d", i)
+		require.NoError(t, repo.CreateSkill(ctx, &models.Skill{
+			ID:                    skillID,
+			Slug:                  skillID,
+			Name:                  skillID,
+			Status:                models.SkillStatusActive,
+			DefaultExposure:       models.SkillExposurePublic,
+			CurrentRevisionID:     skillID + "-r1",
+			CurrentRevisionNumber: 1,
+		}))
+		seedApprovedRevision(t, ctx, repo, &models.SkillRevision{
+			SkillID:               skillID,
+			RevisionNumber:        1,
+			DefaultExposure:       models.SkillExposurePublic,
+			ApprovalID:            "approval-" + skillID,
+			ApprovalAuthorityType: models.SkillApprovalAuthorityAdmin,
+			ApprovalAuthorityID:   "ops",
+			ApprovedBy:            "ops",
+			PrincipalID:           "principal-1",
+		})
+	}
+
+	// Seed hidden revisions — these sort after "aaaa-public-*" but within the
+	// scan cap so the service may encounter them after filling the page.
+	const hiddenCount = 50
+	for i := 0; i < hiddenCount; i++ {
+		skillID := fmt.Sprintf("hidden-%03d", i)
+		require.NoError(t, repo.CreateSkill(ctx, &models.Skill{
+			ID:                    skillID,
+			Slug:                  skillID,
+			Name:                  skillID,
+			Status:                models.SkillStatusActive,
+			DefaultExposure:       models.SkillExposurePrivate,
+			CurrentRevisionID:     skillID + "-r1",
+			CurrentRevisionNumber: 1,
+		}))
+		seedApprovedRevision(t, ctx, repo, &models.SkillRevision{
+			SkillID:               skillID,
+			RevisionNumber:        1,
+			DefaultExposure:       models.SkillExposurePrivate,
+			ApprovalID:            "approval-" + skillID,
+			ApprovalAuthorityType: models.SkillApprovalAuthorityAdmin,
+			ApprovalAuthorityID:   "ops",
+			ApprovedBy:            "ops",
+			PrincipalID:           "principal-1",
+		})
+	}
+
+	repo.listRevisionsByStatusCallCount = 0
+
+	// Public viewer, limit 2 — there are 3 public entries, so the page fills
+	// and a continuation cursor is returned.
+	catalog, cursor, err := svc.ListCatalog(ctx, Viewer{}, CatalogFilter{Limit: 2})
+	require.NoError(t, err)
+	require.Len(t, catalog, 2, "expected 2 visible entries")
+	require.NotEmpty(t, cursor, "expected a continuation cursor for the next page")
+	// The cursor must reference a visible (public) revision, never a hidden one.
+	require.NotContains(t, cursor, "hidden", "public continuation cursor must not leak hidden skill identifiers")
+	require.Contains(t, cursor, "SKILL#aaaa-public", "public continuation cursor should reference a visible revision")
+
+	// Page 2: one more public entry, then only hidden beyond — no more cursor
+	// because there are no more visible entries.
+	catalog2, cursor2, err := svc.ListCatalog(ctx, Viewer{}, CatalogFilter{Limit: 2, Cursor: cursor})
+	require.NoError(t, err)
+	require.Len(t, catalog2, 1, "expected the last visible entry on the second page")
+	require.Empty(t, cursor2, "expected no cursor when no more visible entries exist")
+	require.NotContains(t, cursor2, "hidden", "cursor must not leak hidden IDs even when exhausted")
+
+	t.Logf("public=%d hidden=%d calls=%d", publicCount, hiddenCount, repo.listRevisionsByStatusCallCount)
 }
 
 func TestServiceGetBundleIncludesContentAndRejectsUnpublished(t *testing.T) {

--- a/pkg/services/skills/service_test.go
+++ b/pkg/services/skills/service_test.go
@@ -27,6 +27,10 @@ type fakeSkillRepo struct {
 	updateSkillErr            error
 	updateRevisionErr         error
 	createAssignmentErr       error
+
+	// listRevisionsByStatusCallCount tracks how many times ListSkillRevisionsByStatus
+	// was called. Used by regression tests to prove bounded scan behavior.
+	listRevisionsByStatusCallCount int
 }
 
 func newFakeSkillRepo() *fakeSkillRepo {
@@ -199,6 +203,7 @@ func (f *fakeSkillRepo) ListSkillRevisions(_ context.Context, skillID string, _ 
 }
 
 func (f *fakeSkillRepo) ListSkillRevisionsByStatus(_ context.Context, status string, limit int, cursor string) ([]*models.SkillRevision, string, error) {
+	f.listRevisionsByStatusCallCount++
 	if f.listRevisionsErr != nil {
 		return nil, "", f.listRevisionsErr
 	}
@@ -803,6 +808,138 @@ func TestServiceListCatalogCursorDoesNotRevealHiddenRevisions(t *testing.T) {
 	require.Len(t, catalog, 1)
 	require.Equal(t, "public-b", catalog[0].Skill.ID)
 	require.Empty(t, cursor)
+}
+
+// TestServiceListCatalogScansAreBounded proves that ListCatalog cannot make
+// unbounded ListSkillRevisionsByStatus calls when many approved revisions are
+// hidden from the public viewer (CSR-039 regression). The service must cap raw
+// revision inspection and return a cursor for continuation rather than scanning
+// indefinitely.
+func TestServiceListCatalogScansAreBounded(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeSkillRepo()
+	svc := NewService(repo)
+
+	// Seed many hidden (private) approved revisions that will appear before any
+	// public revisions in the repo's cursor-ordered listing.
+	const hiddenCount = 301
+	for i := 0; i < hiddenCount; i++ {
+		skillID := fmt.Sprintf("hidden-%03d", i)
+		require.NoError(t, repo.CreateSkill(ctx, &models.Skill{
+			ID:                    skillID,
+			Slug:                  skillID,
+			Name:                  skillID,
+			Status:                models.SkillStatusActive,
+			DefaultExposure:       models.SkillExposurePrivate,
+			CurrentRevisionID:     skillID + "-r1",
+			CurrentRevisionNumber: 1,
+		}))
+		seedApprovedRevision(t, ctx, repo, &models.SkillRevision{
+			SkillID:               skillID,
+			RevisionNumber:        1,
+			DefaultExposure:       models.SkillExposurePrivate,
+			ApprovalID:            "approval-" + skillID,
+			ApprovalAuthorityType: models.SkillApprovalAuthorityAdmin,
+			ApprovalAuthorityID:   "ops",
+			ApprovedBy:            "ops",
+			PrincipalID:           "principal-1",
+		})
+	}
+
+	// Add a few public revisions that would be visible — but they sort after
+	// "hidden-*" so they land beyond the scan cap.
+	const publicCount = 5
+	for i := 0; i < publicCount; i++ {
+		skillID := fmt.Sprintf("public-%03d", i)
+		require.NoError(t, repo.CreateSkill(ctx, &models.Skill{
+			ID:                    skillID,
+			Slug:                  skillID,
+			Name:                  skillID,
+			Status:                models.SkillStatusActive,
+			DefaultExposure:       models.SkillExposurePublic,
+			CurrentRevisionID:     skillID + "-r1",
+			CurrentRevisionNumber: 1,
+		}))
+		seedApprovedRevision(t, ctx, repo, &models.SkillRevision{
+			SkillID:               skillID,
+			RevisionNumber:        1,
+			DefaultExposure:       models.SkillExposurePublic,
+			ApprovalID:            "approval-" + skillID,
+			ApprovalAuthorityType: models.SkillApprovalAuthorityAdmin,
+			ApprovalAuthorityID:   "ops",
+			ApprovedBy:            "ops",
+			PrincipalID:           "principal-1",
+		})
+	}
+
+	// Reset call counter after seeding.
+	repo.listRevisionsByStatusCallCount = 0
+
+	// Public viewer, default limit (25 per page).
+	catalog, cursor, err := svc.ListCatalog(ctx, Viewer{}, CatalogFilter{Limit: 25})
+	require.NoError(t, err)
+
+	// The fake repo returns revisions in cursor-sorted order: "hidden-*" < "public-*",
+	// so all hidden revisions precede visible ones. With 25 per page and a cap of
+	// maxCatalogScanRevisions=300, the service must stop after at most 12 calls.
+	maxExpectedCalls := (maxCatalogScanRevisions + 24) / 25 // ceil(300/25)
+	require.LessOrEqual(t, repo.listRevisionsByStatusCallCount, maxExpectedCalls,
+		"ListCatalog made %d ListSkillRevisionsByStatus calls; expected at most %d (scan cap not enforced)",
+		repo.listRevisionsByStatusCallCount, maxExpectedCalls)
+
+	// Because all visible revisions are past the scan cap, the public viewer
+	// should see zero entries and receive a continuation cursor.
+	require.Empty(t, catalog, "expected no visible entries when all public revisions are beyond scan cap")
+	require.NotEmpty(t, cursor, "expected a continuation cursor when scan cap is hit with no visible entries")
+
+	t.Logf("hidden=%d public=%d calls=%d cap=%d maxCalls=%d cursor=%q",
+		hiddenCount, publicCount, repo.listRevisionsByStatusCallCount,
+		maxCatalogScanRevisions, maxExpectedCalls, cursor)
+}
+
+func TestServiceListCatalogScansAreBoundedWithLimit100(t *testing.T) {
+	ctx := context.Background()
+	repo := newFakeSkillRepo()
+	svc := NewService(repo)
+
+	// Seed enough hidden revisions to exceed the cap at limit 100.
+	for i := 0; i < 350; i++ {
+		skillID := fmt.Sprintf("hidden-%03d", i)
+		require.NoError(t, repo.CreateSkill(ctx, &models.Skill{
+			ID:                    skillID,
+			Slug:                  skillID,
+			Name:                  skillID,
+			Status:                models.SkillStatusActive,
+			DefaultExposure:       models.SkillExposurePrivate,
+			CurrentRevisionID:     skillID + "-r1",
+			CurrentRevisionNumber: 1,
+		}))
+		seedApprovedRevision(t, ctx, repo, &models.SkillRevision{
+			SkillID:               skillID,
+			RevisionNumber:        1,
+			DefaultExposure:       models.SkillExposurePrivate,
+			ApprovalID:            "approval-" + skillID,
+			ApprovalAuthorityType: models.SkillApprovalAuthorityAdmin,
+			ApprovalAuthorityID:   "ops",
+			ApprovedBy:            "ops",
+			PrincipalID:           "principal-1",
+		})
+	}
+
+	repo.listRevisionsByStatusCallCount = 0
+
+	catalog, cursor, err := svc.ListCatalog(ctx, Viewer{}, CatalogFilter{Limit: 100})
+	require.NoError(t, err)
+
+	// With limit 100 and cap 300, at most 3 calls.
+	maxExpectedCalls := (maxCatalogScanRevisions + 99) / 100 // ceil(300/100)
+	require.LessOrEqual(t, repo.listRevisionsByStatusCallCount, maxExpectedCalls,
+		"ListCatalog made %d calls at limit 100; expected at most %d",
+		repo.listRevisionsByStatusCallCount, maxExpectedCalls)
+	require.Empty(t, catalog)
+	require.NotEmpty(t, cursor)
+
+	t.Logf("limit=100 calls=%d maxCalls=%d", repo.listRevisionsByStatusCallCount, maxExpectedCalls)
 }
 
 func TestServiceGetBundleIncludesContentAndRejectsUnpublished(t *testing.T) {

--- a/pkg/storage/repositories/search_integration_example_round09_semantic_test.go
+++ b/pkg/storage/repositories/search_integration_example_round09_semantic_test.go
@@ -46,7 +46,7 @@ func TestSearchServiceIntegration_Round09_SemanticSearchBranches(t *testing.T) {
 			},
 		}
 
-		return ai.NewAIService(cfg, &ai.AIConfig{})
+		return ai.NewAIService(cfg, &ai.Config{})
 	}
 
 	setupBudgetOK := func(mockQuery *mocks.MockQuery) {


### PR DESCRIPTION
## Summary

Remediates three medium-severity cost-amplification findings by adding rate limiting, download size bounds, and catalog scan bounds:

- **CSR-031** — Added `ratelimit.ApplyRateLimit` (30 req/5min) to `GET /api/v1/conversations/lookup` to prevent unbound remote actor fetches via repeated DM counterpart lookup requests.
- **CSR-034** — Added `MaxImageDownloadBytes` (default 10 MiB) to `Config` with Content-Length check + `io.LimitReader` defense-in-depth in `uploadImageToS3` to prevent unbounded remote media downloads from amplifying S3 and Lambda costs.
- **CSR-039** — Added route-level rate limiting to `GET /api/v1/skills` and `GET /api/v1/skills/catalog`, **plus** a per-request raw-revision inspection cap (`maxCatalogScanRevisions=300`) in `ListCatalog` that stops scanning when the cap is hit. When no visible entries are found before the cap (e.g., all revisions are hidden from a public viewer), no continuation cursor is returned — the raw repo cursor is never leaked to non-admin callers. This bounds per-request storage work when many approved revisions are hidden (non-public exposure), closing CSR-039 at the service boundary.

## Rework (2026-05-24)

Arch review identified a privacy regression: the original implementation returned `rawNextCursor` from the repository when the scan cap was hit with zero visible entries, leaking non-public skill/revision identifiers (e.g., `SKILL#hidden-299#REVISION#00000001`) to public callers. Fix:

- `ListCatalog` now returns `""` (no continuation cursor) when `maxCatalogScanRevisions` is hit before any visible entry is found, rather than leaking the raw cursor.
- New regression test `TestServiceListCatalogPartialCursorDoesNotLeakHiddenIDs` verifies that cursors from partially-filled visible pages reference only visible revisions.
- Updated `TestServiceListCatalogScansAreBounded` and `TestServiceListCatalogScansAreBoundedWithLimit100` to assert that public cursors do NOT contain `SKILL#hidden` or `hidden-` substrings.
- Branch rebased onto current `origin/project-38-security-remediation` (absorbed #1088).

## Changes

| File | Change |
|------|--------|
| `cmd/api/routes.go` | Rate-limit conversations/lookup, skills, skills/catalog routes |
| `cmd/api/routes_auth_options_test.go` | Route registration and auth coverage assertions for CSR-031/CSR-039 routes |
| `pkg/ai/config.go` | Set `MaxImageDownloadBytes` default in `DefaultConfig()` |
| `pkg/ai/errors.go` | Add `ErrImageDownloadTooLarge` sentinel |
| `pkg/ai/service.go` | Add `MaxImageDownloadBytes` field to `Config`, enforce bound in `uploadImageToS3` with Content-Length check + LimitReader |
| `pkg/ai/service_round20_coverage_test.go` | Tests for oversized/default/within-limit download scenarios |
| `pkg/services/skills/service.go` | Add `maxCatalogScanRevisions=300` cap to `ListCatalog` pagination loop (CSR-039), **plus** privacy-safe cursor: return no cursor when zero visible entries hit the cap |
| `pkg/services/skills/service_test.go` | Regression tests: bounded scan (limit 25, limit 100), partial-cursor privacy, call-count tracking in fake repo; all assert no hidden IDs in public cursors |

## Validation

```
gofmt -l pkg/services/skills/service.go pkg/services/skills/service_test.go  # clean
go test ./pkg/services/skills/... ./pkg/ai/... ./cmd/api/... ./pkg/services/conversations/... ./pkg/ratelimit/... -count=1  # pass
go vet ./pkg/services/skills/... ./pkg/ai/... ./cmd/api/... ./pkg/services/conversations/... ./pkg/ratelimit/...  # clean
```

## Issue linkage

Closes #1076
