### PR TITLE
fix: CSR-029, CSR-055 — close out M6.1 CMS bookmark residuals

### DIFF
--- a/pkg/services/cms/article_service.go
+++ b/pkg/services/cms/article_service.go
@@ -303,9 +303,11 @@ func (s *ArticleService) UpdateArticle(ctx context.Context, article *models.Arti
 
 	if err := validateArticleRenderable(article); err != nil {
 		logCMSArticleRenderFailure(s.logger, "update_article", article, err)
+		if slugCreated {
+			cmsDeleteArticleSlugIndexForTenant(ctx, s.articleRepo.GetDB(), cmsTenantFromID(article.ID), slug)
+		}
 		return err
 	}
-
 	enrichArticleContent(article)
 
 	if err := s.articleRepo.UpdateArticle(ctx, article); err != nil {

--- a/pkg/services/cms/article_service.go
+++ b/pkg/services/cms/article_service.go
@@ -289,6 +289,15 @@ func (s *ArticleService) UpdateArticle(ctx context.Context, article *models.Arti
 		slugCreated = created
 	}
 
+	// Roll back the slug index if it was created during this call and a
+	// subsequent step fails. Extracted to keep UpdateArticle under the
+	// gocognit threshold (CSR-029).
+	cleanupSlugIfCreated := func() {
+		if slugCreated {
+			cmsDeleteArticleSlugIndexForTenant(ctx, s.articleRepo.GetDB(), cmsTenantFromID(article.ID), slug)
+		}
+	}
+
 	// Snapshot existing state before applying the update.
 	if s.revisionService != nil && existing != nil {
 		_, _ = s.revisionService.CreateRevision(ctx, existing)
@@ -303,17 +312,13 @@ func (s *ArticleService) UpdateArticle(ctx context.Context, article *models.Arti
 
 	if err := validateArticleRenderable(article); err != nil {
 		logCMSArticleRenderFailure(s.logger, "update_article", article, err)
-		if slugCreated {
-			cmsDeleteArticleSlugIndexForTenant(ctx, s.articleRepo.GetDB(), cmsTenantFromID(article.ID), slug)
-		}
+		cleanupSlugIfCreated()
 		return err
 	}
 	enrichArticleContent(article)
 
 	if err := s.articleRepo.UpdateArticle(ctx, article); err != nil {
-		if slugCreated {
-			cmsDeleteArticleSlugIndexForTenant(ctx, s.articleRepo.GetDB(), cmsTenantFromID(article.ID), slug)
-		}
+		cleanupSlugIfCreated()
 		return err
 	}
 

--- a/pkg/services/cms/article_service_round31_more_coverage_test.go
+++ b/pkg/services/cms/article_service_round31_more_coverage_test.go
@@ -271,3 +271,40 @@ func TestArticleService_federateArticleWriteActivity_ReturnsWhenActorLookupFails
 
 	svc.federateArticleWriteActivity(ctx, article, activitypub.CreateType, "create")
 }
+
+// TestArticleService_CSR029_UpdateArticleCleansUpSlugIndexOnValidationFailure
+// verifies that when article update validation fails after a slug index has been
+// created, the slug index is deleted to prevent orphaned indexes.
+func TestArticleService_CSR029_UpdateArticleCleansUpSlugIndexOnValidationFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db, q := newCMSMockDB(t)
+
+	// Slug index create succeeds, then validation fails, then slug cleanup must fire.
+	q.On("Create").Return(nil).Once() // slug index create (IfNotExists via cmsEnsureSlugIndex)
+	q.On("Delete").Return(nil).Once() // slug cleanup (cmsDeleteArticleSlugIndexForTenant)
+
+	repo := &fakeArticleRepo{
+		db:       db,
+		articles: map[string]*models.Article{},
+	}
+
+	svc := NewArticleService(repo, fakeActorRepo{err: errors.New("no actor")}, nil, nil, nil, &fakeFederation{}, zap.NewNop())
+
+	// Use a non-canonical article ID so the canonical-slug-immutability check
+	// is not triggered; the slug index is still created before validation.
+	articleID := "https://example.com/objects/update-validation-fail"
+	err := svc.UpdateArticle(ctx, &models.Article{
+		Object: models.Object{
+			ID:           articleID,
+			Name:         "Update Validation Fail",
+			Content:      strings.Repeat("&", cmsrender.MaxArticleSourceBytes/2),
+			Published:    time.Now(),
+			AttributedTo: "https://example.com/users/alice",
+		},
+		Slug:          "validation-slug-test",
+		ContentFormat: "markdown",
+	})
+	require.ErrorIs(t, err, cmsrender.ErrArticleRenderedContentTooLarge)
+}

--- a/pkg/services/cms/article_service_round31_more_coverage_test.go
+++ b/pkg/services/cms/article_service_round31_more_coverage_test.go
@@ -307,4 +307,5 @@ func TestArticleService_CSR029_UpdateArticleCleansUpSlugIndexOnValidationFailure
 		ContentFormat: "markdown",
 	})
 	require.ErrorIs(t, err, cmsrender.ErrArticleRenderedContentTooLarge)
+	q.AssertExpectations(t)
 }

--- a/pkg/storage/repositories/bookmark_repository_test.go
+++ b/pkg/storage/repositories/bookmark_repository_test.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"testing"
 	"time"
@@ -493,3 +494,53 @@ func (b *mockUpdateBuilder) ConditionVersion(int64) core.UpdateBuilder    { retu
 func (b *mockUpdateBuilder) ReturnValues(string) core.UpdateBuilder       { return b }
 func (b *mockUpdateBuilder) Execute() error                               { return nil }
 func (b *mockUpdateBuilder) ExecuteWithResult(any) error                  { return nil }
+
+// TestBookmarkRepository_CSR055_LegacyBookmarksVisible proves that legacy
+// bookmarks stored with a raw RFC3339Nano timestamp SK (the format used before
+// the TIME# / OBJECT# dual-write schema) remain visible through every bookmark
+// read path: GetBookmark, IsBookmarked, GetUserBookmarks, and
+// CheckBookmarksForStatuses. This is a targeted regression probe for CSR-055.
+func TestBookmarkRepository_CSR055_LegacyBookmarksVisible(t *testing.T) {
+	ctx := context.Background()
+	repo := newTestBookmarkRepository()
+	now := time.Date(2024, time.June, 1, 12, 0, 0, 0, time.UTC)
+
+	// Manually build a legacy bookmark: SK is a raw RFC3339Nano timestamp
+	// without any prefix, RecordType is empty, Locked is false.
+	legacy := &models.Bookmark{
+		PK:         fmt.Sprintf("%s#%s", models.BookmarkPartitionPrefix, "legacy-user"),
+		SK:         now.Format(time.RFC3339Nano),
+		Username:   "legacy-user",
+		ObjectID:   "legacy-status-1",
+		CreatedAt:  now,
+		RecordType: "",
+		Locked:     false,
+	}
+	repo.store[repo.makeKey(legacy.PK, legacy.SK)] = legacy
+
+	// Verify the legacy SK is recognized as a legacy timestamp.
+	require.True(t, isLegacyBookmarkTimestampSK(legacy.SK), "legacy SK should be recognized")
+	require.True(t, isReadableTimeBookmark(*legacy), "legacy bookmark should be readable")
+
+	// GetBookmark should find the legacy bookmark via findTimeBookmarkFn fallback.
+	found, err := repo.GetBookmark(ctx, "legacy-user", "legacy-status-1")
+	require.NoError(t, err)
+	require.NotNil(t, found)
+	require.Equal(t, "legacy-status-1", found.ObjectID)
+
+	// IsBookmarked should return true.
+	bookmarked, err := repo.IsBookmarked(ctx, "legacy-user", "legacy-status-1")
+	require.NoError(t, err)
+	require.True(t, bookmarked)
+
+	// GetUserBookmarks should include the legacy bookmark.
+	bookmarks, _, err := repo.GetUserBookmarks(ctx, "legacy-user", 10, "")
+	require.NoError(t, err)
+	require.Len(t, bookmarks, 1)
+	require.Equal(t, "legacy-status-1", bookmarks[0].ObjectID)
+
+	// CheckBookmarksForStatuses should find the legacy bookmark.
+	statusMap, err := repo.CheckBookmarksForStatuses(ctx, "legacy-user", []string{"legacy-status-1"})
+	require.NoError(t, err)
+	require.True(t, statusMap["legacy-status-1"], "legacy bookmark should be found in batch check")
+}


### PR DESCRIPTION
## Summary

Closes #1080

Fixes and closes out two Codex security findings from M6.1 Residual Correctness Closeout.

### CSR-029 (medium) — Article update validation leaves orphaned slug indexes

**Disposition: fix**

`UpdateArticle` creates a slug index before validation, but did not clean it up when `validateArticleRenderable` failed. This left orphaned `CMSSlugIndex` rows pointing to articles that were never persisted.

- **Fix**: Added slug index cleanup in `UpdateArticle`'s validation-failure path (same pattern already used when `articleRepo.UpdateArticle` fails).
- **Test**: `TestArticleService_CSR029_UpdateArticleCleansUpSlugIndexOnValidationFailure` verifies the mock DB receives a `Delete` call when validation fails after slug index creation.

### CSR-055 (informational) — Legacy bookmarks become invisible after TIME# schema change

**Disposition: stale-current-code**

Legacy bookmarks with raw RFC3339Nano timestamp SKs remain visible through all bookmark read paths. The dual-stream query in `queryReadableBookmarkStream` correctly separates TIME-prefixed and legacy timestamp SKs, and the `findTimeBookmarkFn` fallback with `isReadableTimeBookmark` catches un-prefixed legacy records.

- **Probe**: `TestBookmarkRepository_CSR055_LegacyBookmarksVisible` verifies legacy bookmarks are found via `GetBookmark`, `IsBookmarked`, `GetUserBookmarks`, and `CheckBookmarksForStatuses`.

## Files changed

| File | Change |
|------|--------|
| `pkg/services/cms/article_service.go` | +4/-1: slug index cleanup on validation failure |
| `pkg/services/cms/article_service_round31_more_coverage_test.go` | +37: CSR-029 regression test |
| `pkg/storage/repositories/bookmark_repository_test.go` | +51: CSR-055 regression probe |

## Validation

- `go vet ./pkg/services/cms/...` — clean
- `go vet ./pkg/storage/repositories/...` — clean
- `go test ./pkg/services/cms/...` — PASS (0.034s)
- `go test ./pkg/storage/repositories/...` — PASS (22.357s)
- `go build ./...` — clean

## CSR checklist

- [x] `CSR-029` — **medium** — Article update validation leaves orphaned slug indexes
  - Disposition: **fix**
  - Evidence: `article_service.go` slug cleanup + regression test
  - Regression: `TestArticleService_CSR029_UpdateArticleCleansUpSlugIndexOnValidationFailure`
- [x] `CSR-055` — **informational** — Legacy bookmarks become invisible after TIME# schema change
  - Disposition: **stale-current-code**
  - Evidence: Full read-path regression probe
  - Regression: `TestBookmarkRepository_CSR055_LegacyBookmarksVisible`

## Caveats

- CSR-055 is dispositioned as stale-current-code rather than fixed — the existing dual-stream query design and legacy-fallback paths already handle pre-TIME#-schema bookmarks correctly. If future operators report specific legacy bookmark visibility issues not covered by the current probe, this can be revisited.
- CMS article update semantics and bookmark API/storage contracts are preserved unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)