### PR TITLE
feat: instance-key authenticated metrics daily endpoint for lesser-host M0.4

### DIFF
--- a/cmd/api/handlers/metrics.go
+++ b/cmd/api/handlers/metrics.go
@@ -11,6 +11,108 @@ import (
 
 const bytesPerGB = 1024 * 1024 * 1024
 
+// HandleGetInstanceMetricsDailyLift handles GET /api/v1/instance/metrics/daily
+// with instance-key bearer auth for lesser-host portal cost/usage consumption.
+func (h *Handler) HandleGetInstanceMetricsDailyLift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	if h == nil || h.cfg == nil {
+		return common.RespondServiceUnavailable(ctx, "instance metrics")
+	}
+
+	// Authenticate with instance API key (same pattern as notification delivery).
+	expectedKeys, err := h.notificationDeliveryKeys(ctx.Context())
+	if err != nil {
+		h.logger.Warn("failed to resolve instance keys for metrics", zap.Error(err))
+		return common.RespondServiceUnavailable(ctx, "instance metrics")
+	}
+	if len(expectedKeys) == 0 {
+		return common.RespondServiceUnavailable(ctx, "instance metrics")
+	}
+
+	token, err := common.ExtractBearerToken(ctx.Header("Authorization"))
+	if err != nil {
+		return common.RespondMissingAuth(ctx)
+	}
+	if !matchesNotificationDeliveryKey(token, expectedKeys) {
+		return common.RespondForbidden(ctx, "invalid instance api key")
+	}
+
+	// Parse date range from query parameters.
+	// from/to: YYYY-MM-DD (preferred for host portal cost window).
+	// days: fallback bounded to <= 30.
+	fromStr := queryValue(ctx, "from")
+	toStr := queryValue(ctx, "to")
+	daysStr := queryValue(ctx, "days")
+
+	var startDate, endDate time.Time
+
+	if fromStr != "" && toStr != "" {
+		fromParsed, err := time.Parse(common.DateFormat, fromStr)
+		if err != nil {
+			return common.RespondBadRequest(ctx, "invalid from date format; use YYYY-MM-DD")
+		}
+		toParsed, err := time.Parse(common.DateFormat, toStr)
+		if err != nil {
+			return common.RespondBadRequest(ctx, "invalid to date format; use YYYY-MM-DD")
+		}
+		if toParsed.Before(fromParsed) {
+			return common.RespondBadRequest(ctx, "from date must be before or equal to to date")
+		}
+		startDate = fromParsed
+		// Make end date inclusive by adding one day.
+		endDate = toParsed.AddDate(0, 0, 1)
+	} else {
+		days, err := common.ParseAndValidateIntWithBounds("days", daysStr, 1, 30, 7)
+		if err != nil {
+			days = 7
+		}
+		endDate = time.Now().AddDate(0, 0, 1) // include today
+		startDate = endDate.AddDate(0, 0, -days)
+	}
+
+	// Get daily aggregates from cost tracking repository.
+	dailyAggregates, err := h.repos.Cost().GetDailyAggregates(ctx.Context(), startDate, endDate)
+	if err != nil {
+		h.logger.Error("failed to get daily aggregates for instance metrics", zap.Error(err))
+		return common.RespondInternalServerError(ctx, "failed to retrieve instance metrics")
+	}
+
+	// Build response with stable shape for host to map.
+	dailyRows := make([]map[string]any, 0)
+	for _, daily := range dailyAggregates {
+		row := map[string]any{
+			"date":               daily.Date.Format(common.DateFormat),
+			"total_requests":     daily.TotalRequests,
+			"unique_users":       daily.UniqueUsers,
+			"dynamodb_reads":     daily.TotalReads,
+			"dynamodb_writes":    daily.TotalWrites,
+			"lambda_duration_ms": daily.TotalDurationMs,
+			"cost_cents":         int64(daily.TotalCostDollars * 100),
+			"cost_dollars":       daily.TotalCostDollars,
+			"currency":           "USD",
+		}
+		dailyRows = append(dailyRows, row)
+	}
+
+	// Adjust end back for display (it was bumped for inclusive query).
+	displayEnd := endDate.AddDate(0, 0, -1)
+	daysInPeriod := int(displayEnd.Sub(startDate).Hours()/24) + 1
+	if daysInPeriod < 1 {
+		daysInPeriod = 1
+	}
+
+	response := map[string]any{
+		"period": map[string]any{
+			"start":    startDate.Format(common.DateFormat),
+			"end":      displayEnd.Format(common.DateFormat),
+			"days":     daysInPeriod,
+			"timezone": "UTC",
+		},
+		"daily": dailyRows,
+	}
+
+	return okJSON(response)
+}
+
 // HandleGetInstanceMetricsLift returns current instance metrics
 func (h *Handler) HandleGetInstanceMetricsLift(ctx *apptheory.Context) (*apptheory.Response, error) {
 	h.logger.Info("HandleGetInstanceMetricsLift called")

--- a/cmd/api/handlers/metrics_round29_instance_daily_test.go
+++ b/cmd/api/handlers/metrics_round29_instance_daily_test.go
@@ -1,0 +1,212 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstanceMetricsDaily_Round29_AuthAndDateValidation(t *testing.T) {
+	now := time.Now()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+
+	cfg := round11TestConfig()
+	cfg.InstanceAPIKey = "instance-metrics-key-42"
+
+	state := &round10QueryState{
+		costAggregations: []*storagemodels.DynamoDBCostAggregation{
+			{
+				Period:                  "day",
+				OperationType:           "all",
+				WindowStart:             today.AddDate(0, 0, -2),
+				TotalOperations:         100,
+				TotalReadCapacityUnits:  50,
+				TotalWriteCapacityUnits: 25,
+				AverageDuration:         10.0,
+				TotalCostDollars:        0.05,
+			},
+			{
+				Period:                  "day",
+				OperationType:           "all",
+				WindowStart:             today.AddDate(0, 0, -1),
+				TotalOperations:         200,
+				TotalReadCapacityUnits:  80,
+				TotalWriteCapacityUnits: 40,
+				AverageDuration:         12.0,
+				TotalCostDollars:        0.08,
+			},
+			{
+				Period:                  "day",
+				OperationType:           "all",
+				WindowStart:             today,
+				TotalOperations:         150,
+				TotalReadCapacityUnits:  60,
+				TotalWriteCapacityUnits: 30,
+				AverageDuration:         11.0,
+				TotalCostDollars:        0.06,
+			},
+		},
+	}
+
+	h, _, _ := round11NewHandler(t, cfg, state)
+
+	t.Run("missing auth is rejected", func(t *testing.T) {
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/instance/metrics/daily", nil, map[string]string{"days": "3"}, nil)
+		require.NoError(t, err)
+		requireStatus(t, http.StatusUnauthorized)(h.HandleGetInstanceMetricsDailyLift(ctx))
+	})
+
+	t.Run("invalid key is rejected", func(t *testing.T) {
+		headers := map[string]string{"Authorization": "Bearer wrong-key"}
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/instance/metrics/daily", headers, map[string]string{"days": "3"}, nil)
+		require.NoError(t, err)
+		requireStatus(t, http.StatusForbidden)(h.HandleGetInstanceMetricsDailyLift(ctx))
+	})
+
+	t.Run("valid key returns daily aggregates", func(t *testing.T) {
+		headers := map[string]string{"Authorization": "Bearer " + cfg.InstanceAPIKey}
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/instance/metrics/daily", headers, map[string]string{"days": "3"}, nil)
+		require.NoError(t, err)
+
+		resp, err := h.HandleGetInstanceMetricsDailyLift(ctx)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.Status)
+
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+
+		// Verify period metadata.
+		period, ok := body["period"].(map[string]any)
+		require.True(t, ok, "period missing or wrong type")
+		require.NotEmpty(t, period["start"])
+		require.NotEmpty(t, period["end"])
+		require.Equal(t, "UTC", period["timezone"])
+		daysVal, ok := period["days"].(float64)
+		require.True(t, ok)
+		require.GreaterOrEqual(t, int(daysVal), 1)
+		require.LessOrEqual(t, int(daysVal), 3)
+
+		// Verify daily rows.
+		daily, ok := body["daily"].([]any)
+		require.True(t, ok, "daily missing or wrong type")
+		require.NotEmpty(t, daily, "should have aggregate rows from seeded data")
+
+		// Check row shape.
+		firstRow, ok := daily[0].(map[string]any)
+		require.True(t, ok)
+
+		require.NotEmpty(t, firstRow["date"])
+		_, hasRequests := firstRow["total_requests"]
+		require.True(t, hasRequests, "total_requests missing from row")
+		_, hasUsers := firstRow["unique_users"]
+		require.True(t, hasUsers, "unique_users missing from row")
+		_, hasReads := firstRow["dynamodb_reads"]
+		require.True(t, hasReads, "dynamodb_reads missing from row")
+		_, hasWrites := firstRow["dynamodb_writes"]
+		require.True(t, hasWrites, "dynamodb_writes missing from row")
+		_, hasDuration := firstRow["lambda_duration_ms"]
+		require.True(t, hasDuration, "lambda_duration_ms missing from row")
+		_, hasCents := firstRow["cost_cents"]
+		require.True(t, hasCents, "cost_cents missing from row")
+		_, hasDollars := firstRow["cost_dollars"]
+		require.True(t, hasDollars, "cost_dollars missing from row")
+		require.Equal(t, "USD", firstRow["currency"])
+	})
+
+	t.Run("empty data returns empty daily array", func(t *testing.T) {
+		// Handler with empty cost aggregations (explicit empty slice avoids harness defaults).
+		emptyState := &round10QueryState{
+			costAggregations: []*storagemodels.DynamoDBCostAggregation{},
+		}
+		hEmpty, _, _ := round11NewHandler(t, cfg, emptyState)
+
+		headers := map[string]string{"Authorization": "Bearer " + cfg.InstanceAPIKey}
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/instance/metrics/daily", headers, map[string]string{"days": "3"}, nil)
+		require.NoError(t, err)
+
+		resp, err := hEmpty.HandleGetInstanceMetricsDailyLift(ctx)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.Status)
+
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		daily, ok := body["daily"].([]any)
+		require.True(t, ok)
+		require.Empty(t, daily, "empty data should produce empty daily array")
+	})
+
+	t.Run("from/to query params take precedence", func(t *testing.T) {
+		headers := map[string]string{"Authorization": "Bearer " + cfg.InstanceAPIKey}
+		from := today.AddDate(0, 0, -2).Format("2006-01-02")
+		to := today.Format("2006-01-02")
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/instance/metrics/daily", headers, map[string]string{
+			"from": from,
+			"to":   to,
+		}, nil)
+		require.NoError(t, err)
+
+		resp, err := h.HandleGetInstanceMetricsDailyLift(ctx)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.Status)
+
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+
+		period, ok := body["period"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, from, period["start"])
+		require.Equal(t, to, period["end"])
+	})
+
+	t.Run("invalid from date format is rejected", func(t *testing.T) {
+		headers := map[string]string{"Authorization": "Bearer " + cfg.InstanceAPIKey}
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/instance/metrics/daily", headers, map[string]string{
+			"from": "not-a-date",
+			"to":   today.Format("2006-01-02"),
+		}, nil)
+		require.NoError(t, err)
+		requireStatus(t, http.StatusBadRequest)(h.HandleGetInstanceMetricsDailyLift(ctx))
+	})
+
+	t.Run("invalid to date format is rejected", func(t *testing.T) {
+		headers := map[string]string{"Authorization": "Bearer " + cfg.InstanceAPIKey}
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/instance/metrics/daily", headers, map[string]string{
+			"from": today.Format("2006-01-02"),
+			"to":   "bad-date",
+		}, nil)
+		require.NoError(t, err)
+		requireStatus(t, http.StatusBadRequest)(h.HandleGetInstanceMetricsDailyLift(ctx))
+	})
+
+	t.Run("from after to is rejected", func(t *testing.T) {
+		headers := map[string]string{"Authorization": "Bearer " + cfg.InstanceAPIKey}
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/instance/metrics/daily", headers, map[string]string{
+			"from": today.Format("2006-01-02"),
+			"to":   today.AddDate(0, 0, -2).Format("2006-01-02"),
+		}, nil)
+		require.NoError(t, err)
+		requireStatus(t, http.StatusBadRequest)(h.HandleGetInstanceMetricsDailyLift(ctx))
+	})
+
+	t.Run("days bounded to max 30", func(t *testing.T) {
+		headers := map[string]string{"Authorization": "Bearer " + cfg.InstanceAPIKey}
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/instance/metrics/daily", headers, map[string]string{"days": "100"}, nil)
+		require.NoError(t, err)
+
+		resp, err := h.HandleGetInstanceMetricsDailyLift(ctx)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.Status)
+
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		period, ok := body["period"].(map[string]any)
+		require.True(t, ok)
+		daysVal, ok := period["days"].(float64)
+		require.True(t, ok)
+		require.LessOrEqual(t, int(daysVal), 30)
+	})
+}

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -579,6 +579,7 @@ func configureRoutes(app *apptheory.App) {
 
 	// Instance endpoints
 	app.Get("/api/v1/instance", apiHandler.HandleGetInstanceV1Lift)
+	app.Get("/api/v1/instance/metrics/daily", apiHandler.HandleGetInstanceMetricsDailyLift)
 	app.Get("/api/v1/instance/peers", apiHandler.HandleGetInstancePeersLift)
 	app.Get("/api/v1/instance/activity", apiHandler.HandleGetInstanceActivityLift)
 	app.Get("/api/v1/instance/domain_blocks", apiHandler.HandleGetInstanceDomainBlocksLift)

--- a/cmd/api/testdata/routes_manifest.txt
+++ b/cmd/api/testdata/routes_manifest.txt
@@ -84,6 +84,7 @@ GET /api/v1/imports/{id}
 GET /api/v1/instance
 GET /api/v1/instance/activity
 GET /api/v1/instance/domain_blocks
+GET /api/v1/instance/metrics/daily
 GET /api/v1/instance/peers
 GET /api/v1/instance/translation_languages
 GET /api/v1/lists

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -14689,6 +14689,26 @@ paths:
             x-lesser-lambda: api
             x-lesser-routeSources:
                 - cmd/api/routes.go
+    /api/v1/instance/metrics/daily:
+        get:
+            operationId: get_api_v1_instance_metrics_daily
+            tags:
+                - instance
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Map7d31df2b'
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+            x-lesser-handler: HandleGetInstanceMetricsDailyLift
+            x-lesser-lambda: api
+            x-lesser-routeSources:
+                - cmd/api/routes.go
     /api/v1/instance/peers:
         get:
             operationId: get_api_v1_instance_peers

--- a/docs/specs/graphql_coverage.yaml
+++ b/docs/specs/graphql_coverage.yaml
@@ -55,6 +55,11 @@ exemptions:
       match:
         prefixes:
             - /api/v1/trust
+    - id: lesser_host_metrics
+      reason: Managed-instance lesser-host metrics/cost endpoints are REST-only (instance-key authenticated, no user-facing GraphQL equivalent).
+      match:
+        exact:
+            - /api/v1/instance/metrics/daily
     - id: lesser_soul
       reason: lesser-soul proof publication and internal notification delivery remain REST-only.
       match:
@@ -930,6 +935,10 @@ routes:
       status: covered
       graphql:
         - Query.instanceDomainBlocks
+    - method: GET
+      path: /api/v1/instance/metrics/daily
+      policy: rest_only
+      exemptedBy: lesser_host_metrics
     - method: GET
       path: /api/v1/instance/peers
       policy: graphql_required


### PR DESCRIPTION
## Summary
- Adds GET /api/v1/instance/metrics/daily with instance-key bearer auth (same pattern as notification delivery)
- Returns real daily aggregate data from the cost tracking repository (GetDailyAggregates)
- Accepts from/to YYYY-MM-DD query params (preferred for host portal cost window) with days fallback bounded to <= 30
- Stable response shape with period metadata and daily rows including total_requests, unique_users, dynamodb_reads, dynamodb_writes, lambda_duration_ms, cost_cents, cost_dollars, currency USD
- Empty data returns genuine empty daily array (never fabricates data)

## Changes
- `cmd/api/handlers/metrics.go`: new HandleGetInstanceMetricsDailyLift handler
- `cmd/api/routes.go`: route mounted without OAuth scope middleware
- `cmd/api/handlers/metrics_round29_instance_daily_test.go`: 8 subtests covering auth, date validation, response shape, empty data
- `cmd/api/testdata/routes_manifest.txt`: updated snapshot

## Test Plan
- [x] Route mounted without OAuth scope middleware (verified by route manifest snapshot)
- [x] Missing bearer → 401
- [x] Invalid bearer → 403 with "invalid instance api key"
- [x] Valid bearer returns real aggregate rows from repository
- [x] Empty data returns empty daily array
- [x] from/to query params take precedence
- [x] Invalid date formats rejected
- [x] from after to rejected
- [x] days bounded to <= 30
- [x] Existing metrics tests pass
- [x] Route manifest snapshot matches

## Host-side mapping notes
- Auth: same instance API key as notification delivery (cfg.InstanceAPIKey)
- Endpoint: GET /api/v1/instance/metrics/daily?from=YYYY-MM-DD&to=YYYY-MM-DD
- Response: { period: { start, end, days, timezone: "UTC" }, daily: [{ date, total_requests, unique_users, dynamodb_reads, dynamodb_writes, lambda_duration_ms, cost_cents, cost_dollars, currency: "USD" }] }