### PR TITLE
chore: bump x/image for govulncheck

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/yuin/goldmark v1.7.13
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.51.0
-	golang.org/x/image v0.39.0
+	golang.org/x/image v0.41.0
 	golang.org/x/net v0.55.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/text v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
 golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
 golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
-golang.org/x/image v0.39.0 h1:skVYidAEVKgn8lZ602XO75asgXBgLj9G/FE3RbuPFww=
-golang.org/x/image v0.39.0/go.mod h1:sIbmppfU+xFLPIG0FoVUTvyBMmgng1/XAMhQ2ft0hpA=
+golang.org/x/image v0.41.0 h1:8wS72eGJMJaBxK6okTzd4WaXumUlTVlb753MlsSvTCo=
+golang.org/x/image v0.41.0/go.mod h1:uIc348UZMSvS5Z65CVZ7iDPaNobNFEPeJ4kbqTOszmA=
 golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
 golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=


### PR DESCRIPTION
## Summary
- bump `golang.org/x/image` from `v0.39.0` to `v0.41.0`
- run `go mod tidy`
- no feature code changes; no `pkg/media/image_processor.go` API adaptation was required

Closes #1116

## Contract / stewardship impact
- Federation trust: none
- Mastodon/API surface: none
- Schema/TableTheory: none
- AGPL/dependency posture: existing upstream Go module bump only; no new dependency introduced

## Govulncheck evidence
Before, on `origin/project-43-security-remediation`:
```text
Vulnerability #1: GO-2026-5032
  Module: golang.org/x/image
    Found in: golang.org/x/image@v0.39.0
    Fixed in: golang.org/x/image@v0.41.0

Vulnerability #2: GO-2026-5031
  Module: golang.org/x/image
    Found in: golang.org/x/image@v0.39.0
    Fixed in: golang.org/x/image@v0.41.0
```

After this bump:
```text
=== Symbol Results ===

No vulnerabilities found.

Your code is affected by 0 vulnerabilities.
```

## Validation
- [x] `govulncheck ./...`
- [x] `go test ./...`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go build -o lesser ./cmd/lesser && ./lesser build lambdas && ./lesser verify ci`

`./lesser verify ci` result:
```text
✓ verify ci complete (lint, security, supply chain, verify suite, strict contracts, overall/pkg/cmd coverage gates)
```

## Provenance
- Branch created from `origin/project-43-security-remediation`.
- Commit is local GPG-signed because this dependency-bump workflow used local `go mod tidy` and full local validation before push.
