### PR TITLE
fix: preserve remote note attribution

### DIFF
--- a/cmd/api/handlers/ai.go
+++ b/cmd/api/handlers/ai.go
@@ -10,7 +10,6 @@ import (
 	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/common"
 	ai "github.com/equaltoai/lesser/pkg/services/ai"
-	"github.com/equaltoai/lesser/pkg/transformations"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 )
 
@@ -128,7 +127,7 @@ func (h *Handler) aiAnalysisOwnerUsername(ctx context.Context, objectID string) 
 	if owner := strings.TrimSpace(status.AuthorUsername); owner != "" {
 		return owner, nil
 	}
-	return strings.TrimPrefix(strings.TrimSpace(transformations.ExtractUsernameFromActorID(status.AuthorID)), "@"), nil
+	return h.localUsernameForStoredActorCandidate(status.AuthorID), nil
 }
 
 // HandleRequestAIAnalysisLift triggers AI analysis for an object

--- a/cmd/api/handlers/ai_round12_coverage_test.go
+++ b/cmd/api/handlers/ai_round12_coverage_test.go
@@ -341,11 +341,18 @@ func TestAI_Round12_AuthorizationHelpers_Coverage(t *testing.T) {
 				StatusID: "actor-id-only",
 				AuthorID: "https://example.com/users/carol",
 			},
+			"remote-actor-id-only": {
+				StatusID: "remote-actor-id-only",
+				AuthorID: "https://remote.example/users/alice",
+			},
 		},
 	})
 	owner, err = handler.aiAnalysisOwnerUsername(ctx, "actor-id-only")
 	require.NoError(t, err)
 	require.Equal(t, "carol", owner)
+	owner, err = handler.aiAnalysisOwnerUsername(ctx, "remote-actor-id-only")
+	require.NoError(t, err)
+	require.Empty(t, owner)
 
 	liftCtx, err := round10NewLiftContext(http.MethodGet, "/api/v1/ai/analysis/status-1", nil, nil, nil)
 	require.NoError(t, err)

--- a/cmd/api/handlers/helpers.go
+++ b/cmd/api/handlers/helpers.go
@@ -563,6 +563,153 @@ func (h *Handler) localUsernameForStoredActorCandidate(candidate string) string 
 	return strings.TrimSpace(candidate)
 }
 
+func (h *Handler) actorIdentifierLooksRemote(identifier string) bool {
+	identifier = normalizeResolvedAccountID(identifier)
+	if identifier == "" {
+		return false
+	}
+
+	localDomain := ""
+	if h != nil && h.cfg != nil {
+		localDomain = normalizeLocalActorDomain(h.cfg.Domain)
+	}
+
+	lowerIdentifier := strings.ToLower(identifier)
+	if strings.HasPrefix(lowerIdentifier, "http://") || strings.HasPrefix(lowerIdentifier, "https://") {
+		parsed, err := url.Parse(identifier)
+		if err != nil || parsed == nil {
+			return false
+		}
+		host := normalizeLocalActorDomain(parsed.Hostname())
+		if host == "" {
+			return false
+		}
+		if localDomain == "" {
+			return true
+		}
+		return host != localDomain
+	}
+
+	handle := strings.TrimPrefix(identifier, "@")
+	if strings.Count(handle, "@") != 1 {
+		return false
+	}
+	parts := strings.Split(handle, "@")
+	if len(parts) != 2 {
+		return false
+	}
+	domain := normalizeLocalActorDomain(parts[1])
+	if domain == "" {
+		return false
+	}
+	if localDomain == "" {
+		return true
+	}
+	return domain != localDomain
+}
+
+func (h *Handler) resolveAttributedActorForObject(ctx context.Context, attributedTo string) *activitypub.Actor {
+	actorID := normalizeResolvedAccountID(attributedTo)
+	if actorID == "" || h == nil {
+		return nil
+	}
+
+	if h.actorIdentifierLooksRemote(actorID) {
+		if actor := h.cachedRemoteActorForIdentifier(ctx, actorID); actor != nil {
+			return actor
+		}
+		return syntheticRemoteActorFromIdentifier(actorID)
+	}
+
+	username := h.localUsernameForStoredActorCandidate(actorID)
+	if username == "" || h.registry == nil || h.registry.Accounts() == nil {
+		return nil
+	}
+
+	account, err := h.registry.Accounts().GetAccount(ctx, username)
+	if err != nil || account == nil {
+		return nil
+	}
+	return account.Actor
+}
+
+func (h *Handler) cachedRemoteActorForIdentifier(ctx context.Context, actorID string) *activitypub.Actor {
+	if h == nil || h.repos == nil {
+		return nil
+	}
+	actorRepo := h.repos.Actor()
+	if actorRepo == nil {
+		return nil
+	}
+
+	candidates := []string{strings.TrimSpace(actorID)}
+	if handle := extractHandleFromActorID(actorID); handle != "" {
+		candidates = append(candidates, handle)
+	}
+	if strings.Contains(strings.TrimPrefix(actorID, "@"), "@") {
+		candidates = append(candidates, strings.TrimPrefix(actorID, "@"))
+	}
+
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if _, exists := seen[candidate]; exists {
+			continue
+		}
+		seen[candidate] = struct{}{}
+
+		actor, err := actorRepo.GetCachedRemoteActor(ctx, candidate)
+		if err == nil && actor != nil {
+			return actor
+		}
+	}
+
+	return nil
+}
+
+func syntheticRemoteActorFromIdentifier(actorID string) *activitypub.Actor {
+	actorID = normalizeResolvedAccountID(actorID)
+	if actorID == "" {
+		return nil
+	}
+
+	username := remoteActorPlaceholderUsername(actorID)
+	return &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   actorID,
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: username,
+		Name:              username,
+		URL:               actorID,
+	}
+}
+
+func remoteActorPlaceholderUsername(actorID string) string {
+	actorID = strings.TrimSpace(actorID)
+	if actorID == "" {
+		return ""
+	}
+
+	handle := strings.TrimPrefix(actorID, "@")
+	if strings.Count(handle, "@") == 1 {
+		if username, _, ok := strings.Cut(handle, "@"); ok {
+			return strings.TrimSpace(username)
+		}
+	}
+
+	if handle := extractHandleFromActorID(actorID); handle != "" {
+		if username, _, ok := strings.Cut(handle, "@"); ok {
+			return strings.TrimSpace(username)
+		}
+	}
+
+	return strings.TrimPrefix(transformations.ExtractUsernameFromActorID(actorID), "@")
+}
+
 func (h *Handler) resolveStatusAuthorActor(ctx context.Context, storageStatus *storageModels.Status) *activitypub.Actor {
 	if storageStatus == nil {
 		return nil
@@ -1470,7 +1617,7 @@ func (h *Handler) statusLookupObjectIDs(storageStatus *storageModels.Status) []s
 
 	authorUsername := strings.TrimSpace(storageStatus.AuthorUsername)
 	if authorUsername == "" {
-		authorUsername = strings.TrimSpace(transformations.ExtractUsernameFromActorID(storageStatus.AuthorID))
+		authorUsername = h.localUsernameForStoredActorCandidate(storageStatus.AuthorID)
 	}
 	if h != nil && h.cfg != nil && authorUsername != "" && strings.TrimSpace(storageStatus.StatusID) != "" {
 		ids = appendUniqueLookupID(ids, fmt.Sprintf("%s/users/%s/statuses/%s", h.cfg.BaseURL(), authorUsername, storageStatus.StatusID))

--- a/cmd/api/handlers/l17_remote_actor_guard_test.go
+++ b/cmd/api/handlers/l17_remote_actor_guard_test.go
@@ -1,0 +1,366 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/services/notes"
+	"github.com/equaltoai/lesser/pkg/storage"
+	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+func l17RemoteActor(username, domain string) *activitypub.Actor {
+	actorID := "https://" + domain + "/users/" + username
+	return &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   actorID,
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: username,
+		Name:              "Remote " + username,
+		URL:               "https://" + domain + "/@" + username,
+		Inbox:             actorID + "/inbox",
+		Outbox:            actorID + "/outbox",
+	}
+}
+
+func l17CachedRemoteActor(handle string, actor *activitypub.Actor) storagemodels.RemoteActor {
+	now := time.Now().UTC()
+	cached := storagemodels.RemoteActor{
+		Handle:    handle,
+		Actor:     actor,
+		CachedAt:  now.Add(-time.Minute),
+		UpdatedAt: now.Add(-time.Minute),
+		ExpiresAt: now.Add(time.Hour),
+	}
+	cached.UpdateKeys()
+	return cached
+}
+
+func l17LocalAccount(cfgDomain, username string) *storage.Account {
+	actorID := "https://" + cfgDomain + "/users/" + username
+	return &storage.Account{
+		User: &storage.User{
+			Username:    username,
+			DisplayName: "Local " + username,
+			Approved:    true,
+		},
+		Actor: &activitypub.Actor{
+			BaseObject: activitypub.BaseObject{
+				ID:   actorID,
+				Type: activitypub.PersonType,
+			},
+			PreferredUsername: username,
+			Name:              "Local " + username,
+			URL:               "https://" + cfgDomain + "/@" + username,
+			Inbox:             actorID + "/inbox",
+			Outbox:            actorID + "/outbox",
+		},
+	}
+}
+
+func l17AccountsStub(cfgDomain string) *AccountsServiceStub {
+	return &AccountsServiceStub{
+		GetAccountFunc: func(_ context.Context, username string) (*storage.Account, error) {
+			if username == "alice" {
+				return l17LocalAccount(cfgDomain, username), nil
+			}
+			return nil, errors.New("not found")
+		},
+	}
+}
+
+func TestL17RemoteActorHelperBranches(t *testing.T) {
+	cfg := round11TestConfig()
+	remoteActor := l17RemoteActor("alice", "remote.example")
+	cached := l17CachedRemoteActor("alice@remote.example", remoteActor)
+	state := &round10QueryState{
+		remoteActorsByPK: map[string]storagemodels.RemoteActor{
+			cached.PK: cached,
+		},
+	}
+	h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{AccountsSvc: l17AccountsStub(cfg.Domain)})
+	ctx := context.Background()
+
+	t.Run("remote detector separates remote and local identifiers", func(t *testing.T) {
+		require.True(t, h.actorIdentifierLooksRemote(remoteActor.ID))
+		require.True(t, h.actorIdentifierLooksRemote("@alice@remote.example"))
+		require.False(t, h.actorIdentifierLooksRemote(cfg.BaseURL()+"/users/alice"))
+		require.False(t, h.actorIdentifierLooksRemote("@alice@"+cfg.Domain))
+		require.False(t, h.actorIdentifierLooksRemote("alice"))
+		require.False(t, h.actorIdentifierLooksRemote(""))
+		require.False(t, h.actorIdentifierLooksRemote("https://%"))
+		require.False(t, h.actorIdentifierLooksRemote("https:///users/alice"))
+		require.True(t, (*Handler)(nil).actorIdentifierLooksRemote(remoteActor.ID))
+		require.True(t, (*Handler)(nil).actorIdentifierLooksRemote("@alice@remote.example"))
+		require.False(t, (*Handler)(nil).actorIdentifierLooksRemote("alice@"))
+	})
+
+	t.Run("cached remote lookup tries URL and handle candidates", func(t *testing.T) {
+		fromURL := h.cachedRemoteActorForIdentifier(ctx, remoteActor.ID)
+		require.NotNil(t, fromURL)
+		require.Equal(t, remoteActor.ID, fromURL.ID)
+
+		fromHandle := h.cachedRemoteActorForIdentifier(ctx, "@alice@remote.example")
+		require.NotNil(t, fromHandle)
+		require.Equal(t, remoteActor.ID, fromHandle.ID)
+
+		require.Nil(t, h.cachedRemoteActorForIdentifier(ctx, "https://missing.example/users/alice"))
+		require.Nil(t, h.cachedRemoteActorForIdentifier(ctx, "missing@remote.example"))
+		require.Nil(t, h.cachedRemoteActorForIdentifier(ctx, "   "))
+		require.Nil(t, (*Handler)(nil).cachedRemoteActorForIdentifier(ctx, remoteActor.ID))
+	})
+
+	t.Run("synthetic placeholders preserve remote identity", func(t *testing.T) {
+		require.Empty(t, remoteActorPlaceholderUsername(""))
+		require.Equal(t, "alice", remoteActorPlaceholderUsername("alice@remote.example"))
+		require.Equal(t, "alice", remoteActorPlaceholderUsername(remoteActor.ID))
+		require.NotEmpty(t, remoteActorPlaceholderUsername("https://remote.example/@alice"))
+		require.NotEmpty(t, remoteActorPlaceholderUsername("urn:remote:alice"))
+
+		require.Nil(t, syntheticRemoteActorFromIdentifier(""))
+		synthetic := syntheticRemoteActorFromIdentifier("https://uncached.example/users/bob")
+		require.NotNil(t, synthetic)
+		require.Equal(t, "https://uncached.example/users/bob", synthetic.ID)
+		require.Equal(t, "bob", synthetic.PreferredUsername)
+		require.Equal(t, "bob", synthetic.Name)
+		require.Equal(t, "https://uncached.example/users/bob", synthetic.URL)
+	})
+
+	t.Run("attributed actor resolver returns cached remote, synthetic remote, and local actors", func(t *testing.T) {
+		require.Nil(t, h.resolveAttributedActorForObject(ctx, ""))
+		require.Nil(t, (*Handler)(nil).resolveAttributedActorForObject(ctx, cfg.BaseURL()+"/users/alice"))
+
+		cachedActor := h.resolveAttributedActorForObject(ctx, remoteActor.ID)
+		require.NotNil(t, cachedActor)
+		require.Equal(t, remoteActor.ID, cachedActor.ID)
+		require.Equal(t, "Remote alice", cachedActor.Name)
+
+		synthetic := h.resolveAttributedActorForObject(ctx, "https://uncached.example/users/alice")
+		require.NotNil(t, synthetic)
+		require.Equal(t, "https://uncached.example/users/alice", synthetic.ID)
+		require.Equal(t, "alice", synthetic.PreferredUsername)
+		require.NotEqual(t, cfg.BaseURL()+"/users/alice", synthetic.ID)
+
+		local := h.resolveAttributedActorForObject(ctx, cfg.BaseURL()+"/users/alice")
+		require.NotNil(t, local)
+		require.Equal(t, cfg.BaseURL()+"/users/alice", local.ID)
+		require.Equal(t, "Local alice", local.Name)
+
+		missingLocal := h.resolveAttributedActorForObject(ctx, cfg.BaseURL()+"/users/missing")
+		require.Nil(t, missingLocal)
+	})
+}
+
+func TestL17AIAnalysisOwnerUsernameRemoteAndLocalFallbacks(t *testing.T) {
+	cfg := round11TestConfig()
+	h, _, _ := round11NewHandler(t, cfg, &round10QueryState{
+		statusByID: map[string]storagemodels.Status{
+			"stored-owner": {
+				StatusID:       "stored-owner",
+				AuthorUsername: "alice",
+				AuthorID:       cfg.BaseURL() + "/users/ignored",
+			},
+			"local-author-id": {
+				StatusID: "local-author-id",
+				AuthorID: cfg.BaseURL() + "/users/alice",
+			},
+			"remote-author-id": {
+				StatusID: "remote-author-id",
+				AuthorID: "https://remote.example/users/alice",
+			},
+		},
+	})
+
+	owner, err := h.aiAnalysisOwnerUsername(context.Background(), "stored-owner")
+	require.NoError(t, err)
+	require.Equal(t, "alice", owner)
+
+	owner, err = h.aiAnalysisOwnerUsername(context.Background(), "local-author-id")
+	require.NoError(t, err)
+	require.Equal(t, "alice", owner)
+
+	owner, err = h.aiAnalysisOwnerUsername(context.Background(), "remote-author-id")
+	require.NoError(t, err)
+	require.Empty(t, owner)
+}
+
+func TestL17SiblingAttributionExtractorsRemoteAndLocalBranches(t *testing.T) {
+	cfg := round11TestConfig()
+	remoteActor := l17RemoteActor("alice", "remote.example")
+	cached := l17CachedRemoteActor("alice@remote.example", remoteActor)
+	h, _, _ := round11NewHandler(t, cfg, &round10QueryState{
+		remoteActorsByPK: map[string]storagemodels.RemoteActor{
+			cached.PK: cached,
+		},
+	}, &RegistryStub{AccountsSvc: l17AccountsStub(cfg.Domain)})
+
+	liftCtx, err := round10NewLiftContext(http.MethodGet, "/test", nil, nil, nil)
+	require.NoError(t, err)
+
+	localNote := &activitypub.Note{AttributedTo: cfg.BaseURL() + "/users/alice"}
+	cachedRemoteNote := &activitypub.Note{AttributedTo: remoteActor.ID}
+	uncachedRemoteNote := &activitypub.Note{AttributedTo: "https://uncached.example/users/alice"}
+
+	t.Run("statuses getActorForObject keeps remote and local paths distinct", func(t *testing.T) {
+		local := h.getActorForObject(context.Background(), localNote)
+		require.NotNil(t, local)
+		require.Equal(t, cfg.BaseURL()+"/users/alice", local.ID)
+
+		cachedRemote := h.getActorForObject(context.Background(), cachedRemoteNote)
+		require.NotNil(t, cachedRemote)
+		require.Equal(t, remoteActor.ID, cachedRemote.ID)
+		require.NotEqual(t, cfg.BaseURL()+"/users/alice", cachedRemote.ID)
+
+		placeholder := h.getActorForObject(context.Background(), uncachedRemoteNote)
+		require.NotNil(t, placeholder)
+		require.Equal(t, uncachedRemoteNote.AttributedTo, placeholder.ID)
+		require.NotEqual(t, cfg.BaseURL()+"/users/alice", placeholder.ID)
+	})
+
+	t.Run("status info getHistoryAuthorActor keeps remote and local paths distinct", func(t *testing.T) {
+		local := h.getHistoryAuthorActor(liftCtx, map[string]any{"attributedTo": localNote.AttributedTo})
+		require.NotNil(t, local)
+		require.Equal(t, cfg.BaseURL()+"/users/alice", local.ID)
+
+		cachedRemote := h.getHistoryAuthorActor(liftCtx, map[string]any{"attributedTo": cachedRemoteNote.AttributedTo})
+		require.NotNil(t, cachedRemote)
+		require.Equal(t, remoteActor.ID, cachedRemote.ID)
+
+		placeholder := h.getHistoryAuthorActor(liftCtx, map[string]any{"attributedTo": uncachedRemoteNote.AttributedTo})
+		require.NotNil(t, placeholder)
+		require.Equal(t, uncachedRemoteNote.AttributedTo, placeholder.ID)
+		require.NotEqual(t, cfg.BaseURL()+"/users/alice", placeholder.ID)
+	})
+
+	t.Run("oEmbed author helpers keep remote and local paths distinct", func(t *testing.T) {
+		local := h.getOEmbedAuthorActor(liftCtx, localNote)
+		require.NotNil(t, local)
+		require.Equal(t, cfg.BaseURL()+"/users/alice", local.ID)
+
+		cachedRemote := h.getOEmbedAuthorActor(liftCtx, cachedRemoteNote)
+		require.NotNil(t, cachedRemote)
+		require.Equal(t, remoteActor.ID, cachedRemote.ID)
+
+		placeholder := h.getOEmbedAuthorActor(liftCtx, uncachedRemoteNote)
+		require.NotNil(t, placeholder)
+		require.Equal(t, uncachedRemoteNote.AttributedTo, placeholder.ID)
+		require.NotEqual(t, cfg.BaseURL()+"/users/alice", placeholder.ID)
+
+		localInfo := h.getEmbedAuthorInfo(liftCtx, localNote)
+		require.NotNil(t, localInfo.actor)
+		require.Equal(t, "alice", localInfo.username)
+		require.Equal(t, "Local alice", localInfo.name)
+
+		cachedRemoteInfo := h.getEmbedAuthorInfo(liftCtx, cachedRemoteNote)
+		require.NotNil(t, cachedRemoteInfo.actor)
+		require.Equal(t, remoteActor.ID, cachedRemoteInfo.actor.ID)
+		require.Equal(t, "alice", cachedRemoteInfo.username)
+		require.Equal(t, "Remote alice", cachedRemoteInfo.name)
+
+		placeholderInfo := h.getEmbedAuthorInfo(liftCtx, uncachedRemoteNote)
+		require.NotNil(t, placeholderInfo.actor)
+		require.Equal(t, uncachedRemoteNote.AttributedTo, placeholderInfo.actor.ID)
+		require.NotEqual(t, cfg.BaseURL()+"/users/alice", placeholderInfo.actor.ID)
+
+		fallbackHandler, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
+		fallbackActor := fallbackHandler.getOEmbedAuthorActor(liftCtx, localNote)
+		require.NotNil(t, fallbackActor)
+		require.Equal(t, localNote.AttributedTo, fallbackActor.ID)
+		require.Equal(t, "alice", fallbackActor.PreferredUsername)
+
+		fallbackInfo := fallbackHandler.getEmbedAuthorInfo(liftCtx, localNote)
+		require.Nil(t, fallbackInfo.actor)
+		require.Equal(t, "alice", fallbackInfo.username)
+	})
+
+	t.Run("notification status author extraction keeps remote and local paths distinct", func(t *testing.T) {
+		local := h.extractStatusAuthor(liftCtx, localNote)
+		require.NotNil(t, local)
+		require.Equal(t, cfg.BaseURL()+"/users/alice", local.ID)
+
+		cachedRemote := h.extractStatusAuthor(liftCtx, cachedRemoteNote)
+		require.NotNil(t, cachedRemote)
+		require.Equal(t, remoteActor.ID, cachedRemote.ID)
+
+		placeholder := h.extractStatusAuthor(liftCtx, uncachedRemoteNote)
+		require.NotNil(t, placeholder)
+		require.Equal(t, uncachedRemoteNote.AttributedTo, placeholder.ID)
+		require.NotEqual(t, cfg.BaseURL()+"/users/alice", placeholder.ID)
+	})
+}
+
+func TestL17StatusInfoSourceGuardDoesNotTreatRemoteAuthorAsLocalOwner(t *testing.T) {
+	cfg := round11TestConfig()
+	token := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{auth.ScopeRead})
+	headers := map[string]string{"authorization": "Bearer " + token}
+
+	localStatus := &storagemodels.Status{
+		StatusID: "local-source",
+		AuthorID: cfg.BaseURL() + "/users/alice",
+		Note: &activitypub.Note{
+			BaseObject:   activitypub.BaseObject{ID: cfg.BaseURL() + "/objects/local-source", Type: activitypub.NoteType},
+			AttributedTo: cfg.BaseURL() + "/users/alice",
+			Content:      "local source",
+		},
+	}
+	remoteStatus := &storagemodels.Status{
+		StatusID: "remote-source",
+		AuthorID: "https://remote.example/users/alice",
+		Note: &activitypub.Note{
+			BaseObject:   activitypub.BaseObject{ID: "https://remote.example/objects/remote-source", Type: activitypub.NoteType},
+			AttributedTo: "https://remote.example/users/alice",
+			Content:      "remote source",
+		},
+	}
+	notesSvc := &NotesServiceStub{
+		GetNoteWithViewerFunc: func(_ context.Context, query *notes.GetNoteQuery) (*storagemodels.Status, error) {
+			switch query.StatusID {
+			case "local-source":
+				return localStatus, nil
+			case "remote-source":
+				return remoteStatus, nil
+			default:
+				return nil, errors.New("not found")
+			}
+		},
+	}
+	h, _, _ := round11NewHandler(t, cfg, &round10QueryState{}, &RegistryStub{NotesSvc: notesSvc})
+
+	localCtx, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/local-source/source", headers, nil, nil)
+	require.NoError(t, err)
+	localCtx.Params["id"] = "local-source"
+	requireStatus(t, http.StatusOK)(h.HandleGetStatusSourceLift(localCtx))
+
+	remoteCtx, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/remote-source/source", headers, nil, nil)
+	require.NoError(t, err)
+	remoteCtx.Params["id"] = "remote-source"
+	requireStatus(t, http.StatusNotFound)(h.HandleGetStatusSourceLift(remoteCtx))
+}
+
+func TestL17StatusLookupObjectIDsGuardSkipsRemoteAuthorURLProjection(t *testing.T) {
+	cfg := round11TestConfig()
+	h, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
+
+	localIDs := h.statusLookupObjectIDs(&storagemodels.Status{
+		StatusID: "local-1",
+		AuthorID: cfg.BaseURL() + "/users/alice",
+	})
+	require.Contains(t, localIDs, cfg.BaseURL()+"/users/alice/statuses/local-1")
+	require.Contains(t, localIDs, cfg.BaseURL()+"/objects/local-1")
+	require.Contains(t, localIDs, "local-1")
+
+	remoteIDs := h.statusLookupObjectIDs(&storagemodels.Status{
+		StatusID: "remote-1",
+		AuthorID: "https://remote.example/users/alice",
+	})
+	require.NotContains(t, remoteIDs, cfg.BaseURL()+"/users/alice/statuses/remote-1")
+	require.NotContains(t, remoteIDs, cfg.BaseURL()+"/objects/remote-1")
+	require.Equal(t, []string{"remote-1"}, remoteIDs)
+}

--- a/cmd/api/handlers/misc.go
+++ b/cmd/api/handlers/misc.go
@@ -1402,12 +1402,20 @@ func (h *Handler) extractStatusAuthor(ctx *apptheory.Context, obj any) *activity
 		return nil
 	}
 
-	parts := strings.Split(note.AttributedTo, "/")
-	if err := common.ValidateSliceNotEmpty("attributed_to_parts", parts); err != nil {
-		return nil
+	if h.actorIdentifierLooksRemote(note.AttributedTo) {
+		if actor := h.cachedRemoteActorForIdentifier(ctx.Context(), note.AttributedTo); actor != nil {
+			return actor
+		}
+		return syntheticRemoteActorFromIdentifier(note.AttributedTo)
 	}
 
-	username := parts[len(parts)-1]
+	username := h.localUsernameForStoredActorCandidate(note.AttributedTo)
+	if err := common.ValidateRequiredParam("username", username); err != nil {
+		return nil
+	}
+	if h.repos == nil || h.repos.Actor() == nil {
+		return nil
+	}
 	statusActor, _ := h.repos.Actor().GetActor(ctx.Context(), username)
 	return statusActor
 }

--- a/cmd/api/handlers/oembed.go
+++ b/cmd/api/handlers/oembed.go
@@ -169,29 +169,31 @@ func (h *Handler) getOEmbedAuthorActor(ctx *apptheory.Context, note *activitypub
 		return nil
 	}
 
-	// Extract username from actor ID
-	parts := strings.Split(note.AttributedTo, "/")
-	if err := common.ValidateSliceNotEmpty("parts", parts); err != nil {
+	if actor := h.resolveAttributedActorForObject(ctx.Context(), note.AttributedTo); actor != nil {
+		return actor
+	}
+
+	username := h.localUsernameForStoredActorCandidate(note.AttributedTo)
+	if username == "" {
+		username = remoteActorPlaceholderUsername(note.AttributedTo)
+	}
+	if username == "" {
 		return nil
 	}
 
-	username := parts[len(parts)-1]
-	result, err := h.registry.Accounts().GetAccount(ctx.Context(), username)
-	if err != nil {
-		h.logger.Warn("failed to get author account", zap.String("username", username), zap.Error(err))
-		// Create a minimal actor
-		return &activitypub.Actor{
-			BaseObject: activitypub.BaseObject{
-				ID: note.AttributedTo,
-			},
-			PreferredUsername: username,
-			Name:              username,
-			URL:               note.AttributedTo,
-		}
+	if h.logger != nil {
+		h.logger.Warn("failed to get author account", zap.String("username", username))
 	}
-	authorActor := result.Actor
-
-	return authorActor
+	// Create a minimal actor.
+	return &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   note.AttributedTo,
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: username,
+		Name:              username,
+		URL:               note.AttributedTo,
+	}
 }
 
 // sendOEmbedResponse sends the oEmbed response in the requested format
@@ -505,20 +507,23 @@ func (h *Handler) getEmbedAuthorInfo(ctx *apptheory.Context, note *activitypub.N
 		return info
 	}
 
-	// Extract username from actor ID
-	parts := strings.Split(note.AttributedTo, "/")
-	if err := common.ValidateSliceNotEmpty("parts", parts); err == nil {
-		username := parts[len(parts)-1]
-		info.username = username
-
-		result, err := h.registry.Accounts().GetAccount(ctx.Context(), username)
-		if err == nil && result != nil && result.Actor != nil {
-			info.actor = result.Actor
-			info.name = result.Actor.Name
-			if err := common.ValidateRequiredParam("actorName", info.name); err != nil {
-				info.name = result.Actor.PreferredUsername
-			}
+	if actor := h.resolveAttributedActorForObject(ctx.Context(), note.AttributedTo); actor != nil {
+		info.actor = actor
+		info.username = actor.PreferredUsername
+		if info.username == "" {
+			info.username = remoteActorPlaceholderUsername(note.AttributedTo)
 		}
+		info.name = actor.Name
+		if err := common.ValidateRequiredParam("actorName", info.name); err != nil {
+			info.name = actor.PreferredUsername
+		}
+		return info
+	}
+
+	if username := h.localUsernameForStoredActorCandidate(note.AttributedTo); username != "" {
+		info.username = username
+	} else if username := remoteActorPlaceholderUsername(note.AttributedTo); username != "" {
+		info.username = username
 	}
 
 	return info

--- a/cmd/api/handlers/status_info.go
+++ b/cmd/api/handlers/status_info.go
@@ -54,7 +54,7 @@ func (h *Handler) HandleGetStatusSourceLift(ctx *apptheory.Context) (*apptheory.
 
 	authorUsername := strings.TrimSpace(result.AuthorUsername)
 	if authorUsername == "" {
-		authorUsername = transformations.ExtractUsernameFromActorID(result.AuthorID)
+		authorUsername = h.localUsernameForStoredActorCandidate(result.AuthorID)
 	}
 	if authorUsername != claims.Username {
 		return common.RespondNotFound(ctx, "status not found")
@@ -201,16 +201,7 @@ func (h *Handler) getHistoryAuthorActor(ctx *apptheory.Context, currentObject an
 		return nil
 	}
 
-	// Extract username from actor ID
-	parts := strings.Split(attributedTo, "/")
-	if err := common.ValidateSliceNotEmpty("parts", parts); err == nil {
-		username := parts[len(parts)-1]
-		result, _ := h.registry.Accounts().GetAccount(ctx.Context(), username)
-		if result != nil {
-			return result.Actor
-		}
-	}
-	return nil
+	return h.resolveAttributedActorForObject(ctx.Context(), attributedTo)
 }
 
 // extractAttributedTo extracts the attributedTo field from an object

--- a/cmd/api/handlers/status_info_round12_coverage_test.go
+++ b/cmd/api/handlers/status_info_round12_coverage_test.go
@@ -135,6 +135,10 @@ func TestStatusInfoRound12_Coverage(t *testing.T) {
 		require.Equal(t, "", h.extractAttributedTo(map[string]any{"attributedTo": 123}))
 		require.Nil(t, h.getHistoryAuthorActor(ctx, map[string]any{}))
 		require.NotNil(t, h.getHistoryAuthorActor(ctx, map[string]any{"attributedTo": cfg.BaseURL() + "/users/alice"}))
+		remoteHistoryActor := h.getHistoryAuthorActor(ctx, map[string]any{"attributedTo": "https://remote.example/users/alice"})
+		require.NotNil(t, remoteHistoryActor)
+		require.Equal(t, "https://remote.example/users/alice", remoteHistoryActor.ID)
+		require.NotEqual(t, cfg.BaseURL()+"/users/alice", remoteHistoryActor.ID)
 
 		// extractEditContent covers note + map paths (and extractNoteContent branches)
 		edit := models.StatusEdit{CreatedAt: "baseline"}

--- a/cmd/api/handlers/statuses.go
+++ b/cmd/api/handlers/statuses.go
@@ -1147,16 +1147,7 @@ func (h *Handler) getActorForObject(ctx context.Context, obj interface{}) *activ
 		return nil
 	}
 
-	username := transformations.ExtractUsernameFromActorID(attributedTo)
-	if err := common.ValidateRequiredParam("username", username); err != nil {
-		return nil
-	}
-
-	account, err := h.registry.Accounts().GetAccount(ctx, username)
-	if err != nil {
-		return nil
-	}
-	return account.Actor
+	return h.resolveAttributedActorForObject(ctx, attributedTo)
 }
 
 // getStatusDescendants retrieves the descendants (replies) of a status, enforcing viewer privacy.

--- a/cmd/api/handlers/statuses_round19_unused_helpers_test.go
+++ b/cmd/api/handlers/statuses_round19_unused_helpers_test.go
@@ -90,6 +90,11 @@ func TestStatusesRound19_UnusedHelpers(t *testing.T) {
 		require.NotNil(t, actor)
 		require.Equal(t, "https://example.com/users/alice", actor.ID)
 
+		remoteActor := h.getActorForObject(context.Background(), &activitypub.Note{AttributedTo: "https://remote.example/users/alice"})
+		require.NotNil(t, remoteActor)
+		require.Equal(t, "https://remote.example/users/alice", remoteActor.ID)
+		require.NotEqual(t, "https://example.com/users/alice", remoteActor.ID)
+
 		replyStatus := h.convertReplyToStatus(context.Background(), &activitypub.Note{
 			BaseObject:   activitypub.BaseObject{ID: "https://example.com/objects/s1"},
 			AttributedTo: "https://example.com/users/alice",

--- a/graph/actor_resolution_helpers.go
+++ b/graph/actor_resolution_helpers.go
@@ -152,6 +152,35 @@ func (r *Resolver) materializeActorResolution(ctx context.Context, resolution *f
 	return r.convertAccountToActor(account)
 }
 
+func (r *Resolver) resolveNoteAttributedActor(ctx context.Context, attributedTo string) *activitypub.Actor {
+	actorID := strings.TrimSpace(attributedTo)
+	if actorID == "" {
+		return nil
+	}
+
+	if resolution, err := r.resolveStoredActorLookup(ctx, actorID); err == nil && resolution != nil {
+		return r.materializeActorResolution(ctx, resolution)
+	} else if err != nil && !graphActorLookupNotFound(err) && r != nil && r.Logger != nil {
+		r.Logger.Debug("failed to resolve note attributed actor", zap.String("actor_id", actorID), zap.Error(err))
+	}
+
+	if actorIdentifierLooksRemote(actorID, r.localActorDomain()) {
+		return r.buildPlaceholderActor(actorID, "")
+	}
+
+	username := r.localUsernameForLookup(actorID)
+	if username == "" || r.Registry == nil || r.Registry.Accounts() == nil {
+		return nil
+	}
+
+	account, err := r.Registry.Accounts().GetAccount(ctx, username)
+	if err != nil || account == nil {
+		return nil
+	}
+
+	return r.convertAccountToActor(account)
+}
+
 func (r *Resolver) localUsernameForLookup(actorID string) string {
 	actorID = strings.TrimSpace(actorID)
 	if actorID == "" {

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -1019,19 +1019,8 @@ func (r *Resolver) convertNoteToObject(ctx context.Context, note *activitypub.No
 		}
 	}
 
-	// Get actor information
-	var actor *activitypub.Actor
-	if note.AttributedTo != "" {
-		// Extract username from actor ID
-		parts := strings.Split(note.AttributedTo, "/")
-		username := parts[len(parts)-1]
-		if username != "" {
-			result, err := r.Registry.Accounts().GetAccount(ctx, username)
-			if err == nil && result != nil {
-				actor = r.convertAccountToActor(result)
-			}
-		}
-	}
+	// Get actor information without collapsing remote actor URLs to local usernames.
+	actor := r.resolveNoteAttributedActor(ctx, note.AttributedTo)
 
 	// Convert attachments
 	attachments := make([]*activitypub.Attachment, len(note.Attachment))

--- a/graph/schema_remote_actor_round32_test.go
+++ b/graph/schema_remote_actor_round32_test.go
@@ -3,8 +3,11 @@ package graph
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/common"
+	"github.com/equaltoai/lesser/pkg/services/threads"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/stretchr/testify/require"
 )
@@ -58,4 +61,70 @@ func TestRound32ActivityResolver_ActorPreservesRemoteIdentifiers(t *testing.T) {
 	require.NotNil(t, handleActor)
 	require.Equal(t, remoteActorHandle, handleActor.ID)
 	require.Equal(t, "alice", handleActor.PreferredUsername)
+}
+
+func TestRound32ConvertThreadContextRemoteNoteDoesNotUseLocalAccount(t *testing.T) {
+	resolver, graphStorage := newRound12GraphResolver(t)
+	graphStorage.SeedAccountUser(&storage.User{
+		Username:    "alice",
+		DisplayName: "Local Alice",
+		Approved:    true,
+	})
+
+	now := time.Now().UTC()
+	remoteActorURL := "https://remote.example/users/alice"
+	threadCtx := resolver.convertThreadContextResultToModel(context.Background(), &threads.ThreadContextResult{
+		RootNote: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:        "https://remote.example/notes/1",
+				Type:      activitypub.NoteType,
+				Published: &now,
+			},
+			AttributedTo: remoteActorURL,
+			Content:      "remote alice should not resolve to local alice",
+		},
+		LastActivity: now,
+		SyncStatus:   threads.SyncStatusComplete,
+	})
+
+	require.NotNil(t, threadCtx)
+	require.NotNil(t, threadCtx.RootNote)
+	require.NotNil(t, threadCtx.RootNote.Actor)
+	require.Equal(t, remoteActorURL, threadCtx.RootNote.Actor.ID)
+	require.Equal(t, "alice", threadCtx.RootNote.Actor.PreferredUsername)
+	require.NotEqual(t, resolver.Config.ActorURL("alice"), threadCtx.RootNote.Actor.ID)
+	require.NotEqual(t, "Local Alice", threadCtx.RootNote.Actor.Name)
+}
+
+func TestRound32ConvertThreadContextLocalNoteStillUsesLocalAccount(t *testing.T) {
+	resolver, graphStorage := newRound12GraphResolver(t)
+	graphStorage.SeedAccountUser(&storage.User{
+		Username:    "alice",
+		DisplayName: "Local Alice",
+		Approved:    true,
+	})
+
+	now := time.Now().UTC()
+	localActorURL := resolver.Config.ActorURL("alice")
+	threadCtx := resolver.convertThreadContextResultToModel(context.Background(), &threads.ThreadContextResult{
+		RootNote: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:        resolver.Config.ObjectURL("objects", "local-note-1"),
+				Type:      activitypub.NoteType,
+				Published: &now,
+			},
+			AttributedTo: localActorURL,
+			Content:      "local alice should still resolve locally",
+		},
+		LastActivity: now,
+		SyncStatus:   threads.SyncStatusComplete,
+	})
+
+	require.NotNil(t, threadCtx)
+	require.NotNil(t, threadCtx.RootNote)
+	require.NotNil(t, threadCtx.RootNote.Actor)
+	require.True(t, common.IsLocalActorID(threadCtx.RootNote.Actor.ID, resolver.Config.Domain))
+	require.Contains(t, threadCtx.RootNote.Actor.ID, "/users/alice")
+	require.Equal(t, "alice", threadCtx.RootNote.Actor.PreferredUsername)
+	require.Equal(t, "Local Alice", threadCtx.RootNote.Actor.Name)
 }

--- a/graph/schema_remote_actor_round32_test.go
+++ b/graph/schema_remote_actor_round32_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/services/threads"
 	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/testing/inmemory"
 	"github.com/stretchr/testify/require"
 )
 
@@ -127,4 +128,89 @@ func TestRound32ConvertThreadContextLocalNoteStillUsesLocalAccount(t *testing.T)
 	require.Contains(t, threadCtx.RootNote.Actor.ID, "/users/alice")
 	require.Equal(t, "alice", threadCtx.RootNote.Actor.PreferredUsername)
 	require.Equal(t, "Local Alice", threadCtx.RootNote.Actor.Name)
+}
+
+func TestRound32ConvertNoteToObjectAttributedActorGuardBranches(t *testing.T) {
+	resolver, graphStorage := newRound12GraphResolver(t)
+	graphStorage.SeedAccountUser(&storage.User{
+		Username:    "alice",
+		DisplayName: "Local Alice",
+		Approved:    true,
+	})
+
+	actorRepo, ok := graphStorage.Actor().(*inmemory.ActorRepository)
+	require.True(t, ok)
+
+	remoteActor := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://remote.example/users/alice",
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: "alice",
+		Name:              "Remote Alice",
+		URL:               "https://remote.example/@alice",
+		Inbox:             "https://remote.example/users/alice/inbox",
+		Outbox:            "https://remote.example/users/alice/outbox",
+	}
+	actorRepo.SetCachedRemoteActor(remoteActor.ID, remoteActor, time.Hour)
+
+	now := time.Now().UTC()
+	ctx := context.Background()
+
+	t.Run("cached remote actor URL stays remote", func(t *testing.T) {
+		obj := resolver.convertNoteToObject(ctx, &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:        "https://remote.example/notes/1",
+				Type:      activitypub.NoteType,
+				Published: &now,
+			},
+			AttributedTo: remoteActor.ID,
+			Content:      "cached remote alice",
+		})
+
+		require.NotNil(t, obj)
+		require.NotNil(t, obj.Actor)
+		require.Equal(t, remoteActor.ID, obj.Actor.ID)
+		require.Equal(t, "Remote Alice", obj.Actor.Name)
+		require.NotEqual(t, resolver.Config.ActorURL("alice"), obj.Actor.ID)
+	})
+
+	t.Run("uncached remote actor URL uses placeholder instead of local account", func(t *testing.T) {
+		uncachedRemoteID := "https://uncached.example/users/alice"
+		obj := resolver.convertNoteToObject(ctx, &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:        "https://uncached.example/notes/1",
+				Type:      activitypub.NoteType,
+				Published: &now,
+			},
+			AttributedTo: uncachedRemoteID,
+			Content:      "uncached remote alice",
+		})
+
+		require.NotNil(t, obj)
+		require.NotNil(t, obj.Actor)
+		require.Equal(t, uncachedRemoteID, obj.Actor.ID)
+		require.Equal(t, "alice", obj.Actor.PreferredUsername)
+		require.NotEqual(t, resolver.Config.ActorURL("alice"), obj.Actor.ID)
+		require.NotEqual(t, "Local Alice", obj.Actor.Name)
+	})
+
+	t.Run("local actor URL still resolves through local account", func(t *testing.T) {
+		obj := resolver.convertNoteToObject(ctx, &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:        resolver.Config.ObjectURL("objects", "local-note-2"),
+				Type:      activitypub.NoteType,
+				Published: &now,
+			},
+			AttributedTo: resolver.Config.ActorURL("alice"),
+			Content:      "local alice",
+		})
+
+		require.NotNil(t, obj)
+		require.NotNil(t, obj.Actor)
+		require.True(t, common.IsLocalActorID(obj.Actor.ID, resolver.Config.Domain))
+		require.Contains(t, obj.Actor.ID, "/users/alice")
+		require.Equal(t, "alice", obj.Actor.PreferredUsername)
+		require.Equal(t, "Local Alice", obj.Actor.Name)
+	})
 }


### PR DESCRIPTION
## Summary

Fixes #1101 (Project 43 M1 L-17) by preventing remote ActivityPub actor identifiers from being reduced to bare local usernames before local account lookup.

## Surfaces affected

- GraphQL object conversion: `convertNoteToObject` now uses the same remote-actor guard pattern as `activityResolver.Actor`.
- Mastodon/status helper fallbacks: status context/history/oEmbed/embed/AI owner helper paths now avoid local account lookup when `AttributedTo` / `AuthorID` is remote.
- Regression coverage for a federated note attributed to `https://remote.example/users/alice` when local `alice` exists, plus local-authored note preservation.

## Federation-trust audit

- Signing / verification: no HTTP Signature signing or inbound verification changes.
- Actor identity: strengthened. Remote actor URLs/handles are detected before local `GetAccount` fallback; uncached remote actors materialize as remote placeholders instead of local accounts.
- Actor object shape: no schema/contract shape change; only attribution identity selection changes.
- Delivery / inbox: no delivery, retry, inbox, relay, or domain-block behavior changed.
- Governance state: untouched.

## Implementation notes

- `graph/schema.resolvers.go` `convertNoteToObject` now delegates actor attribution to `resolveNoteAttributedActor`, which tries stored exact actor resolution, guards remote identifiers with `actorIdentifierLooksRemote`, then only calls `GetAccount` for local usernames from `localUsernameForLookup`.
- Audited sibling naive extraction paths where remote `AttributedTo` / `AuthorID` can flow. Fixed the requested status/history/AI/status-lookup helpers and the same L-17 note-attribution pattern in oEmbed/embed and `extractStatusAuthor`.
- Did not touch account resolver/API account lookup surfaces related to L-05/L-09.

## Validation

- `go test ./graph ./cmd/api/handlers` ✅
- `go build ./...` ✅
- `go vet ./...` ✅

Per assignment, I did **not** run `./lesser verify ci` locally; GitHub CI should run the full gate on this PR.

## Acceptance checklist

- [x] Federated note `AttributedTo=https://remote.example/users/alice` no longer resolves/stamps local `alice` via `convertNoteToObject`.
- [x] Regression exercises the `convertNoteToObject` path via `convertThreadContextResultToModel`.
- [x] Local-authored notes still resolve their local actor.
- [x] Sibling remote-input lookup helpers audited and guarded where in L-17 scope.
- [x] L-05/L-09 left out of scope.

## Provenance

Local fallback path used because the routed `github_commit_files` API requires full-file contents and this change spans large generated/resolver/helper files. Commit is GPG-signed locally and pushed to `origin`.
