### PR TITLE
fix: guard cached remote actor canonical IDs

### DIFF
--- a/cmd/api/handlers/conversation_list_prefetch.go
+++ b/cmd/api/handlers/conversation_list_prefetch.go
@@ -6,6 +6,7 @@ import (
 
 	apimodels "github.com/equaltoai/lesser/cmd/api/models"
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/storage"
 	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/transformations"
@@ -305,6 +306,9 @@ func (h *Handler) conversationAPIRemoteAccountForParticipantRef(ctx context.Cont
 			}
 			actor, err := h.repos.Actor().GetCachedRemoteActor(ctx, candidate)
 			if err == nil && actor != nil {
+				if !common.CachedRemoteActorIDMatchesLookup(actor.ID, ref.ParticipantID) {
+					continue
+				}
 				return storageAccountFromActor(actor, localDomain)
 			}
 		}

--- a/cmd/api/handlers/federated_conversations_projection_test.go
+++ b/cmd/api/handlers/federated_conversations_projection_test.go
@@ -139,6 +139,37 @@ func TestConversationAPIRemoteAccountForParticipantRef_UsesCachedRemoteActor(t *
 	repos.AssertExpectations(t)
 }
 
+func TestConversationAPIRemoteAccountForParticipantRef_RejectsCanonicalMismatch(t *testing.T) {
+	ctx := context.Background()
+	victimActorID := "https://remote.example/users/bob"
+	craftedActorID := victimActorID + "/anything"
+	repos := &MockRepositoryStorage{}
+	actorRepo := &testmocks.MockActorRepository{}
+	repos.On("Actor").Return(actorRepo).Maybe()
+	victimActor := &activitypub.Actor{
+		BaseObject:        activitypub.BaseObject{ID: victimActorID, Type: activitypub.PersonType},
+		PreferredUsername: "bob",
+		Name:              "Cached Bob",
+		URL:               victimActorID,
+	}
+	actorRepo.On("GetCachedRemoteActor", ctx, craftedActorID).Return(victimActor, nil).Once()
+	actorRepo.On("GetCachedRemoteActor", ctx, "bob@remote.example").Return(victimActor, nil).Once()
+
+	h := &Handler{cfg: &config.Config{Domain: "example.com"}, repos: repos}
+	account := h.conversationAPIRemoteAccountForParticipantRef(ctx, storageModels.ConversationParticipantRef{
+		ParticipantType: storageModels.ConversationParticipantTypeRemoteActor,
+		ParticipantID:   craftedActorID,
+		Acct:            "bob@remote.example",
+	})
+
+	require.NotNil(t, account)
+	require.Equal(t, craftedActorID, account.Actor.ID)
+	require.NotEqual(t, victimActorID, account.Actor.ID)
+	require.NotEqual(t, "Cached Bob", account.User.DisplayName)
+	actorRepo.AssertExpectations(t)
+	repos.AssertExpectations(t)
+}
+
 func TestConversationAPIProjectionHelpers_EdgeBranches(t *testing.T) {
 	ctx := context.Background()
 

--- a/cmd/api/handlers/helpers.go
+++ b/cmd/api/handlers/helpers.go
@@ -499,6 +499,7 @@ func (h *Handler) loadStoredStatusAuthorActor(ctx context.Context, storageStatus
 	if storageStatus.Note != nil {
 		candidates = append(candidates, strings.TrimSpace(storageStatus.Note.AttributedTo))
 	}
+	actorURLLookupConstraint := statusActorURLLookupConstraint(storageStatus)
 
 	seen := make(map[string]struct{}, len(candidates))
 	for _, candidate := range candidates {
@@ -520,6 +521,10 @@ func (h *Handler) loadStoredStatusAuthorActor(ctx context.Context, storageStatus
 
 		actor, err := h.repos.Actor().GetCachedRemoteActor(ctx, candidate)
 		if err == nil && actor != nil {
+			if !common.CachedRemoteActorIDMatchesLookup(actor.ID, candidate) ||
+				!common.CachedRemoteActorIDMatchesLookup(actor.ID, actorURLLookupConstraint) {
+				continue
+			}
 			return actor
 		}
 	}
@@ -663,11 +668,31 @@ func (h *Handler) cachedRemoteActorForIdentifier(ctx context.Context, actorID st
 
 		actor, err := actorRepo.GetCachedRemoteActor(ctx, candidate)
 		if err == nil && actor != nil {
+			if !common.CachedRemoteActorIDMatchesLookup(actor.ID, actorID) {
+				continue
+			}
 			return actor
 		}
 	}
 
 	return nil
+}
+
+func statusActorURLLookupConstraint(status *storageModels.Status) string {
+	if status == nil {
+		return ""
+	}
+	candidates := []string{strings.TrimSpace(status.AuthorID)}
+	if status.Note != nil {
+		candidates = append(candidates, strings.TrimSpace(status.Note.AttributedTo))
+	}
+	for _, candidate := range candidates {
+		lowerCandidate := strings.ToLower(strings.TrimSpace(candidate))
+		if strings.HasPrefix(lowerCandidate, "http://") || strings.HasPrefix(lowerCandidate, "https://") {
+			return candidate
+		}
+	}
+	return ""
 }
 
 func syntheticRemoteActorFromIdentifier(actorID string) *activitypub.Actor {

--- a/cmd/api/handlers/l17_remote_actor_guard_test.go
+++ b/cmd/api/handlers/l17_remote_actor_guard_test.go
@@ -111,6 +111,15 @@ func TestL17RemoteActorHelperBranches(t *testing.T) {
 		require.NotNil(t, fromHandle)
 		require.Equal(t, remoteActor.ID, fromHandle.ID)
 
+		craftedActorID := remoteActor.ID + "/anything"
+		require.Nil(t, h.cachedRemoteActorForIdentifier(ctx, craftedActorID))
+		require.Nil(t, h.cachedRemoteNotificationActor(ctx, craftedActorID))
+
+		craftedSynthetic := h.resolveAttributedActorForObject(ctx, craftedActorID)
+		require.NotNil(t, craftedSynthetic)
+		require.Equal(t, craftedActorID, craftedSynthetic.ID)
+		require.NotEqual(t, remoteActor.ID, craftedSynthetic.ID)
+
 		require.Nil(t, h.cachedRemoteActorForIdentifier(ctx, "https://missing.example/users/alice"))
 		require.Nil(t, h.cachedRemoteActorForIdentifier(ctx, "missing@remote.example"))
 		require.Nil(t, h.cachedRemoteActorForIdentifier(ctx, "   "))
@@ -155,6 +164,19 @@ func TestL17RemoteActorHelperBranches(t *testing.T) {
 
 		missingLocal := h.resolveAttributedActorForObject(ctx, cfg.BaseURL()+"/users/missing")
 		require.Nil(t, missingLocal)
+	})
+
+	t.Run("stored status author rejects canonical mismatch before handle fallback", func(t *testing.T) {
+		craftedActorID := remoteActor.ID + "/anything"
+		actor := h.loadStoredStatusAuthorActor(ctx, &storagemodels.Status{
+			StatusID:       "crafted-status",
+			AuthorID:       craftedActorID,
+			AuthorUsername: "alice@remote.example",
+			Note: &activitypub.Note{
+				AttributedTo: craftedActorID,
+			},
+		})
+		require.Nil(t, actor)
 	})
 }
 

--- a/cmd/api/handlers/misc.go
+++ b/cmd/api/handlers/misc.go
@@ -1266,6 +1266,9 @@ func (h *Handler) cachedRemoteNotificationActor(ctx context.Context, actorID str
 		}
 		actor, err := h.repos.Actor().GetCachedRemoteActor(ctx, candidate)
 		if err == nil && actor != nil {
+			if !common.CachedRemoteActorIDMatchesLookup(actor.ID, actorID) {
+				continue
+			}
 			return actor
 		}
 	}

--- a/graph/actor_resolution_helpers.go
+++ b/graph/actor_resolution_helpers.go
@@ -105,6 +105,9 @@ func (r *Resolver) resolveStoredActorLookup(ctx context.Context, actorID string)
 
 	actor, err := store.Actor().GetCachedRemoteActor(ctx, actorID)
 	if err == nil && actor != nil {
+		if !common.CachedRemoteActorIDMatchesLookup(actor.ID, actorID) {
+			return nil, common.ActorNotFoundError{Username: actorID}
+		}
 		return &federation.ExactActorResolution{
 			Actor:         actor,
 			ActorIdentity: federation.DescribeActorIdentity(actor, r.localActorDomain()),

--- a/graph/conversation_list_prefetch.go
+++ b/graph/conversation_list_prefetch.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/equaltoai/lesser/graph/model"
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/storage"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 )
@@ -327,6 +328,9 @@ func (r *Resolver) conversationRemoteAccountForParticipantRef(ctx context.Contex
 			}
 			actor, err := store.Actor().GetCachedRemoteActor(ctx, candidate)
 			if err == nil && actor != nil {
+				if !common.CachedRemoteActorIDMatchesLookup(actor.ID, ref.ParticipantID) {
+					continue
+				}
 				return &storage.Account{Actor: actor}
 			}
 		}

--- a/graph/conversation_list_prefetch_test.go
+++ b/graph/conversation_list_prefetch_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/storage"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/equaltoai/lesser/pkg/testing/inmemory"
 	"github.com/stretchr/testify/require"
 )
 
@@ -183,4 +184,31 @@ func TestConversationAccountsFromParticipantRefs_UsesSyntheticRemoteFallback(t *
 	require.Len(t, actors, 1)
 	require.Equal(t, remoteID, actors[0].ID)
 	require.Equal(t, "bob", actors[0].PreferredUsername)
+}
+
+func TestConversationRemoteAccountForParticipantRef_RejectsCanonicalMismatch(t *testing.T) {
+	resolver, graphStorage := newRound12GraphResolver(t)
+	actorRepo, ok := graphStorage.Actor().(*inmemory.ActorRepository)
+	require.True(t, ok)
+
+	victimActorID := "https://remote.example/users/bob"
+	craftedActorID := victimActorID + "/anything"
+	actorRepo.SetCachedRemoteActor("bob@remote.example", &activitypub.Actor{
+		BaseObject:        activitypub.BaseObject{ID: victimActorID, Type: activitypub.PersonType},
+		PreferredUsername: "bob",
+		Name:              "Cached Bob",
+		URL:               victimActorID,
+	}, time.Hour)
+
+	account := resolver.conversationRemoteAccountForParticipantRef(context.Background(), storagemodels.ConversationParticipantRef{
+		ParticipantType: storagemodels.ConversationParticipantTypeRemoteActor,
+		ParticipantID:   craftedActorID,
+		Acct:            "bob@remote.example",
+	})
+
+	require.NotNil(t, account)
+	require.NotNil(t, account.Actor)
+	require.Equal(t, craftedActorID, account.Actor.ID)
+	require.NotEqual(t, victimActorID, account.Actor.ID)
+	require.NotEqual(t, "Cached Bob", account.Actor.Name)
 }

--- a/graph/notification_actor_round38_security_test.go
+++ b/graph/notification_actor_round38_security_test.go
@@ -9,7 +9,10 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/storage/models"
+	pkgtesting "github.com/equaltoai/lesser/pkg/testing"
+	testmocks "github.com/equaltoai/lesser/pkg/testing/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,6 +59,67 @@ func TestLoadNotificationActor_RejectsRemoteIdentityAsLocal(t *testing.T) {
 			assert.Nil(t, actor, "remote actor ID %q must not be resolved as a local actor", tt.actorID)
 		})
 	}
+}
+
+func TestLoadNotificationActor_RejectsCachedRemoteCanonicalIDMismatch(t *testing.T) {
+	ctx := context.Background()
+	craftedActorID := "https://remote.example/users/victim/anything"
+	victimActor := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://remote.example/users/victim",
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: "victim",
+		Name:              "Remote Victim",
+		URL:               "https://remote.example/@victim",
+		Inbox:             "https://remote.example/users/victim/inbox",
+		Outbox:            "https://remote.example/users/victim/outbox",
+	}
+
+	actorRepo := testmocks.NewMockActorRepository()
+	actorRepo.On("GetCachedRemoteActor", mock.Anything, craftedActorID).Return(victimActor, nil).Twice()
+
+	r, _ := newRound12GraphResolver(t)
+	r.Storage = pkgtesting.NewMockRepositoryStorage(pkgtesting.WithActorRepository(actorRepo))
+
+	resolution, err := r.resolveStoredActorLookup(ctx, craftedActorID)
+	require.Nil(t, resolution)
+	require.Error(t, err)
+	require.True(t, graphActorLookupNotFound(err), "expected actor-not-found error, got %v", err)
+
+	actor := r.loadNotificationActor(ctx, &models.Notification{ActorID: craftedActorID})
+	require.Nil(t, actor, "crafted notification ActorID must not materialize as cached victim actor")
+
+	actorRepo.AssertExpectations(t)
+}
+
+func TestLoadNotificationActor_AllowsCachedRemoteCanonicalIDMatch(t *testing.T) {
+	ctx := context.Background()
+	actorID := "https://remote.example/users/victim/"
+	victimActor := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://remote.example/users/victim",
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: "victim",
+		Name:              "Remote Victim",
+		URL:               "https://remote.example/@victim",
+		Inbox:             "https://remote.example/users/victim/inbox",
+		Outbox:            "https://remote.example/users/victim/outbox",
+	}
+
+	actorRepo := testmocks.NewMockActorRepository()
+	actorRepo.On("GetCachedRemoteActor", mock.Anything, actorID).Return(victimActor, nil).Once()
+
+	r, _ := newRound12GraphResolver(t)
+	r.Storage = pkgtesting.NewMockRepositoryStorage(pkgtesting.WithActorRepository(actorRepo))
+
+	actor := r.loadNotificationActor(ctx, &models.Notification{ActorID: actorID})
+	require.NotNil(t, actor)
+	require.Equal(t, victimActor.ID, actor.ID)
+	require.Equal(t, "Remote Victim", actor.Name)
+
+	actorRepo.AssertExpectations(t)
 }
 
 // TestLocalUsernameForLookup_RemoteDomainsNotLocal verifies that

--- a/graph/status_object_helpers.go
+++ b/graph/status_object_helpers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/equaltoai/lesser/graph/model"
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/services/notes"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"go.uber.org/zap"
@@ -129,6 +130,7 @@ func (r *Resolver) resolveActorForStatus(ctx context.Context, status *models.Sta
 
 	username := resolveStatusAuthorUsername(status)
 	lookupCandidates := statusActorLookupCandidates(status)
+	actorURLLookupConstraint := statusActorURLLookupConstraint(status)
 	authorIsRemote := statusAuthorIsRemote(status, r.localActorDomain())
 	if len(lookupCandidates) == 0 {
 		if convertLogger != nil {
@@ -157,6 +159,9 @@ func (r *Resolver) resolveActorForStatus(ctx context.Context, status *models.Sta
 				zap.Error(err))
 		}
 		if err != nil || resolution == nil {
+			continue
+		}
+		if resolution.Actor != nil && !common.CachedRemoteActorIDMatchesLookup(resolution.Actor.ID, actorURLLookupConstraint) {
 			continue
 		}
 
@@ -307,6 +312,27 @@ func statusActorLookupCandidates(status *models.Status) []string {
 	appendStatusActorLookupCandidate(&candidates, status.AuthorUsername)
 
 	return candidates
+}
+
+func statusActorURLLookupConstraint(status *models.Status) string {
+	if status == nil {
+		return ""
+	}
+	for _, candidate := range []string{
+		strings.TrimSpace(status.AuthorID),
+		func() string {
+			if status.Note == nil {
+				return ""
+			}
+			return strings.TrimSpace(status.Note.AttributedTo)
+		}(),
+	} {
+		lowerCandidate := strings.ToLower(strings.TrimSpace(candidate))
+		if strings.HasPrefix(lowerCandidate, "http://") || strings.HasPrefix(lowerCandidate, "https://") {
+			return candidate
+		}
+	}
+	return ""
 }
 
 func appendStatusActorLookupCandidate(dst *[]string, candidate string) {

--- a/graph/status_object_remote_actor_round34_test.go
+++ b/graph/status_object_remote_actor_round34_test.go
@@ -99,3 +99,57 @@ func TestRound34ConvertStatusToGraphQLObject_DegradesToRemotePlaceholderWithoutC
 	require.Equal(t, "alice", obj.Actor.PreferredUsername)
 	require.NotEqual(t, config.Get().ActorURL("alice"), obj.Actor.ID)
 }
+
+func TestRound34ConvertStatusToGraphQLObject_RejectsCachedRemoteCanonicalMismatch(t *testing.T) {
+	storage := pkgtesting.NewMockRepositoryStorage()
+	actorRepo, ok := storage.Actor().(*inmemory.ActorRepository)
+	require.True(t, ok)
+
+	victimActor := &activitypub.Actor{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://remote.example/users/victim",
+			Type: activitypub.PersonType,
+		},
+		PreferredUsername: "victim",
+		Name:              "Remote Victim",
+		Inbox:             "https://remote.example/users/victim/inbox",
+		Outbox:            "https://remote.example/users/victim/outbox",
+	}
+	actorRepo.SetCachedRemoteActor("victim@remote.example", victimActor, time.Hour)
+
+	resolver := &Resolver{
+		Storage: storage,
+		Config: &config.Config{
+			Domain: "localhost",
+		},
+		Logger: zap.NewNop(),
+	}
+
+	now := time.Now().UTC()
+	craftedActorID := "https://remote.example/users/victim/anything"
+	status := &storageModels.Status{
+		StatusID:       "status-remote-crafted",
+		AuthorID:       craftedActorID,
+		AuthorUsername: "victim@remote.example",
+		Content:        "crafted actor id should not hydrate victim",
+		CreatedAt:      now.Add(-time.Minute),
+		UpdatedAt:      now,
+		Visibility:     storageModels.VisibilityPublic,
+		Note: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:        "https://remote.example/notes/1",
+				Type:      activitypub.NoteType,
+				Published: &now,
+			},
+			AttributedTo: craftedActorID,
+			Content:      "crafted actor id should not hydrate victim",
+		},
+	}
+
+	obj := resolver.ConvertStatusToGraphQLObject(context.Background(), status)
+	require.NotNil(t, obj)
+	require.NotNil(t, obj.Actor)
+	require.Equal(t, craftedActorID, obj.Actor.ID)
+	require.NotEqual(t, victimActor.ID, obj.Actor.ID)
+	require.NotEqual(t, victimActor.Name, obj.Actor.Name)
+}

--- a/pkg/common/actor_id.go
+++ b/pkg/common/actor_id.go
@@ -1,0 +1,84 @@
+package common
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// CanonicalActorID validates and canonicalizes an ActivityPub actor URI.
+func CanonicalActorID(actorID string) (string, error) {
+	actorID = strings.TrimSpace(actorID)
+	if actorID == "" {
+		return "", fmt.Errorf("actor ID is required")
+	}
+	if actorIDContainsControlRune(actorID) || strings.ContainsAny(actorID, " \t\r\n") {
+		return "", fmt.Errorf("actor ID contains invalid characters")
+	}
+	if err := ValidateActivityPubURL(actorID, "actor_id"); err != nil {
+		return "", err
+	}
+
+	parsed, err := url.Parse(actorID)
+	if err != nil || parsed == nil {
+		return "", fmt.Errorf("actor ID must be a valid URL")
+	}
+	if parsed.User != nil {
+		return "", fmt.Errorf("actor ID must not contain userinfo")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("actor ID must not contain query or fragment")
+	}
+	if parsed.Opaque != "" || strings.TrimSpace(parsed.Hostname()) == "" || strings.TrimSpace(parsed.Path) == "" || parsed.Path == "/" {
+		return "", fmt.Errorf("actor ID must include host and path")
+	}
+	for _, segment := range strings.Split(parsed.EscapedPath(), "/") {
+		if segment == "" {
+			continue
+		}
+		unescaped, err := url.PathUnescape(segment)
+		if err != nil {
+			return "", fmt.Errorf("actor ID path contains invalid escaping")
+		}
+		if unescaped == "." || unescaped == ".." || actorIDContainsControlRune(unescaped) {
+			return "", fmt.Errorf("actor ID path contains unsafe segment")
+		}
+	}
+
+	path := strings.TrimRight(parsed.EscapedPath(), "/")
+	if path == "/users" || path == "/@" {
+		return "", fmt.Errorf("actor ID must include host and path")
+	}
+
+	return strings.ToLower(parsed.Scheme) + "://" + strings.ToLower(parsed.Host) + path, nil
+}
+
+// SameCanonicalActorID reports whether two ActivityPub actor URI strings
+// canonicalize to the same actor ID.
+func SameCanonicalActorID(left, right string) bool {
+	leftCanonical, leftErr := CanonicalActorID(left)
+	rightCanonical, rightErr := CanonicalActorID(right)
+	return leftErr == nil && rightErr == nil && leftCanonical == rightCanonical
+}
+
+// CachedRemoteActorIDMatchesLookup reports whether a cached remote actor ID may
+// satisfy a cache lookup. Handle/acct lookups have no canonical actor URL to
+// compare, so they are allowed; HTTP(S) URL lookups require exact canonical ID
+// equality, and malformed actor URLs do not match cached actors.
+func CachedRemoteActorIDMatchesLookup(cachedActorID, lookup string) bool {
+	lookup = strings.TrimSpace(lookup)
+	lowerLookup := strings.ToLower(lookup)
+	if !strings.HasPrefix(lowerLookup, "http://") && !strings.HasPrefix(lowerLookup, "https://") {
+		return true
+	}
+	return SameCanonicalActorID(cachedActorID, lookup)
+}
+
+func actorIDContainsControlRune(value string) bool {
+	for _, r := range value {
+		if r < 0x20 || r == 0x7f {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/common/actor_id_test.go
+++ b/pkg/common/actor_id_test.go
@@ -1,0 +1,188 @@
+package common
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalActorID(t *testing.T) {
+	tests := []struct {
+		name    string
+		actorID string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "lowercases scheme and host",
+			actorID: "HTTPS://REMOTE.EXAMPLE/users/alice",
+			want:    "https://remote.example/users/alice",
+		},
+		{
+			name:    "trims trailing slash",
+			actorID: "https://remote.example/users/alice/",
+			want:    "https://remote.example/users/alice",
+		},
+		{
+			name:    "preserves path case",
+			actorID: "https://remote.example/users/Alice",
+			want:    "https://remote.example/users/Alice",
+		},
+		{
+			name:    "rejects handle",
+			actorID: "alice@remote.example",
+			wantErr: true,
+		},
+		{
+			name:    "rejects query",
+			actorID: "https://remote.example/users/alice?next=https://evil.example",
+			wantErr: true,
+		},
+		{
+			name:    "rejects fragment",
+			actorID: "https://remote.example/users/alice#main-key",
+			wantErr: true,
+		},
+		{
+			name:    "rejects userinfo",
+			actorID: "https://alice@remote.example/users/alice",
+			wantErr: true,
+		},
+		{
+			name:    "rejects unsafe segment",
+			actorID: "https://remote.example/users/../admin",
+			wantErr: true,
+		},
+		{
+			name:    "rejects control rune",
+			actorID: "https://remote.example/users/alice\nHost: evil.example",
+			wantErr: true,
+		},
+		{
+			name:    "rejects overlong url",
+			actorID: "https://remote.example/users/" + strings.Repeat("a", 2001),
+			wantErr: true,
+		},
+		{
+			name:    "rejects generic users path",
+			actorID: "https://remote.example/users",
+			wantErr: true,
+		},
+		{
+			name:    "rejects generic at path",
+			actorID: "https://remote.example/@",
+			wantErr: true,
+		},
+		{
+			name:    "rejects root path",
+			actorID: "https://remote.example/",
+			wantErr: true,
+		},
+		{
+			name:    "rejects empty",
+			actorID: "",
+			wantErr: true,
+		},
+		{
+			name:    "rejects bad escaping",
+			actorID: "https://remote.example/users/%zz",
+			wantErr: true,
+		},
+		{
+			name:    "rejects encoded unsafe segment",
+			actorID: "https://remote.example/users/%2e%2e/admin",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CanonicalActorID(tt.actorID)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Empty(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSameCanonicalActorID(t *testing.T) {
+	require.True(t, SameCanonicalActorID(
+		"HTTPS://REMOTE.EXAMPLE/users/alice/",
+		"https://remote.example/users/alice",
+	))
+	require.False(t, SameCanonicalActorID(
+		"https://remote.example/users/alice",
+		"https://remote.example/users/alice/anything",
+	))
+	require.False(t, SameCanonicalActorID(
+		"https://remote.example/users/Alice",
+		"https://remote.example/users/alice",
+	))
+	require.False(t, SameCanonicalActorID(
+		"alice@remote.example",
+		"https://remote.example/users/alice",
+	))
+}
+
+func TestCachedRemoteActorIDMatchesLookup(t *testing.T) {
+	tests := []struct {
+		name          string
+		cachedActorID string
+		lookup        string
+		want          bool
+	}{
+		{
+			name:          "exact canonical url matches",
+			cachedActorID: "https://remote.example/users/victim",
+			lookup:        "HTTPS://REMOTE.EXAMPLE/users/victim/",
+			want:          true,
+		},
+		{
+			name:          "crafted trailing path does not match",
+			cachedActorID: "https://remote.example/users/victim",
+			lookup:        "https://remote.example/users/victim/anything",
+			want:          false,
+		},
+		{
+			name:          "different actor does not match",
+			cachedActorID: "https://remote.example/users/victim",
+			lookup:        "https://remote.example/users/other",
+			want:          false,
+		},
+		{
+			name:          "invalid cached actor cannot satisfy canonical lookup",
+			cachedActorID: "victim@remote.example",
+			lookup:        "https://remote.example/users/victim",
+			want:          false,
+		},
+		{
+			name:          "url lookup with query cannot satisfy cached actor",
+			cachedActorID: "https://remote.example/users/victim",
+			lookup:        "https://remote.example/users/victim?spoof=https://evil.example/users/root",
+			want:          false,
+		},
+		{
+			name:          "handle lookup remains allowed",
+			cachedActorID: "https://remote.example/users/victim",
+			lookup:        "victim@remote.example",
+			want:          true,
+		},
+		{
+			name:          "blank lookup remains allowed for non-url cache consumers",
+			cachedActorID: "https://remote.example/users/victim",
+			lookup:        "",
+			want:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, CachedRemoteActorIDMatchesLookup(tt.cachedActorID, tt.lookup))
+		})
+	}
+}

--- a/pkg/reputation/actor_id.go
+++ b/pkg/reputation/actor_id.go
@@ -1,7 +1,6 @@
 package reputation
 
 import (
-	"fmt"
 	"net/url"
 	"strings"
 
@@ -10,60 +9,8 @@ import (
 
 // ValidateActorID validates a canonical ActivityPub actor URI used by reputation lookups.
 func ValidateActorID(actorID string) error {
-	_, err := canonicalActorID(actorID)
+	_, err := common.CanonicalActorID(actorID)
 	return err
-}
-
-func canonicalActorID(actorID string) (string, error) {
-	actorID = strings.TrimSpace(actorID)
-	if actorID == "" {
-		return "", fmt.Errorf("actor ID is required")
-	}
-	if containsControlRune(actorID) || strings.ContainsAny(actorID, " \t\r\n") {
-		return "", fmt.Errorf("actor ID contains invalid characters")
-	}
-	if err := common.ValidateActivityPubURL(actorID, "actor_id"); err != nil {
-		return "", err
-	}
-
-	parsed, err := url.Parse(actorID)
-	if err != nil || parsed == nil {
-		return "", fmt.Errorf("actor ID must be a valid URL")
-	}
-	if parsed.User != nil {
-		return "", fmt.Errorf("actor ID must not contain userinfo")
-	}
-	if parsed.RawQuery != "" || parsed.Fragment != "" {
-		return "", fmt.Errorf("actor ID must not contain query or fragment")
-	}
-	if parsed.Opaque != "" || strings.TrimSpace(parsed.Hostname()) == "" || strings.TrimSpace(parsed.Path) == "" || parsed.Path == "/" {
-		return "", fmt.Errorf("actor ID must include host and path")
-	}
-	for _, segment := range strings.Split(parsed.EscapedPath(), "/") {
-		if segment == "" {
-			continue
-		}
-		unescaped, err := url.PathUnescape(segment)
-		if err != nil {
-			return "", fmt.Errorf("actor ID path contains invalid escaping")
-		}
-		if unescaped == "." || unescaped == ".." || containsControlRune(unescaped) {
-			return "", fmt.Errorf("actor ID path contains unsafe segment")
-		}
-	}
-
-	path := strings.TrimRight(parsed.EscapedPath(), "/")
-	if path == "/users" || path == "/@" {
-		return "", fmt.Errorf("actor ID must include host and path")
-	}
-
-	return strings.ToLower(parsed.Scheme) + "://" + strings.ToLower(parsed.Host) + path, nil
-}
-
-func sameCanonicalActorID(left, right string) bool {
-	leftCanonical, leftErr := canonicalActorID(left)
-	rightCanonical, rightErr := canonicalActorID(right)
-	return leftErr == nil && rightErr == nil && leftCanonical == rightCanonical
 }
 
 func actorIDHost(actorID string) string {
@@ -72,13 +19,4 @@ func actorIDHost(actorID string) string {
 		return ""
 	}
 	return strings.ToLower(strings.TrimSpace(parsed.Hostname()))
-}
-
-func containsControlRune(value string) bool {
-	for _, r := range value {
-		if r < 0x20 || r == 0x7f {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/reputation/actor_id_test.go
+++ b/pkg/reputation/actor_id_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,7 +70,7 @@ func TestCSR046_CanonicalActorIdempotency(t *testing.T) {
 	}
 	for _, pair := range samePairs {
 		t.Run("same_"+pair[0], func(t *testing.T) {
-			require.True(t, sameCanonicalActorID(pair[0], pair[1]),
+			require.True(t, common.SameCanonicalActorID(pair[0], pair[1]),
 				"%q and %q should canonicalize to the same ID", pair[0], pair[1])
 		})
 	}
@@ -84,7 +85,7 @@ func TestCSR046_CanonicalActorIdempotency(t *testing.T) {
 	}
 	for _, pair := range diffPairs {
 		t.Run("diff_"+pair[0], func(t *testing.T) {
-			require.False(t, sameCanonicalActorID(pair[0], pair[1]),
+			require.False(t, common.SameCanonicalActorID(pair[0], pair[1]),
 				"%q and %q should canonicalize to different IDs", pair[0], pair[1])
 		})
 	}

--- a/pkg/reputation/service.go
+++ b/pkg/reputation/service.go
@@ -237,7 +237,7 @@ func (s *Service) GetReputation(ctx context.Context, actorID string) (*Reputatio
 		// No reputation history, calculate new
 		return s.calculateAndStore(ctx, actorID)
 	}
-	if !sameCanonicalActorID(storedRep.ActorID, actorID) {
+	if !common.SameCanonicalActorID(storedRep.ActorID, actorID) {
 		s.logger.Warn("stored reputation actor did not match requested actor; recalculating",
 			zap.String("requested_actor", actorID),
 			zap.String("stored_actor", storedRep.ActorID))
@@ -398,7 +398,7 @@ func (s *Service) getRemoteActorData(ctx context.Context, actorID string) (*acti
 			zap.Error(err))
 		return nil, fmt.Errorf("actor not found: %w", err)
 	}
-	if actor == nil || !sameCanonicalActorID(actor.ID, actorID) {
+	if actor == nil || !common.SameCanonicalActorID(actor.ID, actorID) {
 		return nil, fmt.Errorf("actor not found: %s", actorID)
 	}
 	return actor, nil
@@ -869,7 +869,7 @@ func (s *Service) ImportReputation(ctx context.Context, document string) (*Impor
 		}, nil
 	}
 
-	if pr.Reputation != nil && !sameCanonicalActorID(pr.Actor, pr.Reputation.ActorID) {
+	if pr.Reputation != nil && !common.SameCanonicalActorID(pr.Actor, pr.Reputation.ActorID) {
 		return &ImportResult{
 			Success: false,
 			Error:   "Reputation actor does not match document actor",


### PR DESCRIPTION
## Summary
- extract canonical ActivityPub actor-ID comparison into `pkg/common`
- guard cached remote actor materialization so HTTP(S) lookup URLs must canonically equal the cached actor ID
- apply the guard to GraphQL notification/status/activity resolution and API notification/status/conversation cached remote actor paths where crafted ActorIDs can reach
- add regressions proving `https://remote.example/users/victim/anything` does not materialize as cached `victim@remote.example`

Fixes #1100.

## Federation trust
- Strengthens actor identity resolution by rejecting cached remote actor hits whose canonical ID does not match the requested ActorID URL.
- Does not change HTTP Signature signing/verification, inbox/outbox delivery, actor object shape, key material, or domain-block behavior.

## API / schema impact
- No GraphQL schema or Mastodon REST shape changes.
- Observable behavior changes only for spoofed/malformed remote actor lookup URLs: they now return not-found/fallback synthetic actors instead of cached victims.

## Schema / storage impact
- No DynamoDB schema, PK/SK, GSI, or TableTheory tag changes.

## AGPL / dependencies
- No dependency or license changes.

## Validation
- `git diff --check`
- `go build ./...`
- `go vet ./...`
- `go test ./pkg/common ./pkg/reputation ./graph ./cmd/api/handlers`
- `go test -coverprofile=cover.l09.out ./pkg/common ./pkg/reputation ./graph ./cmd/api/handlers`
- `go tool cover -func=cover.l09.out` inspected touched files (`pkg/common/actor_id.go`: 92.9/100/100/100 for new helpers)
- Coverage gate subset (not full `./lesser verify ci`, per assignment):
  - `./lesser test coverage --scope overall --short --verbose=false --exclude-generated=false --html=false`
  - `go run ./tools/coverage_scoreboard --profile coverage_overall.out --mode package --top 10 --min-total 85.0` → 87.672%
  - `go run ./tools/coverage_scoreboard --profile coverage_overall.out --mode package --top 10 --package github.com/equaltoai/lesser/pkg --min-total 90.0` → 90.015%
  - `go run ./tools/coverage_scoreboard --profile coverage_overall.out --mode package --top 10 --package github.com/equaltoai/lesser/cmd --min-total 90.0` → 90.029%

## Rollout
- Standard dev → staging (if used) → live soak.
- Monitor GraphQL/API notification materialization and remote actor fallback rates; no deployment performed here.

## Provenance
- Issue/email read through lesser_lab routed tools.
- Commit created locally because routed commit API is a poor fit for multi-file changes including large helper files; commit is GPG-signed (`6dd6676dd4db3efedfb12d2ccb9e59e73478a86d`, good signature from Aron Price <aron23@gmail.com>).
