### PR TITLE
fix agent env seed guard

### DIFF
--- a/cmd/lesser/instance_feature_config_sync.go
+++ b/cmd/lesser/instance_feature_config_sync.go
@@ -178,6 +178,14 @@ func seedManagedConfigFromEnvOnce(ctx context.Context, instanceRepo *repositorie
 }
 
 func seedAgentManagedDefaultsFromEnvOnce(ctx context.Context, instanceRepo *repositories.InstanceRepository, stageName, tableName string) error {
+	agentExists, err := instanceRepo.AgentConfigExists(ctx)
+	if err != nil {
+		return err
+	}
+	if agentExists {
+		return nil
+	}
+
 	agentsEnabled := envBoolPtr("ALLOW_AGENTS")
 	registrationEnabled := envBoolPtr("ALLOW_AGENT_REGISTRATION")
 	if agentsEnabled == nil && registrationEnabled == nil {

--- a/cmd/lesser/instance_feature_config_sync_test.go
+++ b/cmd/lesser/instance_feature_config_sync_test.go
@@ -70,6 +70,8 @@ func TestEnvFeatureConfigSeedAvailable_FalseWhenNoEnvSet(t *testing.T) {
 	t.Setenv("LESSER_HOST_ATTESTATIONS_URL", "")
 	t.Setenv("LESSER_HOST_INSTANCE_KEY_ARN", "")
 	t.Setenv("TRANSLATION_ENABLED", "")
+	t.Setenv("ALLOW_AGENTS", "")
+	t.Setenv("ALLOW_AGENT_REGISTRATION", "")
 	t.Setenv("TIP_ENABLED", "")
 	t.Setenv("TIP_CHAIN_ID", "")
 	t.Setenv("TIP_CONTRACT_ADDRESS", "")
@@ -987,7 +989,7 @@ func TestSeedAgentManagedDefaultsFromEnvOnce_SeedsAllowAgentsOnly(t *testing.T) 
 	q := new(dynamormmocks.MockQuery)
 
 	setupMockInstanceRepoDB(db, q)
-	setupMockFirstForFeatureConfigs(q)
+	q.On("First", mock.AnythingOfType("*models.AgentInstanceConfig")).Return(dynamormerrors.ErrItemNotFound).Twice()
 
 	t.Setenv("ALLOW_AGENTS", "true")
 
@@ -1005,7 +1007,7 @@ func TestSeedAgentManagedDefaultsFromEnvOnce_SeedsRegistrationOnly(t *testing.T)
 	q := new(dynamormmocks.MockQuery)
 
 	setupMockInstanceRepoDB(db, q)
-	setupMockFirstForFeatureConfigs(q)
+	q.On("First", mock.AnythingOfType("*models.AgentInstanceConfig")).Return(dynamormerrors.ErrItemNotFound).Twice()
 
 	t.Setenv("ALLOW_AGENT_REGISTRATION", "true")
 
@@ -1023,7 +1025,7 @@ func TestSeedAgentManagedDefaultsFromEnvOnce_SeedsWhenConfigNotConfigured(t *tes
 	q := new(dynamormmocks.MockQuery)
 
 	setupMockInstanceRepoDB(db, q)
-	setupMockFirstForFeatureConfigs(q)
+	q.On("First", mock.AnythingOfType("*models.AgentInstanceConfig")).Return(dynamormerrors.ErrItemNotFound).Twice()
 
 	t.Setenv("ALLOW_AGENTS", "true")
 	t.Setenv("ALLOW_AGENT_REGISTRATION", "true")
@@ -1049,33 +1051,31 @@ func TestSeedAgentManagedDefaultsFromEnvOnce_NoOpWhenEnvUnset(t *testing.T) {
 	require.NoError(t, seedAgentManagedDefaultsFromEnvOnce(ctx, instanceRepo, "dev", "test-table"))
 }
 
-func TestSeedAgentManagedDefaultsFromEnvOnce_AppliesEnvOverrideWhenAlreadyConfigured(t *testing.T) {
+func TestSeedAgentManagedDefaultsFromEnvOnce_DoesNotOverwriteExistingAdminRegistrationPolicy(t *testing.T) {
 	ctx := context.Background()
 	db := new(dynamormmocks.MockDB)
 	q := new(dynamormmocks.MockQuery)
 
 	setupMockInstanceRepoDB(db, q)
 
-	// Row already exists with AllowAgents=true.
+	// Row already exists with admin-disabled agent registration.
 	q.On("First", mock.AnythingOfType("*models.AgentInstanceConfig")).Run(func(args mock.Arguments) {
 		out := args.Get(0).(*models.AgentInstanceConfig)
 		out.PK = "INSTANCE#CONFIG"
 		out.SK = "AGENT_CONFIG"
 		out.AllowAgents = true
+		out.AllowAgentRegistration = false
 	}).Return(nil).Once()
 
-	// SetAgentInstanceConfig will call First again (EnsureAgentInstanceConfig) then Update.
-	// setupMockFirstForFeatureConfigs provides .Maybe() for any unmatched First calls.
-	// Update is mocked in setupMockInstanceRepoDB via .Maybe().
-
-	t.Setenv("ALLOW_AGENTS", "false")
+	t.Setenv("ALLOW_AGENT_REGISTRATION", "true")
 
 	instanceRepo := repositories.NewInstanceRepository(db, "test-table", zap.NewNop())
 	require.NoError(t, seedAgentManagedDefaultsFromEnvOnce(ctx, instanceRepo, "dev", "test-table"))
 
 	cfg, err := instanceRepo.GetAgentInstanceConfig(ctx)
 	require.NoError(t, err)
-	assert.False(t, cfg.AllowAgents) // env override applied even when row exists
+	assert.False(t, cfg.AllowAgentRegistration)
+	q.AssertNotCalled(t, "Update", mock.Anything)
 }
 
 func TestEnsureAndApplyManagedProvisioningConfig_ReturnsErrorWhenSetAgentFails(t *testing.T) {
@@ -1114,8 +1114,8 @@ func TestSeedAgentManagedDefaultsFromEnvOnce_ReturnsErrorWhenEnsureFails(t *test
 	db := new(dynamormmocks.MockDB)
 	q := new(dynamormmocks.MockQuery)
 
-	// Override First for AgentInstanceConfig to return a non-NotFound error.
-	q.On("First", mock.AnythingOfType("*models.AgentInstanceConfig")).Return(errors.New("ensure failed")).Once()
+	// AgentConfigExists returns a non-NotFound error before EnsureAgentInstanceConfig runs.
+	q.On("First", mock.AnythingOfType("*models.AgentInstanceConfig")).Return(errors.New("exists failed")).Once()
 	setupMockInstanceRepoDB(db, q)
 	setupMockFirstForFeatureConfigs(q)
 

--- a/pkg/storage/repositories/instance_repository.go
+++ b/pkg/storage/repositories/instance_repository.go
@@ -221,6 +221,23 @@ func (r *InstanceRepository) invalidateAgentConfigCache() {
 	r.agentCache.mu.Unlock()
 }
 
+// AgentConfigExists reports whether the agent config record exists in storage.
+func (r *InstanceRepository) AgentConfigExists(ctx context.Context) (bool, error) {
+	cfg := &models.AgentInstanceConfig{}
+	err := r.agentRepo.Get(ctx, storage.InstanceConfigKey, "AGENT_CONFIG", cfg)
+	if err != nil {
+		if appErrors.HasCode(err, appErrors.CodeNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	if strings.TrimSpace(cfg.PK) == "" || strings.TrimSpace(cfg.SK) == "" {
+		return false, nil
+	}
+	r.setCachedAgentConfig(cfg)
+	return true, nil
+}
+
 // GetInstanceState returns the current instance activation state.
 // If no state exists yet, it defaults to a locked state without persisting.
 func (r *InstanceRepository) GetInstanceState(ctx context.Context) (*models.InstanceState, error) {

--- a/pkg/storage/repositories/instance_repository_agent_config_test.go
+++ b/pkg/storage/repositories/instance_repository_agent_config_test.go
@@ -2,25 +2,160 @@ package repositories
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	theorydb "github.com/theory-cloud/tabletheory/pkg/core"
 	dynamormerrors "github.com/theory-cloud/tabletheory/pkg/errors"
 	dynamormmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
 	"go.uber.org/zap"
 )
+
+func setupMockAgentConfigRepoDB(db *dynamormmocks.MockDB, q *dynamormmocks.MockQuery) {
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.Anything).Return(q).Maybe()
+	q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q).Maybe()
+}
+
+type testInstanceTransactionalDB struct {
+	*dynamormmocks.MockDB
+	err    error
+	called bool
+}
+
+func (db *testInstanceTransactionalDB) TransactWrite(ctx context.Context, fn func(theorydb.TransactionBuilder) error) error {
+	db.called = true
+	if db.err != nil {
+		return db.err
+	}
+	return fn(nil)
+}
+
+func TestNewInstanceTransactWriteFn_RequiresTransactionalDB(t *testing.T) {
+	fn := newInstanceTransactWriteFn(new(dynamormmocks.MockDB))
+	err := fn(context.Background(), func(theorydb.TransactionBuilder) error {
+		return nil
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database does not support transact write operations")
+}
+
+func TestNewInstanceTransactWriteFn_DelegatesAndPropagatesErrors(t *testing.T) {
+	ctx := context.Background()
+	db := &testInstanceTransactionalDB{MockDB: new(dynamormmocks.MockDB)}
+	fnCalled := false
+
+	err := newInstanceTransactWriteFn(db)(ctx, func(theorydb.TransactionBuilder) error {
+		fnCalled = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, db.called)
+	assert.True(t, fnCalled)
+
+	expectedErr := errors.New("transact failed")
+	failingDB := &testInstanceTransactionalDB{MockDB: new(dynamormmocks.MockDB), err: expectedErr}
+	err = newInstanceTransactWriteFn(failingDB)(ctx, func(theorydb.TransactionBuilder) error {
+		t.Fatal("transaction callback should not run when DB fails first")
+		return nil
+	})
+	require.ErrorIs(t, err, expectedErr)
+	assert.True(t, failingDB.called)
+}
+
+func TestInstanceRepository_AgentConfigExists_ReturnsFalseOnNotFound(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockAgentConfigRepoDB(db, q)
+	q.On("First", mock.AnythingOfType("*models.AgentInstanceConfig")).Return(dynamormerrors.ErrItemNotFound).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	ok, err := repo.AgentConfigExists(ctx)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestInstanceRepository_AgentConfigExists_ReturnsTrueAndCaches(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockAgentConfigRepoDB(db, q)
+	q.On("First", mock.AnythingOfType("*models.AgentInstanceConfig")).Run(func(args mock.Arguments) {
+		out := args.Get(0).(*models.AgentInstanceConfig)
+		out.PK = "INSTANCE#CONFIG"
+		out.SK = "AGENT_CONFIG"
+		out.AllowAgentRegistration = true
+	}).Return(nil).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	ok, err := repo.AgentConfigExists(ctx)
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	cached, cacheOK := repo.getCachedAgentConfig()
+	require.True(t, cacheOK)
+	assert.Equal(t, "AGENT_CONFIG", cached.SK)
+	assert.True(t, cached.AllowAgentRegistration)
+}
+
+func TestInstanceRepository_AgentConfigExists_ReturnsFalseWhenKeysBlank(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockAgentConfigRepoDB(db, q)
+	q.On("First", mock.AnythingOfType("*models.AgentInstanceConfig")).Return(nil).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	ok, err := repo.AgentConfigExists(ctx)
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	_, cacheOK := repo.getCachedAgentConfig()
+	assert.False(t, cacheOK)
+}
+
+func TestInstanceRepository_AgentConfigExists_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockAgentConfigRepoDB(db, q)
+	q.On("First", mock.AnythingOfType("*models.AgentInstanceConfig")).Return(errors.New("boom")).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	ok, err := repo.AgentConfigExists(ctx)
+	require.Error(t, err)
+	assert.False(t, ok)
+}
+
+func TestInstanceRepository_InvalidateAgentConfigCacheClearsCachedValue(t *testing.T) {
+	repo := &InstanceRepository{}
+	cfg := models.NewAgentInstanceConfig()
+	repo.setCachedAgentConfig(cfg)
+
+	cached, ok := repo.getCachedAgentConfig()
+	require.True(t, ok)
+	assert.Same(t, cfg, cached)
+
+	repo.invalidateAgentConfigCache()
+	_, ok = repo.getCachedAgentConfig()
+	assert.False(t, ok)
+}
 
 func TestInstanceRepository_GetAgentInstanceConfig_DefaultWhenMissingAndCaches(t *testing.T) {
 	ctx := context.Background()
 	db := new(dynamormmocks.MockDB)
 	q := new(dynamormmocks.MockQuery)
 
-	db.On("WithContext", mock.Anything).Return(db)
-	db.On("Model", mock.Anything).Return(q)
-	q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q)
+	setupMockAgentConfigRepoDB(db, q)
 	q.On("First", mock.AnythingOfType("*models.AgentInstanceConfig")).Return(dynamormerrors.ErrItemNotFound).Once()
 
 	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
@@ -38,14 +173,74 @@ func TestInstanceRepository_GetAgentInstanceConfig_DefaultWhenMissingAndCaches(t
 	assert.Same(t, cfg, cfg2)
 }
 
+func TestInstanceRepository_GetAgentInstanceConfig_ReturnsExistingAndCaches(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockAgentConfigRepoDB(db, q)
+	q.On("First", mock.AnythingOfType("*models.AgentInstanceConfig")).Run(func(args mock.Arguments) {
+		out := args.Get(0).(*models.AgentInstanceConfig)
+		out.PK = "INSTANCE#CONFIG"
+		out.SK = "AGENT_CONFIG"
+		out.AllowAgents = true
+	}).Return(nil).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	cfg, err := repo.GetAgentInstanceConfig(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.True(t, cfg.AllowAgents)
+
+	cfg2, err := repo.GetAgentInstanceConfig(ctx)
+	require.NoError(t, err)
+	assert.Same(t, cfg, cfg2)
+}
+
+func TestInstanceRepository_GetAgentInstanceConfig_ReturnsError(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockAgentConfigRepoDB(db, q)
+	q.On("First", mock.AnythingOfType("*models.AgentInstanceConfig")).Return(errors.New("boom")).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	cfg, err := repo.GetAgentInstanceConfig(ctx)
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestInstanceRepository_EnsureAgentInstanceConfig_ReturnsExistingAndCaches(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockAgentConfigRepoDB(db, q)
+	q.On("First", mock.AnythingOfType("*models.AgentInstanceConfig")).Run(func(args mock.Arguments) {
+		out := args.Get(0).(*models.AgentInstanceConfig)
+		out.PK = "INSTANCE#CONFIG"
+		out.SK = "AGENT_CONFIG"
+		out.AllowAgentRegistration = true
+	}).Return(nil).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	cfg, err := repo.EnsureAgentInstanceConfig(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.True(t, cfg.AllowAgentRegistration)
+
+	cached, ok := repo.getCachedAgentConfig()
+	require.True(t, ok)
+	assert.Same(t, cfg, cached)
+}
+
 func TestInstanceRepository_EnsureAgentInstanceConfig_CreateWhenMissing(t *testing.T) {
 	ctx := context.Background()
 	db := new(dynamormmocks.MockDB)
 	q := new(dynamormmocks.MockQuery)
 
-	db.On("WithContext", mock.Anything).Return(db).Maybe()
-	db.On("Model", mock.Anything).Return(q).Maybe()
-	q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q).Maybe()
+	setupMockAgentConfigRepoDB(db, q)
 
 	q.On("First", mock.AnythingOfType("*models.AgentInstanceConfig")).Return(dynamormerrors.ErrItemNotFound).Once()
 	q.On("Create").Return(nil).Once()
@@ -63,14 +258,57 @@ func TestInstanceRepository_EnsureAgentInstanceConfig_CreateWhenMissing(t *testi
 	assert.Same(t, cfg, cached)
 }
 
+func TestInstanceRepository_EnsureAgentInstanceConfig_ReturnsGetError(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockAgentConfigRepoDB(db, q)
+	q.On("First", mock.AnythingOfType("*models.AgentInstanceConfig")).Return(errors.New("boom")).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	cfg, err := repo.EnsureAgentInstanceConfig(ctx)
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestInstanceRepository_EnsureAgentInstanceConfig_ReturnsCreateError(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockAgentConfigRepoDB(db, q)
+	q.On("First", mock.AnythingOfType("*models.AgentInstanceConfig")).Return(dynamormerrors.ErrItemNotFound).Once()
+	q.On("Create").Return(errors.New("create failed")).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	cfg, err := repo.EnsureAgentInstanceConfig(ctx)
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestInstanceRepository_EnsureAgentInstanceConfig_ReturnsReadbackError(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockAgentConfigRepoDB(db, q)
+	q.On("First", mock.AnythingOfType("*models.AgentInstanceConfig")).Return(dynamormerrors.ErrItemNotFound).Once()
+	q.On("Create").Return(dynamormerrors.ErrConditionFailed).Once()
+	q.On("First", mock.AnythingOfType("*models.AgentInstanceConfig")).Return(errors.New("readback failed")).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	cfg, err := repo.EnsureAgentInstanceConfig(ctx)
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+}
+
 func TestInstanceRepository_EnsureAgentInstanceConfig_ConcurrentCreateReadsBack(t *testing.T) {
 	ctx := context.Background()
 	db := new(dynamormmocks.MockDB)
 	q := new(dynamormmocks.MockQuery)
 
-	db.On("WithContext", mock.Anything).Return(db).Maybe()
-	db.On("Model", mock.Anything).Return(q).Maybe()
-	q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q).Maybe()
+	setupMockAgentConfigRepoDB(db, q)
 
 	q.On("First", mock.AnythingOfType("*models.AgentInstanceConfig")).Return(dynamormerrors.ErrItemNotFound).Once()
 	q.On("Create").Return(dynamormerrors.ErrConditionFailed).Once()
@@ -91,13 +329,32 @@ func TestInstanceRepository_EnsureAgentInstanceConfig_ConcurrentCreateReadsBack(
 	assert.Same(t, cfg, cached)
 }
 
+func TestInstanceRepository_SetAgentInstanceConfig_UpdateSucceedsAndCaches(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockAgentConfigRepoDB(db, q)
+	q.On("Update", mock.Anything).Return(nil).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	cfg := models.NewAgentInstanceConfig()
+	cfg.AllowAgentRegistration = true
+
+	require.NoError(t, repo.SetAgentInstanceConfig(ctx, cfg))
+
+	cached, ok := repo.getCachedAgentConfig()
+	require.True(t, ok)
+	assert.Same(t, cfg, cached)
+	assert.True(t, cached.AllowAgentRegistration)
+}
+
 func TestInstanceRepository_SetAgentInstanceConfig_UpsertsAndCaches(t *testing.T) {
 	ctx := context.Background()
 	db := new(dynamormmocks.MockDB)
 	q := new(dynamormmocks.MockQuery)
 
-	db.On("WithContext", mock.Anything).Return(db).Maybe()
-	db.On("Model", mock.Anything).Return(q).Maybe()
+	setupMockAgentConfigRepoDB(db, q)
 
 	q.On("Update", mock.Anything).Return(dynamormerrors.ErrItemNotFound).Once()
 	q.On("Create").Return(nil).Once()
@@ -112,6 +369,35 @@ func TestInstanceRepository_SetAgentInstanceConfig_UpsertsAndCaches(t *testing.T
 	require.True(t, ok)
 	assert.Same(t, cfg, cached)
 	assert.True(t, cached.AllowAgents)
+}
+
+func TestInstanceRepository_SetAgentInstanceConfig_ReturnsUpdateError(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockAgentConfigRepoDB(db, q)
+	q.On("Update", mock.Anything).Return(errors.New("update failed")).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	cfg := models.NewAgentInstanceConfig()
+
+	require.Error(t, repo.SetAgentInstanceConfig(ctx, cfg))
+}
+
+func TestInstanceRepository_SetAgentInstanceConfig_ReturnsCreateError(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockAgentConfigRepoDB(db, q)
+	q.On("Update", mock.Anything).Return(dynamormerrors.ErrItemNotFound).Once()
+	q.On("Create").Return(errors.New("create failed")).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	cfg := models.NewAgentInstanceConfig()
+
+	require.Error(t, repo.SetAgentInstanceConfig(ctx, cfg))
 }
 
 func TestInstanceRepository_SetAgentInstanceConfig_NilRejected(t *testing.T) {

--- a/pkg/storage/repositories/instance_repository_feature_config_test.go
+++ b/pkg/storage/repositories/instance_repository_feature_config_test.go
@@ -291,6 +291,36 @@ func TestInstanceRepository_ConfigExists_ReturnsFalseOnNotFound(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestInstanceRepository_ConfigExists_ReturnsStorageErrors(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockDB(db, q)
+	q.On("First", mock.AnythingOfType("*models.InstanceTrustConfig")).Return(assert.AnError).Once()
+	q.On("First", mock.AnythingOfType("*models.InstanceTranslationConfig")).Return(assert.AnError).Once()
+	q.On("First", mock.AnythingOfType("*models.InstanceTipsConfig")).Return(assert.AnError).Once()
+	q.On("First", mock.AnythingOfType("*models.AIInstanceConfig")).Return(assert.AnError).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+
+	ok, err := repo.TrustConfigExists(ctx)
+	require.ErrorIs(t, err, assert.AnError)
+	assert.False(t, ok)
+
+	ok, err = repo.TranslationConfigExists(ctx)
+	require.ErrorIs(t, err, assert.AnError)
+	assert.False(t, ok)
+
+	ok, err = repo.TipsConfigExists(ctx)
+	require.ErrorIs(t, err, assert.AnError)
+	assert.False(t, ok)
+
+	ok, err = repo.AIConfigExists(ctx)
+	require.ErrorIs(t, err, assert.AnError)
+	assert.False(t, ok)
+}
+
 func TestInstanceRepository_ConfigExists_ReturnsTrueAndCaches(t *testing.T) {
 	ctx := context.Background()
 	db := new(dynamormmocks.MockDB)
@@ -612,6 +642,55 @@ func TestInstanceRepository_SetTrustOverride_UpdatesAndCaches(t *testing.T) {
 	assert.Equal(t, "arn:aws:secretsmanager:us-east-1:123:secret:abc", *cached.Override.InstanceKeySecretARN)
 }
 
+func TestInstanceRepository_SetTrustManagedDefaults_CreatesWhenUpdateNotFound(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockDB(db, q)
+	q.On("First", mock.AnythingOfType("*models.InstanceTrustConfig")).Run(func(args mock.Arguments) {
+		out := args.Get(0).(*models.InstanceTrustConfig)
+		out.PK = "INSTANCE#CONFIG"
+		out.SK = models.SKTrustConfig
+	}).Return(nil).Once()
+	q.On("Update", mock.Anything).Return(dynamormerrors.ErrItemNotFound).Once()
+	q.On("Create").Return(nil).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	baseURL := "https://managed.example"
+	require.NoError(t, repo.SetTrustManagedDefaults(ctx, models.InstanceTrustConfigPatch{BaseURL: &baseURL}))
+
+	cached, ok := repo.getCachedTrustConfig()
+	require.True(t, ok)
+	require.NotNil(t, cached.Managed)
+	assert.Equal(t, "https://managed.example", cached.Managed.BaseURL)
+}
+
+func TestInstanceRepository_SetTrustOverride_CreatesWhenUpdateNotFound(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockDB(db, q)
+	q.On("First", mock.AnythingOfType("*models.InstanceTrustConfig")).Run(func(args mock.Arguments) {
+		out := args.Get(0).(*models.InstanceTrustConfig)
+		out.PK = "INSTANCE#CONFIG"
+		out.SK = models.SKTrustConfig
+	}).Return(nil).Once()
+	q.On("Update", mock.Anything).Return(dynamormerrors.ErrItemNotFound).Once()
+	q.On("Create").Return(nil).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	baseURL := "https://override.example"
+	require.NoError(t, repo.SetTrustOverride(ctx, models.InstanceTrustConfigPatch{BaseURL: &baseURL}))
+
+	cached, ok := repo.getCachedTrustConfig()
+	require.True(t, ok)
+	require.NotNil(t, cached.Override)
+	require.NotNil(t, cached.Override.BaseURL)
+	assert.Equal(t, "https://override.example", *cached.Override.BaseURL)
+}
+
 func TestInstanceRepository_SetTranslationManagedDefaults_UpdatesAndCaches(t *testing.T) {
 	ctx := context.Background()
 	db := new(dynamormmocks.MockDB)
@@ -850,6 +929,87 @@ func TestInstanceRepository_SetTipsOverride_UpdatesAndCaches(t *testing.T) {
 	assert.Equal(t, "0xoverride", *cached.Override.ContractAddress)
 }
 
+func TestInstanceRepository_SetTipsManagedDefaults_NoOpWhenPatchEmpty(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockDB(db, q)
+	q.On("First", mock.AnythingOfType("*models.InstanceTipsConfig")).Run(func(args mock.Arguments) {
+		out := args.Get(0).(*models.InstanceTipsConfig)
+		out.PK = "INSTANCE#CONFIG"
+		out.SK = models.SKTipsConfig
+	}).Return(nil).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	require.NoError(t, repo.SetTipsManagedDefaults(ctx, models.InstanceTipsConfigPatch{}))
+}
+
+func TestInstanceRepository_SetTipsOverride_NoOpWhenPatchEmpty(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockDB(db, q)
+	q.On("First", mock.AnythingOfType("*models.InstanceTipsConfig")).Run(func(args mock.Arguments) {
+		out := args.Get(0).(*models.InstanceTipsConfig)
+		out.PK = "INSTANCE#CONFIG"
+		out.SK = models.SKTipsConfig
+	}).Return(nil).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	require.NoError(t, repo.SetTipsOverride(ctx, models.InstanceTipsConfigPatch{}))
+}
+
+func TestInstanceRepository_SetTipsManagedDefaults_CreatesWhenUpdateNotFound(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockDB(db, q)
+	q.On("First", mock.AnythingOfType("*models.InstanceTipsConfig")).Run(func(args mock.Arguments) {
+		out := args.Get(0).(*models.InstanceTipsConfig)
+		out.PK = "INSTANCE#CONFIG"
+		out.SK = models.SKTipsConfig
+	}).Return(nil).Once()
+	q.On("Update", mock.Anything).Return(dynamormerrors.ErrItemNotFound).Once()
+	q.On("Create").Return(nil).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	enabled := true
+	require.NoError(t, repo.SetTipsManagedDefaults(ctx, models.InstanceTipsConfigPatch{Enabled: &enabled}))
+
+	cached, ok := repo.getCachedTipsConfig()
+	require.True(t, ok)
+	require.NotNil(t, cached.Managed)
+	assert.True(t, cached.Managed.Enabled)
+}
+
+func TestInstanceRepository_SetTipsOverride_CreatesWhenUpdateNotFound(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockDB(db, q)
+	q.On("First", mock.AnythingOfType("*models.InstanceTipsConfig")).Run(func(args mock.Arguments) {
+		out := args.Get(0).(*models.InstanceTipsConfig)
+		out.PK = "INSTANCE#CONFIG"
+		out.SK = models.SKTipsConfig
+	}).Return(nil).Once()
+	q.On("Update", mock.Anything).Return(dynamormerrors.ErrItemNotFound).Once()
+	q.On("Create").Return(nil).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	enabled := true
+	require.NoError(t, repo.SetTipsOverride(ctx, models.InstanceTipsConfigPatch{Enabled: &enabled}))
+
+	cached, ok := repo.getCachedTipsConfig()
+	require.True(t, ok)
+	require.NotNil(t, cached.Override)
+	require.NotNil(t, cached.Override.Enabled)
+	assert.True(t, *cached.Override.Enabled)
+}
+
 func TestInstanceRepository_ClearTipsOverride_RemovesOverrideAttribute(t *testing.T) {
 	ctx := context.Background()
 	db := new(dynamormmocks.MockDB)
@@ -1045,6 +1205,87 @@ func TestInstanceRepository_SetAIOverride_UpdatesAndCaches(t *testing.T) {
 	assert.True(t, *cached.Override.SpamDetectionEnabled)
 	assert.True(t, *cached.Override.PIIDetectionEnabled)
 	assert.True(t, *cached.Override.AIContentDetection)
+}
+
+func TestInstanceRepository_SetAIManagedDefaults_NoOpWhenPatchEmpty(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockDB(db, q)
+	q.On("First", mock.AnythingOfType("*models.AIInstanceConfig")).Run(func(args mock.Arguments) {
+		out := args.Get(0).(*models.AIInstanceConfig)
+		out.PK = "INSTANCE#CONFIG"
+		out.SK = models.SKAIConfig
+	}).Return(nil).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	require.NoError(t, repo.SetAIManagedDefaults(ctx, models.AIInstanceConfigPatch{}))
+}
+
+func TestInstanceRepository_SetAIOverride_NoOpWhenPatchEmpty(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockDB(db, q)
+	q.On("First", mock.AnythingOfType("*models.AIInstanceConfig")).Run(func(args mock.Arguments) {
+		out := args.Get(0).(*models.AIInstanceConfig)
+		out.PK = "INSTANCE#CONFIG"
+		out.SK = models.SKAIConfig
+	}).Return(nil).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	require.NoError(t, repo.SetAIOverride(ctx, models.AIInstanceConfigPatch{}))
+}
+
+func TestInstanceRepository_SetAIManagedDefaults_CreatesWhenUpdateNotFound(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockDB(db, q)
+	q.On("First", mock.AnythingOfType("*models.AIInstanceConfig")).Run(func(args mock.Arguments) {
+		out := args.Get(0).(*models.AIInstanceConfig)
+		out.PK = "INSTANCE#CONFIG"
+		out.SK = models.SKAIConfig
+	}).Return(nil).Once()
+	q.On("Update", mock.Anything).Return(dynamormerrors.ErrItemNotFound).Once()
+	q.On("Create").Return(nil).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	aiEnabled := true
+	require.NoError(t, repo.SetAIManagedDefaults(ctx, models.AIInstanceConfigPatch{AIEnabled: &aiEnabled}))
+
+	cached, ok := repo.getCachedAIConfig()
+	require.True(t, ok)
+	require.NotNil(t, cached.Managed)
+	assert.True(t, cached.Managed.AIEnabled)
+}
+
+func TestInstanceRepository_SetAIOverride_CreatesWhenUpdateNotFound(t *testing.T) {
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+
+	setupMockDB(db, q)
+	q.On("First", mock.AnythingOfType("*models.AIInstanceConfig")).Run(func(args mock.Arguments) {
+		out := args.Get(0).(*models.AIInstanceConfig)
+		out.PK = "INSTANCE#CONFIG"
+		out.SK = models.SKAIConfig
+	}).Return(nil).Once()
+	q.On("Update", mock.Anything).Return(dynamormerrors.ErrItemNotFound).Once()
+	q.On("Create").Return(nil).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	aiEnabled := true
+	require.NoError(t, repo.SetAIOverride(ctx, models.AIInstanceConfigPatch{AIEnabled: &aiEnabled}))
+
+	cached, ok := repo.getCachedAIConfig()
+	require.True(t, ok)
+	require.NotNil(t, cached.Override)
+	require.NotNil(t, cached.Override.AIEnabled)
+	assert.True(t, *cached.Override.AIEnabled)
 }
 
 func TestInstanceRepository_ClearAIOverride_RemovesOverrideAttribute(t *testing.T) {


### PR DESCRIPTION
## Milestone
Project 43 M1 / L-11 — env seeding must not overwrite admin agent-registration policy.

## Classification
Security remediation / operational config integrity.

## Summary
- Adds `InstanceRepository.AgentConfigExists(ctx)` for the AGENT_CONFIG row, mirroring the trust/translation/tips existence guards.
- Changes `seedAgentManagedDefaultsFromEnvOnce` to return immediately when AGENT_CONFIG already exists, before applying `ALLOW_AGENTS` or `ALLOW_AGENT_REGISTRATION` env values.
- Keeps fresh-deploy behavior: when AGENT_CONFIG is absent, `EnsureAgentInstanceConfig` creates it and env defaults can seed it once.
- Adds regressions for existing admin-disabled registration staying disabled despite stale env, plus fresh deploy env seeding.
- Adds repository coverage around `AgentConfigExists` and nearby feature-config branches to keep the lean coverage gate at/above 90%.

Fixes #1102.

## Surfaces affected
- `cmd/lesser/instance_feature_config_sync.go` env seed path only.
- `pkg/storage/repositories` AGENT_CONFIG existence lookup.
- No Mastodon REST, GraphQL, ActivityPub actor shape, DynamoDB key/tag, or dependency changes.

## Acceptance checklist
- [x] Existing AGENT_CONFIG row with `AllowAgentRegistration=false` is not overwritten when `ALLOW_AGENT_REGISTRATION=true` is present.
- [x] Fresh deploy / no AGENT_CONFIG row still seeds from env.
- [x] Stored policy remains false, so the existing public `/api/v1/agents/register` gate remains forbidden through the existing `AllowAgentRegistration` check.
- [x] Regression covers both existing-row and fresh-deploy paths.

## Validation
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cmd/lesser ./pkg/storage/repositories`
- [x] `go test -cover ./cmd/lesser ./pkg/storage/repositories` (`cmd/lesser` 90.3%, `pkg/storage/repositories` 90.0%)
- [x] `git diff --check`

## Not run
- `./lesser verify ci` — intentionally not run locally per L-11 assignment; GitHub CI should run the full gate.

## Provenance
GPG-signed local commit and same-repo push to `origin`, with this PR created via `gh pr create` because the requested exact `codex/...` branch and multi-file test update were a better fit for local git than routed bounded-file commit. Routed `lesser_lab` tools were used for the issue/email read path.

## Rollout notes
Deploy through normal Project 43 staging discipline after merge. No schema migration or config-row rewrite required; the change only prevents legacy env seeding from modifying an existing AGENT_CONFIG row.
