### PR TITLE
fix reputation actor uri parsing

### DIFF
--- a/cmd/api/handlers/reputation_round12_test.go
+++ b/cmd/api/handlers/reputation_round12_test.go
@@ -121,6 +121,16 @@ func TestReputationHandlersRound12(t *testing.T) {
 		requireStatus(t, http.StatusBadRequest)(h.HandleGetReputationLift(ctx))
 	})
 
+	t.Run("get reputation rejects crafted multi-segment local actor id before writes", func(t *testing.T) {
+		noWriteState := &round10QueryState{createErrorOnce: errors.New("unexpected storage write")}
+		noWriteHandler, _, _ := round11NewHandler(t, cfg, noWriteState)
+
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/reputation/crafted", headers, nil, nil)
+		require.NoError(t, err)
+		ctx.Params["actor_id"] = "https://example.com/users/admin/mallory"
+		requireStatus(t, http.StatusBadRequest)(noWriteHandler.HandleGetReputationLift(ctx))
+	})
+
 	t.Run("get reputation invalid token", func(t *testing.T) {
 		badHeaders := map[string]string{"Authorization": "Bearer bad-token"}
 		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/reputation/alice", badHeaders, nil, nil)

--- a/pkg/common/actor_id.go
+++ b/pkg/common/actor_id.go
@@ -49,8 +49,48 @@ func CanonicalActorID(actorID string) (string, error) {
 	if path == "/users" || path == "/@" {
 		return "", fmt.Errorf("actor ID must include host and path")
 	}
+	if _, _, err := activityPubUsernameFromActorPath(path); err != nil {
+		return "", err
+	}
 
 	return strings.ToLower(parsed.Scheme) + "://" + strings.ToLower(parsed.Host) + path, nil
+}
+
+// ActorUsernameFromID extracts a local ActivityPub username from an actor
+// identifier. Lesser-owned actor routes are intentionally strict: actor URLs of
+// the form /users/<username> and /@<username> must contain exactly one username
+// segment. Multi-segment paths such as /users/admin/mallory are not a username
+// for one component and a storage key for another; they are invalid.
+func ActorUsernameFromID(actorID string) (string, error) {
+	actorID = strings.TrimSpace(actorID)
+	if actorID == "" {
+		return "", fmt.Errorf("actor ID is required")
+	}
+
+	if !strings.Contains(actorID, "://") {
+		username := strings.TrimPrefix(actorID, "@")
+		if err := ValidateActivityPubUsername(username); err != nil {
+			return "", err
+		}
+		return username, nil
+	}
+
+	canonical, err := CanonicalActorID(actorID)
+	if err != nil {
+		return "", err
+	}
+	parsed, err := url.Parse(canonical)
+	if err != nil || parsed == nil {
+		return "", fmt.Errorf("actor ID must be a valid URL")
+	}
+	username, ok, err := activityPubUsernameFromActorPath(parsed.EscapedPath())
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("actor ID path is not a supported local actor route")
+	}
+	return username, nil
 }
 
 // SameCanonicalActorID reports whether two ActivityPub actor URI strings
@@ -81,4 +121,32 @@ func actorIDContainsControlRune(value string) bool {
 		}
 	}
 	return false
+}
+
+func activityPubUsernameFromActorPath(path string) (string, bool, error) {
+	path = strings.TrimRight(strings.TrimSpace(path), "/")
+	switch {
+	case strings.HasPrefix(path, "/users/"):
+		return activityPubUsernameFromSingleSegment(strings.TrimPrefix(path, "/users/"), true)
+	case strings.HasPrefix(path, "/@"):
+		return activityPubUsernameFromSingleSegment(strings.TrimPrefix(path, "/@"), true)
+	case path == "/users" || path == "/@":
+		return "", true, fmt.Errorf("actor ID must include a concrete actor username")
+	default:
+		return "", false, nil
+	}
+}
+
+func activityPubUsernameFromSingleSegment(escapedUsername string, knownActorPath bool) (string, bool, error) {
+	if escapedUsername == "" || strings.Contains(escapedUsername, "/") {
+		return "", knownActorPath, fmt.Errorf("actor ID must use exactly one actor username segment")
+	}
+	username, err := url.PathUnescape(escapedUsername)
+	if err != nil {
+		return "", knownActorPath, fmt.Errorf("actor ID username contains invalid escaping")
+	}
+	if err := ValidateActivityPubUsername(username); err != nil {
+		return "", knownActorPath, err
+	}
+	return username, knownActorPath, nil
 }

--- a/pkg/common/actor_id_test.go
+++ b/pkg/common/actor_id_test.go
@@ -75,6 +75,21 @@ func TestCanonicalActorID(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "rejects multi segment users actor path",
+			actorID: "https://remote.example/users/alice/mallory",
+			wantErr: true,
+		},
+		{
+			name:    "rejects multi segment at actor path",
+			actorID: "https://remote.example/@alice/mallory",
+			wantErr: true,
+		},
+		{
+			name:    "rejects invalid users actor username",
+			actorID: "https://remote.example/users/-alice",
+			wantErr: true,
+		},
+		{
 			name:    "rejects root path",
 			actorID: "https://remote.example/",
 			wantErr: true,
@@ -127,6 +142,74 @@ func TestSameCanonicalActorID(t *testing.T) {
 		"alice@remote.example",
 		"https://remote.example/users/alice",
 	))
+}
+
+func TestActorUsernameFromID(t *testing.T) {
+	tests := []struct {
+		name    string
+		actorID string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "users URL",
+			actorID: "https://example.com/users/alice",
+			want:    "alice",
+		},
+		{
+			name:    "users URL with trailing slash",
+			actorID: "https://example.com/users/alice/",
+			want:    "alice",
+		},
+		{
+			name:    "at URL",
+			actorID: "https://example.com/@bob",
+			want:    "bob",
+		},
+		{
+			name:    "plain username",
+			actorID: "carol",
+			want:    "carol",
+		},
+		{
+			name:    "handle username",
+			actorID: "@dave",
+			want:    "dave",
+		},
+		{
+			name:    "rejects crafted users path",
+			actorID: "https://example.com/users/admin/mallory",
+			wantErr: true,
+		},
+		{
+			name:    "rejects crafted at path",
+			actorID: "https://example.com/@admin/mallory",
+			wantErr: true,
+		},
+		{
+			name:    "rejects unsupported actor path",
+			actorID: "https://example.com/api/v1/actors/alice",
+			wantErr: true,
+		},
+		{
+			name:    "rejects invalid username",
+			actorID: "https://example.com/users/-alice",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ActorUsernameFromID(tt.actorID)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Empty(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestCachedRemoteActorIDMatchesLookup(t *testing.T) {

--- a/pkg/reputation/service.go
+++ b/pkg/reputation/service.go
@@ -219,9 +219,11 @@ func NewService(cfg *Config) (*Service, error) {
 
 // GetReputation retrieves the current reputation for an actor
 func (s *Service) GetReputation(ctx context.Context, actorID string) (*Reputation, error) {
-	if err := ValidateActorID(actorID); err != nil {
+	canonicalActorID, err := common.CanonicalActorID(actorID)
+	if err != nil {
 		return nil, fmt.Errorf("invalid actor ID: %w", err)
 	}
+	actorID = canonicalActorID
 
 	// Get reputation from storage
 	storedRep, err := s.userRepo.GetReputation(ctx, actorID)
@@ -279,6 +281,12 @@ func (s *Service) GetReputation(ctx context.Context, actorID string) (*Reputatio
 
 // calculateAndStore calculates and stores reputation for an actor
 func (s *Service) calculateAndStore(ctx context.Context, actorID string) (*Reputation, error) {
+	canonicalActorID, err := common.CanonicalActorID(actorID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid actor ID: %w", err)
+	}
+	actorID = canonicalActorID
+
 	// Gather calculation input
 	input, err := s.gatherCalculationInput(ctx, actorID)
 	if err != nil {
@@ -296,6 +304,10 @@ func (s *Service) calculateAndStore(ctx context.Context, actorID string) (*Reput
 		return nil, fmt.Errorf("failed to sign reputation: %w", err)
 	}
 
+	if err := s.assertCalculationMatchesStorageKey(input, rep); err != nil {
+		return nil, err
+	}
+
 	// Store reputation
 	if err := s.storeReputation(ctx, rep); err != nil {
 		return nil, fmt.Errorf("failed to store reputation: %w", err)
@@ -311,7 +323,11 @@ func (s *Service) gatherCalculationInput(ctx context.Context, actorID string) (*
 	}
 
 	// Extract username and get actor
-	username := s.extractUsername(actorID)
+	username, usernameErr := s.extractUsername(actorID)
+	if usernameErr != nil && !s.isRemoteActorID(actorID) {
+		return nil, usernameErr
+	}
+	input.ActorUsername = username
 	actor, err := s.getActorData(ctx, actorID, username)
 	if err != nil {
 		return nil, err
@@ -339,28 +355,14 @@ func (s *Service) gatherCalculationInput(ctx context.Context, actorID string) (*
 }
 
 // extractUsername extracts the username from an actor ID
-func (s *Service) extractUsername(actorID string) string {
-	username := actorID
-
-	// Try to extract from /users/ format
-	if idx := strings.LastIndex(actorID, "/users/"); idx != -1 {
-		username = actorID[idx+7:] // 7 is len("/users/")
-	} else if idx := strings.LastIndex(actorID, "/@"); idx != -1 {
-		username = actorID[idx+2:] // 2 is len("/@")
-	} else if strings.HasPrefix(actorID, "@") {
-		username = actorID[1:] // Remove leading @
-	}
-
-	// Remove any trailing slashes or query parameters
-	if idx := strings.IndexAny(username, "/?#"); idx != -1 {
-		username = username[:idx]
-	}
-
+func (s *Service) extractUsername(actorID string) (string, error) {
+	username, err := common.ActorUsernameFromID(actorID)
 	s.logger.Debug("Extracting username from actor ID",
 		zap.String("actorID", actorID),
-		zap.String("extracted_username", username))
+		zap.String("extracted_username", username),
+		zap.Error(err))
 
-	return username
+	return username, err
 }
 
 // getActorData retrieves actor data from storage
@@ -375,7 +377,10 @@ func (s *Service) getActorData(ctx context.Context, actorID, username string) (*
 			zap.String("actorID", actorID),
 			zap.String("username", username),
 			zap.Error(err))
-		return nil, fmt.Errorf("failed to get actor: %w", err)
+		return nil, fmt.Errorf("actor not found: %w", err)
+	}
+	if actor == nil || !common.SameCanonicalActorID(actor.ID, actorID) {
+		return nil, fmt.Errorf("actor not found: %s", actorID)
 	}
 	return actor, nil
 }
@@ -427,7 +432,13 @@ func (s *Service) gatherActivityMetrics(ctx context.Context, input *CalculationI
 
 // getPostCount retrieves the total number of posts (statuses) by an actor
 func (s *Service) getPostCount(ctx context.Context, actorID string) int {
-	username := s.extractUsername(actorID)
+	username, err := s.extractUsername(actorID)
+	if err != nil {
+		s.logger.Warn("Failed to extract username for post count",
+			zap.String("actorID", actorID),
+			zap.Error(err))
+		return 0
+	}
 
 	// Try cache first (cache for 10 minutes)
 	cacheKey := fmt.Sprintf("post_count_%s", username)
@@ -452,7 +463,13 @@ func (s *Service) getPostCount(ctx context.Context, actorID string) int {
 
 // getLastActivityTime retrieves the timestamp of the most recent activity by an actor
 func (s *Service) getLastActivityTime(ctx context.Context, actorID string) time.Time {
-	username := s.extractUsername(actorID)
+	username, err := s.extractUsername(actorID)
+	if err != nil {
+		s.logger.Warn("Failed to extract username for last activity",
+			zap.String("actorID", actorID),
+			zap.Error(err))
+		return time.Now().Add(-30 * 24 * time.Hour)
+	}
 
 	// Try cache first (cache for 5 minutes - activity timestamps change more frequently)
 	cacheKey := fmt.Sprintf("last_activity_%s", username)
@@ -763,6 +780,41 @@ func (s *Service) importedReputationStoreOptions(actorID string) []storeReputati
 	actorHost := actorIDHost(actorID)
 	if localHost == "" || actorHost == "" || actorHost != localHost {
 		return []storeReputationOption{withCanonicalActorKey()}
+	}
+	return nil
+}
+
+func (s *Service) assertCalculationMatchesStorageKey(input *CalculationInput, rep *Reputation) error {
+	if input == nil || rep == nil {
+		return fmt.Errorf("reputation calculation produced empty input or reputation")
+	}
+	if !common.SameCanonicalActorID(rep.ActorID, input.ActorID) {
+		return fmt.Errorf("calculated reputation actor mismatch: %s != %s", rep.ActorID, input.ActorID)
+	}
+
+	localHost := actorIDHost(s.instanceURL)
+	actorHost := actorIDHost(input.ActorID)
+	if localHost == "" || actorHost == "" || actorHost != localHost {
+		return nil
+	}
+
+	username, err := common.ActorUsernameFromID(input.ActorID)
+	if err != nil {
+		return err
+	}
+	if input.ActorUsername != "" && input.ActorUsername != username {
+		return fmt.Errorf("calculation username %q does not match canonical actor username %q", input.ActorUsername, username)
+	}
+
+	pk, err := models.ReputationActorPartitionKeyForRecord(input.ActorID, map[string]any{
+		"instanceURL": s.instanceURL,
+	})
+	if err != nil {
+		return err
+	}
+	expectedPK := fmt.Sprintf(models.KeyPatternActor, username)
+	if pk != expectedPK {
+		return fmt.Errorf("calculation username %q does not match reputation storage key %q", username, pk)
 	}
 	return nil
 }

--- a/pkg/reputation/service_round20_coverage_test.go
+++ b/pkg/reputation/service_round20_coverage_test.go
@@ -342,13 +342,14 @@ func (r *round20CommunityNoteRepo) GetCommunityNoteVotes(ctx context.Context, no
 }
 
 type round20Calculator struct {
-	rep *Reputation
-	err error
+	rep   *Reputation
+	err   error
+	input *CalculationInput
 }
 
 func (c *round20Calculator) Calculate(ctx context.Context, input *CalculationInput) (*Reputation, error) {
 	_ = ctx
-	_ = input
+	c.input = input
 	if c.err != nil {
 		return nil, c.err
 	}
@@ -566,10 +567,17 @@ func TestImportReputationRejectsMismatchedOuterAndInnerActors(t *testing.T) {
 func TestService_Round20_ExtractUsername_ParseSeverity_AndOutcome(t *testing.T) {
 	svc := &Service{logger: zap.NewNop()}
 
-	require.Equal(t, "alice", svc.extractUsername("https://example.com/users/alice"))
-	require.Equal(t, "bob", svc.extractUsername("https://example.com/@bob"))
-	require.Equal(t, "carol", svc.extractUsername("@carol"))
-	require.Equal(t, "dave", svc.extractUsername("dave?x=1"))
+	username, err := svc.extractUsername("https://example.com/users/alice")
+	require.NoError(t, err)
+	require.Equal(t, "alice", username)
+	username, err = svc.extractUsername("https://example.com/@bob")
+	require.NoError(t, err)
+	require.Equal(t, "bob", username)
+	username, err = svc.extractUsername("@carol")
+	require.NoError(t, err)
+	require.Equal(t, "carol", username)
+	_, err = svc.extractUsername("https://example.com/users/admin/mallory")
+	require.Error(t, err)
 
 	require.Equal(t, 1, svc.parseSeverity("1"))
 	require.Equal(t, 4, svc.parseSeverity("4"))
@@ -807,6 +815,184 @@ func TestService_GetReputation_RemoteActorDoesNotUseLocalUsername(t *testing.T) 
 	require.Contains(t, err.Error(), "actor not found")
 	require.Equal(t, 0, actorRepo.usernameCalls, "remote actor reputation must not fall back to local username lookup")
 	require.Equal(t, 1, actorRepo.remoteCalls)
+}
+
+func TestService_L05RejectsCraftedActorURIWithoutStorageWrite(t *testing.T) {
+	ctx := context.Background()
+	craftedActorID := "https://example.com/users/admin/mallory"
+
+	getCalls := 0
+	storeCalls := 0
+	userRepo := &round20UserRepo{
+		getFn: func(_ context.Context, _ string) (*storage.Reputation, error) {
+			getCalls++
+			return nil, storage.ErrNotFound
+		},
+		storeFn: func(_ context.Context, _ string, _ *storage.Reputation) error {
+			storeCalls++
+			return nil
+		},
+	}
+	actorRepo := &round20ActorRepo{
+		actorByUsername: map[string]*activitypub.Actor{
+			"admin": {BaseObject: activitypub.BaseObject{ID: "https://example.com/users/admin"}},
+		},
+	}
+	svc := &Service{
+		userRepo:    userRepo,
+		actorRepo:   actorRepo,
+		logger:      zap.NewNop(),
+		instanceURL: "https://example.com",
+	}
+
+	for i := 0; i < 2; i++ {
+		rep, err := svc.GetReputation(ctx, craftedActorID)
+		require.Error(t, err)
+		require.Nil(t, rep)
+		require.Contains(t, err.Error(), "invalid actor ID")
+	}
+	require.Equal(t, 0, getCalls, "invalid crafted actor URI must not perform reputation storage reads")
+	require.Equal(t, 0, actorRepo.usernameCalls, "invalid crafted actor URI must not resolve admin actor data")
+	require.Equal(t, 0, storeCalls, "invalid crafted actor URI must not create reputation rows")
+}
+
+func TestService_L05RepeatedMissingLocalActorDoesNotStoreReputation(t *testing.T) {
+	ctx := context.Background()
+	actorID := "https://example.com/users/mallory"
+
+	storeCalls := 0
+	userRepo := &round20UserRepo{
+		getFn: func(_ context.Context, _ string) (*storage.Reputation, error) {
+			return nil, storage.ErrNotFound
+		},
+		storeFn: func(_ context.Context, _ string, _ *storage.Reputation) error {
+			storeCalls++
+			return nil
+		},
+	}
+	actorRepo := &round20ActorRepo{}
+	svc := &Service{
+		userRepo:    userRepo,
+		actorRepo:   actorRepo,
+		logger:      zap.NewNop(),
+		instanceURL: "https://example.com",
+	}
+
+	for i := 0; i < 3; i++ {
+		rep, err := svc.GetReputation(ctx, actorID)
+		require.Error(t, err)
+		require.Nil(t, rep)
+		require.Contains(t, err.Error(), "actor not found")
+	}
+	require.Equal(t, 3, actorRepo.usernameCalls, "valid but missing actors may be checked each read")
+	require.Equal(t, 0, storeCalls, "never-resolvable actor reads must not append reputation rows")
+}
+
+func TestService_L05LocalActorResolutionMustMatchCanonicalActorID(t *testing.T) {
+	ctx := context.Background()
+	actorID := "https://example.com/users/mallory"
+
+	storeCalls := 0
+	userRepo := &round20UserRepo{
+		getFn: func(_ context.Context, _ string) (*storage.Reputation, error) {
+			return nil, storage.ErrNotFound
+		},
+		storeFn: func(_ context.Context, _ string, _ *storage.Reputation) error {
+			storeCalls++
+			return nil
+		},
+	}
+	actorRepo := &round20ActorRepo{
+		actorByUsername: map[string]*activitypub.Actor{
+			"mallory": {BaseObject: activitypub.BaseObject{ID: "https://example.com/users/admin"}},
+		},
+	}
+	svc := &Service{
+		userRepo:    userRepo,
+		actorRepo:   actorRepo,
+		logger:      zap.NewNop(),
+		instanceURL: "https://example.com",
+	}
+
+	rep, err := svc.GetReputation(ctx, actorID)
+	require.Error(t, err)
+	require.Nil(t, rep)
+	require.Contains(t, err.Error(), "actor not found")
+	require.Equal(t, 0, storeCalls, "mismatched actor resolution must not write reputation")
+}
+
+func TestService_L05CalculationUsernameMatchesStoragePartitionKey(t *testing.T) {
+	ctx := context.Background()
+	actorID := "https://example.com/users/alice"
+	now := time.Now()
+	var storedPK string
+
+	userRepo := &round20UserRepo{
+		getFn: func(_ context.Context, _ string) (*storage.Reputation, error) {
+			return nil, storage.ErrNotFound
+		},
+		storeFn: func(_ context.Context, actorID string, reputation *storage.Reputation) error {
+			reputationModel := &models.Reputation{}
+			require.NoError(t, reputationModel.UpdateKeys(actorID, reputation))
+			storedPK = reputationModel.PK
+			return nil
+		},
+	}
+	calculator := &round20Calculator{rep: &Reputation{
+		ActorID:      actorID,
+		InstanceURL:  "https://example.com",
+		CalculatedAt: now,
+		Version:      "1",
+	}}
+	svc := &Service{
+		userRepo:          userRepo,
+		actorRepo:         &round20ActorRepo{actorByUsername: map[string]*activitypub.Actor{"alice": {BaseObject: activitypub.BaseObject{ID: actorID, Published: ptrTime(now.AddDate(-1, 0, 0))}}}},
+		statusRepo:        &round20StatusRepo{countByUsername: map[string]int{"alice": 1}, timelineByUser: map[string][]*models.Status{"alice": nil}},
+		activityRepo:      &round20ActivityRepo{activitiesByUser: map[string][]*activitypub.Activity{"alice": nil}},
+		relationshipRepo:  &round20RelationshipRepo{followersByUser: map[string][]string{actorID: nil}},
+		trustRepo:         &round20TrustRepo{},
+		moderationRepo:    &round20ModerationRepo{},
+		communityNoteRepo: &round20CommunityNoteRepo{},
+		cache:             &round20CacheDB{store: &round20CacheStore{}},
+		calculator:        calculator,
+		signer:            &round20Signer{},
+		vouchManager:      &round20VouchManager{},
+		logger:            zap.NewNop(),
+		instanceURL:       "https://example.com",
+	}
+
+	rep, err := svc.GetReputation(ctx, actorID)
+	require.NoError(t, err)
+	require.NotNil(t, rep)
+	require.Equal(t, "alice", calculator.input.ActorUsername)
+	require.Equal(t, "ACTOR#alice", storedPK)
+	require.Equal(t, "ACTOR#"+calculator.input.ActorUsername, storedPK)
+}
+
+func TestService_L05CalculationStorageKeyAssertionErrors(t *testing.T) {
+	svc := &Service{instanceURL: "https://example.com", logger: zap.NewNop()}
+	validInput := &CalculationInput{ActorID: "https://example.com/users/alice", ActorUsername: "alice"}
+	validRep := &Reputation{ActorID: "https://example.com/users/alice"}
+
+	require.Error(t, svc.assertCalculationMatchesStorageKey(nil, validRep))
+	require.Error(t, svc.assertCalculationMatchesStorageKey(validInput, nil))
+
+	err := svc.assertCalculationMatchesStorageKey(validInput, &Reputation{ActorID: "https://example.com/users/bob"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "actor mismatch")
+
+	err = svc.assertCalculationMatchesStorageKey(
+		&CalculationInput{ActorID: "https://example.com/users/alice", ActorUsername: "mallory"},
+		validRep,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "calculation username")
+
+	remoteSvc := &Service{instanceURL: "https://example.com", logger: zap.NewNop()}
+	require.NoError(t, remoteSvc.assertCalculationMatchesStorageKey(
+		&CalculationInput{ActorID: "https://remote.example/users/alice"},
+		&Reputation{ActorID: "https://remote.example/users/alice"},
+	))
 }
 
 func TestService_getActorData_UsesCachedRemoteActorForRemoteIDs(t *testing.T) {
@@ -1083,7 +1269,7 @@ func TestService_Round20_ErrorAndEdgeBranches(t *testing.T) {
 		_, err := svc.calculateAndStore(ctx, "https://example.com/users/alice")
 		require.Error(t, err)
 
-		svc.actorRepo = &round20ActorRepo{actorByUsername: map[string]*activitypub.Actor{"alice": {BaseObject: activitypub.BaseObject{ID: "id"}}}}
+		svc.actorRepo = &round20ActorRepo{actorByUsername: map[string]*activitypub.Actor{"alice": {BaseObject: activitypub.BaseObject{ID: "https://example.com/users/alice"}}}}
 		svc.statusRepo = &round20StatusRepo{}
 		svc.activityRepo = &round20ActivityRepo{}
 		svc.relationshipRepo = &round20RelationshipRepo{}
@@ -1096,7 +1282,7 @@ func TestService_Round20_ErrorAndEdgeBranches(t *testing.T) {
 		_, err = svc.calculateAndStore(ctx, "https://example.com/users/alice")
 		require.Error(t, err)
 
-		svc.calculator = &round20Calculator{rep: &Reputation{ActorID: "id", CalculatedAt: time.Now(), Version: "1"}}
+		svc.calculator = &round20Calculator{rep: &Reputation{ActorID: "https://example.com/users/alice", CalculatedAt: time.Now(), Version: "1"}}
 		svc.signer = &round20Signer{signRepErr: errors.New("sign")}
 		_, err = svc.calculateAndStore(ctx, "https://example.com/users/alice")
 		require.Error(t, err)

--- a/pkg/reputation/types.go
+++ b/pkg/reputation/types.go
@@ -88,7 +88,8 @@ type PortableReputation struct {
 
 // CalculationInput contains all data needed to calculate reputation
 type CalculationInput struct {
-	ActorID string
+	ActorID       string
+	ActorUsername string
 
 	// Activity metrics
 	PostCount      int

--- a/pkg/storage/models/reputation.go
+++ b/pkg/storage/models/reputation.go
@@ -117,8 +117,8 @@ func ReputationActorPartitionKeyForRecord(actorID string, reputation interface{}
 
 	instanceURL := reputationInstanceURL(reputation)
 	if instanceURL != "" && reputationActorHostMatchesInstance(canonicalActorID, instanceURL) {
-		username := strings.TrimSpace(strings.TrimPrefix(extractUsernameFromActorID(strings.TrimRight(actorID, "/")), "@"))
-		if err := common.ValidateRequiredParam("username", username); err != nil {
+		username, err := common.ActorUsernameFromID(canonicalActorID)
+		if err != nil {
 			return "", err
 		}
 		return fmt.Sprintf(KeyPatternActor, username), nil
@@ -138,8 +138,8 @@ func ReputationActorPartitionKeyCandidates(actorID string) ([]string, error) {
 	}
 
 	candidates := []string{fmt.Sprintf(KeyPatternActor, canonicalActorID)}
-	username := strings.TrimSpace(strings.TrimPrefix(extractUsernameFromActorID(strings.TrimRight(actorID, "/")), "@"))
-	if username != "" {
+	username, err := common.ActorUsernameFromID(canonicalActorID)
+	if err == nil && username != "" {
 		legacy := fmt.Sprintf(KeyPatternActor, username)
 		if legacy != candidates[0] {
 			candidates = append(candidates, legacy)
@@ -204,40 +204,7 @@ func reputationActorHostMatchesInstance(actorID, instanceURL string) bool {
 }
 
 func canonicalReputationActorID(actorID string) (string, error) {
-	actorID = strings.TrimSpace(actorID)
-	if actorID == "" {
-		return "", fmt.Errorf("actor ID is required")
-	}
-	if strings.IndexFunc(actorID, func(r rune) bool { return r < 0x20 || r == 0x7f }) >= 0 {
-		return "", fmt.Errorf("actor ID contains control characters")
-	}
-	if err := common.ValidateActivityPubURL(actorID, "actor_id"); err != nil {
-		return "", err
-	}
-
-	parsed, err := url.Parse(actorID)
-	if err != nil || parsed == nil {
-		return "", err
-	}
-	scheme := strings.ToLower(strings.TrimSpace(parsed.Scheme))
-	if scheme != schemeHTTP && scheme != schemeHTTPS {
-		return "", fmt.Errorf("actor ID must use HTTP or HTTPS")
-	}
-	if parsed.User != nil || strings.TrimSpace(parsed.Hostname()) == "" {
-		return "", fmt.Errorf("actor ID must include a bare host")
-	}
-	if parsed.RawQuery != "" || parsed.Fragment != "" {
-		return "", fmt.Errorf("actor ID must not include query or fragment")
-	}
-	path := strings.TrimRight(parsed.EscapedPath(), "/")
-	if path == "" {
-		return "", fmt.Errorf("actor ID must include a path")
-	}
-	if path == "/users" || path == "/@" {
-		return "", fmt.Errorf("actor ID must include a concrete actor path")
-	}
-
-	return fmt.Sprintf("%s://%s%s", scheme, strings.ToLower(parsed.Host), path), nil
+	return common.CanonicalActorID(actorID)
 }
 
 // ToStorageReputation converts the model back to a map that can be used as storage.Reputation

--- a/pkg/storage/models/reputation_actor_key_test.go
+++ b/pkg/storage/models/reputation_actor_key_test.go
@@ -29,6 +29,29 @@ func TestReputationActorPartitionKeyForRecordBindsRemoteDomain(t *testing.T) {
 	require.NotEqual(t, remotePK, otherRemotePK)
 }
 
+func TestReputationActorPartitionKeyForRecordRejectsCraftedLocalActorPaths(t *testing.T) {
+	localRep := &storage.Reputation{
+		InstanceURL:  "https://example.com",
+		CalculatedAt: time.Now().UTC(),
+	}
+
+	for _, actorID := range []string{
+		"https://example.com/users/admin/mallory",
+		"https://example.com/users/alice/bob",
+		"https://example.com/@admin/mallory",
+	} {
+		t.Run(actorID, func(t *testing.T) {
+			pk, err := models.ReputationActorPartitionKeyForRecord(actorID, localRep)
+			require.Error(t, err)
+			require.Empty(t, pk)
+
+			candidates, err := models.ReputationActorPartitionKeyCandidates(actorID)
+			require.Error(t, err)
+			require.Nil(t, candidates)
+		})
+	}
+}
+
 func TestReputationActorPartitionKeyCandidatesIncludeLegacyFallback(t *testing.T) {
 	candidates, err := models.ReputationActorPartitionKeyCandidates("https://remote.example/users/alice")
 	require.NoError(t, err)
@@ -50,6 +73,10 @@ func TestReputationActorIDHelpersCanonicalizeAndRejectUnsafeIDs(t *testing.T) {
 	require.False(t, models.ReputationActorIDsMatch(
 		"acct:alice@example.com",
 		"https://example.com/users/alice",
+	))
+	require.False(t, models.ReputationActorIDsMatch(
+		"https://example.com/users/admin/mallory",
+		"https://example.com/users/admin",
 	))
 
 	_, err := models.ReputationActorPartitionKeyCandidates("acct:alice@example.com")

--- a/pkg/storage/models/status.go
+++ b/pkg/storage/models/status.go
@@ -358,13 +358,11 @@ func (s *Status) setupGSIKeys() {
 
 // extractUsernameFromActorID extracts username from an ActivityPub actor ID
 func extractUsernameFromActorID(actorID string) string {
-	// Handle different actor ID formats
-	// e.g., "https://example.com/users/username" -> "username"
-	parts := strings.Split(actorID, "/")
-	if len(parts) > 0 {
-		return parts[len(parts)-1]
+	username, err := common.ActorUsernameFromID(actorID)
+	if err != nil {
+		return ""
 	}
-	return ""
+	return username
 }
 
 // extractStatusIDFromURL extracts status ID from a status URL

--- a/pkg/storage/models/status_test.go
+++ b/pkg/storage/models/status_test.go
@@ -7,8 +7,16 @@ import (
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
+
+func TestExtractUsernameFromActorIDRejectsCraftedMultiSegmentActorPath(t *testing.T) {
+	require.Equal(t, "alice", extractUsernameFromActorID("https://example.com/users/alice"))
+	require.Equal(t, "bob", extractUsernameFromActorID("https://example.com/@bob"))
+	require.Empty(t, extractUsernameFromActorID("https://example.com/users/admin/mallory"))
+	require.Empty(t, extractUsernameFromActorID("https://example.com/@admin/mallory"))
+}
 
 // StatusModelTestSuite contains tests for Status model
 type StatusModelTestSuite struct {
@@ -639,7 +647,7 @@ func (suite *StatusModelTestSuite) TestExtractUsernameFromActorID() {
 		{
 			name:     "URL with trailing slash",
 			actorID:  "https://example.com/users/bob/",
-			expected: "",
+			expected: "bob",
 		},
 		{
 			name:     "simple username",


### PR DESCRIPTION
## Summary
- add one shared strict actor username parser in `pkg/common` and route reputation/service + storage/status username derivation through it
- reject malformed `/users/<username>/...` and `/@<username>/...` actor URIs during canonicalization, with usernames validated by `common.ValidateActivityPubUsername`
- canonicalize reputation lookups before storage access, require local actor resolution to match the requested canonical actor ID, and assert calculation username matches the local reputation storage partition key before writes
- add L-05 regressions for crafted multi-segment actor URIs, repeated missing reads with zero writes, and the existing reputation guard paths

## Federation trust / API / schema notes
- Federation trust: strengthens actor identity handling for local actor URI routes; no HTTP Signature, inbox/outbox, or actor-object shape changes.
- Mastodon/API surface: `/api/v1/reputation/:actor_id` still rejects invalid actor IDs with 400; malformed multi-segment local actor URLs now fail before any reputation storage read/write.
- Schema: no TableTheory tags, SK formats, or GSI definitions changed. Existing local reputation rows remain keyed as `ACTOR#<username>`; remote reputation rows remain canonical-actor-keyed.
- AGPL/dependencies: no dependency or license changes.

## Validation
- `go build ./...` ✅
- `go vet ./pkg/reputation/... ./pkg/storage/... ./cmd/api/handlers/...` ✅
- `go test ./pkg/common ./pkg/reputation/... ./pkg/storage/models/... ./cmd/api/handlers/...` ✅
- Guard focus: `go test ./pkg/storage/models -run TestReputationActor && go test ./pkg/reputation -run 'TestService_Round20|TestService_L05'` ✅
- Coverage:
  - `go test -cover ./pkg/common ./pkg/reputation ./pkg/storage/models` ✅
    - `pkg/common`: 91.5%
    - `pkg/reputation`: 90.1%
    - `pkg/storage/models`: 90.9%
  - `go test -cover ./cmd/api/handlers` ✅ command passed; package reports 89.3% (pre-existing package-wide baseline below 90; this PR does not change handler production code, only adds an endpoint regression test).

Full `./lesser verify ci` intentionally not run locally per Arch's L-05 assignment; PR CI should run the full gate.

## Acceptance checklist
- [x] Crafted local actor URI `/users/admin/mallory` is rejected up front and performs zero reputation storage writes.
- [x] `/users/<a>/<b>` and `/@<a>/<b>` no longer produce divergent calculator vs storage usernames.
- [x] Calculator source username is asserted against the local storage partition key before writes.
- [x] Repeated reads of a never-resolvable crafted/missing actor do not call `StoreReputation` / create rows.
- [x] Existing read-side guard tests in `reputation_actor_key_test.go` and `service_round20_coverage_test.go` pass.

## Rollout
Standard dev → staging → live soak. Watch reputation lookup 400s, actor-not-found rates, and DynamoDB reputation row write volume after deploy.

Refs #1099.
