### PR TITLE
fix oauth device consent scope gate

### DIFF
--- a/cmd/api/handlers/oauth_device_verification.go
+++ b/cmd/api/handlers/oauth_device_verification.go
@@ -16,7 +16,10 @@ import (
 
 var oauthDeviceUserCodePattern = regexp.MustCompile(`^[A-HJ-NP-Z2-9]{4}-[A-HJ-NP-Z2-9]{4}$`)
 
-const oauthDeviceErrorInvalidRequest = "invalid_request"
+const (
+	oauthDeviceErrorInvalidRequest    = "invalid_request"
+	oauthDeviceErrorInsufficientScope = "insufficient_scope"
+)
 
 func normalizeOAuthDeviceUserCode(input string) string {
 	trimmed := strings.ToUpper(strings.TrimSpace(input))
@@ -74,6 +77,19 @@ func oauthScopeSetsEqual(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+func oauthDeviceConsentMissingScope(claims *auth.Claims, requestedScopes []string) string {
+	for _, scope := range requestedScopes {
+		scope = strings.TrimSpace(scope)
+		if scope == "" {
+			continue
+		}
+		if claims == nil || !claims.HasScope(scope) {
+			return scope
+		}
+	}
+	return ""
 }
 
 func validateOAuthDeviceConsentBinding(params map[string]string, session *storage.OAuthDeviceSession) (string, string) {
@@ -310,6 +326,19 @@ func (h *Handler) HandleOAuthDeviceConsentLift(ctx *apptheory.Context) (*apptheo
 			Error:            code,
 			ErrorDescription: description,
 		})
+	}
+
+	if action == actionApprove {
+		// Device consent is intentionally principal-bound rather than OAuth-client-bound:
+		// hosted UI tokens may approve CLI/device sessions for the same operator. The
+		// non-negotiable safety gate is that the approving token must already cover
+		// every scope being granted to the device session.
+		if missingScope := oauthDeviceConsentMissingScope(claims, session.Scopes); missingScope != "" {
+			return apptheory.JSON(http.StatusForbidden, apimodels.OAuthErrorResponse{
+				Error:            oauthDeviceErrorInsufficientScope,
+				ErrorDescription: "approving token does not cover requested scope: " + missingScope,
+			})
+		}
 	}
 
 	switch action {

--- a/cmd/api/handlers/oauth_device_verification_round12_test.go
+++ b/cmd/api/handlers/oauth_device_verification_round12_test.go
@@ -176,3 +176,100 @@ func TestOAuthDeviceConsentLiftRound12(t *testing.T) {
 		require.Equal(t, "pending", strings.ToLower(state.oauthDeviceSessionsByUserCode["STUV-WXYZ"].Status))
 	})
 }
+
+func TestOAuthDeviceConsentLiftRound12_L01ScopeSubsetEnforced(t *testing.T) {
+	cfgDevice := round11TestConfig()
+	cfgDevice.AllowDeviceFlow = true
+	now := time.Now().UTC()
+
+	newHandler := func(t *testing.T, userCode string, sessionScopes []string) (*Handler, *round10QueryState) {
+		t.Helper()
+		state := &round10QueryState{
+			oauthDeviceSessionsByUserCode: map[string]storagemodels.OAuthDeviceSession{
+				userCode: {
+					DeviceCodeHash:  "hash-" + userCode,
+					UserCode:        userCode,
+					ClientID:        "device-client",
+					Scopes:          sessionScopes,
+					Status:          oauthDeviceSessionStatusPending,
+					IntervalSeconds: oauthDevicePollIntervalSeconds,
+					CreatedAt:       now.Add(-1 * time.Minute),
+					UpdatedAt:       now.Add(-1 * time.Minute),
+					ExpiresAt:       now.Add(5 * time.Minute),
+				},
+			},
+		}
+		h, _, _ := round11NewHandler(t, cfgDevice, state)
+		return h, state
+	}
+
+	accessToken := func(t *testing.T, h *Handler, scopes []string) string {
+		t.Helper()
+		// The approving token is intentionally minted for a different OAuth client to
+		// keep hosted UI consent working while the scope subset gate carries the
+		// privilege boundary.
+		oauthSvc := mustCreateOAuthService(t, cfgDevice.JWTSecret, cfgDevice, h.repos, h.logger)
+		token, _, err := oauthSvc.GenerateTokens(context.Background(), "alice", "hosted-ui-client", "", scopes)
+		require.NoError(t, err)
+		return token
+	}
+
+	consentBody := func(userCode, scope string) []byte {
+		return []byte("user_code=" + userCode + "&action=approve&client_id=device-client&scope=" + scope)
+	}
+
+	t.Run("read token cannot approve write admin device session", func(t *testing.T) {
+		userCode := "ABCD-EFGH"
+		h, state := newHandler(t, userCode, []string{auth.ScopeRead, auth.ScopeWrite, auth.ScopeAdmin})
+		token := accessToken(t, h, []string{auth.ScopeRead})
+
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/device/consent", map[string]string{
+			"authorization": "Bearer " + token,
+		}, nil, consentBody(userCode, "read+write+admin"))
+		resp := requireStatus(t, http.StatusForbidden)(h.HandleOAuthDeviceConsentLift(ctx))
+
+		var body apimodels.OAuthErrorResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "insufficient_scope", body.Error)
+		require.Contains(t, body.ErrorDescription, auth.ScopeWrite)
+		session := state.oauthDeviceSessionsByUserCode[userCode]
+		require.Equal(t, oauthDeviceSessionStatusPending, strings.ToLower(session.Status))
+		require.Empty(t, session.ApprovedUsername)
+	})
+
+	t.Run("equal scopes approve", func(t *testing.T) {
+		userCode := "JKLM-NPQR"
+		h, state := newHandler(t, userCode, []string{auth.ScopeRead, auth.ScopeWrite})
+		token := accessToken(t, h, []string{auth.ScopeRead, auth.ScopeWrite})
+
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/device/consent", map[string]string{
+			"authorization": "Bearer " + token,
+		}, nil, consentBody(userCode, "write+read"))
+		resp := requireStatus(t, http.StatusOK)(h.HandleOAuthDeviceConsentLift(ctx))
+
+		var body apimodels.OAuthDeviceConsentResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, oauthDeviceSessionStatusApproved, strings.ToLower(body.Status))
+		session := state.oauthDeviceSessionsByUserCode[userCode]
+		require.Equal(t, oauthDeviceSessionStatusApproved, strings.ToLower(session.Status))
+		require.Equal(t, "alice", session.ApprovedUsername)
+	})
+
+	t.Run("superset scopes approve", func(t *testing.T) {
+		userCode := "PQRS-TUVW"
+		h, state := newHandler(t, userCode, []string{auth.ScopeRead, auth.ScopeWrite})
+		token := accessToken(t, h, []string{auth.ScopeRead, auth.ScopeWrite, auth.ScopeAdmin})
+
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/device/consent", map[string]string{
+			"authorization": "Bearer " + token,
+		}, nil, consentBody(userCode, "read+write"))
+		resp := requireStatus(t, http.StatusOK)(h.HandleOAuthDeviceConsentLift(ctx))
+
+		var body apimodels.OAuthDeviceConsentResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, oauthDeviceSessionStatusApproved, strings.ToLower(body.Status))
+		session := state.oauthDeviceSessionsByUserCode[userCode]
+		require.Equal(t, oauthDeviceSessionStatusApproved, strings.ToLower(session.Status))
+		require.Equal(t, "alice", session.ApprovedUsername)
+	})
+}


### PR DESCRIPTION
## Summary
- enforce an approving token scope-subset gate before OAuth device sessions can be approved
- return `403 insufficient_scope` when the authenticated token lacks any scope requested by the device session
- document the client-binding decision: device consent remains principal-bound / intentionally cross-client so hosted UI tokens can approve CLI/device sessions; the privilege boundary is the scope subset check

## Acceptance coverage
- read-only token approving `read write admin` session is rejected with `403 insufficient_scope`
- equal-scope token approval still succeeds
- superset-scope token approval still succeeds, including a hosted-UI-style token minted for a different OAuth client
- denial flow is unchanged

## Security / contract notes
- Security: closes the L-01 scope-escalation path where a low-privilege token could approve a broader device session later exchanged for full session scopes.
- OAuth contract: additive hardening for over-broad approval; existing equal/superset and hosted UI approval flows remain supported.
- Federation/schema/AGPL/dependencies: no changes.

## Validation
- `go build ./...` — PASS
- `go vet ./cmd/api/handlers/...` — PASS
- `go test ./cmd/api/handlers/...` — PASS (`ok github.com/equaltoai/lesser/cmd/api/handlers 17.198s`)
- `go test -cover ./cmd/api/handlers/...` — PASS command, `coverage: 89.3% of statements`
  - Caveat: `origin/project-43-security-remediation` reports the same pre-existing package coverage band (`89.341%`); this branch reports `89.347%` and covers both new L-01 403 and success branches.
- Targeted: `go test ./cmd/api/handlers/... -run 'TestOAuthDeviceConsentLiftRound12_L01ScopeSubsetEnforced|TestOAuthDeviceConsentLiftRound12|TestOAuthDeviceConsent_CSR024_ScopeBindingEdgeCases' -count=1` — PASS

Full `./lesser verify ci` intentionally not run per lean assignment instructions; PR CI/verify gate will cover it.

## Provenance
- Commit is local GPG-signed (`a7ab061274e940c1ece20f52e17663417daf3ed1`, key `74521A0748B611BCC96D4EA872D6153132D52023`, issuer `aron23@gmail.com`).
- Routed lesser_lab tools were used for memory liveness, assignment email, and issue read; local signed commit + `gh pr create` fallback used to preserve the requested `codex/...` branch shape.
