### PR TITLE
fix community note rate-limit cursor order

### DIFF
--- a/cmd/api/handlers/notes_round12_test.go
+++ b/cmd/api/handlers/notes_round12_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -137,20 +138,31 @@ func TestNotesHandlersRound12(t *testing.T) {
 		requireStatus(t, http.StatusBadRequest)(h.HandleCreateNoteLift(ctx))
 	})
 
-	t.Run("create note rate limited", func(t *testing.T) {
+	t.Run("create note rate limited despite many older author notes", func(t *testing.T) {
 		minRep := round12StoredReputationModel(t, aliceActorID, 100)
 		authorKey := "AUTHOR#" + aliceActorID + "#NOTES"
+		now := time.Now().UTC().Truncate(time.Second)
+		authorNotes := make([]storagemodels.CommunityNote, 0, 106)
+		for i := 0; i < 105; i++ {
+			authorNotes = append(authorNotes, storagemodels.CommunityNote{
+				ID:        fmt.Sprintf("old-%03d", i),
+				AuthorID:  aliceActorID,
+				Content:   "existing old",
+				CreatedAt: now.Add(-48*time.Hour - time.Duration(i)*time.Minute),
+			})
+		}
+		authorNotes = append(authorNotes, storagemodels.CommunityNote{
+			ID:        "recent-at-limit",
+			AuthorID:  aliceActorID,
+			Content:   "existing recent",
+			CreatedAt: now.Add(-1 * time.Hour),
+		})
 		rateState := &round10QueryState{
 			reputationsByPK: map[string][]storagemodels.Reputation{
 				alicePK: {minRep},
 			},
 			communityNotesByGSI3PK: map[string][]storagemodels.CommunityNote{
-				authorKey: {{
-					ID:        "existing",
-					AuthorID:  aliceActorID,
-					Content:   "existing",
-					CreatedAt: time.Now().Add(-1 * time.Hour),
-				}},
+				authorKey: authorNotes,
 			},
 		}
 		rateHandler, _, _ := round11NewHandler(t, cfg, rateState, &RegistryStub{NotesSvc: notesSvc})

--- a/cmd/api/handlers/round10_test_helpers_test.go
+++ b/cmd/api/handlers/round10_test_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -28,9 +29,12 @@ type round10Where struct {
 }
 
 type round10QueryState struct {
-	wheres []round10Where
-	model  any
-	sets   map[string]any
+	wheres         []round10Where
+	model          any
+	sets           map[string]any
+	limit          int
+	orderField     string
+	orderDirection string
 
 	usersByUsername               map[string]storagemodels.User
 	actorsByUser                  map[string]storagemodels.Actor
@@ -146,6 +150,9 @@ type round10QueryState struct {
 func (s *round10QueryState) reset() {
 	s.wheres = nil
 	s.sets = nil
+	s.limit = 0
+	s.orderField = ""
+	s.orderDirection = ""
 }
 
 func (s *round10QueryState) whereValue(field string) (any, bool) {
@@ -164,6 +171,46 @@ func (s *round10QueryState) whereString(field string) (string, bool) {
 	}
 	str, ok := v.(string)
 	return str, ok
+}
+
+func round10CommunityNoteGSI3SK(note storagemodels.CommunityNote) string {
+	if note.GSI3SK != "" {
+		return note.GSI3SK
+	}
+	return note.CreatedAt.Format(time.RFC3339) + "#" + note.ID
+}
+
+func round10ApplyCommunityNoteAuthorQuery(state *round10QueryState, notes []storagemodels.CommunityNote) []storagemodels.CommunityNote {
+	items := append([]storagemodels.CommunityNote(nil), notes...)
+	for i := range items {
+		if items[i].GSI3SK == "" {
+			items[i].GSI3SK = round10CommunityNoteGSI3SK(items[i])
+		}
+	}
+
+	sort.SliceStable(items, func(i, j int) bool {
+		left := round10CommunityNoteGSI3SK(items[i])
+		right := round10CommunityNoteGSI3SK(items[j])
+		if strings.EqualFold(state.orderField, "gsi3SK") && strings.EqualFold(state.orderDirection, "DESC") {
+			return left > right
+		}
+		return left < right
+	})
+
+	if cursor, ok := state.whereString("gsi3SK"); ok && cursor != "" {
+		filtered := items[:0]
+		for _, note := range items {
+			if round10CommunityNoteGSI3SK(note) < cursor {
+				filtered = append(filtered, note)
+			}
+		}
+		items = filtered
+	}
+
+	if state.limit > 0 && len(items) > state.limit {
+		items = items[:state.limit]
+	}
+	return items
 }
 
 func round10ResolveUserForRead(state *round10QueryState) storagemodels.User {
@@ -415,9 +462,21 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 	mockQuery.On("Filter", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery).Maybe()
 	mockQuery.On("OrFilter", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery).Maybe()
 	mockQuery.On("Index", mock.Anything).Return(mockQuery).Maybe()
-	mockQuery.On("Limit", mock.Anything).Return(mockQuery).Maybe()
+	mockQuery.On("Limit", mock.Anything).Return(mockQuery).Run(func(args mock.Arguments) {
+		switch value := args.Get(0).(type) {
+		case int:
+			state.limit = value
+		case int32:
+			state.limit = int(value)
+		case int64:
+			state.limit = int(value)
+		}
+	}).Maybe()
 	mockQuery.On("Cursor", mock.Anything).Return(mockQuery).Maybe()
-	mockQuery.On("OrderBy", mock.Anything, mock.Anything).Return(mockQuery).Maybe()
+	mockQuery.On("OrderBy", mock.Anything, mock.Anything).Return(mockQuery).Run(func(args mock.Arguments) {
+		state.orderField, _ = args.Get(0).(string)
+		state.orderDirection, _ = args.Get(1).(string)
+	}).Maybe()
 	mockQuery.On("ConsistentRead").Return(mockQuery).Maybe()
 	mockQuery.On("WithContext", mock.Anything).Return(mockQuery).Maybe()
 	mockQuery.On("IfNotExists").Return(mockQuery).Maybe()
@@ -2390,7 +2449,7 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 			gsi3pk, _ := state.whereString("gsi3PK")
 			if gsi3pk != "" {
 				if notes, ok := state.communityNotesByGSI3PK[gsi3pk]; ok {
-					*d = notes
+					*d = round10ApplyCommunityNoteAuthorQuery(state, notes)
 					return
 				}
 			}

--- a/pkg/notes/service.go
+++ b/pkg/notes/service.go
@@ -216,11 +216,21 @@ func (s *Service) CheckNoteRateLimit(ctx context.Context, userID string, limit i
 		}
 
 		for _, note := range notes {
-			if note != nil && note.CreatedAt.After(cutoff) {
-				count++
-				if count >= limit {
-					return false, 0
+			if note == nil {
+				continue
+			}
+
+			if !note.CreatedAt.After(cutoff) {
+				remaining := limit - count
+				if remaining < 0 {
+					remaining = 0
 				}
+				return true, remaining
+			}
+
+			count++
+			if count >= limit {
+				return false, 0
 			}
 		}
 

--- a/pkg/notes/service_test.go
+++ b/pkg/notes/service_test.go
@@ -3,6 +3,7 @@ package notes
 import (
 	"context"
 	"errors"
+	"sort"
 	"strconv"
 	"testing"
 	"time"
@@ -32,8 +33,9 @@ type stubCommunityNoteRepo struct {
 	userVotesErr error
 	userVotes    map[string]*storage.CommunityNoteVote
 
-	notesByAuthorErr error
-	notesByAuthor    []*storage.CommunityNote
+	notesByAuthorErr   error
+	notesByAuthor      []*storage.CommunityNote
+	notesByAuthorCalls int
 
 	updateScoreErr error
 	updatedScore   struct {
@@ -73,25 +75,42 @@ func (s *stubCommunityNoteRepo) GetCommunityNotesByAuthor(_ context.Context, _ s
 	if s.notesByAuthorErr != nil {
 		return nil, "", s.notesByAuthorErr
 	}
-	start := 0
-	if cursor != "" {
-		parsed, err := strconv.Atoi(cursor)
-		if err == nil && parsed >= 0 {
-			start = parsed
+	s.notesByAuthorCalls++
+
+	ordered := make([]*storage.CommunityNote, 0, len(s.notesByAuthor))
+	for _, note := range s.notesByAuthor {
+		if note != nil {
+			ordered = append(ordered, note)
 		}
 	}
-	if start >= len(s.notesByAuthor) {
-		return []*storage.CommunityNote{}, "", nil
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return communityNoteAuthorCursor(ordered[i]) > communityNoteAuthorCursor(ordered[j])
+	})
+
+	results := make([]*storage.CommunityNote, 0, len(ordered))
+	for _, note := range ordered {
+		noteCursor := communityNoteAuthorCursor(note)
+		if cursor != "" && noteCursor >= cursor {
+			continue
+		}
+		results = append(results, note)
+		if limit > 0 && len(results) == limit {
+			break
+		}
 	}
-	end := len(s.notesByAuthor)
-	if limit > 0 && start+limit < end {
-		end = start + limit
-	}
+
 	nextCursor := ""
-	if end < len(s.notesByAuthor) {
-		nextCursor = strconv.Itoa(end)
+	if limit > 0 && len(results) == limit {
+		nextCursor = communityNoteAuthorCursor(results[len(results)-1])
 	}
-	return s.notesByAuthor[start:end], nextCursor, nil
+	return results, nextCursor, nil
+}
+
+func communityNoteAuthorCursor(note *storage.CommunityNote) string {
+	if note == nil {
+		return ""
+	}
+	return note.CreatedAt.Format(time.RFC3339) + "#" + note.ID
 }
 
 func (s *stubCommunityNoteRepo) UpdateCommunityNoteScore(_ context.Context, noteID string, score float64, status string) error {
@@ -126,11 +145,11 @@ func TestService_CreateNote_StoresDefaults(t *testing.T) {
 	assert.Equal(t, note.ID, repo.createdNote.ID)
 }
 
-func TestService_CheckNoteRateLimit_PaginatesPastOldNotes(t *testing.T) {
-	now := time.Now()
-	oldNotes := make([]*storage.CommunityNote, communityNoteRateLimitPageSize)
+func TestService_CheckNoteRateLimit_DeniesWithRecentNotesAfterManyOldRawNotes(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	oldNotes := make([]*storage.CommunityNote, communityNoteRateLimitPageSize+5)
 	for i := range oldNotes {
-		oldNotes[i] = &storage.CommunityNote{ID: strconv.Itoa(i), CreatedAt: now.Add(-48 * time.Hour)}
+		oldNotes[i] = &storage.CommunityNote{ID: "old-" + strconv.Itoa(i), CreatedAt: now.Add(-48*time.Hour - time.Duration(i)*time.Minute)}
 	}
 	recentNotes := []*storage.CommunityNote{
 		{ID: "recent-1", CreatedAt: now.Add(-2 * time.Hour)},
@@ -144,6 +163,7 @@ func TestService_CheckNoteRateLimit_PaginatesPastOldNotes(t *testing.T) {
 	allowed, remaining := svc.CheckNoteRateLimit(context.Background(), "alice", 2)
 	assert.False(t, allowed)
 	assert.Equal(t, 0, remaining)
+	assert.Equal(t, 1, repo.notesByAuthorCalls)
 }
 
 func TestService_StoreNote_ErrorWrapped(t *testing.T) {
@@ -258,18 +278,22 @@ func TestService_RecalculateNoteScore_UpdatesStorage(t *testing.T) {
 }
 
 func TestService_CheckNoteRateLimit_CountsRecentNotes(t *testing.T) {
-	now := time.Now()
+	now := time.Now().UTC().Truncate(time.Second)
+	oldNotes := make([]*storage.CommunityNote, communityNoteRateLimitPageSize+5)
+	for i := range oldNotes {
+		oldNotes[i] = &storage.CommunityNote{ID: "old-" + strconv.Itoa(i), CreatedAt: now.Add(-48*time.Hour - time.Duration(i)*time.Minute)}
+	}
 	repo := &stubCommunityNoteRepo{
-		notesByAuthor: []*storage.CommunityNote{
+		notesByAuthor: append(oldNotes, []*storage.CommunityNote{
 			{ID: "n1", CreatedAt: now.Add(-2 * time.Hour)},
-			{ID: "n2", CreatedAt: now.Add(-48 * time.Hour)},
-		},
+		}...),
 	}
 	svc := &Service{repo: repo, logger: zap.NewNop()}
 
 	allowed, remaining := svc.CheckNoteRateLimit(context.Background(), "alice", 2)
 	assert.True(t, allowed)
 	assert.Equal(t, 1, remaining)
+	assert.Equal(t, 1, repo.notesByAuthorCalls)
 }
 
 // TestService_CheckRateLimit_DeniesWhenAtLimit verifies CSR-048:

--- a/pkg/storage/repositories/community_note_repository.go
+++ b/pkg/storage/repositories/community_note_repository.go
@@ -305,9 +305,11 @@ func (r *CommunityNoteRepository) GetCommunityNotesByAuthor(ctx context.Context,
 	query := r.GetDB().WithContext(ctx).Model(&models.CommunityNote{}).
 		Index("gsi3").
 		Where("gsi3PK", "=", fmt.Sprintf("AUTHOR#%s#NOTES", authorID)).
-		Limit(limit)
+		Limit(limit).
+		OrderBy("gsi3SK", "DESC")
 
-	// Add cursor if provided - preserve exact cursor logic
+	// Add cursor if provided. With DESC ordering, gsi3SK < cursor advances
+	// from newest notes toward older notes.
 	if cursor != "" {
 		// Parse cursor - expecting format "timestamp#noteID" - preserve exact parsing
 		parts := strings.Split(cursor, "#")

--- a/pkg/storage/repositories/community_note_repository_round09_coverage_test.go
+++ b/pkg/storage/repositories/community_note_repository_round09_coverage_test.go
@@ -191,6 +191,7 @@ func TestCommunityNoteRepository_round09_vote_paths_and_author_listing(t *testin
 		mockQuery.On("Index", "gsi3").Return(mockQuery).Once()
 		mockQuery.On("Where", "gsi3PK", "=", "AUTHOR#u1#NOTES").Return(mockQuery).Once()
 		mockQuery.On("Limit", 2).Return(mockQuery).Once()
+		mockQuery.On("OrderBy", "gsi3SK", "DESC").Return(mockQuery).Once()
 		mockQuery.On("Where", "gsi3SK", "<", "123#n1").Return(mockQuery).Once()
 		mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
 			dest := args.Get(0).(*[]models.CommunityNote)
@@ -205,6 +206,7 @@ func TestCommunityNoteRepository_round09_vote_paths_and_author_listing(t *testin
 		mockQuery.On("Index", "gsi3").Return(mockQuery).Once()
 		mockQuery.On("Where", "gsi3PK", "=", "AUTHOR#u1#NOTES").Return(mockQuery).Once()
 		mockQuery.On("Limit", 2).Return(mockQuery).Once()
+		mockQuery.On("OrderBy", "gsi3SK", "DESC").Return(mockQuery).Once()
 		mockQuery.On("All", mock.Anything).Return(dynamormerrors.ErrItemNotFound).Once()
 		notes, next, err = repo.GetCommunityNotesByAuthor(ctx, "u1", 2, "badcursor")
 		require.NoError(t, err)

--- a/pkg/testing/inmemory/community_note_repository.go
+++ b/pkg/testing/inmemory/community_note_repository.go
@@ -3,7 +3,9 @@ package inmemory
 
 import (
 	"context"
+	"sort"
 	"sync"
+	"time"
 
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
@@ -86,30 +88,40 @@ func (r *CommunityNoteRepository) GetCommunityNotesByAuthor(_ context.Context, a
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	noteIDs := r.notesByAuthor[authorID]
-	var results []*storage.CommunityNote
-
-	startIdx := 0
-	if cursor != "" {
-		for i, id := range noteIDs {
-			if id == cursor {
-				startIdx = i + 1
-				break
-			}
+	ordered := make([]*storage.CommunityNote, 0, len(r.notesByAuthor[authorID]))
+	for _, noteID := range r.notesByAuthor[authorID] {
+		if note, exists := r.notes[noteID]; exists && note != nil {
+			ordered = append(ordered, note)
 		}
 	}
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return inMemoryCommunityNoteAuthorCursor(ordered[i]) > inMemoryCommunityNoteAuthorCursor(ordered[j])
+	})
 
-	for i := startIdx; i < len(noteIDs) && (limit <= 0 || len(results) < limit); i++ {
-		if note, exists := r.notes[noteIDs[i]]; exists {
-			results = append(results, note)
+	results := make([]*storage.CommunityNote, 0, len(ordered))
+	for _, note := range ordered {
+		noteCursor := inMemoryCommunityNoteAuthorCursor(note)
+		if cursor != "" && noteCursor >= cursor {
+			continue
+		}
+		results = append(results, note)
+		if limit > 0 && len(results) == limit {
+			break
 		}
 	}
 
 	nextCursor := ""
-	if limit > 0 && startIdx+limit < len(noteIDs) {
-		nextCursor = noteIDs[startIdx+limit-1]
+	if limit > 0 && len(results) == limit {
+		nextCursor = inMemoryCommunityNoteAuthorCursor(results[len(results)-1])
 	}
 	return results, nextCursor, nil
+}
+
+func inMemoryCommunityNoteAuthorCursor(note *storage.CommunityNote) string {
+	if note == nil {
+		return ""
+	}
+	return note.CreatedAt.Format(time.RFC3339) + "#" + note.ID
 }
 
 // UpdateCommunityNoteScore updates a note's score and visibility


### PR DESCRIPTION
## Summary
- fixes L-06 by querying community notes by author newest-first (`OrderBy("gsi3SK", "DESC")`) while keeping the existing `gsi3SK < cursor` pagination semantics
- bounds `CheckNoteRateLimit` by short-circuiting once the newest-first scan reaches a note outside the 24h window
- replaces the misleading integer-offset rate-limit test stub with GSI3 cursor semantics and adds a handler regression with >100 older notes plus a recent note at the daily limit

Fix option: **(a)** — newest-first GSI3 ordering plus cutoff short-circuit.

## Regression fidelity
The `pkg/notes` stub now synthesizes real author GSI3 sort keys as `<RFC3339 createdAt>#<noteID>`, orders them DESC, and applies the same exclusive `gsi3SK < cursor` page boundary used by the repository. The regression seeds >100 old notes first in the raw slice and then recent notes with the largest GSI3 sort keys; the service denies on the first newest-first page and asserts only one author-query page was needed.

## Contract / compatibility notes
- Federation trust: no ActivityPub signing, inbox/outbox, actor identity, relay, or delivery logic touched.
- Mastodon/API surface: response shapes and error shape unchanged. The create-note gate now returns the already-existing 429 rate-limit response for the previously-bypassed over-limit case. Author note listing semantics become newest-first for the existing GSI3 query; this is a semantic refinement and aligns with expected timeline-style ordering.
- Schema: no PK/SK, GSI definition, projection, or TableTheory tag changes. Query ordering only.
- AGPL/dependencies: no dependency or license changes.

## Validation
- `go build ./...` ✅
- `go vet ./pkg/notes/... ./pkg/storage/repositories/...` ✅
- `go test ./pkg/notes/... ./pkg/storage/repositories/...` ✅
- `go test -cover ./pkg/notes/... ./pkg/storage/repositories/...` ✅ (`pkg/notes` 86.4%, `pkg/storage/repositories` 90.0%)
- `go test -coverprofile=/tmp/l06-coverage.out ./pkg/notes/... ./pkg/storage/repositories/... && go tool cover -func=/tmp/l06-coverage.out | tail -5` ✅ aggregate `total: 90.0%`
- `go test ./cmd/api/handlers -run TestNotesHandlersRound12` ✅

Full `./lesser verify ci` intentionally not run per lean-validation assignment instructions; PR verify gate should run full CI.

## Rollout
Standard lesser rollout: merge to `project-43-security-remediation`, then dev soak before any staging/live promotion. No state migration required.

Closes #1107.
