### PR TITLE
ci: harden verify resource defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  LESSER_GOCACHE_CACHE_SALT: v1
 
 jobs:
   verify:
@@ -37,11 +38,13 @@ jobs:
             go.sum
             infra/cdk/go.sum
 
+      - name: Configure Go build cache
+        run: |
+          echo "GOCACHE=$GITHUB_WORKSPACE/tmp/go-cache/go${{ steps.setup-go.outputs.go-version }}" >> "$GITHUB_ENV"
+          mkdir -p "$GITHUB_WORKSPACE/tmp/go-cache/go${{ steps.setup-go.outputs.go-version }}"
+
       - name: Disk usage (post setup-go)
         run: bash scripts/ci_disk_usage.sh "post setup-go"
-
-      - name: Install Go tools
-        run: bash scripts/install_ci_tools.sh
 
       - name: Cache Lesser XDG caches
         uses: actions/cache@v5
@@ -52,8 +55,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-lesser-xdg-go${{ steps.setup-go.outputs.go-version }}-
 
-      - name: Disk usage (post xdg cache restore)
-        run: bash scripts/ci_disk_usage.sh "post xdg cache restore"
+      - name: Cache Go build cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            tmp/go-cache/go${{ steps.setup-go.outputs.go-version }}
+          key: ${{ runner.os }}-gocache-${{ env.LESSER_GOCACHE_CACHE_SALT }}-go${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-gocache-${{ env.LESSER_GOCACHE_CACHE_SALT }}-go${{ steps.setup-go.outputs.go-version }}-
+
+      - name: Disk usage (post cache restore)
+        run: bash scripts/ci_disk_usage.sh "post cache restore"
+
+      - name: Install Go tools
+        run: bash scripts/install_ci_tools.sh
 
       - name: Build lesser CLI
         run: go build -o lesser ./cmd/lesser

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ TEST_ENVIRONMENT ?= test
 TEST_STAGE ?= test
 INTEGRATION_ENVIRONMENT ?= integration
 INTEGRATION_STAGE ?= integration
+LESSER_TEST_GOMEMLIMIT ?= 6GiB
+LESSER_TEST_PARALLELISM ?= 4
+LESSER_TEST_RACE_PARALLELISM ?= 2
 
 # Seed/validation configuration
 SEED_BASE_URL ?= https://dev.lesser.host
@@ -706,7 +709,8 @@ test:
 	@ENVIRONMENT=$(TEST_ENVIRONMENT) STAGE=$(TEST_STAGE) \
 		JWT_SECRET=$${JWT_SECRET:-dummy_value} \
 		DYNAMODB_ENCRYPTION_KEY=$${DYNAMODB_ENCRYPTION_KEY:-0123456789abcdef0123456789abcdef} \
-		GOCACHE=$(CURDIR)/tmp/go-cache go test -v ./...
+		GOMEMLIMIT=$${GOMEMLIMIT:-$(LESSER_TEST_GOMEMLIMIT)} \
+		GOCACHE=$(CURDIR)/tmp/go-cache go test -p=$(LESSER_TEST_PARALLELISM) -v ./...
 
 .PHONY: schema
 schema:
@@ -719,7 +723,8 @@ test-coverage:
 	@ENVIRONMENT=$(TEST_ENVIRONMENT) STAGE=$(TEST_STAGE) \
 		JWT_SECRET=$${JWT_SECRET:-dummy_value} \
 		DYNAMODB_ENCRYPTION_KEY=$${DYNAMODB_ENCRYPTION_KEY:-0123456789abcdef0123456789abcdef} \
-		GOCACHE=$(CURDIR)/tmp/go-cache go test -v -coverprofile=coverage.out ./...
+		GOMEMLIMIT=$${GOMEMLIMIT:-$(LESSER_TEST_GOMEMLIMIT)} \
+		GOCACHE=$(CURDIR)/tmp/go-cache go test -p=$(LESSER_TEST_PARALLELISM) -v -coverprofile=coverage.out ./...
 	@go tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report generated: coverage.html"
 
@@ -729,7 +734,8 @@ test-race:
 	@mkdir -p tmp/go-cache
 	@ENVIRONMENT=$(TEST_ENVIRONMENT) STAGE=$(TEST_STAGE) \
 		JWT_SECRET=$${JWT_SECRET:-dummy_value} \
-		GOCACHE=$(CURDIR)/tmp/go-cache go test -race -v ./...
+		GOMEMLIMIT=$${GOMEMLIMIT:-$(LESSER_TEST_GOMEMLIMIT)} \
+		GOCACHE=$(CURDIR)/tmp/go-cache go test -p=$(LESSER_TEST_RACE_PARALLELISM) -race -v ./...
 
 ## Run integration tests
 test-integration:
@@ -746,7 +752,8 @@ test-unit:
 	@mkdir -p tmp/go-cache
 	@ENVIRONMENT=$(TEST_ENVIRONMENT) STAGE=$(TEST_STAGE) \
 		JWT_SECRET=$${JWT_SECRET:-dummy_value} \
-		GOCACHE=$(CURDIR)/tmp/go-cache go test -short -v ./...
+		GOMEMLIMIT=$${GOMEMLIMIT:-$(LESSER_TEST_GOMEMLIMIT)} \
+		GOCACHE=$(CURDIR)/tmp/go-cache go test -p=$(LESSER_TEST_PARALLELISM) -short -v ./...
 
 ## Clear all data from DynamoDB table
 clear-data:

--- a/cmd/lesser/test_cmd.go
+++ b/cmd/lesser/test_cmd.go
@@ -14,8 +14,14 @@ import (
 )
 
 const (
-	defaultCoverageBatchSize = 25
-	coverageBatchSizeEnvVar  = "LESSER_TEST_COVERAGE_BATCH_SIZE"
+	defaultCoverageBatchSize     = 25
+	defaultTestGOMEMLIMIT        = "6GiB"
+	defaultTestParallelism       = 4
+	defaultTestRaceParallelism   = 2
+	coverageBatchSizeEnvVar      = "LESSER_TEST_COVERAGE_BATCH_SIZE"
+	lesserTestGOMEMLIMITEnv      = "LESSER_TEST_GOMEMLIMIT"
+	lesserTestParallelismEnv     = "LESSER_TEST_PARALLELISM"
+	lesserTestRaceParallelismEnv = "LESSER_TEST_RACE_PARALLELISM"
 )
 
 func runTest(argv []string) error {
@@ -63,7 +69,7 @@ func runTestAll(argv []string) error {
 		return err
 	}
 
-	return runGoTests(args, []string{"test", "-v", "./..."}, nil)
+	return runGoTests(args, memorySafeGoTestArgs([]string{"test", "-v", "./..."}, false), nil)
 }
 
 func runTestUnit(argv []string) error {
@@ -77,7 +83,7 @@ func runTestUnit(argv []string) error {
 		return err
 	}
 
-	return runGoTests(args, []string{"test", "-short", "-v", "./..."}, nil)
+	return runGoTests(args, memorySafeGoTestArgs([]string{"test", "-short", "-v", "./..."}, false), nil)
 }
 
 func runTestIntegration(argv []string) error {
@@ -110,7 +116,7 @@ func runTestRace(argv []string) error {
 		return err
 	}
 
-	return runGoTests(args, []string{"test", "-race", "-v", "./..."}, nil)
+	return runGoTests(args, memorySafeGoTestArgs([]string{"test", "-race", "-v", "./..."}, true), nil)
 }
 
 func runTestCoverage(argv []string) error {
@@ -192,6 +198,7 @@ func runTestCoverage(argv []string) error {
 	}
 
 	goArgs := []string{"test"}
+	goArgs = memorySafeGoTestArgs(goArgs, false)
 	if short {
 		goArgs = append(goArgs, "-short")
 	}
@@ -263,6 +270,56 @@ func resolveCoverageBatchSize() int {
 		}
 	}
 	return defaultCoverageBatchSize
+}
+
+func memorySafeGoTestArgs(goArgs []string, race bool) []string {
+	jobs := resolveTestParallelism(race)
+	if jobs <= 0 || len(goArgs) == 0 || goTestArgsHaveParallelism(goArgs) {
+		return goArgs
+	}
+
+	out := make([]string, 0, len(goArgs)+1)
+	out = append(out, goArgs[0], fmt.Sprintf("%s=%d", goBuildParallelismFlag, jobs))
+	out = append(out, goArgs[1:]...)
+	return out
+}
+
+func goTestArgsHaveParallelism(goArgs []string) bool {
+	for _, arg := range goArgs {
+		if arg == goBuildParallelismFlag || strings.HasPrefix(arg, goBuildParallelismFlag+"=") {
+			return true
+		}
+	}
+	return false
+}
+
+func resolveTestParallelism(race bool) int {
+	envName := lesserTestParallelismEnv
+	fallback := defaultTestParallelism
+	if race {
+		envName = lesserTestRaceParallelismEnv
+		fallback = defaultTestRaceParallelism
+	}
+
+	if raw := strings.TrimSpace(os.Getenv(envName)); raw != "" {
+		if strings.EqualFold(raw, envValueOff) {
+			return 0
+		}
+		if jobs, err := strconv.Atoi(raw); err == nil && jobs > 0 {
+			return jobs
+		}
+	}
+	return fallback
+}
+
+func resolveTestGOMEMLIMIT() string {
+	if value := strings.TrimSpace(os.Getenv(lesserTestGOMEMLIMITEnv)); value != "" {
+		return value
+	}
+	if strings.TrimSpace(os.Getenv(goMemoryLimitEnvVar)) != "" {
+		return ""
+	}
+	return defaultTestGOMEMLIMIT
 }
 
 func mergeCoverageProfiles(destPath string, profilePaths []string) error {
@@ -480,6 +537,9 @@ func runGoTests(args testArgs, goArgs []string, extraEnv map[string]string) erro
 		"STAGE":       args.Stage,
 		"JWT_SECRET":  envOrDefault("JWT_SECRET", "dummy_value"),
 		"GOCACHE":     goCache,
+	}
+	if limit := resolveTestGOMEMLIMIT(); limit != "" {
+		env[goMemoryLimitEnvVar] = limit
 	}
 	if _, ok := env["DYNAMODB_ENCRYPTION_KEY"]; !ok {
 		env["DYNAMODB_ENCRYPTION_KEY"] = envOrDefault("DYNAMODB_ENCRYPTION_KEY", "0123456789abcdef0123456789abcdef")

--- a/cmd/lesser/test_cmd_test.go
+++ b/cmd/lesser/test_cmd_test.go
@@ -131,6 +131,85 @@ func TestRunTest_DispatchesSubcommands(t *testing.T) {
 	require.NotEmpty(t, goCalls)
 }
 
+func TestRunTest_MemorySafeDefaults(t *testing.T) {
+	previousRepoRoot := findRepoRootFn
+	previousRunCommand := runCommandFn
+	previousCapture := captureCommandOutputFn
+	previousEnsureTool := ensureToolAvailableFn
+	t.Cleanup(func() {
+		findRepoRootFn = previousRepoRoot
+		runCommandFn = previousRunCommand
+		captureCommandOutputFn = previousCapture
+		ensureToolAvailableFn = previousEnsureTool
+	})
+
+	t.Setenv(lesserTestGOMEMLIMITEnv, "")
+	t.Setenv(lesserTestParallelismEnv, "")
+	t.Setenv(lesserTestRaceParallelismEnv, "")
+	t.Setenv(goMemoryLimitEnvVar, "")
+
+	repoRoot := t.TempDir()
+	findRepoRootFn = func() (string, error) { return repoRoot, nil }
+	ensureToolAvailableFn = func(string) error { return nil }
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "go.mod"), []byte("module github.com/equaltoai/lesser\n"), 0o644))
+
+	captureCommandOutputFn = func(_ context.Context, _ string, _ map[string]string, _ string, _ ...string) (string, error) {
+		return "github.com/equaltoai/lesser/pkg/foo\n", nil
+	}
+
+	type goCall struct {
+		args []string
+		env  map[string]string
+	}
+	var calls []goCall
+	runCommandFn = func(_ context.Context, name string, args []string, opts execOptions) error {
+		if name != "go" || firstArgOrEmpty(args) != "test" {
+			return nil
+		}
+		env := make(map[string]string, len(opts.Env))
+		for key, value := range opts.Env {
+			env[key] = value
+		}
+		calls = append(calls, goCall{args: append([]string(nil), args...), env: env})
+		return writeCoverageProfileFromArgs(repoRoot, args)
+	}
+
+	require.NoError(t, runTestAll(nil))
+	require.NoError(t, runTestUnit(nil))
+	require.NoError(t, runTestRace(nil))
+	require.NoError(t, runTestCoverage([]string{"--scope", "pkg", "--html=false"}))
+	require.Len(t, calls, 4)
+
+	require.Contains(t, calls[0].args, "-p=4")
+	require.Equal(t, defaultTestGOMEMLIMIT, calls[0].env[goMemoryLimitEnvVar])
+
+	require.Contains(t, calls[1].args, "-p=4")
+	require.Contains(t, calls[1].args, "-short")
+	require.Equal(t, defaultTestGOMEMLIMIT, calls[1].env[goMemoryLimitEnvVar])
+
+	require.Contains(t, calls[2].args, "-p=2")
+	require.Contains(t, calls[2].args, "-race")
+	require.Equal(t, defaultTestGOMEMLIMIT, calls[2].env[goMemoryLimitEnvVar])
+
+	require.Contains(t, calls[3].args, "-p=4")
+	require.NotContains(t, calls[3].args, "-short")
+	require.Equal(t, defaultTestGOMEMLIMIT, calls[3].env[goMemoryLimitEnvVar])
+}
+
+func TestRunTest_MemorySafeOverrides(t *testing.T) {
+	t.Setenv(lesserTestParallelismEnv, "7")
+	t.Setenv(lesserTestRaceParallelismEnv, "3")
+	t.Setenv(lesserTestGOMEMLIMITEnv, "8GiB")
+	t.Setenv(goMemoryLimitEnvVar, "5GiB")
+
+	require.Equal(t, []string{"test", "-p=7", "-v", "./..."}, memorySafeGoTestArgs([]string{"test", "-v", "./..."}, false))
+	require.Equal(t, []string{"test", "-p=3", "-race", "-v", "./..."}, memorySafeGoTestArgs([]string{"test", "-race", "-v", "./..."}, true))
+	require.Equal(t, "8GiB", resolveTestGOMEMLIMIT())
+
+	t.Setenv(lesserTestParallelismEnv, envValueOff)
+	require.Equal(t, []string{"test", "-v", "./..."}, memorySafeGoTestArgs([]string{"test", "-v", "./..."}, false))
+}
+
 func TestRunTestCoverage_ErrorsWhenNoPackagesRemainAfterFiltering(t *testing.T) {
 	previousRepoRoot := findRepoRootFn
 	previousCapture := captureCommandOutputFn

--- a/cmd/lesser/verify_cmd.go
+++ b/cmd/lesser/verify_cmd.go
@@ -11,13 +11,13 @@ import (
 )
 
 const (
-	defaultVerifyCIJobs               = 20
+	defaultVerifyCIJobs               = 4
 	defaultVerifyCILintBatchSize      = 50
 	defaultVerifyCISecScanBatchSize   = 25
 	defaultVerifyCIVulnCheckBatchSize = 15
 	defaultVerifyCICoverageBatchSize  = 25
-	defaultVerifyCIGOMEMLIMIT         = "1536MiB"
-	defaultVerifyCIGOGC               = "50"
+	defaultVerifyCIGOMEMLIMIT         = "2048MiB"
+	defaultVerifyCIGOGC               = "80"
 	envValueOff                       = "off"
 	lesserVerifyCIJobsEnv             = "LESSER_VERIFY_CI_JOBS"
 	lesserVerifyCIGOMEMLIMITEnv       = "LESSER_VERIFY_CI_GOMEMLIMIT"


### PR DESCRIPTION
## Summary
- persist the Go build cache in CI at `tmp/go-cache/go${{ steps.setup-go.outputs.go-version }}` with a salted `gocache` cache key while keeping the existing XDG cache
- right-size `./lesser verify ci` defaults to 4 jobs / `GOMAXPROCS=4` / `GOFLAGS=-p=4`, `GOMEMLIMIT=2048MiB`, and `GOGC=80`
- add memory-safe defaults for developer test paths: `GOMEMLIMIT` default 6GiB, unit/coverage/all `-p=4`, race `-p=2`, with `LESSER_TEST_*` env overrides

Refs #1132.

## Contract / stewardship notes
- Federation trust: no product/federation path changes.
- Mastodon/API surface: no REST, GraphQL, ActivityPub, or OpenAPI contract changes.
- Schema: no DynamoDB model, PK/SK, GSI, or TableTheory tag changes.
- AGPL/dependencies: no dependency or license changes.
- CI/test semantics: no coverage threshold changes and no intended test selection changes; only cache/resource defaults changed.

## Validation
- `go test ./cmd/lesser` — pass
- `python3` PyYAML structural parse of `.github/workflows/ci.yml` and cache path/key assertions — pass (`actionlint` not installed locally)
- `make -n test test-coverage test-race test-unit` — confirms `GOMEMLIMIT=${GOMEMLIMIT:-6GiB}`, `-p=4` for all/unit/coverage, `-p=2` for race
- `GOMEMLIMIT=6GiB go test -short -p 4 ./pkg/notes/... ./pkg/storage/repositories/...` — pass
- `go build ./...` — pass
- `go vet ./cmd/lesser/...` — pass
- `go build -o lesser ./cmd/lesser` — pass
- `./lesser build lambdas` — pass, built 38 Lambda artifacts
- `./lesser verify ci` — pass locally with `jobs=4`, `GOMEMLIMIT=2048MiB`, `GOGC=80`; elapsed 363s with warm local caches

## Caveats
- The first GitHub Actions run will cold-miss the new `gocache` key, so the speedup should appear on subsequent runs.
