### PR TITLE
[Project 43] lesser M2 — Abuse/DoS & data-integrity controls (release → main)

### DIFF
--- a/cmd/api/handlers/metrics.go
+++ b/cmd/api/handlers/metrics.go
@@ -9,7 +9,15 @@ import (
 	"go.uber.org/zap"
 )
 
-const bytesPerGB = 1024 * 1024 * 1024
+const (
+	bytesPerGB = 1024 * 1024 * 1024
+
+	// Keep explicit from/to windows aligned with the days path's 1..30 bound.
+	// The from/to values are inclusive UTC dates, so a 30-day window has a
+	// maximum parsed date delta of 29 * 24h.
+	instanceMetricsDailyMaxRangeDays = 30
+	instanceMetricsDailyMaxDateDelta = time.Duration(instanceMetricsDailyMaxRangeDays-1) * 24 * time.Hour
+)
 
 // HandleGetInstanceMetricsDailyLift handles GET /api/v1/instance/metrics/daily
 // with instance-key bearer auth for lesser-host portal cost/usage consumption.
@@ -56,6 +64,14 @@ func (h *Handler) HandleGetInstanceMetricsDailyLift(ctx *apptheory.Context) (*ap
 		}
 		if toParsed.Before(fromParsed) {
 			return common.RespondBadRequest(ctx, "from date must be before or equal to to date")
+		}
+		todayUTC := time.Now().UTC()
+		todayUTC = time.Date(todayUTC.Year(), todayUTC.Month(), todayUTC.Day(), 0, 0, 0, 0, time.UTC)
+		if fromParsed.After(todayUTC) || toParsed.After(todayUTC) {
+			return common.RespondBadRequest(ctx, "date range cannot include future dates")
+		}
+		if toParsed.Sub(fromParsed) > instanceMetricsDailyMaxDateDelta {
+			return common.RespondBadRequest(ctx, "date range too large; maximum is 30 days")
 		}
 		startDate = fromParsed
 		// Make end date inclusive by adding one day.

--- a/cmd/api/handlers/metrics_round29_instance_daily_test.go
+++ b/cmd/api/handlers/metrics_round29_instance_daily_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestInstanceMetricsDaily_Round29_AuthAndDateValidation(t *testing.T) {
-	now := time.Now()
+	now := time.Now().UTC()
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
 
 	cfg := round11TestConfig()
@@ -162,6 +162,29 @@ func TestInstanceMetricsDaily_Round29_AuthAndDateValidation(t *testing.T) {
 		require.Equal(t, to, period["end"])
 	})
 
+	t.Run("maximum explicit range is accepted", func(t *testing.T) {
+		headers := map[string]string{"Authorization": "Bearer " + cfg.InstanceAPIKey}
+		from := today.AddDate(0, 0, -instanceMetricsDailyMaxRangeDays+1).Format("2006-01-02")
+		to := today.Format("2006-01-02")
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/instance/metrics/daily", headers, map[string]string{
+			"from": from,
+			"to":   to,
+		}, nil)
+		require.NoError(t, err)
+
+		resp, err := h.HandleGetInstanceMetricsDailyLift(ctx)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.Status)
+
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		period, ok := body["period"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, from, period["start"])
+		require.Equal(t, to, period["end"])
+		require.Equal(t, float64(instanceMetricsDailyMaxRangeDays), period["days"])
+	})
+
 	t.Run("invalid from date format is rejected", func(t *testing.T) {
 		headers := map[string]string{"Authorization": "Bearer " + cfg.InstanceAPIKey}
 		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/instance/metrics/daily", headers, map[string]string{
@@ -190,6 +213,58 @@ func TestInstanceMetricsDaily_Round29_AuthAndDateValidation(t *testing.T) {
 		}, nil)
 		require.NoError(t, err)
 		requireStatus(t, http.StatusBadRequest)(h.HandleGetInstanceMetricsDailyLift(ctx))
+	})
+
+	t.Run("future from date is rejected", func(t *testing.T) {
+		headers := map[string]string{"Authorization": "Bearer " + cfg.InstanceAPIKey}
+		tomorrow := today.AddDate(0, 0, 1).Format("2006-01-02")
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/instance/metrics/daily", headers, map[string]string{
+			"from": tomorrow,
+			"to":   tomorrow,
+		}, nil)
+		require.NoError(t, err)
+
+		resp, err := h.HandleGetInstanceMetricsDailyLift(ctx)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.Status)
+
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Contains(t, body["error"], "future")
+	})
+
+	t.Run("future to date is rejected", func(t *testing.T) {
+		headers := map[string]string{"Authorization": "Bearer " + cfg.InstanceAPIKey}
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/instance/metrics/daily", headers, map[string]string{
+			"from": today.Format("2006-01-02"),
+			"to":   today.AddDate(0, 0, 1).Format("2006-01-02"),
+		}, nil)
+		require.NoError(t, err)
+
+		resp, err := h.HandleGetInstanceMetricsDailyLift(ctx)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.Status)
+
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Contains(t, body["error"], "future")
+	})
+
+	t.Run("over maximum explicit range is rejected", func(t *testing.T) {
+		headers := map[string]string{"Authorization": "Bearer " + cfg.InstanceAPIKey}
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/instance/metrics/daily", headers, map[string]string{
+			"from": today.AddDate(0, 0, -instanceMetricsDailyMaxRangeDays).Format("2006-01-02"),
+			"to":   today.Format("2006-01-02"),
+		}, nil)
+		require.NoError(t, err)
+
+		resp, err := h.HandleGetInstanceMetricsDailyLift(ctx)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.Status)
+
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Contains(t, body["error"], "date range too large")
 	})
 
 	t.Run("days bounded to max 30", func(t *testing.T) {

--- a/cmd/api/handlers/notes_round12_test.go
+++ b/cmd/api/handlers/notes_round12_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -137,20 +138,31 @@ func TestNotesHandlersRound12(t *testing.T) {
 		requireStatus(t, http.StatusBadRequest)(h.HandleCreateNoteLift(ctx))
 	})
 
-	t.Run("create note rate limited", func(t *testing.T) {
+	t.Run("create note rate limited despite many older author notes", func(t *testing.T) {
 		minRep := round12StoredReputationModel(t, aliceActorID, 100)
 		authorKey := "AUTHOR#" + aliceActorID + "#NOTES"
+		now := time.Now().UTC().Truncate(time.Second)
+		authorNotes := make([]storagemodels.CommunityNote, 0, 106)
+		for i := 0; i < 105; i++ {
+			authorNotes = append(authorNotes, storagemodels.CommunityNote{
+				ID:        fmt.Sprintf("old-%03d", i),
+				AuthorID:  aliceActorID,
+				Content:   "existing old",
+				CreatedAt: now.Add(-48*time.Hour - time.Duration(i)*time.Minute),
+			})
+		}
+		authorNotes = append(authorNotes, storagemodels.CommunityNote{
+			ID:        "recent-at-limit",
+			AuthorID:  aliceActorID,
+			Content:   "existing recent",
+			CreatedAt: now.Add(-1 * time.Hour),
+		})
 		rateState := &round10QueryState{
 			reputationsByPK: map[string][]storagemodels.Reputation{
 				alicePK: {minRep},
 			},
 			communityNotesByGSI3PK: map[string][]storagemodels.CommunityNote{
-				authorKey: {{
-					ID:        "existing",
-					AuthorID:  aliceActorID,
-					Content:   "existing",
-					CreatedAt: time.Now().Add(-1 * time.Hour),
-				}},
+				authorKey: authorNotes,
 			},
 		}
 		rateHandler, _, _ := round11NewHandler(t, cfg, rateState, &RegistryStub{NotesSvc: notesSvc})

--- a/cmd/api/handlers/round10_test_helpers_test.go
+++ b/cmd/api/handlers/round10_test_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -28,9 +29,12 @@ type round10Where struct {
 }
 
 type round10QueryState struct {
-	wheres []round10Where
-	model  any
-	sets   map[string]any
+	wheres         []round10Where
+	model          any
+	sets           map[string]any
+	limit          int
+	orderField     string
+	orderDirection string
 
 	usersByUsername               map[string]storagemodels.User
 	actorsByUser                  map[string]storagemodels.Actor
@@ -146,6 +150,9 @@ type round10QueryState struct {
 func (s *round10QueryState) reset() {
 	s.wheres = nil
 	s.sets = nil
+	s.limit = 0
+	s.orderField = ""
+	s.orderDirection = ""
 }
 
 func (s *round10QueryState) whereValue(field string) (any, bool) {
@@ -164,6 +171,46 @@ func (s *round10QueryState) whereString(field string) (string, bool) {
 	}
 	str, ok := v.(string)
 	return str, ok
+}
+
+func round10CommunityNoteGSI3SK(note storagemodels.CommunityNote) string {
+	if note.GSI3SK != "" {
+		return note.GSI3SK
+	}
+	return note.CreatedAt.Format(time.RFC3339) + "#" + note.ID
+}
+
+func round10ApplyCommunityNoteAuthorQuery(state *round10QueryState, notes []storagemodels.CommunityNote) []storagemodels.CommunityNote {
+	items := append([]storagemodels.CommunityNote(nil), notes...)
+	for i := range items {
+		if items[i].GSI3SK == "" {
+			items[i].GSI3SK = round10CommunityNoteGSI3SK(items[i])
+		}
+	}
+
+	sort.SliceStable(items, func(i, j int) bool {
+		left := round10CommunityNoteGSI3SK(items[i])
+		right := round10CommunityNoteGSI3SK(items[j])
+		if strings.EqualFold(state.orderField, "gsi3SK") && strings.EqualFold(state.orderDirection, "DESC") {
+			return left > right
+		}
+		return left < right
+	})
+
+	if cursor, ok := state.whereString("gsi3SK"); ok && cursor != "" {
+		filtered := items[:0]
+		for _, note := range items {
+			if round10CommunityNoteGSI3SK(note) < cursor {
+				filtered = append(filtered, note)
+			}
+		}
+		items = filtered
+	}
+
+	if state.limit > 0 && len(items) > state.limit {
+		items = items[:state.limit]
+	}
+	return items
 }
 
 func round10ResolveUserForRead(state *round10QueryState) storagemodels.User {
@@ -415,9 +462,21 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 	mockQuery.On("Filter", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery).Maybe()
 	mockQuery.On("OrFilter", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery).Maybe()
 	mockQuery.On("Index", mock.Anything).Return(mockQuery).Maybe()
-	mockQuery.On("Limit", mock.Anything).Return(mockQuery).Maybe()
+	mockQuery.On("Limit", mock.Anything).Return(mockQuery).Run(func(args mock.Arguments) {
+		switch value := args.Get(0).(type) {
+		case int:
+			state.limit = value
+		case int32:
+			state.limit = int(value)
+		case int64:
+			state.limit = int(value)
+		}
+	}).Maybe()
 	mockQuery.On("Cursor", mock.Anything).Return(mockQuery).Maybe()
-	mockQuery.On("OrderBy", mock.Anything, mock.Anything).Return(mockQuery).Maybe()
+	mockQuery.On("OrderBy", mock.Anything, mock.Anything).Return(mockQuery).Run(func(args mock.Arguments) {
+		state.orderField, _ = args.Get(0).(string)
+		state.orderDirection, _ = args.Get(1).(string)
+	}).Maybe()
 	mockQuery.On("ConsistentRead").Return(mockQuery).Maybe()
 	mockQuery.On("WithContext", mock.Anything).Return(mockQuery).Maybe()
 	mockQuery.On("IfNotExists").Return(mockQuery).Maybe()
@@ -2390,7 +2449,7 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 			gsi3pk, _ := state.whereString("gsi3PK")
 			if gsi3pk != "" {
 				if notes, ok := state.communityNotesByGSI3PK[gsi3pk]; ok {
-					*d = notes
+					*d = round10ApplyCommunityNoteAuthorQuery(state, notes)
 					return
 				}
 			}

--- a/cmd/inbox/internal/routing/federated_conversations_inbound_test.go
+++ b/cmd/inbox/internal/routing/federated_conversations_inbound_test.go
@@ -381,6 +381,88 @@ func TestInboxHandler_M14_ReplayedRemoteDirectDoesNotOverwriteConversationMetada
 	require.Empty(t, publisher.events)
 }
 
+func TestInboxHandler_L14_EqualTimestampUniqueDirectMessageAdvancesMetadata(t *testing.T) {
+	env := newInboxTestEnv(t)
+	ctx := context.Background()
+	notifications := inmemory.NewNotificationRepository()
+	conversations := inmemory.NewConversationRepository()
+	statuses := inmemory.NewStatusRepository()
+	objects := inmemory.NewObjectRepository()
+	publisher := &inboundDirectCapturePublisher{}
+	env.handler.notificationRepository = notifications
+	env.handler.conversationRepository = conversations
+	env.handler.statusRepository = statuses
+	env.handler.objectRepository = objects
+	env.handler.publisher = publisher
+
+	published := time.Date(2026, 4, 28, 13, 0, 0, 0, time.UTC)
+	conversationID := "conv-equal-unique"
+	participantRefs := models.NormalizeConversationParticipantRefs([]models.ConversationParticipantRef{
+		{
+			ParticipantType: models.ConversationParticipantTypeLocalUser,
+			ParticipantID:   "alice",
+		},
+		{
+			ParticipantType: models.ConversationParticipantTypeRemoteActor,
+			ParticipantID:   env.remoteActorID,
+			Acct:            "bob@remote.example",
+			Domain:          "remote.example",
+			ResolvedAt:      &published,
+		},
+	})
+	participants := models.ConversationParticipantIDsFromRefs(participantRefs)
+	existingConversation := &models.Conversation{
+		ID:                conversationID,
+		Participants:      participants,
+		ParticipantRefs:   participantRefs,
+		LastStatusID:      "first-equal-timestamp-status",
+		LastMessageTime:   published,
+		TotalMessageCount: 7,
+		CreatedAt:         published.Add(-24 * time.Hour),
+		UpdatedAt:         published.Add(-time.Minute),
+	}
+	require.NoError(t, conversations.CreateConversationWithParticipantStates(ctx, existingConversation, participants, nil))
+
+	equalNoteID := "https://remote.example/users/bob/statuses/direct-equal-unique"
+	equalStatusID := models.CanonicalStatusIDForDomain(equalNoteID, env.handler.localDomain())
+	equalNote := &activitypub.Note{
+		BaseObject: activitypub.BaseObject{
+			Context:   activitypub.Context,
+			ID:        equalNoteID,
+			Type:      activitypub.NoteType,
+			Published: &published,
+			To:        []string{env.local.ID},
+		},
+		AttributedTo: env.remoteActorID,
+		Content:      "<p>equal timestamp unique direct message @alice</p>",
+		Tag: []activitypub.Tag{{
+			Type: "Mention",
+			Href: env.local.ID,
+			Name: "@alice@localhost",
+		}},
+	}
+	equalActivity := remoteCreateActivityForNote(t, env.remoteActorID, equalNote, "https://remote.example/activities/direct-equal-unique")
+
+	require.NoError(t, env.handler.processRemoteCreateActivity(ctx, equalActivity, env.local))
+
+	stored, err := conversations.GetConversation(ctx, conversationID)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(8), stored.TotalMessageCount)
+	require.Equal(t, equalStatusID, stored.LastStatusID)
+	require.Equal(t, published, stored.LastMessageTime)
+	require.Equal(t, published, stored.UpdatedAt)
+	require.ElementsMatch(t, participants, stored.Participants)
+	require.Equal(t, participantRefs, stored.ParticipantRefs)
+
+	stateResult, err := conversations.ListUserConversationStatesByFolder(ctx, "alice", interfaces.UserConversationFolder(models.UserConversationFolderInbox), interfaces.PaginationOptions{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, stateResult.Items, 1)
+	require.Equal(t, equalStatusID, stateResult.Items[0].PreviewStatusID)
+	require.Equal(t, published, stateResult.Items[0].PreviewStatusPublishedAt)
+	require.Equal(t, published, stateResult.Items[0].SortAt)
+}
+
 // TestInboxHandler_M14_OlderUniqueDirectMessageIncrementsCountPreservesMetadata verifies
 // CSR-042: a new unique inbound direct message with an older publishedAt still increments
 // TotalMessageCount while preserving the conversation's LastStatusID / LastMessageTime /

--- a/cmd/inbox/internal/routing/inbox.go
+++ b/cmd/inbox/internal/routing/inbox.go
@@ -2831,7 +2831,7 @@ func (ih *InboxHandler) persistInboundDirectConversation(
 
 	skipConversationMetadata := !createConversation &&
 		!conversation.LastMessageTime.IsZero() &&
-		!publishedAt.After(conversation.LastMessageTime)
+		publishedAt.Before(conversation.LastMessageTime)
 
 	// CSR-042: Always count unique messages, even when preserving
 	// last-message metadata for an older inbound status. The status-level

--- a/pkg/ai/bedrock_client_test.go
+++ b/pkg/ai/bedrock_client_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/bedrock"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	appconfig "github.com/equaltoai/lesser/pkg/config"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
@@ -43,6 +44,14 @@ func TestBedrockClient_isClaudeModel(t *testing.T) {
 	require.True(t, (&BedrockClient{modelID: "claude-v2"}).isClaudeModel())
 	require.False(t, (&BedrockClient{modelID: "ai21.j2-ultra"}).isClaudeModel())
 	require.False(t, (&BedrockClient{modelID: ""}).isClaudeModel())
+}
+
+func TestBedrockClient_ConfigHelpersUseDefaults(t *testing.T) {
+	appconfig.ResetForTests()
+	t.Cleanup(appconfig.ResetForTests)
+
+	require.Equal(t, "us-east-1", getAWSRegion())
+	require.Equal(t, "anthropic.claude-3-haiku-20240307-v1:0", getBedrockModelID())
 }
 
 func TestBedrockClient_buildReputationAnalysisPrompt_IncludesInputs(t *testing.T) {

--- a/pkg/ai/service.go
+++ b/pkg/ai/service.go
@@ -1,6 +1,7 @@
 package ai
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1124,15 +1125,27 @@ func (s *AIService) uploadImageToS3(ctx context.Context, imageURL string) (strin
 	fileExt := s.getFileExtensionFromContentType(contentType)
 	s3Key := fmt.Sprintf("ai-analysis/%s%s", imageID, fileExt)
 
-	// Wrap body with a size-limited reader as defense-in-depth against
-	// servers that omit or misrepresent Content-Length.
-	limitedBody := io.LimitReader(resp.Body, maxBytes)
+	// Read one byte beyond the accepted maximum before uploading so
+	// chunked, missing, or understated Content-Length responses cannot be
+	// persisted as silently truncated S3 objects.
+	imageBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
+	if int64(len(imageBytes)) > maxBytes {
+		s.logger.Warn("refusing oversized image download",
+			zap.String("url", imageURL),
+			zap.Int64("content_length", resp.ContentLength),
+			zap.Int64("max_bytes", maxBytes),
+			zap.Int("bytes_read", len(imageBytes)))
+		return "", fmt.Errorf("%w: downloaded image exceeds limit %d", ErrImageDownloadTooLarge, maxBytes)
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to read image download: %w", err)
+	}
 
 	// Upload to S3
 	_, err = s.s3Client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:      aws.String(s.config.S3Bucket),
 		Key:         aws.String(s3Key),
-		Body:        io.Reader(limitedBody),
+		Body:        bytes.NewReader(imageBytes),
 		ContentType: aws.String(contentType),
 		// Set appropriate metadata
 		Metadata: map[string]string{

--- a/pkg/ai/service_round20_coverage_test.go
+++ b/pkg/ai/service_round20_coverage_test.go
@@ -193,18 +193,22 @@ func (r *round20Rekognition) RecognizeCelebrities(ctx context.Context, params *r
 }
 
 type round20S3 struct {
-	putObjectErr error
-	putObjectIn  *s3.PutObjectInput
+	putObjectErr  error
+	putObjectIn   *s3.PutObjectInput
+	putObjectBody []byte
+	calls         int
 }
 
 func (s *round20S3) PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
 	_ = ctx
 	_ = optFns
+	s.calls++
 	s.putObjectIn = params
 	if s.putObjectErr != nil {
 		return nil, s.putObjectErr
 	}
-	_, _ = io.ReadAll(params.Body)
+	body, _ := io.ReadAll(params.Body)
+	s.putObjectBody = body
 	return &s3.PutObjectOutput{}, nil
 }
 
@@ -254,6 +258,32 @@ type round20ErrCloseReadCloser struct {
 }
 
 func (r *round20ErrCloseReadCloser) Close() error { return r.closeErr }
+
+func TestAIService_Round20_ConstructorsAndRequestLookup(t *testing.T) {
+	cfg := aws.Config{Region: "us-east-1"}
+	aiConfig := &Config{S3Bucket: "bucket"}
+
+	svc := NewAIService(cfg, aiConfig)
+	require.NotNil(t, svc)
+	require.NotNil(t, svc.comprehend)
+	require.NotNil(t, svc.rekognition)
+	require.NotNil(t, svc.bedrock)
+	require.NotNil(t, svc.s3Client)
+	require.NotNil(t, svc.sqsClient)
+	require.NotNil(t, svc.httpClient)
+	require.Same(t, aiConfig, svc.config)
+
+	sqsClient := &round20SQS{}
+	svc = NewAIServiceWithSQS(cfg, aiConfig, sqsClient)
+	require.NotNil(t, svc)
+	require.Same(t, sqsClient, svc.sqsClient)
+
+	req, err := (&AIService{logger: zap.NewNop()}).GetAnalysisRequest(context.Background(), "ai-req-1")
+	require.NoError(t, err)
+	require.Equal(t, "ai-req-1", req.ID)
+	require.Equal(t, StatusPending, req.Status)
+	require.False(t, req.RequestedAt.IsZero())
+}
 
 func TestAIService_Round20_AnalyzeText_ComprehendPaths(t *testing.T) {
 	t.Run("happy_path_with_toxicity_and_pii", func(t *testing.T) {
@@ -689,6 +719,7 @@ func TestAIService_Round20_UploadImageToS3_ContentLengthBound(t *testing.T) {
 	})
 
 	t.Run("content_length_within_limit_succeeds", func(t *testing.T) {
+		s3Client := &round20S3{}
 		svc := &AIService{
 			config: &Config{
 				S3Bucket:              "bucket",
@@ -704,13 +735,111 @@ func TestAIService_Round20_UploadImageToS3_ContentLengthBound(t *testing.T) {
 					},
 				},
 			},
-			s3Client: &round20S3{},
+			s3Client: s3Client,
 			logger:   zap.NewNop(),
 		}
 
 		key, err := svc.uploadImageToS3(context.Background(), "https://example.com/small/")
 		require.NoError(t, err)
 		require.NotEmpty(t, key)
+		require.Equal(t, 1, s3Client.calls)
+		require.Equal(t, []byte("smallimg"), s3Client.putObjectBody)
+	})
+
+	t.Run("chunked_without_content_length_exceeding_limit_is_rejected_before_upload", func(t *testing.T) {
+		s3Client := &round20S3{}
+		svc := &AIService{
+			config: &Config{
+				S3Bucket:              "bucket",
+				MaxImageDownloadBytes: 4,
+			},
+			httpClient: &round20HTTPClient{
+				respByURL: map[string]*http.Response{
+					"https://example.com/chunked/": {
+						StatusCode:       http.StatusOK,
+						ContentLength:    -1,
+						TransferEncoding: []string{"chunked"},
+						Header:           http.Header{"Content-Type": []string{"image/jpeg"}},
+						Body:             io.NopCloser(strings.NewReader("12345")),
+					},
+				},
+			},
+			s3Client: s3Client,
+			logger:   zap.NewNop(),
+		}
+
+		_, err := svc.uploadImageToS3(context.Background(), "https://example.com/chunked/")
+		require.ErrorIs(t, err, ErrImageDownloadTooLarge)
+		require.Zero(t, s3Client.calls)
+		require.Nil(t, s3Client.putObjectIn)
+		require.Empty(t, s3Client.putObjectBody)
+	})
+
+	t.Run("understated_content_length_exceeding_limit_is_rejected_before_upload", func(t *testing.T) {
+		s3Client := &round20S3{}
+		svc := &AIService{
+			config: &Config{
+				S3Bucket:              "bucket",
+				MaxImageDownloadBytes: 4,
+			},
+			httpClient: &round20HTTPClient{
+				respByURL: map[string]*http.Response{
+					"https://example.com/understated/": {
+						StatusCode:    http.StatusOK,
+						ContentLength: 4,
+						Header:        http.Header{"Content-Type": []string{"image/jpeg"}},
+						Body:          io.NopCloser(strings.NewReader("12345")),
+					},
+				},
+			},
+			s3Client: s3Client,
+			logger:   zap.NewNop(),
+		}
+
+		_, err := svc.uploadImageToS3(context.Background(), "https://example.com/understated/")
+		require.ErrorIs(t, err, ErrImageDownloadTooLarge)
+		require.Zero(t, s3Client.calls)
+		require.Nil(t, s3Client.putObjectIn)
+		require.Empty(t, s3Client.putObjectBody)
+	})
+
+	t.Run("valid_sub_limit_download_uploads_and_analyzes", func(t *testing.T) {
+		s3Client := &round20S3{}
+		parent := "Safe"
+		rekognitionClient := &round20Rekognition{
+			detectModerationLabelsOut: &rekognition.DetectModerationLabelsOutput{
+				ModerationLabels: []rekognitiontypes.ModerationLabel{
+					{Name: aws.String("Benign"), Confidence: aws.Float32(99), ParentName: aws.String(parent)},
+				},
+			},
+		}
+		svc := &AIService{
+			config: &Config{
+				S3Bucket:              "bucket",
+				MaxImageDownloadBytes: 8,
+			},
+			httpClient: &round20HTTPClient{
+				respByURL: map[string]*http.Response{
+					"https://example.com/safe/": {
+						StatusCode:    http.StatusOK,
+						ContentLength: -1,
+						Header:        http.Header{"Content-Type": []string{"image/png"}},
+						Body:          io.NopCloser(strings.NewReader("safeimg")),
+					},
+				},
+			},
+			rekognition: rekognitionClient,
+			s3Client:    s3Client,
+			logger:      zap.NewNop(),
+		}
+
+		analysis, err := svc.analyzeImages(context.Background(), []string{"https://example.com/safe/"})
+		require.NoError(t, err)
+		require.NotNil(t, analysis)
+		require.Equal(t, 1, s3Client.calls)
+		require.Equal(t, []byte("safeimg"), s3Client.putObjectBody)
+		require.Len(t, analysis.ModerationLabels, 1)
+		require.Equal(t, "Benign", analysis.ModerationLabels[0].Name)
 	})
 }
 

--- a/pkg/notes/service.go
+++ b/pkg/notes/service.go
@@ -216,11 +216,21 @@ func (s *Service) CheckNoteRateLimit(ctx context.Context, userID string, limit i
 		}
 
 		for _, note := range notes {
-			if note != nil && note.CreatedAt.After(cutoff) {
-				count++
-				if count >= limit {
-					return false, 0
+			if note == nil {
+				continue
+			}
+
+			if !note.CreatedAt.After(cutoff) {
+				remaining := limit - count
+				if remaining < 0 {
+					remaining = 0
 				}
+				return true, remaining
+			}
+
+			count++
+			if count >= limit {
+				return false, 0
 			}
 		}
 

--- a/pkg/notes/service_test.go
+++ b/pkg/notes/service_test.go
@@ -3,6 +3,7 @@ package notes
 import (
 	"context"
 	"errors"
+	"sort"
 	"strconv"
 	"testing"
 	"time"
@@ -32,8 +33,9 @@ type stubCommunityNoteRepo struct {
 	userVotesErr error
 	userVotes    map[string]*storage.CommunityNoteVote
 
-	notesByAuthorErr error
-	notesByAuthor    []*storage.CommunityNote
+	notesByAuthorErr   error
+	notesByAuthor      []*storage.CommunityNote
+	notesByAuthorCalls int
 
 	updateScoreErr error
 	updatedScore   struct {
@@ -73,25 +75,42 @@ func (s *stubCommunityNoteRepo) GetCommunityNotesByAuthor(_ context.Context, _ s
 	if s.notesByAuthorErr != nil {
 		return nil, "", s.notesByAuthorErr
 	}
-	start := 0
-	if cursor != "" {
-		parsed, err := strconv.Atoi(cursor)
-		if err == nil && parsed >= 0 {
-			start = parsed
+	s.notesByAuthorCalls++
+
+	ordered := make([]*storage.CommunityNote, 0, len(s.notesByAuthor))
+	for _, note := range s.notesByAuthor {
+		if note != nil {
+			ordered = append(ordered, note)
 		}
 	}
-	if start >= len(s.notesByAuthor) {
-		return []*storage.CommunityNote{}, "", nil
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return communityNoteAuthorCursor(ordered[i]) > communityNoteAuthorCursor(ordered[j])
+	})
+
+	results := make([]*storage.CommunityNote, 0, len(ordered))
+	for _, note := range ordered {
+		noteCursor := communityNoteAuthorCursor(note)
+		if cursor != "" && noteCursor >= cursor {
+			continue
+		}
+		results = append(results, note)
+		if limit > 0 && len(results) == limit {
+			break
+		}
 	}
-	end := len(s.notesByAuthor)
-	if limit > 0 && start+limit < end {
-		end = start + limit
-	}
+
 	nextCursor := ""
-	if end < len(s.notesByAuthor) {
-		nextCursor = strconv.Itoa(end)
+	if limit > 0 && len(results) == limit {
+		nextCursor = communityNoteAuthorCursor(results[len(results)-1])
 	}
-	return s.notesByAuthor[start:end], nextCursor, nil
+	return results, nextCursor, nil
+}
+
+func communityNoteAuthorCursor(note *storage.CommunityNote) string {
+	if note == nil {
+		return ""
+	}
+	return note.CreatedAt.Format(time.RFC3339) + "#" + note.ID
 }
 
 func (s *stubCommunityNoteRepo) UpdateCommunityNoteScore(_ context.Context, noteID string, score float64, status string) error {
@@ -126,11 +145,11 @@ func TestService_CreateNote_StoresDefaults(t *testing.T) {
 	assert.Equal(t, note.ID, repo.createdNote.ID)
 }
 
-func TestService_CheckNoteRateLimit_PaginatesPastOldNotes(t *testing.T) {
-	now := time.Now()
-	oldNotes := make([]*storage.CommunityNote, communityNoteRateLimitPageSize)
+func TestService_CheckNoteRateLimit_DeniesWithRecentNotesAfterManyOldRawNotes(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	oldNotes := make([]*storage.CommunityNote, communityNoteRateLimitPageSize+5)
 	for i := range oldNotes {
-		oldNotes[i] = &storage.CommunityNote{ID: strconv.Itoa(i), CreatedAt: now.Add(-48 * time.Hour)}
+		oldNotes[i] = &storage.CommunityNote{ID: "old-" + strconv.Itoa(i), CreatedAt: now.Add(-48*time.Hour - time.Duration(i)*time.Minute)}
 	}
 	recentNotes := []*storage.CommunityNote{
 		{ID: "recent-1", CreatedAt: now.Add(-2 * time.Hour)},
@@ -144,6 +163,7 @@ func TestService_CheckNoteRateLimit_PaginatesPastOldNotes(t *testing.T) {
 	allowed, remaining := svc.CheckNoteRateLimit(context.Background(), "alice", 2)
 	assert.False(t, allowed)
 	assert.Equal(t, 0, remaining)
+	assert.Equal(t, 1, repo.notesByAuthorCalls)
 }
 
 func TestService_StoreNote_ErrorWrapped(t *testing.T) {
@@ -258,18 +278,22 @@ func TestService_RecalculateNoteScore_UpdatesStorage(t *testing.T) {
 }
 
 func TestService_CheckNoteRateLimit_CountsRecentNotes(t *testing.T) {
-	now := time.Now()
+	now := time.Now().UTC().Truncate(time.Second)
+	oldNotes := make([]*storage.CommunityNote, communityNoteRateLimitPageSize+5)
+	for i := range oldNotes {
+		oldNotes[i] = &storage.CommunityNote{ID: "old-" + strconv.Itoa(i), CreatedAt: now.Add(-48*time.Hour - time.Duration(i)*time.Minute)}
+	}
 	repo := &stubCommunityNoteRepo{
-		notesByAuthor: []*storage.CommunityNote{
+		notesByAuthor: append(oldNotes, []*storage.CommunityNote{
 			{ID: "n1", CreatedAt: now.Add(-2 * time.Hour)},
-			{ID: "n2", CreatedAt: now.Add(-48 * time.Hour)},
-		},
+		}...),
 	}
 	svc := &Service{repo: repo, logger: zap.NewNop()}
 
 	allowed, remaining := svc.CheckNoteRateLimit(context.Background(), "alice", 2)
 	assert.True(t, allowed)
 	assert.Equal(t, 1, remaining)
+	assert.Equal(t, 1, repo.notesByAuthorCalls)
 }
 
 // TestService_CheckRateLimit_DeniesWhenAtLimit verifies CSR-048:

--- a/pkg/services/notes/service_round15_mainline_test.go
+++ b/pkg/services/notes/service_round15_mainline_test.go
@@ -94,6 +94,7 @@ func setupPermissiveDynamormMocks(mockDB *mocks.MockDB, mockQuery *mocks.MockQue
 		}
 	}).Return(mockQuery).Maybe()
 	mockQuery.On("Filter", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery).Maybe()
+	mockQuery.On("FilterGroup", mock.Anything).Return(mockQuery).Maybe()
 	mockQuery.On("OrderBy", mock.Anything, mock.Anything).Return(mockQuery).Maybe()
 	mockQuery.On("Limit", mock.Anything).Return(mockQuery).Maybe()
 	mockQuery.On("Cursor", mock.Anything).Return(mockQuery).Maybe()

--- a/pkg/storage/models/bookmark_test.go
+++ b/pkg/storage/models/bookmark_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 	"time"
 
+	dynamodbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/stretchr/testify/require"
+	theorytypes "github.com/theory-cloud/tabletheory/pkg/types"
 )
 
 func TestBookmarkUpdateKeysTimeRecord(t *testing.T) {
@@ -95,4 +97,23 @@ func TestUpdateKeysRequiresTimeSKForObject(t *testing.T) {
 		RecordType: BookmarkRecordTypeObject,
 	}
 	require.Error(t, b.UpdateKeys())
+}
+
+func TestBookmarkUnmarshalAcceptsLegacyJSONObjectIDAttribute(t *testing.T) {
+	createdAt := time.Date(2025, time.January, 1, 0, 0, 0, 123, time.UTC)
+	legacySK := createdAt.Format(time.RFC3339Nano) + "#status-legacy-json"
+
+	var bookmark Bookmark
+	err := theorytypes.NewConverter().FromAttributeValue(&dynamodbtypes.AttributeValueMemberM{Value: map[string]dynamodbtypes.AttributeValue{
+		"PK":         &dynamodbtypes.AttributeValueMemberS{Value: "BOOKMARK#legacy-user"},
+		"SK":         &dynamodbtypes.AttributeValueMemberS{Value: legacySK},
+		"username":   &dynamodbtypes.AttributeValueMemberS{Value: "legacy-user"},
+		"object_id":  &dynamodbtypes.AttributeValueMemberS{Value: "status-legacy-json"},
+		"created_at": &dynamodbtypes.AttributeValueMemberS{Value: createdAt.Format(time.RFC3339Nano)},
+	}}, &bookmark)
+
+	require.NoError(t, err)
+	require.Equal(t, "legacy-user", bookmark.Username)
+	require.Equal(t, "status-legacy-json", bookmark.ObjectID)
+	require.True(t, bookmark.CreatedAt.Equal(createdAt))
 }

--- a/pkg/storage/repositories/bookmark_repository.go
+++ b/pkg/storage/repositories/bookmark_repository.go
@@ -317,7 +317,9 @@ func (r *BookmarkRepository) CheckBookmarksForStatuses(ctx context.Context, user
 			if bookmark == nil {
 				continue
 			}
-			result[bookmark.ObjectID] = true
+			if objectID := bookmarkObjectID(*bookmark); objectID != "" {
+				result[objectID] = true
+			}
 		}
 
 		for _, statusID := range batch {
@@ -535,13 +537,39 @@ func isReadableTimeBookmark(bookmark models.Bookmark) bool {
 
 func isLegacyBookmarkTimestampSK(sk string) bool {
 	trimmed := strings.TrimSpace(sk)
-	if trimmed == "" || strings.Contains(trimmed, "#") {
+	timestamp, objectID, ok := legacyBookmarkSKParts(trimmed)
+	if !ok || timestamp == "" || strings.TrimSpace(objectID) == "" {
 		return false
 	}
-	if _, err := time.Parse(time.RFC3339Nano, trimmed); err == nil {
+
+	return isBookmarkTimestampSegment(timestamp)
+}
+
+func legacyBookmarkSKParts(sk string) (string, string, bool) {
+	trimmed := strings.TrimSpace(sk)
+	if trimmed == "" {
+		return "", "", false
+	}
+
+	timestamp, objectID, ok := strings.Cut(trimmed, "#")
+	if !ok {
+		return "", "", false
+	}
+	if timestamp == models.BookmarkSortKeyPrefixTime || timestamp == models.BookmarkSortKeyPrefixObject {
+		return "", "", false
+	}
+	return timestamp, objectID, true
+}
+
+func isBookmarkTimestampSegment(segment string) bool {
+	segment = strings.TrimSpace(segment)
+	if segment == "" {
+		return false
+	}
+	if _, err := time.Parse(time.RFC3339Nano, segment); err == nil {
 		return true
 	}
-	if _, err := time.Parse(time.RFC3339, trimmed); err == nil {
+	if _, err := time.Parse(time.RFC3339, segment); err == nil {
 		return true
 	}
 	return false
@@ -560,6 +588,8 @@ func bookmarkCreatedAt(bookmark models.Bookmark) time.Time {
 		} else {
 			sk = remainder
 		}
+	} else if timestamp, _, ok := legacyBookmarkSKParts(sk); ok {
+		sk = timestamp
 	}
 
 	if parsed, err := time.Parse(time.RFC3339Nano, sk); err == nil {
@@ -569,6 +599,35 @@ func bookmarkCreatedAt(bookmark models.Bookmark) time.Time {
 		return parsed
 	}
 	return time.Time{}
+}
+
+func bookmarkObjectID(bookmark models.Bookmark) string {
+	if strings.TrimSpace(bookmark.ObjectID) != "" {
+		return bookmark.ObjectID
+	}
+
+	sk := strings.TrimSpace(bookmark.SK)
+	if strings.HasPrefix(sk, models.BookmarkSortKeyPrefixObject+"#") {
+		return strings.TrimPrefix(sk, models.BookmarkSortKeyPrefixObject+"#")
+	}
+	if strings.HasPrefix(sk, models.BookmarkSortKeyPrefixTime+"#") {
+		remainder := strings.TrimPrefix(sk, models.BookmarkSortKeyPrefixTime+"#")
+		if _, objectID, ok := strings.Cut(remainder, "#"); ok {
+			return objectID
+		}
+		return ""
+	}
+	if _, objectID, ok := legacyBookmarkSKParts(sk); ok {
+		return objectID
+	}
+	return ""
+}
+
+func filterBookmarkObjectID(query core.Query, objectID string) core.Query {
+	return query.FilterGroup(func(group core.Query) {
+		group.Filter("ObjectID", "=", objectID)
+		group.OrFilter("object_id", "=", objectID)
+	})
 }
 
 const (
@@ -730,6 +789,9 @@ func appendReadableBookmarkStreamPage(
 		if bookmark.CreatedAt.IsZero() {
 			bookmark.CreatedAt = bookmarkCreatedAt(bookmark)
 		}
+		if bookmark.ObjectID == "" {
+			bookmark.ObjectID = bookmarkObjectID(bookmark)
+		}
 		result = append(result, bookmark)
 		if len(result) >= target {
 			return result, true
@@ -830,7 +892,7 @@ func validateBookmarkPageCursor(cursor bookmarkPageCursor) error {
 
 func isLegacyBookmarkCursorSK(sk string) bool {
 	trimmed := strings.TrimSuffix(sk, "\xff")
-	return isLegacyBookmarkTimestampSK(trimmed)
+	return isLegacyBookmarkTimestampSK(trimmed) || isBookmarkTimestampSegment(trimmed)
 }
 
 func encodeBookmarkPageCursor(cursor bookmarkPageCursor) string {
@@ -987,37 +1049,43 @@ func (r *BookmarkRepository) dynamoGetObjectBookmark(ctx context.Context, userna
 func (r *BookmarkRepository) dynamoFindTimeBookmarkByObject(ctx context.Context, username, objectID string) (*models.Bookmark, error) {
 	pk := buildBookmarkPK(username)
 	var bookmarks []models.Bookmark
-	err := r.db.WithContext(ctx).Model(&models.Bookmark{}).
+	timeQuery := r.db.WithContext(ctx).Model(&models.Bookmark{}).
 		Where("PK", "=", pk).
-		Where("SK", "BEGINS_WITH", models.BookmarkSortKeyPrefixTime).
-		Filter("ObjectID", "=", objectID).
+		Where("SK", "BEGINS_WITH", models.BookmarkSortKeyPrefixTime)
+	err := filterBookmarkObjectID(timeQuery, objectID).
 		Limit(1).
 		All(&bookmarks)
 	if err != nil && !errors.IsNotFound(err) {
 		return nil, err
 	}
 	for _, bookmark := range bookmarks {
-		if bookmark.ObjectID == objectID && (strings.HasPrefix(bookmark.SK, models.BookmarkSortKeyPrefixTime+"#") || bookmark.RecordType == models.BookmarkRecordTypeTime) {
+		if bookmarkObjectID(bookmark) == objectID && (strings.HasPrefix(bookmark.SK, models.BookmarkSortKeyPrefixTime+"#") || bookmark.RecordType == models.BookmarkRecordTypeTime) {
 			if bookmark.CreatedAt.IsZero() {
 				bookmark.CreatedAt = bookmarkCreatedAt(bookmark)
+			}
+			if bookmark.ObjectID == "" {
+				bookmark.ObjectID = bookmarkObjectID(bookmark)
 			}
 			return &bookmark, nil
 		}
 	}
 
 	bookmarks = nil
-	err = r.db.WithContext(ctx).Model(&models.Bookmark{}).
-		Where("PK", "=", pk).
-		Filter("ObjectID", "=", objectID).
+	legacyQuery := r.db.WithContext(ctx).Model(&models.Bookmark{}).
+		Where("PK", "=", pk)
+	err = filterBookmarkObjectID(legacyQuery, objectID).
 		Limit(25).
 		All(&bookmarks)
 	if err != nil && !errors.IsNotFound(err) {
 		return nil, err
 	}
 	for _, bookmark := range bookmarks {
-		if bookmark.ObjectID == objectID && isReadableTimeBookmark(bookmark) {
+		if bookmarkObjectID(bookmark) == objectID && isReadableTimeBookmark(bookmark) {
 			if bookmark.CreatedAt.IsZero() {
 				bookmark.CreatedAt = bookmarkCreatedAt(bookmark)
+			}
+			if bookmark.ObjectID == "" {
+				bookmark.ObjectID = bookmarkObjectID(bookmark)
 			}
 			return &bookmark, nil
 		}

--- a/pkg/storage/repositories/bookmark_repository_m10_test.go
+++ b/pkg/storage/repositories/bookmark_repository_m10_test.go
@@ -22,7 +22,7 @@ func TestBookmarkRepository_M10_DynamoFindTimeBookmarkByObjectReadsLegacyTimesta
 	mockDB.On("WithContext", mock.Anything).Return(mockDB)
 	mockDB.On("Model", mock.Anything).Return(mockQuery)
 	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery)
-	mockQuery.On("Filter", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery)
+	mockQuery.On("FilterGroup", mock.Anything).Return(mockQuery)
 	mockQuery.On("Limit", mock.Anything).Return(mockQuery)
 
 	allCalls := 0
@@ -36,7 +36,7 @@ func TestBookmarkRepository_M10_DynamoFindTimeBookmarkByObjectReadsLegacyTimesta
 		*dest = []models.Bookmark{
 			{
 				PK:       buildBookmarkPK("alice"),
-				SK:       createdAt.Format(time.RFC3339Nano),
+				SK:       legacyBookmarkSK(createdAt, "status-1"),
 				Username: "alice",
 				ObjectID: "status-1",
 				Locked:   false,
@@ -93,7 +93,7 @@ func TestBookmarkRepository_M10_QueryUnlockedTimeBookmarksIncludesLegacyTimestam
 		*dest = []models.Bookmark{
 			{
 				PK:       pk,
-				SK:       base.Add(3 * time.Minute).Format(time.RFC3339Nano),
+				SK:       legacyBookmarkSK(base.Add(3*time.Minute), "status-legacy"),
 				Username: "alice",
 				ObjectID: "status-legacy",
 				Locked:   false,
@@ -120,8 +120,8 @@ func TestBookmarkRepository_M10_QueryUnlockedTimeBookmarksPaginatesMixedNamespac
 
 	timeSK4 := "TIME#" + base.Add(4*time.Minute).Format(time.RFC3339Nano) + "#status-time-4"
 	timeSK1 := "TIME#" + base.Add(time.Minute).Format(time.RFC3339Nano) + "#status-time-1"
-	legacySK3 := base.Add(3 * time.Minute).Format(time.RFC3339Nano)
-	legacySK2 := base.Add(2 * time.Minute).Format(time.RFC3339Nano)
+	legacySK3 := legacyBookmarkSK(base.Add(3*time.Minute), "status-legacy-3")
+	legacySK2 := legacyBookmarkSK(base.Add(2*time.Minute), "status-legacy-2")
 
 	mockDB.On("WithContext", mock.Anything).Return(mockDB)
 	mockDB.On("Model", mock.Anything).Return(mockQuery)
@@ -185,7 +185,7 @@ func TestBookmarkRepository_M10_CountUserBookmarksCountsLegacyAndTimeRecords(t *
 		dest := args.Get(0).(*[]models.Bookmark)
 		*dest = []models.Bookmark{
 			{PK: pk, SK: "TIME#" + base.Format(time.RFC3339Nano) + "#status-time", ObjectID: "status-time", Locked: false},
-			{PK: pk, SK: base.Add(-time.Minute).Format(time.RFC3339Nano), ObjectID: "status-legacy", Locked: false},
+			{PK: pk, SK: legacyBookmarkSK(base.Add(-time.Minute), "status-legacy"), ObjectID: "status-legacy", Locked: false},
 			{PK: pk, SK: "OBJECT#status-time", ObjectID: "status-time", RecordType: models.BookmarkRecordTypeObject},
 			{PK: pk, SK: "TIME#" + base.Add(-2*time.Minute).Format(time.RFC3339Nano) + "#status-locked", ObjectID: "status-locked", Locked: true},
 		}
@@ -200,17 +200,18 @@ func TestBookmarkRepository_M10_CountUserBookmarksCountsLegacyAndTimeRecords(t *
 func TestBookmarkRepository_M10_BookmarkPageCursorCompatibility(t *testing.T) {
 	createdAt := time.Date(2025, 12, 28, 12, 30, 0, 123, time.UTC)
 	timeSK := "TIME#" + createdAt.Format(time.RFC3339Nano) + "#status-time"
-	legacySK := createdAt.Format(time.RFC3339Nano)
+	legacySK := legacyBookmarkSK(createdAt, "status-legacy")
+	legacyTimeUpperBound := createdAt.Format(time.RFC3339Nano) + "\xff"
 
 	fromTime, err := parseBookmarkPageCursor(timeSK)
 	require.NoError(t, err)
 	require.Equal(t, timeSK, fromTime.TimeSK)
-	require.Equal(t, legacySK+"\xff", fromTime.LegacySK)
+	require.Equal(t, legacyTimeUpperBound, fromTime.LegacySK)
 
 	fromLegacy, err := parseBookmarkPageCursor(legacySK)
 	require.NoError(t, err)
 	require.Equal(t, legacySK, fromLegacy.LegacySK)
-	require.Equal(t, "TIME#"+legacySK, fromLegacy.TimeSK)
+	require.Equal(t, "TIME#"+createdAt.Format(time.RFC3339Nano), fromLegacy.TimeSK)
 
 	encoded := encodeBookmarkPageCursor(bookmarkPageCursor{TimeSK: timeSK, LegacySK: legacySK})
 	decoded, err := parseBookmarkPageCursor(encoded)

--- a/pkg/storage/repositories/bookmark_repository_round08_additional_coverage_test.go
+++ b/pkg/storage/repositories/bookmark_repository_round08_additional_coverage_test.go
@@ -40,7 +40,7 @@ func TestBookmarkRepository_Round08_CountAndQueryUnlockedTimeBookmarks(t *testin
 				{PK: pk, SK: "TIME#" + base.Add(2*time.Minute).Format(time.RFC3339Nano) + "#o3", ObjectID: "o3", CreatedAt: base.Add(2 * time.Minute), Locked: false},
 				{PK: pk, SK: "TIME#" + base.Add(time.Minute).Format(time.RFC3339Nano) + "#o2", ObjectID: "o2", CreatedAt: base.Add(time.Minute), Locked: false},
 				{PK: pk, SK: "OBJECT#o1", ObjectID: "o1", CreatedAt: base, RecordType: models.BookmarkRecordTypeObject},
-				{PK: pk, SK: base.Add(-time.Minute).Format(time.RFC3339Nano), ObjectID: "legacy", CreatedAt: base.Add(-time.Minute), Locked: false},
+				{PK: pk, SK: legacyBookmarkSK(base.Add(-time.Minute), "legacy"), ObjectID: "legacy", CreatedAt: base.Add(-time.Minute), Locked: false},
 			}
 			return
 		}
@@ -52,7 +52,7 @@ func TestBookmarkRepository_Round08_CountAndQueryUnlockedTimeBookmarks(t *testin
 			return
 		}
 		*dest = []models.Bookmark{
-			{PK: pk, SK: base.Add(-time.Minute).Format(time.RFC3339Nano), ObjectID: "legacy", CreatedAt: base.Add(-time.Minute), Locked: false},
+			{PK: pk, SK: legacyBookmarkSK(base.Add(-time.Minute), "legacy"), ObjectID: "legacy", CreatedAt: base.Add(-time.Minute), Locked: false},
 		}
 	}).Return(nil)
 

--- a/pkg/storage/repositories/bookmark_repository_round08_error_branches_test.go
+++ b/pkg/storage/repositories/bookmark_repository_round08_error_branches_test.go
@@ -85,7 +85,7 @@ func TestBookmarkRepository_Round08_DynamoLookup_ErrorBranches(t *testing.T) {
 	mockDB.On("Model", mock.Anything).Return(mockQuery)
 	mockQuery.On("ConsistentRead").Return(mockQuery)
 	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery)
-	mockQuery.On("Filter", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery)
+	mockQuery.On("FilterGroup", mock.Anything).Return(mockQuery)
 	mockQuery.On("Limit", mock.Anything).Return(mockQuery)
 
 	mockQuery.On("First", mock.Anything).Return(errors.New("first failed")).Once()
@@ -299,7 +299,7 @@ func TestBookmarkRepository_Round08_DynamoFindTimeBookmarkByObject_EmptyList(t *
 	mockDB.On("WithContext", mock.Anything).Return(mockDB)
 	mockDB.On("Model", mock.Anything).Return(mockQuery)
 	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery)
-	mockQuery.On("Filter", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery)
+	mockQuery.On("FilterGroup", mock.Anything).Return(mockQuery)
 	mockQuery.On("Limit", mock.Anything).Return(mockQuery)
 	mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
 		dest := args.Get(0).(*[]models.Bookmark)

--- a/pkg/storage/repositories/bookmark_repository_round08_more_coverage_test.go
+++ b/pkg/storage/repositories/bookmark_repository_round08_more_coverage_test.go
@@ -130,6 +130,7 @@ func TestBookmarkRepository_Round08_DynamoHelpers_TransactWriteBatchGetAndLookup
 	mockDB.On("Model", mock.Anything).Return(mockQuery)
 	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery)
 	mockQuery.On("Filter", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery)
+	mockQuery.On("FilterGroup", mock.Anything).Return(mockQuery)
 	mockQuery.On("Limit", mock.Anything).Return(mockQuery)
 
 	repo := NewBookmarkRepository(mockDB, "test-table", zap.NewNop())

--- a/pkg/storage/repositories/bookmark_repository_test.go
+++ b/pkg/storage/repositories/bookmark_repository_test.go
@@ -2,7 +2,6 @@ package repositories
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"testing"
 	"time"
@@ -39,6 +38,10 @@ func newTestBookmarkRepository() *testBookmarkRepository {
 	return repo
 }
 
+func legacyBookmarkSK(createdAt time.Time, objectID string) string {
+	return createdAt.Format(time.RFC3339Nano) + "#" + objectID
+}
+
 func (r *testBookmarkRepository) overrideHooks() {
 	r.transactWriteFn = r.mockTransactWrite
 	r.batchGetFn = r.mockBatchGet
@@ -53,11 +56,15 @@ func (r *testBookmarkRepository) overrideHooks() {
 	r.findTimeBookmarkFn = func(_ context.Context, username, objectID string) (*models.Bookmark, error) {
 		pk := buildBookmarkPK(username)
 		for _, bookmark := range r.store {
-			if bookmark.PK != pk || bookmark.ObjectID != objectID {
+			if bookmark.PK != pk || bookmarkObjectID(*bookmark) != objectID {
 				continue
 			}
 			if bookmark.RecordType == models.BookmarkRecordTypeTime || isTimeBookmarkSK(bookmark.SK) || isReadableTimeBookmark(*bookmark) {
-				return r.clone(bookmark), nil
+				clone := r.clone(bookmark)
+				if clone.ObjectID == "" {
+					clone.ObjectID = bookmarkObjectID(*clone)
+				}
+				return clone, nil
 			}
 		}
 		return nil, nil
@@ -290,7 +297,7 @@ func TestBookmarkRepositoryLegacyTimestampBookmarksRemainVisible(t *testing.T) {
 	createdAt := time.Date(2026, time.May, 14, 16, 45, 0, 0, time.UTC)
 	legacy := &models.Bookmark{
 		PK:        buildBookmarkPK("frank"),
-		SK:        createdAt.Format(time.RFC3339Nano),
+		SK:        legacyBookmarkSK(createdAt, "status-legacy"),
 		Username:  "frank",
 		ObjectID:  "status-legacy",
 		CreatedAt: createdAt,
@@ -496,7 +503,7 @@ func (b *mockUpdateBuilder) Execute() error                               { retu
 func (b *mockUpdateBuilder) ExecuteWithResult(any) error                  { return nil }
 
 // TestBookmarkRepository_CSR055_LegacyBookmarksVisible proves that legacy
-// bookmarks stored with a raw RFC3339Nano timestamp SK (the format used before
+// bookmarks stored with the real timestamp#objectID SK (the format used before
 // the TIME# / OBJECT# dual-write schema) remain visible through every bookmark
 // read path: GetBookmark, IsBookmarked, GetUserBookmarks, and
 // CheckBookmarksForStatuses. This is a targeted regression probe for CSR-055.
@@ -505,11 +512,11 @@ func TestBookmarkRepository_CSR055_LegacyBookmarksVisible(t *testing.T) {
 	repo := newTestBookmarkRepository()
 	now := time.Date(2024, time.June, 1, 12, 0, 0, 0, time.UTC)
 
-	// Manually build a legacy bookmark: SK is a raw RFC3339Nano timestamp
-	// without any prefix, RecordType is empty, Locked is false.
+	// Manually build a legacy bookmark: SK is the genuine pre-refactor
+	// RFC3339Nano timestamp#objectID shape, RecordType is empty, Locked is false.
 	legacy := &models.Bookmark{
-		PK:         fmt.Sprintf("%s#%s", models.BookmarkPartitionPrefix, "legacy-user"),
-		SK:         now.Format(time.RFC3339Nano),
+		PK:         buildBookmarkPK("legacy-user"),
+		SK:         legacyBookmarkSK(now, "legacy-status-1"),
 		Username:   "legacy-user",
 		ObjectID:   "legacy-status-1",
 		CreatedAt:  now,
@@ -521,6 +528,10 @@ func TestBookmarkRepository_CSR055_LegacyBookmarksVisible(t *testing.T) {
 	// Verify the legacy SK is recognized as a legacy timestamp.
 	require.True(t, isLegacyBookmarkTimestampSK(legacy.SK), "legacy SK should be recognized")
 	require.True(t, isReadableTimeBookmark(*legacy), "legacy bookmark should be readable")
+	require.False(t, isLegacyBookmarkTimestampSK("TIME#"+now.Format(time.RFC3339Nano)+"#legacy-status-1"))
+	require.False(t, isLegacyBookmarkTimestampSK("OBJECT#legacy-status-1"))
+	require.False(t, isLegacyBookmarkTimestampSK(now.Format(time.RFC3339Nano)))
+	require.Equal(t, "legacy-status-1", bookmarkObjectID(models.Bookmark{SK: legacy.SK}))
 
 	// GetBookmark should find the legacy bookmark via findTimeBookmarkFn fallback.
 	found, err := repo.GetBookmark(ctx, "legacy-user", "legacy-status-1")

--- a/pkg/storage/repositories/community_note_repository.go
+++ b/pkg/storage/repositories/community_note_repository.go
@@ -305,9 +305,11 @@ func (r *CommunityNoteRepository) GetCommunityNotesByAuthor(ctx context.Context,
 	query := r.GetDB().WithContext(ctx).Model(&models.CommunityNote{}).
 		Index("gsi3").
 		Where("gsi3PK", "=", fmt.Sprintf("AUTHOR#%s#NOTES", authorID)).
-		Limit(limit)
+		Limit(limit).
+		OrderBy("gsi3SK", "DESC")
 
-	// Add cursor if provided - preserve exact cursor logic
+	// Add cursor if provided. With DESC ordering, gsi3SK < cursor advances
+	// from newest notes toward older notes.
 	if cursor != "" {
 		// Parse cursor - expecting format "timestamp#noteID" - preserve exact parsing
 		parts := strings.Split(cursor, "#")

--- a/pkg/storage/repositories/community_note_repository_round09_coverage_test.go
+++ b/pkg/storage/repositories/community_note_repository_round09_coverage_test.go
@@ -191,6 +191,7 @@ func TestCommunityNoteRepository_round09_vote_paths_and_author_listing(t *testin
 		mockQuery.On("Index", "gsi3").Return(mockQuery).Once()
 		mockQuery.On("Where", "gsi3PK", "=", "AUTHOR#u1#NOTES").Return(mockQuery).Once()
 		mockQuery.On("Limit", 2).Return(mockQuery).Once()
+		mockQuery.On("OrderBy", "gsi3SK", "DESC").Return(mockQuery).Once()
 		mockQuery.On("Where", "gsi3SK", "<", "123#n1").Return(mockQuery).Once()
 		mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
 			dest := args.Get(0).(*[]models.CommunityNote)
@@ -205,6 +206,7 @@ func TestCommunityNoteRepository_round09_vote_paths_and_author_listing(t *testin
 		mockQuery.On("Index", "gsi3").Return(mockQuery).Once()
 		mockQuery.On("Where", "gsi3PK", "=", "AUTHOR#u1#NOTES").Return(mockQuery).Once()
 		mockQuery.On("Limit", 2).Return(mockQuery).Once()
+		mockQuery.On("OrderBy", "gsi3SK", "DESC").Return(mockQuery).Once()
 		mockQuery.On("All", mock.Anything).Return(dynamormerrors.ErrItemNotFound).Once()
 		notes, next, err = repo.GetCommunityNotesByAuthor(ctx, "u1", 2, "badcursor")
 		require.NoError(t, err)

--- a/pkg/storage/repositories/round08_permissive_mocks_test.go
+++ b/pkg/storage/repositories/round08_permissive_mocks_test.go
@@ -22,6 +22,7 @@ func setupPermissiveRound08Mocks(mockDB *mocks.MockDB, mockQuery *mocks.MockQuer
 	mockQuery.On("Index", mock.Anything).Return(mockQuery).Maybe()
 	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery).Maybe()
 	mockQuery.On("Filter", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery).Maybe()
+	mockQuery.On("FilterGroup", mock.Anything).Return(mockQuery).Maybe()
 	mockQuery.On("OrderBy", mock.Anything, mock.Anything).Return(mockQuery).Maybe()
 	mockQuery.On("Limit", mock.Anything).Return(mockQuery).Maybe()
 	mockQuery.On("Cursor", mock.Anything).Return(mockQuery).Maybe()

--- a/pkg/storage/repositories_exttests/status_repository_ext_test.go
+++ b/pkg/storage/repositories_exttests/status_repository_ext_test.go
@@ -140,6 +140,7 @@ func setupPermissiveStatusMocks(mockDB *mocks.MockDB, mockQuery *mocks.MockQuery
 	mockQuery.On("Index", mock.Anything).Return(mockQuery).Maybe()
 	mockQuery.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery).Maybe()
 	mockQuery.On("Filter", mock.Anything, mock.Anything, mock.Anything).Return(mockQuery).Maybe()
+	mockQuery.On("FilterGroup", mock.Anything).Return(mockQuery).Maybe()
 	mockQuery.On("OrderBy", mock.Anything, mock.Anything).Return(mockQuery).Maybe()
 	mockQuery.On("Limit", mock.Anything).Return(mockQuery).Maybe()
 	mockQuery.On("Cursor", mock.Anything).Return(mockQuery).Maybe()

--- a/pkg/testing/inmemory/community_note_repository.go
+++ b/pkg/testing/inmemory/community_note_repository.go
@@ -3,7 +3,9 @@ package inmemory
 
 import (
 	"context"
+	"sort"
 	"sync"
+	"time"
 
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
@@ -86,30 +88,40 @@ func (r *CommunityNoteRepository) GetCommunityNotesByAuthor(_ context.Context, a
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	noteIDs := r.notesByAuthor[authorID]
-	var results []*storage.CommunityNote
-
-	startIdx := 0
-	if cursor != "" {
-		for i, id := range noteIDs {
-			if id == cursor {
-				startIdx = i + 1
-				break
-			}
+	ordered := make([]*storage.CommunityNote, 0, len(r.notesByAuthor[authorID]))
+	for _, noteID := range r.notesByAuthor[authorID] {
+		if note, exists := r.notes[noteID]; exists && note != nil {
+			ordered = append(ordered, note)
 		}
 	}
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return inMemoryCommunityNoteAuthorCursor(ordered[i]) > inMemoryCommunityNoteAuthorCursor(ordered[j])
+	})
 
-	for i := startIdx; i < len(noteIDs) && (limit <= 0 || len(results) < limit); i++ {
-		if note, exists := r.notes[noteIDs[i]]; exists {
-			results = append(results, note)
+	results := make([]*storage.CommunityNote, 0, len(ordered))
+	for _, note := range ordered {
+		noteCursor := inMemoryCommunityNoteAuthorCursor(note)
+		if cursor != "" && noteCursor >= cursor {
+			continue
+		}
+		results = append(results, note)
+		if limit > 0 && len(results) == limit {
+			break
 		}
 	}
 
 	nextCursor := ""
-	if limit > 0 && startIdx+limit < len(noteIDs) {
-		nextCursor = noteIDs[startIdx+limit-1]
+	if limit > 0 && len(results) == limit {
+		nextCursor = inMemoryCommunityNoteAuthorCursor(results[len(results)-1])
 	}
 	return results, nextCursor, nil
+}
+
+func inMemoryCommunityNoteAuthorCursor(note *storage.CommunityNote) string {
+	if note == nil {
+		return ""
+	}
+	return note.CreatedAt.Format(time.RFC3339) + "#" + note.ID
 }
 
 // UpdateCommunityNoteScore updates a note's score and visibility


### PR DESCRIPTION
## Project 43 — lesser M2 release (dedicated → main)

Milestone **Codex 2026-05-30 M2 — Abuse/DoS & data-integrity controls**. Merges the M2 remediation work on `project-43-security-remediation` into `main`. **Release gate: awaiting Aron's approval — do not auto-merge.**

Branch is **11 ahead / 0 behind main** (clean linear ancestry — conflict-free; no sync needed). lesser M1 already on main (#1125).

### Included (5/5 merged to dedicated; each GPG-verified, full `./lesser verify ci` green, Arch Tier-1 reviewed)
| Finding | Sev | PR | Summary |
|---|---|---|---|
| L-13 | MED | #1126 | Oversized AI images silently truncated → read maxBytes+1, abort `ErrImageDownloadTooLarge` before PutObject (no truncated object reaches Rekognition) |
| L-14 | MED | #1127 | Equal-timestamp DMs skipped metadata → guard uses strictly-older `publishedAt.Before(...)`; distinct equal-ts message advances LastStatusID/LastMessageTime |
| L-19 | LOW | #1128 | Unbounded metrics date range DoS → cap span (≤30 days) + reject future dates → 400; bounds the aggregate fetch |
| L-06 | MED | #1129 | Community-note rate-limit bypass via stale (oldest-first) pagination → `OrderBy gsi3SK DESC` + cutoff short-circuit; **misleading integer-offset stub corrected to real cursor semantics** |
| L-20 | INFO | #1130 | Legacy bookmarks invisible after TIME# schema change → recognize real `{RFC3339Nano}#{objectID}` legacy SK (reject TIME#/OBJECT#); masking tests corrected to the real shape |

### Closeout verification (Arch, Tier-1, dedicated HEAD `f5d7f2c4`)
- All 5 fix commits ancestors of the dedicated branch; 11 ahead / 0 behind main (linear, no merge divergence).
- Tree-wide conflict-marker scan: **clean**.
- Notable: L-06 and L-20 were **adversarially re-confirmed still-vulnerable** (prior "fixes" targeted wrong cursor ordering / a non-existent SK shape) and corrected, *including the tests that had masked them*. L-20 also surfaced (and fixed) a cross-package consumer-mock regression the full gate caught — see #1130.

### CI reliability note
Several merges in this milestone hit pre-existing **timing-flaky** tests in the verify gate (#1123 signing-parity, #1131 circuit-breaker) — unrelated false-fails cleared by re-run. Root cause + a fix plan are tracked in **#1132** (Phase 0 CI hardening in progress).

### Scope
lesser M2 only. lesser M3 (L-08 #1109, L-10 #1110, L-15 #1111 — notification/object-visibility) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
