### PR TITLE
[Project 43] lesser M3 — Notification & object visibility enforcement (release → main)

### DIFF
--- a/cmd/api/handlers/misc.go
+++ b/cmd/api/handlers/misc.go
@@ -999,11 +999,6 @@ func (h *Handler) notificationPostSnapshot(view *notificationView) (map[string]i
 	return snapshot, true
 }
 
-func (h *Handler) statusFromNotificationSnapshot(ctx *apptheory.Context, view *notificationView) *models.Status {
-	status, _ := h.statusFromNotificationSnapshotForExpansion(ctx, view)
-	return status
-}
-
 func (h *Handler) statusFromNotificationSnapshotForExpansion(ctx *apptheory.Context, view *notificationView) (*models.Status, bool) {
 	snapshot, ok := h.notificationPostSnapshot(view)
 	if !ok {

--- a/cmd/api/handlers/misc.go
+++ b/cmd/api/handlers/misc.go
@@ -927,13 +927,23 @@ func (h *Handler) shouldIncludeStatus(view *notificationView) bool {
 
 // attachStatusToNotification attaches status information to a notification.
 func (h *Handler) attachStatusToNotification(ctx *apptheory.Context, view *notificationView, apiNotif *models.Notification) {
-	if snapshotStatus := h.statusFromNotificationSnapshot(ctx, view); snapshotStatus != nil {
-		apiNotif.Status = snapshotStatus
+	if snapshotStatus, handled := h.statusFromNotificationSnapshotForExpansion(ctx, view); handled {
+		if snapshotStatus != nil {
+			apiNotif.Status = snapshotStatus
+		}
 		return
 	}
 
 	statusID := view.statusID()
 	if statusID == "" {
+		return
+	}
+
+	if h.notificationStatusDeleted(ctx.Context(), statusID) {
+		h.logger.Debug("skipping notification status expansion because status is deleted",
+			zap.String("notification_id", view.ID),
+			zap.String("status_id", statusID),
+			zap.String("viewer", view.UserID))
 		return
 	}
 
@@ -946,7 +956,8 @@ func (h *Handler) attachStatusToNotification(ctx *apptheory.Context, view *notif
 		return
 	}
 
-	if !h.notificationObjectVisibleToViewer(ctx.Context(), view, obj) {
+	visibility, attributedTo, recipients, mentions := notificationObjectVisibilityContext(obj)
+	if !h.notificationStatusVisibleToViewer(ctx.Context(), view, visibility, attributedTo, recipients, mentions) {
 		h.logger.Debug("skipping notification status expansion due to visibility",
 			zap.String("notification_id", view.ID),
 			zap.String("status_id", statusID),
@@ -957,9 +968,15 @@ func (h *Handler) attachStatusToNotification(ctx *apptheory.Context, view *notif
 	statusActor := h.extractStatusAuthor(ctx, obj)
 	if objMap, ok := obj.(map[string]interface{}); ok {
 		status := transformations.ObjectToStatusBase(objMap, statusActor, h.cfg.BaseURL())
+		if normalizedVisibility := normalizeNotificationStatusVisibility(visibility); normalizedVisibility != "" {
+			status.Visibility = normalizedVisibility
+		}
 		apiNotif.Status = &status
 	} else {
 		status := transformations.ObjectToStatusAny(obj, statusActor, h.cfg.BaseURL())
+		if normalizedVisibility := normalizeNotificationStatusVisibility(visibility); normalizedVisibility != "" {
+			status.Visibility = normalizedVisibility
+		}
 		apiNotif.Status = &status
 	}
 }
@@ -983,22 +1000,36 @@ func (h *Handler) notificationPostSnapshot(view *notificationView) (map[string]i
 }
 
 func (h *Handler) statusFromNotificationSnapshot(ctx *apptheory.Context, view *notificationView) *models.Status {
+	status, _ := h.statusFromNotificationSnapshotForExpansion(ctx, view)
+	return status
+}
+
+func (h *Handler) statusFromNotificationSnapshotForExpansion(ctx *apptheory.Context, view *notificationView) (*models.Status, bool) {
 	snapshot, ok := h.notificationPostSnapshot(view)
 	if !ok {
-		return nil
+		return nil, false
+	}
+
+	snapshotStatusID := strings.TrimSpace(notificationSnapshotString(snapshot, "id"))
+	if h.notificationStatusDeleted(ctx.Context(), snapshotStatusID, view.statusID()) {
+		h.logger.Debug("skipping notification snapshot expansion because status is deleted",
+			zap.String("notification_id", view.ID),
+			zap.String("status_id", firstNonEmptyString(snapshotStatusID, view.statusID())),
+			zap.String("viewer", view.UserID))
+		return nil, true
 	}
 
 	if !h.notificationSnapshotVisibleToViewer(ctx.Context(), view, snapshot) {
 		h.logger.Debug("skipping notification snapshot expansion due to visibility",
 			zap.String("notification_id", view.ID),
 			zap.String("viewer", view.UserID))
-		return nil
+		return nil, true
 	}
 
 	statusActor := h.notificationSnapshotActor(ctx, snapshot)
 	status := transformations.ObjectToStatusBase(notificationSnapshotObjectMap(snapshot), statusActor, h.cfg.BaseURL())
 	if status.ID == "" {
-		return nil
+		return nil, true
 	}
 
 	if safeURL, ok := common.SafeHTTPURL(status.URL); ok {
@@ -1015,7 +1046,7 @@ func (h *Handler) statusFromNotificationSnapshot(ctx *apptheory.Context, view *n
 		status.Visibility = visibility
 	}
 
-	return &status
+	return &status, true
 }
 
 func (h *Handler) notificationSnapshotVisibleToViewer(ctx context.Context, view *notificationView, snapshot map[string]interface{}) bool {
@@ -1028,11 +1059,6 @@ func (h *Handler) notificationSnapshotVisibleToViewer(ctx context.Context, view 
 	)
 }
 
-func (h *Handler) notificationObjectVisibleToViewer(ctx context.Context, view *notificationView, obj any) bool {
-	visibility, attributedTo, recipients, mentions := notificationObjectVisibilityContext(obj)
-	return h.notificationStatusVisibleToViewer(ctx, view, visibility, attributedTo, recipients, mentions)
-}
-
 func (h *Handler) notificationStatusVisibleToViewer(
 	ctx context.Context,
 	view *notificationView,
@@ -1041,9 +1067,17 @@ func (h *Handler) notificationStatusVisibleToViewer(
 	recipients []string,
 	mentions []string,
 ) bool {
-	visibility = strings.TrimSpace(visibility)
+	visibility = normalizeNotificationStatusVisibility(visibility)
 	if visibility == "" {
-		visibility = storagemodels.VisibilityPublic
+		if h != nil && h.logger != nil {
+			notificationID := ""
+			if view != nil {
+				notificationID = view.ID
+			}
+			h.logger.Warn("empty notification status visibility denied",
+				zap.String("notification_id", notificationID))
+		}
+		return false
 	}
 
 	switch visibility {
@@ -1074,6 +1108,80 @@ func (h *Handler) notificationStatusVisibleToViewer(
 			zap.String("visibility", visibility))
 		return false
 	}
+}
+
+func normalizeNotificationStatusVisibility(visibility string) string {
+	return strings.ToLower(strings.TrimSpace(visibility))
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func (h *Handler) notificationStatusDeleted(ctx context.Context, statusIDs ...string) bool {
+	if h == nil || h.repos == nil || h.repos.Object() == nil {
+		return true
+	}
+
+	for _, statusID := range h.notificationDeletionStatusCandidates(statusIDs...) {
+		deleted, err := h.repos.Object().IsTombstoned(ctx, statusID)
+		if err != nil {
+			if h.logger != nil {
+				h.logger.Warn("failed to check notification status tombstone state",
+					zap.String("status_id", statusID),
+					zap.Error(err))
+			}
+			return true
+		}
+		if deleted {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (h *Handler) notificationDeletionStatusCandidates(statusIDs ...string) []string {
+	candidates := make([]string, 0, len(statusIDs)*3)
+	seen := make(map[string]struct{}, len(statusIDs)*3)
+	add := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		candidates = append(candidates, value)
+	}
+
+	for _, statusID := range statusIDs {
+		statusID = strings.TrimSpace(statusID)
+		if statusID == "" {
+			continue
+		}
+		add(statusID)
+
+		if parsed, err := url.Parse(statusID); err == nil && parsed != nil && parsed.Scheme != "" && parsed.Host != "" {
+			parts := strings.Split(strings.Trim(strings.TrimSpace(parsed.Path), "/"), "/")
+			if len(parts) > 0 {
+				add(parts[len(parts)-1])
+			}
+			continue
+		}
+
+		if h != nil && h.cfg != nil {
+			add(strings.TrimRight(h.cfg.BaseURL(), "/") + "/objects/" + statusID)
+		}
+	}
+
+	return candidates
 }
 
 func (h *Handler) notificationViewerFollowsAuthor(ctx context.Context, viewer, author string) bool {

--- a/cmd/api/handlers/misc_round11_test.go
+++ b/cmd/api/handlers/misc_round11_test.go
@@ -49,6 +49,7 @@ func TestMiscSearchAndHelpers_Round11(t *testing.T) {
 				Published:    now.Add(-1 * time.Hour),
 				AttributedTo: "https://example.com/users/alice",
 				URL:          cfg.BaseURL() + "/objects/obj-1",
+				Visibility:   storagemodels.VisibilityPublic,
 			},
 		},
 		objectsByID: map[string]storagemodels.Object{
@@ -59,6 +60,7 @@ func TestMiscSearchAndHelpers_Round11(t *testing.T) {
 				Published:    now.Add(-1 * time.Hour),
 				AttributedTo: "https://example.com/users/alice",
 				URL:          cfg.BaseURL() + "/objects/obj-1",
+				Visibility:   storagemodels.VisibilityPublic,
 			},
 		},
 		statusByID: map[string]storagemodels.Status{
@@ -115,6 +117,7 @@ func TestMiscNotificationsAndGrouping_Round11(t *testing.T) {
 				Content:      "hello",
 				Published:    now.Add(-1 * time.Hour),
 				AttributedTo: "https://example.com/users/alice",
+				Visibility:   storagemodels.VisibilityPublic,
 			},
 		},
 		notificationsByID: map[string]storagemodels.Notification{

--- a/cmd/api/handlers/misc_round12_coverage_test.go
+++ b/cmd/api/handlers/misc_round12_coverage_test.go
@@ -174,6 +174,7 @@ func TestMisc_Notifications_AttachStatusAndAuthor_Round12(t *testing.T) {
 				Content:      "hello",
 				Published:    now.Add(-1 * time.Hour),
 				AttributedTo: cfg.BaseURL() + "/users/bob",
+				Visibility:   storagemodels.VisibilityPublic,
 			},
 			"obj-1": {
 				ID:           "obj-1",
@@ -181,6 +182,7 @@ func TestMisc_Notifications_AttachStatusAndAuthor_Round12(t *testing.T) {
 				Content:      "image content",
 				Published:    now.Add(-2 * time.Hour),
 				AttributedTo: cfg.BaseURL() + "/users/bob",
+				Visibility:   storagemodels.VisibilityPublic,
 			},
 		},
 	}
@@ -499,6 +501,16 @@ func TestMisc_NotificationHandlers_ErrorBranches_Round12(t *testing.T) {
 						PreferredUsername: "alice",
 						Name:              "Alice",
 					},
+				},
+			},
+			objectsByID: map[string]storagemodels.Object{
+				"status-1": {
+					ID:           "status-1",
+					Type:         activitypub.NoteType,
+					Content:      "hello",
+					Published:    now.Add(-1 * time.Hour),
+					AttributedTo: cfg.BaseURL() + "/users/alice",
+					Visibility:   storagemodels.VisibilityPublic,
 				},
 			},
 		}

--- a/cmd/api/handlers/misc_round29_snapshot_helpers_test.go
+++ b/cmd/api/handlers/misc_round29_snapshot_helpers_test.go
@@ -41,17 +41,18 @@ func TestMisc_NotificationSnapshotHelpers_Round29(t *testing.T) {
 		require.False(t, ok)
 	})
 
-	t.Run("statusFromNotificationSnapshot returns nil for malformed snapshots", func(t *testing.T) {
+	t.Run("statusFromNotificationSnapshotForExpansion returns nil for malformed snapshots", func(t *testing.T) {
 		ctx, err := round10NewLiftContext("GET", "/test", nil, nil, nil)
 		require.NoError(t, err)
 
-		status := handler.statusFromNotificationSnapshot(ctx, &notificationView{
+		status, handled := handler.statusFromNotificationSnapshotForExpansion(ctx, &notificationView{
 			Data: map[string]interface{}{
 				"postSnapshot": map[string]interface{}{
 					"id": 123,
 				},
 			},
 		})
+		require.True(t, handled)
 		require.Nil(t, status)
 	})
 
@@ -71,7 +72,7 @@ func TestMisc_NotificationSnapshotHelpers_Round29(t *testing.T) {
 		ctx, err := round10NewLiftContext("GET", "/test", nil, nil, nil)
 		require.NoError(t, err)
 
-		status := handler.statusFromNotificationSnapshot(ctx, &notificationView{
+		status, handled := handler.statusFromNotificationSnapshotForExpansion(ctx, &notificationView{
 			ID:     "n-private",
 			Type:   models.NotificationTypeMention,
 			UserID: "alice",
@@ -84,6 +85,7 @@ func TestMisc_NotificationSnapshotHelpers_Round29(t *testing.T) {
 				},
 			},
 		})
+		require.True(t, handled)
 		require.Nil(t, status)
 	})
 
@@ -100,7 +102,7 @@ func TestMisc_NotificationSnapshotHelpers_Round29(t *testing.T) {
 		ctx, err := round10NewLiftContext("GET", "/test", nil, nil, nil)
 		require.NoError(t, err)
 
-		status := followerHandler.statusFromNotificationSnapshot(ctx, &notificationView{
+		status, handled := followerHandler.statusFromNotificationSnapshotForExpansion(ctx, &notificationView{
 			ID:     "n-private",
 			Type:   models.NotificationTypeMention,
 			UserID: "alice",
@@ -113,6 +115,7 @@ func TestMisc_NotificationSnapshotHelpers_Round29(t *testing.T) {
 				},
 			},
 		})
+		require.True(t, handled)
 		require.NotNil(t, status)
 		require.Equal(t, "private", status.Visibility)
 	})

--- a/cmd/api/handlers/misc_round29_snapshot_helpers_test.go
+++ b/cmd/api/handlers/misc_round29_snapshot_helpers_test.go
@@ -241,8 +241,16 @@ func TestMisc_NotificationStatusVisibleToViewer_Round29(t *testing.T) {
 	ctx, err := round10NewLiftContext("GET", "/test", nil, nil, nil)
 	require.NoError(t, err)
 
-	t.Run("public defaults visible before notification scoping", func(t *testing.T) {
-		require.True(t, handler.notificationStatusVisibleToViewer(ctx.Context(), nil, "", "", nil, nil))
+	t.Run("empty visibility fails closed before notification scoping", func(t *testing.T) {
+		require.False(t, handler.notificationStatusVisibleToViewer(ctx.Context(), nil, "", "", nil, nil))
+		require.True(t, handler.notificationStatusVisibleToViewer(
+			ctx.Context(),
+			nil,
+			storagemodels.VisibilityPublic,
+			"",
+			nil,
+			nil,
+		))
 	})
 
 	t.Run("private requires scoped notification viewer", func(t *testing.T) {

--- a/cmd/api/handlers/notification_status_materialization_security_test.go
+++ b/cmd/api/handlers/notification_status_materialization_security_test.go
@@ -1,0 +1,268 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/cmd/api/models"
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/config"
+	"github.com/equaltoai/lesser/pkg/services/notifications"
+	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+)
+
+func TestNotificationStatusMaterialization_DeletedSnapshotOmitted_M3(t *testing.T) {
+	cfg := round11TestConfig()
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	statusID := cfg.BaseURL() + "/objects/deleted-status"
+
+	notif := &storagemodels.Notification{
+		ID:         "n-deleted",
+		UserID:     "alice",
+		ActorID:    "bob",
+		Type:       models.NotificationTypeMention,
+		TargetID:   statusID,
+		TargetType: notificationTargetTypeStatus,
+		CreatedAt:  now,
+		Data: map[string]interface{}{
+			notificationPostSnapshotKey: map[string]interface{}{
+				"id":           statusID,
+				"url":          cfg.BaseURL() + "/@bob/deleted-status",
+				"content":      "<p>deleted body must not leak</p>",
+				"createdAt":    now.Add(-time.Minute).Format(time.RFC3339),
+				"visibility":   storagemodels.VisibilityPublic,
+				"attributedTo": cfg.BaseURL() + "/users/bob",
+			},
+		},
+	}
+
+	handler, _, _ := round11NewHandler(t, cfg, &round10QueryState{
+		actorsByUser: notificationMaterializationActors(cfg, "alice", "bob"),
+		objectsByID: map[string]storagemodels.Object{
+			statusID: {
+				ID:           statusID,
+				Type:         activitypub.NoteType,
+				Content:      "<p>live deleted body must not leak</p>",
+				Published:    now.Add(-time.Minute),
+				AttributedTo: cfg.BaseURL() + "/users/bob",
+				Visibility:   storagemodels.VisibilityPublic,
+			},
+		},
+		tombstonesByObjectID: map[string]storagemodels.Tombstone{
+			statusID: {
+				ID:         statusID,
+				Type:       "Tombstone",
+				FormerType: activitypub.NoteType,
+				DeletedBy:  cfg.BaseURL() + "/users/bob",
+				Deleted:    now,
+				CreatedAt:  now,
+			},
+		},
+	})
+	handler.registry = &RegistryStub{
+		NotificationsSvc: &NotificationsServiceStub{
+			ListNotificationsFunc: func(context.Context, *notifications.ListNotificationsQuery) (*notifications.NotificationListResult, error) {
+				return &notifications.NotificationListResult{Notifications: []*storagemodels.Notification{notif}}, nil
+			},
+			GetNotificationFunc: func(context.Context, *notifications.GetNotificationQuery) (*storagemodels.Notification, error) {
+				return notif, nil
+			},
+		},
+	}
+
+	listResp := requireStatus(t, http.StatusOK)(handler.HandleGetNotificationsLift(notificationReadContext(t, cfg, "alice", http.MethodGet, "/api/v1/notifications")))
+	require.NotContains(t, string(listResp.Body), "deleted body")
+	var listed []models.Notification
+	require.NoError(t, json.Unmarshal(listResp.Body, &listed))
+	require.Len(t, listed, 1)
+	require.Nil(t, listed[0].Status)
+
+	singleCtx := notificationReadContext(t, cfg, "alice", http.MethodGet, "/api/v1/notifications/n-deleted")
+	singleCtx.Params["id"] = "n-deleted"
+	singleResp := requireStatus(t, http.StatusOK)(handler.HandleGetNotificationLift(singleCtx))
+	require.NotContains(t, string(singleResp.Body), "deleted body")
+	var single models.Notification
+	require.NoError(t, json.Unmarshal(singleResp.Body, &single))
+	require.Nil(t, single.Status)
+}
+
+func TestNotificationStatusMaterialization_ObjectPathVisibility_M3(t *testing.T) {
+	cfg := round11TestConfig()
+	now := time.Date(2026, 5, 31, 12, 30, 0, 0, time.UTC)
+	privateID := "private-status"
+	directID := "direct-status"
+	publicID := "public-status"
+	unlistedID := "unlisted-status"
+	snapshotDeniedID := "snapshot-denied-status"
+
+	notificationsByUser := map[string][]*storagemodels.Notification{
+		"mallory": {
+			notificationForStatus("n-mallory-private", "mallory", privateID, now),
+			notificationForStatus("n-mallory-direct", "mallory", directID, now),
+			notificationForStatus("n-mallory-public", "mallory", publicID, now),
+			notificationForStatus("n-mallory-unlisted", "mallory", unlistedID, now),
+			notificationWithSnapshot("n-mallory-denied-snapshot", "mallory", snapshotDeniedID, now, map[string]interface{}{
+				"id":           snapshotDeniedID,
+				"content":      "<p>denied snapshot must not fall through</p>",
+				"createdAt":    now.Format(time.RFC3339),
+				"visibility":   storagemodels.VisibilityPrivate,
+				"attributedTo": cfg.BaseURL() + "/users/bob",
+			}),
+		},
+		"alice": {
+			notificationForStatus("n-alice-private", "alice", privateID, now),
+		},
+		"carol": {
+			notificationForStatus("n-carol-direct", "carol", directID, now),
+		},
+	}
+
+	handler, _, _ := round11NewHandler(t, cfg, &round10QueryState{
+		actorsByUser: notificationMaterializationActors(cfg, "alice", "bob", "carol", "mallory"),
+		relationshipRecords: []storagemodels.RelationshipRecord{
+			{
+				PK:    "FOLLOW#alice",
+				SK:    "FOLLOWING#bob",
+				State: storagemodels.RelationshipAccepted,
+			},
+		},
+		objectsByID: map[string]storagemodels.Object{
+			privateID: {
+				ID:           privateID,
+				Type:         activitypub.NoteType,
+				Content:      "<p>private body</p>",
+				Published:    now,
+				AttributedTo: cfg.BaseURL() + "/users/bob",
+				Visibility:   storagemodels.VisibilityPrivate,
+				To:           []string{cfg.BaseURL() + "/users/bob/followers"},
+			},
+			directID: {
+				ID:           directID,
+				Type:         activitypub.NoteType,
+				Content:      "<p>direct body</p>",
+				Published:    now,
+				AttributedTo: cfg.BaseURL() + "/users/bob",
+				Visibility:   storagemodels.VisibilityDirect,
+				To:           []string{cfg.ActorURL("carol")},
+			},
+			publicID: {
+				ID:           publicID,
+				Type:         activitypub.NoteType,
+				Content:      "<p>public body</p>",
+				Published:    now,
+				AttributedTo: cfg.BaseURL() + "/users/bob",
+				Visibility:   storagemodels.VisibilityPublic,
+			},
+			unlistedID: {
+				ID:           unlistedID,
+				Type:         activitypub.NoteType,
+				Content:      "<p>unlisted body</p>",
+				Published:    now,
+				AttributedTo: cfg.BaseURL() + "/users/bob",
+				Visibility:   storagemodels.VisibilityUnlisted,
+			},
+			snapshotDeniedID: {
+				ID:           snapshotDeniedID,
+				Type:         activitypub.NoteType,
+				Content:      "<p>fallback object body must not leak</p>",
+				Published:    now,
+				AttributedTo: cfg.BaseURL() + "/users/bob",
+				Visibility:   storagemodels.VisibilityPublic,
+			},
+		},
+	})
+	handler.registry = &RegistryStub{
+		NotificationsSvc: &NotificationsServiceStub{
+			ListNotificationsFunc: func(_ context.Context, query *notifications.ListNotificationsQuery) (*notifications.NotificationListResult, error) {
+				return &notifications.NotificationListResult{Notifications: notificationsByUser[query.UserID]}, nil
+			},
+		},
+	}
+
+	mallory := notificationsByID(notificationListForUser(t, handler, cfg, "mallory"))
+	require.Nil(t, mallory["n-mallory-private"].Status)
+	require.Nil(t, mallory["n-mallory-direct"].Status)
+	require.Nil(t, mallory["n-mallory-denied-snapshot"].Status)
+	require.NotNil(t, mallory["n-mallory-public"].Status)
+	require.Equal(t, storagemodels.VisibilityPublic, mallory["n-mallory-public"].Status.Visibility)
+	require.NotNil(t, mallory["n-mallory-unlisted"].Status)
+	require.Equal(t, storagemodels.VisibilityUnlisted, mallory["n-mallory-unlisted"].Status.Visibility)
+
+	alice := notificationsByID(notificationListForUser(t, handler, cfg, "alice"))
+	require.NotNil(t, alice["n-alice-private"].Status)
+	require.Equal(t, "<p>private body</p>", alice["n-alice-private"].Status.Content)
+	require.Equal(t, storagemodels.VisibilityPrivate, alice["n-alice-private"].Status.Visibility)
+
+	carol := notificationsByID(notificationListForUser(t, handler, cfg, "carol"))
+	require.NotNil(t, carol["n-carol-direct"].Status)
+	require.Equal(t, "<p>direct body</p>", carol["n-carol-direct"].Status.Content)
+	require.Equal(t, storagemodels.VisibilityDirect, carol["n-carol-direct"].Status.Visibility)
+}
+
+func notificationReadContext(t *testing.T, cfg *config.Config, username, method, path string) *apptheory.Context {
+	t.Helper()
+
+	token := round11SignAccessToken(t, cfg.JWTSecret, username, []string{"read:notifications", auth.ScopeRead})
+	ctx, err := round10NewLiftContext(method, path, map[string]string{"Authorization": "Bearer " + token}, nil, nil)
+	require.NoError(t, err)
+	return ctx
+}
+
+func notificationListForUser(t *testing.T, h *Handler, cfg *config.Config, username string) []models.Notification {
+	t.Helper()
+
+	resp := requireStatus(t, http.StatusOK)(h.HandleGetNotificationsLift(notificationReadContext(t, cfg, username, http.MethodGet, "/api/v1/notifications")))
+	var out []models.Notification
+	require.NoError(t, json.Unmarshal(resp.Body, &out))
+	return out
+}
+
+func notificationsByID(notifications []models.Notification) map[string]models.Notification {
+	out := make(map[string]models.Notification, len(notifications))
+	for _, notification := range notifications {
+		out[notification.ID] = notification
+	}
+	return out
+}
+
+func notificationForStatus(id, userID, statusID string, createdAt time.Time) *storagemodels.Notification {
+	return &storagemodels.Notification{
+		ID:         id,
+		UserID:     userID,
+		ActorID:    "bob",
+		Type:       models.NotificationTypeMention,
+		TargetID:   statusID,
+		TargetType: notificationTargetTypeStatus,
+		CreatedAt:  createdAt,
+	}
+}
+
+func notificationWithSnapshot(id, userID, statusID string, createdAt time.Time, snapshot map[string]interface{}) *storagemodels.Notification {
+	notification := notificationForStatus(id, userID, statusID, createdAt)
+	notification.Data = map[string]interface{}{notificationPostSnapshotKey: snapshot}
+	return notification
+}
+
+func notificationMaterializationActors(cfg *config.Config, usernames ...string) map[string]storagemodels.Actor {
+	actors := make(map[string]storagemodels.Actor, len(usernames))
+	for _, username := range usernames {
+		actors[username] = storagemodels.Actor{
+			Username: username,
+			Actor: &activitypub.Actor{
+				BaseObject: activitypub.BaseObject{
+					ID:   cfg.ActorURL(username),
+					Type: "Person",
+				},
+				PreferredUsername: username,
+				Name:              username,
+			},
+		}
+	}
+	return actors
+}

--- a/cmd/api/handlers/notifications_comm_list_round28_test.go
+++ b/cmd/api/handlers/notifications_comm_list_round28_test.go
@@ -146,6 +146,7 @@ func TestNotifications_ListIncludesReplyNotifications_Round28(t *testing.T) {
 				Content:      "reply body",
 				Published:    now.Add(-1 * time.Minute),
 				AttributedTo: cfg.BaseURL() + "/users/bob",
+				Visibility:   storageModels.VisibilityPublic,
 			},
 		},
 	}
@@ -228,6 +229,7 @@ func TestNotifications_ListHandlesSnapshotAndLegacyStatuses_Round28(t *testing.T
 				Content:      "legacy body",
 				Published:    now.Add(-2 * time.Minute),
 				AttributedTo: cfg.BaseURL() + "/users/bob",
+				Visibility:   storageModels.VisibilityPublic,
 			},
 		},
 		firstErrorPK: map[string]error{

--- a/cmd/objects/main.go
+++ b/cmd/objects/main.go
@@ -31,6 +31,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const objectsServiceName = "objects"
+
 var (
 	lambdaCtx *common.LambdaContext
 	cfg       *config.Config
@@ -58,7 +60,7 @@ func init() {
 func initializeObjects() {
 	// Standardized Lambda initialization with automatic service detection
 	lambdaCtx = mustInitializeLambdaFn(common.LambdaConfig{
-		ServiceName: "objects",
+		ServiceName: objectsServiceName,
 		LambdaType:  common.LambdaTypeAPI,
 	})
 
@@ -70,7 +72,7 @@ func initializeObjects() {
 	}
 
 	deps, err := lambdastorage.Initialize(context.Background(), lambdaCtx, lambdastorage.Options{
-		ServiceName:          "objects",
+		ServiceName:          objectsServiceName,
 		RequireRepositories:  true,
 		NewDB:                newLambdaOptimizedClientFn,
 		NewRepositoryStorage: newRepositoryFactoryFn,
@@ -227,6 +229,14 @@ func (h *Handler) HandleGetObject(ctx *apptheory.Context) (*apptheory.Response, 
 		// Verify authorized fetch
 		verifiedFetchActor, err = h.authorizedFetchService.VerifyAuthorizedFetch(runCtx, httpReq)
 		if err != nil {
+			// Tombstoned non-public objects must stay indistinguishable from
+			// nonexistent objects even when authorized fetch is enabled. If the
+			// tombstone is legacy or otherwise not visible to this requester, hide
+			// it before returning the generic authorized-fetch 401/403 response.
+			if h.shouldSuppressTombstoneForActor(runCtx, lookupID, objectID, requestID, nil) {
+				return objectsJSONError(http.StatusNotFound, fmt.Sprintf("object %s not found", objectID)), nil
+			}
+
 			// Check if signature is missing vs invalid
 			if strings.Contains(err.Error(), "missing signature") {
 				logger.Debug("unauthorized request - missing signature",
@@ -259,8 +269,7 @@ func (h *Handler) HandleGetObject(ctx *apptheory.Context) (*apptheory.Response, 
 	// attributed to a specific actor and its tombstone must not be returned
 	// before verifying authorized-fetch credentials.
 	if tombstoneResp, handled, tombErr := h.handleTombstonedObjectVisible(
-		runCtx, lookupID, objectID, requestID, wantsHTML,
-		authorizedFetchEnabled, verifiedFetchActor,
+		runCtx, lookupID, objectID, requestID, wantsHTML, verifiedFetchActor,
 	); handled {
 		return tombstoneResp, tombErr
 	}
@@ -270,8 +279,7 @@ func (h *Handler) HandleGetObject(ctx *apptheory.Context) (*apptheory.Response, 
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			if tombstoneResp, handled, tombErr := h.handleTombstonedObjectVisible(
-				runCtx, lookupID, objectID, requestID, wantsHTML,
-				authorizedFetchEnabled, verifiedFetchActor,
+				runCtx, lookupID, objectID, requestID, wantsHTML, verifiedFetchActor,
 			); handled {
 				return tombstoneResp, tombErr
 			}
@@ -455,14 +463,13 @@ func (h *Handler) handleTombstonedObject(ctx context.Context, lookupID, objectID
 // signal deletion to the author's own federation peers.
 //
 // Legacy tombstones (IsPublic=false, AttributedTo="") were created before
-// visibility context was stored. They are treated conservatively: hidden when
-// authorized fetch is enabled without verification; shown otherwise (backward
-// compatibility).
+// visibility context was stored. They are treated conservatively and hidden from
+// all callers because the handler cannot prove that the original object was
+// public or identify the original author.
 func (h *Handler) handleTombstonedObjectVisible(
 	ctx context.Context,
 	lookupID, objectID, requestID string,
 	wantsHTML bool,
-	authorizedFetchEnabled bool,
 	verifiedFetchActor *activitypub.Actor,
 ) (*apptheory.Response, bool, error) {
 	if h.objectRepo == nil {
@@ -481,80 +488,76 @@ func (h *Handler) handleTombstonedObjectVisible(
 			zap.String("request_id", requestID),
 			zap.Error(err),
 		)
-		// Without tombstone details we cannot determine visibility. When
-		// authorized fetch is enabled, err on the side of hiding to avoid
-		// leaking a potentially non-public deletion.
-		if authorizedFetchEnabled && verifiedFetchActor == nil {
-			logger.Debug("suppressing tombstone response for unauthorized viewer",
-				zap.String("object_id", objectID),
-				zap.String("request_id", requestID),
-			)
-			return nil, false, nil
-		}
-		return objectsJSONError(http.StatusGone, fmt.Sprintf("object %s deleted", objectID)), true, nil
+		// Without tombstone details we cannot determine whether the original
+		// object was public or who authored it. Hide rather than leak a deletion
+		// marker for a potentially non-public object.
+		return nil, false, nil
 	}
 
-	// Public tombstone: original object was publicly addressed. Return
-	// unconditionally — revealing that a public object was deleted is not
-	// a visibility leak.
-	if tombstone.IsPublic {
-		return h.handleTombstonedObject(ctx, lookupID, objectID, requestID, wantsHTML)
-	}
-
-	// Non-public tombstone: the original object's addressing did not include
-	// the public collection, so its deletion metadata must be gated.
-	//
-	// When the tombstone carries an AttributedTo, only the verified author
-	// may see it. When authorized fetch is globally disabled, even unsigned
-	// requests are hidden — consistent with live non-public object behavior
-	// (see TestHandleGetObject_PrivateVisibilityGate_Round29).
-	if strings.TrimSpace(tombstone.AttributedTo) != "" {
-		if !authorizedFetchEnabled {
-			logger.Debug("suppressing non-public tombstone when authorized fetch is disabled",
-				zap.String("object_id", objectID),
-				zap.String("attributed_to", tombstone.AttributedTo),
-				zap.String("request_id", requestID),
-			)
-			return nil, false, nil
-		}
-
-		if verifiedFetchActor == nil {
-			logger.Debug("suppressing non-public tombstone for unverified viewer",
-				zap.String("object_id", objectID),
-				zap.String("attributed_to", tombstone.AttributedTo),
-				zap.String("request_id", requestID),
-			)
-			return nil, false, nil
-		}
-
-		actorID := objectsActorID(verifiedFetchActor)
-		if !objectsActorIdentifiersMatch(actorID, tombstone.AttributedTo) {
-			logger.Debug("suppressing non-public tombstone for non-author verified fetch",
-				zap.String("object_id", objectID),
-				zap.String("attributed_to", tombstone.AttributedTo),
-				zap.String("verified_actor_id", actorID),
-				zap.String("request_id", requestID),
-			)
-			return nil, false, nil
-		}
-
-		// Verified actor is the original author — allow the tombstone.
-		return h.handleTombstonedObject(ctx, lookupID, objectID, requestID, wantsHTML)
-	}
-
-	// Legacy tombstone: IsPublic is false (zero value) and AttributedTo is
-	// empty. These tombstones were created before visibility context was
-	// stored. When authorized fetch is enabled without verification, hide
-	// conservatively; otherwise show (backward compatibility).
-	if authorizedFetchEnabled && verifiedFetchActor == nil {
-		logger.Debug("suppressing legacy tombstone for unauthorized viewer",
+	if !objectsTombstoneVisibleToActor(tombstone, verifiedFetchActor) {
+		logger.Debug("suppressing tombstone response for unauthorized viewer",
 			zap.String("object_id", objectID),
+			zap.String("attributed_to", tombstone.AttributedTo),
+			zap.Bool("is_public", tombstone.IsPublic),
 			zap.String("request_id", requestID),
 		)
 		return nil, false, nil
 	}
 
 	return h.handleTombstonedObject(ctx, lookupID, objectID, requestID, wantsHTML)
+}
+
+func (h *Handler) shouldSuppressTombstoneForActor(
+	ctx context.Context,
+	lookupID, objectID, requestID string,
+	verifiedFetchActor *activitypub.Actor,
+) bool {
+	if h.objectRepo == nil {
+		return false
+	}
+
+	tombstoned, err := h.objectRepo.IsTombstoned(ctx, lookupID)
+	if err != nil || !tombstoned {
+		return false
+	}
+
+	tombstone, err := h.objectRepo.GetTombstone(ctx, lookupID)
+	if err != nil {
+		logger.Warn("failed to load tombstone details for authorized-fetch visibility check",
+			zap.String("object_id", objectID),
+			zap.String("request_id", requestID),
+			zap.Error(err),
+		)
+		return true
+	}
+
+	if objectsTombstoneVisibleToActor(tombstone, verifiedFetchActor) {
+		return false
+	}
+
+	logger.Debug("suppressing authorized-fetch error for hidden tombstone",
+		zap.String("object_id", objectID),
+		zap.String("attributed_to", tombstone.AttributedTo),
+		zap.Bool("is_public", tombstone.IsPublic),
+		zap.String("request_id", requestID),
+	)
+	return true
+}
+
+func objectsTombstoneVisibleToActor(tombstone *storageModels.Tombstone, verifiedFetchActor *activitypub.Actor) bool {
+	if tombstone == nil {
+		return false
+	}
+	if tombstone.IsPublic {
+		return true
+	}
+
+	attributedTo := strings.TrimSpace(tombstone.AttributedTo)
+	if attributedTo == "" {
+		return false
+	}
+
+	return objectsActorIdentifiersMatch(objectsActorID(verifiedFetchActor), attributedTo)
 }
 
 func (h *Handler) resolveObjectLookup(ctx *apptheory.Context) (string, string) {
@@ -1095,7 +1098,7 @@ func buildApp(handler *Handler, lambdaLogger *zap.Logger) *apptheory.App {
 	app.Use(func(next apptheory.Handler) apptheory.Handler {
 		return func(ctx *apptheory.Context) (*apptheory.Response, error) {
 			if ctx != nil {
-				ctx.Set("requestID", objectsRequestID(ctx, "objects"))
+				ctx.Set("requestID", objectsRequestID(ctx, objectsServiceName))
 			}
 			return next(ctx)
 		}
@@ -1469,7 +1472,7 @@ func objectsRequestID(ctx *apptheory.Context, prefix string) string {
 	}
 	prefix = strings.TrimSpace(prefix)
 	if prefix == "" {
-		prefix = "objects"
+		prefix = objectsServiceName
 	}
 	return fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
 }

--- a/cmd/objects/round12_objects_test.go
+++ b/cmd/objects/round12_objects_test.go
@@ -622,7 +622,7 @@ func TestHandleGetObject_FetchResponses_Round12(t *testing.T) {
 		require.Equal(t, "https://example.com/users/alice/statuses/123", body["id"])
 	})
 
-	t.Run("canonical status route preserves authorized fetch behavior", func(t *testing.T) {
+	t.Run("canonical status route returns authorized fetch error when no hidden tombstone exists", func(t *testing.T) {
 		objRepo := &fakeObjectRepo{obj: map[string]any{"id": "https://example.com/users/alice/statuses/123", "type": "Note"}}
 		h := &Handler{
 			instanceRepo:           instanceRepo,
@@ -646,7 +646,7 @@ func TestHandleGetObject_FetchResponses_Round12(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Equal(t, 401, resp.Status)
-		require.Empty(t, objRepo.gotID)
+		require.Equal(t, "https://example.com/users/alice/statuses/123", objRepo.gotID)
 	})
 
 	t.Run("canonical status route returns tombstone when object was deleted", func(t *testing.T) {
@@ -655,10 +655,12 @@ func TestHandleGetObject_FetchResponses_Round12(t *testing.T) {
 			err:        errors.New("not found"),
 			tombstoned: true,
 			tombstone: &storageModels.Tombstone{
-				ID:         "https://example.com/users/alice/statuses/123",
-				FormerType: activitypub.NoteType,
-				Deleted:    deletedAt,
-				DeletedBy:  "https://example.com/users/alice",
+				ID:           "https://example.com/users/alice/statuses/123",
+				FormerType:   activitypub.NoteType,
+				Deleted:      deletedAt,
+				DeletedBy:    "https://example.com/users/alice",
+				AttributedTo: "https://example.com/users/alice",
+				IsPublic:     true,
 			},
 		}
 		h := &Handler{
@@ -696,10 +698,12 @@ func TestHandleGetObject_FetchResponses_Round12(t *testing.T) {
 			err:        errors.New("not found"),
 			tombstoned: true,
 			tombstone: &storageModels.Tombstone{
-				ID:         articleID,
-				FormerType: activitypub.ArticleType,
-				Deleted:    deletedAt,
-				DeletedBy:  "https://example.com/users/alice",
+				ID:           articleID,
+				FormerType:   activitypub.ArticleType,
+				Deleted:      deletedAt,
+				DeletedBy:    "https://example.com/users/alice",
+				AttributedTo: "https://example.com/users/alice",
+				IsPublic:     true,
 			},
 		}
 		h := &Handler{
@@ -747,10 +751,12 @@ func TestHandleGetObject_FetchResponses_Round12(t *testing.T) {
 			},
 			tombstoned: true,
 			tombstone: &storageModels.Tombstone{
-				ID:         articleID,
-				FormerType: activitypub.ArticleType,
-				Deleted:    deletedAt,
-				DeletedBy:  "https://example.com/users/alice",
+				ID:           articleID,
+				FormerType:   activitypub.ArticleType,
+				Deleted:      deletedAt,
+				DeletedBy:    "https://example.com/users/alice",
+				AttributedTo: "https://example.com/users/alice",
+				IsPublic:     true,
 			},
 		}
 		h := &Handler{
@@ -784,10 +790,12 @@ func TestHandleGetObject_FetchResponses_Round12(t *testing.T) {
 			err:        errors.New("not found"),
 			tombstoned: true,
 			tombstone: &storageModels.Tombstone{
-				ID:         legacyID,
-				FormerType: activitypub.ArticleType,
-				Deleted:    deletedAt,
-				DeletedBy:  "https://example.com/users/alice",
+				ID:           legacyID,
+				FormerType:   activitypub.ArticleType,
+				Deleted:      deletedAt,
+				DeletedBy:    "https://example.com/users/alice",
+				AttributedTo: "https://example.com/users/alice",
+				IsPublic:     true,
 			},
 		}
 		h := &Handler{
@@ -1563,8 +1571,8 @@ func TestObjectsSecurityHeaders_Round12(t *testing.T) {
 
 // TestTombstoneVisibility_Round38 verifies tombstone visibility is governed by
 // the IsPublic field, which records whether the original object was publicly
-// addressed. Non-public tombstones are gated behind authorized fetch and
-// author verification; public tombstones are returned unconditionally.
+// addressed. Non-public tombstones are hidden unless the requester is verified
+// as the original author; public tombstones are returned unconditionally.
 // This is consistent with live-object visibility semantics (see
 // TestHandleGetObject_PrivateVisibilityGate_Round29). CSR-030 regression coverage.
 func TestTombstoneVisibility_Round38(t *testing.T) {
@@ -1584,7 +1592,7 @@ func TestTombstoneVisibility_Round38(t *testing.T) {
 
 	deletedAt := time.Date(2026, time.May, 22, 10, 0, 0, 0, time.UTC)
 
-	t.Run("non-public attributed tombstone hidden when auth enabled and no signature", func(t *testing.T) {
+	t.Run("non-public attributed tombstone hidden as not found when auth enabled and no signature", func(t *testing.T) {
 		objID := "https://example.com/users/alice/statuses/private-deleted"
 		objRepo := &fakeObjectRepo{
 			err:        errors.New("not found"),
@@ -1619,7 +1627,7 @@ func TestTombstoneVisibility_Round38(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, resp)
-		require.Equal(t, http.StatusUnauthorized, resp.Status)
+		require.Equal(t, http.StatusNotFound, resp.Status)
 	})
 
 	t.Run("non-public attributed tombstone hidden when authorized fetch is globally disabled", func(t *testing.T) {
@@ -1650,6 +1658,38 @@ func TestTombstoneVisibility_Round38(t *testing.T) {
 				Method:  http.MethodGet,
 				Path:    "/users/alice/statuses/private-deleted",
 				Headers: map[string][]string{"accept": {"application/activity+json"}},
+			},
+			Params: map[string]string{"username": "alice", "id": "private-deleted"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusNotFound, resp.Status)
+	})
+
+	t.Run("non-public attributed tombstone hidden for HTML when authorized fetch is disabled", func(t *testing.T) {
+		objID := "https://example.com/users/alice/statuses/private-deleted"
+		objRepo := &fakeObjectRepo{
+			err:        errors.New("not found"),
+			tombstoned: true,
+			tombstone: &storageModels.Tombstone{
+				ID:           objID,
+				FormerType:   activitypub.NoteType,
+				Deleted:      deletedAt,
+				DeletedBy:    "https://example.com/users/alice",
+				AttributedTo: "https://example.com/users/alice",
+				IsPublic:     false,
+			},
+		}
+		h := &Handler{
+			instanceRepo:           instanceRepo,
+			objectRepo:             objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{enabled: false},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method:  http.MethodGet,
+				Path:    "/users/alice/statuses/private-deleted",
+				Headers: map[string][]string{"accept": {"text/html"}},
 			},
 			Params: map[string]string{"username": "alice", "id": "private-deleted"},
 		})
@@ -1821,9 +1861,9 @@ func TestTombstoneVisibility_Round38(t *testing.T) {
 		require.Equal(t, http.StatusNotFound, resp.Status)
 	})
 
-	t.Run("legacy tombstone without IsPublic or AttributedTo visible when auth disabled", func(t *testing.T) {
+	t.Run("legacy tombstone without IsPublic or AttributedTo hidden when auth disabled", func(t *testing.T) {
 		// Legacy tombstone (IsPublic=false zero-value, AttributedTo empty):
-		// backward compatible when authorized fetch is disabled.
+		// hide conservatively because we cannot prove public visibility or author.
 		objID := "https://example.com/objects/legacy-deleted"
 		objRepo := &fakeObjectRepo{
 			err:        errors.New("not found"),
@@ -1852,7 +1892,45 @@ func TestTombstoneVisibility_Round38(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, resp)
-		require.Equal(t, http.StatusGone, resp.Status)
+		require.Equal(t, http.StatusNotFound, resp.Status)
+	})
+
+	t.Run("legacy tombstone without IsPublic or AttributedTo hidden when auth enabled and no signature", func(t *testing.T) {
+		objID := "https://example.com/objects/legacy-deleted"
+		objRepo := &fakeObjectRepo{
+			err:        errors.New("not found"),
+			tombstoned: true,
+			tombstone: &storageModels.Tombstone{
+				ID:           objID,
+				FormerType:   activitypub.NoteType,
+				Deleted:      deletedAt,
+				DeletedBy:    "https://example.com/users/alice",
+				AttributedTo: "",
+				IsPublic:     false,
+			},
+		}
+		h := &Handler{
+			instanceRepo: instanceRepo,
+			objectRepo:   objRepo,
+			authorizedFetchService: &fakeAuthorizedFetch{
+				enabled:   true,
+				verifyErr: errors.New("missing signature"),
+			},
+		}
+		resp, err := h.HandleGetObject(&apptheory.Context{
+			Request: apptheory.Request{
+				Method: http.MethodGet,
+				Path:   "/objects/legacy-deleted",
+				Headers: map[string][]string{
+					"accept": {"application/activity+json"},
+					"host":   {"example.com"},
+				},
+			},
+			Params: map[string]string{"id": "legacy-deleted"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Equal(t, http.StatusNotFound, resp.Status)
 	})
 
 	t.Run("public tombstone with HTML Accept returns text response", func(t *testing.T) {
@@ -1895,11 +1973,10 @@ func TestTombstoneVisibility_Round38(t *testing.T) {
 		require.Contains(t, string(resp.Body), "deleted")
 	})
 
-	t.Run("tombstoned object with missing metadata returns 410 when auth disabled", func(t *testing.T) {
+	t.Run("tombstoned object with missing metadata is hidden when auth disabled", func(t *testing.T) {
 		// IsTombstoned=true but GetTombstone returns an error because
-		// the tombstone metadata row is missing. With authorized fetch
-		// disabled the error fallthrough returns 410 Gone (safe because
-		// auth is off — we are not leaking visibility metadata).
+		// the tombstone metadata row is missing. Without metadata the handler
+		// cannot prove the deleted object was public, so it must hide the tombstone.
 		objID := "https://example.com/objects/broken-tombstone"
 		objRepo := &fakeObjectRepo{
 			err:        errors.New("not found"),
@@ -1921,8 +1998,7 @@ func TestTombstoneVisibility_Round38(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, resp)
-		require.Equal(t, http.StatusGone, resp.Status)
-		require.Contains(t, string(resp.Body), "deleted")
+		require.Equal(t, http.StatusNotFound, resp.Status)
 	})
 }
 
@@ -1932,7 +2008,7 @@ func TestTombstoneVisibility_Round38(t *testing.T) {
 func TestHandleTombstonedObjectVisible_NilRepoBranch_Round38(t *testing.T) {
 	h := &Handler{}
 	resp, handled, err := h.handleTombstonedObjectVisible(
-		context.Background(), "lookup", "object", "req", false, false, nil,
+		context.Background(), "lookup", "object", "req", false, nil,
 	)
 	require.NoError(t, err)
 	require.Nil(t, resp)

--- a/pkg/storage/repositories/object_repository.go
+++ b/pkg/storage/repositories/object_repository.go
@@ -625,6 +625,7 @@ func (r *ObjectRepository) modelToActivityPubObject(ctx context.Context, objMode
 			"content":      objModel.Content,
 			"published":    objModel.Published,
 			"updated":      objModel.Updated,
+			"visibility":   objModel.Visibility,
 		}
 
 		if objModel.To != nil {
@@ -651,6 +652,7 @@ func objectModelToActivityPubNote(objModel *models.Object) *activitypub.Note {
 		},
 		Content:      objModel.Content,
 		AttributedTo: objModel.AttributedTo,
+		Visibility:   objModel.Visibility,
 	}
 
 	if objModel.InReplyTo != nil {

--- a/pkg/storage/repositories/object_repository_additional_coverage_test.go
+++ b/pkg/storage/repositories/object_repository_additional_coverage_test.go
@@ -41,6 +41,36 @@ func TestObjectRepository_BackgroundFetchAndCache(t *testing.T) {
 	})
 }
 
+func TestObjectRepository_ModelToActivityPubObjectPreservesVisibility(t *testing.T) {
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+
+	note := objectModelToActivityPubNote(&models.Object{
+		ID:           "note-visibility",
+		Type:         activitypub.NoteType,
+		Content:      "private note",
+		AttributedTo: "https://example.com/users/bob",
+		Published:    now,
+		Updated:      now,
+		Visibility:   models.VisibilityPrivate,
+	})
+	require.Equal(t, models.VisibilityPrivate, note.Visibility)
+
+	repo := &ObjectRepository{}
+	generic, err := repo.modelToActivityPubObject(context.Background(), &models.Object{
+		ID:           "question-visibility",
+		Type:         "Question",
+		Content:      "private question",
+		AttributedTo: "https://example.com/users/bob",
+		Published:    now,
+		Updated:      now,
+		Visibility:   models.VisibilityDirect,
+	})
+	require.NoError(t, err)
+	genericMap, ok := generic.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, models.VisibilityDirect, genericMap["visibility"])
+}
+
 func TestObjectRepository_ThreadContextFallbackPaths(t *testing.T) {
 	ctx := context.Background()
 	baseTime := time.Date(2025, 1, 4, 5, 6, 7, 0, time.UTC)


### PR DESCRIPTION
## Project 43 — lesser M3 release (dedicated → main)

Milestone **Codex 2026-05-30 M3 — Notification & object visibility enforcement**. Merges M3 remediation on `project-43-security-remediation` into `main`. **Release gate: awaiting Aron's approval — do not auto-merge.**

Branch is **5 ahead / 0 behind main** (clean linear; conflict-free). lesser M1 + M2 already on main.

### Included (3/3 merged to dedicated; GPG-verified, verify gate green, Arch Tier-1 reviewed)
| Finding | Sev | PR | Summary |
|---|---|---|---|
| L-08 | MED | #1136 | Notification GET leaked deleted-post content via frozen snapshot → IsTombstoned deletion check before snapshot/object expansion (both list + single-get) |
| L-15 | LOW | #1136 | Notification list rendered private/direct as public → fail-OPEN visibility default removed (empty/unknown DENIES); Object.Visibility preserved on read; snapshot-denial terminal |
| L-10 | MED | #1137 | Tombstone responses leaked 410-vs-404 for deleted non-public objects when authorized-fetch disabled (the default) → non-public/legacy tombstones now 404 regardless of auth-fetch state; public→410; verified author→410 |

### Closeout (Arch, Tier-1)
- All 3 fixes adversarially-confirmed STILL-VULNERABLE before this work (prior fixes had fail-open visibility / auth-fetch-dependent gates); now fail-closed with exploit-level regression tests (deleted-snapshot, empty-visibility-denied, auth-disabled-non-public-404) + a dedicated notification_status_materialization_security_test.go.
- 5 ahead / 0 behind main (linear); coverage gates pass; golangci-lint clean.

### Scope
lesser M3 only — completes all lesser Project 43 milestones (M1–M3). Remaining Project 43 lesser follow-up: #1121 (GC-02 OpenAPI-generator root → closes greater GC-02 #720), shipped separately to main.
