### PR TITLE
Auth-surface SSOT P0 — read-only reconciliation gate (freezes posture; no runtime change)

### DIFF
--- a/cmd/api/auth_surface_reconciliation_test.go
+++ b/cmd/api/auth_surface_reconciliation_test.go
@@ -1,0 +1,773 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	authSurfaceGoldenRelPath     = "cmd/api/testdata/auth_surface_golden.json"
+	authSurfaceExceptionsRelPath = "cmd/api/testdata/auth_surface_exceptions.json"
+)
+
+var updateAuthSurfaceGolden = flag.Bool(
+	"update-auth-surface-golden",
+	false,
+	"rewrite the auth-surface reconciliation golden snapshot",
+)
+
+type authSurfaceGuard string
+
+const (
+	authSurfaceGuardNone     authSurfaceGuard = "none"
+	authSurfaceGuardOptional authSurfaceGuard = "optional"
+	authSurfaceGuardRequired authSurfaceGuard = "required"
+)
+
+type authSurfacePosture string
+
+const (
+	authSurfacePostureAnonymous    authSurfacePosture = "anonymous"
+	authSurfacePostureAuthRequired authSurfacePosture = "auth-required"
+)
+
+type authSurfaceSecurity string
+
+const (
+	authSurfaceSecurityPublic   authSurfaceSecurity = "public"
+	authSurfaceSecurityOptional authSurfaceSecurity = "optional"
+	authSurfaceSecurityRequired authSurfaceSecurity = "required"
+)
+
+type authSurfaceVerdict string
+
+const (
+	authSurfaceVerdictAgree     authSurfaceVerdict = "agree"
+	authSurfaceVerdictOverMark  authSurfaceVerdict = "overMark"
+	authSurfaceVerdictUnderMark authSurfaceVerdict = "underMark"
+	authSurfaceVerdictFailOpen  authSurfaceVerdict = "failOpen"
+	authSurfaceVerdictDocDrift  authSurfaceVerdict = "docDrift"
+)
+
+type authSurfaceRoute struct {
+	Method string
+	Path   string
+	Lambda string
+	Guard  authSurfaceGuard
+	Source string
+}
+
+type authSurfaceSnapshotEntry struct {
+	Method          string              `json:"method"`
+	Path            string              `json:"path"`
+	RuntimePosture  authSurfacePosture  `json:"runtimePosture"`
+	OpenAPISecurity authSurfaceSecurity `json:"openapiSecurity"`
+	Verdict         authSurfaceVerdict  `json:"verdict"`
+}
+
+type authSurfaceException struct {
+	Method  string             `json:"method"`
+	Path    string             `json:"path"`
+	Verdict authSurfaceVerdict `json:"verdict"`
+	Owner   string             `json:"owner"`
+	Expiry  string             `json:"expiry"`
+	Note    string             `json:"note"`
+}
+
+type authSurfaceOpenAPIDoc struct {
+	Paths map[string]map[string]authSurfaceOpenAPIOperation `yaml:"paths"`
+}
+
+type authSurfaceOpenAPIOperation struct {
+	Security     []map[string][]string `yaml:"security"`
+	LesserLambda string                `yaml:"x-lesser-lambda"`
+}
+
+func TestAuthSurfaceReconciliationGolden(t *testing.T) {
+	repoRoot := authSurfaceRepoRoot(t)
+	actual := authSurfaceClassifyCurrent(t, repoRoot)
+
+	if *updateAuthSurfaceGolden {
+		writeAuthSurfaceGolden(t, filepath.Join(repoRoot, authSurfaceGoldenRelPath), actual)
+		return
+	}
+
+	golden := readAuthSurfaceGolden(t, filepath.Join(repoRoot, authSurfaceGoldenRelPath))
+	if failures := compareAuthSurfaceSnapshots(golden, actual); len(failures) > 0 {
+		t.Fatalf("auth surface golden drift:\n%s", strings.Join(failures, "\n"))
+	}
+
+	exceptions := readAuthSurfaceExceptions(t, filepath.Join(repoRoot, authSurfaceExceptionsRelPath))
+	if failures := validateAuthSurfaceExceptions(actual, exceptions); len(failures) > 0 {
+		t.Fatalf("auth surface exception drift:\n%s", strings.Join(failures, "\n"))
+	}
+
+	t.Logf("auth surface verdict counts: %s", formatAuthSurfaceCounts(actual, exceptions))
+}
+
+func TestAuthSurfaceReconcilerDetectsSyntheticDrift(t *testing.T) {
+	golden := []authSurfaceSnapshotEntry{{
+		Method:          http.MethodGet,
+		Path:            "/synthetic/drift",
+		RuntimePosture:  authSurfacePostureAnonymous,
+		OpenAPISecurity: authSurfaceSecurityPublic,
+		Verdict:         authSurfaceVerdictAgree,
+	}}
+	flipped := []authSurfaceSnapshotEntry{{
+		Method:          http.MethodGet,
+		Path:            "/synthetic/drift",
+		RuntimePosture:  authSurfacePostureAuthRequired,
+		OpenAPISecurity: authSurfaceSecurityPublic,
+		Verdict:         authSurfaceVerdictUnderMark,
+	}}
+
+	failures := compareAuthSurfaceSnapshots(golden, flipped)
+	if len(failures) == 0 {
+		t.Fatal("synthetic auth-surface drift was not detected")
+	}
+}
+
+func authSurfaceClassifyCurrent(t *testing.T, repoRoot string) []authSurfaceSnapshotEntry {
+	t.Helper()
+
+	routes := enumerateAuthSurfaceRoutes(t, repoRoot)
+	operations := readAuthSurfaceOpenAPIOperations(t, repoRoot)
+
+	snapshots := make([]authSurfaceSnapshotEntry, 0, len(routes))
+	for _, route := range routes {
+		operation := operations[authSurfaceRouteKey(route.Method, route.Path)]
+		if operation.LesserLambda != "" && operation.LesserLambda != route.Lambda {
+			t.Fatalf(
+				"OpenAPI x-lesser-lambda mismatch for %s: route=%s openapi=%s",
+				authSurfaceRouteKey(route.Method, route.Path),
+				route.Lambda,
+				operation.LesserLambda,
+			)
+		}
+		runtimePosture := runtimeEffectiveAuthSurfacePosture(route)
+		openAPISecurity := authSurfaceOpenAPISecurity(operation)
+		verdict := classifyAuthSurfaceVerdict(route, runtimePosture, openAPISecurity)
+		snapshots = append(snapshots, authSurfaceSnapshotEntry{
+			Method:          route.Method,
+			Path:            route.Path,
+			RuntimePosture:  runtimePosture,
+			OpenAPISecurity: openAPISecurity,
+			Verdict:         verdict,
+		})
+	}
+
+	sortAuthSurfaceSnapshots(snapshots)
+	return snapshots
+}
+
+func enumerateAuthSurfaceRoutes(t *testing.T, repoRoot string) []authSurfaceRoute {
+	t.Helper()
+
+	routes := make([]authSurfaceRoute, 0, 340)
+	routes = append(routes, parseAuthSurfaceAppRoutes(t, repoRoot, "cmd/api/routes.go", "api")...)
+	routes = append(routes, parseAuthSurfaceAppRoutes(t, repoRoot, "cmd/api/main.go", "api")...)
+	routes = append(routes, parseAuthSurfaceAppRoutes(t, repoRoot, "cmd/sse/main.go", "sse")...)
+	routes = append(routes, parseWebFingerInventoryRoutes(t, repoRoot)...)
+
+	seen := map[string]authSurfaceRoute{}
+	for _, route := range routes {
+		key := authSurfaceRouteKey(route.Method, route.Path)
+		if previous, ok := seen[key]; ok {
+			t.Fatalf("duplicate auth-surface route %s from %s and %s", key, previous.Source, route.Source)
+		}
+		seen[key] = route
+	}
+
+	sort.Slice(routes, func(i, j int) bool {
+		if routes[i].Path == routes[j].Path {
+			return routes[i].Method < routes[j].Method
+		}
+		return routes[i].Path < routes[j].Path
+	})
+	return routes
+}
+
+func parseAuthSurfaceAppRoutes(t *testing.T, repoRoot, relPath, lambda string) []authSurfaceRoute {
+	t.Helper()
+
+	absPath := filepath.Join(repoRoot, filepath.FromSlash(relPath))
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, absPath, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", relPath, err)
+	}
+
+	var routes []authSurfaceRoute
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		route, ok := authSurfaceRouteFromCall(call, lambda, relPath)
+		if ok {
+			routes = append(routes, route)
+		}
+		return true
+	})
+	return routes
+}
+
+func authSurfaceRouteFromCall(call *ast.CallExpr, lambda, source string) (authSurfaceRoute, bool) {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || selector.Sel == nil {
+		return authSurfaceRoute{}, false
+	}
+	receiver, ok := selector.X.(*ast.Ident)
+	if !ok || receiver.Name != "app" {
+		return authSurfaceRoute{}, false
+	}
+
+	if selector.Sel.Name == "Handle" {
+		return authSurfaceRouteFromHandleArgs(call.Args, lambda, source)
+	}
+
+	method := strings.ToUpper(selector.Sel.Name)
+	switch method {
+	case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, http.MethodHead:
+		return authSurfaceRouteFromArgs(method, call.Args, 1, lambda, source)
+	default:
+		return authSurfaceRoute{}, false
+	}
+}
+
+func authSurfaceRouteFromHandleArgs(args []ast.Expr, lambda, source string) (authSurfaceRoute, bool) {
+	if len(args) < 3 {
+		return authSurfaceRoute{}, false
+	}
+	method, ok := authSurfaceStringLiteral(args[0])
+	if !ok {
+		return authSurfaceRoute{}, false
+	}
+	return authSurfaceRouteFromArgs(strings.ToUpper(method), args[1:], 1, lambda, source)
+}
+
+func authSurfaceRouteFromArgs(
+	method string,
+	args []ast.Expr,
+	handlerIndex int,
+	lambda string,
+	source string,
+) (authSurfaceRoute, bool) {
+	if len(args) <= handlerIndex {
+		return authSurfaceRoute{}, false
+	}
+	path, ok := authSurfaceStringLiteral(args[0])
+	if !ok {
+		return authSurfaceRoute{}, false
+	}
+	return authSurfaceRoute{
+		Method: method,
+		Path:   path,
+		Lambda: lambda,
+		Guard:  inferAuthSurfaceGuard(args[handlerIndex:]),
+		Source: source,
+	}, true
+}
+
+func parseWebFingerInventoryRoutes(t *testing.T, repoRoot string) []authSurfaceRoute {
+	t.Helper()
+
+	const relPath = "cmd/webfinger/main.go"
+	absPath := filepath.Join(repoRoot, filepath.FromSlash(relPath))
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, absPath, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", relPath, err)
+	}
+
+	var routes []authSurfaceRoute
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name == nil || fn.Name.Name != "webfingerRouteInventory" || fn.Body == nil {
+			continue
+		}
+		ast.Inspect(fn.Body, func(node ast.Node) bool {
+			literal, ok := node.(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			method, path, ok := authSurfaceWebFingerInventoryEntry(literal)
+			if ok {
+				routes = append(routes, authSurfaceRoute{
+					Method: method,
+					Path:   path,
+					Lambda: "webfinger",
+					Guard:  authSurfaceGuardNone,
+					Source: relPath,
+				})
+			}
+			return true
+		})
+	}
+
+	if len(routes) == 0 {
+		t.Fatalf("no webfinger inventory routes found in %s", relPath)
+	}
+	return routes
+}
+
+func authSurfaceWebFingerInventoryEntry(literal *ast.CompositeLit) (string, string, bool) {
+	var method, path string
+	for _, elt := range literal.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		switch key.Name {
+		case "Method":
+			method = authSurfaceHTTPMethodExpr(kv.Value)
+		case "Path":
+			path, _ = authSurfaceStringLiteral(kv.Value)
+		}
+	}
+	if method == "" || path == "" {
+		return "", "", false
+	}
+	return method, path, true
+}
+
+func authSurfaceHTTPMethodExpr(expr ast.Expr) string {
+	if value, ok := authSurfaceStringLiteral(expr); ok {
+		return strings.ToUpper(value)
+	}
+	selector, ok := expr.(*ast.SelectorExpr)
+	if !ok || selector.Sel == nil {
+		return ""
+	}
+	receiver, ok := selector.X.(*ast.Ident)
+	if !ok || receiver.Name != "http" {
+		return ""
+	}
+	switch selector.Sel.Name {
+	case "MethodGet":
+		return http.MethodGet
+	case "MethodPost":
+		return http.MethodPost
+	case "MethodPut":
+		return http.MethodPut
+	case "MethodPatch":
+		return http.MethodPatch
+	case "MethodDelete":
+		return http.MethodDelete
+	case "MethodHead":
+		return http.MethodHead
+	default:
+		return ""
+	}
+}
+
+func inferAuthSurfaceGuard(args []ast.Expr) authSurfaceGuard {
+	guard := authSurfaceGuardNone
+	for _, arg := range args {
+		if candidate := inferAuthSurfaceGuardExpr(arg); authSurfaceGuardPriority(candidate) > authSurfaceGuardPriority(guard) {
+			guard = candidate
+		}
+	}
+	return guard
+}
+
+func inferAuthSurfaceGuardExpr(expr ast.Expr) authSurfaceGuard {
+	switch value := expr.(type) {
+	case *ast.Ident:
+		return authSurfaceGuardToken(value.Name)
+	case *ast.SelectorExpr:
+		if value.Sel == nil {
+			return authSurfaceGuardNone
+		}
+		return authSurfaceGuardToken(value.Sel.Name)
+	case *ast.CallExpr:
+		guard := inferAuthSurfaceGuardExpr(value.Fun)
+		for _, arg := range value.Args {
+			candidate := inferAuthSurfaceGuardExpr(arg)
+			if authSurfaceGuardPriority(candidate) > authSurfaceGuardPriority(guard) {
+				guard = candidate
+			}
+		}
+		return guard
+	default:
+		return authSurfaceGuardNone
+	}
+}
+
+func authSurfaceGuardToken(name string) authSurfaceGuard {
+	switch {
+	case name == "optionalAuth" || name == "OptionalAuth":
+		return authSurfaceGuardOptional
+	case strings.HasPrefix(name, "require") || strings.HasPrefix(name, "Require"):
+		return authSurfaceGuardRequired
+	default:
+		return authSurfaceGuardNone
+	}
+}
+
+func authSurfaceGuardPriority(guard authSurfaceGuard) int {
+	switch guard {
+	case authSurfaceGuardRequired:
+		return 2
+	case authSurfaceGuardOptional:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func authSurfaceStringLiteral(expr ast.Expr) (string, bool) {
+	literal, ok := expr.(*ast.BasicLit)
+	if !ok || literal.Kind != token.STRING {
+		return "", false
+	}
+	value, err := strconv.Unquote(literal.Value)
+	if err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func readAuthSurfaceOpenAPIOperations(
+	t *testing.T,
+	repoRoot string,
+) map[string]authSurfaceOpenAPIOperation {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(repoRoot, "docs/contracts/openapi.yaml")) // #nosec G304 -- repo testdata.
+	if err != nil {
+		t.Fatalf("read openapi: %v", err)
+	}
+	var doc authSurfaceOpenAPIDoc
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse openapi: %v", err)
+	}
+
+	operations := map[string]authSurfaceOpenAPIOperation{}
+	for path, item := range doc.Paths {
+		for method, operation := range item {
+			upperMethod := strings.ToUpper(method)
+			switch upperMethod {
+			case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, http.MethodHead:
+				operations[authSurfaceRouteKey(upperMethod, path)] = operation
+			}
+		}
+	}
+	return operations
+}
+
+func runtimeEffectiveAuthSurfacePosture(route authSurfaceRoute) authSurfacePosture {
+	switch route.Lambda {
+	case "api":
+		if apiRequestIsPublic(route.Method, route.Path) && route.Guard != authSurfaceGuardRequired {
+			return authSurfacePostureAnonymous
+		}
+		return authSurfacePostureAuthRequired
+	case "sse":
+		if route.Path == "/api/v1/streaming" || route.Path == "/api/v1/streaming/health" {
+			return authSurfacePostureAnonymous
+		}
+		return authSurfacePostureAuthRequired
+	case "webfinger":
+		return authSurfacePostureAnonymous
+	default:
+		return authSurfacePostureAuthRequired
+	}
+}
+
+func authSurfaceOpenAPISecurity(operation authSurfaceOpenAPIOperation) authSurfaceSecurity {
+	if len(operation.Security) == 0 {
+		return authSurfaceSecurityPublic
+	}
+
+	hasAnonymousAlternative := false
+	hasBearerAlternative := false
+	for _, alternative := range operation.Security {
+		if len(alternative) == 0 {
+			hasAnonymousAlternative = true
+			continue
+		}
+		if _, ok := alternative["bearerAuth"]; ok {
+			hasBearerAlternative = true
+		}
+		if _, ok := alternative["setupBearer"]; ok {
+			hasBearerAlternative = true
+		}
+	}
+
+	if hasAnonymousAlternative && hasBearerAlternative {
+		return authSurfaceSecurityOptional
+	}
+	if hasBearerAlternative {
+		return authSurfaceSecurityRequired
+	}
+	if hasAnonymousAlternative {
+		return authSurfaceSecurityPublic
+	}
+	return authSurfaceSecurityRequired
+}
+
+func classifyAuthSurfaceVerdict(
+	route authSurfaceRoute,
+	runtimePosture authSurfacePosture,
+	openAPISecurity authSurfaceSecurity,
+) authSurfaceVerdict {
+	if runtimePosture == authSurfacePostureAnonymous && isAuthSurfaceUnexpectedPublicMutation(route) {
+		return authSurfaceVerdictFailOpen
+	}
+	if runtimePosture == authSurfacePostureAnonymous && openAPISecurity == authSurfaceSecurityRequired {
+		return authSurfaceVerdictOverMark
+	}
+	if runtimePosture == authSurfacePostureAuthRequired && openAPISecurity != authSurfaceSecurityRequired {
+		return authSurfaceVerdictUnderMark
+	}
+	return authSurfaceVerdictAgree
+}
+
+func isAuthSurfaceUnexpectedPublicMutation(route authSurfaceRoute) bool {
+	if route.Method == http.MethodGet || route.Method == http.MethodHead {
+		return false
+	}
+	return !authSurfaceExpectedPublicMutations[authSurfaceRouteKey(route.Method, route.Path)]
+}
+
+var authSurfaceExpectedPublicMutations = map[string]bool{
+	"POST /api/v1/accounts":                   true,
+	"POST /api/v1/apps":                       true,
+	"POST /api/v1/auth/webauthn/login/begin":  true,
+	"POST /api/v1/auth/webauthn/login/finish": true,
+	"POST /api/v1/search/statuses":            true,
+	"POST /auth/wallet/challenge":             true,
+	"POST /auth/wallet/link":                  true,
+	"POST /auth/wallet/login":                 true,
+	"POST /auth/wallet/verify":                true,
+	"POST /oauth/consent":                     true,
+	"POST /oauth/device/code":                 true,
+	"POST /oauth/device/consent":              true,
+	"POST /oauth/device/verify":               true,
+	"POST /oauth/register":                    true,
+	"POST /oauth/revoke":                      true,
+	"POST /oauth/token":                       true,
+	"POST /setup/admin":                       true,
+	"POST /setup/bootstrap/challenge":         true,
+	"POST /setup/bootstrap/verify":            true,
+	"POST /setup/finalize":                    true,
+}
+
+func compareAuthSurfaceSnapshots(
+	golden []authSurfaceSnapshotEntry,
+	actual []authSurfaceSnapshotEntry,
+) []string {
+	goldenByRoute := authSurfaceSnapshotMap(golden)
+	actualByRoute := authSurfaceSnapshotMap(actual)
+
+	var failures []string
+	for key, actualEntry := range actualByRoute {
+		goldenEntry, ok := goldenByRoute[key]
+		if !ok {
+			failures = append(failures, fmt.Sprintf("new route %s appears outside the golden snapshot", key))
+			continue
+		}
+		if actualEntry.RuntimePosture != goldenEntry.RuntimePosture ||
+			actualEntry.OpenAPISecurity != goldenEntry.OpenAPISecurity ||
+			actualEntry.Verdict != goldenEntry.Verdict {
+			failures = append(failures, fmt.Sprintf(
+				"%s changed: golden runtime=%s openapi=%s verdict=%s; actual runtime=%s openapi=%s verdict=%s",
+				key,
+				goldenEntry.RuntimePosture,
+				goldenEntry.OpenAPISecurity,
+				goldenEntry.Verdict,
+				actualEntry.RuntimePosture,
+				actualEntry.OpenAPISecurity,
+				actualEntry.Verdict,
+			))
+		}
+	}
+	for key := range goldenByRoute {
+		if _, ok := actualByRoute[key]; !ok {
+			failures = append(failures, fmt.Sprintf("golden route %s is no longer registered", key))
+		}
+	}
+	sort.Strings(failures)
+	return failures
+}
+
+func validateAuthSurfaceExceptions(
+	actual []authSurfaceSnapshotEntry,
+	exceptions []authSurfaceException,
+) []string {
+	actualByRoute := authSurfaceSnapshotMap(actual)
+	exceptionsByRoute := map[string]authSurfaceException{}
+	docDriftCount := 0
+	var failures []string
+
+	for _, exception := range exceptions {
+		if exception.Verdict == authSurfaceVerdictDocDrift {
+			docDriftCount++
+			continue
+		}
+		key := authSurfaceRouteKey(exception.Method, exception.Path)
+		if _, ok := exceptionsByRoute[key]; ok {
+			failures = append(failures, fmt.Sprintf("duplicate exception for %s", key))
+			continue
+		}
+		exceptionsByRoute[key] = exception
+		actualEntry, ok := actualByRoute[key]
+		if !ok {
+			failures = append(failures, fmt.Sprintf("exception %s no longer matches a registered route", key))
+			continue
+		}
+		if actualEntry.Verdict != exception.Verdict {
+			failures = append(failures, fmt.Sprintf(
+				"exception %s expected verdict %s, actual %s",
+				key,
+				exception.Verdict,
+				actualEntry.Verdict,
+			))
+		}
+	}
+
+	for _, actualEntry := range actual {
+		if actualEntry.Verdict == authSurfaceVerdictAgree {
+			continue
+		}
+		key := authSurfaceRouteKey(actualEntry.Method, actualEntry.Path)
+		if _, ok := exceptionsByRoute[key]; !ok {
+			failures = append(failures, fmt.Sprintf("non-agree route %s lacks an exception", key))
+		}
+	}
+	if docDriftCount != 6 {
+		failures = append(failures, fmt.Sprintf("expected 6 informational docDrift exceptions, got %d", docDriftCount))
+	}
+	sort.Strings(failures)
+	return failures
+}
+
+func authSurfaceSnapshotMap(entries []authSurfaceSnapshotEntry) map[string]authSurfaceSnapshotEntry {
+	out := make(map[string]authSurfaceSnapshotEntry, len(entries))
+	for _, entry := range entries {
+		out[authSurfaceRouteKey(entry.Method, entry.Path)] = entry
+	}
+	return out
+}
+
+func readAuthSurfaceGolden(t *testing.T, path string) []authSurfaceSnapshotEntry {
+	t.Helper()
+	var entries []authSurfaceSnapshotEntry
+	readAuthSurfaceJSON(t, path, &entries)
+	return entries
+}
+
+func readAuthSurfaceExceptions(t *testing.T, path string) []authSurfaceException {
+	t.Helper()
+	var entries []authSurfaceException
+	readAuthSurfaceJSON(t, path, &entries)
+	return entries
+}
+
+func readAuthSurfaceJSON(t *testing.T, path string, target any) {
+	t.Helper()
+	file, err := os.Open(path) // #nosec G304 -- repo testdata.
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			t.Fatalf("close %s: %v", path, closeErr)
+		}
+	}()
+
+	decoder := json.NewDecoder(file)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		t.Fatalf("decode %s: trailing JSON content", path)
+	}
+}
+
+func writeAuthSurfaceGolden(t *testing.T, path string, entries []authSurfaceSnapshotEntry) {
+	t.Helper()
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal golden: %v", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil { // #nosec G306 -- repo testdata.
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func formatAuthSurfaceCounts(entries []authSurfaceSnapshotEntry, exceptions []authSurfaceException) string {
+	counts := map[authSurfaceVerdict]int{}
+	for _, entry := range entries {
+		counts[entry.Verdict]++
+	}
+	for _, exception := range exceptions {
+		if exception.Verdict == authSurfaceVerdictDocDrift {
+			counts[authSurfaceVerdictDocDrift]++
+		}
+	}
+	return fmt.Sprintf(
+		"totalRoutes=%d agree=%d overMark=%d underMark=%d failOpen=%d docDrift=%d",
+		len(entries),
+		counts[authSurfaceVerdictAgree],
+		counts[authSurfaceVerdictOverMark],
+		counts[authSurfaceVerdictUnderMark],
+		counts[authSurfaceVerdictFailOpen],
+		counts[authSurfaceVerdictDocDrift],
+	)
+}
+
+func sortAuthSurfaceSnapshots(entries []authSurfaceSnapshotEntry) {
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Path == entries[j].Path {
+			return entries[i].Method < entries[j].Method
+		}
+		return entries[i].Path < entries[j].Path
+	})
+}
+
+func authSurfaceRouteKey(method, path string) string {
+	return strings.ToUpper(strings.TrimSpace(method)) + " " + strings.TrimSpace(path)
+}
+
+func authSurfaceRepoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			if _, err := os.Stat(filepath.Join(dir, "cmd/api/routes.go")); err == nil {
+				return dir
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("unable to locate repo root")
+		}
+		dir = parent
+	}
+}

--- a/cmd/api/testdata/auth_surface_exceptions.json
+++ b/cmd/api/testdata/auth_surface_exceptions.json
@@ -1,0 +1,306 @@
+[
+  {
+    "method": "GET",
+    "path": "/api/v1/accounts/search",
+    "verdict": "overMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI marks bearer required, but runtime gate allows anonymous optional-auth account search; current-main discrepancy from brief baseline."
+  },
+  {
+    "method": "POST",
+    "path": "/setup/admin",
+    "verdict": "overMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "Allowlist-public setup POST has no route guard while OpenAPI requires setupBearer; handler-defended bootstrap flow; fail-closed verification deferred to P1/P2."
+  },
+  {
+    "method": "POST",
+    "path": "/setup/finalize",
+    "verdict": "overMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "Allowlist-public setup POST has no route guard while OpenAPI requires bearerAuth; handler-defended bootstrap flow; fail-closed verification deferred to P1/P2."
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/accounts/{id}/quote_permissions",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/agents",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/auth/challenge",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/auth/token",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/register",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/register/challenge",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/agents/{username}",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/{username}/access-leases/{leaseID}/renew/challenge",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/{username}/access-leases/{leaseID}/session-key",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/{username}/access-leases/{leaseID}/session-key/challenge",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/{username}/access-leases/{leaseID}/token",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/announcements",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/custom_emojis",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/directory",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/skills",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/skills/catalog",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/skills/{skillId}",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/skills/{skillId}/revisions",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/skills/{skillId}/revisions/{revisionNumber}",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/skills/{skillId}/revisions/{revisionNumber}/bundle",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/vouches/{actor_id}",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "GET",
+    "path": "/auth/device",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "GET",
+    "path": "/health",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "GET",
+    "path": "/health/detailed",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "GET",
+    "path": "/health/live",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "GET",
+    "path": "/health/ready",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "POST",
+    "path": "/oauth/device/code",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "POST",
+    "path": "/oauth/device/verify",
+    "verdict": "underMark",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "OpenAPI advertises public/optional, but apiRequestIsPublic default-deny gate denies anonymous requests before the guardless/optional route can serve them."
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/notifications/deliver",
+    "verdict": "failOpen",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1",
+    "note": "handler-defended; gate-level backstop deferred to P1. Handler enforces instance API-key bearer and returns 503 if no keys are configured."
+  },
+  {
+    "method": "DOC",
+    "path": "docs/security-public-surface.md#accounts-search-shadow",
+    "verdict": "docDrift",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1/P2",
+    "note": "Brief baseline records accounts/search allowlist prose/code drift; current main resolves this as route-level GET /api/v1/accounts/search overMark rather than suggestions underMark."
+  },
+  {
+    "method": "DOC",
+    "path": "cmd/api/public_surface_middleware.go#search-statuses-duplicate",
+    "verdict": "docDrift",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1/P2",
+    "note": "/api/v1/search/statuses is public-surface duplicated by GET prefix and POST exact allowlist while routes require read scope."
+  },
+  {
+    "method": "DOC",
+    "path": "cmd/api/routes.go#admin-requireauth-rbac",
+    "verdict": "docDrift",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1/P2",
+    "note": "Admin routes use bare requireAuth at the route layer while RBAC is enforced in-handler by requireAdminLift; SSOT manifest should make this explicit."
+  },
+  {
+    "method": "DOC",
+    "path": "docs/security-public-surface.md#three-source-public-split",
+    "verdict": "docDrift",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1/P2",
+    "note": "Public posture is split across generator inference, apiRequestIsPublic, and prose docs instead of one manifest."
+  },
+  {
+    "method": "DOC",
+    "path": "cmd/api/health.go#dead-register-health-routes",
+    "verdict": "docDrift",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1/P2",
+    "note": "health.go RegisterHealthRoutes is not wired; cmd/api/main.go configureHealthRoutes registers the live health endpoints."
+  },
+  {
+    "method": "DOC",
+    "path": "docs/security-public-surface.md#trust-proxy-hand-maintained",
+    "verdict": "docDrift",
+    "owner": "lesser-auth-surface-ssot",
+    "expiry": "resolves-in-P1/P2",
+    "note": "lesser.host trust proxy public surface is agreed only by hand-maintained mechanisms; latent drift risk until manifest SSOT."
+  }
+]

--- a/cmd/api/testdata/auth_surface_golden.json
+++ b/cmd/api/testdata/auth_surface_golden.json
@@ -1,0 +1,2298 @@
+[
+  {
+    "method": "GET",
+    "path": "/",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "HEAD",
+    "path": "/",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/.well-known/lesser-soul-agent",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/.well-known/nodeinfo",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/.well-known/oauth-authorization-server",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/.well-known/reputation-keys",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/.well-known/webfinger",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/oembed",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/accounts",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/accounts/quote_permissions",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/accounts/relationships",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/accounts/search",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "required",
+    "verdict": "overMark"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/accounts/search/suggestions",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "PATCH",
+    "path": "/api/v1/accounts/update_credentials",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/accounts/verify_credentials",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/accounts/{id}/block",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/accounts/{id}/follow",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/accounts/{id}/followers",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/accounts/{id}/following",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/accounts/{id}/mute",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/accounts/{id}/notes",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/accounts/{id}/quote_permissions",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "public",
+    "verdict": "underMark"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/accounts/{id}/statuses",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "optional",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/accounts/{id}/unblock",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/accounts/{id}/unfollow",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/accounts/{id}/unmute",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/admin/accounts",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/accounts",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/admin/accounts/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/accounts/{id}/action",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/accounts/{id}/approve",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/accounts/{id}/enable",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/accounts/{id}/reject",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/accounts/{id}/unsensitive",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/accounts/{id}/unsilence",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/accounts/{id}/unsuspend",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/admin/agents/policy",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/admin/agents/policy",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/agents/{username}/unlock",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/agents/{username}/unverify",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/agents/{username}/verify",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/announcements",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/custom_emojis",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/admin/custom_emojis/{shortcode}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/admin/custom_emojis/{shortcode}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/admin/domain_allows",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/domain_allows",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/admin/domain_allows/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/admin/domain_blocks",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/domain_blocks",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/admin/domain_blocks/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/admin/domain_blocks/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/admin/domain_blocks/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/admin/email_domain_blocks",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/email_domain_blocks",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/admin/email_domain_blocks/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/admin/federation/instance/{domain}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/admin/federation/instances",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/admin/federation/statistics",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/admin/moderation/events",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/moderation/events/{id}/override",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/admin/moderation/overview",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/admin/moderation/reviewers",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/moderation/reviewers/{id}/demote",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/moderation/reviewers/{id}/promote",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/admin/moderation/trust/graph",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/admin/moderation/trust/{from}/{to}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/admin/reports",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/admin/reports/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/reports/{id}/assign_to_self",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/reports/{id}/reopen",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/reports/{id}/resolve",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/reports/{id}/unassign",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/admin/skills/proposals",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/admin/skills/proposals/{proposalId}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/admin/skills/{skillId}/assignments",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/skills/{skillId}/assignments",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/skills/{skillId}/assignments/{assignmentId}/revoke",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/skills/{skillId}/proposals/{proposalId}/promote",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/skills/{skillId}/revisions/{revisionNumber}/approve",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/skills/{skillId}/revisions/{revisionNumber}/revoke",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/admin/soul/well-known",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/admin/statuses",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/admin/statuses/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/admin/statuses/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/statuses/{id}/sensitive",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/admin/statuses/{id}/unsensitive",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/agents",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "public",
+    "verdict": "underMark"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/auth/challenge",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "public",
+    "verdict": "underMark"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/auth/token",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "public",
+    "verdict": "underMark"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/delegate",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/agents/memory/search",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/memory/search",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/register",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "public",
+    "verdict": "underMark"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/register/challenge",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "public",
+    "verdict": "underMark"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/agents/{username}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/agents/{username}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "public",
+    "verdict": "underMark"
+  },
+  {
+    "method": "PATCH",
+    "path": "/api/v1/agents/{username}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/agents/{username}/access-leases",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/{username}/access-leases",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/{username}/access-leases/challenge/agent",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/{username}/access-leases/challenge/principal",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/{username}/access-leases/{leaseID}/renew/challenge",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "public",
+    "verdict": "underMark"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/{username}/access-leases/{leaseID}/revoke",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/{username}/access-leases/{leaseID}/session-key",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "public",
+    "verdict": "underMark"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/{username}/access-leases/{leaseID}/session-key/challenge",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "public",
+    "verdict": "underMark"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/{username}/access-leases/{leaseID}/token",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "public",
+    "verdict": "underMark"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/agents/{username}/activity",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/{username}/rotate-key",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/{username}/rotate-key/challenge",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/agents/{username}/runtime-sessions",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/{username}/runtime-sessions/{sessionID}/revoke",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/agents/{username}/suspend",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/announcements",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "optional",
+    "verdict": "underMark"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/announcements/{id}/dismiss",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/announcements/{id}/reactions/{name}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/announcements/{id}/reactions/{name}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/apps",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/apps/{id}/rotate_secret",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/auth/webauthn/credentials",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/auth/webauthn/credentials/{credentialId}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/auth/webauthn/credentials/{credentialId}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/auth/webauthn/login/begin",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/auth/webauthn/login/finish",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/auth/webauthn/register/begin",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/auth/webauthn/register/finish",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/blocks",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/bookmarks",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/conversations",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/conversations/lookup",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/conversations/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/conversations/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/conversations/{id}/read",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/custom_emojis",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "public",
+    "verdict": "underMark"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/directory",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "public",
+    "verdict": "underMark"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/domain_blocks",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/domain_blocks",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/domain_blocks",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/endorsements",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/exports",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/exports",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/exports/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/exports/{id}/download",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/favourites",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/follow_requests",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/follow_requests/{account_id}/authorize",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/follow_requests/{account_id}/reject",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/imports",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/imports",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/imports/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/imports/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/instance",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/instance/activity",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/instance/domain_blocks",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/instance/metrics/daily",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/instance/peers",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/instance/translation_languages",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/lists",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/lists",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/lists/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/lists/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/lists/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/lists/{id}/accounts",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/lists/{id}/accounts",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/lists/{id}/accounts",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/markers",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/markers",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/media",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/media/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/media/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/moderation/consensus/{event_id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/moderation/flag",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/moderation/history/{object_id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/moderation/queue",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/moderation/review",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/moderation/trust",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/moderation/trust",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/moderation/trust/{actor_id}/score",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/mutes",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/notes",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/notes/{id}/vote",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/notes/{object_id}",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "optional",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/notifications",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/notifications/clear",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/notifications/deliver",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "failOpen"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/notifications/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/notifications/{id}/dismiss",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/preferences",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "PATCH",
+    "path": "/api/v1/preferences",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/push/subscription",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/push/subscription",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/push/subscription",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/push/subscription",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/reports",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/reputation/export",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/reputation/import",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/reputation/verify",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/reputation/{actor_id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/scheduled_statuses",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/scheduled_statuses/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/scheduled_statuses/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/scheduled_statuses/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/search/statuses",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/search/statuses",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/skills",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "optional",
+    "verdict": "underMark"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/skills/catalog",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "optional",
+    "verdict": "underMark"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/skills/resolve",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/skills/{skillId}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "optional",
+    "verdict": "underMark"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/skills/{skillId}/revisions",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "optional",
+    "verdict": "underMark"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/skills/{skillId}/revisions/{revisionNumber}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "optional",
+    "verdict": "underMark"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/skills/{skillId}/revisions/{revisionNumber}/bundle",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "optional",
+    "verdict": "underMark"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/souls/bound/me",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/souls/bound/me/mint-conversations",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/souls/bound/me/mint-conversations/{conversationId}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/souls/mine",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/souls/{agentId}/incorporate",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/statuses",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/statuses/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/statuses/{id}",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "optional",
+    "verdict": "agree"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v1/statuses/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/statuses/{id}/bookmark",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/statuses/{id}/context",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "optional",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/statuses/{id}/favourite",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/statuses/{id}/favourited_by",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/statuses/{id}/history",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "optional",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/statuses/{id}/mute",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/statuses/{id}/pin",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/statuses/{id}/quote",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/statuses/{id}/quote/{quote_id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/statuses/{id}/quotes",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/statuses/{id}/reblog",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/statuses/{id}/reblogged_by",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/statuses/{id}/source",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/statuses/{id}/translate",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/statuses/{id}/unbookmark",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/statuses/{id}/unfavourite",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/statuses/{id}/unmute",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/statuses/{id}/unpin",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/statuses/{id}/unreblog",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/streaming",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/streaming/direct",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/streaming/hashtag",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/streaming/hashtag/local",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/streaming/health",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/streaming/list",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/streaming/oauth/device",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/streaming/public",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/streaming/public/local",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/streaming/public/remote",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/streaming/user",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/streaming/user/notification",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/suggestions",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/suggestions/{account_id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/timelines/direct",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/timelines/home",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/timelines/link",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/timelines/list/{list_id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/timelines/public",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "optional",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/timelines/tag/{hashtag}",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "optional",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/trends",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/trends/links",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/trends/statuses",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/trends/tags",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/trust/ai/claims/verify",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/trust/ai/jobs/{jobId}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/trust/attestations",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/trust/attestations/{id}",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/trust/jwks.json",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/trust/previews",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/trust/previews/images/{imageId}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/trust/previews/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/trust/publish/jobs",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/trust/publish/jobs/{jobId}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/trust/renders",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/trust/renders/{renderId}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/trust/renders/{renderId}/snapshot",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/trust/renders/{renderId}/thumbnail",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/vouches",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/vouches/{actor_id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "public",
+    "verdict": "underMark"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v1/vouches/{vouch_id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v2/filters",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v2/filters",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v2/filters/test",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v2/filters/{filter_id}/keywords",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v2/filters/{filter_id}/keywords",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v2/filters/{filter_id}/keywords/{keyword_id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v2/filters/{filter_id}/statuses",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v2/filters/{filter_id}/statuses",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v2/filters/{filter_id}/statuses/{status_id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/v2/filters/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v2/filters/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "PUT",
+    "path": "/api/v2/filters/{id}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v2/instance",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v2/notifications/grouped",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v2/notifications/groups/{group_id}/read",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v2/search",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "optional",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v2/suggestions",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v2/trends",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v2/trends/links",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v2/trends/statuses",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v2/trends/tags",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/auth/device",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "public",
+    "verdict": "underMark"
+  },
+  {
+    "method": "POST",
+    "path": "/auth/wallet/challenge",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/auth/wallet/link",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "optional",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/auth/wallet/list",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/auth/wallet/login",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "DELETE",
+    "path": "/auth/wallet/unlink/{address}",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/auth/wallet/verify",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/embed/{id}",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/health",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "public",
+    "verdict": "underMark"
+  },
+  {
+    "method": "GET",
+    "path": "/health/detailed",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "public",
+    "verdict": "underMark"
+  },
+  {
+    "method": "GET",
+    "path": "/health/live",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "public",
+    "verdict": "underMark"
+  },
+  {
+    "method": "GET",
+    "path": "/health/ready",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "public",
+    "verdict": "underMark"
+  },
+  {
+    "method": "GET",
+    "path": "/nodeinfo/2.0",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/oauth/authorize",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "optional",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/oauth/consent",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/oauth/device/code",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "public",
+    "verdict": "underMark"
+  },
+  {
+    "method": "POST",
+    "path": "/oauth/device/consent",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "required",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/oauth/device/verify",
+    "runtimePosture": "auth-required",
+    "openapiSecurity": "public",
+    "verdict": "underMark"
+  },
+  {
+    "method": "POST",
+    "path": "/oauth/register",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "optional",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/oauth/revoke",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/oauth/token",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "GET",
+    "path": "/robots.txt",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/setup/admin",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "required",
+    "verdict": "overMark"
+  },
+  {
+    "method": "POST",
+    "path": "/setup/bootstrap/challenge",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/setup/bootstrap/verify",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/setup/finalize",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "required",
+    "verdict": "overMark"
+  },
+  {
+    "method": "GET",
+    "path": "/setup/status",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  }
+]


### PR DESCRIPTION
## Summary

Phase 0 read-only reconciliation gate for the auth-surface SSOT initiative.

This PR adds only:
- `cmd/api/auth_surface_reconciliation_test.go`
- `cmd/api/testdata/auth_surface_golden.json`
- `cmd/api/testdata/auth_surface_exceptions.json`

No runtime routes, middleware, handlers, generated OpenAPI contract, workflows, lockfiles, or deployment files are changed.

## What the gate freezes

The test enumerates the registered route surface from source:
- `cmd/api/routes.go` route calls, including `app.Handle("HEAD", ...)`
- `cmd/api/main.go` health route registrations
- `cmd/sse/main.go` SSE route registrations
- `cmd/webfinger/main.go` WebFinger route inventory

It computes the runtime-effective anonymous posture, reads the committed OpenAPI security block for each operation, classifies each route, compares the full result to the golden snapshot, and requires all non-`agree` route verdicts to appear in the exceptions file.

The current branch posture freezes as:
- `totalRoutes=328`
- `agree=296`
- `overMark=3`
- `underMark=28`
- `failOpen=1`
- `docDrift=6` informational exceptions

That differs from the assignment baseline of `totalRoutes=239 agree=207 overMark=2 underMark=29 failOpen=1 docDrift=6`; see Caveat below.

## Known exceptions

The route-level exception set remains 32 total known divergences, with owner/expiry notes for P1/P2 convergence. The net fail-open exception is still:

- `POST /api/v1/notifications/deliver` — handler-defended; gate-level backstop deferred to P1. Handler enforces instance API-key bearer and returns 503 if no keys are configured.

The exceptions file also records 6 informational `docDrift` entries from the brief.

## Caveat: baseline reconciliation discrepancy

Current `origin/main` / `auth-surface-ssot` contains 328 registered routes in the requested source inventory (327 OpenAPI operations for API/SSE/WebFinger plus runtime-only `HEAD /`). That is +89 versus the brief's 239 route baseline.

The route-level divergence count remains 32, but the distribution differs:
- `GET /api/v1/accounts/search` is currently an `overMark` because runtime allows anonymous optional-auth search while OpenAPI marks bearer required.
- `GET /api/v1/accounts/search/suggestions` is currently `agree` because `apiRequestIsPublic` returns true for the `/api/v1/accounts/search` prefix and OpenAPI is public.

So this PR freezes current source truth rather than silently forcing the older 239-route baseline.

## Validation

Passed locally:

```bash
go build ./...
go vet ./cmd/api/...
golangci-lint run --config .golangci.yml --timeout 20m --new-from-rev auth-surface-ssot ./cmd/api/...
golangci-lint run --config .golangci.yml --timeout 20m cmd/api/auth_surface_reconciliation_test.go
go test ./cmd/api -run '^TestAuthSurfaceReconciliationGolden$' -count=1 -v
go test ./cmd/api -run '^TestAuthSurfaceReconcilerDetectsSyntheticDrift$' -count=1 -v
go test ./cmd/api -count=1
go test ./...
```

Note: `golangci-lint run --config .golangci.yml --timeout 20m ./cmd/api/...` reports pre-existing `goconst`/`govet` findings outside this PR; the new-code and touched-file lint runs above are clean.

## Rollout

No deploy needed for Phase 0 beyond normal CI: read-only test + testdata only. P1+ owns runtime/backstop convergence.

## Provenance

Local GPG-signed commit on exact requested branch because the routed lesser_lab commit tool publishes agent-scoped branches, while this assignment required `codex/auth-ssot-p0-reconciliation-gate` targeting `auth-surface-ssot`.

TheoryMCP trailers are included in the commit body.
