### PR TITLE
feat: complete soul bootstrap finalize binding

### DIFF
--- a/docs/contracts/graphql-schema.graphql
+++ b/docs/contracts/graphql-schema.graphql
@@ -4722,10 +4722,26 @@ type SoulBootstrapSigningCheckpoint {
   messageHex: String
   digestHex: String
   canonicalJson: String
+  expectedVersion: Int
+  nextVersion: Int
+  boundaryRequirementsJson: String
+  finalizeRequestTemplateJson: String
+  registrationPreviewJson: String
   hostRequestId: String
   issuedAt: Time
   declaredAt: Time
   completedAt: Time
+}
+
+type SoulBootstrapPublicationEvidence {
+  agentId: ID
+  publishedVersion: Int
+  registrationUri: String
+  registrationS3Key: String
+  versionedRegistrationUri: String
+  versionedRegistrationS3Key: String
+  anchorState: String
+  publishedAt: Time
 }
 
 type SoulBootstrapCorrelationState {
@@ -4758,6 +4774,7 @@ type SoulBootstrapState {
   phase: SoulBootstrapPhase!
   state: String!
   signingCheckpoints: [SoulBootstrapSigningCheckpoint!]!
+  publication: SoulBootstrapPublicationEvidence
   error: SoulBootstrapErrorState
   correlation: SoulBootstrapCorrelationState
   updatedAt: Time

--- a/graph/agents.graphql
+++ b/graph/agents.graphql
@@ -564,10 +564,26 @@ type SoulBootstrapSigningCheckpoint {
   messageHex: String
   digestHex: String
   canonicalJson: String
+  expectedVersion: Int
+  nextVersion: Int
+  boundaryRequirementsJson: String
+  finalizeRequestTemplateJson: String
+  registrationPreviewJson: String
   hostRequestId: String
   issuedAt: Time
   declaredAt: Time
   completedAt: Time
+}
+
+type SoulBootstrapPublicationEvidence {
+  agentId: ID
+  publishedVersion: Int
+  registrationUri: String
+  registrationS3Key: String
+  versionedRegistrationUri: String
+  versionedRegistrationS3Key: String
+  anchorState: String
+  publishedAt: Time
 }
 
 type SoulBootstrapCorrelationState {
@@ -600,6 +616,7 @@ type SoulBootstrapState {
   phase: SoulBootstrapPhase!
   state: String!
   signingCheckpoints: [SoulBootstrapSigningCheckpoint!]!
+  publication: SoulBootstrapPublicationEvidence
   error: SoulBootstrapErrorState
   correlation: SoulBootstrapCorrelationState
   updatedAt: Time

--- a/graph/generated.go
+++ b/graph/generated.go
@@ -2969,22 +2969,38 @@ type ComplexityRoot struct {
 		Executable func(childComplexity int) int
 	}
 
+	SoulBootstrapPublicationEvidence struct {
+		AgentID                    func(childComplexity int) int
+		AnchorState                func(childComplexity int) int
+		PublishedAt                func(childComplexity int) int
+		PublishedVersion           func(childComplexity int) int
+		RegistrationS3Key          func(childComplexity int) int
+		RegistrationURI            func(childComplexity int) int
+		VersionedRegistrationS3Key func(childComplexity int) int
+		VersionedRegistrationURI   func(childComplexity int) int
+	}
+
 	SoulBootstrapSigningCheckpoint struct {
-		CanonicalJSON    func(childComplexity int) int
-		CompletedAt      func(childComplexity int) int
-		DeclaredAt       func(childComplexity int) int
-		DigestHex        func(childComplexity int) int
-		HostRequestID    func(childComplexity int) int
-		IssuedAt         func(childComplexity int) int
-		Message          func(childComplexity int) int
-		MessageEncoding  func(childComplexity int) int
-		MessageHex       func(childComplexity int) int
-		Name             func(childComplexity int) int
-		PrincipalAddress func(childComplexity int) int
-		SignerAddress    func(childComplexity int) int
-		SigningMethod    func(childComplexity int) int
-		Status           func(childComplexity int) int
-		Version          func(childComplexity int) int
+		BoundaryRequirementsJSON    func(childComplexity int) int
+		CanonicalJSON               func(childComplexity int) int
+		CompletedAt                 func(childComplexity int) int
+		DeclaredAt                  func(childComplexity int) int
+		DigestHex                   func(childComplexity int) int
+		ExpectedVersion             func(childComplexity int) int
+		FinalizeRequestTemplateJSON func(childComplexity int) int
+		HostRequestID               func(childComplexity int) int
+		IssuedAt                    func(childComplexity int) int
+		Message                     func(childComplexity int) int
+		MessageEncoding             func(childComplexity int) int
+		MessageHex                  func(childComplexity int) int
+		Name                        func(childComplexity int) int
+		NextVersion                 func(childComplexity int) int
+		PrincipalAddress            func(childComplexity int) int
+		RegistrationPreviewJSON     func(childComplexity int) int
+		SignerAddress               func(childComplexity int) int
+		SigningMethod               func(childComplexity int) int
+		Status                      func(childComplexity int) int
+		Version                     func(childComplexity int) int
 	}
 
 	SoulBootstrapState struct {
@@ -2996,6 +3012,7 @@ type ComplexityRoot struct {
 		HostSoulAgentID    func(childComplexity int) int
 		Phase              func(childComplexity int) int
 		PrincipalAddress   func(childComplexity int) int
+		Publication        func(childComplexity int) int
 		SigningCheckpoints func(childComplexity int) int
 		State              func(childComplexity int) int
 		UpdatedAt          func(childComplexity int) int
@@ -19616,6 +19633,69 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.SoulBootstrapMutationPayload.Executable(childComplexity), true
 
+	case "SoulBootstrapPublicationEvidence.agentId":
+		if e.complexity.SoulBootstrapPublicationEvidence.AgentID == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapPublicationEvidence.AgentID(childComplexity), true
+
+	case "SoulBootstrapPublicationEvidence.anchorState":
+		if e.complexity.SoulBootstrapPublicationEvidence.AnchorState == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapPublicationEvidence.AnchorState(childComplexity), true
+
+	case "SoulBootstrapPublicationEvidence.publishedAt":
+		if e.complexity.SoulBootstrapPublicationEvidence.PublishedAt == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapPublicationEvidence.PublishedAt(childComplexity), true
+
+	case "SoulBootstrapPublicationEvidence.publishedVersion":
+		if e.complexity.SoulBootstrapPublicationEvidence.PublishedVersion == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapPublicationEvidence.PublishedVersion(childComplexity), true
+
+	case "SoulBootstrapPublicationEvidence.registrationS3Key":
+		if e.complexity.SoulBootstrapPublicationEvidence.RegistrationS3Key == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapPublicationEvidence.RegistrationS3Key(childComplexity), true
+
+	case "SoulBootstrapPublicationEvidence.registrationUri":
+		if e.complexity.SoulBootstrapPublicationEvidence.RegistrationURI == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapPublicationEvidence.RegistrationURI(childComplexity), true
+
+	case "SoulBootstrapPublicationEvidence.versionedRegistrationS3Key":
+		if e.complexity.SoulBootstrapPublicationEvidence.VersionedRegistrationS3Key == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapPublicationEvidence.VersionedRegistrationS3Key(childComplexity), true
+
+	case "SoulBootstrapPublicationEvidence.versionedRegistrationUri":
+		if e.complexity.SoulBootstrapPublicationEvidence.VersionedRegistrationURI == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapPublicationEvidence.VersionedRegistrationURI(childComplexity), true
+
+	case "SoulBootstrapSigningCheckpoint.boundaryRequirementsJson":
+		if e.complexity.SoulBootstrapSigningCheckpoint.BoundaryRequirementsJSON == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapSigningCheckpoint.BoundaryRequirementsJSON(childComplexity), true
+
 	case "SoulBootstrapSigningCheckpoint.canonicalJson":
 		if e.complexity.SoulBootstrapSigningCheckpoint.CanonicalJSON == nil {
 			break
@@ -19643,6 +19723,20 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.SoulBootstrapSigningCheckpoint.DigestHex(childComplexity), true
+
+	case "SoulBootstrapSigningCheckpoint.expectedVersion":
+		if e.complexity.SoulBootstrapSigningCheckpoint.ExpectedVersion == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapSigningCheckpoint.ExpectedVersion(childComplexity), true
+
+	case "SoulBootstrapSigningCheckpoint.finalizeRequestTemplateJson":
+		if e.complexity.SoulBootstrapSigningCheckpoint.FinalizeRequestTemplateJSON == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapSigningCheckpoint.FinalizeRequestTemplateJSON(childComplexity), true
 
 	case "SoulBootstrapSigningCheckpoint.hostRequestId":
 		if e.complexity.SoulBootstrapSigningCheckpoint.HostRequestID == nil {
@@ -19686,12 +19780,26 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.SoulBootstrapSigningCheckpoint.Name(childComplexity), true
 
+	case "SoulBootstrapSigningCheckpoint.nextVersion":
+		if e.complexity.SoulBootstrapSigningCheckpoint.NextVersion == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapSigningCheckpoint.NextVersion(childComplexity), true
+
 	case "SoulBootstrapSigningCheckpoint.principalAddress":
 		if e.complexity.SoulBootstrapSigningCheckpoint.PrincipalAddress == nil {
 			break
 		}
 
 		return e.complexity.SoulBootstrapSigningCheckpoint.PrincipalAddress(childComplexity), true
+
+	case "SoulBootstrapSigningCheckpoint.registrationPreviewJson":
+		if e.complexity.SoulBootstrapSigningCheckpoint.RegistrationPreviewJSON == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapSigningCheckpoint.RegistrationPreviewJSON(childComplexity), true
 
 	case "SoulBootstrapSigningCheckpoint.signerAddress":
 		if e.complexity.SoulBootstrapSigningCheckpoint.SignerAddress == nil {
@@ -19776,6 +19884,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.SoulBootstrapState.PrincipalAddress(childComplexity), true
+
+	case "SoulBootstrapState.publication":
+		if e.complexity.SoulBootstrapState.Publication == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapState.Publication(childComplexity), true
 
 	case "SoulBootstrapState.signingCheckpoints":
 		if e.complexity.SoulBootstrapState.SigningCheckpoints == nil {
@@ -49481,6 +49596,8 @@ func (ec *executionContext) fieldContext_AgentWorkflowSurface_soulBootstrap(_ co
 				return ec.fieldContext_SoulBootstrapState_state(ctx, field)
 			case "signingCheckpoints":
 				return ec.fieldContext_SoulBootstrapState_signingCheckpoints(ctx, field)
+			case "publication":
+				return ec.fieldContext_SoulBootstrapState_publication(ctx, field)
 			case "error":
 				return ec.fieldContext_SoulBootstrapState_error(ctx, field)
 			case "correlation":
@@ -131209,6 +131326,334 @@ func (ec *executionContext) fieldContext_SoulBootstrapMutationPayload_error(_ co
 	return fc, nil
 }
 
+func (ec *executionContext) _SoulBootstrapPublicationEvidence_agentId(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapPublicationEvidence) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapPublicationEvidence_agentId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AgentID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOID2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapPublicationEvidence_agentId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapPublicationEvidence",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapPublicationEvidence_publishedVersion(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapPublicationEvidence) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapPublicationEvidence_publishedVersion(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PublishedVersion, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapPublicationEvidence_publishedVersion(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapPublicationEvidence",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapPublicationEvidence_registrationUri(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapPublicationEvidence) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapPublicationEvidence_registrationUri(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RegistrationURI, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapPublicationEvidence_registrationUri(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapPublicationEvidence",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapPublicationEvidence_registrationS3Key(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapPublicationEvidence) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapPublicationEvidence_registrationS3Key(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RegistrationS3Key, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapPublicationEvidence_registrationS3Key(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapPublicationEvidence",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapPublicationEvidence_versionedRegistrationUri(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapPublicationEvidence) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapPublicationEvidence_versionedRegistrationUri(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.VersionedRegistrationURI, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapPublicationEvidence_versionedRegistrationUri(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapPublicationEvidence",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapPublicationEvidence_versionedRegistrationS3Key(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapPublicationEvidence) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapPublicationEvidence_versionedRegistrationS3Key(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.VersionedRegistrationS3Key, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapPublicationEvidence_versionedRegistrationS3Key(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapPublicationEvidence",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapPublicationEvidence_anchorState(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapPublicationEvidence) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapPublicationEvidence_anchorState(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AnchorState, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapPublicationEvidence_anchorState(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapPublicationEvidence",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapPublicationEvidence_publishedAt(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapPublicationEvidence) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapPublicationEvidence_publishedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PublishedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapPublicationEvidence_publishedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapPublicationEvidence",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _SoulBootstrapSigningCheckpoint_version(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapSigningCheckpoint) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_SoulBootstrapSigningCheckpoint_version(ctx, field)
 	if err != nil {
@@ -131654,6 +132099,211 @@ func (ec *executionContext) _SoulBootstrapSigningCheckpoint_canonicalJson(ctx co
 }
 
 func (ec *executionContext) fieldContext_SoulBootstrapSigningCheckpoint_canonicalJson(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapSigningCheckpoint",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapSigningCheckpoint_expectedVersion(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapSigningCheckpoint) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapSigningCheckpoint_expectedVersion(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ExpectedVersion, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapSigningCheckpoint_expectedVersion(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapSigningCheckpoint",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapSigningCheckpoint_nextVersion(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapSigningCheckpoint) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapSigningCheckpoint_nextVersion(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NextVersion, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapSigningCheckpoint_nextVersion(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapSigningCheckpoint",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapSigningCheckpoint_boundaryRequirementsJson(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapSigningCheckpoint) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapSigningCheckpoint_boundaryRequirementsJson(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BoundaryRequirementsJSON, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapSigningCheckpoint_boundaryRequirementsJson(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapSigningCheckpoint",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapSigningCheckpoint_finalizeRequestTemplateJson(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapSigningCheckpoint) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapSigningCheckpoint_finalizeRequestTemplateJson(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FinalizeRequestTemplateJSON, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapSigningCheckpoint_finalizeRequestTemplateJson(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapSigningCheckpoint",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapSigningCheckpoint_registrationPreviewJson(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapSigningCheckpoint) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapSigningCheckpoint_registrationPreviewJson(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RegistrationPreviewJSON, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapSigningCheckpoint_registrationPreviewJson(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "SoulBootstrapSigningCheckpoint",
 		Field:      field,
@@ -132272,6 +132922,16 @@ func (ec *executionContext) fieldContext_SoulBootstrapState_signingCheckpoints(_
 				return ec.fieldContext_SoulBootstrapSigningCheckpoint_digestHex(ctx, field)
 			case "canonicalJson":
 				return ec.fieldContext_SoulBootstrapSigningCheckpoint_canonicalJson(ctx, field)
+			case "expectedVersion":
+				return ec.fieldContext_SoulBootstrapSigningCheckpoint_expectedVersion(ctx, field)
+			case "nextVersion":
+				return ec.fieldContext_SoulBootstrapSigningCheckpoint_nextVersion(ctx, field)
+			case "boundaryRequirementsJson":
+				return ec.fieldContext_SoulBootstrapSigningCheckpoint_boundaryRequirementsJson(ctx, field)
+			case "finalizeRequestTemplateJson":
+				return ec.fieldContext_SoulBootstrapSigningCheckpoint_finalizeRequestTemplateJson(ctx, field)
+			case "registrationPreviewJson":
+				return ec.fieldContext_SoulBootstrapSigningCheckpoint_registrationPreviewJson(ctx, field)
 			case "hostRequestId":
 				return ec.fieldContext_SoulBootstrapSigningCheckpoint_hostRequestId(ctx, field)
 			case "issuedAt":
@@ -132282,6 +132942,65 @@ func (ec *executionContext) fieldContext_SoulBootstrapState_signingCheckpoints(_
 				return ec.fieldContext_SoulBootstrapSigningCheckpoint_completedAt(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type SoulBootstrapSigningCheckpoint", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapState_publication(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapState) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapState_publication(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Publication, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.SoulBootstrapPublicationEvidence)
+	fc.Result = res
+	return ec.marshalOSoulBootstrapPublicationEvidence2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapPublicationEvidence(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapState_publication(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapState",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "agentId":
+				return ec.fieldContext_SoulBootstrapPublicationEvidence_agentId(ctx, field)
+			case "publishedVersion":
+				return ec.fieldContext_SoulBootstrapPublicationEvidence_publishedVersion(ctx, field)
+			case "registrationUri":
+				return ec.fieldContext_SoulBootstrapPublicationEvidence_registrationUri(ctx, field)
+			case "registrationS3Key":
+				return ec.fieldContext_SoulBootstrapPublicationEvidence_registrationS3Key(ctx, field)
+			case "versionedRegistrationUri":
+				return ec.fieldContext_SoulBootstrapPublicationEvidence_versionedRegistrationUri(ctx, field)
+			case "versionedRegistrationS3Key":
+				return ec.fieldContext_SoulBootstrapPublicationEvidence_versionedRegistrationS3Key(ctx, field)
+			case "anchorState":
+				return ec.fieldContext_SoulBootstrapPublicationEvidence_anchorState(ctx, field)
+			case "publishedAt":
+				return ec.fieldContext_SoulBootstrapPublicationEvidence_publishedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SoulBootstrapPublicationEvidence", field.Name)
 		},
 	}
 	return fc, nil
@@ -132671,6 +133390,8 @@ func (ec *executionContext) fieldContext_SoulBootstrapSurface_state(_ context.Co
 				return ec.fieldContext_SoulBootstrapState_state(ctx, field)
 			case "signingCheckpoints":
 				return ec.fieldContext_SoulBootstrapState_signingCheckpoints(ctx, field)
+			case "publication":
+				return ec.fieldContext_SoulBootstrapState_publication(ctx, field)
 			case "error":
 				return ec.fieldContext_SoulBootstrapState_error(ctx, field)
 			case "correlation":
@@ -176143,6 +176864,56 @@ func (ec *executionContext) _SoulBootstrapMutationPayload(ctx context.Context, s
 	return out
 }
 
+var soulBootstrapPublicationEvidenceImplementors = []string{"SoulBootstrapPublicationEvidence"}
+
+func (ec *executionContext) _SoulBootstrapPublicationEvidence(ctx context.Context, sel ast.SelectionSet, obj *model.SoulBootstrapPublicationEvidence) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, soulBootstrapPublicationEvidenceImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("SoulBootstrapPublicationEvidence")
+		case "agentId":
+			out.Values[i] = ec._SoulBootstrapPublicationEvidence_agentId(ctx, field, obj)
+		case "publishedVersion":
+			out.Values[i] = ec._SoulBootstrapPublicationEvidence_publishedVersion(ctx, field, obj)
+		case "registrationUri":
+			out.Values[i] = ec._SoulBootstrapPublicationEvidence_registrationUri(ctx, field, obj)
+		case "registrationS3Key":
+			out.Values[i] = ec._SoulBootstrapPublicationEvidence_registrationS3Key(ctx, field, obj)
+		case "versionedRegistrationUri":
+			out.Values[i] = ec._SoulBootstrapPublicationEvidence_versionedRegistrationUri(ctx, field, obj)
+		case "versionedRegistrationS3Key":
+			out.Values[i] = ec._SoulBootstrapPublicationEvidence_versionedRegistrationS3Key(ctx, field, obj)
+		case "anchorState":
+			out.Values[i] = ec._SoulBootstrapPublicationEvidence_anchorState(ctx, field, obj)
+		case "publishedAt":
+			out.Values[i] = ec._SoulBootstrapPublicationEvidence_publishedAt(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var soulBootstrapSigningCheckpointImplementors = []string{"SoulBootstrapSigningCheckpoint"}
 
 func (ec *executionContext) _SoulBootstrapSigningCheckpoint(ctx context.Context, sel ast.SelectionSet, obj *model.SoulBootstrapSigningCheckpoint) graphql.Marshaler {
@@ -176182,6 +176953,16 @@ func (ec *executionContext) _SoulBootstrapSigningCheckpoint(ctx context.Context,
 			out.Values[i] = ec._SoulBootstrapSigningCheckpoint_digestHex(ctx, field, obj)
 		case "canonicalJson":
 			out.Values[i] = ec._SoulBootstrapSigningCheckpoint_canonicalJson(ctx, field, obj)
+		case "expectedVersion":
+			out.Values[i] = ec._SoulBootstrapSigningCheckpoint_expectedVersion(ctx, field, obj)
+		case "nextVersion":
+			out.Values[i] = ec._SoulBootstrapSigningCheckpoint_nextVersion(ctx, field, obj)
+		case "boundaryRequirementsJson":
+			out.Values[i] = ec._SoulBootstrapSigningCheckpoint_boundaryRequirementsJson(ctx, field, obj)
+		case "finalizeRequestTemplateJson":
+			out.Values[i] = ec._SoulBootstrapSigningCheckpoint_finalizeRequestTemplateJson(ctx, field, obj)
+		case "registrationPreviewJson":
+			out.Values[i] = ec._SoulBootstrapSigningCheckpoint_registrationPreviewJson(ctx, field, obj)
 		case "hostRequestId":
 			out.Values[i] = ec._SoulBootstrapSigningCheckpoint_hostRequestId(ctx, field, obj)
 		case "issuedAt":
@@ -176259,6 +177040,8 @@ func (ec *executionContext) _SoulBootstrapState(ctx context.Context, sel ast.Sel
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "publication":
+			out.Values[i] = ec._SoulBootstrapState_publication(ctx, field, obj)
 		case "error":
 			out.Values[i] = ec._SoulBootstrapState_error(ctx, field, obj)
 		case "correlation":
@@ -191636,6 +192419,13 @@ func (ec *executionContext) marshalOSoulBootstrapErrorState2ᚖgithubᚗcomᚋeq
 		return graphql.Null
 	}
 	return ec._SoulBootstrapErrorState(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOSoulBootstrapPublicationEvidence2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapPublicationEvidence(ctx context.Context, sel ast.SelectionSet, v *model.SoulBootstrapPublicationEvidence) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._SoulBootstrapPublicationEvidence(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOSoulBootstrapSurface2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapSurface(ctx context.Context, sel ast.SelectionSet, v *model.SoulBootstrapSurface) graphql.Marshaler {

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -2740,22 +2740,38 @@ type SoulBootstrapMutationPayload struct {
 	Error      *SoulBootstrapErrorState `json:"error,omitempty"`
 }
 
+type SoulBootstrapPublicationEvidence struct {
+	AgentID                    *string `json:"agentId,omitempty"`
+	PublishedVersion           *int    `json:"publishedVersion,omitempty"`
+	RegistrationURI            *string `json:"registrationUri,omitempty"`
+	RegistrationS3Key          *string `json:"registrationS3Key,omitempty"`
+	VersionedRegistrationURI   *string `json:"versionedRegistrationUri,omitempty"`
+	VersionedRegistrationS3Key *string `json:"versionedRegistrationS3Key,omitempty"`
+	AnchorState                *string `json:"anchorState,omitempty"`
+	PublishedAt                *Time   `json:"publishedAt,omitempty"`
+}
+
 type SoulBootstrapSigningCheckpoint struct {
-	Version          *string `json:"version,omitempty"`
-	Name             string  `json:"name"`
-	Status           string  `json:"status"`
-	PrincipalAddress *string `json:"principalAddress,omitempty"`
-	SignerAddress    *string `json:"signerAddress,omitempty"`
-	SigningMethod    *string `json:"signingMethod,omitempty"`
-	MessageEncoding  *string `json:"messageEncoding,omitempty"`
-	Message          *string `json:"message,omitempty"`
-	MessageHex       *string `json:"messageHex,omitempty"`
-	DigestHex        *string `json:"digestHex,omitempty"`
-	CanonicalJSON    *string `json:"canonicalJson,omitempty"`
-	HostRequestID    *string `json:"hostRequestId,omitempty"`
-	IssuedAt         *Time   `json:"issuedAt,omitempty"`
-	DeclaredAt       *Time   `json:"declaredAt,omitempty"`
-	CompletedAt      *Time   `json:"completedAt,omitempty"`
+	Version                     *string `json:"version,omitempty"`
+	Name                        string  `json:"name"`
+	Status                      string  `json:"status"`
+	PrincipalAddress            *string `json:"principalAddress,omitempty"`
+	SignerAddress               *string `json:"signerAddress,omitempty"`
+	SigningMethod               *string `json:"signingMethod,omitempty"`
+	MessageEncoding             *string `json:"messageEncoding,omitempty"`
+	Message                     *string `json:"message,omitempty"`
+	MessageHex                  *string `json:"messageHex,omitempty"`
+	DigestHex                   *string `json:"digestHex,omitempty"`
+	CanonicalJSON               *string `json:"canonicalJson,omitempty"`
+	ExpectedVersion             *int    `json:"expectedVersion,omitempty"`
+	NextVersion                 *int    `json:"nextVersion,omitempty"`
+	BoundaryRequirementsJSON    *string `json:"boundaryRequirementsJson,omitempty"`
+	FinalizeRequestTemplateJSON *string `json:"finalizeRequestTemplateJson,omitempty"`
+	RegistrationPreviewJSON     *string `json:"registrationPreviewJson,omitempty"`
+	HostRequestID               *string `json:"hostRequestId,omitempty"`
+	IssuedAt                    *Time   `json:"issuedAt,omitempty"`
+	DeclaredAt                  *Time   `json:"declaredAt,omitempty"`
+	CompletedAt                 *Time   `json:"completedAt,omitempty"`
 }
 
 type SoulBootstrapState struct {
@@ -2769,6 +2785,7 @@ type SoulBootstrapState struct {
 	Phase              SoulBootstrapPhase                `json:"phase"`
 	State              string                            `json:"state"`
 	SigningCheckpoints []*SoulBootstrapSigningCheckpoint `json:"signingCheckpoints"`
+	Publication        *SoulBootstrapPublicationEvidence `json:"publication,omitempty"`
 	Error              *SoulBootstrapErrorState          `json:"error,omitempty"`
 	Correlation        *SoulBootstrapCorrelationState    `json:"correlation,omitempty"`
 	UpdatedAt          *Time                             `json:"updatedAt,omitempty"`

--- a/graph/soul_bootstrap_resolvers.go
+++ b/graph/soul_bootstrap_resolvers.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"time"
@@ -20,6 +21,7 @@ const (
 	soulBootstrapCorrelationOpPrincipalDeclaration = "principal_declaration"
 	soulBootstrapCorrelationOpConversation         = "conversation"
 	soulBootstrapCorrelationOpFinalize             = "finalize"
+	soulBootstrapErrorSourceLesser                 = "lesser"
 )
 
 func (r *queryResolver) SoulBootstrap(ctx context.Context, username string) (*model.SoulBootstrapSurface, error) {
@@ -67,7 +69,7 @@ func (r *mutationResolver) BeginSoulBootstrap(ctx context.Context, input model.B
 			Capabilities:  input.Capabilities,
 		})
 		if err != nil {
-			return soulBootstrapErrorState(agentUser.Username, correlation, err, now), nil
+			return soulBootstrapErrorState(agentUser, existing, correlation, err, now), nil
 		}
 		return soulBootstrapStateAfterBegin(agentUser, existing, correlation, result, now), nil
 	})
@@ -127,7 +129,7 @@ func (r *mutationResolver) PrepareSoulBootstrapPrincipalDeclaration(ctx context.
 			DeclaredAt:           time.Time(input.DeclaredAt),
 		})
 		if err != nil {
-			return soulBootstrapErrorState(agentUser.Username, correlation, err, now), nil
+			return soulBootstrapErrorState(agentUser, existing, correlation, err, now), nil
 		}
 		return soulBootstrapStateAfterPrincipalPreflight(agentUser, existing, correlation, registrationID, result, now), nil
 	})
@@ -160,82 +162,178 @@ func (r *mutationResolver) VerifySoulBootstrapPrincipalDeclaration(ctx context.C
 			DeclaredAt:           time.Time(input.DeclaredAt),
 		})
 		if err != nil {
-			return soulBootstrapErrorState(agentUser.Username, correlation, err, now), nil
+			return soulBootstrapErrorState(agentUser, existing, correlation, err, now), nil
 		}
 		return soulBootstrapStateAfterPrincipalVerify(agentUser, existing, correlation, registrationID, result, now), nil
 	})
 }
 
 func (r *mutationResolver) SendSoulBootstrapConversationMessage(ctx context.Context, input model.SendSoulBootstrapConversationMessageInput) (*model.SoulBootstrapMutationPayload, error) {
-	return r.soulBootstrapHostBridgeUnavailablePayload(ctx, input.Username, graphBootstrapCorrelation(
+	correlation := graphBootstrapCorrelation(
 		input.CorrelationKey,
 		input.IdempotencyKey,
 		soulBootstrapCorrelationOpConversation,
-	))
+	)
+	return r.executeSoulBootstrapReviewMutation(ctx, input.Username, func(
+		ctx context.Context,
+		agentUser *storage.User,
+		_ *storage.AgentGovernanceState,
+		service soulBootstrapHostService,
+		existing *workflow.SoulBootstrapState,
+		now time.Time,
+	) (*workflow.SoulBootstrapState, error) {
+		registrationID, err := soulBootstrapRegistrationID(existing, input.RegistrationID)
+		if err != nil {
+			return soulBootstrapErrorState(agentUser, existing, correlation, err, now), nil
+		}
+		conversationID, err := soulBootstrapOptionalConversationID(existing, input.ConversationID)
+		if err != nil {
+			return soulBootstrapErrorState(agentUser, existing, correlation, err, now), nil
+		}
+		result, err := service.SendBootstrapConversationMessage(ctx, soulservice.BootstrapConversationMessageInput{
+			RegistrationID: registrationID,
+			ConversationID: conversationID,
+			Message:        input.Message,
+			Model:          derefString(input.Model),
+		})
+		if err != nil {
+			return soulBootstrapErrorState(agentUser, existing, correlation, err, now), nil
+		}
+		return soulBootstrapStateAfterConversationMessage(agentUser, existing, correlation, result, now), nil
+	})
 }
 
 func (r *mutationResolver) CompleteSoulBootstrapConversation(ctx context.Context, input model.CompleteSoulBootstrapConversationInput) (*model.SoulBootstrapMutationPayload, error) {
-	return r.soulBootstrapHostBridgeUnavailablePayload(ctx, input.Username, graphBootstrapCorrelation(
+	correlation := graphBootstrapCorrelation(
 		input.CorrelationKey,
 		input.IdempotencyKey,
 		soulBootstrapCorrelationOpConversation,
-	))
+	)
+	return r.executeSoulBootstrapReviewMutation(ctx, input.Username, func(
+		ctx context.Context,
+		agentUser *storage.User,
+		_ *storage.AgentGovernanceState,
+		service soulBootstrapHostService,
+		existing *workflow.SoulBootstrapState,
+		now time.Time,
+	) (*workflow.SoulBootstrapState, error) {
+		registrationID, err := soulBootstrapRegistrationID(existing, input.RegistrationID)
+		if err != nil {
+			return soulBootstrapErrorState(agentUser, existing, correlation, err, now), nil
+		}
+		conversationID, err := soulBootstrapRequiredConversationID(existing, input.ConversationID)
+		if err != nil {
+			return soulBootstrapErrorState(agentUser, existing, correlation, err, now), nil
+		}
+		result, err := service.CompleteBootstrapConversation(ctx, soulservice.BootstrapConversationCompleteInput{
+			RegistrationID: registrationID,
+			ConversationID: conversationID,
+		})
+		if err != nil {
+			return soulBootstrapErrorState(agentUser, existing, correlation, err, now), nil
+		}
+		return soulBootstrapStateAfterConversationComplete(agentUser, existing, correlation, result, now), nil
+	})
 }
 
 func (r *mutationResolver) PrepareSoulBootstrapFinalize(ctx context.Context, input model.PrepareSoulBootstrapFinalizeInput) (*model.SoulBootstrapMutationPayload, error) {
-	return r.soulBootstrapHostBridgeUnavailablePayload(ctx, input.Username, graphBootstrapCorrelation(
+	correlation := graphBootstrapCorrelation(
 		input.CorrelationKey,
 		input.IdempotencyKey,
 		soulBootstrapCorrelationOpFinalize,
-	))
+	)
+	return r.executeSoulBootstrapReviewMutation(ctx, input.Username, func(
+		ctx context.Context,
+		agentUser *storage.User,
+		_ *storage.AgentGovernanceState,
+		service soulBootstrapHostService,
+		existing *workflow.SoulBootstrapState,
+		now time.Time,
+	) (*workflow.SoulBootstrapState, error) {
+		registrationID, err := soulBootstrapRegistrationID(existing, input.RegistrationID)
+		if err != nil {
+			return soulBootstrapErrorState(agentUser, existing, correlation, err, now), nil
+		}
+		conversationID, err := soulBootstrapRequiredConversationID(existing, input.ConversationID)
+		if err != nil {
+			return soulBootstrapErrorState(agentUser, existing, correlation, err, now), nil
+		}
+		boundarySignatures, err := graphBootstrapSignatureMap(input.BoundarySignaturesJSON)
+		if err != nil {
+			return soulBootstrapErrorState(agentUser, existing, correlation, err, now), nil
+		}
+		result, err := service.PrepareBootstrapFinalize(ctx, soulservice.BootstrapFinalizePreflightInput{
+			RegistrationID:     registrationID,
+			ConversationID:     conversationID,
+			BoundarySignatures: boundarySignatures,
+		})
+		if err != nil {
+			return soulBootstrapErrorState(agentUser, existing, correlation, err, now), nil
+		}
+		return soulBootstrapStateAfterFinalizePreflight(agentUser, existing, correlation, result, now), nil
+	})
 }
 
 func (r *mutationResolver) FinalizeSoulBootstrap(ctx context.Context, input model.FinalizeSoulBootstrapInput) (*model.SoulBootstrapMutationPayload, error) {
-	return r.soulBootstrapHostBridgeUnavailablePayload(ctx, input.Username, graphBootstrapCorrelation(
+	correlation := graphBootstrapCorrelation(
 		input.CorrelationKey,
 		input.IdempotencyKey,
 		soulBootstrapCorrelationOpFinalize,
-	))
-}
-
-func (r *mutationResolver) soulBootstrapHostBridgeUnavailablePayload(
-	ctx context.Context,
-	username string,
-	correlation *workflow.SoulBootstrapCorrelationState,
-) (*model.SoulBootstrapMutationPayload, error) {
-	claims, err := r.requireAuthClaims(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if err := requireDroneWriteScope(claims); err != nil {
-		return nil, err
-	}
-
-	agentUser, governance, err := r.loadDroneAgent(ctx, username)
-	if err != nil {
-		return nil, err
-	}
-	if !r.canViewDroneWorkflow(ctx, claims, agentUser) {
-		return nil, apperrors.Forbidden("not authorized to mutate soul bootstrap")
-	}
-
-	now := time.Now().UTC()
-	unavailable := workflow.NewSoulBootstrapHostBridgeUnavailableState(agentUser.Username, correlation, now)
-	surface, err := r.buildSoulBootstrapSurface(ctx, claims.Username, agentUser, governance, unavailable)
-	if err != nil {
-		return nil, err
-	}
-	return &model.SoulBootstrapMutationPayload{
-		Bootstrap:  surface,
-		Executable: false,
-		Error:      surface.Error,
-	}, nil
+	)
+	return r.executeSoulBootstrapReviewMutation(ctx, input.Username, func(
+		ctx context.Context,
+		agentUser *storage.User,
+		_ *storage.AgentGovernanceState,
+		service soulBootstrapHostService,
+		existing *workflow.SoulBootstrapState,
+		now time.Time,
+	) (*workflow.SoulBootstrapState, error) {
+		registrationID, err := soulBootstrapRegistrationID(existing, input.RegistrationID)
+		if err != nil {
+			return soulBootstrapErrorState(agentUser, existing, correlation, err, now), nil
+		}
+		conversationID, err := soulBootstrapRequiredConversationID(existing, input.ConversationID)
+		if err != nil {
+			return soulBootstrapErrorState(agentUser, existing, correlation, err, now), nil
+		}
+		boundarySignatures, err := graphBootstrapSignatureMap(input.BoundarySignaturesJSON)
+		if err != nil {
+			return soulBootstrapErrorState(agentUser, existing, correlation, err, now), nil
+		}
+		issuedAt, expectedVersion := soulBootstrapFinalizeDefaults(existing, input.IssuedAt, input.ExpectedVersion)
+		result, err := service.FinalizeBootstrap(ctx, soulservice.BootstrapFinalizeInput{
+			RegistrationID:     registrationID,
+			ConversationID:     conversationID,
+			BoundarySignatures: boundarySignatures,
+			IssuedAt:           issuedAt,
+			ExpectedVersion:    expectedVersion,
+			SelfAttestation:    firstNonEmpty(derefString(input.SelfAttestation), derefString(input.Signature)),
+		})
+		if err != nil {
+			return soulBootstrapErrorState(agentUser, existing, correlation, err, now), nil
+		}
+		published := soulBootstrapStateAfterFinalize(agentUser, existing, correlation, result, now)
+		bindingPrincipal := soulBootstrapBindingPrincipalUsername(agentUser, "")
+		if bindingPrincipal == "" {
+			bindingPrincipal = soulBootstrapHostLocalID(agentUser)
+		}
+		soul, err := service.Incorporate(ctx, bindingPrincipal, agentUser.Username, result.HostSoulAgentID)
+		if err != nil {
+			return soulBootstrapErrorState(agentUser, published, correlation, err, now), nil
+		}
+		return soulBootstrapStateAfterBinding(agentUser, published, correlation, soul, result, now), nil
+	})
 }
 
 type soulBootstrapHostService interface {
+	Incorporate(context.Context, string, string, string) (*soulservice.Soul, error)
 	BeginBootstrapRegistration(context.Context, soulservice.BootstrapBeginInput) (*soulservice.BootstrapBeginResult, error)
 	PrepareBootstrapPrincipalDeclaration(context.Context, soulservice.BootstrapPrincipalPreflightInput) (*soulservice.BootstrapPrincipalPreflightResult, error)
 	VerifyBootstrapPrincipalDeclaration(context.Context, soulservice.BootstrapPrincipalVerifyInput) (*soulservice.BootstrapPrincipalVerifyResult, error)
+	SendBootstrapConversationMessage(context.Context, soulservice.BootstrapConversationMessageInput) (*soulservice.BootstrapConversationMessageResult, error)
+	CompleteBootstrapConversation(context.Context, soulservice.BootstrapConversationCompleteInput) (*soulservice.BootstrapConversationCompleteResult, error)
+	PrepareBootstrapFinalize(context.Context, soulservice.BootstrapFinalizePreflightInput) (*soulservice.BootstrapFinalizePreflightResult, error)
+	FinalizeBootstrap(context.Context, soulservice.BootstrapFinalizeInput) (*soulservice.BootstrapFinalizeResult, error)
 }
 
 type soulBootstrapMutationFunc func(
@@ -252,6 +350,23 @@ func (r *mutationResolver) executeSoulBootstrapMutation(
 	username string,
 	mutate soulBootstrapMutationFunc,
 ) (*model.SoulBootstrapMutationPayload, error) {
+	return r.executeSoulBootstrapMutationWithAuth(ctx, username, false, mutate)
+}
+
+func (r *mutationResolver) executeSoulBootstrapReviewMutation(
+	ctx context.Context,
+	username string,
+	mutate soulBootstrapMutationFunc,
+) (*model.SoulBootstrapMutationPayload, error) {
+	return r.executeSoulBootstrapMutationWithAuth(ctx, username, true, mutate)
+}
+
+func (r *mutationResolver) executeSoulBootstrapMutationWithAuth(
+	ctx context.Context,
+	username string,
+	allowReviewer bool,
+	mutate soulBootstrapMutationFunc,
+) (*model.SoulBootstrapMutationPayload, error) {
 	claims, err := r.requireAuthClaims(ctx)
 	if err != nil {
 		return nil, err
@@ -264,7 +379,15 @@ func (r *mutationResolver) executeSoulBootstrapMutation(
 	if err != nil {
 		return nil, err
 	}
-	if !r.canViewDroneWorkflow(ctx, claims, agentUser) {
+	workflowState, err := r.loadDroneWorkflowState(agentUser)
+	if err != nil {
+		return nil, apperrors.InternalWithCause(err, "failed to decode drone workflow metadata")
+	}
+	authorized := r.canViewDroneWorkflow(ctx, claims, agentUser)
+	if allowReviewer {
+		authorized = r.canReviewDroneWorkflow(ctx, claims, agentUser, workflowState)
+	}
+	if !authorized {
 		return nil, apperrors.Forbidden("not authorized to mutate soul bootstrap")
 	}
 
@@ -273,10 +396,6 @@ func (r *mutationResolver) executeSoulBootstrapMutation(
 		return nil, apperrors.InternalWithCause(err, "failed to initialize soul bootstrap service")
 	}
 
-	workflowState, err := r.loadDroneWorkflowState(agentUser)
-	if err != nil {
-		return nil, apperrors.InternalWithCause(err, "failed to decode drone workflow metadata")
-	}
 	existing := (*workflow.SoulBootstrapState)(nil)
 	if workflowState != nil {
 		existing = workflowState.SoulBootstrap
@@ -291,6 +410,7 @@ func (r *mutationResolver) executeSoulBootstrapMutation(
 		workflowState = &workflow.DroneWorkflowState{}
 	}
 	workflowState.SoulBootstrap = workflow.NormalizeSoulBootstrap(nextState, agentUser.Username)
+	applySoulBootstrapWorkflowProjection(ctx, r.Resolver, claims.Username, agentUser, workflowState, workflowState.SoulBootstrap, now)
 	workflowState.UpdatedAt = &now
 	if err := r.persistDroneWorkflowState(ctx, agentUser, workflowState); err != nil {
 		return nil, err
@@ -450,25 +570,323 @@ func soulBootstrapStateAfterPrincipalVerify(
 	return workflow.NormalizeSoulBootstrap(state, username)
 }
 
-func soulBootstrapErrorState(username string, correlation *workflow.SoulBootstrapCorrelationState, err error, now time.Time) *workflow.SoulBootstrapState {
+func soulBootstrapStateAfterConversationMessage(
+	agentUser *storage.User,
+	existing *workflow.SoulBootstrapState,
+	correlation *workflow.SoulBootstrapCorrelationState,
+	result *soulservice.BootstrapConversationMessageResult,
+	now time.Time,
+) *workflow.SoulBootstrapState {
+	username := ""
+	if agentUser != nil {
+		username = agentUser.Username
+	}
+	state := workflow.NormalizeSoulBootstrap(existing, username)
+	state.Phase = workflow.SoulBootstrapPhaseConversation
+	state.State = workflow.SoulBootstrapStateConversationInProgress
+	if strings.TrimSpace(result.RegistrationID) != "" {
+		state.HostRegistrationID = strings.TrimSpace(result.RegistrationID)
+	}
+	if strings.TrimSpace(result.ConversationID) != "" {
+		state.HostConversationID = strings.TrimSpace(result.ConversationID)
+	}
+	state.Correlation = mergeSoulBootstrapCorrelation(state.Correlation, correlation)
+	if state.Correlation == nil {
+		state.Correlation = &workflow.SoulBootstrapCorrelationState{}
+	}
+	state.Correlation.LastHostRequestID = strings.TrimSpace(result.HostRequestID)
+	state.SigningCheckpoints = upsertSoulBootstrapCheckpoint(state.SigningCheckpoints, workflow.SoulBootstrapSigningCheckpoint{
+		Name:          "conversation",
+		Status:        "in_progress",
+		HostRequestID: result.HostRequestID,
+		CompletedAt:   &now,
+	})
+	state.Error = nil
+	state.UpdatedAt = &now
+	return workflow.NormalizeSoulBootstrap(state, username)
+}
+
+func soulBootstrapStateAfterConversationComplete(
+	agentUser *storage.User,
+	existing *workflow.SoulBootstrapState,
+	correlation *workflow.SoulBootstrapCorrelationState,
+	result *soulservice.BootstrapConversationCompleteResult,
+	now time.Time,
+) *workflow.SoulBootstrapState {
+	username := ""
+	if agentUser != nil {
+		username = agentUser.Username
+	}
+	state := workflow.NormalizeSoulBootstrap(existing, username)
+	state.Phase = workflow.SoulBootstrapPhaseConversation
+	state.State = workflow.SoulBootstrapStateConversationCompleted
+	if strings.TrimSpace(result.RegistrationID) != "" {
+		state.HostRegistrationID = strings.TrimSpace(result.RegistrationID)
+	}
+	if strings.TrimSpace(result.HostSoulAgentID) != "" {
+		state.HostSoulAgentID = strings.TrimSpace(result.HostSoulAgentID)
+	}
+	if strings.TrimSpace(result.ConversationID) != "" {
+		state.HostConversationID = strings.TrimSpace(result.ConversationID)
+	}
+	state.Correlation = mergeSoulBootstrapCorrelation(state.Correlation, correlation)
+	if state.Correlation == nil {
+		state.Correlation = &workflow.SoulBootstrapCorrelationState{}
+	}
+	state.Correlation.LastHostRequestID = strings.TrimSpace(result.HostRequestID)
+	completedAt := result.CompletedAt
+	if completedAt == nil {
+		completedAt = &now
+	}
+	state.SigningCheckpoints = upsertSoulBootstrapCheckpoint(state.SigningCheckpoints, workflow.SoulBootstrapSigningCheckpoint{
+		Name:          "conversation",
+		Status:        strings.TrimSpace(defaultString(result.Status, "completed")),
+		CanonicalJSON: strings.TrimSpace(result.ProducedDeclarations),
+		HostRequestID: result.HostRequestID,
+		CompletedAt:   completedAt,
+	})
+	state.Error = nil
+	state.UpdatedAt = &now
+	return workflow.NormalizeSoulBootstrap(state, username)
+}
+
+func soulBootstrapStateAfterFinalizePreflight(
+	agentUser *storage.User,
+	existing *workflow.SoulBootstrapState,
+	correlation *workflow.SoulBootstrapCorrelationState,
+	result *soulservice.BootstrapFinalizePreflightResult,
+	now time.Time,
+) *workflow.SoulBootstrapState {
+	username := ""
+	if agentUser != nil {
+		username = agentUser.Username
+	}
+	state := workflow.NormalizeSoulBootstrap(existing, username)
+	state.Phase = workflow.SoulBootstrapPhaseFinalize
+	state.State = workflow.SoulBootstrapStateFinalizeReady
+	state.Correlation = mergeSoulBootstrapCorrelation(state.Correlation, correlation)
+	if state.Correlation == nil {
+		state.Correlation = &workflow.SoulBootstrapCorrelationState{}
+	}
+	state.Correlation.LastHostRequestID = strings.TrimSpace(result.HostRequestID)
+	state.SigningCheckpoints = upsertSoulBootstrapCheckpoint(state.SigningCheckpoints, workflow.SoulBootstrapSigningCheckpoint{
+		Version:                     result.Version,
+		Name:                        "finalize",
+		Status:                      "ready",
+		SignerAddress:               strings.ToLower(strings.TrimSpace(result.SelfAttestationSigning.SignerWallet)),
+		SigningMethod:               result.SelfAttestationSigning.SigningMethod,
+		MessageEncoding:             result.SelfAttestationSigning.MessageEncoding,
+		MessageHex:                  result.SelfAttestationSigning.MessageHex,
+		DigestHex:                   result.SelfAttestationSigning.DigestHex,
+		CanonicalJSON:               result.SelfAttestationSigning.CanonicalJSON,
+		ExpectedVersion:             result.ExpectedVersion,
+		NextVersion:                 result.NextVersion,
+		BoundaryRequirementsJSON:    result.BoundaryRequirementsJSON,
+		FinalizeRequestTemplateJSON: result.FinalizeRequestTemplateJSON,
+		RegistrationPreviewJSON:     result.RegistrationPreviewJSON,
+		HostRequestID:               result.HostRequestID,
+		IssuedAt:                    result.IssuedAt,
+	})
+	state.Error = nil
+	state.UpdatedAt = &now
+	return workflow.NormalizeSoulBootstrap(state, username)
+}
+
+func soulBootstrapStateAfterFinalize(
+	agentUser *storage.User,
+	existing *workflow.SoulBootstrapState,
+	correlation *workflow.SoulBootstrapCorrelationState,
+	result *soulservice.BootstrapFinalizeResult,
+	now time.Time,
+) *workflow.SoulBootstrapState {
+	username := ""
+	if agentUser != nil {
+		username = agentUser.Username
+	}
+	state := workflow.NormalizeSoulBootstrap(existing, username)
+	state.Phase = workflow.SoulBootstrapPhaseFinalize
+	state.State = workflow.SoulBootstrapStateFinalizePublished
+	if strings.TrimSpace(result.HostSoulAgentID) != "" {
+		state.HostSoulAgentID = strings.TrimSpace(result.HostSoulAgentID)
+	}
+	if strings.TrimSpace(result.PrincipalAddress) != "" {
+		state.PrincipalAddress = strings.ToLower(strings.TrimSpace(result.PrincipalAddress))
+	}
+	state.Publication = soulBootstrapPublicationEvidence(result.Publication)
+	state.Correlation = mergeSoulBootstrapCorrelation(state.Correlation, correlation)
+	if state.Correlation == nil {
+		state.Correlation = &workflow.SoulBootstrapCorrelationState{}
+	}
+	state.Correlation.LastHostRequestID = strings.TrimSpace(result.HostRequestID)
+	state.SigningCheckpoints = upsertSoulBootstrapCheckpoint(state.SigningCheckpoints, workflow.SoulBootstrapSigningCheckpoint{
+		Version:       result.Version,
+		Name:          "finalize",
+		Status:        "published",
+		HostRequestID: result.HostRequestID,
+		CompletedAt:   &now,
+	})
+	state.Error = nil
+	state.UpdatedAt = &now
+	return workflow.NormalizeSoulBootstrap(state, username)
+}
+
+func soulBootstrapStateAfterBinding(
+	agentUser *storage.User,
+	existing *workflow.SoulBootstrapState,
+	correlation *workflow.SoulBootstrapCorrelationState,
+	soul *soulservice.Soul,
+	result *soulservice.BootstrapFinalizeResult,
+	now time.Time,
+) *workflow.SoulBootstrapState {
+	username := ""
+	if agentUser != nil {
+		username = agentUser.Username
+	}
+	state := workflow.NormalizeSoulBootstrap(existing, username)
+	state.Phase = workflow.SoulBootstrapPhaseComplete
+	state.State = workflow.SoulBootstrapStateCompleteBound
+	if soul != nil && strings.TrimSpace(soul.AgentID) != "" {
+		state.HostSoulAgentID = strings.TrimSpace(soul.AgentID)
+	} else if result != nil && strings.TrimSpace(result.HostSoulAgentID) != "" {
+		state.HostSoulAgentID = strings.TrimSpace(result.HostSoulAgentID)
+	}
+	if soul != nil && strings.TrimSpace(soul.PrincipalAddress) != "" {
+		state.PrincipalAddress = strings.ToLower(strings.TrimSpace(soul.PrincipalAddress))
+	} else if result != nil && strings.TrimSpace(result.PrincipalAddress) != "" {
+		state.PrincipalAddress = strings.ToLower(strings.TrimSpace(result.PrincipalAddress))
+	}
+	if result != nil && state.Publication == nil {
+		state.Publication = soulBootstrapPublicationEvidence(result.Publication)
+	}
+	state.Correlation = mergeSoulBootstrapCorrelation(state.Correlation, correlation)
+	state.SigningCheckpoints = upsertSoulBootstrapCheckpoint(state.SigningCheckpoints, workflow.SoulBootstrapSigningCheckpoint{
+		Name:        "binding",
+		Status:      "bound",
+		CompletedAt: &now,
+	})
+	state.Error = nil
+	state.UpdatedAt = &now
+	return workflow.NormalizeSoulBootstrap(state, username)
+}
+
+func soulBootstrapPublicationEvidence(in soulservice.BootstrapPublicationEvidence) *workflow.SoulBootstrapPublicationEvidence {
+	if strings.TrimSpace(in.AgentID) == "" && in.PublishedVersion == 0 {
+		return nil
+	}
+	return &workflow.SoulBootstrapPublicationEvidence{
+		AgentID:                    strings.TrimSpace(in.AgentID),
+		PublishedVersion:           in.PublishedVersion,
+		RegistrationURI:            strings.TrimSpace(in.RegistrationURI),
+		RegistrationS3Key:          strings.TrimSpace(in.RegistrationS3Key),
+		VersionedRegistrationURI:   strings.TrimSpace(in.VersionedRegistrationURI),
+		VersionedRegistrationS3Key: strings.TrimSpace(in.VersionedRegistrationS3Key),
+		AnchorState:                strings.TrimSpace(in.AnchorState),
+		PublishedAt:                in.PublishedAt,
+	}
+}
+
+func soulBootstrapErrorState(
+	agentUser *storage.User,
+	existing *workflow.SoulBootstrapState,
+	correlation *workflow.SoulBootstrapCorrelationState,
+	err error,
+	now time.Time,
+) *workflow.SoulBootstrapState {
+	username := ""
+	bodyID := ""
+	if agentUser != nil {
+		username = agentUser.Username
+		bodyID = soulBootstrapBodyID(agentUser)
+	}
+	state := workflow.NormalizeSoulBootstrap(existing, username)
+	if state == nil {
+		state = &workflow.SoulBootstrapState{}
+	}
+	details := soulBootstrapErrorDetails(err)
+	state.Username = username
+	state.BodyID = defaultString(state.BodyID, bodyID)
+	state.Phase = workflow.SoulBootstrapPhaseError
+	state.State = soulBootstrapErrorWorkflowState(details.Code)
+	state.Correlation = mergeSoulBootstrapCorrelation(state.Correlation, correlation)
+	state.Error = &workflow.SoulBootstrapErrorState{
+		Code:          details.Code,
+		Message:       details.Message,
+		Source:        details.Source,
+		StatusCode:    details.StatusCode,
+		HostRequestID: details.HostRequestID,
+		At:            &now,
+	}
+	state.UpdatedAt = &now
+	return workflow.NormalizeSoulBootstrap(state, username)
+}
+
+type soulBootstrapErrorInfo struct {
+	Code          string
+	Message       string
+	Source        string
+	StatusCode    int
+	HostRequestID string
+}
+
+func soulBootstrapErrorDetails(err error) soulBootstrapErrorInfo {
 	var hostErr *soulservice.HostBootstrapError
 	if errors.As(err, &hostErr) {
-		return workflow.NewSoulBootstrapErrorState(
-			username,
-			correlation,
-			hostErr.Code,
-			hostErr.Message,
-			hostErr.Source,
-			hostErr.StatusCode,
-			hostErr.HostRequestID,
-			now,
-		)
+		return soulBootstrapErrorInfo{
+			Code:          defaultString(hostErr.Code, workflow.SoulBootstrapErrorHostUnavailable),
+			Message:       defaultString(hostErr.Message, "Soul bootstrap could not complete."),
+			Source:        defaultString(hostErr.Source, soulBootstrapErrorSourceLesser),
+			StatusCode:    hostErr.StatusCode,
+			HostRequestID: strings.TrimSpace(hostErr.HostRequestID),
+		}
 	}
 	code := workflow.SoulBootstrapErrorHostUnavailable
+	message := "Soul bootstrap Host bridge is unavailable."
+	source := soulBootstrapErrorSourceLesser
 	if errors.Is(err, soulservice.ErrHostTrustNotConfigured) {
 		code = workflow.SoulBootstrapErrorHostTrustNotConfigured
 	}
-	return workflow.NewSoulBootstrapErrorState(username, correlation, code, "Soul bootstrap Host bridge is unavailable.", "lesser", 0, "", now)
+	if errors.Is(err, soulservice.ErrHostInstanceKeyMissing) {
+		code = workflow.SoulBootstrapErrorHostInstanceKeyMissing
+	}
+	if errors.Is(err, soulservice.ErrHostInstanceKeyUnavailable) {
+		code = workflow.SoulBootstrapErrorHostInstanceKeyUnavailable
+	}
+	if errors.Is(err, soulservice.ErrHostSigningPayloadUnsupported) {
+		code = workflow.SoulBootstrapErrorHostSigningPayloadUnsupported
+		message = "Host returned unsupported or incomplete bootstrap signing material."
+	}
+	if errors.Is(err, soulservice.ErrSoulAlreadyBound) || errors.Is(err, soulservice.ErrTargetAgentAlreadyHasSoul) {
+		code = workflow.SoulBootstrapErrorSoulBindingConflict
+		message = "Soul binding conflicts with an existing local binding."
+	}
+	if errors.Is(err, soulservice.ErrSoulNotAvailable) {
+		code = workflow.SoulBootstrapErrorSoulNotAvailable
+		message = "Host-published soul is not available for this local body."
+	}
+	return soulBootstrapErrorInfo{Code: code, Message: message, Source: source}
+}
+
+func soulBootstrapErrorWorkflowState(code string) string {
+	switch strings.TrimSpace(code) {
+	case workflow.SoulBootstrapErrorHostTrustNotConfigured:
+		return workflow.SoulBootstrapStateHostTrustNotConfigured
+	case workflow.SoulBootstrapErrorHostInstanceKeyMissing:
+		return workflow.SoulBootstrapStateHostInstanceKeyMissing
+	case workflow.SoulBootstrapErrorHostInstanceKeyUnavailable:
+		return workflow.SoulBootstrapStateHostInstanceKeyUnavailable
+	case workflow.SoulBootstrapErrorHostSigningPayloadUnsupported:
+		return workflow.SoulBootstrapStateHostSigningPayloadUnsupported
+	case workflow.SoulBootstrapErrorHostRegistrationIDRequired,
+		workflow.SoulBootstrapErrorHostConversationIDRequired,
+		workflow.SoulBootstrapErrorHostBootstrapReplayRejected:
+		return workflow.SoulBootstrapStateCorrelationMismatch
+	case workflow.SoulBootstrapErrorSoulBindingConflict:
+		return workflow.SoulBootstrapStateBindingConflict
+	case workflow.SoulBootstrapErrorSoulNotAvailable:
+		return workflow.SoulBootstrapStateSoulNotAvailable
+	default:
+		return workflow.SoulBootstrapStateHostUnavailable
+	}
 }
 
 func mergeSoulBootstrapCorrelation(existing *workflow.SoulBootstrapCorrelationState, next *workflow.SoulBootstrapCorrelationState) *workflow.SoulBootstrapCorrelationState {
@@ -561,6 +979,21 @@ func mergeSoulBootstrapCheckpoint(existing workflow.SoulBootstrapSigningCheckpoi
 	}
 	if strings.TrimSpace(next.CanonicalJSON) != "" {
 		merged.CanonicalJSON = next.CanonicalJSON
+	}
+	if next.ExpectedVersion != 0 {
+		merged.ExpectedVersion = next.ExpectedVersion
+	}
+	if next.NextVersion != 0 {
+		merged.NextVersion = next.NextVersion
+	}
+	if strings.TrimSpace(next.BoundaryRequirementsJSON) != "" {
+		merged.BoundaryRequirementsJSON = next.BoundaryRequirementsJSON
+	}
+	if strings.TrimSpace(next.FinalizeRequestTemplateJSON) != "" {
+		merged.FinalizeRequestTemplateJSON = next.FinalizeRequestTemplateJSON
+	}
+	if strings.TrimSpace(next.RegistrationPreviewJSON) != "" {
+		merged.RegistrationPreviewJSON = next.RegistrationPreviewJSON
 	}
 	if strings.TrimSpace(next.HostRequestID) != "" {
 		merged.HostRequestID = next.HostRequestID
@@ -709,6 +1142,7 @@ func graphSoulBootstrapStoredStateModel(state *workflow.SoulBootstrapState) *mod
 		Phase:              graphSoulBootstrapPhase(state.Phase),
 		State:              state.State,
 		SigningCheckpoints: graphSoulBootstrapSigningCheckpoints(state.SigningCheckpoints),
+		Publication:        graphSoulBootstrapPublication(state.Publication),
 		Error:              graphSoulBootstrapError(state.Error),
 		Correlation:        graphSoulBootstrapCorrelationModel(state.Correlation),
 		UpdatedAt:          graphTimePtr(state.UpdatedAt),
@@ -743,24 +1177,45 @@ func graphSoulBootstrapSigningCheckpoints(in []workflow.SoulBootstrapSigningChec
 	out := make([]*model.SoulBootstrapSigningCheckpoint, 0, len(in))
 	for _, item := range in {
 		out = append(out, &model.SoulBootstrapSigningCheckpoint{
-			Version:          optionalString(item.Version),
-			Name:             item.Name,
-			Status:           item.Status,
-			PrincipalAddress: optionalString(item.PrincipalAddress),
-			SignerAddress:    optionalString(item.SignerAddress),
-			SigningMethod:    optionalString(item.SigningMethod),
-			MessageEncoding:  optionalString(item.MessageEncoding),
-			Message:          optionalString(item.Message),
-			MessageHex:       optionalString(item.MessageHex),
-			DigestHex:        optionalString(item.DigestHex),
-			CanonicalJSON:    optionalString(item.CanonicalJSON),
-			HostRequestID:    optionalString(item.HostRequestID),
-			IssuedAt:         graphTimePtr(item.IssuedAt),
-			DeclaredAt:       graphTimePtr(item.DeclaredAt),
-			CompletedAt:      graphTimePtr(item.CompletedAt),
+			Version:                     optionalString(item.Version),
+			Name:                        item.Name,
+			Status:                      item.Status,
+			PrincipalAddress:            optionalString(item.PrincipalAddress),
+			SignerAddress:               optionalString(item.SignerAddress),
+			SigningMethod:               optionalString(item.SigningMethod),
+			MessageEncoding:             optionalString(item.MessageEncoding),
+			Message:                     optionalString(item.Message),
+			MessageHex:                  optionalString(item.MessageHex),
+			DigestHex:                   optionalString(item.DigestHex),
+			CanonicalJSON:               optionalString(item.CanonicalJSON),
+			ExpectedVersion:             optionalBootstrapExpectedVersion(item),
+			NextVersion:                 optionalInt(item.NextVersion),
+			BoundaryRequirementsJSON:    optionalString(item.BoundaryRequirementsJSON),
+			FinalizeRequestTemplateJSON: optionalString(item.FinalizeRequestTemplateJSON),
+			RegistrationPreviewJSON:     optionalString(item.RegistrationPreviewJSON),
+			HostRequestID:               optionalString(item.HostRequestID),
+			IssuedAt:                    graphTimePtr(item.IssuedAt),
+			DeclaredAt:                  graphTimePtr(item.DeclaredAt),
+			CompletedAt:                 graphTimePtr(item.CompletedAt),
 		})
 	}
 	return out
+}
+
+func graphSoulBootstrapPublication(in *workflow.SoulBootstrapPublicationEvidence) *model.SoulBootstrapPublicationEvidence {
+	if in == nil {
+		return nil
+	}
+	return &model.SoulBootstrapPublicationEvidence{
+		AgentID:                    optionalString(in.AgentID),
+		PublishedVersion:           optionalInt(in.PublishedVersion),
+		RegistrationURI:            optionalString(in.RegistrationURI),
+		RegistrationS3Key:          optionalString(in.RegistrationS3Key),
+		VersionedRegistrationURI:   optionalString(in.VersionedRegistrationURI),
+		VersionedRegistrationS3Key: optionalString(in.VersionedRegistrationS3Key),
+		AnchorState:                optionalString(in.AnchorState),
+		PublishedAt:                graphTimePtr(in.PublishedAt),
+	}
 }
 
 func graphSoulBootstrapError(in *workflow.SoulBootstrapErrorState) *model.SoulBootstrapErrorState {
@@ -854,9 +1309,287 @@ func graphBootstrapCorrelation(correlationKey *string, idempotencyKey *string, o
 	return correlation
 }
 
+func soulBootstrapRegistrationID(existing *workflow.SoulBootstrapState, input *string) (string, error) {
+	stored := ""
+	if existing != nil {
+		stored = strings.TrimSpace(existing.HostRegistrationID)
+	}
+	provided := strings.TrimSpace(derefString(input))
+	if stored != "" && provided != "" && stored != provided {
+		return "", &soulservice.HostBootstrapError{
+			Code:    workflow.SoulBootstrapErrorHostBootstrapReplayRejected,
+			Message: "registration id does not match local bootstrap state",
+			Source:  soulBootstrapErrorSourceLesser,
+			Err:     soulservice.ErrHostSigningPayloadUnsupported,
+		}
+	}
+	registrationID := provided
+	if registrationID == "" {
+		registrationID = stored
+	}
+	if registrationID == "" {
+		return "", &soulservice.HostBootstrapError{
+			Code:    workflow.SoulBootstrapErrorHostRegistrationIDRequired,
+			Message: "registration id is required",
+			Source:  soulBootstrapErrorSourceLesser,
+			Err:     soulservice.ErrHostSigningPayloadUnsupported,
+		}
+	}
+	return registrationID, nil
+}
+
+func soulBootstrapOptionalConversationID(existing *workflow.SoulBootstrapState, input *string) (string, error) {
+	stored := ""
+	if existing != nil {
+		stored = strings.TrimSpace(existing.HostConversationID)
+	}
+	provided := strings.TrimSpace(derefString(input))
+	if stored != "" && provided != "" && stored != provided {
+		return "", &soulservice.HostBootstrapError{
+			Code:    workflow.SoulBootstrapErrorHostBootstrapReplayRejected,
+			Message: "conversation id does not match local bootstrap state",
+			Source:  soulBootstrapErrorSourceLesser,
+			Err:     soulservice.ErrHostSigningPayloadUnsupported,
+		}
+	}
+	if provided != "" {
+		return provided, nil
+	}
+	return stored, nil
+}
+
+func soulBootstrapRequiredConversationID(existing *workflow.SoulBootstrapState, input string) (string, error) {
+	provided := strings.TrimSpace(input)
+	stored := ""
+	if existing != nil {
+		stored = strings.TrimSpace(existing.HostConversationID)
+	}
+	if stored != "" && provided != "" && stored != provided {
+		return "", &soulservice.HostBootstrapError{
+			Code:    workflow.SoulBootstrapErrorHostBootstrapReplayRejected,
+			Message: "conversation id does not match local bootstrap state",
+			Source:  soulBootstrapErrorSourceLesser,
+			Err:     soulservice.ErrHostSigningPayloadUnsupported,
+		}
+	}
+	conversationID := provided
+	if conversationID == "" {
+		conversationID = stored
+	}
+	if conversationID == "" {
+		return "", &soulservice.HostBootstrapError{
+			Code:    workflow.SoulBootstrapErrorHostConversationIDRequired,
+			Message: "conversation id is required",
+			Source:  soulBootstrapErrorSourceLesser,
+			Err:     soulservice.ErrHostSigningPayloadUnsupported,
+		}
+	}
+	return conversationID, nil
+}
+
+func graphBootstrapSignatureMap(raw *string) (map[string]string, error) {
+	value := strings.TrimSpace(derefString(raw))
+	if value == "" {
+		return map[string]string{}, nil
+	}
+	var decoded map[string]string
+	if err := json.Unmarshal([]byte(value), &decoded); err != nil {
+		return nil, &soulservice.HostBootstrapError{
+			Code:    "HOST_INVALID_REQUEST",
+			Message: "boundarySignaturesJson must be a JSON object of string signatures",
+			Source:  soulBootstrapErrorSourceLesser,
+			Err:     soulservice.ErrHostSigningPayloadUnsupported,
+		}
+	}
+	out := make(map[string]string, len(decoded))
+	for key, signature := range decoded {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out[key] = strings.TrimSpace(signature)
+	}
+	return out, nil
+}
+
+func soulBootstrapFinalizeDefaults(existing *workflow.SoulBootstrapState, issuedAt *model.Time, expectedVersion *int) (time.Time, int) {
+	resolvedIssuedAt := time.Time{}
+	if issuedAt != nil {
+		resolvedIssuedAt = time.Time(*issuedAt)
+	}
+	resolvedExpectedVersion := 0
+	if expectedVersion != nil {
+		resolvedExpectedVersion = *expectedVersion
+	}
+	if existing == nil {
+		return resolvedIssuedAt, resolvedExpectedVersion
+	}
+	for _, checkpoint := range existing.SigningCheckpoints {
+		if !strings.EqualFold(strings.TrimSpace(checkpoint.Name), "finalize") {
+			continue
+		}
+		if resolvedIssuedAt.IsZero() && checkpoint.IssuedAt != nil {
+			resolvedIssuedAt = *checkpoint.IssuedAt
+		}
+		if expectedVersion == nil && checkpoint.ExpectedVersion >= 0 {
+			resolvedExpectedVersion = checkpoint.ExpectedVersion
+		}
+		break
+	}
+	return resolvedIssuedAt, resolvedExpectedVersion
+}
+
+func soulBootstrapBindingPrincipalUsername(agentUser *storage.User, fallback string) string {
+	if agentUser != nil {
+		if owner := strings.TrimPrefix(strings.TrimSpace(agentUser.AgentOwner), "@"); owner != "" {
+			return owner
+		}
+	}
+	return strings.TrimSpace(fallback)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func applySoulBootstrapWorkflowProjection(
+	ctx context.Context,
+	r *Resolver,
+	viewerUsername string,
+	agentUser *storage.User,
+	workflowState *workflow.DroneWorkflowState,
+	bootstrap *workflow.SoulBootstrapState,
+	now time.Time,
+) {
+	if workflowState == nil || bootstrap == nil {
+		return
+	}
+	bootstrap = workflow.NormalizeSoulBootstrap(bootstrap, "")
+	ownerActor := workflow.DroneActor{}
+	finalizerActor := workflow.DroneActor{}
+	if r != nil {
+		ownerActor = r.droneWorkflowActor(ctx, soulBootstrapBindingPrincipalUsername(agentUser, viewerUsername), "steward")
+		finalizerActor = r.droneWorkflowActor(ctx, viewerUsername, "launch_owner")
+	}
+	if strings.TrimSpace(ownerActor.ID) == "" {
+		ownerActor = finalizerActor
+	}
+
+	if strings.TrimSpace(bootstrap.HostConversationID) != "" {
+		workflowState.Conversation = &workflow.DroneConversationState{
+			ConversationID: bootstrap.HostConversationID,
+			UpdatedAt:      &now,
+		}
+	}
+
+	switch {
+	case bootstrap.Phase == workflow.SoulBootstrapPhasePrincipalDeclaration:
+		workflowState.CurrentPhase = workflow.DroneWorkflowPhaseDeclaration
+		workflowState.CurrentState = workflow.DroneWorkflowStateDeclarationReady
+	case bootstrap.Phase == workflow.SoulBootstrapPhaseConversation:
+		if bootstrap.State == workflow.SoulBootstrapStateConversationCompleted {
+			workflowState.CurrentPhase = workflow.DroneWorkflowPhaseSigning
+			workflowState.CurrentState = workflow.DroneWorkflowStateSigningPending
+		} else {
+			workflowState.CurrentPhase = workflow.DroneWorkflowPhaseDeclaration
+			workflowState.CurrentState = workflow.DroneWorkflowStateDeclarationReady
+		}
+	case bootstrap.Phase == workflow.SoulBootstrapPhaseFinalize && bootstrap.State == workflow.SoulBootstrapStateFinalizeReady:
+		workflowState.CurrentPhase = workflow.DroneWorkflowPhaseSigning
+		workflowState.CurrentState = workflow.DroneWorkflowStateSigningPending
+	case bootstrap.Phase == workflow.SoulBootstrapPhaseFinalize:
+		workflowState.CurrentPhase = workflow.DroneWorkflowPhaseGraduation
+		workflowState.CurrentState = workflow.DroneWorkflowStateGraduationReady
+	case bootstrap.Phase == workflow.SoulBootstrapPhaseComplete:
+		workflowState.SoulAgentID = strings.TrimSpace(bootstrap.HostSoulAgentID)
+		workflowState.CurrentPhase = workflow.DroneWorkflowPhaseContinuity
+		workflowState.CurrentState = workflow.DroneWorkflowStateContinuityStable
+	case bootstrap.Phase == workflow.SoulBootstrapPhaseError:
+		// Preserve the last projected non-error phase so UI can show the current
+		// actionable card alongside the typed bootstrap error.
+	default:
+		return
+	}
+
+	if bootstrap.Phase == workflow.SoulBootstrapPhaseConversation && bootstrap.State == workflow.SoulBootstrapStateConversationCompleted {
+		workflowState.Declaration = &workflow.DroneDeclarationCard{
+			ID:            agentUser.Username + ":bootstrap-declaration",
+			Title:         "Soul bootstrap declaration",
+			Statement:     "Host mint conversation completed and produced declaration material.",
+			Confidence:    "hosted_offchain",
+			Owner:         &ownerActor,
+			DeclaredScope: []string{"identity_continuity", "hosted_offchain_registration"},
+		}
+	}
+	if bootstrap.Phase == workflow.SoulBootstrapPhaseFinalize {
+		workflowState.Checkpoint = &workflow.DroneSignatureCheckpoint{
+			ID:             agentUser.Username + ":bootstrap-finalize",
+			Title:          "Soul bootstrap finalize checkpoint",
+			ReadinessLabel: "Host finalize signing material captured",
+			DueAt:          &now,
+			Signers: []workflow.DroneSignatureSigner{
+				{
+					ID:     defaultString(bootstrap.PrincipalAddress, finalizerActor.ID),
+					Name:   defaultString(bootstrap.PrincipalAddress, finalizerActor.Name),
+					Role:   "principal",
+					Status: workflow.DroneSignatureSignerStatusApproved,
+					Note:   "Host self-attestation checkpoint",
+				},
+			},
+		}
+		if bootstrap.State == workflow.SoulBootstrapStateFinalizePublished {
+			workflowState.Graduation = &workflow.DroneGraduationSummaryCard{
+				ID:                  agentUser.Username + ":bootstrap-graduation",
+				Title:               "Hosted soul publication",
+				Readiness:           workflow.DroneGraduationReadinessReady,
+				Summary:             "Host published the hosted/off-chain soul registration and returned publication evidence.",
+				LaunchOwner:         &finalizerActor,
+				CompletedMilestones: []string{"conversation_completed", "finalize_signed", "host_publication_recorded"},
+				ExitCriteria:        []string{"local_body_binding"},
+				NextStep:            "Bind Host soul to local Lesser body",
+				Metrics: []workflow.DroneMetric{
+					{Label: "Soul agent", Value: bootstrap.HostSoulAgentID},
+				},
+			}
+		}
+	}
+	if bootstrap.Phase == workflow.SoulBootstrapPhaseComplete {
+		anchorState := ""
+		if bootstrap.Publication != nil {
+			anchorState = bootstrap.Publication.AnchorState
+		}
+		workflowState.Continuity = &workflow.DroneContinuityPanel{
+			ID:           agentUser.Username + ":bootstrap-continuity",
+			Title:        "Soul/body continuity",
+			Objective:    "Preserve the existing body identity, timeline presence, and memory continuity through hosted soul binding.",
+			Owner:        ownerActor,
+			FeedbackLoop: "Monitor bootstrap publication evidence, local binding state, and attribution continuity.",
+			Metrics: []workflow.DroneMetric{
+				{Label: "Body", Value: "preserved"},
+				{Label: "Soul binding", Value: "bound"},
+				{Label: "Anchor", Value: defaultString(anchorState, "hosted_offchain")},
+			},
+		}
+	}
+	workflowState.Lifecycle = workflow.BuildDroneLifecycle(workflowState.CurrentPhase, workflowState.CurrentState)
+}
+
 func optionalInt(value int) *int {
 	if value == 0 {
 		return nil
 	}
+	return &value
+}
+
+func optionalBootstrapExpectedVersion(checkpoint workflow.SoulBootstrapSigningCheckpoint) *int {
+	if !strings.EqualFold(strings.TrimSpace(checkpoint.Name), "finalize") {
+		return nil
+	}
+	value := checkpoint.ExpectedVersion
 	return &value
 }

--- a/graph/soul_bootstrap_round44_test.go
+++ b/graph/soul_bootstrap_round44_test.go
@@ -331,6 +331,325 @@ func TestRound44SoulBootstrapPrincipalPreflightAndVerifyPersistIdempotently(t *t
 	require.Equal(t, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", derefString(verified.Bootstrap.State.SigningCheckpoints[0].MessageHex))
 }
 
+func TestRound44SoulBootstrapConversationFinalizeBindsAndProjects(t *testing.T) {
+	resolver, storageRepo := newRound12GraphResolver(t)
+	now := time.Date(2026, 6, 12, 15, 30, 0, 0, time.UTC)
+	issuedAt := time.Date(2026, 6, 12, 15, 35, 0, 0, time.UTC)
+	const (
+		agentID   = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		principal = "0x2222222222222222222222222222222222222222"
+	)
+
+	resolver.soulsClient = &stubSoulService{
+		sendBootstrapConversationFunc: func(_ context.Context, input soulservice.BootstrapConversationMessageInput) (*soulservice.BootstrapConversationMessageResult, error) {
+			require.Equal(t, "reg_123", input.RegistrationID)
+			require.Empty(t, input.ConversationID)
+			require.Equal(t, "Review my hosted identity.", input.Message)
+			return &soulservice.BootstrapConversationMessageResult{
+				RegistrationID: "reg_123",
+				ConversationID: "conv_123",
+				Model:          "claude",
+				FullResponse:   "Host response",
+				HostRequestID:  "host-req-conv",
+			}, nil
+		},
+		completeBootstrapConversationFunc: func(_ context.Context, input soulservice.BootstrapConversationCompleteInput) (*soulservice.BootstrapConversationCompleteResult, error) {
+			require.Equal(t, "reg_123", input.RegistrationID)
+			require.Equal(t, "conv_123", input.ConversationID)
+			return &soulservice.BootstrapConversationCompleteResult{
+				RegistrationID:       "reg_123",
+				HostSoulAgentID:      agentID,
+				ConversationID:       "conv_123",
+				Status:               "completed",
+				ProducedDeclarations: `{"selfDescription":{"summary":"ready"},"capabilities":[],"boundaries":[],"transparency":{}}`,
+				CompletedAt:          &issuedAt,
+				HostRequestID:        "host-req-complete",
+			}, nil
+		},
+		prepareBootstrapFinalizeFunc: func(_ context.Context, input soulservice.BootstrapFinalizePreflightInput) (*soulservice.BootstrapFinalizePreflightResult, error) {
+			require.Equal(t, map[string]string{"b1": "0xboundary"}, input.BoundarySignatures)
+			return &soulservice.BootstrapFinalizePreflightResult{
+				Version:         "1",
+				DigestHex:       "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				IssuedAt:        &issuedAt,
+				ExpectedVersion: 0,
+				NextVersion:     1,
+				SelfAttestationSigning: soulservice.BootstrapFinalizeSigningInput{
+					SignerWallet:    principal,
+					SigningMethod:   "eip191_personal_sign",
+					MessageEncoding: "hex_bytes",
+					MessageHex:      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					DigestHex:       "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+					CanonicalJSON:   `{"host":"finalize"}`,
+				},
+				BoundaryRequirementsJSON:    `[{"boundary_id":"b1"}]`,
+				FinalizeRequestTemplateJSON: `{"expected_version":0}`,
+				RegistrationPreviewJSON:     `{"agent_id":"` + agentID + `"}`,
+				HostRequestID:               "host-req-preflight",
+			}, nil
+		},
+		finalizeBootstrapFunc: func(_ context.Context, input soulservice.BootstrapFinalizeInput) (*soulservice.BootstrapFinalizeResult, error) {
+			require.Equal(t, "reg_123", input.RegistrationID)
+			require.Equal(t, "conv_123", input.ConversationID)
+			require.Equal(t, map[string]string{"b1": "0xboundary"}, input.BoundarySignatures)
+			require.Equal(t, issuedAt, input.IssuedAt)
+			require.Equal(t, 0, input.ExpectedVersion)
+			require.Equal(t, "0xself", input.SelfAttestation)
+			publishedAt := issuedAt.Add(2 * time.Minute)
+			return &soulservice.BootstrapFinalizeResult{
+				Version:          "1",
+				HostSoulAgentID:  agentID,
+				PublishedVersion: 1,
+				PrincipalAddress: principal,
+				Publication: soulservice.BootstrapPublicationEvidence{
+					AgentID:          agentID,
+					PublishedVersion: 1,
+					RegistrationURI:  "s3://bucket/registry/v1/agents/" + agentID + "/registration.json",
+					AnchorState:      "hosted_offchain",
+					PublishedAt:      &publishedAt,
+				},
+				Promotion: soulservice.BootstrapPromotionEvidence{
+					AgentID:                  agentID,
+					RegistrationID:           "reg_123",
+					Stage:                    "graduated",
+					LatestConversationID:     "conv_123",
+					LatestConversationStatus: "completed",
+					PublishedVersion:         1,
+					GraduatedAt:              &publishedAt,
+				},
+				HostRequestID: "host-req-finalize",
+			}, nil
+		},
+		incorporateFunc: func(_ context.Context, principalUsername string, targetAgentUsername string, soulAgentID string) (*soulservice.Soul, error) {
+			require.Equal(t, "owner", principalUsername)
+			require.Equal(t, "drone-epsilon", targetAgentUsername)
+			require.Equal(t, agentID, soulAgentID)
+			return &soulservice.Soul{
+				AgentID:               soulAgentID,
+				PrincipalAddress:      principal,
+				Bound:                 true,
+				BoundAgentUsername:    targetAgentUsername,
+				BoundPrincipalAddress: principal,
+			}, nil
+		},
+	}
+
+	seedMetadata, err := workflow.SetDroneWorkflowMetadata(nil, &workflow.DroneWorkflowState{
+		CurrentPhase: workflow.DroneWorkflowPhaseReview,
+		CurrentState: workflow.DroneWorkflowStateReviewApproved,
+		Review: &workflow.DroneReviewCard{
+			ID:              "drone-epsilon:review",
+			Title:           "Reviewer handoff",
+			Decision:        workflow.DroneReviewDecisionApproved,
+			Reviewer:        workflow.DroneActor{ID: "reviewer", Name: "Reviewer", Role: "reviewer", Handle: "@reviewer"},
+			DecisionSummary: "Reviewer may conduct hosted conversation.",
+		},
+		SoulBootstrap: &workflow.SoulBootstrapState{
+			Username:           "drone-epsilon",
+			BodyID:             "drone-epsilon",
+			HostRegistrationID: "reg_123",
+			HostSoulAgentID:    agentID,
+			Phase:              workflow.SoulBootstrapPhaseConversation,
+			State:              "conversation.pending",
+		},
+	})
+	require.NoError(t, err)
+
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "owner",
+		DisplayName: "Owner",
+		Approved:    true,
+		CreatedAt:   now.Add(-48 * time.Hour),
+		UpdatedAt:   now.Add(-24 * time.Hour),
+	}, nil)
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "reviewer",
+		DisplayName: "Reviewer",
+		Approved:    true,
+		CreatedAt:   now.Add(-48 * time.Hour),
+		UpdatedAt:   now.Add(-24 * time.Hour),
+	}, nil)
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "drone-epsilon",
+		DisplayName: "Drone Epsilon",
+		Approved:    true,
+		IsAgent:     true,
+		AgentOwner:  "@owner",
+		Metadata:    seedMetadata,
+		CreatedAt:   now.Add(-24 * time.Hour),
+		UpdatedAt:   now,
+	}, &storage.AgentGovernanceState{
+		Username:        "drone-epsilon",
+		DelegatedScopes: []string{auth.ScopeRead, auth.ScopeWrite},
+	})
+
+	sent, err := (&mutationResolver{resolver}).SendSoulBootstrapConversationMessage(
+		round13DroneAuthContext("reviewer", auth.ScopeWrite),
+		model.SendSoulBootstrapConversationMessageInput{
+			Username: "drone-epsilon",
+			Message:  "Review my hosted identity.",
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, model.SoulBootstrapPhaseConversation, sent.Bootstrap.State.Phase)
+	require.Equal(t, workflow.SoulBootstrapStateConversationInProgress, sent.Bootstrap.State.State)
+	require.Equal(t, "conv_123", derefString(sent.Bootstrap.State.HostConversationID))
+	require.Equal(t, workflow.DroneWorkflowPhaseDeclaration, sent.Bootstrap.Workflow.CurrentPhase)
+
+	completed, err := (&mutationResolver{resolver}).CompleteSoulBootstrapConversation(
+		round13DroneAuthContext("reviewer", auth.ScopeWrite),
+		model.CompleteSoulBootstrapConversationInput{
+			Username:       "drone-epsilon",
+			ConversationID: "conv_123",
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, workflow.SoulBootstrapStateConversationCompleted, completed.Bootstrap.State.State)
+	require.Equal(t, workflow.DroneWorkflowPhaseSigning, completed.Bootstrap.Workflow.CurrentPhase)
+	require.NotNil(t, completed.Bootstrap.Workflow.Declaration)
+
+	preflight, err := (&mutationResolver{resolver}).PrepareSoulBootstrapFinalize(
+		round13DroneAuthContext("reviewer", auth.ScopeWrite),
+		model.PrepareSoulBootstrapFinalizeInput{
+			Username:               "drone-epsilon",
+			ConversationID:         "conv_123",
+			BoundarySignaturesJSON: round13StringPtr(`{"b1":"0xboundary"}`),
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, model.SoulBootstrapPhaseFinalize, preflight.Bootstrap.State.Phase)
+	require.Equal(t, workflow.SoulBootstrapStateFinalizeReady, preflight.Bootstrap.State.State)
+	var finalizeCheckpoint *model.SoulBootstrapSigningCheckpoint
+	for _, checkpoint := range preflight.Bootstrap.State.SigningCheckpoints {
+		if checkpoint.Name == "finalize" {
+			finalizeCheckpoint = checkpoint
+			break
+		}
+	}
+	require.NotNil(t, finalizeCheckpoint)
+	require.Equal(t, "finalize", finalizeCheckpoint.Name)
+	require.Equal(t, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", derefString(finalizeCheckpoint.MessageHex))
+	require.Equal(t, 0, *finalizeCheckpoint.ExpectedVersion)
+	require.Contains(t, derefString(finalizeCheckpoint.BoundaryRequirementsJSON), `"boundary_id":"b1"`)
+
+	finalized, err := (&mutationResolver{resolver}).FinalizeSoulBootstrap(
+		round13DroneAuthContext("reviewer", auth.ScopeWrite),
+		model.FinalizeSoulBootstrapInput{
+			Username:               "drone-epsilon",
+			ConversationID:         "conv_123",
+			BoundarySignaturesJSON: round13StringPtr(`{"b1":"0xboundary"}`),
+			SelfAttestation:        round13StringPtr("0xself"),
+		},
+	)
+	require.NoError(t, err)
+	require.Nil(t, finalized.Error)
+	require.Equal(t, model.SoulBootstrapPhaseComplete, finalized.Bootstrap.State.Phase)
+	require.Equal(t, workflow.SoulBootstrapStateCompleteBound, finalized.Bootstrap.State.State)
+	require.Equal(t, agentID, derefString(finalized.Bootstrap.State.HostSoulAgentID))
+	require.NotNil(t, finalized.Bootstrap.State.Publication)
+	require.Equal(t, "hosted_offchain", derefString(finalized.Bootstrap.State.Publication.AnchorState))
+	require.Equal(t, workflow.DroneWorkflowPhaseContinuity, finalized.Bootstrap.Workflow.CurrentPhase)
+	require.NotNil(t, finalized.Bootstrap.Workflow.Continuity)
+
+	replay, err := (&mutationResolver{resolver}).CompleteSoulBootstrapConversation(
+		round13DroneAuthContext("reviewer", auth.ScopeWrite),
+		model.CompleteSoulBootstrapConversationInput{
+			Username:       "drone-epsilon",
+			ConversationID: "conv_other",
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, replay.Error)
+	require.Equal(t, workflow.SoulBootstrapErrorHostBootstrapReplayRejected, replay.Error.Code)
+}
+
+func TestRound44SoulBootstrapFinalizeBindingConflictIsTyped(t *testing.T) {
+	resolver, storageRepo := newRound12GraphResolver(t)
+	now := time.Date(2026, 6, 12, 16, 0, 0, 0, time.UTC)
+	issuedAt := time.Date(2026, 6, 12, 16, 5, 0, 0, time.UTC)
+	const agentID = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	resolver.soulsClient = &stubSoulService{
+		finalizeBootstrapFunc: func(_ context.Context, input soulservice.BootstrapFinalizeInput) (*soulservice.BootstrapFinalizeResult, error) {
+			require.Equal(t, "reg_conflict", input.RegistrationID)
+			require.Equal(t, "conv_conflict", input.ConversationID)
+			publishedAt := issuedAt.Add(time.Minute)
+			return &soulservice.BootstrapFinalizeResult{
+				Version:          "1",
+				HostSoulAgentID:  agentID,
+				PublishedVersion: 1,
+				Publication: soulservice.BootstrapPublicationEvidence{
+					AgentID:          agentID,
+					PublishedVersion: 1,
+					AnchorState:      "hosted_offchain",
+					PublishedAt:      &publishedAt,
+				},
+				HostRequestID: "host-req-finalize-conflict",
+			}, nil
+		},
+		incorporateFunc: func(context.Context, string, string, string) (*soulservice.Soul, error) {
+			return nil, soulservice.ErrTargetAgentAlreadyHasSoul
+		},
+	}
+
+	metadata, err := workflow.SetDroneWorkflowMetadata(nil, &workflow.DroneWorkflowState{
+		SoulBootstrap: &workflow.SoulBootstrapState{
+			Username:           "drone-conflict",
+			BodyID:             "drone-conflict",
+			HostRegistrationID: "reg_conflict",
+			HostConversationID: "conv_conflict",
+			Phase:              workflow.SoulBootstrapPhaseFinalize,
+			State:              workflow.SoulBootstrapStateFinalizeReady,
+			SigningCheckpoints: []workflow.SoulBootstrapSigningCheckpoint{
+				{
+					Name:            "finalize",
+					Status:          "ready",
+					ExpectedVersion: 0,
+					IssuedAt:        &issuedAt,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "owner",
+		DisplayName: "Owner",
+		Approved:    true,
+		CreatedAt:   now.Add(-48 * time.Hour),
+		UpdatedAt:   now.Add(-24 * time.Hour),
+	}, nil)
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "drone-conflict",
+		DisplayName: "Drone Conflict",
+		Approved:    true,
+		IsAgent:     true,
+		AgentOwner:  "@owner",
+		Metadata:    metadata,
+		CreatedAt:   now.Add(-24 * time.Hour),
+		UpdatedAt:   now,
+	}, &storage.AgentGovernanceState{
+		Username:        "drone-conflict",
+		DelegatedScopes: []string{auth.ScopeRead, auth.ScopeWrite},
+	})
+
+	payload, err := (&mutationResolver{resolver}).FinalizeSoulBootstrap(
+		round13DroneAuthContext("owner", auth.ScopeWrite),
+		model.FinalizeSoulBootstrapInput{
+			Username:               "drone-conflict",
+			ConversationID:         "conv_conflict",
+			BoundarySignaturesJSON: round13StringPtr(`{"b1":"0xboundary"}`),
+			SelfAttestation:        round13StringPtr("0xself"),
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, payload.Error)
+	require.Equal(t, workflow.SoulBootstrapErrorSoulBindingConflict, payload.Error.Code)
+	require.Equal(t, workflow.SoulBootstrapStateBindingConflict, payload.Bootstrap.State.State)
+	require.Equal(t, agentID, derefString(payload.Bootstrap.State.HostSoulAgentID))
+	require.NotNil(t, payload.Bootstrap.State.Publication)
+}
+
 func TestRound44SoulBootstrapBindingProjectionWinsOverLocalError(t *testing.T) {
 	now := time.Date(2026, 6, 12, 14, 0, 0, 0, time.UTC)
 	workflowState := &workflow.DroneWorkflowState{

--- a/graph/souls_round12_test.go
+++ b/graph/souls_round12_test.go
@@ -15,12 +15,16 @@ import (
 )
 
 type stubSoulService struct {
-	listMineFunc                  func(context.Context, string) ([]soulservice.Soul, error)
-	incorporateFunc               func(context.Context, string, string, string) (*soulservice.Soul, error)
-	resolveBoundFunc              func(context.Context, string) (*soulservice.Soul, error)
-	beginBootstrapFunc            func(context.Context, soulservice.BootstrapBeginInput) (*soulservice.BootstrapBeginResult, error)
-	prepareBootstrapPrincipalFunc func(context.Context, soulservice.BootstrapPrincipalPreflightInput) (*soulservice.BootstrapPrincipalPreflightResult, error)
-	verifyBootstrapPrincipalFunc  func(context.Context, soulservice.BootstrapPrincipalVerifyInput) (*soulservice.BootstrapPrincipalVerifyResult, error)
+	listMineFunc                      func(context.Context, string) ([]soulservice.Soul, error)
+	incorporateFunc                   func(context.Context, string, string, string) (*soulservice.Soul, error)
+	resolveBoundFunc                  func(context.Context, string) (*soulservice.Soul, error)
+	beginBootstrapFunc                func(context.Context, soulservice.BootstrapBeginInput) (*soulservice.BootstrapBeginResult, error)
+	prepareBootstrapPrincipalFunc     func(context.Context, soulservice.BootstrapPrincipalPreflightInput) (*soulservice.BootstrapPrincipalPreflightResult, error)
+	verifyBootstrapPrincipalFunc      func(context.Context, soulservice.BootstrapPrincipalVerifyInput) (*soulservice.BootstrapPrincipalVerifyResult, error)
+	sendBootstrapConversationFunc     func(context.Context, soulservice.BootstrapConversationMessageInput) (*soulservice.BootstrapConversationMessageResult, error)
+	completeBootstrapConversationFunc func(context.Context, soulservice.BootstrapConversationCompleteInput) (*soulservice.BootstrapConversationCompleteResult, error)
+	prepareBootstrapFinalizeFunc      func(context.Context, soulservice.BootstrapFinalizePreflightInput) (*soulservice.BootstrapFinalizePreflightResult, error)
+	finalizeBootstrapFunc             func(context.Context, soulservice.BootstrapFinalizeInput) (*soulservice.BootstrapFinalizeResult, error)
 }
 
 func (s *stubSoulService) ListMine(ctx context.Context, username string) ([]soulservice.Soul, error) {
@@ -63,6 +67,34 @@ func (s *stubSoulService) VerifyBootstrapPrincipalDeclaration(ctx context.Contex
 		return nil, errors.New("verify bootstrap principal declaration not implemented")
 	}
 	return s.verifyBootstrapPrincipalFunc(ctx, input)
+}
+
+func (s *stubSoulService) SendBootstrapConversationMessage(ctx context.Context, input soulservice.BootstrapConversationMessageInput) (*soulservice.BootstrapConversationMessageResult, error) {
+	if s.sendBootstrapConversationFunc == nil {
+		return nil, errors.New("send bootstrap conversation not implemented")
+	}
+	return s.sendBootstrapConversationFunc(ctx, input)
+}
+
+func (s *stubSoulService) CompleteBootstrapConversation(ctx context.Context, input soulservice.BootstrapConversationCompleteInput) (*soulservice.BootstrapConversationCompleteResult, error) {
+	if s.completeBootstrapConversationFunc == nil {
+		return nil, errors.New("complete bootstrap conversation not implemented")
+	}
+	return s.completeBootstrapConversationFunc(ctx, input)
+}
+
+func (s *stubSoulService) PrepareBootstrapFinalize(ctx context.Context, input soulservice.BootstrapFinalizePreflightInput) (*soulservice.BootstrapFinalizePreflightResult, error) {
+	if s.prepareBootstrapFinalizeFunc == nil {
+		return nil, errors.New("prepare bootstrap finalize not implemented")
+	}
+	return s.prepareBootstrapFinalizeFunc(ctx, input)
+}
+
+func (s *stubSoulService) FinalizeBootstrap(ctx context.Context, input soulservice.BootstrapFinalizeInput) (*soulservice.BootstrapFinalizeResult, error) {
+	if s.finalizeBootstrapFunc == nil {
+		return nil, errors.New("finalize bootstrap not implemented")
+	}
+	return s.finalizeBootstrapFunc(ctx, input)
 }
 
 func soulAuthContext(username string, scopes ...string) context.Context {

--- a/pkg/agents/soul_bootstrap.go
+++ b/pkg/agents/soul_bootstrap.go
@@ -37,6 +37,20 @@ const (
 	SoulBootstrapStateHostUnavailable = "error.host_unavailable"
 	// SoulBootstrapStateHostSigningPayloadUnsupported marks unsupported Host signing metadata.
 	SoulBootstrapStateHostSigningPayloadUnsupported = "error.host_signing_payload_unsupported"
+	// SoulBootstrapStateConversationInProgress marks an active Host mint conversation.
+	SoulBootstrapStateConversationInProgress = "conversation.in_progress"
+	// SoulBootstrapStateConversationCompleted marks a completed Host mint conversation.
+	SoulBootstrapStateConversationCompleted = "conversation.completed"
+	// SoulBootstrapStateFinalizeReady marks Host finalize preflight signing material readiness.
+	SoulBootstrapStateFinalizeReady = "finalize.ready"
+	// SoulBootstrapStateFinalizePublished marks Host publication before local binding completes.
+	SoulBootstrapStateFinalizePublished = "finalize.published"
+	// SoulBootstrapStateCorrelationMismatch marks a local replay/correlation mismatch.
+	SoulBootstrapStateCorrelationMismatch = "error.correlation_mismatch"
+	// SoulBootstrapStateBindingConflict marks a safe local soul/body binding conflict.
+	SoulBootstrapStateBindingConflict = "error.binding_conflict"
+	// SoulBootstrapStateSoulNotAvailable marks Host publication evidence that cannot be bound locally.
+	SoulBootstrapStateSoulNotAvailable = "error.soul_not_available"
 	// SoulBootstrapStateCompleteBound marks an existing soul/body binding projection.
 	SoulBootstrapStateCompleteBound = "complete.bound"
 
@@ -52,6 +66,16 @@ const (
 	SoulBootstrapErrorHostUnavailable = "HOST_UNAVAILABLE"
 	// SoulBootstrapErrorHostSigningPayloadUnsupported is exposed for unsupported Host signing metadata.
 	SoulBootstrapErrorHostSigningPayloadUnsupported = "HOST_SIGNING_PAYLOAD_UNSUPPORTED"
+	// SoulBootstrapErrorHostRegistrationIDRequired is exposed when no Host registration id is available.
+	SoulBootstrapErrorHostRegistrationIDRequired = "HOST_REGISTRATION_ID_REQUIRED"
+	// SoulBootstrapErrorHostConversationIDRequired is exposed when no Host conversation id is available.
+	SoulBootstrapErrorHostConversationIDRequired = "HOST_CONVERSATION_ID_REQUIRED"
+	// SoulBootstrapErrorHostBootstrapReplayRejected is exposed when caller ids do not match local bootstrap state.
+	SoulBootstrapErrorHostBootstrapReplayRejected = "HOST_BOOTSTRAP_REPLAY_REJECTED"
+	// SoulBootstrapErrorSoulBindingConflict is exposed when local binding uniqueness rejects finalization.
+	SoulBootstrapErrorSoulBindingConflict = "SOUL_BINDING_CONFLICT"
+	// SoulBootstrapErrorSoulNotAvailable is exposed when Host-published soul identity is not locally bindable.
+	SoulBootstrapErrorSoulNotAvailable = "SOUL_NOT_AVAILABLE"
 )
 
 // SoulBootstrapState stores local correlation state for zero-state soul creation.
@@ -61,39 +85,58 @@ const (
 // represented here; only Host-issued identifiers, signing checkpoint metadata, and
 // client-safe error/correlation values are persisted.
 type SoulBootstrapState struct {
-	Username           string                           `json:"username,omitempty"`
-	BodyID             string                           `json:"body_id,omitempty"`
-	HostRegistrationID string                           `json:"host_registration_id,omitempty"`
-	HostConversationID string                           `json:"host_conversation_id,omitempty"`
-	HostSoulAgentID    string                           `json:"host_soul_agent_id,omitempty"`
-	WalletAddress      string                           `json:"wallet_address,omitempty"`
-	PrincipalAddress   string                           `json:"principal_address,omitempty"`
-	Phase              string                           `json:"phase,omitempty"`
-	State              string                           `json:"state,omitempty"`
-	SigningCheckpoints []SoulBootstrapSigningCheckpoint `json:"signing_checkpoints,omitempty"`
-	Error              *SoulBootstrapErrorState         `json:"error,omitempty"`
-	Correlation        *SoulBootstrapCorrelationState   `json:"correlation,omitempty"`
-	UpdatedAt          *time.Time                       `json:"updated_at,omitempty"`
+	Username           string                            `json:"username,omitempty"`
+	BodyID             string                            `json:"body_id,omitempty"`
+	HostRegistrationID string                            `json:"host_registration_id,omitempty"`
+	HostConversationID string                            `json:"host_conversation_id,omitempty"`
+	HostSoulAgentID    string                            `json:"host_soul_agent_id,omitempty"`
+	WalletAddress      string                            `json:"wallet_address,omitempty"`
+	PrincipalAddress   string                            `json:"principal_address,omitempty"`
+	Phase              string                            `json:"phase,omitempty"`
+	State              string                            `json:"state,omitempty"`
+	SigningCheckpoints []SoulBootstrapSigningCheckpoint  `json:"signing_checkpoints,omitempty"`
+	Publication        *SoulBootstrapPublicationEvidence `json:"publication,omitempty"`
+	Error              *SoulBootstrapErrorState          `json:"error,omitempty"`
+	Correlation        *SoulBootstrapCorrelationState    `json:"correlation,omitempty"`
+	UpdatedAt          *time.Time                        `json:"updated_at,omitempty"`
 }
 
 // SoulBootstrapSigningCheckpoint records non-secret signing material metadata
 // returned by Host preflight endpoints.
 type SoulBootstrapSigningCheckpoint struct {
-	Version          string     `json:"version,omitempty"`
-	Name             string     `json:"name,omitempty"`
-	Status           string     `json:"status,omitempty"`
-	PrincipalAddress string     `json:"principal_address,omitempty"`
-	SignerAddress    string     `json:"signer_address,omitempty"`
-	SigningMethod    string     `json:"signing_method,omitempty"`
-	MessageEncoding  string     `json:"message_encoding,omitempty"`
-	Message          string     `json:"message,omitempty"`
-	MessageHex       string     `json:"message_hex,omitempty"`
-	DigestHex        string     `json:"digest_hex,omitempty"`
-	CanonicalJSON    string     `json:"canonical_json,omitempty"`
-	HostRequestID    string     `json:"host_request_id,omitempty"`
-	IssuedAt         *time.Time `json:"issued_at,omitempty"`
-	DeclaredAt       *time.Time `json:"declared_at,omitempty"`
-	CompletedAt      *time.Time `json:"completed_at,omitempty"`
+	Version                     string     `json:"version,omitempty"`
+	Name                        string     `json:"name,omitempty"`
+	Status                      string     `json:"status,omitempty"`
+	PrincipalAddress            string     `json:"principal_address,omitempty"`
+	SignerAddress               string     `json:"signer_address,omitempty"`
+	SigningMethod               string     `json:"signing_method,omitempty"`
+	MessageEncoding             string     `json:"message_encoding,omitempty"`
+	Message                     string     `json:"message,omitempty"`
+	MessageHex                  string     `json:"message_hex,omitempty"`
+	DigestHex                   string     `json:"digest_hex,omitempty"`
+	CanonicalJSON               string     `json:"canonical_json,omitempty"`
+	ExpectedVersion             int        `json:"expected_version,omitempty"`
+	NextVersion                 int        `json:"next_version,omitempty"`
+	BoundaryRequirementsJSON    string     `json:"boundary_requirements_json,omitempty"`
+	FinalizeRequestTemplateJSON string     `json:"finalize_request_template_json,omitempty"`
+	RegistrationPreviewJSON     string     `json:"registration_preview_json,omitempty"`
+	HostRequestID               string     `json:"host_request_id,omitempty"`
+	IssuedAt                    *time.Time `json:"issued_at,omitempty"`
+	DeclaredAt                  *time.Time `json:"declared_at,omitempty"`
+	CompletedAt                 *time.Time `json:"completed_at,omitempty"`
+}
+
+// SoulBootstrapPublicationEvidence records Host publication evidence without
+// storing any Host instance key or browser credential material.
+type SoulBootstrapPublicationEvidence struct {
+	AgentID                    string     `json:"agent_id,omitempty"`
+	PublishedVersion           int        `json:"published_version,omitempty"`
+	RegistrationURI            string     `json:"registration_uri,omitempty"`
+	RegistrationS3Key          string     `json:"registration_s3_key,omitempty"`
+	VersionedRegistrationURI   string     `json:"versioned_registration_uri,omitempty"`
+	VersionedRegistrationS3Key string     `json:"versioned_registration_s3_key,omitempty"`
+	AnchorState                string     `json:"anchor_state,omitempty"`
+	PublishedAt                *time.Time `json:"published_at,omitempty"`
 }
 
 // SoulBootstrapErrorState stores a typed, client-safe bootstrap error.
@@ -147,6 +190,9 @@ func NormalizeSoulBootstrap(state *SoulBootstrapState, username string) *SoulBoo
 	}
 	if normalized.Error != nil {
 		normalized.Error.trim()
+	}
+	if normalized.Publication != nil {
+		normalized.Publication.trim()
 	}
 	for idx := range normalized.SigningCheckpoints {
 		normalized.SigningCheckpoints[idx].trim()
@@ -218,6 +264,7 @@ func (s *SoulBootstrapState) Clone() *SoulBootstrapState {
 	}
 	cloned.Error = cloneSoulBootstrapError(s.Error)
 	cloned.Correlation = cloneSoulBootstrapCorrelation(s.Correlation)
+	cloned.Publication = cloneSoulBootstrapPublication(s.Publication)
 	cloned.UpdatedAt = cloneDroneTime(s.UpdatedAt)
 	return &cloned
 }
@@ -229,6 +276,15 @@ func (c SoulBootstrapSigningCheckpoint) Clone() SoulBootstrapSigningCheckpoint {
 	cloned.DeclaredAt = cloneDroneTime(c.DeclaredAt)
 	cloned.CompletedAt = cloneDroneTime(c.CompletedAt)
 	return cloned
+}
+
+func cloneSoulBootstrapPublication(in *SoulBootstrapPublicationEvidence) *SoulBootstrapPublicationEvidence {
+	if in == nil {
+		return nil
+	}
+	cloned := *in
+	cloned.PublishedAt = cloneDroneTime(in.PublishedAt)
+	return &cloned
 }
 
 func cloneSoulBootstrapError(in *SoulBootstrapErrorState) *SoulBootstrapErrorState {
@@ -304,6 +360,14 @@ func errorStateForBootstrapCode(code string) string {
 		return SoulBootstrapStateHostInstanceKeyUnavailable
 	case SoulBootstrapErrorHostSigningPayloadUnsupported:
 		return SoulBootstrapStateHostSigningPayloadUnsupported
+	case SoulBootstrapErrorHostRegistrationIDRequired,
+		SoulBootstrapErrorHostConversationIDRequired,
+		SoulBootstrapErrorHostBootstrapReplayRejected:
+		return SoulBootstrapStateCorrelationMismatch
+	case SoulBootstrapErrorSoulBindingConflict:
+		return SoulBootstrapStateBindingConflict
+	case SoulBootstrapErrorSoulNotAvailable:
+		return SoulBootstrapStateSoulNotAvailable
 	default:
 		return SoulBootstrapStateHostUnavailable
 	}
@@ -347,5 +411,20 @@ func (c *SoulBootstrapSigningCheckpoint) trim() {
 	c.MessageHex = strings.TrimSpace(c.MessageHex)
 	c.DigestHex = strings.TrimSpace(c.DigestHex)
 	c.CanonicalJSON = strings.TrimSpace(c.CanonicalJSON)
+	c.BoundaryRequirementsJSON = strings.TrimSpace(c.BoundaryRequirementsJSON)
+	c.FinalizeRequestTemplateJSON = strings.TrimSpace(c.FinalizeRequestTemplateJSON)
+	c.RegistrationPreviewJSON = strings.TrimSpace(c.RegistrationPreviewJSON)
 	c.HostRequestID = strings.TrimSpace(c.HostRequestID)
+}
+
+func (p *SoulBootstrapPublicationEvidence) trim() {
+	if p == nil {
+		return
+	}
+	p.AgentID = strings.TrimSpace(p.AgentID)
+	p.RegistrationURI = strings.TrimSpace(p.RegistrationURI)
+	p.RegistrationS3Key = strings.TrimSpace(p.RegistrationS3Key)
+	p.VersionedRegistrationURI = strings.TrimSpace(p.VersionedRegistrationURI)
+	p.VersionedRegistrationS3Key = strings.TrimSpace(p.VersionedRegistrationS3Key)
+	p.AnchorState = strings.TrimSpace(p.AnchorState)
 }

--- a/pkg/agents/soul_bootstrap_test.go
+++ b/pkg/agents/soul_bootstrap_test.go
@@ -135,3 +135,110 @@ func TestSoulBootstrapErrorStateAndCheckpointMetadata(t *testing.T) {
 	require.Equal(t, "utf8", normalized.SigningCheckpoints[0].MessageEncoding)
 	require.Equal(t, "sign me", normalized.SigningCheckpoints[0].Message)
 }
+
+func TestSoulBootstrapM23PublicationStateCloneAndTrim(t *testing.T) {
+	publishedAt := time.Date(2026, 6, 12, 22, 30, 0, 0, time.UTC)
+	updatedAt := publishedAt.Add(time.Minute)
+
+	state := NormalizeSoulBootstrap(&SoulBootstrapState{
+		Username:           " drone-delta ",
+		BodyID:             " body-delta ",
+		HostRegistrationID: " reg_123 ",
+		HostConversationID: " conv_123 ",
+		HostSoulAgentID:    " 0xsoul ",
+		Phase:              SoulBootstrapPhaseFinalize,
+		SigningCheckpoints: []SoulBootstrapSigningCheckpoint{{
+			Version:                     " 1 ",
+			Name:                        " finalize ",
+			Status:                      " ready ",
+			ExpectedVersion:             0,
+			NextVersion:                 1,
+			BoundaryRequirementsJSON:    ` [{"boundary_id":"b1"}] `,
+			FinalizeRequestTemplateJSON: ` {"self_attestation":""} `,
+			RegistrationPreviewJSON:     ` {"agent_id":"0xsoul"} `,
+			HostRequestID:               " host-req-finalize ",
+		}},
+		Publication: &SoulBootstrapPublicationEvidence{
+			AgentID:                    " 0xsoul ",
+			PublishedVersion:           1,
+			RegistrationURI:            " s3://bucket/registration.json ",
+			RegistrationS3Key:          " registry/registration.json ",
+			VersionedRegistrationURI:   " s3://bucket/versions/1/registration.json ",
+			VersionedRegistrationS3Key: " registry/versions/1/registration.json ",
+			AnchorState:                " hosted_offchain ",
+			PublishedAt:                &publishedAt,
+		},
+		Correlation: &SoulBootstrapCorrelationState{
+			WalletVerificationIdempotencyKey:   " wallet-1 ",
+			PrincipalDeclarationIdempotencyKey: " principal-1 ",
+			ConversationIdempotencyKey:         " conversation-1 ",
+			FinalizeIdempotencyKey:             " finalize-1 ",
+		},
+		UpdatedAt: &updatedAt,
+	}, "")
+
+	require.Equal(t, "drone-delta", state.Username)
+	require.Equal(t, "body-delta", state.BodyID)
+	require.Equal(t, SoulBootstrapPhaseFinalize, state.Phase)
+	require.Equal(t, "finalize.pending", state.State)
+	require.Equal(t, "0xsoul", state.Publication.AgentID)
+	require.Equal(t, "hosted_offchain", state.Publication.AnchorState)
+	require.Equal(t, publishedAt, *state.Publication.PublishedAt)
+	require.Equal(t, "wallet-1", state.Correlation.WalletVerificationIdempotencyKey)
+	require.Equal(t, "conversation-1", state.Correlation.ConversationIdempotencyKey)
+	require.Equal(t, "finalize-1", state.Correlation.FinalizeIdempotencyKey)
+	require.Equal(t, `[{"boundary_id":"b1"}]`, state.SigningCheckpoints[0].BoundaryRequirementsJSON)
+	require.Equal(t, `{"self_attestation":""}`, state.SigningCheckpoints[0].FinalizeRequestTemplateJSON)
+	require.Equal(t, `{"agent_id":"0xsoul"}`, state.SigningCheckpoints[0].RegistrationPreviewJSON)
+
+	cloned := state.Clone()
+	require.NotSame(t, state.Publication, cloned.Publication)
+	require.NotSame(t, state.Publication.PublishedAt, cloned.Publication.PublishedAt)
+	cloned.Publication.AgentID = "changed"
+	require.Equal(t, "0xsoul", state.Publication.AgentID)
+	require.Nil(t, (*SoulBootstrapState)(nil).Clone())
+	require.Nil(t, cloneSoulBootstrapPublication(nil))
+}
+
+func TestSoulBootstrapM23PhaseAndErrorMappings(t *testing.T) {
+	require.Equal(t, SoulBootstrapPhaseConversation, normalizeBootstrapPhase("", SoulBootstrapStateConversationCompleted))
+	require.Equal(t, SoulBootstrapPhaseNotStarted, normalizeBootstrapPhase("", ""))
+	require.Equal(t, "custom", normalizeBootstrapPhase("custom", "conversation.completed"))
+
+	for phase, want := range map[string]string{
+		SoulBootstrapPhaseBegin:                "begin.ready",
+		SoulBootstrapPhaseWalletVerification:   "wallet_verification.pending",
+		SoulBootstrapPhasePrincipalDeclaration: "principal_declaration.pending",
+		SoulBootstrapPhaseConversation:         "conversation.pending",
+		SoulBootstrapPhaseFinalize:             "finalize.pending",
+		SoulBootstrapPhaseError:                SoulBootstrapStateHostBridgeUnavailable,
+		SoulBootstrapPhaseComplete:             SoulBootstrapStateCompleteBound,
+		"unknown":                              SoulBootstrapStateNotStarted,
+	} {
+		require.Equal(t, want, defaultBootstrapStateForPhase(phase))
+	}
+
+	for code, want := range map[string]string{
+		SoulBootstrapErrorHostBridgeUnavailable:         SoulBootstrapStateHostBridgeUnavailable,
+		SoulBootstrapErrorHostTrustNotConfigured:        SoulBootstrapStateHostTrustNotConfigured,
+		SoulBootstrapErrorHostInstanceKeyMissing:        SoulBootstrapStateHostInstanceKeyMissing,
+		SoulBootstrapErrorHostInstanceKeyUnavailable:    SoulBootstrapStateHostInstanceKeyUnavailable,
+		SoulBootstrapErrorHostSigningPayloadUnsupported: SoulBootstrapStateHostSigningPayloadUnsupported,
+		SoulBootstrapErrorHostRegistrationIDRequired:    SoulBootstrapStateCorrelationMismatch,
+		SoulBootstrapErrorHostConversationIDRequired:    SoulBootstrapStateCorrelationMismatch,
+		SoulBootstrapErrorHostBootstrapReplayRejected:   SoulBootstrapStateCorrelationMismatch,
+		SoulBootstrapErrorSoulBindingConflict:           SoulBootstrapStateBindingConflict,
+		SoulBootstrapErrorSoulNotAvailable:              SoulBootstrapStateSoulNotAvailable,
+		SoulBootstrapErrorHostUnavailable:               SoulBootstrapStateHostUnavailable,
+		"unexpected":                                    SoulBootstrapStateHostUnavailable,
+	} {
+		require.Equal(t, want, errorStateForBootstrapCode(code))
+	}
+
+	now := time.Date(2026, 6, 12, 23, 0, 0, 0, time.UTC)
+	defaulted := NewSoulBootstrapErrorState("drone-epsilon", nil, "", "", "", 0, " ", now)
+	require.Equal(t, SoulBootstrapErrorHostUnavailable, defaulted.Error.Code)
+	require.Equal(t, "Soul bootstrap could not complete.", defaulted.Error.Message)
+	require.Equal(t, "lesser", defaulted.Error.Source)
+	require.Equal(t, SoulBootstrapStateHostUnavailable, defaulted.State)
+}

--- a/pkg/services/souls/bootstrap.go
+++ b/pkg/services/souls/bootstrap.go
@@ -1,6 +1,7 @@
 package souls
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -17,6 +18,7 @@ import (
 
 const (
 	hostBootstrapMaxResponseBytes = 256 * 1024
+	hostBootstrapSSETimeout       = 90 * time.Second
 
 	hostBootstrapSigningMethodEIP191 = "eip191_personal_sign"
 	hostBootstrapEncodingHexBytes    = "hex_bytes"
@@ -139,6 +141,129 @@ type BootstrapPrincipalVerifyResult struct {
 	PrincipalAddress string
 	OperationID      string
 	PromotionStage   string
+	HostRequestID    string
+}
+
+// BootstrapConversationMessageInput is the Lesser-local request for sending a
+// Host mint-conversation turn through the server-side instance-key route.
+type BootstrapConversationMessageInput struct {
+	RegistrationID string
+	ConversationID string
+	Message        string
+	Model          string
+}
+
+// BootstrapConversationMessageResult contains the Host conversation ids and
+// terminal assistant response metadata collected from the SSE stream.
+type BootstrapConversationMessageResult struct {
+	RegistrationID string
+	ConversationID string
+	Model          string
+	FullResponse   string
+	HostRequestID  string
+}
+
+// BootstrapConversationCompleteInput is the Lesser-local request for completing
+// a Host mint conversation.
+type BootstrapConversationCompleteInput struct {
+	RegistrationID string
+	ConversationID string
+}
+
+// BootstrapConversationCompleteResult contains Host completion state.
+type BootstrapConversationCompleteResult struct {
+	RegistrationID       string
+	HostSoulAgentID      string
+	ConversationID       string
+	Status               string
+	ProducedDeclarations string
+	CompletedAt          *time.Time
+	HostRequestID        string
+}
+
+// BootstrapFinalizePreflightInput is the Lesser-local request for Host finalize
+// preflight/signing material.
+type BootstrapFinalizePreflightInput struct {
+	RegistrationID     string
+	ConversationID     string
+	BoundarySignatures map[string]string
+}
+
+// BootstrapFinalizeSigningInput contains the Host-owned self-attestation
+// signing payload.
+type BootstrapFinalizeSigningInput struct {
+	SignerWallet    string
+	SigningMethod   string
+	MessageEncoding string
+	MessageHex      string
+	DigestHex       string
+	CanonicalJSON   string
+}
+
+// BootstrapFinalizePreflightResult contains Host-owned finalize signing
+// material. Lesser relays these fields unchanged; it never reconstructs the
+// signing payload locally.
+type BootstrapFinalizePreflightResult struct {
+	Version                     string
+	DigestHex                   string
+	IssuedAt                    *time.Time
+	ExpectedVersion             int
+	NextVersion                 int
+	SelfAttestationSigning      BootstrapFinalizeSigningInput
+	BoundaryRequirementsJSON    string
+	FinalizeRequestTemplateJSON string
+	RegistrationPreviewJSON     string
+	HostRequestID               string
+}
+
+// BootstrapFinalizeInput is the Lesser-local request for Host hosted/off-chain
+// finalize and publication.
+type BootstrapFinalizeInput struct {
+	RegistrationID     string
+	ConversationID     string
+	BoundarySignatures map[string]string
+	IssuedAt           time.Time
+	ExpectedVersion    int
+	SelfAttestation    string
+}
+
+// BootstrapPublicationEvidence contains Host publication evidence for the
+// versioned hosted/off-chain registration artifact.
+type BootstrapPublicationEvidence struct {
+	AgentID                    string
+	PublishedVersion           int
+	RegistrationURI            string
+	RegistrationS3Key          string
+	VersionedRegistrationURI   string
+	VersionedRegistrationS3Key string
+	AnchorState                string
+	PublishedAt                *time.Time
+}
+
+// BootstrapPromotionEvidence contains Host promotion continuity fields.
+type BootstrapPromotionEvidence struct {
+	AgentID                  string
+	RegistrationID           string
+	Stage                    string
+	RequestStatus            string
+	ReviewStatus             string
+	ReadinessStatus          string
+	AnchorState              string
+	LatestConversationID     string
+	LatestConversationStatus string
+	PublishedVersion         int
+	GraduatedAt              *time.Time
+}
+
+// BootstrapFinalizeResult contains Host finalize/publication output needed for
+// Lesser local soul binding and workflow projection.
+type BootstrapFinalizeResult struct {
+	Version          string
+	HostSoulAgentID  string
+	PublishedVersion int
+	PrincipalAddress string
+	Publication      BootstrapPublicationEvidence
+	Promotion        BootstrapPromotionEvidence
 	HostRequestID    string
 }
 
@@ -287,6 +412,191 @@ func (s *Service) VerifyBootstrapPrincipalDeclaration(ctx context.Context, input
 	}, nil
 }
 
+// SendBootstrapConversationMessage relays one mint-conversation turn to Host's
+// instance-key SSE route and consumes the terminal event so GraphQL receives a
+// bounded same-origin mutation result.
+func (s *Service) SendBootstrapConversationMessage(ctx context.Context, input BootstrapConversationMessageInput) (*BootstrapConversationMessageResult, error) {
+	baseURL, _, instanceKey, err := s.hostBootstrapInputs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	registrationID := strings.TrimSpace(input.RegistrationID)
+	if registrationID == "" {
+		return nil, &HostBootstrapError{Code: "HOST_REGISTRATION_ID_REQUIRED", Message: "registration id is required", Source: "lesser", Err: ErrHostSigningPayloadUnsupported}
+	}
+	if strings.TrimSpace(input.Message) == "" {
+		return nil, &HostBootstrapError{Code: "HOST_INVALID_REQUEST", Message: "conversation message is required", Source: "lesser", Err: ErrHostSigningPayloadUnsupported}
+	}
+
+	payload := map[string]any{
+		"message": strings.TrimSpace(input.Message),
+	}
+	if conversationID := strings.TrimSpace(input.ConversationID); conversationID != "" {
+		payload["conversation_id"] = conversationID
+	}
+	if model := strings.TrimSpace(input.Model); model != "" {
+		payload["model"] = model
+	}
+
+	var out hostConversationSSECollectResult
+	requestID, err := s.doHostBootstrapSSE(ctx, baseURL, "/api/v1/soul/instance/agents/register/"+url.PathEscape(registrationID)+"/mint-conversation", instanceKey, payload, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &BootstrapConversationMessageResult{
+		RegistrationID: registrationID,
+		ConversationID: strings.TrimSpace(out.ConversationID),
+		Model:          strings.TrimSpace(out.Model),
+		FullResponse:   strings.TrimSpace(out.FullResponse),
+		HostRequestID:  requestID,
+	}, nil
+}
+
+// CompleteBootstrapConversation completes a Host mint conversation and returns
+// the Host-owned declaration output checkpoint.
+func (s *Service) CompleteBootstrapConversation(ctx context.Context, input BootstrapConversationCompleteInput) (*BootstrapConversationCompleteResult, error) {
+	baseURL, _, instanceKey, err := s.hostBootstrapInputs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	registrationID, conversationID, err := requireBootstrapRegistrationConversation(input.RegistrationID, input.ConversationID)
+	if err != nil {
+		return nil, err
+	}
+
+	var out hostMintConversationResponse
+	requestID, err := s.doHostBootstrapJSON(ctx, http.MethodPost, baseURL, "/api/v1/soul/instance/agents/register/"+url.PathEscape(registrationID)+"/mint-conversation/"+url.PathEscape(conversationID)+"/complete", instanceKey, map[string]any{}, http.StatusOK, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &BootstrapConversationCompleteResult{
+		RegistrationID:       registrationID,
+		HostSoulAgentID:      strings.ToLower(strings.TrimSpace(out.AgentID)),
+		ConversationID:       strings.TrimSpace(out.ConversationID),
+		Status:               strings.TrimSpace(out.Status),
+		ProducedDeclarations: strings.TrimSpace(out.ProducedDeclarations),
+		CompletedAt:          parseHostTimePtr(out.CompletedAt),
+		HostRequestID:        requestID,
+	}, nil
+}
+
+// PrepareBootstrapFinalize calls Host finalize preflight and fails closed on
+// unsupported signing metadata.
+func (s *Service) PrepareBootstrapFinalize(ctx context.Context, input BootstrapFinalizePreflightInput) (*BootstrapFinalizePreflightResult, error) {
+	baseURL, _, instanceKey, err := s.hostBootstrapInputs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	registrationID, conversationID, err := requireBootstrapRegistrationConversation(input.RegistrationID, input.ConversationID)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := map[string]any{
+		"boundary_signatures": normalizeBootstrapSignatureMap(input.BoundarySignatures),
+	}
+
+	var out hostFinalizePreflightResponse
+	requestID, err := s.doHostBootstrapJSON(ctx, http.MethodPost, baseURL, "/api/v1/soul/instance/agents/register/"+url.PathEscape(registrationID)+"/mint-conversation/"+url.PathEscape(conversationID)+"/finalize/preflight", instanceKey, payload, http.StatusOK, &out)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateHostFinalizePreflightPayload(out); err != nil {
+		return nil, err
+	}
+
+	return &BootstrapFinalizePreflightResult{
+		Version:         strings.TrimSpace(out.Version),
+		DigestHex:       strings.TrimSpace(out.DigestHex),
+		IssuedAt:        parseHostTimePtr(out.IssuedAt),
+		ExpectedVersion: out.ExpectedVersion,
+		NextVersion:     out.NextVersion,
+		SelfAttestationSigning: BootstrapFinalizeSigningInput{
+			SignerWallet:    strings.ToLower(strings.TrimSpace(out.SelfAttestationSigning.SignerWallet)),
+			SigningMethod:   strings.TrimSpace(out.SelfAttestationSigning.SigningMethod),
+			MessageEncoding: strings.TrimSpace(out.SelfAttestationSigning.MessageEncoding),
+			MessageHex:      strings.TrimSpace(out.SelfAttestationSigning.MessageHex),
+			DigestHex:       strings.TrimSpace(out.SelfAttestationSigning.DigestHex),
+			CanonicalJSON:   strings.TrimSpace(out.SelfAttestationSigning.CanonicalJSON),
+		},
+		BoundaryRequirementsJSON:    compactHostJSON(out.BoundaryRequirementsRaw),
+		FinalizeRequestTemplateJSON: compactHostJSON(out.FinalizeRequestTemplateRaw),
+		RegistrationPreviewJSON:     compactHostJSON(out.RegistrationPreviewRaw),
+		HostRequestID:               requestID,
+	}, nil
+}
+
+// FinalizeBootstrap relays Host finalize and publication. Hosted/off-chain
+// success does not require on-chain mint transaction fields.
+func (s *Service) FinalizeBootstrap(ctx context.Context, input BootstrapFinalizeInput) (*BootstrapFinalizeResult, error) {
+	baseURL, _, instanceKey, err := s.hostBootstrapInputs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	registrationID, conversationID, err := requireBootstrapRegistrationConversation(input.RegistrationID, input.ConversationID)
+	if err != nil {
+		return nil, err
+	}
+	if input.IssuedAt.IsZero() {
+		return nil, &HostBootstrapError{Code: "HOST_INVALID_REQUEST", Message: "issued_at is required", Source: "lesser", Err: ErrHostSigningPayloadUnsupported}
+	}
+	if input.ExpectedVersion < 0 {
+		return nil, &HostBootstrapError{Code: "HOST_INVALID_REQUEST", Message: "expected_version is invalid", Source: "lesser", Err: ErrHostSigningPayloadUnsupported}
+	}
+	if strings.TrimSpace(input.SelfAttestation) == "" {
+		return nil, &HostBootstrapError{Code: "HOST_INVALID_REQUEST", Message: "self_attestation is required", Source: "lesser", Err: ErrHostSigningPayloadUnsupported}
+	}
+
+	payload := map[string]any{
+		"boundary_signatures": normalizeBootstrapSignatureMap(input.BoundarySignatures),
+		"issued_at":           input.IssuedAt.UTC().Format(time.RFC3339),
+		"expected_version":    input.ExpectedVersion,
+		"self_attestation":    strings.TrimSpace(input.SelfAttestation),
+	}
+
+	var out hostFinalizeResponse
+	requestID, err := s.doHostBootstrapJSON(ctx, http.MethodPost, baseURL, "/api/v1/soul/instance/agents/register/"+url.PathEscape(registrationID)+"/mint-conversation/"+url.PathEscape(conversationID)+"/finalize", instanceKey, payload, http.StatusOK, &out)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateHostFinalizeResponse(out); err != nil {
+		return nil, err
+	}
+
+	agentID := strings.ToLower(strings.TrimSpace(firstNonEmpty(out.AgentID, out.Agent.AgentID, out.Publication.AgentID, out.Promotion.AgentID)))
+	return &BootstrapFinalizeResult{
+		Version:          strings.TrimSpace(out.Version),
+		HostSoulAgentID:  agentID,
+		PublishedVersion: out.PublishedVersion,
+		PrincipalAddress: strings.ToLower(strings.TrimSpace(out.Agent.PrincipalAddress)),
+		Publication: BootstrapPublicationEvidence{
+			AgentID:                    strings.ToLower(strings.TrimSpace(out.Publication.AgentID)),
+			PublishedVersion:           out.Publication.PublishedVersion,
+			RegistrationURI:            strings.TrimSpace(out.Publication.RegistrationURI),
+			RegistrationS3Key:          strings.TrimSpace(out.Publication.RegistrationS3Key),
+			VersionedRegistrationURI:   strings.TrimSpace(out.Publication.VersionedRegistrationURI),
+			VersionedRegistrationS3Key: strings.TrimSpace(out.Publication.VersionedRegistrationS3Key),
+			AnchorState:                strings.TrimSpace(out.Publication.AnchorState),
+			PublishedAt:                parseHostTimePtr(out.Publication.PublishedAt),
+		},
+		Promotion: BootstrapPromotionEvidence{
+			AgentID:                  strings.ToLower(strings.TrimSpace(out.Promotion.AgentID)),
+			RegistrationID:           strings.TrimSpace(out.Promotion.RegistrationID),
+			Stage:                    strings.TrimSpace(out.Promotion.Stage),
+			RequestStatus:            strings.TrimSpace(out.Promotion.RequestStatus),
+			ReviewStatus:             strings.TrimSpace(out.Promotion.ReviewStatus),
+			ReadinessStatus:          strings.TrimSpace(out.Promotion.ReadinessStatus),
+			AnchorState:              strings.TrimSpace(out.Promotion.AnchorState),
+			LatestConversationID:     strings.TrimSpace(out.Promotion.LatestConversationID),
+			LatestConversationStatus: strings.TrimSpace(out.Promotion.LatestConversationStatus),
+			PublishedVersion:         out.Promotion.PublishedVersion,
+			GraduatedAt:              parseHostTimePtr(out.Promotion.GraduatedAt),
+		},
+		HostRequestID: requestID,
+	}, nil
+}
+
 func (s *Service) hostBootstrapInputs(ctx context.Context) (string, string, string, error) {
 	if s == nil || s.instanceRepo == nil || s.cfg == nil {
 		return "", "", "", fmt.Errorf("soul service misconfigured")
@@ -371,6 +681,65 @@ func (s *Service) doHostBootstrapJSON(ctx context.Context, method string, baseUR
 		}
 	}
 
+	return requestID, nil
+}
+
+func (s *Service) doHostBootstrapSSE(ctx context.Context, baseURL string, path string, instanceKey string, payload any, out *hostConversationSSECollectResult) (string, error) {
+	endpoint, err := hostBootstrapURL(baseURL, path)
+	if err != nil {
+		return "", &HostBootstrapError{Code: "HOST_UNAVAILABLE", Message: "Host bootstrap endpoint is unavailable.", Source: "host", Err: fmt.Errorf("%w: %v", ErrHostUnavailable, err)}
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", &HostBootstrapError{Code: "HOST_UNAVAILABLE", Message: "Host bootstrap endpoint is unavailable.", Source: "host", Err: fmt.Errorf("%w: %v", ErrHostUnavailable, err)}
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+instanceKey)
+
+	client := s.httpClient
+	if client == nil {
+		client = &http.Client{Timeout: hostBootstrapSSETimeout}
+	} else if client.Timeout > 0 && client.Timeout < hostBootstrapSSETimeout {
+		cloned := *client
+		cloned.Timeout = hostBootstrapSSETimeout
+		client = &cloned
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", &HostBootstrapError{Code: "HOST_UNAVAILABLE", Message: "Host bootstrap endpoint is unavailable.", Source: "host", Err: fmt.Errorf("%w: %v", ErrHostUnavailable, err)}
+	}
+	defer resp.Body.Close()
+
+	responseBody, truncated, err := common.ReadUntrustedHTTPResponseBody(resp.Body, hostBootstrapMaxResponseBytes)
+	if err != nil {
+		return requestIDFromHeaders(resp.Header), &HostBootstrapError{Code: "HOST_UNAVAILABLE", Message: "Host bootstrap response is unavailable.", Source: "host", Err: fmt.Errorf("%w: %v", ErrHostUnavailable, err)}
+	}
+	requestID := requestIDFromHeaders(resp.Header)
+
+	if resp.StatusCode != http.StatusOK {
+		return requestID, hostBootstrapHTTPError(resp.StatusCode, resp.Header, responseBody, truncated)
+	}
+	if truncated {
+		return requestID, &HostBootstrapError{Code: "HOST_UNAVAILABLE", Message: "Host bootstrap response is too large.", Source: "host", StatusCode: resp.StatusCode, HostRequestID: requestID, Err: ErrHostUnavailable}
+	}
+	if err := parseHostConversationSSE(responseBody, out); err != nil {
+		var hostErr *HostBootstrapError
+		if errors.As(err, &hostErr) {
+			hostErr.StatusCode = resp.StatusCode
+			if hostErr.HostRequestID == "" {
+				hostErr.HostRequestID = requestID
+			}
+			return requestID, hostErr
+		}
+		return requestID, &HostBootstrapError{Code: "HOST_RESPONSE_INVALID", Message: "Host bootstrap response is invalid.", Source: "host", StatusCode: resp.StatusCode, HostRequestID: requestID, Err: fmt.Errorf("%w: %v", ErrHostUnavailable, err)}
+	}
 	return requestID, nil
 }
 
@@ -463,6 +832,203 @@ func requestIDFromHeaders(headers http.Header) string {
 	return ""
 }
 
+func requireBootstrapRegistrationConversation(registrationID string, conversationID string) (string, string, error) {
+	registrationID = strings.TrimSpace(registrationID)
+	if registrationID == "" {
+		return "", "", &HostBootstrapError{Code: "HOST_REGISTRATION_ID_REQUIRED", Message: "registration id is required", Source: "lesser", Err: ErrHostSigningPayloadUnsupported}
+	}
+	conversationID = strings.TrimSpace(conversationID)
+	if conversationID == "" {
+		return "", "", &HostBootstrapError{Code: "HOST_CONVERSATION_ID_REQUIRED", Message: "conversation id is required", Source: "lesser", Err: ErrHostSigningPayloadUnsupported}
+	}
+	return registrationID, conversationID, nil
+}
+
+func normalizeBootstrapSignatureMap(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out[key] = strings.TrimSpace(value)
+	}
+	return out
+}
+
+func parseHostConversationSSE(body []byte, out *hostConversationSSECollectResult) error {
+	if out == nil {
+		return errors.New("nil SSE output")
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(body))
+	scanner.Buffer(make([]byte, 0, 64*1024), hostBootstrapMaxResponseBytes)
+
+	eventName := ""
+	var dataLines []string
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			if err := flushHostConversationSSEEvent(&eventName, &dataLines, out); err != nil {
+				return err
+			}
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "event:"):
+			eventName = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		case strings.HasPrefix(line, "data:"):
+			dataLines = append(dataLines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	if err := flushHostConversationSSEEvent(&eventName, &dataLines, out); err != nil {
+		return err
+	}
+	if !out.Done || strings.TrimSpace(out.ConversationID) == "" {
+		return errors.New("missing terminal conversation_done event")
+	}
+	return nil
+}
+
+func flushHostConversationSSEEvent(eventName *string, dataLines *[]string, out *hostConversationSSECollectResult) error {
+	if eventName == nil || dataLines == nil || out == nil {
+		return nil
+	}
+	if *eventName == "" && len(*dataLines) == 0 {
+		return nil
+	}
+	name := strings.TrimSpace(*eventName)
+	if name == "" {
+		name = "message"
+	}
+	rawData := strings.TrimSpace(strings.Join(*dataLines, "\n"))
+	*eventName = ""
+	*dataLines = nil
+	return applyHostConversationSSEEvent(name, rawData, out)
+}
+
+func applyHostConversationSSEEvent(name string, rawData string, out *hostConversationSSECollectResult) error {
+	switch strings.TrimSpace(name) {
+	case "conversation_start":
+		return applyHostConversationStartEvent(rawData, out)
+	case "conversation_done":
+		return applyHostConversationDoneEvent(rawData, out)
+	case "error":
+		return hostConversationSSEError(rawData)
+	default:
+		return nil
+	}
+}
+
+func applyHostConversationStartEvent(rawData string, out *hostConversationSSECollectResult) error {
+	var payload struct {
+		ConversationID string `json:"conversation_id"`
+		Model          string `json:"model"`
+	}
+	if err := json.Unmarshal([]byte(rawData), &payload); err != nil {
+		return err
+	}
+	if strings.TrimSpace(payload.ConversationID) != "" {
+		out.ConversationID = strings.TrimSpace(payload.ConversationID)
+	}
+	if strings.TrimSpace(payload.Model) != "" {
+		out.Model = strings.TrimSpace(payload.Model)
+	}
+	return nil
+}
+
+func applyHostConversationDoneEvent(rawData string, out *hostConversationSSECollectResult) error {
+	var payload struct {
+		ConversationID string `json:"conversation_id"`
+		FullResponse   string `json:"full_response"`
+	}
+	if err := json.Unmarshal([]byte(rawData), &payload); err != nil {
+		return err
+	}
+	if strings.TrimSpace(payload.ConversationID) != "" {
+		out.ConversationID = strings.TrimSpace(payload.ConversationID)
+	}
+	out.FullResponse = payload.FullResponse
+	out.Done = true
+	return nil
+}
+
+func hostConversationSSEError(rawData string) error {
+	var payload struct {
+		Error string `json:"error"`
+	}
+	_ = json.Unmarshal([]byte(rawData), &payload)
+	message := strings.TrimSpace(payload.Error)
+	if message == "" {
+		message = "Host mint conversation failed."
+	}
+	return &HostBootstrapError{Code: "HOST_CONVERSATION_FAILED", Message: message, Source: "host", Err: ErrHostUnavailable}
+}
+
+func compactHostJSON(raw json.RawMessage) string {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return ""
+	}
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, raw); err != nil {
+		return strings.TrimSpace(string(raw))
+	}
+	return buf.String()
+}
+
+func validateHostFinalizePreflightPayload(out hostFinalizePreflightResponse) error {
+	if strings.TrimSpace(out.Version) != hostBootstrapVersion1 {
+		return &HostBootstrapError{Code: "HOST_SIGNING_PAYLOAD_UNSUPPORTED", Message: "Host returned an unsupported finalize payload version.", Source: "lesser", Err: ErrHostSigningPayloadUnsupported}
+	}
+	if strings.TrimSpace(out.SelfAttestationSigning.SigningMethod) != hostBootstrapSigningMethodEIP191 {
+		return &HostBootstrapError{Code: "HOST_SIGNING_PAYLOAD_UNSUPPORTED", Message: "Host returned an unsupported finalize signing method.", Source: "lesser", Err: ErrHostSigningPayloadUnsupported}
+	}
+	if strings.TrimSpace(out.SelfAttestationSigning.MessageEncoding) != hostBootstrapEncodingHexBytes {
+		return &HostBootstrapError{Code: "HOST_SIGNING_PAYLOAD_UNSUPPORTED", Message: "Host returned an unsupported finalize message encoding.", Source: "lesser", Err: ErrHostSigningPayloadUnsupported}
+	}
+	if strings.TrimSpace(out.SelfAttestationSigning.MessageHex) == "" || strings.TrimSpace(out.SelfAttestationSigning.DigestHex) == "" {
+		return &HostBootstrapError{Code: "HOST_SIGNING_PAYLOAD_UNSUPPORTED", Message: "Host returned incomplete finalize signing material.", Source: "lesser", Err: ErrHostSigningPayloadUnsupported}
+	}
+	if out.ExpectedVersion < 0 || out.NextVersion < 1 {
+		return &HostBootstrapError{Code: "HOST_SIGNING_PAYLOAD_UNSUPPORTED", Message: "Host returned invalid finalize version metadata.", Source: "lesser", Err: ErrHostSigningPayloadUnsupported}
+	}
+	var boundaries []hostFinalizeBoundaryRequirement
+	if len(bytes.TrimSpace(out.BoundaryRequirementsRaw)) > 0 {
+		if err := json.Unmarshal(out.BoundaryRequirementsRaw, &boundaries); err != nil {
+			return &HostBootstrapError{Code: "HOST_SIGNING_PAYLOAD_UNSUPPORTED", Message: "Host returned invalid boundary signing material.", Source: "lesser", Err: ErrHostSigningPayloadUnsupported}
+		}
+	}
+	for _, boundary := range boundaries {
+		if strings.TrimSpace(boundary.SigningMethod) != hostBootstrapSigningMethodEIP191 {
+			return &HostBootstrapError{Code: "HOST_SIGNING_PAYLOAD_UNSUPPORTED", Message: "Host returned an unsupported boundary signing method.", Source: "lesser", Err: ErrHostSigningPayloadUnsupported}
+		}
+		if strings.TrimSpace(boundary.MessageEncoding) != "utf8" {
+			return &HostBootstrapError{Code: "HOST_SIGNING_PAYLOAD_UNSUPPORTED", Message: "Host returned an unsupported boundary message encoding.", Source: "lesser", Err: ErrHostSigningPayloadUnsupported}
+		}
+		if strings.TrimSpace(boundary.Message) == "" || strings.TrimSpace(boundary.DigestHex) == "" {
+			return &HostBootstrapError{Code: "HOST_SIGNING_PAYLOAD_UNSUPPORTED", Message: "Host returned incomplete boundary signing material.", Source: "lesser", Err: ErrHostSigningPayloadUnsupported}
+		}
+	}
+	return nil
+}
+
+func validateHostFinalizeResponse(out hostFinalizeResponse) error {
+	if strings.TrimSpace(out.Version) != hostBootstrapVersion1 {
+		return &HostBootstrapError{Code: "HOST_RESPONSE_INVALID", Message: "Host returned an unsupported finalize response version.", Source: "host", Err: ErrHostUnavailable}
+	}
+	agentID := strings.TrimSpace(firstNonEmpty(out.AgentID, out.Agent.AgentID, out.Publication.AgentID, out.Promotion.AgentID))
+	if _, err := validateAgentID(agentID); err != nil {
+		return &HostBootstrapError{Code: "HOST_RESPONSE_INVALID", Message: "Host finalize response did not include a valid soul agent id.", Source: "host", Err: ErrHostUnavailable}
+	}
+	if out.PublishedVersion < 1 && out.Publication.PublishedVersion < 1 {
+		return &HostBootstrapError{Code: "HOST_RESPONSE_INVALID", Message: "Host finalize response did not include publication evidence.", Source: "host", Err: ErrHostUnavailable}
+	}
+	return nil
+}
+
 func normalizeBootstrapCapabilities(values []string) []string {
 	if len(values) == 0 {
 		return nil
@@ -519,6 +1085,94 @@ type hostRegistrationVerifyResponse struct {
 	Registration hostRegistration      `json:"registration"`
 	Operation    hostOperation         `json:"operation"`
 	Promotion    hostPromotionResponse `json:"promotion,omitempty"`
+}
+
+type hostConversationSSECollectResult struct {
+	ConversationID string
+	Model          string
+	FullResponse   string
+	Done           bool
+}
+
+type hostMintConversationResponse struct {
+	AgentID              string `json:"agent_id"`
+	ConversationID       string `json:"conversation_id"`
+	Model                string `json:"model"`
+	Messages             string `json:"messages"`
+	ProducedDeclarations string `json:"produced_declarations"`
+	Status               string `json:"status"`
+	CompletedAt          string `json:"completed_at"`
+}
+
+type hostFinalizeSigningInput struct {
+	SignerWallet    string `json:"signer_wallet"`
+	SigningMethod   string `json:"signing_method"`
+	MessageEncoding string `json:"message_encoding"`
+	MessageHex      string `json:"message_hex"`
+	DigestHex       string `json:"digest_hex"`
+	CanonicalJSON   string `json:"canonical_json"`
+}
+
+type hostFinalizeBoundaryRequirement struct {
+	BoundaryID      string `json:"boundary_id"`
+	SigningMethod   string `json:"signing_method"`
+	MessageEncoding string `json:"message_encoding"`
+	Message         string `json:"message"`
+	DigestHex       string `json:"digest_hex"`
+}
+
+type hostFinalizePreflightResponse struct {
+	Version                    string                   `json:"version"`
+	DigestHex                  string                   `json:"digest_hex"`
+	IssuedAt                   string                   `json:"issued_at"`
+	ExpectedVersion            int                      `json:"expected_version"`
+	NextVersion                int                      `json:"next_version"`
+	SelfAttestationSigning     hostFinalizeSigningInput `json:"self_attestation_signing"`
+	BoundaryRequirementsRaw    json.RawMessage          `json:"boundary_requirements"`
+	FinalizeRequestTemplateRaw json.RawMessage          `json:"finalize_request_template"`
+	RegistrationPreviewRaw     json.RawMessage          `json:"registration_preview,omitempty"`
+}
+
+type hostFinalizeResponse struct {
+	Version          string                  `json:"version"`
+	AgentID          string                  `json:"agent_id"`
+	Agent            hostFinalizeAgent       `json:"agent"`
+	PublishedVersion int                     `json:"published_version"`
+	Publication      hostFinalizePublication `json:"publication"`
+	Promotion        hostFinalizePromotion   `json:"promotion,omitempty"`
+}
+
+type hostFinalizeAgent struct {
+	AgentID          string `json:"agent_id"`
+	PrincipalAddress string `json:"principal_address"`
+	Wallet           string `json:"wallet"`
+	Status           string `json:"status"`
+	LifecycleStatus  string `json:"lifecycle_status"`
+}
+
+type hostFinalizePublication struct {
+	AgentID                    string `json:"agent_id"`
+	PublishedVersion           int    `json:"published_version"`
+	RegistrationURI            string `json:"registration_uri"`
+	RegistrationS3Key          string `json:"registration_s3_key"`
+	VersionedRegistrationURI   string `json:"versioned_registration_uri"`
+	VersionedRegistrationS3Key string `json:"versioned_registration_s3_key"`
+	AnchorState                string `json:"anchor_state"`
+	PublishedAt                string `json:"published_at"`
+}
+
+type hostFinalizePromotion struct {
+	AgentID                  string `json:"agent_id"`
+	RegistrationID           string `json:"registration_id"`
+	Stage                    string `json:"stage"`
+	RequestStatus            string `json:"request_status"`
+	ReviewStatus             string `json:"review_status"`
+	ReadinessStatus          string `json:"readiness_status"`
+	AnchorState              string `json:"anchor_state"`
+	LatestConversationID     string `json:"latest_conversation_id"`
+	LatestConversationStatus string `json:"latest_conversation_status"`
+	PublishedVersion         int    `json:"published_version"`
+	GraduatedAt              string `json:"graduated_at"`
 }
 
 type hostRegistration struct {

--- a/pkg/services/souls/bootstrap_test.go
+++ b/pkg/services/souls/bootstrap_test.go
@@ -317,6 +317,186 @@ func TestService_VerifyBootstrapPrincipalDeclarationSendsCombinedHostVerifyReque
 	require.Equal(t, "host-req-verify", result.HostRequestID)
 }
 
+func TestService_BootstrapConversationFinalizeRelaysInstanceRoutes(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey = "host-instance-key"
+		agentID     = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		principal   = "0x2222222222222222222222222222222222222222"
+	)
+	issuedAt := time.Date(2026, 6, 12, 21, 15, 0, 0, time.UTC)
+
+	var sawSendBody map[string]any
+	var sawPreflightBody map[string]map[string]string
+	var sawFinalizeBody map[string]any
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer "+instanceKey, r.Header.Get("Authorization"))
+		w.Header().Set("X-Request-Id", "host-req-"+strings.Trim(strings.ReplaceAll(r.URL.Path, "/", "-"), "-"))
+
+		switch r.URL.Path {
+		case "/api/v1/soul/instance/agents/register/reg_123/mint-conversation":
+			require.Equal(t, "text/event-stream", r.Header.Get("Accept"))
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&sawSendBody))
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte("event: conversation_start\n"))
+			_, _ = w.Write([]byte("data: {\"conversation_id\":\"conv_123\",\"model\":\"claude\"}\n\n"))
+			_, _ = w.Write([]byte("event: delta\n"))
+			_, _ = w.Write([]byte("data: {\"text\":\"hello\"}\n\n"))
+			_, _ = w.Write([]byte("event: conversation_done\n"))
+			_, _ = w.Write([]byte("data: {\"conversation_id\":\"conv_123\",\"full_response\":\"complete response\"}\n\n"))
+		case "/api/v1/soul/instance/agents/register/reg_123/mint-conversation/conv_123/complete":
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"agent_id":              agentID,
+				"conversation_id":       "conv_123",
+				"model":                 "claude",
+				"status":                "completed",
+				"produced_declarations": `{"selfDescription":{"summary":"ready"},"capabilities":[],"boundaries":[],"transparency":{}}`,
+				"completed_at":          "2026-06-12T21:16:00Z",
+			}))
+		case "/api/v1/soul/instance/agents/register/reg_123/mint-conversation/conv_123/finalize/preflight":
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&sawPreflightBody))
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"version":          "1",
+				"digest_hex":       "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				"issued_at":        issuedAt.Format(time.RFC3339),
+				"expected_version": 0,
+				"next_version":     1,
+				"declarations_preview": map[string]any{
+					"selfDescription": map[string]any{"summary": "ready"},
+					"capabilities":    []any{},
+					"boundaries":      []any{},
+					"transparency":    map[string]any{},
+				},
+				"boundary_requirements": []map[string]any{
+					{
+						"boundary_id":      "b1",
+						"category":         "safety",
+						"statement":        "Respect boundaries.",
+						"signer_wallet":    principal,
+						"signing_method":   "eip191_personal_sign",
+						"message_encoding": "utf8",
+						"message":          "Sign boundary",
+						"digest_hex":       "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+					},
+				},
+				"self_attestation_signing": map[string]any{
+					"signer_wallet":    principal,
+					"signing_method":   "eip191_personal_sign",
+					"message_encoding": "hex_bytes",
+					"message_hex":      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					"digest_hex":       "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+					"canonical_json":   `{"host":"finalize"}`,
+				},
+				"finalize_request_template": map[string]any{
+					"boundary_signatures": map[string]string{"b1": ""},
+					"issued_at":           issuedAt.Format(time.RFC3339),
+					"expected_version":    0,
+					"self_attestation":    "",
+				},
+				"registration_preview": map[string]any{"agent_id": agentID},
+			}))
+		case "/api/v1/soul/instance/agents/register/reg_123/mint-conversation/conv_123/finalize":
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&sawFinalizeBody))
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"version":           "1",
+				"agent_id":          agentID,
+				"published_version": 1,
+				"agent": map[string]any{
+					"agent_id":          agentID,
+					"principal_address": principal,
+					"wallet":            principal,
+					"status":            "active",
+					"lifecycle_status":  "active",
+				},
+				"publication": map[string]any{
+					"agent_id":                      agentID,
+					"published_version":             1,
+					"registration_uri":              "s3://bucket/registry/v1/agents/" + agentID + "/registration.json",
+					"registration_s3_key":           "registry/v1/agents/" + agentID + "/registration.json",
+					"versioned_registration_uri":    "s3://bucket/registry/v1/agents/" + agentID + "/versions/1/registration.json",
+					"versioned_registration_s3_key": "registry/v1/agents/" + agentID + "/versions/1/registration.json",
+					"anchor_state":                  "hosted_offchain",
+					"published_at":                  "2026-06-12T21:17:00Z",
+				},
+				"promotion": map[string]any{
+					"agent_id":                   agentID,
+					"registration_id":            "reg_123",
+					"stage":                      "graduated",
+					"request_status":             "graduated",
+					"review_status":              "published",
+					"readiness_status":           "graduated",
+					"anchor_state":               "hosted_offchain",
+					"latest_conversation_id":     "conv_123",
+					"latest_conversation_status": "completed",
+					"published_version":          1,
+					"graduated_at":               "2026-06-12T21:17:00Z",
+				},
+			}))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	sent, err := service.SendBootstrapConversationMessage(context.Background(), BootstrapConversationMessageInput{
+		RegistrationID: "reg_123",
+		Message:        "Review my declaration.",
+		Model:          "claude",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Review my declaration.", sawSendBody["message"])
+	require.Equal(t, "claude", sawSendBody["model"])
+	require.Equal(t, "conv_123", sent.ConversationID)
+	require.Equal(t, "complete response", sent.FullResponse)
+
+	completed, err := service.CompleteBootstrapConversation(context.Background(), BootstrapConversationCompleteInput{
+		RegistrationID: "reg_123",
+		ConversationID: "conv_123",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "completed", completed.Status)
+	require.Equal(t, agentID, completed.HostSoulAgentID)
+	require.NotNil(t, completed.CompletedAt)
+
+	preflight, err := service.PrepareBootstrapFinalize(context.Background(), BootstrapFinalizePreflightInput{
+		RegistrationID:     "reg_123",
+		ConversationID:     "conv_123",
+		BoundarySignatures: map[string]string{"b1": "0xsig"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "0xsig", sawPreflightBody["boundary_signatures"]["b1"])
+	require.Equal(t, "eip191_personal_sign", preflight.SelfAttestationSigning.SigningMethod)
+	require.Equal(t, "hex_bytes", preflight.SelfAttestationSigning.MessageEncoding)
+	require.Contains(t, preflight.BoundaryRequirementsJSON, `"boundary_id":"b1"`)
+	require.Contains(t, preflight.FinalizeRequestTemplateJSON, `"expected_version":0`)
+
+	finalized, err := service.FinalizeBootstrap(context.Background(), BootstrapFinalizeInput{
+		RegistrationID:     "reg_123",
+		ConversationID:     "conv_123",
+		BoundarySignatures: map[string]string{"b1": "0xsig"},
+		IssuedAt:           issuedAt,
+		ExpectedVersion:    0,
+		SelfAttestation:    "0xself",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "0xself", sawFinalizeBody["self_attestation"])
+	require.Equal(t, agentID, finalized.HostSoulAgentID)
+	require.Equal(t, principal, finalized.PrincipalAddress)
+	require.Equal(t, "hosted_offchain", finalized.Publication.AnchorState)
+	require.Equal(t, "graduated", finalized.Promotion.Stage)
+}
+
 func TestService_BootstrapRejectsInvalidLocalInputsAndResponses(t *testing.T) {
 	t.Parallel()
 
@@ -338,6 +518,63 @@ func TestService_BootstrapRejectsInvalidLocalInputsAndResponses(t *testing.T) {
 	require.ErrorAs(t, err, &hostErr)
 	require.ErrorIs(t, err, ErrHostSigningPayloadUnsupported)
 	require.Equal(t, "HOST_REGISTRATION_ID_REQUIRED", hostErr.Code)
+
+	_, err = service.SendBootstrapConversationMessage(context.Background(), BootstrapConversationMessageInput{
+		RegistrationID: "reg_123",
+		Message:        " ",
+	})
+	hostErr = nil
+	require.ErrorAs(t, err, &hostErr)
+	require.ErrorIs(t, err, ErrHostSigningPayloadUnsupported)
+	require.Equal(t, "HOST_INVALID_REQUEST", hostErr.Code)
+
+	_, err = service.CompleteBootstrapConversation(context.Background(), BootstrapConversationCompleteInput{})
+	hostErr = nil
+	require.ErrorAs(t, err, &hostErr)
+	require.ErrorIs(t, err, ErrHostSigningPayloadUnsupported)
+	require.Equal(t, "HOST_REGISTRATION_ID_REQUIRED", hostErr.Code)
+
+	_, err = service.PrepareBootstrapFinalize(context.Background(), BootstrapFinalizePreflightInput{
+		RegistrationID: "reg_123",
+	})
+	hostErr = nil
+	require.ErrorAs(t, err, &hostErr)
+	require.ErrorIs(t, err, ErrHostSigningPayloadUnsupported)
+	require.Equal(t, "HOST_CONVERSATION_ID_REQUIRED", hostErr.Code)
+
+	_, err = service.FinalizeBootstrap(context.Background(), BootstrapFinalizeInput{
+		RegistrationID:  "reg_123",
+		ConversationID:  "conv_123",
+		ExpectedVersion: 0,
+		SelfAttestation: "0xself",
+	})
+	hostErr = nil
+	require.ErrorAs(t, err, &hostErr)
+	require.ErrorIs(t, err, ErrHostSigningPayloadUnsupported)
+	require.Equal(t, "HOST_INVALID_REQUEST", hostErr.Code)
+
+	_, err = service.FinalizeBootstrap(context.Background(), BootstrapFinalizeInput{
+		RegistrationID:  "reg_123",
+		ConversationID:  "conv_123",
+		IssuedAt:        time.Date(2026, 6, 12, 22, 0, 0, 0, time.UTC),
+		ExpectedVersion: -1,
+		SelfAttestation: "0xself",
+	})
+	hostErr = nil
+	require.ErrorAs(t, err, &hostErr)
+	require.ErrorIs(t, err, ErrHostSigningPayloadUnsupported)
+	require.Equal(t, "HOST_INVALID_REQUEST", hostErr.Code)
+
+	_, err = service.FinalizeBootstrap(context.Background(), BootstrapFinalizeInput{
+		RegistrationID:  "reg_123",
+		ConversationID:  "conv_123",
+		IssuedAt:        time.Date(2026, 6, 12, 22, 0, 0, 0, time.UTC),
+		ExpectedVersion: 0,
+	})
+	hostErr = nil
+	require.ErrorAs(t, err, &hostErr)
+	require.ErrorIs(t, err, ErrHostSigningPayloadUnsupported)
+	require.Equal(t, "HOST_INVALID_REQUEST", hostErr.Code)
 }
 
 func TestBootstrapHelperBranches(t *testing.T) {
@@ -396,6 +633,40 @@ func TestBootstrapHelperBranches(t *testing.T) {
 	require.Empty(t, firstNonEmpty("", " "))
 	require.Nil(t, normalizeBootstrapCapabilities(nil))
 	require.Equal(t, []string{"A", "b"}, normalizeBootstrapCapabilities([]string{" A ", "b", "a", ""}))
+	require.Equal(t, map[string]string{"b1": "0xsig"}, normalizeBootstrapSignatureMap(map[string]string{" b1 ": " 0xsig ", " ": "ignored"}))
+
+	registrationID, conversationID, err := requireBootstrapRegistrationConversation(" reg_123 ", " conv_123 ")
+	require.NoError(t, err)
+	require.Equal(t, "reg_123", registrationID)
+	require.Equal(t, "conv_123", conversationID)
+	_, _, err = requireBootstrapRegistrationConversation("reg_123", "")
+	require.ErrorIs(t, err, ErrHostSigningPayloadUnsupported)
+
+	require.Equal(t, `{"a":1}`, compactHostJSON(json.RawMessage(` { "a" : 1 } `)))
+	require.Empty(t, compactHostJSON(nil))
+	require.Equal(t, "{bad", compactHostJSON(json.RawMessage(` {bad `)))
+
+	var sseOut hostConversationSSECollectResult
+	require.NoError(t, parseHostConversationSSE([]byte("event: conversation_start\n"+
+		"data: {\"conversation_id\":\"conv_start\",\"model\":\"claude\"}\n\n"+
+		"event: conversation_done\n"+
+		"data: {\"full_response\":\"done\"}\n\n"), &sseOut))
+	require.Equal(t, "conv_start", sseOut.ConversationID)
+	require.Equal(t, "claude", sseOut.Model)
+	require.Equal(t, "done", sseOut.FullResponse)
+	require.Error(t, parseHostConversationSSE([]byte("data: {}\n\n"), nil))
+	require.ErrorContains(t, parseHostConversationSSE([]byte("event: delta\ndata: {}\n\n"), &hostConversationSSECollectResult{}), "terminal")
+	require.Error(t, parseHostConversationSSE([]byte("event: conversation_done\ndata: {bad}\n\n"), &hostConversationSSECollectResult{}))
+	err = parseHostConversationSSE([]byte("event: error\ndata: {\"error\":\"model unavailable\"}\n\n"), &hostConversationSSECollectResult{})
+	hostErr = nil
+	require.ErrorAs(t, err, &hostErr)
+	require.Equal(t, "HOST_CONVERSATION_FAILED", hostErr.Code)
+	require.Equal(t, "model unavailable", hostErr.Message)
+	err = parseHostConversationSSE([]byte("event: error\ndata: {}\n\n"), &hostConversationSSECollectResult{})
+	hostErr = nil
+	require.ErrorAs(t, err, &hostErr)
+	require.Equal(t, "HOST_CONVERSATION_FAILED", hostErr.Code)
+	require.NotEmpty(t, hostErr.Message)
 
 	require.NoError(t, validateHostPrincipalSigningPayload(hostPrincipalPreflightResponse{
 		Version:         "1",
@@ -413,6 +684,66 @@ func TestBootstrapHelperBranches(t *testing.T) {
 		err := validateHostPrincipalSigningPayload(payload)
 		require.ErrorIs(t, err, ErrHostSigningPayloadUnsupported)
 	}
+
+	validFinalize := hostFinalizePreflightResponse{
+		Version:         "1",
+		ExpectedVersion: 0,
+		NextVersion:     1,
+		SelfAttestationSigning: hostFinalizeSigningInput{
+			SigningMethod:   "eip191_personal_sign",
+			MessageEncoding: "hex_bytes",
+			MessageHex:      "0xabc",
+			DigestHex:       "0xabc",
+		},
+		BoundaryRequirementsRaw: json.RawMessage(`[{"boundary_id":"b1","signing_method":"eip191_personal_sign","message_encoding":"utf8","message":"Sign","digest_hex":"0xabc"}]`),
+	}
+	require.NoError(t, validateHostFinalizePreflightPayload(validFinalize))
+	badFinalize := validFinalize
+	badFinalize.Version = "2"
+	require.ErrorIs(t, validateHostFinalizePreflightPayload(badFinalize), ErrHostSigningPayloadUnsupported)
+	badFinalize = validFinalize
+	badFinalize.SelfAttestationSigning.SigningMethod = "unknown"
+	require.ErrorIs(t, validateHostFinalizePreflightPayload(badFinalize), ErrHostSigningPayloadUnsupported)
+	badFinalize = validFinalize
+	badFinalize.SelfAttestationSigning.MessageEncoding = "utf8"
+	require.ErrorIs(t, validateHostFinalizePreflightPayload(badFinalize), ErrHostSigningPayloadUnsupported)
+	badFinalize = validFinalize
+	badFinalize.SelfAttestationSigning.MessageHex = ""
+	require.ErrorIs(t, validateHostFinalizePreflightPayload(badFinalize), ErrHostSigningPayloadUnsupported)
+	badFinalize = validFinalize
+	badFinalize.ExpectedVersion = -1
+	require.ErrorIs(t, validateHostFinalizePreflightPayload(badFinalize), ErrHostSigningPayloadUnsupported)
+	badFinalize = validFinalize
+	badFinalize.NextVersion = 0
+	require.ErrorIs(t, validateHostFinalizePreflightPayload(badFinalize), ErrHostSigningPayloadUnsupported)
+	badFinalize = validFinalize
+	badFinalize.BoundaryRequirementsRaw = json.RawMessage(`{bad`)
+	require.ErrorIs(t, validateHostFinalizePreflightPayload(badFinalize), ErrHostSigningPayloadUnsupported)
+	badFinalize = validFinalize
+	badFinalize.BoundaryRequirementsRaw = json.RawMessage(`[{"boundary_id":"b1","signing_method":"unknown","message_encoding":"utf8","message":"Sign","digest_hex":"0xabc"}]`)
+	require.ErrorIs(t, validateHostFinalizePreflightPayload(badFinalize), ErrHostSigningPayloadUnsupported)
+	badFinalize = validFinalize
+	badFinalize.BoundaryRequirementsRaw = json.RawMessage(`[{"boundary_id":"b1","signing_method":"eip191_personal_sign","message_encoding":"hex_bytes","message":"Sign","digest_hex":"0xabc"}]`)
+	require.ErrorIs(t, validateHostFinalizePreflightPayload(badFinalize), ErrHostSigningPayloadUnsupported)
+	badFinalize = validFinalize
+	badFinalize.BoundaryRequirementsRaw = json.RawMessage(`[{"boundary_id":"b1","signing_method":"eip191_personal_sign","message_encoding":"utf8","message":"","digest_hex":"0xabc"}]`)
+	require.ErrorIs(t, validateHostFinalizePreflightPayload(badFinalize), ErrHostSigningPayloadUnsupported)
+
+	validFinalizeResponse := hostFinalizeResponse{
+		Version:          "1",
+		AgentID:          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		PublishedVersion: 1,
+	}
+	require.NoError(t, validateHostFinalizeResponse(validFinalizeResponse))
+	badFinalizeResponse := validFinalizeResponse
+	badFinalizeResponse.Version = "2"
+	require.ErrorIs(t, validateHostFinalizeResponse(badFinalizeResponse), ErrHostUnavailable)
+	badFinalizeResponse = validFinalizeResponse
+	badFinalizeResponse.AgentID = "not-an-agent-id"
+	require.ErrorIs(t, validateHostFinalizeResponse(badFinalizeResponse), ErrHostUnavailable)
+	badFinalizeResponse = validFinalizeResponse
+	badFinalizeResponse.PublishedVersion = 0
+	require.ErrorIs(t, validateHostFinalizeResponse(badFinalizeResponse), ErrHostUnavailable)
 }
 
 func TestService_BootstrapInvalidHostResponseIsTyped(t *testing.T) {


### PR DESCRIPTION
## Milestone
Project 44 M2.3 — conversation/finalize relay and local soul binding

Closes #1158.

## Classification
contract-stability / schema-additive / operational-reliability / security

## Surfaces affected
- GraphQL bootstrap mutations: `sendSoulBootstrapConversationMessage`, `completeSoulBootstrapConversation`, `prepareSoulBootstrapFinalize`, `finalizeSoulBootstrap`
- Server-side Host instance-key bootstrap client in `pkg/services/souls`
- `drone_workflow.soul_bootstrap` metadata projection for conversation/finalize/publication checkpoints
- Generated GraphQL schema and model bindings

## Specialist walks referenced
- Federation trust: no ActivityPub actor/inbox/outbox/HTTP Signature behavior changes.
- Contract / API: additive GraphQL fields only; no Mastodon REST/OpenAPI changes; GraphQL schema regenerated.
- Schema: additive nested bootstrap metadata only; no PK/SK, GSI, TableTheory tag, or item-type changes.
- Framework: AppTheory/TableTheory usage unchanged; no framework patching.

## Consumer impact
- Greater/Sim can consume the additive GraphQL state after merge; this PR does not touch either repo.
- Host M1.5 conversation/finalize route contract remains the runtime dependency.
- Host instance key remains server-side only and is not exposed through browser/GraphQL state.

## Tasks
- [x] Wire conversation send/complete bootstrap operations through Lesser-authorized same-origin GraphQL mutations.
- [x] Wire finalize preflight/finalize through the server-side Host instance-key client.
- [x] Persist Host conversation id, completion, signing checkpoints, Host soul id, and publication evidence.
- [x] Bind successful hosted/off-chain finalization via existing soul incorporation semantics.
- [x] Fail closed on unsupported Host signing method/encoding/version and map replay/binding conflicts to typed bootstrap errors.
- [x] Project local workflow phases into declaration/signing/graduation/continuity states.

## Validation
- `go test ./graph ./pkg/services/souls ./cmd/api` ✅
- `go test ./pkg/agents ./pkg/services/souls` ✅
- `go test ./...` ✅
- `go vet ./...` ✅
- `gofmt -l <changed go files>` ✅ empty
- `bash scripts/verify_schema.sh` ✅
- `make verify-graphql-coverage` ✅
- `git diff --check` ✅
- `go build -o lesser ./cmd/lesser` ✅
- `./lesser build lambdas` ✅ built 38 Lambda artifacts
- `./lesser verify ci` ✅ complete; pkg coverage 90.009%, cmd coverage 90.012%

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
- Required runtime dependency: Host M1.5 conversation/finalize contract.
- Deferred consumer work: Greater/Sim UI/adapters for the additive GraphQL fields.
- No sibling repo edits in this PR.

---
Provenance: branch originally created via lesser steward routed GitHub tool; PR opened via `gh` fallback because routed Lesser MCP returned OAuth authorization required.
