### PR TITLE
test: harden soul bootstrap contract handoff

### DIFF
--- a/graph/soul_bootstrap_resolvers.go
+++ b/graph/soul_bootstrap_resolvers.go
@@ -61,6 +61,9 @@ func (r *mutationResolver) BeginSoulBootstrap(ctx context.Context, input model.B
 		existing *workflow.SoulBootstrapState,
 		now time.Time,
 	) (*workflow.SoulBootstrapState, error) {
+		if replayState, handled := soulBootstrapBeginReplayState(agentUser, existing, correlation, input.WalletAddress, now); handled {
+			return replayState, nil
+		}
 		bodyID := soulBootstrapBodyID(agentUser)
 		result, err := service.BeginBootstrapRegistration(ctx, soulservice.BootstrapBeginInput{
 			Username:      soulBootstrapHostLocalID(agentUser),
@@ -480,6 +483,44 @@ func soulBootstrapStateAfterBegin(
 	state.Error = nil
 	state.UpdatedAt = &now
 	return workflow.NormalizeSoulBootstrap(state, username)
+}
+
+func soulBootstrapBeginReplayState(
+	agentUser *storage.User,
+	existing *workflow.SoulBootstrapState,
+	correlation *workflow.SoulBootstrapCorrelationState,
+	walletAddress string,
+	now time.Time,
+) (*workflow.SoulBootstrapState, bool) {
+	if existing == nil || correlation == nil || strings.TrimSpace(correlation.BeginIdempotencyKey) == "" {
+		return nil, false
+	}
+	username := ""
+	if agentUser != nil {
+		username = agentUser.Username
+	}
+	state := workflow.NormalizeSoulBootstrap(existing, username)
+	if strings.TrimSpace(state.HostRegistrationID) == "" || state.Correlation == nil {
+		return nil, false
+	}
+	if strings.TrimSpace(state.Correlation.BeginIdempotencyKey) != strings.TrimSpace(correlation.BeginIdempotencyKey) {
+		return nil, false
+	}
+	if storedWallet := strings.TrimSpace(state.WalletAddress); storedWallet != "" {
+		providedWallet := strings.ToLower(strings.TrimSpace(walletAddress))
+		if providedWallet != "" && !strings.EqualFold(storedWallet, providedWallet) {
+			return soulBootstrapErrorState(
+				agentUser,
+				state,
+				correlation,
+				soulBootstrapReplayRejectedError("wallet address does not match local bootstrap state"),
+				now,
+			), true
+		}
+	}
+	state.Correlation = mergeSoulBootstrapCorrelation(state.Correlation, correlation)
+	state.UpdatedAt = &now
+	return workflow.NormalizeSoulBootstrap(state, username), true
 }
 
 func soulBootstrapStateAfterPrincipalPreflight(
@@ -1316,12 +1357,7 @@ func soulBootstrapRegistrationID(existing *workflow.SoulBootstrapState, input *s
 	}
 	provided := strings.TrimSpace(derefString(input))
 	if stored != "" && provided != "" && stored != provided {
-		return "", &soulservice.HostBootstrapError{
-			Code:    workflow.SoulBootstrapErrorHostBootstrapReplayRejected,
-			Message: "registration id does not match local bootstrap state",
-			Source:  soulBootstrapErrorSourceLesser,
-			Err:     soulservice.ErrHostSigningPayloadUnsupported,
-		}
+		return "", soulBootstrapReplayRejectedError("registration id does not match local bootstrap state")
 	}
 	registrationID := provided
 	if registrationID == "" {
@@ -1345,12 +1381,7 @@ func soulBootstrapOptionalConversationID(existing *workflow.SoulBootstrapState, 
 	}
 	provided := strings.TrimSpace(derefString(input))
 	if stored != "" && provided != "" && stored != provided {
-		return "", &soulservice.HostBootstrapError{
-			Code:    workflow.SoulBootstrapErrorHostBootstrapReplayRejected,
-			Message: "conversation id does not match local bootstrap state",
-			Source:  soulBootstrapErrorSourceLesser,
-			Err:     soulservice.ErrHostSigningPayloadUnsupported,
-		}
+		return "", soulBootstrapReplayRejectedError("conversation id does not match local bootstrap state")
 	}
 	if provided != "" {
 		return provided, nil
@@ -1365,12 +1396,7 @@ func soulBootstrapRequiredConversationID(existing *workflow.SoulBootstrapState, 
 		stored = strings.TrimSpace(existing.HostConversationID)
 	}
 	if stored != "" && provided != "" && stored != provided {
-		return "", &soulservice.HostBootstrapError{
-			Code:    workflow.SoulBootstrapErrorHostBootstrapReplayRejected,
-			Message: "conversation id does not match local bootstrap state",
-			Source:  soulBootstrapErrorSourceLesser,
-			Err:     soulservice.ErrHostSigningPayloadUnsupported,
-		}
+		return "", soulBootstrapReplayRejectedError("conversation id does not match local bootstrap state")
 	}
 	conversationID := provided
 	if conversationID == "" {
@@ -1385,6 +1411,15 @@ func soulBootstrapRequiredConversationID(existing *workflow.SoulBootstrapState, 
 		}
 	}
 	return conversationID, nil
+}
+
+func soulBootstrapReplayRejectedError(message string) *soulservice.HostBootstrapError {
+	return &soulservice.HostBootstrapError{
+		Code:    workflow.SoulBootstrapErrorHostBootstrapReplayRejected,
+		Message: message,
+		Source:  soulBootstrapErrorSourceLesser,
+		Err:     soulservice.ErrHostSigningPayloadUnsupported,
+	}
 }
 
 func graphBootstrapSignatureMap(raw *string) (map[string]string, error) {

--- a/graph/soul_bootstrap_round44_test.go
+++ b/graph/soul_bootstrap_round44_test.go
@@ -66,6 +66,68 @@ func TestRound44SoulBootstrapQueryProjectsZeroStateWorkflow(t *testing.T) {
 	require.True(t, apperrors.HasCode(err, apperrors.CodeForbidden))
 }
 
+func TestRound44SoulBootstrapRequiresAuthWriteScopeAndBodyAuthorization(t *testing.T) {
+	resolver, storageRepo := newRound12GraphResolver(t)
+	now := time.Date(2026, 6, 12, 12, 30, 0, 0, time.UTC)
+	resolver.soulsClient = &stubSoulService{
+		beginBootstrapFunc: func(context.Context, soulservice.BootstrapBeginInput) (*soulservice.BootstrapBeginResult, error) {
+			t.Fatal("host bootstrap should not be called when Lesser auth or body authorization fails")
+			return nil, nil
+		},
+	}
+
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "owner",
+		DisplayName: "Owner",
+		Approved:    true,
+		CreatedAt:   now.Add(-48 * time.Hour),
+		UpdatedAt:   now.Add(-24 * time.Hour),
+	}, nil)
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "other-owner",
+		DisplayName: "Other Owner",
+		Approved:    true,
+		CreatedAt:   now.Add(-48 * time.Hour),
+		UpdatedAt:   now.Add(-24 * time.Hour),
+	}, nil)
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "drone-auth",
+		DisplayName: "Drone Auth",
+		Approved:    true,
+		IsAgent:     true,
+		AgentOwner:  "@owner",
+		CreatedAt:   now.Add(-24 * time.Hour),
+		UpdatedAt:   now,
+	}, &storage.AgentGovernanceState{
+		Username:        "drone-auth",
+		DelegatedScopes: []string{auth.ScopeRead, auth.ScopeWrite},
+	})
+
+	_, err := (&queryResolver{resolver}).SoulBootstrap(context.Background(), "drone-auth")
+	require.Error(t, err)
+	require.True(t, apperrors.HasCode(err, apperrors.CodeUnauthorized))
+
+	_, err = (&queryResolver{resolver}).SoulBootstrap(round13DroneAuthContext("owner"), "drone-auth")
+	require.Error(t, err)
+	require.True(t, apperrors.HasCode(err, apperrors.CodeInsufficientScope))
+
+	beginInput := model.BeginSoulBootstrapInput{
+		Username:      "drone-auth",
+		WalletAddress: "0x1111111111111111111111111111111111111111",
+	}
+	_, err = (&mutationResolver{resolver}).BeginSoulBootstrap(context.Background(), beginInput)
+	require.Error(t, err)
+	require.True(t, apperrors.HasCode(err, apperrors.CodeUnauthorized))
+
+	_, err = (&mutationResolver{resolver}).BeginSoulBootstrap(round13DroneAuthContext("owner", auth.ScopeRead), beginInput)
+	require.Error(t, err)
+	require.True(t, apperrors.HasCode(err, apperrors.CodeInsufficientScope))
+
+	_, err = (&mutationResolver{resolver}).BeginSoulBootstrap(round13DroneAuthContext("other-owner", auth.ScopeWrite), beginInput)
+	require.Error(t, err)
+	require.True(t, apperrors.HasCode(err, apperrors.CodeForbidden))
+}
+
 func TestRound44SoulBootstrapBeginPersistsHostState(t *testing.T) {
 	resolver, storageRepo := newRound12GraphResolver(t)
 	now := time.Date(2026, 6, 12, 13, 0, 0, 0, time.UTC)
@@ -161,6 +223,81 @@ func TestRound44SoulBootstrapBeginPersistsHostState(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.True(t, apperrors.HasCode(err, apperrors.CodeForbidden))
+}
+
+func TestRound44SoulBootstrapBeginReplayDoesNotDuplicateHostRegistration(t *testing.T) {
+	resolver, storageRepo := newRound12GraphResolver(t)
+	now := time.Date(2026, 6, 12, 13, 15, 0, 0, time.UTC)
+	const (
+		wallet  = "0x1111111111111111111111111111111111111111"
+		agentID = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+	beginCalls := 0
+	resolver.soulsClient = &stubSoulService{
+		beginBootstrapFunc: func(_ context.Context, input soulservice.BootstrapBeginInput) (*soulservice.BootstrapBeginResult, error) {
+			beginCalls++
+			require.Equal(t, 1, beginCalls, "idempotent begin replay must not call Host again")
+			require.Equal(t, "drone-replay", input.Username)
+			return &soulservice.BootstrapBeginResult{
+				RegistrationID:  "reg_replay",
+				HostSoulAgentID: agentID,
+				WalletAddress:   input.WalletAddress,
+				WalletChallenge: soulservice.BootstrapWalletChallenge{
+					Address: input.WalletAddress,
+					Message: "Sign this stable Host wallet challenge.",
+				},
+				HostRequestID: "host-req-replay",
+			}, nil
+		},
+	}
+
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "owner",
+		DisplayName: "Owner",
+		Approved:    true,
+		CreatedAt:   now.Add(-48 * time.Hour),
+		UpdatedAt:   now.Add(-24 * time.Hour),
+	}, nil)
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "drone-replay",
+		DisplayName: "Drone Replay",
+		Approved:    true,
+		IsAgent:     true,
+		AgentOwner:  "@owner",
+		CreatedAt:   now.Add(-24 * time.Hour),
+		UpdatedAt:   now,
+	}, &storage.AgentGovernanceState{
+		Username:        "drone-replay",
+		DelegatedScopes: []string{auth.ScopeRead, auth.ScopeWrite},
+	})
+
+	input := model.BeginSoulBootstrapInput{
+		Username:       "drone-replay",
+		WalletAddress:  wallet,
+		IdempotencyKey: round13StringPtr("begin-stable-replay"),
+		CorrelationKey: round13StringPtr("corr-stable"),
+	}
+	first, err := (&mutationResolver{resolver}).BeginSoulBootstrap(round13DroneAuthContext("owner", auth.ScopeWrite), input)
+	require.NoError(t, err)
+	require.Nil(t, first.Error)
+	require.Equal(t, "reg_replay", derefString(first.Bootstrap.State.HostRegistrationID))
+	require.Equal(t, "begin-stable-replay", derefString(first.Bootstrap.State.Correlation.BeginIdempotencyKey))
+
+	second, err := (&mutationResolver{resolver}).BeginSoulBootstrap(round13DroneAuthContext("owner", auth.ScopeWrite), input)
+	require.NoError(t, err)
+	require.Nil(t, second.Error)
+	require.Equal(t, 1, beginCalls)
+	require.Equal(t, "reg_replay", derefString(second.Bootstrap.State.HostRegistrationID))
+	require.Equal(t, agentID, derefString(second.Bootstrap.State.HostSoulAgentID))
+
+	mismatch := input
+	mismatch.WalletAddress = "0x2222222222222222222222222222222222222222"
+	rejected, err := (&mutationResolver{resolver}).BeginSoulBootstrap(round13DroneAuthContext("owner", auth.ScopeWrite), mismatch)
+	require.NoError(t, err)
+	require.NotNil(t, rejected.Error)
+	require.Equal(t, 1, beginCalls)
+	require.Equal(t, workflow.SoulBootstrapErrorHostBootstrapReplayRejected, rejected.Error.Code)
+	require.Equal(t, workflow.SoulBootstrapStateCorrelationMismatch, rejected.Bootstrap.State.State)
 }
 
 func TestRound44SoulBootstrapHostErrorsPersistTypedState(t *testing.T) {

--- a/pkg/services/souls/bootstrap_test.go
+++ b/pkg/services/souls/bootstrap_test.go
@@ -322,6 +322,7 @@ func TestService_BootstrapConversationFinalizeRelaysInstanceRoutes(t *testing.T)
 
 	const (
 		instanceKey = "host-instance-key"
+		userBearer  = "user-oauth-token"
 		agentID     = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 		principal   = "0x2222222222222222222222222222222222222222"
 	)
@@ -330,8 +331,11 @@ func TestService_BootstrapConversationFinalizeRelaysInstanceRoutes(t *testing.T)
 	var sawSendBody map[string]any
 	var sawPreflightBody map[string]map[string]string
 	var sawFinalizeBody map[string]any
+	var sawAuthHeaders []string
 	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuthHeaders = append(sawAuthHeaders, r.Header.Get("Authorization"))
 		require.Equal(t, "Bearer "+instanceKey, r.Header.Get("Authorization"))
+		require.NotEqual(t, "Bearer "+userBearer, r.Header.Get("Authorization"))
 		w.Header().Set("X-Request-Id", "host-req-"+strings.Trim(strings.ReplaceAll(r.URL.Path, "/", "-"), "-"))
 
 		switch r.URL.Path {
@@ -495,6 +499,11 @@ func TestService_BootstrapConversationFinalizeRelaysInstanceRoutes(t *testing.T)
 	require.Equal(t, principal, finalized.PrincipalAddress)
 	require.Equal(t, "hosted_offchain", finalized.Publication.AnchorState)
 	require.Equal(t, "graduated", finalized.Promotion.Stage)
+	require.Len(t, sawAuthHeaders, 4)
+	for _, authHeader := range sawAuthHeaders {
+		require.Equal(t, "Bearer "+instanceKey, authHeader)
+		require.NotEqual(t, "Bearer "+userBearer, authHeader)
+	}
 }
 
 func TestService_BootstrapRejectsInvalidLocalInputsAndResponses(t *testing.T) {


### PR DESCRIPTION
## Milestone
Project 44 M2.4 — Lesser bootstrap auth/idempotency/error tests and contract handoff.

Closes #1159.

## Classification
security / contract-stability / test-coverage

## Surfaces affected
- GraphQL soul bootstrap resolver path in `graph/soul_bootstrap_resolvers.go`
- GraphQL bootstrap tests in `graph/soul_bootstrap_round44_test.go`
- Host instance-key bootstrap service tests in `pkg/services/souls/bootstrap_test.go`
- Published contract artifacts regenerated/verified with no schema diff

## Specialist walks referenced
- Federation trust: no ActivityPub actor/inbox/outbox/HTTP Signature behavior changes.
- Contract / API: GraphQL schema regenerated via `scripts/generate_schema.sh` and verified; no GraphQL schema diff in this PR. No REST parity code change; OpenAPI verified unchanged.
- Schema: no DynamoDB PK/SK/GSI/TableTheory tag or item-type changes.
- Framework: AppTheory/TableTheory usage unchanged; no framework patching.

## Consumer impact
- Greater Components M3 can use this PR head as the Lesser M2 handoff contract once merged/pinned.
- Browser/Sim auth remains same-origin into Lesser. Lesser alone calls Host server-side with `Authorization: Bearer <instance-key>`.
- No browser Host-token, instance-key exposure, or sibling repo change is introduced.

## Tasks
- [x] Prove OAuth user auth is required at the Lesser GraphQL boundary.
- [x] Prove write scope is required for soul bootstrap mutations.
- [x] Prove cross-user/body bootstrap mutation attempts are forbidden before Host is called.
- [x] Prove Host conversation/finalize calls receive only the server-side instance key, not a browser bearer token.
- [x] Add local idempotent begin replay so a matching persisted begin idempotency key does not create a duplicate Host registration.
- [x] Fail closed on mismatched begin replay wallet input without calling Host again.
- [x] Keep existing typed Host config/key/non-2xx/signing/finalize/binding-conflict coverage green.
- [x] Regenerate and verify GraphQL contract artifacts.
- [x] Verify GraphQL coverage inventory.

## Validation
- `go test ./graph ./pkg/agents ./pkg/services/souls ./cmd/api` ✅
- `go test ./...` ✅
- `bash scripts/generate_schema.sh` ✅ (no contract diff)
- `bash scripts/verify_schema.sh` ✅
- `make verify-graphql-coverage` ✅
- `make verify-openapi` ✅ (run for handoff confidence; no REST parity touched)
- `go vet ./...` ✅
- `gofmt -l .` ✅ empty
- `git diff --check` ✅
- `go build -o lesser ./cmd/lesser` ✅
- `./lesser build lambdas` ✅ built 38 Lambda artifacts
- `./lesser verify ci` ✅ complete; overall coverage 87.654%, pkg coverage 90.009%, cmd coverage 90.012%

## M3 Greater handoff
- Lesser commit to pin after merge: `83c5c83562b64300bfa5e53889f1106d38d6acfe` (PR head)
- Contract files to pin/read:
  - `docs/contracts/graphql-schema.graphql` — regenerated and verified; no M2.4 diff
  - `graph/agents.graphql` — source GraphQL soul bootstrap contract; unchanged in M2.4
  - `docs/specs/graphql_coverage.yaml` — verified; unchanged in M2.4
  - `docs/contracts/openapi.yaml` — verified; unchanged because no REST parity changed
- GraphQL operation names:
  - Query: `soulBootstrap(username: String!)`
  - Mutations: `beginSoulBootstrap`, `verifySoulBootstrapWallet`, `prepareSoulBootstrapPrincipalDeclaration`, `verifySoulBootstrapPrincipalDeclaration`, `sendSoulBootstrapConversationMessage`, `completeSoulBootstrapConversation`, `prepareSoulBootstrapFinalize`, `finalizeSoulBootstrap`
- Generated type expectations:
  - `SoulBootstrapSurface` with `body`, `workflow`, `state`, `soulBindingState`, `existingSoulAgentId`, `hostBridgeAvailable`, `executable`, `nextAction`, `error`
  - `SoulBootstrapState` with Host ids, wallet/principal addresses, `phase`, typed `state`, `signingCheckpoints`, optional `publication`, optional `error`, optional `correlation`, `updatedAt`
  - `SoulBootstrapSigningCheckpoint` includes Host-relayed signing metadata (`signingMethod`, `messageEncoding`, `message`, `messageHex`, `digestHex`, `canonicalJson`) plus finalize metadata (`expectedVersion`, `nextVersion`, `boundaryRequirementsJson`, `finalizeRequestTemplateJson`, `registrationPreviewJson`)
  - `SoulBootstrapPublicationEvidence`, `SoulBootstrapCorrelationState`, and `SoulBootstrapErrorState` are the generated handoff types for publication, idempotency, and actionable error rendering

## Caveats
- No Greater or Simulacrum code touched.
- No REST parity was added or changed; OpenAPI was verified but not regenerated into a diff.
- Idempotent duplicate-registration prevention is Lesser-side after a begin state is persisted with a matching begin idempotency key. First-call replay/correlation semantics still depend on Host’s register/begin contract; mismatched local replay wallet input fails closed locally without a Host call.
- Memory MCP/routed Lesser GitHub tools were not exposed in this Codex session, so GitHub branch/commit/PR publication used local git plus the general GitHub app fallback.

## Stage rollout plan (handoff to deploy-instance after merge)
- [ ] Merged to main
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live