### PR TITLE
Repair hosted refresh state from Host evidence

### DIFF
--- a/graph/soul_bootstrap_resolvers.go
+++ b/graph/soul_bootstrap_resolvers.go
@@ -47,6 +47,9 @@ func (r *queryResolver) SoulBootstrap(ctx context.Context, username string) (*mo
 	if !r.canAccessDroneReviewWorkflow(ctx, claims, agentUser, workflowState) {
 		return nil, apperrors.Forbidden("not authorized to view soul bootstrap")
 	}
+	if err := r.reconcileHostedSoulBootstrapState(ctx, claims.Username, agentUser, workflowState); err != nil {
+		return nil, err
+	}
 	return r.buildSoulBootstrapSurface(ctx, claims.Username, agentUser, governance, nil)
 }
 
@@ -486,6 +489,7 @@ type soulBootstrapHostService interface {
 	VerifyBootstrapPrincipalDeclaration(context.Context, soulservice.BootstrapPrincipalVerifyInput) (*soulservice.BootstrapPrincipalVerifyResult, error)
 	SendBootstrapConversationMessage(context.Context, soulservice.BootstrapConversationMessageInput) (*soulservice.BootstrapConversationMessageResult, error)
 	CompleteBootstrapConversation(context.Context, soulservice.BootstrapConversationCompleteInput) (*soulservice.BootstrapConversationCompleteResult, error)
+	ReadBootstrapConversation(context.Context, soulservice.BootstrapConversationCompleteInput) (*soulservice.BootstrapConversationCompleteResult, error)
 	PrepareBootstrapFinalize(context.Context, soulservice.BootstrapFinalizePreflightInput) (*soulservice.BootstrapFinalizePreflightResult, error)
 	FinalizeBootstrap(context.Context, soulservice.BootstrapFinalizeInput) (*soulservice.BootstrapFinalizeResult, error)
 	PublishHostedBootstrap(context.Context, soulservice.HostedBootstrapPublishInput) (*soulservice.BootstrapFinalizeResult, error)
@@ -639,6 +643,66 @@ func (r *Resolver) soulBootstrapService() (soulBootstrapHostService, error) {
 		return nil, errors.New("soul bootstrap service is not available")
 	}
 	return bootstrap, nil
+}
+
+func (r *Resolver) reconcileHostedSoulBootstrapState(
+	ctx context.Context,
+	viewerUsername string,
+	agentUser *storage.User,
+	workflowState *workflow.DroneWorkflowState,
+) error {
+	if r == nil || agentUser == nil || workflowState == nil || workflowState.SoulBootstrap == nil {
+		return nil
+	}
+	state := workflow.NormalizeSoulBootstrap(workflowState.SoulBootstrap, agentUser.Username)
+	if !soulBootstrapShouldReadRepairHostedState(state) {
+		return nil
+	}
+	service, err := r.soulBootstrapService()
+	if err != nil {
+		return nil
+	}
+	result, err := service.ReadBootstrapConversation(ctx, soulservice.BootstrapConversationCompleteInput{
+		RegistrationID: state.HostRegistrationID,
+		ConversationID: state.HostConversationID,
+	})
+	if err != nil {
+		return nil
+	}
+	if err := soulservice.ValidateHostedBootstrapCompletionEvidence(result, state.HostConversationID); err != nil {
+		return nil
+	}
+
+	now := time.Now().UTC()
+	next := soulBootstrapStateAfterHostedConversationComplete(agentUser, state, state.Correlation, result, now)
+	workflowState.SoulBootstrap = workflow.NormalizeSoulBootstrap(next, agentUser.Username)
+	applySoulBootstrapWorkflowProjection(ctx, r, viewerUsername, agentUser, workflowState, workflowState.SoulBootstrap, now)
+	workflowState.UpdatedAt = &now
+	if err := r.persistDroneWorkflowState(ctx, agentUser, workflowState); err != nil {
+		return apperrors.InternalWithCause(err, "failed to persist reconciled hosted soul bootstrap state")
+	}
+	return nil
+}
+
+func soulBootstrapShouldReadRepairHostedState(state *workflow.SoulBootstrapState) bool {
+	state = workflow.NormalizeSoulBootstrap(state, "")
+	if state == nil || state.BootstrapMode != workflow.SoulBootstrapModeHosted {
+		return false
+	}
+	if strings.TrimSpace(state.HostRegistrationID) == "" || strings.TrimSpace(state.HostConversationID) == "" {
+		return false
+	}
+	if soulBootstrapHasTerminalConversationDeclarationEvidence(state.SigningCheckpoints, state.HostConversationID) {
+		return false
+	}
+	if state.Phase == workflow.SoulBootstrapPhaseError {
+		return strings.EqualFold(strings.TrimSpace(state.NextAction), workflow.SoulBootstrapNextActionRefreshState) ||
+			strings.EqualFold(strings.TrimSpace(state.RecoveryAction), workflow.SoulBootstrapRecoveryActionRefreshState) ||
+			(state.Error != nil && soulBootstrapConversationNotInProgressConflict(state.Error.Code, state.Error.StatusCode, state.Error.Message))
+	}
+	return state.Phase == workflow.SoulBootstrapPhaseConversation &&
+		state.State == workflow.SoulBootstrapStateConversationCompleted &&
+		strings.EqualFold(strings.TrimSpace(state.NextAction), workflow.SoulBootstrapNextActionPublishHostedSoul)
 }
 
 func soulBootstrapStateAfterBegin(

--- a/graph/soul_bootstrap_round44_test.go
+++ b/graph/soul_bootstrap_round44_test.go
@@ -573,6 +573,110 @@ func TestRound44CompleteHostedSoulGenesisPersistsRecoveredTerminalConversationEv
 	require.Equal(t, soulBootstrapCheckpointHostedConversation, storedWorkflow.SoulBootstrap.SigningCheckpoints[0].Name)
 }
 
+func TestRound44SoulBootstrapQueryRepairsHostedRefreshStateFromHost(t *testing.T) {
+	resolver, storageRepo := newRound12GraphResolver(t)
+	now := time.Date(2026, 6, 18, 1, 30, 0, 0, time.UTC)
+	errorAt := now.Add(-11 * time.Hour)
+	completedAt := now.Add(-3 * time.Hour)
+	validDeclaration := `{"selfDescription":{"summary":"repaired"},"capabilities":[],"boundaries":[],"transparency":{"source":"host_read"}}`
+	readCalls := 0
+
+	resolver.soulsClient = &stubSoulService{
+		readBootstrapConversationFunc: func(_ context.Context, input soulservice.BootstrapConversationCompleteInput) (*soulservice.BootstrapConversationCompleteResult, error) {
+			readCalls++
+			require.Equal(t, "reg_stale", input.RegistrationID)
+			require.Equal(t, "conv_stale", input.ConversationID)
+			return &soulservice.BootstrapConversationCompleteResult{
+				RegistrationID:       "reg_stale",
+				HostSoulAgentID:      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				ConversationID:       "conv_stale",
+				Status:               "completed",
+				ProducedDeclarations: validDeclaration,
+				CompletedAt:          &completedAt,
+				HostRequestID:        "host-req-read-repair",
+			}, nil
+		},
+	}
+
+	metadata, err := workflow.SetDroneWorkflowMetadata(nil, &workflow.DroneWorkflowState{
+		SoulBootstrap: &workflow.SoulBootstrapState{
+			Username:           "drone-refresh",
+			BodyID:             "drone-refresh",
+			HostRegistrationID: "reg_stale",
+			HostConversationID: "conv_stale",
+			HostSoulAgentID:    "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			BootstrapMode:      workflow.SoulBootstrapModeHosted,
+			AuthorityModel:     workflow.SoulBootstrapAuthorityModelInstanceTrust,
+			AnchorState:        workflow.SoulBootstrapAnchorStateHostedOffchain,
+			AssuranceState:     workflow.SoulBootstrapAnchorStateHostedOffchain,
+			Phase:              workflow.SoulBootstrapPhaseError,
+			State:              workflow.SoulBootstrapStateHostUnavailable,
+			NextAction:         workflow.SoulBootstrapNextActionRefreshState,
+			RecoveryCategory:   workflow.SoulBootstrapRecoveryCategoryRefreshState,
+			RecoveryAction:     workflow.SoulBootstrapRecoveryActionRefreshState,
+			Error: &workflow.SoulBootstrapErrorState{
+				Code:             "soul_instance.conflict",
+				Message:          "conversation is not in progress",
+				Source:           "host",
+				StatusCode:       409,
+				HostRequestID:    "host-req-old-conflict",
+				RecoveryCategory: workflow.SoulBootstrapRecoveryCategoryRefreshState,
+				RecoveryAction:   workflow.SoulBootstrapRecoveryActionRefreshState,
+				At:               &errorAt,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "owner",
+		DisplayName: "Owner",
+		Approved:    true,
+		CreatedAt:   now.Add(-48 * time.Hour),
+		UpdatedAt:   now.Add(-24 * time.Hour),
+	}, nil)
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "drone-refresh",
+		DisplayName: "Drone Refresh",
+		Approved:    true,
+		IsAgent:     true,
+		AgentOwner:  "@owner",
+		Metadata:    metadata,
+		CreatedAt:   now.Add(-24 * time.Hour),
+		UpdatedAt:   now,
+	}, &storage.AgentGovernanceState{
+		Username:        "drone-refresh",
+		DelegatedScopes: []string{auth.ScopeRead, auth.ScopeWrite},
+	})
+
+	surface, err := (&queryResolver{resolver}).SoulBootstrap(round13DroneAuthContext("owner", auth.ScopeRead), "drone-refresh")
+	require.NoError(t, err)
+	require.Equal(t, 1, readCalls)
+	require.NotNil(t, surface)
+	require.Nil(t, surface.Error)
+	require.Nil(t, surface.State.Error)
+	require.Equal(t, model.SoulBootstrapPhaseConversation, surface.State.Phase)
+	require.Equal(t, workflow.SoulBootstrapStateConversationCompleted, surface.State.State)
+	require.Equal(t, model.SoulBootstrapNextActionPublishHostedSoul, surface.TypedNextAction)
+	require.Len(t, surface.State.SigningCheckpoints, 1)
+	checkpoint := surface.State.SigningCheckpoints[0]
+	require.Equal(t, soulBootstrapCheckpointHostedConversation, checkpoint.Name)
+	require.Equal(t, "completed", checkpoint.Status)
+	require.JSONEq(t, validDeclaration, derefString(checkpoint.CanonicalJSON))
+	require.Equal(t, "host-req-read-repair", derefString(checkpoint.HostRequestID))
+	require.NotNil(t, surface.Workflow.Declaration)
+
+	storedUser, err := storageRepo.Account().GetUser(context.Background(), "drone-refresh")
+	require.NoError(t, err)
+	storedWorkflow, err := workflow.ParseDroneWorkflowMetadata(storedUser.Metadata)
+	require.NoError(t, err)
+	require.NotNil(t, storedWorkflow.SoulBootstrap)
+	require.Nil(t, storedWorkflow.SoulBootstrap.Error)
+	require.Equal(t, workflow.SoulBootstrapNextActionPublishHostedSoul, storedWorkflow.SoulBootstrap.NextAction)
+	require.Len(t, storedWorkflow.SoulBootstrap.SigningCheckpoints, 1)
+	require.Equal(t, soulBootstrapCheckpointHostedConversation, storedWorkflow.SoulBootstrap.SigningCheckpoints[0].Name)
+}
+
 func TestRound44CompleteHostedSoulGenesisConflictRecoveryFailuresDoNotRefreshLoop(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/graph/souls_round12_test.go
+++ b/graph/souls_round12_test.go
@@ -25,6 +25,7 @@ type stubSoulService struct {
 	verifyBootstrapPrincipalFunc      func(context.Context, soulservice.BootstrapPrincipalVerifyInput) (*soulservice.BootstrapPrincipalVerifyResult, error)
 	sendBootstrapConversationFunc     func(context.Context, soulservice.BootstrapConversationMessageInput) (*soulservice.BootstrapConversationMessageResult, error)
 	completeBootstrapConversationFunc func(context.Context, soulservice.BootstrapConversationCompleteInput) (*soulservice.BootstrapConversationCompleteResult, error)
+	readBootstrapConversationFunc     func(context.Context, soulservice.BootstrapConversationCompleteInput) (*soulservice.BootstrapConversationCompleteResult, error)
 	prepareBootstrapFinalizeFunc      func(context.Context, soulservice.BootstrapFinalizePreflightInput) (*soulservice.BootstrapFinalizePreflightResult, error)
 	finalizeBootstrapFunc             func(context.Context, soulservice.BootstrapFinalizeInput) (*soulservice.BootstrapFinalizeResult, error)
 	publishHostedBootstrapFunc        func(context.Context, soulservice.HostedBootstrapPublishInput) (*soulservice.BootstrapFinalizeResult, error)
@@ -98,6 +99,13 @@ func (s *stubSoulService) CompleteBootstrapConversation(ctx context.Context, inp
 		return nil, errors.New("complete bootstrap conversation not implemented")
 	}
 	return s.completeBootstrapConversationFunc(ctx, input)
+}
+
+func (s *stubSoulService) ReadBootstrapConversation(ctx context.Context, input soulservice.BootstrapConversationCompleteInput) (*soulservice.BootstrapConversationCompleteResult, error) {
+	if s.readBootstrapConversationFunc == nil {
+		return nil, errors.New("read bootstrap conversation not implemented")
+	}
+	return s.readBootstrapConversationFunc(ctx, input)
 }
 
 func (s *stubSoulService) PrepareBootstrapFinalize(ctx context.Context, input soulservice.BootstrapFinalizePreflightInput) (*soulservice.BootstrapFinalizePreflightResult, error) {


### PR DESCRIPTION
## Summary

Adds a bounded Lesser read-repair path for hosted/off-chain soul bootstrap refreshes.

When `soulBootstrap(username:)` sees hosted/instance-trust state that:

- already has a Host registration id and conversation id,
- lacks terminal hosted declaration evidence, and
- is either an error/`REFRESH_STATE` shape or a conversation-completed-without-evidence shape,

Lesser now reads Host's private instance mint-conversation record. If Host returns terminal completed evidence with valid produced declarations for the same conversation id, Lesser persists the same `hosted_conversation` checkpoint shape used by `completeHostedSoulGenesis`, clears the stale error, projects workflow declaration state, and returns `PUBLISH_HOSTED_SOUL`.

## Root cause

Live TheoryLive Della Marlowe was still stuck after deploying lesser-host v1.0.3 / Lesser v1.5.4 because the visible state was not a fresh Host transport failure. Host already had completed terminal declarations for conversation `kktjRV5iAtrYIj1mizgZrg`, and live Host read/idempotent complete returned `200` with declarations after deploy.

The stuck UI was re-rendering a stale Lesser metadata row from `2026-06-17T14:47:27Z` containing `REFRESH_STATE` + Host 409 `conversation is not in progress`, with no local `hosted_conversation` checkpoint. Sim's refresh action only re-fetches Lesser GraphQL state, and Lesser's query path previously did not reconcile Host state.

## Impact

This lets the existing Sim `Refresh Hosted State` button become an actual repair path for stale hosted bootstrap state after Host has terminal evidence. It does not add a new GraphQL contract or require Greater/Sim regeneration.

## Validation

- `go test ./graph -run 'TestRound44(SoulBootstrapQueryRepairsHostedRefreshStateFromHost|CompleteHostedSoulGenesisPersistsRecoveredTerminalConversationEvidence|CompleteHostedSoulGenesisConflictRecoveryFailuresDoNotRefreshLoop)'`
- `go test ./graph`
- `go test ./...`
- `git diff --check`
- `git ls-files '*.go' | xargs gofmt -l` returned empty

## Provenance

- Agent: Arch via local Codex session
- Target: equaltoai/lesser Project 44 M8.7 repair extension
- Basis: live AWS profiles `TheoryLive` and `Lesser`, CloudWatch request ids, Della Lesser/Host DynamoDB state, and source inspection in Lesser/lesser-host/Sim
- Note: theorymcp_lab GitHub OAuth was unavailable in this session, so branch push and PR creation use `gh` fallback authenticated as `aron23`.
