### PR TITLE
feat: relay hosted genesis conversation (#1203)

### DIFF
--- a/docs/contracts/graphql-schema.graphql
+++ b/docs/contracts/graphql-schema.graphql
@@ -4810,6 +4810,32 @@ type SoulBootstrapPublishGate {
   requiresActiveConversationTerminalDeclarationEvidence: Boolean!
 }
 
+enum SoulBootstrapHostedGenesisMessageRole {
+  USER
+  ASSISTANT
+}
+
+type SoulBootstrapHostedGenesisMessage {
+  id: ID!
+  role: SoulBootstrapHostedGenesisMessageRole!
+  content: String!
+  order: Int!
+  createdAt: Time
+  truncated: Boolean!
+}
+
+type SoulBootstrapHostedGenesisConversation {
+  registrationId: ID
+  conversationId: ID!
+  status: String!
+  latestTurnId: ID
+  messageCount: Int!
+  messages: [SoulBootstrapHostedGenesisMessage!]!
+  messagesTruncated: Boolean!
+  requestId: String
+  updatedAt: Time
+}
+
 type SoulBootstrapCorrelationState {
   correlationKey: String
   beginIdempotencyKey: String
@@ -4859,6 +4885,8 @@ type SoulBootstrapState {
   retryable: Boolean!
   restartRequired: Boolean!
   restartAvailable: Boolean!
+  availableActions: [SoulBootstrapNextAction!]!
+  hostedGenesisConversation: SoulBootstrapHostedGenesisConversation
   signingCheckpoints: [SoulBootstrapSigningCheckpoint!]!
   terminalDeclarationEvidence: SoulBootstrapTerminalDeclarationEvidence
   publication: SoulBootstrapPublicationEvidence
@@ -4884,6 +4912,7 @@ type SoulBootstrapSurface {
   executable: Boolean!
   nextAction: String
   typedNextAction: SoulBootstrapNextAction!
+  availableActions: [SoulBootstrapNextAction!]!
   recoveryCategory: SoulBootstrapRecoveryCategory
   recoveryAction: SoulBootstrapRecoveryAction
   retryable: Boolean!

--- a/graph/agents.graphql
+++ b/graph/agents.graphql
@@ -652,6 +652,32 @@ type SoulBootstrapPublishGate {
   requiresActiveConversationTerminalDeclarationEvidence: Boolean!
 }
 
+enum SoulBootstrapHostedGenesisMessageRole {
+  USER
+  ASSISTANT
+}
+
+type SoulBootstrapHostedGenesisMessage {
+  id: ID!
+  role: SoulBootstrapHostedGenesisMessageRole!
+  content: String!
+  order: Int!
+  createdAt: Time
+  truncated: Boolean!
+}
+
+type SoulBootstrapHostedGenesisConversation {
+  registrationId: ID
+  conversationId: ID!
+  status: String!
+  latestTurnId: ID
+  messageCount: Int!
+  messages: [SoulBootstrapHostedGenesisMessage!]!
+  messagesTruncated: Boolean!
+  requestId: String
+  updatedAt: Time
+}
+
 type SoulBootstrapCorrelationState {
   correlationKey: String
   beginIdempotencyKey: String
@@ -701,6 +727,8 @@ type SoulBootstrapState {
   retryable: Boolean!
   restartRequired: Boolean!
   restartAvailable: Boolean!
+  availableActions: [SoulBootstrapNextAction!]!
+  hostedGenesisConversation: SoulBootstrapHostedGenesisConversation
   signingCheckpoints: [SoulBootstrapSigningCheckpoint!]!
   terminalDeclarationEvidence: SoulBootstrapTerminalDeclarationEvidence
   publication: SoulBootstrapPublicationEvidence
@@ -726,6 +754,7 @@ type SoulBootstrapSurface {
   executable: Boolean!
   nextAction: String
   typedNextAction: SoulBootstrapNextAction!
+  availableActions: [SoulBootstrapNextAction!]!
   recoveryCategory: SoulBootstrapRecoveryCategory
   recoveryAction: SoulBootstrapRecoveryAction
   retryable: Boolean!

--- a/graph/generated.go
+++ b/graph/generated.go
@@ -2975,6 +2975,27 @@ type ComplexityRoot struct {
 		StatusCode       func(childComplexity int) int
 	}
 
+	SoulBootstrapHostedGenesisConversation struct {
+		ConversationID    func(childComplexity int) int
+		LatestTurnID      func(childComplexity int) int
+		MessageCount      func(childComplexity int) int
+		Messages          func(childComplexity int) int
+		MessagesTruncated func(childComplexity int) int
+		RegistrationID    func(childComplexity int) int
+		RequestID         func(childComplexity int) int
+		Status            func(childComplexity int) int
+		UpdatedAt         func(childComplexity int) int
+	}
+
+	SoulBootstrapHostedGenesisMessage struct {
+		Content   func(childComplexity int) int
+		CreatedAt func(childComplexity int) int
+		ID        func(childComplexity int) int
+		Order     func(childComplexity int) int
+		Role      func(childComplexity int) int
+		Truncated func(childComplexity int) int
+	}
+
 	SoulBootstrapIdentityTarget struct {
 		BodyID      func(childComplexity int) int
 		DisplayName func(childComplexity int) int
@@ -3033,6 +3054,7 @@ type ComplexityRoot struct {
 		AnchorState                 func(childComplexity int) int
 		AssuranceState              func(childComplexity int) int
 		AuthorityModel              func(childComplexity int) int
+		AvailableActions            func(childComplexity int) int
 		BodyID                      func(childComplexity int) int
 		BootstrapMode               func(childComplexity int) int
 		Correlation                 func(childComplexity int) int
@@ -3041,6 +3063,7 @@ type ComplexityRoot struct {
 		HostConversationStatus      func(childComplexity int) int
 		HostRegistrationID          func(childComplexity int) int
 		HostSoulAgentID             func(childComplexity int) int
+		HostedGenesisConversation   func(childComplexity int) int
 		LastHostRequestID           func(childComplexity int) int
 		Phase                       func(childComplexity int) int
 		PrincipalAddress            func(childComplexity int) int
@@ -3065,6 +3088,7 @@ type ComplexityRoot struct {
 	}
 
 	SoulBootstrapSurface struct {
+		AvailableActions    func(childComplexity int) int
 		Body                func(childComplexity int) int
 		Error               func(childComplexity int) int
 		Executable          func(childComplexity int) int
@@ -19783,6 +19807,111 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.SoulBootstrapErrorState.StatusCode(childComplexity), true
 
+	case "SoulBootstrapHostedGenesisConversation.conversationId":
+		if e.complexity.SoulBootstrapHostedGenesisConversation.ConversationID == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapHostedGenesisConversation.ConversationID(childComplexity), true
+
+	case "SoulBootstrapHostedGenesisConversation.latestTurnId":
+		if e.complexity.SoulBootstrapHostedGenesisConversation.LatestTurnID == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapHostedGenesisConversation.LatestTurnID(childComplexity), true
+
+	case "SoulBootstrapHostedGenesisConversation.messageCount":
+		if e.complexity.SoulBootstrapHostedGenesisConversation.MessageCount == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapHostedGenesisConversation.MessageCount(childComplexity), true
+
+	case "SoulBootstrapHostedGenesisConversation.messages":
+		if e.complexity.SoulBootstrapHostedGenesisConversation.Messages == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapHostedGenesisConversation.Messages(childComplexity), true
+
+	case "SoulBootstrapHostedGenesisConversation.messagesTruncated":
+		if e.complexity.SoulBootstrapHostedGenesisConversation.MessagesTruncated == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapHostedGenesisConversation.MessagesTruncated(childComplexity), true
+
+	case "SoulBootstrapHostedGenesisConversation.registrationId":
+		if e.complexity.SoulBootstrapHostedGenesisConversation.RegistrationID == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapHostedGenesisConversation.RegistrationID(childComplexity), true
+
+	case "SoulBootstrapHostedGenesisConversation.requestId":
+		if e.complexity.SoulBootstrapHostedGenesisConversation.RequestID == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapHostedGenesisConversation.RequestID(childComplexity), true
+
+	case "SoulBootstrapHostedGenesisConversation.status":
+		if e.complexity.SoulBootstrapHostedGenesisConversation.Status == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapHostedGenesisConversation.Status(childComplexity), true
+
+	case "SoulBootstrapHostedGenesisConversation.updatedAt":
+		if e.complexity.SoulBootstrapHostedGenesisConversation.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapHostedGenesisConversation.UpdatedAt(childComplexity), true
+
+	case "SoulBootstrapHostedGenesisMessage.content":
+		if e.complexity.SoulBootstrapHostedGenesisMessage.Content == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapHostedGenesisMessage.Content(childComplexity), true
+
+	case "SoulBootstrapHostedGenesisMessage.createdAt":
+		if e.complexity.SoulBootstrapHostedGenesisMessage.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapHostedGenesisMessage.CreatedAt(childComplexity), true
+
+	case "SoulBootstrapHostedGenesisMessage.id":
+		if e.complexity.SoulBootstrapHostedGenesisMessage.ID == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapHostedGenesisMessage.ID(childComplexity), true
+
+	case "SoulBootstrapHostedGenesisMessage.order":
+		if e.complexity.SoulBootstrapHostedGenesisMessage.Order == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapHostedGenesisMessage.Order(childComplexity), true
+
+	case "SoulBootstrapHostedGenesisMessage.role":
+		if e.complexity.SoulBootstrapHostedGenesisMessage.Role == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapHostedGenesisMessage.Role(childComplexity), true
+
+	case "SoulBootstrapHostedGenesisMessage.truncated":
+		if e.complexity.SoulBootstrapHostedGenesisMessage.Truncated == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapHostedGenesisMessage.Truncated(childComplexity), true
+
 	case "SoulBootstrapIdentityTarget.bodyId":
 		if e.complexity.SoulBootstrapIdentityTarget.BodyID == nil {
 			break
@@ -20077,6 +20206,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.SoulBootstrapState.AuthorityModel(childComplexity), true
 
+	case "SoulBootstrapState.availableActions":
+		if e.complexity.SoulBootstrapState.AvailableActions == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapState.AvailableActions(childComplexity), true
+
 	case "SoulBootstrapState.bodyId":
 		if e.complexity.SoulBootstrapState.BodyID == nil {
 			break
@@ -20132,6 +20268,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.SoulBootstrapState.HostSoulAgentID(childComplexity), true
+
+	case "SoulBootstrapState.hostedGenesisConversation":
+		if e.complexity.SoulBootstrapState.HostedGenesisConversation == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapState.HostedGenesisConversation(childComplexity), true
 
 	case "SoulBootstrapState.lastHostRequestId":
 		if e.complexity.SoulBootstrapState.LastHostRequestID == nil {
@@ -20279,6 +20422,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.SoulBootstrapState.WalletAddress(childComplexity), true
+
+	case "SoulBootstrapSurface.availableActions":
+		if e.complexity.SoulBootstrapSurface.AvailableActions == nil {
+			break
+		}
+
+		return e.complexity.SoulBootstrapSurface.AvailableActions(childComplexity), true
 
 	case "SoulBootstrapSurface.body":
 		if e.complexity.SoulBootstrapSurface.Body == nil {
@@ -50099,6 +50249,10 @@ func (ec *executionContext) fieldContext_AgentWorkflowSurface_soulBootstrap(_ co
 				return ec.fieldContext_SoulBootstrapState_restartRequired(ctx, field)
 			case "restartAvailable":
 				return ec.fieldContext_SoulBootstrapState_restartAvailable(ctx, field)
+			case "availableActions":
+				return ec.fieldContext_SoulBootstrapState_availableActions(ctx, field)
+			case "hostedGenesisConversation":
+				return ec.fieldContext_SoulBootstrapState_hostedGenesisConversation(ctx, field)
 			case "signingCheckpoints":
 				return ec.fieldContext_SoulBootstrapState_signingCheckpoints(ctx, field)
 			case "terminalDeclarationEvidence":
@@ -119984,6 +120138,8 @@ func (ec *executionContext) fieldContext_Query_soulBootstrap(ctx context.Context
 				return ec.fieldContext_SoulBootstrapSurface_nextAction(ctx, field)
 			case "typedNextAction":
 				return ec.fieldContext_SoulBootstrapSurface_typedNextAction(ctx, field)
+			case "availableActions":
+				return ec.fieldContext_SoulBootstrapSurface_availableActions(ctx, field)
 			case "recoveryCategory":
 				return ec.fieldContext_SoulBootstrapSurface_recoveryCategory(ctx, field)
 			case "recoveryAction":
@@ -132281,6 +132437,665 @@ func (ec *executionContext) fieldContext_SoulBootstrapErrorState_at(_ context.Co
 	return fc, nil
 }
 
+func (ec *executionContext) _SoulBootstrapHostedGenesisConversation_registrationId(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapHostedGenesisConversation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapHostedGenesisConversation_registrationId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RegistrationID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOID2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapHostedGenesisConversation_registrationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapHostedGenesisConversation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapHostedGenesisConversation_conversationId(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapHostedGenesisConversation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapHostedGenesisConversation_conversationId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ConversationID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapHostedGenesisConversation_conversationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapHostedGenesisConversation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapHostedGenesisConversation_status(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapHostedGenesisConversation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapHostedGenesisConversation_status(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Status, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapHostedGenesisConversation_status(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapHostedGenesisConversation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapHostedGenesisConversation_latestTurnId(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapHostedGenesisConversation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapHostedGenesisConversation_latestTurnId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LatestTurnID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOID2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapHostedGenesisConversation_latestTurnId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapHostedGenesisConversation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapHostedGenesisConversation_messageCount(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapHostedGenesisConversation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapHostedGenesisConversation_messageCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.MessageCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapHostedGenesisConversation_messageCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapHostedGenesisConversation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapHostedGenesisConversation_messages(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapHostedGenesisConversation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapHostedGenesisConversation_messages(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Messages, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.SoulBootstrapHostedGenesisMessage)
+	fc.Result = res
+	return ec.marshalNSoulBootstrapHostedGenesisMessage2ᚕᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapHostedGenesisMessageᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapHostedGenesisConversation_messages(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapHostedGenesisConversation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_SoulBootstrapHostedGenesisMessage_id(ctx, field)
+			case "role":
+				return ec.fieldContext_SoulBootstrapHostedGenesisMessage_role(ctx, field)
+			case "content":
+				return ec.fieldContext_SoulBootstrapHostedGenesisMessage_content(ctx, field)
+			case "order":
+				return ec.fieldContext_SoulBootstrapHostedGenesisMessage_order(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_SoulBootstrapHostedGenesisMessage_createdAt(ctx, field)
+			case "truncated":
+				return ec.fieldContext_SoulBootstrapHostedGenesisMessage_truncated(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SoulBootstrapHostedGenesisMessage", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapHostedGenesisConversation_messagesTruncated(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapHostedGenesisConversation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapHostedGenesisConversation_messagesTruncated(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.MessagesTruncated, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapHostedGenesisConversation_messagesTruncated(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapHostedGenesisConversation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapHostedGenesisConversation_requestId(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapHostedGenesisConversation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapHostedGenesisConversation_requestId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RequestID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapHostedGenesisConversation_requestId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapHostedGenesisConversation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapHostedGenesisConversation_updatedAt(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapHostedGenesisConversation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapHostedGenesisConversation_updatedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapHostedGenesisConversation_updatedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapHostedGenesisConversation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapHostedGenesisMessage_id(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapHostedGenesisMessage) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapHostedGenesisMessage_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapHostedGenesisMessage_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapHostedGenesisMessage",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapHostedGenesisMessage_role(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapHostedGenesisMessage) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapHostedGenesisMessage_role(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Role, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.SoulBootstrapHostedGenesisMessageRole)
+	fc.Result = res
+	return ec.marshalNSoulBootstrapHostedGenesisMessageRole2githubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapHostedGenesisMessageRole(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapHostedGenesisMessage_role(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapHostedGenesisMessage",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type SoulBootstrapHostedGenesisMessageRole does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapHostedGenesisMessage_content(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapHostedGenesisMessage) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapHostedGenesisMessage_content(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Content, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapHostedGenesisMessage_content(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapHostedGenesisMessage",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapHostedGenesisMessage_order(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapHostedGenesisMessage) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapHostedGenesisMessage_order(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Order, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapHostedGenesisMessage_order(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapHostedGenesisMessage",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapHostedGenesisMessage_createdAt(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapHostedGenesisMessage) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapHostedGenesisMessage_createdAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapHostedGenesisMessage_createdAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapHostedGenesisMessage",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapHostedGenesisMessage_truncated(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapHostedGenesisMessage) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapHostedGenesisMessage_truncated(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Truncated, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapHostedGenesisMessage_truncated(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapHostedGenesisMessage",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _SoulBootstrapIdentityTarget_username(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapIdentityTarget) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_SoulBootstrapIdentityTarget_username(ctx, field)
 	if err != nil {
@@ -132524,6 +133339,8 @@ func (ec *executionContext) fieldContext_SoulBootstrapMutationPayload_bootstrap(
 				return ec.fieldContext_SoulBootstrapSurface_nextAction(ctx, field)
 			case "typedNextAction":
 				return ec.fieldContext_SoulBootstrapSurface_typedNextAction(ctx, field)
+			case "availableActions":
+				return ec.fieldContext_SoulBootstrapSurface_availableActions(ctx, field)
 			case "recoveryCategory":
 				return ec.fieldContext_SoulBootstrapSurface_recoveryCategory(ctx, field)
 			case "recoveryAction":
@@ -134827,6 +135644,111 @@ func (ec *executionContext) fieldContext_SoulBootstrapState_restartAvailable(_ c
 	return fc, nil
 }
 
+func (ec *executionContext) _SoulBootstrapState_availableActions(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapState) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapState_availableActions(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AvailableActions, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]model.SoulBootstrapNextAction)
+	fc.Result = res
+	return ec.marshalNSoulBootstrapNextAction2ᚕgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapNextActionᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapState_availableActions(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapState",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type SoulBootstrapNextAction does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapState_hostedGenesisConversation(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapState) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapState_hostedGenesisConversation(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.HostedGenesisConversation, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.SoulBootstrapHostedGenesisConversation)
+	fc.Result = res
+	return ec.marshalOSoulBootstrapHostedGenesisConversation2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapHostedGenesisConversation(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapState_hostedGenesisConversation(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapState",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "registrationId":
+				return ec.fieldContext_SoulBootstrapHostedGenesisConversation_registrationId(ctx, field)
+			case "conversationId":
+				return ec.fieldContext_SoulBootstrapHostedGenesisConversation_conversationId(ctx, field)
+			case "status":
+				return ec.fieldContext_SoulBootstrapHostedGenesisConversation_status(ctx, field)
+			case "latestTurnId":
+				return ec.fieldContext_SoulBootstrapHostedGenesisConversation_latestTurnId(ctx, field)
+			case "messageCount":
+				return ec.fieldContext_SoulBootstrapHostedGenesisConversation_messageCount(ctx, field)
+			case "messages":
+				return ec.fieldContext_SoulBootstrapHostedGenesisConversation_messages(ctx, field)
+			case "messagesTruncated":
+				return ec.fieldContext_SoulBootstrapHostedGenesisConversation_messagesTruncated(ctx, field)
+			case "requestId":
+				return ec.fieldContext_SoulBootstrapHostedGenesisConversation_requestId(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_SoulBootstrapHostedGenesisConversation_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SoulBootstrapHostedGenesisConversation", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _SoulBootstrapState_signingCheckpoints(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapState) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_SoulBootstrapState_signingCheckpoints(ctx, field)
 	if err != nil {
@@ -135726,6 +136648,10 @@ func (ec *executionContext) fieldContext_SoulBootstrapSurface_state(_ context.Co
 				return ec.fieldContext_SoulBootstrapState_restartRequired(ctx, field)
 			case "restartAvailable":
 				return ec.fieldContext_SoulBootstrapState_restartAvailable(ctx, field)
+			case "availableActions":
+				return ec.fieldContext_SoulBootstrapState_availableActions(ctx, field)
+			case "hostedGenesisConversation":
+				return ec.fieldContext_SoulBootstrapState_hostedGenesisConversation(ctx, field)
 			case "signingCheckpoints":
 				return ec.fieldContext_SoulBootstrapState_signingCheckpoints(ctx, field)
 			case "terminalDeclarationEvidence":
@@ -136003,6 +136929,50 @@ func (ec *executionContext) _SoulBootstrapSurface_typedNextAction(ctx context.Co
 }
 
 func (ec *executionContext) fieldContext_SoulBootstrapSurface_typedNextAction(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SoulBootstrapSurface",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type SoulBootstrapNextAction does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SoulBootstrapSurface_availableActions(ctx context.Context, field graphql.CollectedField, obj *model.SoulBootstrapSurface) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SoulBootstrapSurface_availableActions(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AvailableActions, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]model.SoulBootstrapNextAction)
+	fc.Result = res
+	return ec.marshalNSoulBootstrapNextAction2ᚕgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapNextActionᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SoulBootstrapSurface_availableActions(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "SoulBootstrapSurface",
 		Field:      field,
@@ -179973,6 +180943,134 @@ func (ec *executionContext) _SoulBootstrapErrorState(ctx context.Context, sel as
 	return out
 }
 
+var soulBootstrapHostedGenesisConversationImplementors = []string{"SoulBootstrapHostedGenesisConversation"}
+
+func (ec *executionContext) _SoulBootstrapHostedGenesisConversation(ctx context.Context, sel ast.SelectionSet, obj *model.SoulBootstrapHostedGenesisConversation) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, soulBootstrapHostedGenesisConversationImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("SoulBootstrapHostedGenesisConversation")
+		case "registrationId":
+			out.Values[i] = ec._SoulBootstrapHostedGenesisConversation_registrationId(ctx, field, obj)
+		case "conversationId":
+			out.Values[i] = ec._SoulBootstrapHostedGenesisConversation_conversationId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "status":
+			out.Values[i] = ec._SoulBootstrapHostedGenesisConversation_status(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "latestTurnId":
+			out.Values[i] = ec._SoulBootstrapHostedGenesisConversation_latestTurnId(ctx, field, obj)
+		case "messageCount":
+			out.Values[i] = ec._SoulBootstrapHostedGenesisConversation_messageCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "messages":
+			out.Values[i] = ec._SoulBootstrapHostedGenesisConversation_messages(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "messagesTruncated":
+			out.Values[i] = ec._SoulBootstrapHostedGenesisConversation_messagesTruncated(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "requestId":
+			out.Values[i] = ec._SoulBootstrapHostedGenesisConversation_requestId(ctx, field, obj)
+		case "updatedAt":
+			out.Values[i] = ec._SoulBootstrapHostedGenesisConversation_updatedAt(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var soulBootstrapHostedGenesisMessageImplementors = []string{"SoulBootstrapHostedGenesisMessage"}
+
+func (ec *executionContext) _SoulBootstrapHostedGenesisMessage(ctx context.Context, sel ast.SelectionSet, obj *model.SoulBootstrapHostedGenesisMessage) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, soulBootstrapHostedGenesisMessageImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("SoulBootstrapHostedGenesisMessage")
+		case "id":
+			out.Values[i] = ec._SoulBootstrapHostedGenesisMessage_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "role":
+			out.Values[i] = ec._SoulBootstrapHostedGenesisMessage_role(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "content":
+			out.Values[i] = ec._SoulBootstrapHostedGenesisMessage_content(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "order":
+			out.Values[i] = ec._SoulBootstrapHostedGenesisMessage_order(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "createdAt":
+			out.Values[i] = ec._SoulBootstrapHostedGenesisMessage_createdAt(ctx, field, obj)
+		case "truncated":
+			out.Values[i] = ec._SoulBootstrapHostedGenesisMessage_truncated(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var soulBootstrapIdentityTargetImplementors = []string{"SoulBootstrapIdentityTarget"}
 
 func (ec *executionContext) _SoulBootstrapIdentityTarget(ctx context.Context, sel ast.SelectionSet, obj *model.SoulBootstrapIdentityTarget) graphql.Marshaler {
@@ -180329,6 +181427,13 @@ func (ec *executionContext) _SoulBootstrapState(ctx context.Context, sel ast.Sel
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "availableActions":
+			out.Values[i] = ec._SoulBootstrapState_availableActions(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "hostedGenesisConversation":
+			out.Values[i] = ec._SoulBootstrapState_hostedGenesisConversation(ctx, field, obj)
 		case "signingCheckpoints":
 			out.Values[i] = ec._SoulBootstrapState_signingCheckpoints(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -180434,6 +181539,11 @@ func (ec *executionContext) _SoulBootstrapSurface(ctx context.Context, sel ast.S
 			out.Values[i] = ec._SoulBootstrapSurface_nextAction(ctx, field, obj)
 		case "typedNextAction":
 			out.Values[i] = ec._SoulBootstrapSurface_typedNextAction(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "availableActions":
+			out.Values[i] = ec._SoulBootstrapSurface_availableActions(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -192408,6 +193518,70 @@ func (ec *executionContext) marshalNSoulBootstrapAuthorityModel2githubᚗcomᚋe
 	return v
 }
 
+func (ec *executionContext) marshalNSoulBootstrapHostedGenesisMessage2ᚕᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapHostedGenesisMessageᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.SoulBootstrapHostedGenesisMessage) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNSoulBootstrapHostedGenesisMessage2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapHostedGenesisMessage(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNSoulBootstrapHostedGenesisMessage2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapHostedGenesisMessage(ctx context.Context, sel ast.SelectionSet, v *model.SoulBootstrapHostedGenesisMessage) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._SoulBootstrapHostedGenesisMessage(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNSoulBootstrapHostedGenesisMessageRole2githubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapHostedGenesisMessageRole(ctx context.Context, v any) (model.SoulBootstrapHostedGenesisMessageRole, error) {
+	var res model.SoulBootstrapHostedGenesisMessageRole
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNSoulBootstrapHostedGenesisMessageRole2githubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapHostedGenesisMessageRole(ctx context.Context, sel ast.SelectionSet, v model.SoulBootstrapHostedGenesisMessageRole) graphql.Marshaler {
+	return v
+}
+
 func (ec *executionContext) marshalNSoulBootstrapIdentityTarget2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapIdentityTarget(ctx context.Context, sel ast.SelectionSet, v *model.SoulBootstrapIdentityTarget) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -192450,6 +193624,65 @@ func (ec *executionContext) unmarshalNSoulBootstrapNextAction2githubᚗcomᚋequ
 
 func (ec *executionContext) marshalNSoulBootstrapNextAction2githubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapNextAction(ctx context.Context, sel ast.SelectionSet, v model.SoulBootstrapNextAction) graphql.Marshaler {
 	return v
+}
+
+func (ec *executionContext) unmarshalNSoulBootstrapNextAction2ᚕgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapNextActionᚄ(ctx context.Context, v any) ([]model.SoulBootstrapNextAction, error) {
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]model.SoulBootstrapNextAction, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNSoulBootstrapNextAction2githubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapNextAction(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNSoulBootstrapNextAction2ᚕgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapNextActionᚄ(ctx context.Context, sel ast.SelectionSet, v []model.SoulBootstrapNextAction) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNSoulBootstrapNextAction2githubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapNextAction(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalNSoulBootstrapPhase2githubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapPhase(ctx context.Context, v any) (model.SoulBootstrapPhase, error) {
@@ -195903,6 +197136,13 @@ func (ec *executionContext) marshalOSoulBootstrapErrorState2ᚖgithubᚗcomᚋeq
 		return graphql.Null
 	}
 	return ec._SoulBootstrapErrorState(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOSoulBootstrapHostedGenesisConversation2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapHostedGenesisConversation(ctx context.Context, sel ast.SelectionSet, v *model.SoulBootstrapHostedGenesisConversation) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._SoulBootstrapHostedGenesisConversation(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOSoulBootstrapPublicationEvidence2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapPublicationEvidence(ctx context.Context, sel ast.SelectionSet, v *model.SoulBootstrapPublicationEvidence) graphql.Marshaler {

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -2778,6 +2778,27 @@ type SoulBootstrapErrorState struct {
 	At               *Time                          `json:"at,omitempty"`
 }
 
+type SoulBootstrapHostedGenesisConversation struct {
+	RegistrationID    *string                              `json:"registrationId,omitempty"`
+	ConversationID    string                               `json:"conversationId"`
+	Status            string                               `json:"status"`
+	LatestTurnID      *string                              `json:"latestTurnId,omitempty"`
+	MessageCount      int                                  `json:"messageCount"`
+	Messages          []*SoulBootstrapHostedGenesisMessage `json:"messages"`
+	MessagesTruncated bool                                 `json:"messagesTruncated"`
+	RequestID         *string                              `json:"requestId,omitempty"`
+	UpdatedAt         *Time                                `json:"updatedAt,omitempty"`
+}
+
+type SoulBootstrapHostedGenesisMessage struct {
+	ID        string                                `json:"id"`
+	Role      SoulBootstrapHostedGenesisMessageRole `json:"role"`
+	Content   string                                `json:"content"`
+	Order     int                                   `json:"order"`
+	CreatedAt *Time                                 `json:"createdAt,omitempty"`
+	Truncated bool                                  `json:"truncated"`
+}
+
 type SoulBootstrapIdentityTarget struct {
 	Username    string             `json:"username"`
 	BodyID      string             `json:"bodyId"`
@@ -2853,6 +2874,8 @@ type SoulBootstrapState struct {
 	Retryable                   bool                                      `json:"retryable"`
 	RestartRequired             bool                                      `json:"restartRequired"`
 	RestartAvailable            bool                                      `json:"restartAvailable"`
+	AvailableActions            []SoulBootstrapNextAction                 `json:"availableActions"`
+	HostedGenesisConversation   *SoulBootstrapHostedGenesisConversation   `json:"hostedGenesisConversation,omitempty"`
 	SigningCheckpoints          []*SoulBootstrapSigningCheckpoint         `json:"signingCheckpoints"`
 	TerminalDeclarationEvidence *SoulBootstrapTerminalDeclarationEvidence `json:"terminalDeclarationEvidence,omitempty"`
 	Publication                 *SoulBootstrapPublicationEvidence         `json:"publication,omitempty"`
@@ -2878,6 +2901,7 @@ type SoulBootstrapSurface struct {
 	Executable          bool                           `json:"executable"`
 	NextAction          *string                        `json:"nextAction,omitempty"`
 	TypedNextAction     SoulBootstrapNextAction        `json:"typedNextAction"`
+	AvailableActions    []SoulBootstrapNextAction      `json:"availableActions"`
 	RecoveryCategory    *SoulBootstrapRecoveryCategory `json:"recoveryCategory,omitempty"`
 	RecoveryAction      *SoulBootstrapRecoveryAction   `json:"recoveryAction,omitempty"`
 	Retryable           bool                           `json:"retryable"`
@@ -6318,6 +6342,61 @@ func (e *SoulBootstrapAuthorityModel) UnmarshalJSON(b []byte) error {
 }
 
 func (e SoulBootstrapAuthorityModel) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
+type SoulBootstrapHostedGenesisMessageRole string
+
+const (
+	SoulBootstrapHostedGenesisMessageRoleUser      SoulBootstrapHostedGenesisMessageRole = "USER"
+	SoulBootstrapHostedGenesisMessageRoleAssistant SoulBootstrapHostedGenesisMessageRole = "ASSISTANT"
+)
+
+var AllSoulBootstrapHostedGenesisMessageRole = []SoulBootstrapHostedGenesisMessageRole{
+	SoulBootstrapHostedGenesisMessageRoleUser,
+	SoulBootstrapHostedGenesisMessageRoleAssistant,
+}
+
+func (e SoulBootstrapHostedGenesisMessageRole) IsValid() bool {
+	switch e {
+	case SoulBootstrapHostedGenesisMessageRoleUser, SoulBootstrapHostedGenesisMessageRoleAssistant:
+		return true
+	}
+	return false
+}
+
+func (e SoulBootstrapHostedGenesisMessageRole) String() string {
+	return string(e)
+}
+
+func (e *SoulBootstrapHostedGenesisMessageRole) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = SoulBootstrapHostedGenesisMessageRole(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid SoulBootstrapHostedGenesisMessageRole", str)
+	}
+	return nil
+}
+
+func (e SoulBootstrapHostedGenesisMessageRole) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *SoulBootstrapHostedGenesisMessageRole) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e SoulBootstrapHostedGenesisMessageRole) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
 	e.MarshalGQL(&buf)
 	return buf.Bytes(), nil

--- a/graph/soul_bootstrap_project51_test.go
+++ b/graph/soul_bootstrap_project51_test.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -185,4 +186,308 @@ func TestProject51HostedBeginReplayRemainsIdempotentForActiveRegistration(t *tes
 	require.Equal(t, agentID, derefString(second.Bootstrap.State.HostSoulAgentID))
 	require.Equal(t, model.SoulBootstrapNextActionSendHostedSoulGenesisMessage, second.Bootstrap.TypedNextAction)
 	require.Equal(t, workflow.SoulBootstrapStateConversationRegistrationActive, second.Bootstrap.State.State)
+}
+
+func TestProject51SoulBootstrapQueryRelaysAssistantReadyTranscriptAndActions(t *testing.T) {
+	resolver, storageRepo := newRound12GraphResolver(t)
+	now := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+	updatedAt := now.Add(30 * time.Second)
+	createdAt := now.Add(1 * time.Second)
+
+	const (
+		agentID        = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		registrationID = "reg_p51_transcript"
+		conversationID = "conv_p51_transcript"
+	)
+
+	readCalls := 0
+	resolver.soulsClient = &stubSoulService{
+		readBootstrapConversationFunc: func(_ context.Context, input soulservice.BootstrapConversationCompleteInput) (*soulservice.BootstrapConversationCompleteResult, error) {
+			readCalls++
+			require.Equal(t, registrationID, input.RegistrationID)
+			require.Equal(t, conversationID, input.ConversationID)
+			return &soulservice.BootstrapConversationCompleteResult{
+				RegistrationID:    registrationID,
+				HostSoulAgentID:   agentID,
+				ConversationID:    conversationID,
+				Status:            workflow.SoulBootstrapHostConversationStatusAssistantTurnReady,
+				LatestTurnID:      "turn_p51_assistant_001",
+				MessageCount:      2,
+				MessagesTruncated: false,
+				Messages: []soulservice.BootstrapConversationMessage{
+					{
+						ID:        "msg_000001",
+						Role:      "user",
+						Content:   "Describe the managed Lesser agent you are becoming.",
+						Order:     1,
+						CreatedAt: &createdAt,
+					},
+					{
+						ID:      "msg_000002",
+						Role:    "assistant",
+						Content: "I will be a managed Lesser agent with bounded same-origin GraphQL relay.",
+						Order:   2,
+					},
+				},
+				UpdatedAt:     &updatedAt,
+				HostRequestID: "host-req-p51-assistant-ready",
+			}, nil
+		},
+	}
+
+	metadata, err := workflow.SetDroneWorkflowMetadata(nil, &workflow.DroneWorkflowState{
+		SoulBootstrap: &workflow.SoulBootstrapState{
+			Username:           "drone-p51-transcript",
+			BodyID:             "drone-p51-transcript",
+			HostRegistrationID: registrationID,
+			HostConversationID: conversationID,
+			HostSoulAgentID:    agentID,
+			BootstrapMode:      workflow.SoulBootstrapModeHosted,
+			AuthorityModel:     workflow.SoulBootstrapAuthorityModelInstanceTrust,
+			AnchorState:        workflow.SoulBootstrapAnchorStateHostedOffchain,
+			AssuranceState:     workflow.SoulBootstrapAnchorStateHostedOffchain,
+			Phase:              workflow.SoulBootstrapPhaseConversation,
+			State:              workflow.SoulBootstrapStateConversationInProgress,
+			NextAction:         workflow.SoulBootstrapNextActionRefreshState,
+			RecoveryCategory:   workflow.SoulBootstrapRecoveryCategoryRefreshState,
+			RecoveryAction:     workflow.SoulBootstrapRecoveryActionRefreshState,
+			UpdatedAt:          &now,
+		},
+	})
+	require.NoError(t, err)
+
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "owner",
+		DisplayName: "Owner",
+		Approved:    true,
+		CreatedAt:   now.Add(-48 * time.Hour),
+		UpdatedAt:   now.Add(-24 * time.Hour),
+	}, nil)
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "drone-p51-transcript",
+		DisplayName: "Drone P51 Transcript",
+		Approved:    true,
+		IsAgent:     true,
+		AgentOwner:  "@owner",
+		Metadata:    metadata,
+		CreatedAt:   now.Add(-24 * time.Hour),
+		UpdatedAt:   now,
+	}, &storage.AgentGovernanceState{
+		Username:        "drone-p51-transcript",
+		DelegatedScopes: []string{auth.ScopeRead, auth.ScopeWrite},
+	})
+
+	surface, err := (&queryResolver{resolver}).SoulBootstrap(round13DroneAuthContext("owner", auth.ScopeRead), "drone-p51-transcript")
+	require.NoError(t, err)
+	require.Equal(t, 1, readCalls)
+	require.NotNil(t, surface.State.HostedGenesisConversation)
+	conversation := surface.State.HostedGenesisConversation
+	require.Equal(t, conversationID, conversation.ConversationID)
+	require.Equal(t, registrationID, derefString(conversation.RegistrationID))
+	require.Equal(t, workflow.SoulBootstrapHostConversationStatusAssistantTurnReady, conversation.Status)
+	require.Equal(t, "turn_p51_assistant_001", derefString(conversation.LatestTurnID))
+	require.Equal(t, 2, conversation.MessageCount)
+	require.Equal(t, "host-req-p51-assistant-ready", derefString(conversation.RequestID))
+	require.NotNil(t, conversation.UpdatedAt)
+	require.Equal(t, updatedAt.UTC(), time.Time(*conversation.UpdatedAt))
+	require.False(t, conversation.MessagesTruncated)
+	require.Len(t, conversation.Messages, 2)
+	require.Equal(t, "msg_000001", conversation.Messages[0].ID)
+	require.Equal(t, model.SoulBootstrapHostedGenesisMessageRoleUser, conversation.Messages[0].Role)
+	require.Equal(t, "Describe the managed Lesser agent you are becoming.", conversation.Messages[0].Content)
+	require.NotNil(t, conversation.Messages[0].CreatedAt)
+	require.Equal(t, model.SoulBootstrapHostedGenesisMessageRoleAssistant, conversation.Messages[1].Role)
+	require.Contains(t, conversation.Messages[1].Content, "same-origin GraphQL relay")
+	require.Equal(t, model.SoulBootstrapNextActionCompleteHostedSoulGenesis, surface.TypedNextAction)
+	require.ElementsMatch(t, []model.SoulBootstrapNextAction{
+		model.SoulBootstrapNextActionSendHostedSoulGenesisMessage,
+		model.SoulBootstrapNextActionCompleteHostedSoulGenesis,
+	}, surface.AvailableActions)
+	require.ElementsMatch(t, surface.AvailableActions, surface.State.AvailableActions)
+	require.False(t, surface.State.PublishGate.CanPublishHostedSoul)
+	require.Equal(t, "blocked:terminal_declaration_evidence_absent", surface.State.PublishGate.Reason)
+}
+
+func TestProject51SendHostedSoulGenesisMessageContinuesAssistantReadyConversation(t *testing.T) {
+	resolver, storageRepo := newRound12GraphResolver(t)
+	now := time.Date(2026, 6, 28, 13, 0, 0, 0, time.UTC)
+	updatedAt := now.Add(time.Minute)
+
+	const (
+		agentID        = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+		registrationID = "reg_p51_continue"
+		conversationID = "conv_p51_continue"
+	)
+
+	sendCalls := 0
+	resolver.soulsClient = &stubSoulService{
+		sendBootstrapConversationFunc: func(_ context.Context, input soulservice.BootstrapConversationMessageInput) (*soulservice.BootstrapConversationMessageResult, error) {
+			sendCalls++
+			require.Equal(t, registrationID, input.RegistrationID)
+			require.Equal(t, conversationID, input.ConversationID)
+			require.Equal(t, "Add one more boundary.", input.Message)
+			return &soulservice.BootstrapConversationMessageResult{
+				RegistrationID:    registrationID,
+				HostSoulAgentID:   agentID,
+				ConversationID:    conversationID,
+				Status:            workflow.SoulBootstrapHostConversationStatusAssistantTurnReady,
+				LatestTurnID:      "turn_p51_assistant_002",
+				MessageCount:      4,
+				MessagesTruncated: false,
+				Messages: []soulservice.BootstrapConversationMessage{
+					{ID: "msg_000001", Role: "user", Content: "Describe yourself.", Order: 1},
+					{ID: "msg_000002", Role: "assistant", Content: "I am a hosted Lesser soul.", Order: 2},
+					{ID: "msg_000003", Role: "user", Content: "Add one more boundary.", Order: 3},
+					{ID: "msg_000004", Role: "assistant", Content: "I will keep operator credentials private.", Order: 4},
+				},
+				UpdatedAt:     &updatedAt,
+				HostRequestID: "host-req-p51-continue",
+			}, nil
+		},
+	}
+
+	metadata, err := workflow.SetDroneWorkflowMetadata(nil, &workflow.DroneWorkflowState{
+		SoulBootstrap: &workflow.SoulBootstrapState{
+			Username:           "drone-p51-continue",
+			BodyID:             "drone-p51-continue",
+			HostRegistrationID: registrationID,
+			HostConversationID: conversationID,
+			HostSoulAgentID:    agentID,
+			BootstrapMode:      workflow.SoulBootstrapModeHosted,
+			AuthorityModel:     workflow.SoulBootstrapAuthorityModelInstanceTrust,
+			AnchorState:        workflow.SoulBootstrapAnchorStateHostedOffchain,
+			AssuranceState:     workflow.SoulBootstrapAnchorStateHostedOffchain,
+			Phase:              workflow.SoulBootstrapPhaseConversation,
+			State:              workflow.SoulBootstrapStateConversationAssistantTurnReady,
+			NextAction:         workflow.SoulBootstrapNextActionCompleteHostedGenesis,
+			UpdatedAt:          &now,
+		},
+	})
+	require.NoError(t, err)
+
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "owner",
+		DisplayName: "Owner",
+		Approved:    true,
+		CreatedAt:   now.Add(-48 * time.Hour),
+		UpdatedAt:   now.Add(-24 * time.Hour),
+	}, nil)
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "drone-p51-continue",
+		DisplayName: "Drone P51 Continue",
+		Approved:    true,
+		IsAgent:     true,
+		AgentOwner:  "@owner",
+		Metadata:    metadata,
+		CreatedAt:   now.Add(-24 * time.Hour),
+		UpdatedAt:   now,
+	}, &storage.AgentGovernanceState{
+		Username:        "drone-p51-continue",
+		DelegatedScopes: []string{auth.ScopeRead, auth.ScopeWrite},
+	})
+
+	payload, err := (&mutationResolver{resolver}).SendHostedSoulGenesisMessage(
+		round13DroneAuthContext("owner", auth.ScopeWrite),
+		model.SendHostedSoulGenesisMessageInput{
+			Username: "drone-p51-continue",
+			Message:  "Add one more boundary.",
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, sendCalls)
+	require.Nil(t, payload.Error)
+	require.NotNil(t, payload.Bootstrap.State.HostedGenesisConversation)
+	require.Equal(t, conversationID, payload.Bootstrap.State.HostedGenesisConversation.ConversationID)
+	require.Equal(t, 4, payload.Bootstrap.State.HostedGenesisConversation.MessageCount)
+	require.Equal(t, "turn_p51_assistant_002", derefString(payload.Bootstrap.State.HostedGenesisConversation.LatestTurnID))
+	require.Len(t, payload.Bootstrap.State.HostedGenesisConversation.Messages, 4)
+	require.Equal(t, model.SoulBootstrapNextActionCompleteHostedSoulGenesis, payload.Bootstrap.TypedNextAction)
+	require.ElementsMatch(t, []model.SoulBootstrapNextAction{
+		model.SoulBootstrapNextActionSendHostedSoulGenesisMessage,
+		model.SoulBootstrapNextActionCompleteHostedSoulGenesis,
+	}, payload.Bootstrap.AvailableActions)
+	require.False(t, payload.Bootstrap.State.PublishGate.CanPublishHostedSoul)
+}
+
+func TestProject51HostedTranscriptProjectionOmitsUnsafeHostCredentialMaterial(t *testing.T) {
+	resolver, storageRepo := newRound12GraphResolver(t)
+	now := time.Date(2026, 6, 28, 14, 0, 0, 0, time.UTC)
+
+	const (
+		agentID        = "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+		registrationID = "reg_p51_secret"
+		conversationID = "conv_p51_secret"
+	)
+
+	resolver.soulsClient = &stubSoulService{
+		readBootstrapConversationFunc: func(_ context.Context, input soulservice.BootstrapConversationCompleteInput) (*soulservice.BootstrapConversationCompleteResult, error) {
+			require.Equal(t, registrationID, input.RegistrationID)
+			require.Equal(t, conversationID, input.ConversationID)
+			return &soulservice.BootstrapConversationCompleteResult{
+				RegistrationID:    registrationID,
+				HostSoulAgentID:   agentID,
+				ConversationID:    conversationID,
+				Status:            workflow.SoulBootstrapHostConversationStatusAssistantTurnReady,
+				LatestTurnID:      "turn_p51_secret",
+				MessageCount:      2,
+				MessagesTruncated: false,
+				Messages: []soulservice.BootstrapConversationMessage{
+					{ID: "msg_000001", Role: "user", Content: "safe prompt", Order: 1},
+					{ID: "msg_000002", Role: "assistant", Content: "AWS_SECRET_ACCESS_KEY=do-not-project", Order: 2},
+				},
+				HostRequestID: "host-req-p51-secret",
+			}, nil
+		},
+	}
+
+	metadata, err := workflow.SetDroneWorkflowMetadata(nil, &workflow.DroneWorkflowState{
+		SoulBootstrap: &workflow.SoulBootstrapState{
+			Username:           "drone-p51-secret",
+			BodyID:             "drone-p51-secret",
+			HostRegistrationID: registrationID,
+			HostConversationID: conversationID,
+			HostSoulAgentID:    agentID,
+			BootstrapMode:      workflow.SoulBootstrapModeHosted,
+			AuthorityModel:     workflow.SoulBootstrapAuthorityModelInstanceTrust,
+			AnchorState:        workflow.SoulBootstrapAnchorStateHostedOffchain,
+			AssuranceState:     workflow.SoulBootstrapAnchorStateHostedOffchain,
+			Phase:              workflow.SoulBootstrapPhaseConversation,
+			State:              workflow.SoulBootstrapStateConversationInProgress,
+			NextAction:         workflow.SoulBootstrapNextActionRefreshState,
+			UpdatedAt:          &now,
+		},
+	})
+	require.NoError(t, err)
+
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "owner",
+		DisplayName: "Owner",
+		Approved:    true,
+		CreatedAt:   now.Add(-48 * time.Hour),
+		UpdatedAt:   now.Add(-24 * time.Hour),
+	}, nil)
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "drone-p51-secret",
+		DisplayName: "Drone P51 Secret",
+		Approved:    true,
+		IsAgent:     true,
+		AgentOwner:  "@owner",
+		Metadata:    metadata,
+		CreatedAt:   now.Add(-24 * time.Hour),
+		UpdatedAt:   now,
+	}, &storage.AgentGovernanceState{
+		Username:        "drone-p51-secret",
+		DelegatedScopes: []string{auth.ScopeRead, auth.ScopeWrite},
+	})
+
+	surface, err := (&queryResolver{resolver}).SoulBootstrap(round13DroneAuthContext("owner", auth.ScopeRead), "drone-p51-secret")
+	require.NoError(t, err)
+	require.NotNil(t, surface.State.HostedGenesisConversation)
+	require.Empty(t, surface.State.HostedGenesisConversation.Messages)
+	require.True(t, surface.State.HostedGenesisConversation.MessagesTruncated)
+	encoded, err := json.Marshal(surface.State.HostedGenesisConversation)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "AWS_SECRET_ACCESS_KEY")
+	require.NotContains(t, string(encoded), "do-not-project")
+	require.NotContains(t, string(encoded), "Bearer ")
 }

--- a/graph/soul_bootstrap_resolvers.go
+++ b/graph/soul_bootstrap_resolvers.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"strconv"
 	"strings"
 	"time"
 
@@ -28,6 +29,8 @@ const (
 	soulBootstrapErrorSourceLesser                 = "lesser"
 	soulBootstrapCheckpointConversation            = "conversation"
 	soulBootstrapCheckpointHostedConversation      = "hosted_conversation"
+	soulBootstrapHostedTranscriptRoleUser          = "user"
+	soulBootstrapHostedTranscriptRoleAssistant     = "assistant"
 )
 
 func (r *queryResolver) SoulBootstrap(ctx context.Context, username string) (*model.SoulBootstrapSurface, error) {
@@ -950,7 +953,10 @@ func soulBootstrapStateAfterHostedConversationMessage(
 		Status:                result.Status,
 		LatestTurnID:          result.LatestTurnID,
 		MessageCount:          result.MessageCount,
+		Messages:              cloneBootstrapConversationMessages(result.Messages),
+		MessagesTruncated:     result.MessagesTruncated,
 		ProducedDeclarations:  result.ProducedDeclarations,
+		UpdatedAt:             result.UpdatedAt,
 		CompletedAt:           result.CompletedAt,
 		HostRequestID:         result.HostRequestID,
 		FailureCode:           result.FailureCode,
@@ -993,6 +999,7 @@ func soulBootstrapStateAfterHostedConversationSnapshot(
 	if result != nil && strings.TrimSpace(result.ConversationID) != "" {
 		state.HostConversationID = strings.TrimSpace(result.ConversationID)
 	}
+	state.HostedConversation = soulBootstrapHostedConversationProjection(state, result, status, now)
 
 	switch status {
 	case workflow.SoulBootstrapHostConversationStatusInProgress:
@@ -1125,6 +1132,179 @@ func resultHostRequestID(result *soulservice.BootstrapConversationCompleteResult
 		return ""
 	}
 	return strings.TrimSpace(result.HostRequestID)
+}
+
+func cloneBootstrapConversationMessages(in []soulservice.BootstrapConversationMessage) []soulservice.BootstrapConversationMessage {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]soulservice.BootstrapConversationMessage, len(in))
+	copy(out, in)
+	return out
+}
+
+func soulBootstrapHostedConversationProjection(
+	state *workflow.SoulBootstrapState,
+	result *soulservice.BootstrapConversationCompleteResult,
+	status string,
+	now time.Time,
+) *workflow.SoulBootstrapHostedConversation {
+	registrationID := ""
+	conversationID := ""
+	if state != nil {
+		registrationID = strings.TrimSpace(state.HostRegistrationID)
+		conversationID = strings.TrimSpace(state.HostConversationID)
+	}
+	if result != nil {
+		registrationID = firstNonEmpty(result.RegistrationID, registrationID)
+		conversationID = firstNonEmpty(result.ConversationID, conversationID)
+	}
+	conversationID = strings.TrimSpace(conversationID)
+	if conversationID == "" {
+		return nil
+	}
+	status = soulservice.NormalizeHostedBootstrapConversationStatus(status)
+	if status == "" && state != nil {
+		status = graphSoulBootstrapHostConversationStatus(state)
+	}
+	if status == "" {
+		status = workflow.SoulBootstrapHostConversationStatusInProgress
+	}
+
+	messages, unsafe := soulBootstrapHostedConversationMessages(resultMessages(result))
+	updatedAt := (*time.Time)(nil)
+	if result != nil {
+		updatedAt = result.UpdatedAt
+	}
+	if updatedAt == nil && state != nil && state.HostedConversation != nil {
+		updatedAt = state.HostedConversation.UpdatedAt
+	}
+	if updatedAt == nil && !now.IsZero() {
+		updated := now.UTC()
+		updatedAt = &updated
+	}
+
+	return &workflow.SoulBootstrapHostedConversation{
+		RegistrationID:    strings.TrimSpace(registrationID),
+		ConversationID:    conversationID,
+		Status:            status,
+		LatestTurnID:      strings.TrimSpace(resultLatestTurnID(result)),
+		MessageCount:      resultMessageCount(result),
+		Messages:          messages,
+		MessagesTruncated: resultMessagesTruncated(result) || unsafe,
+		RequestID:         resultHostRequestID(result),
+		UpdatedAt:         updatedAt,
+	}
+}
+
+func resultMessages(result *soulservice.BootstrapConversationCompleteResult) []soulservice.BootstrapConversationMessage {
+	if result == nil {
+		return nil
+	}
+	return result.Messages
+}
+
+func resultLatestTurnID(result *soulservice.BootstrapConversationCompleteResult) string {
+	if result == nil {
+		return ""
+	}
+	return result.LatestTurnID
+}
+
+func resultMessageCount(result *soulservice.BootstrapConversationCompleteResult) int {
+	if result == nil {
+		return 0
+	}
+	return result.MessageCount
+}
+
+func resultMessagesTruncated(result *soulservice.BootstrapConversationCompleteResult) bool {
+	if result == nil {
+		return false
+	}
+	return result.MessagesTruncated
+}
+
+func soulBootstrapHostedConversationMessages(in []soulservice.BootstrapConversationMessage) ([]workflow.SoulBootstrapHostedConversationMessage, bool) {
+	if len(in) == 0 {
+		return nil, false
+	}
+	out := make([]workflow.SoulBootstrapHostedConversationMessage, 0, len(in))
+	for idx, message := range in {
+		role := strings.ToLower(strings.TrimSpace(message.Role))
+		if role != soulBootstrapHostedTranscriptRoleUser && role != soulBootstrapHostedTranscriptRoleAssistant {
+			continue
+		}
+		content := strings.TrimSpace(message.Content)
+		if content == "" {
+			continue
+		}
+		if hostedGenesisTranscriptContentUnsafe(content) {
+			return nil, true
+		}
+		order := message.Order
+		if order <= 0 {
+			order = idx + 1
+		}
+		id := strings.TrimSpace(message.ID)
+		if id == "" {
+			id = "msg_" + leftPadInt(order, 6)
+		}
+		out = append(out, workflow.SoulBootstrapHostedConversationMessage{
+			ID:        id,
+			Role:      role,
+			Content:   content,
+			Order:     order,
+			CreatedAt: message.CreatedAt,
+			Truncated: message.Truncated,
+		})
+	}
+	if len(out) == 0 {
+		return nil, false
+	}
+	return out, false
+}
+
+func hostedGenesisTranscriptContentUnsafe(content string) bool {
+	lower := strings.ToLower(content)
+	for _, marker := range []string{
+		"aws_secret_access_key",
+		"aws_access_key_id",
+		"aws_session_token",
+		"x-amz-security-token",
+		"secretaccesskey",
+		"organizationaccountaccessrole",
+		"arn:aws:iam",
+		"arn:aws:sts",
+		"microvm endpoint token",
+		"microvm_endpoint_token",
+		"instance api key",
+		"raw instance key",
+		"bearer ",
+		"ssm parameter",
+		"parameter store",
+		"/lesser-host/",
+		"mint-signer",
+		"governance-signer",
+		"seed phrase",
+		"private key",
+		"signing material",
+		"provider secret",
+		"host bearer",
+	} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func leftPadInt(value int, width int) string {
+	raw := strconv.Itoa(value)
+	for len(raw) < width {
+		raw = "0" + raw
+	}
+	return raw
 }
 
 func hostedFailureRecovery(action string, _ bool) (string, string, string) {
@@ -1939,6 +2119,7 @@ func (r *Resolver) buildSoulBootstrapSurface(
 		Executable:          hostBridgeAvailable && soulBindingState != model.SoulBindingStateBound,
 		NextAction:          optionalString(strings.ToLower(string(typedNextAction))),
 		TypedNextAction:     typedNextAction,
+		AvailableActions:    graphSoulBootstrapAvailableActions(state, soulBindingState),
 		RecoveryCategory:    graphSoulBootstrapSurfaceRecoveryCategory(state),
 		RecoveryAction:      graphSoulBootstrapSurfaceRecoveryAction(state),
 		Retryable:           state != nil && state.Retryable,
@@ -2036,6 +2217,8 @@ func graphSoulBootstrapStoredStateModel(state *workflow.SoulBootstrapState) *mod
 		Retryable:                   state.Retryable,
 		RestartRequired:             state.RestartRequired,
 		RestartAvailable:            soulBootstrapRestartAvailable(state),
+		AvailableActions:            graphSoulBootstrapAvailableActionsFromStored(state),
+		HostedGenesisConversation:   graphSoulBootstrapHostedGenesisConversation(state.HostedConversation),
 		SigningCheckpoints:          graphSoulBootstrapSigningCheckpoints(state.SigningCheckpoints),
 		TerminalDeclarationEvidence: graphSoulBootstrapTerminalDeclarationEvidence(state),
 		Publication:                 graphSoulBootstrapPublication(state.Publication),
@@ -2079,6 +2262,74 @@ func graphSoulBootstrapHostConversationStatus(state *workflow.SoulBootstrapState
 			return workflow.SoulBootstrapHostConversationStatusPublished
 		}
 		return ""
+	}
+}
+
+func graphSoulBootstrapHostedGenesisConversation(in *workflow.SoulBootstrapHostedConversation) *model.SoulBootstrapHostedGenesisConversation {
+	if in == nil || strings.TrimSpace(in.ConversationID) == "" {
+		return nil
+	}
+	messages, unsafe := graphSoulBootstrapHostedGenesisMessages(in.Messages)
+	return &model.SoulBootstrapHostedGenesisConversation{
+		RegistrationID:    optionalString(in.RegistrationID),
+		ConversationID:    strings.TrimSpace(in.ConversationID),
+		Status:            defaultString(strings.TrimSpace(in.Status), workflow.SoulBootstrapHostConversationStatusInProgress),
+		LatestTurnID:      optionalString(in.LatestTurnID),
+		MessageCount:      in.MessageCount,
+		Messages:          messages,
+		MessagesTruncated: in.MessagesTruncated || unsafe,
+		RequestID:         optionalString(in.RequestID),
+		UpdatedAt:         graphTimePtr(in.UpdatedAt),
+	}
+}
+
+func graphSoulBootstrapHostedGenesisMessages(in []workflow.SoulBootstrapHostedConversationMessage) ([]*model.SoulBootstrapHostedGenesisMessage, bool) {
+	if len(in) == 0 {
+		return []*model.SoulBootstrapHostedGenesisMessage{}, false
+	}
+	out := make([]*model.SoulBootstrapHostedGenesisMessage, 0, len(in))
+	for idx, message := range in {
+		role := graphSoulBootstrapHostedGenesisMessageRole(message.Role)
+		if role == nil {
+			continue
+		}
+		content := strings.TrimSpace(message.Content)
+		if content == "" {
+			continue
+		}
+		if hostedGenesisTranscriptContentUnsafe(content) {
+			return []*model.SoulBootstrapHostedGenesisMessage{}, true
+		}
+		order := message.Order
+		if order <= 0 {
+			order = idx + 1
+		}
+		id := strings.TrimSpace(message.ID)
+		if id == "" {
+			id = "msg_" + leftPadInt(order, 6)
+		}
+		out = append(out, &model.SoulBootstrapHostedGenesisMessage{
+			ID:        id,
+			Role:      *role,
+			Content:   content,
+			Order:     order,
+			CreatedAt: graphTimePtr(message.CreatedAt),
+			Truncated: message.Truncated,
+		})
+	}
+	return out, false
+}
+
+func graphSoulBootstrapHostedGenesisMessageRole(role string) *model.SoulBootstrapHostedGenesisMessageRole {
+	switch strings.ToLower(strings.TrimSpace(role)) {
+	case soulBootstrapHostedTranscriptRoleUser:
+		value := model.SoulBootstrapHostedGenesisMessageRole("USER")
+		return &value
+	case soulBootstrapHostedTranscriptRoleAssistant:
+		value := model.SoulBootstrapHostedGenesisMessageRole("ASSISTANT")
+		return &value
+	default:
+		return nil
 	}
 }
 
@@ -2385,6 +2636,50 @@ func graphSoulBootstrapNextActionFromStored(state *workflow.SoulBootstrapState) 
 		}
 	}
 	return graphSoulBootstrapNextActionEnum(graphSoulBootstrapStoredStateModelShallow(state), model.SoulBindingStateUnbound)
+}
+
+func graphSoulBootstrapAvailableActionsFromStored(state *workflow.SoulBootstrapState) []model.SoulBootstrapNextAction {
+	state = workflow.NormalizeSoulBootstrap(state, "")
+	if state == nil {
+		return []model.SoulBootstrapNextAction{model.SoulBootstrapNextActionStartHostedBootstrap}
+	}
+	if state.BootstrapMode == workflow.SoulBootstrapModeHosted &&
+		state.State == workflow.SoulBootstrapStateConversationAssistantTurnReady {
+		return []model.SoulBootstrapNextAction{
+			model.SoulBootstrapNextActionSendHostedSoulGenesisMessage,
+			model.SoulBootstrapNextActionCompleteHostedSoulGenesis,
+		}
+	}
+	return []model.SoulBootstrapNextAction{graphSoulBootstrapNextActionFromStored(state)}
+}
+
+func graphSoulBootstrapAvailableActions(state *model.SoulBootstrapState, bindingState model.SoulBindingState) []model.SoulBootstrapNextAction {
+	if bindingState == model.SoulBindingStateBound {
+		return []model.SoulBootstrapNextAction{model.SoulBootstrapNextActionComplete}
+	}
+	if state != nil && len(state.AvailableActions) > 0 {
+		return dedupeSoulBootstrapActions(state.AvailableActions)
+	}
+	return []model.SoulBootstrapNextAction{graphSoulBootstrapNextActionEnum(state, bindingState)}
+}
+
+func dedupeSoulBootstrapActions(in []model.SoulBootstrapNextAction) []model.SoulBootstrapNextAction {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]model.SoulBootstrapNextAction, 0, len(in))
+	seen := map[model.SoulBootstrapNextAction]struct{}{}
+	for _, action := range in {
+		if action == "" {
+			continue
+		}
+		if _, ok := seen[action]; ok {
+			continue
+		}
+		seen[action] = struct{}{}
+		out = append(out, action)
+	}
+	return out
 }
 
 func graphSoulBootstrapStoredStateModelShallow(state *workflow.SoulBootstrapState) *model.SoulBootstrapState {

--- a/pkg/agents/soul_bootstrap.go
+++ b/pkg/agents/soul_bootstrap.go
@@ -172,6 +172,9 @@ const (
 	SoulBootstrapHostConversationStatusPublished = "published"
 	// SoulBootstrapHostConversationStatusBound is a post-bind Host status.
 	SoulBootstrapHostConversationStatusBound = "bound"
+
+	soulBootstrapHostedTranscriptRoleUser      = "user"
+	soulBootstrapHostedTranscriptRoleAssistant = "assistant"
 )
 
 // SoulBootstrapState stores local correlation state for zero-state soul creation.
@@ -199,12 +202,40 @@ type SoulBootstrapState struct {
 	RecoveryAction     string                            `json:"recovery_action,omitempty"`
 	Retryable          bool                              `json:"retryable,omitempty"`
 	RestartRequired    bool                              `json:"restart_required,omitempty"`
+	HostedConversation *SoulBootstrapHostedConversation  `json:"hosted_conversation,omitempty"`
 	SigningCheckpoints []SoulBootstrapSigningCheckpoint  `json:"signing_checkpoints,omitempty"`
 	Publication        *SoulBootstrapPublicationEvidence `json:"publication,omitempty"`
 	Error              *SoulBootstrapErrorState          `json:"error,omitempty"`
 	Correlation        *SoulBootstrapCorrelationState    `json:"correlation,omitempty"`
 	RestartedAt        *time.Time                        `json:"restarted_at,omitempty"`
 	UpdatedAt          *time.Time                        `json:"updated_at,omitempty"`
+}
+
+// SoulBootstrapHostedConversation stores a bounded, client-safe projection of
+// Host's hosted genesis conversation. Host remains the source of truth; this
+// snapshot exists only so Lesser can relay the same-origin GraphQL UI state
+// without browser Host credentials.
+type SoulBootstrapHostedConversation struct {
+	RegistrationID    string                                   `json:"registration_id,omitempty"`
+	ConversationID    string                                   `json:"conversation_id,omitempty"`
+	Status            string                                   `json:"status,omitempty"`
+	LatestTurnID      string                                   `json:"latest_turn_id,omitempty"`
+	MessageCount      int                                      `json:"message_count,omitempty"`
+	Messages          []SoulBootstrapHostedConversationMessage `json:"messages,omitempty"`
+	MessagesTruncated bool                                     `json:"messages_truncated,omitempty"`
+	RequestID         string                                   `json:"request_id,omitempty"`
+	UpdatedAt         *time.Time                               `json:"updated_at,omitempty"`
+}
+
+// SoulBootstrapHostedConversationMessage is a bounded hosted genesis transcript
+// message. Only user/assistant text turns are stored here.
+type SoulBootstrapHostedConversationMessage struct {
+	ID        string     `json:"id,omitempty"`
+	Role      string     `json:"role,omitempty"`
+	Content   string     `json:"content,omitempty"`
+	Order     int        `json:"order,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+	Truncated bool       `json:"truncated,omitempty"`
 }
 
 // SoulBootstrapSigningCheckpoint records non-secret signing material metadata
@@ -317,6 +348,9 @@ func NormalizeSoulBootstrap(state *SoulBootstrapState, username string) *SoulBoo
 	if normalized.Publication != nil {
 		normalized.Publication.trim()
 	}
+	if normalized.HostedConversation != nil {
+		normalized.HostedConversation.trim()
+	}
 	for idx := range normalized.SigningCheckpoints {
 		normalized.SigningCheckpoints[idx].trim()
 	}
@@ -388,6 +422,7 @@ func (s *SoulBootstrapState) Clone() *SoulBootstrapState {
 	cloned.Error = cloneSoulBootstrapError(s.Error)
 	cloned.Correlation = cloneSoulBootstrapCorrelation(s.Correlation)
 	cloned.Publication = cloneSoulBootstrapPublication(s.Publication)
+	cloned.HostedConversation = cloneSoulBootstrapHostedConversation(s.HostedConversation)
 	cloned.RestartedAt = cloneDroneTime(s.RestartedAt)
 	cloned.UpdatedAt = cloneDroneTime(s.UpdatedAt)
 	return &cloned
@@ -408,6 +443,20 @@ func cloneSoulBootstrapPublication(in *SoulBootstrapPublicationEvidence) *SoulBo
 	}
 	cloned := *in
 	cloned.PublishedAt = cloneDroneTime(in.PublishedAt)
+	return &cloned
+}
+
+func cloneSoulBootstrapHostedConversation(in *SoulBootstrapHostedConversation) *SoulBootstrapHostedConversation {
+	if in == nil {
+		return nil
+	}
+	cloned := *in
+	cloned.Messages = make([]SoulBootstrapHostedConversationMessage, len(in.Messages))
+	copy(cloned.Messages, in.Messages)
+	for idx := range cloned.Messages {
+		cloned.Messages[idx].CreatedAt = cloneDroneTime(cloned.Messages[idx].CreatedAt)
+	}
+	cloned.UpdatedAt = cloneDroneTime(in.UpdatedAt)
 	return &cloned
 }
 
@@ -601,4 +650,43 @@ func (p *SoulBootstrapPublicationEvidence) trim() {
 	p.VersionedRegistrationURI = strings.TrimSpace(p.VersionedRegistrationURI)
 	p.VersionedRegistrationS3Key = strings.TrimSpace(p.VersionedRegistrationS3Key)
 	p.AnchorState = strings.TrimSpace(p.AnchorState)
+}
+
+func (c *SoulBootstrapHostedConversation) trim() {
+	if c == nil {
+		return
+	}
+	c.RegistrationID = strings.TrimSpace(c.RegistrationID)
+	c.ConversationID = strings.TrimSpace(c.ConversationID)
+	c.Status = strings.TrimSpace(c.Status)
+	c.LatestTurnID = strings.TrimSpace(c.LatestTurnID)
+	c.RequestID = strings.TrimSpace(c.RequestID)
+	if len(c.Messages) == 0 {
+		c.Messages = nil
+		return
+	}
+	out := make([]SoulBootstrapHostedConversationMessage, 0, len(c.Messages))
+	for _, message := range c.Messages {
+		message.trim()
+		if message.Role == "" || message.Content == "" {
+			continue
+		}
+		out = append(out, message)
+	}
+	c.Messages = out
+}
+
+func (m *SoulBootstrapHostedConversationMessage) trim() {
+	if m == nil {
+		return
+	}
+	m.ID = strings.TrimSpace(m.ID)
+	m.Role = strings.ToLower(strings.TrimSpace(m.Role))
+	if m.Role != soulBootstrapHostedTranscriptRoleUser && m.Role != soulBootstrapHostedTranscriptRoleAssistant {
+		m.Role = ""
+	}
+	m.Content = strings.TrimSpace(m.Content)
+	if m.Order < 0 {
+		m.Order = 0
+	}
 }

--- a/pkg/agents/soul_bootstrap_test.go
+++ b/pkg/agents/soul_bootstrap_test.go
@@ -200,6 +200,72 @@ func TestSoulBootstrapM23PublicationStateCloneAndTrim(t *testing.T) {
 	require.Nil(t, cloneSoulBootstrapPublication(nil))
 }
 
+func TestSoulBootstrapHostedConversationStateCloneAndTrim(t *testing.T) {
+	createdAt := time.Date(2026, 6, 28, 13, 10, 1, 0, time.UTC)
+	updatedAt := createdAt.Add(30 * time.Second)
+
+	state := NormalizeSoulBootstrap(&SoulBootstrapState{
+		Username: "drone-hosted-transcript",
+		HostedConversation: &SoulBootstrapHostedConversation{
+			RegistrationID:    " reg_hosted ",
+			ConversationID:    " conv_hosted ",
+			Status:            " assistant_turn_ready ",
+			LatestTurnID:      " turn_hosted ",
+			MessageCount:      3,
+			MessagesTruncated: true,
+			RequestID:         " req-hosted ",
+			UpdatedAt:         &updatedAt,
+			Messages: []SoulBootstrapHostedConversationMessage{
+				{
+					ID:        " msg_000001 ",
+					Role:      " USER ",
+					Content:   " hello hosted ",
+					Order:     1,
+					CreatedAt: &createdAt,
+				},
+				{
+					ID:      "msg_000002",
+					Role:    "system",
+					Content: "internal",
+					Order:   2,
+				},
+				{
+					ID:      "msg_000003",
+					Role:    soulBootstrapHostedTranscriptRoleAssistant,
+					Content: " ",
+					Order:   -1,
+				},
+			},
+		},
+	}, "")
+
+	require.NotNil(t, state.HostedConversation)
+	require.Equal(t, "reg_hosted", state.HostedConversation.RegistrationID)
+	require.Equal(t, "conv_hosted", state.HostedConversation.ConversationID)
+	require.Equal(t, SoulBootstrapHostConversationStatusAssistantTurnReady, state.HostedConversation.Status)
+	require.Equal(t, "turn_hosted", state.HostedConversation.LatestTurnID)
+	require.Equal(t, "req-hosted", state.HostedConversation.RequestID)
+	require.True(t, state.HostedConversation.MessagesTruncated)
+	require.Len(t, state.HostedConversation.Messages, 1)
+	require.Equal(t, "msg_000001", state.HostedConversation.Messages[0].ID)
+	require.Equal(t, soulBootstrapHostedTranscriptRoleUser, state.HostedConversation.Messages[0].Role)
+	require.Equal(t, "hello hosted", state.HostedConversation.Messages[0].Content)
+	require.Equal(t, createdAt, *state.HostedConversation.Messages[0].CreatedAt)
+
+	cloned := state.Clone()
+	require.NotSame(t, state.HostedConversation, cloned.HostedConversation)
+	require.NotSame(t, state.HostedConversation.UpdatedAt, cloned.HostedConversation.UpdatedAt)
+	require.NotSame(t, state.HostedConversation.Messages[0].CreatedAt, cloned.HostedConversation.Messages[0].CreatedAt)
+	cloned.HostedConversation.Messages[0].Content = "changed"
+	require.Equal(t, "hello hosted", state.HostedConversation.Messages[0].Content)
+	require.Nil(t, cloneSoulBootstrapHostedConversation(nil))
+
+	var nilConversation *SoulBootstrapHostedConversation
+	nilConversation.trim()
+	var nilMessage *SoulBootstrapHostedConversationMessage
+	nilMessage.trim()
+}
+
 func TestSoulBootstrapM23PhaseAndErrorMappings(t *testing.T) {
 	require.Equal(t, SoulBootstrapPhaseConversation, normalizeBootstrapPhase("", SoulBootstrapStateConversationCompleted))
 	require.Equal(t, SoulBootstrapPhaseNotStarted, normalizeBootstrapPhase("", ""))

--- a/pkg/services/souls/bootstrap.go
+++ b/pkg/services/souls/bootstrap.go
@@ -23,6 +23,8 @@ const (
 	hostBootstrapVersion1            = "1"
 
 	hostConversationStatusDeclarationReady = "declaration_ready"
+	hostConversationMessageRoleUser        = "user"
+	hostConversationMessageRoleAssistant   = "assistant"
 
 	// SoulAuthorityModelWalletPrincipal is Host's wallet/principal authority model.
 	SoulAuthorityModelWalletPrincipal = "wallet_principal"
@@ -178,14 +180,29 @@ type BootstrapConversationMessageResult struct {
 	Model                 string
 	LatestTurnID          string
 	MessageCount          int
+	Messages              []BootstrapConversationMessage
+	MessagesTruncated     bool
 	FullResponse          string
 	ProducedDeclarations  string
+	UpdatedAt             *time.Time
 	CompletedAt           *time.Time
 	HostRequestID         string
 	FailureCode           string
 	FailureMessage        string
 	FailureRetryable      bool
 	FailureRecoveryAction string
+}
+
+// BootstrapConversationMessage is Host's bounded, client-safe hosted genesis
+// transcript turn projection. It intentionally carries no Host credentials,
+// provider secrets, signing material, or infrastructure state.
+type BootstrapConversationMessage struct {
+	ID        string
+	Role      string
+	Content   string
+	Order     int
+	CreatedAt *time.Time
+	Truncated bool
 }
 
 // BootstrapConversationCompleteInput is the Lesser-local request for completing
@@ -203,7 +220,10 @@ type BootstrapConversationCompleteResult struct {
 	Status                string
 	LatestTurnID          string
 	MessageCount          int
+	Messages              []BootstrapConversationMessage
+	MessagesTruncated     bool
 	ProducedDeclarations  string
+	UpdatedAt             *time.Time
 	CompletedAt           *time.Time
 	HostRequestID         string
 	FailureCode           string
@@ -677,7 +697,10 @@ func bootstrapConversationCompleteResultFromHost(registrationID string, out host
 		Status:                NormalizeHostedBootstrapConversationStatus(out.Status),
 		LatestTurnID:          strings.TrimSpace(out.LatestTurnID),
 		MessageCount:          out.MessageCount,
+		Messages:              bootstrapConversationMessagesFromHost(out.MessagesRaw),
+		MessagesTruncated:     out.MessagesTruncated,
 		ProducedDeclarations:  hostRawJSONValue(out.ProducedDeclarationsRaw),
+		UpdatedAt:             parseHostTimePtr(out.UpdatedAt),
 		CompletedAt:           parseHostTimePtr(out.CompletedAt),
 		HostRequestID:         strings.TrimSpace(requestID),
 		FailureCode:           strings.TrimSpace(out.Failure.Code),
@@ -696,8 +719,11 @@ func bootstrapConversationMessageResultFromHost(registrationID string, out hostM
 		Model:                 strings.TrimSpace(out.Model),
 		LatestTurnID:          strings.TrimSpace(out.LatestTurnID),
 		MessageCount:          out.MessageCount,
+		Messages:              bootstrapConversationMessagesFromHost(out.MessagesRaw),
+		MessagesTruncated:     out.MessagesTruncated,
 		FullResponse:          strings.TrimSpace(out.FullResponse),
 		ProducedDeclarations:  hostRawJSONValue(out.ProducedDeclarationsRaw),
+		UpdatedAt:             parseHostTimePtr(out.UpdatedAt),
 		CompletedAt:           parseHostTimePtr(out.CompletedAt),
 		HostRequestID:         strings.TrimSpace(requestID),
 		FailureCode:           strings.TrimSpace(out.Failure.Code),
@@ -718,7 +744,10 @@ func completeResultFromMessageResult(in *BootstrapConversationMessageResult) *Bo
 		Status:                in.Status,
 		LatestTurnID:          in.LatestTurnID,
 		MessageCount:          in.MessageCount,
+		Messages:              cloneBootstrapConversationMessages(in.Messages),
+		MessagesTruncated:     in.MessagesTruncated,
 		ProducedDeclarations:  in.ProducedDeclarations,
+		UpdatedAt:             in.UpdatedAt,
 		CompletedAt:           in.CompletedAt,
 		HostRequestID:         in.HostRequestID,
 		FailureCode:           in.FailureCode,
@@ -726,6 +755,15 @@ func completeResultFromMessageResult(in *BootstrapConversationMessageResult) *Bo
 		FailureRetryable:      in.FailureRetryable,
 		FailureRecoveryAction: in.FailureRecoveryAction,
 	}
+}
+
+func cloneBootstrapConversationMessages(in []BootstrapConversationMessage) []BootstrapConversationMessage {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]BootstrapConversationMessage, len(in))
+	copy(out, in)
+	return out
 }
 
 // PrepareBootstrapFinalize calls Host finalize preflight and fails closed on
@@ -1447,6 +1485,110 @@ func hostRawJSONValue(raw json.RawMessage) string {
 	return compactHostJSON(trimmed)
 }
 
+func bootstrapConversationMessagesFromHost(raw json.RawMessage) []BootstrapConversationMessage {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil
+	}
+	if trimmed[0] == '"' {
+		var encoded string
+		if err := json.Unmarshal(trimmed, &encoded); err != nil {
+			return nil
+		}
+		trimmed = bytes.TrimSpace([]byte(encoded))
+		if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+			return nil
+		}
+	}
+
+	var messages []struct {
+		ID        string `json:"id"`
+		Role      string `json:"role"`
+		Content   string `json:"content"`
+		Order     int    `json:"order"`
+		CreatedAt string `json:"created_at"`
+		Truncated bool   `json:"truncated"`
+	}
+	if err := json.Unmarshal(trimmed, &messages); err != nil || len(messages) == 0 {
+		return nil
+	}
+
+	out := make([]BootstrapConversationMessage, 0, len(messages))
+	for idx, message := range messages {
+		role := normalizeHostConversationMessageRole(message.Role)
+		content := strings.TrimSpace(message.Content)
+		if role == "" || content == "" {
+			continue
+		}
+		if hostConversationMessageContentUnsafe(content) {
+			return nil
+		}
+		order := message.Order
+		if order <= 0 {
+			order = idx + 1
+		}
+		id := strings.TrimSpace(message.ID)
+		if id == "" {
+			id = fmt.Sprintf("msg_%06d", order)
+		}
+		out = append(out, BootstrapConversationMessage{
+			ID:        id,
+			Role:      role,
+			Content:   content,
+			Order:     order,
+			CreatedAt: parseHostTimePtr(message.CreatedAt),
+			Truncated: message.Truncated,
+		})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func normalizeHostConversationMessageRole(role string) string {
+	switch strings.ToLower(strings.TrimSpace(role)) {
+	case hostConversationMessageRoleUser, hostConversationMessageRoleAssistant:
+		return strings.ToLower(strings.TrimSpace(role))
+	default:
+		return ""
+	}
+}
+
+func hostConversationMessageContentUnsafe(content string) bool {
+	lower := strings.ToLower(content)
+	for _, marker := range []string{
+		"aws_secret_access_key",
+		"aws_access_key_id",
+		"aws_session_token",
+		"x-amz-security-token",
+		"secretaccesskey",
+		"organizationaccountaccessrole",
+		"arn:aws:iam",
+		"arn:aws:sts",
+		"microvm endpoint token",
+		"microvm_endpoint_token",
+		"instance api key",
+		"raw instance key",
+		"bearer ",
+		"ssm parameter",
+		"parameter store",
+		"/lesser-host/",
+		"mint-signer",
+		"governance-signer",
+		"seed phrase",
+		"private key",
+		"signing material",
+		"provider secret",
+		"host bearer",
+	} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}
+
 // ValidateHostedBootstrapCompletionEvidence fails closed unless Host returned
 // terminal completion evidence for the requested hosted mint conversation.
 func ValidateHostedBootstrapCompletionEvidence(result *BootstrapConversationCompleteResult, expectedConversationID string) error {
@@ -1833,12 +1975,14 @@ type hostMintConversationResponse struct {
 	AgentID                 string                  `json:"agent_id"`
 	ConversationID          string                  `json:"conversation_id"`
 	Model                   string                  `json:"model"`
-	Messages                string                  `json:"messages"`
+	MessagesRaw             json.RawMessage         `json:"messages"`
+	MessagesTruncated       bool                    `json:"messages_truncated"`
 	FullResponse            string                  `json:"full_response"`
 	LatestTurnID            string                  `json:"latest_turn_id"`
 	MessageCount            int                     `json:"message_count"`
 	ProducedDeclarationsRaw json.RawMessage         `json:"produced_declarations"`
 	Status                  string                  `json:"status"`
+	UpdatedAt               string                  `json:"updated_at"`
 	CompletedAt             string                  `json:"completed_at"`
 	RequestID               string                  `json:"request_id"`
 	Failure                 hostConversationFailure `json:"failure"`

--- a/pkg/services/souls/bootstrap_test.go
+++ b/pkg/services/souls/bootstrap_test.go
@@ -885,6 +885,89 @@ func TestProject51ServiceReplaysHostV106ConversationFixtures(t *testing.T) {
 	require.NotContains(t, completed.ProducedDeclarations, "raw_transcript")
 }
 
+func TestProject51ServiceAssistantTurnReadyFixtureIncludesTranscript(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey    = "host-instance-key"
+		registrationID = "reg_01jzhostedgenesis"
+		conversationID = "conv_01jzhostedgenesis"
+		agentID        = "0x2222222222222222222222222222222222222222222222222222222222222222"
+	)
+
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/soul/instance/agents/register/"+registrationID+"/mint-conversation/"+conversationID, r.URL.Path)
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "Bearer "+instanceKey, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write(project51HostConversationFixture(t, "hosted-genesis.conversation.assistant-turn-ready.example.json"))
+		require.NoError(t, err)
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	result, err := service.ReadBootstrapConversation(context.Background(), BootstrapConversationCompleteInput{
+		RegistrationID: registrationID,
+		ConversationID: conversationID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, registrationID, result.RegistrationID)
+	require.Equal(t, agentID, result.HostSoulAgentID)
+	require.Equal(t, conversationID, result.ConversationID)
+	require.Equal(t, "assistant_turn_ready", result.Status)
+	require.Equal(t, "turn_01jzhostedgenesis_user", result.LatestTurnID)
+	require.Equal(t, 2, result.MessageCount)
+	require.Equal(t, "req_hosted_genesis_04", result.HostRequestID)
+	require.NotNil(t, result.UpdatedAt)
+	require.Equal(t, "2026-06-18T13:10:30Z", result.UpdatedAt.Format(time.RFC3339))
+	require.False(t, result.MessagesTruncated)
+	require.Len(t, result.Messages, 2)
+	require.Equal(t, BootstrapConversationMessage{
+		ID:      "msg_000001",
+		Role:    "user",
+		Content: "Describe the managed Lesser agent you are becoming.",
+		Order:   1,
+		CreatedAt: func() *time.Time {
+			createdAt := time.Date(2026, 6, 18, 13, 10, 1, 0, time.UTC)
+			return &createdAt
+		}(),
+	}, result.Messages[0])
+	require.Equal(t, "msg_000002", result.Messages[1].ID)
+	require.Equal(t, "assistant", result.Messages[1].Role)
+	require.Contains(t, result.Messages[1].Content, "bounded tools")
+	require.Empty(t, result.ProducedDeclarations)
+}
+
+func TestBootstrapConversationMessagesFromHostHandlesLegacyStringAndUnsafeContent(t *testing.T) {
+	t.Parallel()
+
+	legacyTranscript := `[{"role":"USER","content":" hello lesser ","order":0},{"id":"tool_ignored","role":"tool","content":"internal"},{"role":"assistant","content":"reply","order":2,"truncated":true}]`
+	encodedLegacyTranscript, err := json.Marshal(legacyTranscript)
+	require.NoError(t, err)
+
+	messages := bootstrapConversationMessagesFromHost(json.RawMessage(encodedLegacyTranscript))
+	require.Len(t, messages, 2)
+	require.Equal(t, "msg_000001", messages[0].ID)
+	require.Equal(t, hostConversationMessageRoleUser, messages[0].Role)
+	require.Equal(t, "hello lesser", messages[0].Content)
+	require.Equal(t, 1, messages[0].Order)
+	require.Nil(t, messages[0].CreatedAt)
+	require.Equal(t, "msg_000002", messages[1].ID)
+	require.Equal(t, hostConversationMessageRoleAssistant, messages[1].Role)
+	require.True(t, messages[1].Truncated)
+
+	require.Nil(t, bootstrapConversationMessagesFromHost(json.RawMessage(``)))
+	require.Nil(t, bootstrapConversationMessagesFromHost(json.RawMessage(`null`)))
+	require.Nil(t, bootstrapConversationMessagesFromHost(json.RawMessage(`"not-json"`)))
+	require.Nil(t, bootstrapConversationMessagesFromHost(json.RawMessage(`[{"role":"assistant","content":"Bearer host-token"}]`)))
+}
+
 func TestProject51ServiceFailedFixtureProjectsHostRecoveryTruth(t *testing.T) {
 	t.Parallel()
 

--- a/testdata/hosted-genesis/v1.0.6/hosted-genesis.conversation.assistant-turn-ready.example.json
+++ b/testdata/hosted-genesis/v1.0.6/hosted-genesis.conversation.assistant-turn-ready.example.json
@@ -1,0 +1,36 @@
+{
+  "version": "1",
+  "request_id": "req_hosted_genesis_04",
+  "conversation": {
+    "registration_id": "reg_01jzhostedgenesis",
+    "conversation_id": "conv_01jzhostedgenesis",
+    "agent_id": "0x2222222222222222222222222222222222222222222222222222222222222222",
+    "status": "assistant_turn_ready",
+    "latest_turn_id": "turn_01jzhostedgenesis_user",
+    "message_count": 2,
+    "messages": [
+      {
+        "id": "msg_000001",
+        "role": "user",
+        "content": "Describe the managed Lesser agent you are becoming.",
+        "order": 1,
+        "created_at": "2026-06-18T13:10:01Z"
+      },
+      {
+        "id": "msg_000002",
+        "role": "assistant",
+        "content": "I will be a managed Lesser agent with bounded tools, transparent provenance, and no credential disclosure.",
+        "order": 2
+      }
+    ],
+    "request_id": "req_hosted_genesis_04",
+    "trace_ids": {
+      "host_request_id": "req_hosted_genesis_04",
+      "correlation_id": "lesser-bootstrap-01",
+      "idempotency_key": "idem-hosted-genesis-03"
+    },
+    "poll_after_seconds": 2,
+    "created_at": "2026-06-18T13:10:00Z",
+    "updated_at": "2026-06-18T13:10:30Z"
+  }
+}


### PR DESCRIPTION
Project 51 M6.13 relays Host assistant_turn_ready transcript messages through Lesser's same-origin GraphQL soulBootstrap surface, adds explicit available actions so hosted genesis can continue or complete, and preserves declaration publish gating.

GraphQL schema/codegen and contract schema were regenerated; Host credentials and unsafe transcript material remain omitted from the client projection.