### PR TITLE
feat: add recoverHostedSoulGenesisTurn mutation and listHostedGenesisConversations query (Project 51 genesis v2)

### DIFF
--- a/docs/contracts/graphql-schema.graphql
+++ b/docs/contracts/graphql-schema.graphql
@@ -4836,6 +4836,16 @@ type SoulBootstrapHostedGenesisConversation {
   updatedAt: Time
 }
 
+type HostedGenesisConversationSummary {
+  conversationId: String!
+  registrationId: String
+  status: String!
+  messageCount: Int!
+  latestTurnId: String
+  createdAt: Time
+  updatedAt: Time
+}
+
 type SoulBootstrapCorrelationState {
   correlationKey: String
   beginIdempotencyKey: String
@@ -5146,6 +5156,7 @@ extend type Query {
   myDroneReviews: [ReviewDecisionCard!]!
   droneWorkflow(username: String!): AgentWorkflowSurface
   soulBootstrap(username: String!): SoulBootstrapSurface
+  listHostedGenesisConversations(username: String!): [HostedGenesisConversationSummary!]!
 }
 
 extend type Mutation {

--- a/docs/contracts/graphql-schema.graphql
+++ b/docs/contracts/graphql-schema.graphql
@@ -5023,6 +5023,15 @@ input CompleteHostedSoulGenesisInput {
   correlationKey: String
 }
 
+input RecoverHostedSoulGenesisTurnInput {
+  username: String!
+  conversationId: String!
+  registrationId: String
+  correlationKey: String
+  idempotencyKey: String
+  recoveryAttemptId: String
+}
+
 input PublishHostedSoulInput {
   username: String!
   registrationId: ID
@@ -5167,6 +5176,7 @@ extend type Mutation {
   startHostedSoulBootstrap(input: StartHostedSoulBootstrapInput!): SoulBootstrapMutationPayload!
   sendHostedSoulGenesisMessage(input: SendHostedSoulGenesisMessageInput!): SoulBootstrapMutationPayload!
   completeHostedSoulGenesis(input: CompleteHostedSoulGenesisInput!): SoulBootstrapMutationPayload!
+  recoverHostedSoulGenesisTurn(input: RecoverHostedSoulGenesisTurnInput!): SoulBootstrapMutationPayload!
   publishHostedSoul(input: PublishHostedSoulInput!): SoulBootstrapMutationPayload!
   restartSoulBootstrap(input: RestartSoulBootstrapInput!): SoulBootstrapMutationPayload!
   beginSoulBootstrap(input: BeginSoulBootstrapInput!): SoulBootstrapMutationPayload!

--- a/graph/agents.graphql
+++ b/graph/agents.graphql
@@ -865,6 +865,15 @@ input CompleteHostedSoulGenesisInput {
   correlationKey: String
 }
 
+input RecoverHostedSoulGenesisTurnInput {
+  username: String!
+  conversationId: String!
+  registrationId: String
+  correlationKey: String
+  idempotencyKey: String
+  recoveryAttemptId: String
+}
+
 input PublishHostedSoulInput {
   username: String!
   registrationId: ID
@@ -1009,6 +1018,7 @@ extend type Mutation {
   startHostedSoulBootstrap(input: StartHostedSoulBootstrapInput!): SoulBootstrapMutationPayload!
   sendHostedSoulGenesisMessage(input: SendHostedSoulGenesisMessageInput!): SoulBootstrapMutationPayload!
   completeHostedSoulGenesis(input: CompleteHostedSoulGenesisInput!): SoulBootstrapMutationPayload!
+  recoverHostedSoulGenesisTurn(input: RecoverHostedSoulGenesisTurnInput!): SoulBootstrapMutationPayload!
   publishHostedSoul(input: PublishHostedSoulInput!): SoulBootstrapMutationPayload!
   restartSoulBootstrap(input: RestartSoulBootstrapInput!): SoulBootstrapMutationPayload!
   beginSoulBootstrap(input: BeginSoulBootstrapInput!): SoulBootstrapMutationPayload!

--- a/graph/agents.graphql
+++ b/graph/agents.graphql
@@ -678,6 +678,16 @@ type SoulBootstrapHostedGenesisConversation {
   updatedAt: Time
 }
 
+type HostedGenesisConversationSummary {
+  conversationId: String!
+  registrationId: String
+  status: String!
+  messageCount: Int!
+  latestTurnId: String
+  createdAt: Time
+  updatedAt: Time
+}
+
 type SoulBootstrapCorrelationState {
   correlationKey: String
   beginIdempotencyKey: String
@@ -988,6 +998,7 @@ extend type Query {
   myDroneReviews: [ReviewDecisionCard!]!
   droneWorkflow(username: String!): AgentWorkflowSurface
   soulBootstrap(username: String!): SoulBootstrapSurface
+  listHostedGenesisConversations(username: String!): [HostedGenesisConversationSummary!]!
 }
 
 extend type Mutation {

--- a/graph/generated.go
+++ b/graph/generated.go
@@ -1474,6 +1474,16 @@ type ComplexityRoot struct {
 		Type        func(childComplexity int) int
 	}
 
+	HostedGenesisConversationSummary struct {
+		ConversationID func(childComplexity int) int
+		CreatedAt      func(childComplexity int) int
+		LatestTurnID   func(childComplexity int) int
+		MessageCount   func(childComplexity int) int
+		RegistrationID func(childComplexity int) int
+		Status         func(childComplexity int) int
+		UpdatedAt      func(childComplexity int) int
+	}
+
 	HourlyBandwidth struct {
 		Hour     func(childComplexity int) int
 		PeakMbps func(childComplexity int) int
@@ -2438,158 +2448,159 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		AccountQuotePermissions   func(childComplexity int, username string) int
-		Actor                     func(childComplexity int, id *string, username *string) int
-		AdminAccount              func(childComplexity int, id string) int
-		AdminAccounts             func(childComplexity int, first *int, after *model.Cursor) int
-		AdminAgentPolicy          func(childComplexity int) int
-		AdminDomainAllows         func(childComplexity int, first *int, after *model.Cursor) int
-		AdminDomainBlock          func(childComplexity int, id string) int
-		AdminDomainBlocks         func(childComplexity int, first *int, after *model.Cursor) int
-		AdminEmailDomainBlocks    func(childComplexity int, first *int, after *model.Cursor) int
-		AdminFederationInstance   func(childComplexity int, domain string) int
-		AdminFederationInstances  func(childComplexity int, first *int, after *model.Cursor) int
-		AdminFederationStatistics func(childComplexity int, start *model.Time, end *model.Time) int
-		AdminInstanceConfig       func(childComplexity int) int
-		AdminModerationEvents     func(childComplexity int, filter *model.AdminModerationEventFilter, first *int, after *model.Cursor) int
-		AdminModerationReviewers  func(childComplexity int) int
-		AdminReport               func(childComplexity int, id string) int
-		AdminReports              func(childComplexity int, status *model.AdminReportStatus, first *int, after *model.Cursor) int
-		AdminStatus               func(childComplexity int, id string) int
-		AdminStatuses             func(childComplexity int, filter *model.AdminStatusFilter, first *int, after *model.Cursor) int
-		AdminTrustGraph           func(childComplexity int, limit *int) int
-		AffectedRelationships     func(childComplexity int, severedRelationshipID string) int
-		Agent                     func(childComplexity int, username string) int
-		AgentAccessLeases         func(childComplexity int, username string) int
-		AgentActivity             func(childComplexity int, username string, first *int, after *model.Cursor) int
-		AgentMemorySearch         func(childComplexity int, query string, tags []string, dateRange *model.DateRangeInput, first *int, after *model.Cursor) int
-		AgentRuntimeSessions      func(childComplexity int, username string) int
-		Agents                    func(childComplexity int, first *int, after *model.Cursor, typeArg *model.AgentType, query *string, verified *bool, ownerUsername *string) int
-		AiAnalysis                func(childComplexity int, objectID string) int
-		AiCapabilities            func(childComplexity int) int
-		AiStats                   func(childComplexity int, period model.Period) int
-		AllSeries                 func(childComplexity int, authorID *string, first *int, after *model.Cursor) int
-		Announcements             func(childComplexity int) int
-		Article                   func(childComplexity int, id string) int
-		ArticleBySlug             func(childComplexity int, slug string) int
-		Articles                  func(childComplexity int, authorID *string, seriesID *string, categoryID *string, first *int, after *model.Cursor) int
-		BandwidthUsage            func(childComplexity int, period model.TimePeriod) int
-		Blocks                    func(childComplexity int, first *int, after *model.Cursor) int
-		Bookmarks                 func(childComplexity int, first *int, after *model.Cursor) int
-		Categories                func(childComplexity int, parentID *string) int
-		Category                  func(childComplexity int, id string) int
-		CategoryBySlug            func(childComplexity int, slug string) int
-		CommunityNotesByAuthor    func(childComplexity int, username string, first *int, after *model.Cursor) int
-		Conversation              func(childComplexity int, id string) int
-		ConversationMessages      func(childComplexity int, conversationID string, first *int, after *model.Cursor) int
-		Conversations             func(childComplexity int, folder *model.ConversationFolder, first *int, after *model.Cursor) int
-		CostBreakdown             func(childComplexity int, period *model.Period) int
-		CostProjections           func(childComplexity int, period model.Period) int
-		CustomEmojis              func(childComplexity int) int
-		DomainBlocks              func(childComplexity int, first *int, after *model.Cursor) int
-		Draft                     func(childComplexity int, id string) int
-		DraftPreview              func(childComplexity int, id string) int
-		DroneWorkflow             func(childComplexity int, username string) int
-		Endorsements              func(childComplexity int) int
-		ExplainObject             func(childComplexity int, id string) int
-		Export                    func(childComplexity int, id string) int
-		Exports                   func(childComplexity int, first *int, after *model.Cursor) int
-		Favourites                func(childComplexity int, first *int, after *model.Cursor) int
-		FederationCosts           func(childComplexity int, first *int, after *string, orderBy *model.CostOrderBy) int
-		FederationFlow            func(childComplexity int, period model.TimePeriod) int
-		FederationHealth          func(childComplexity int, threshold *float64) int
-		FederationLimits          func(childComplexity int, active *bool, first *int, after *string) int
-		FederationMap             func(childComplexity int, depth *int) int
-		FederationStatus          func(childComplexity int, domain string) int
-		Filter                    func(childComplexity int, id string) int
-		Filters                   func(childComplexity int) int
-		FollowRequests            func(childComplexity int, first *int, after *model.Cursor) int
-		FollowedHashtags          func(childComplexity int, first *int, after *string) int
-		Followers                 func(childComplexity int, username string, limit *int, cursor *model.Cursor) int
-		Following                 func(childComplexity int, username string, limit *int, cursor *model.Cursor) int
-		GroupedNotifications      func(childComplexity int, input *model.GroupedNotificationsInput) int
-		Hashtag                   func(childComplexity int, name string) int
-		HashtagTimeline           func(childComplexity int, hashtag string, first *int, after *string, mediaOnly *bool) int
-		Import                    func(childComplexity int, id string) int
-		Imports                   func(childComplexity int, first *int, after *model.Cursor) int
-		InfrastructureHealth      func(childComplexity int) int
-		Instance                  func(childComplexity int) int
-		InstanceActivity          func(childComplexity int, limit *int) int
-		InstanceBudgets           func(childComplexity int, exceeded *bool) int
-		InstanceDomainBlocks      func(childComplexity int, limit *int) int
-		InstanceHealthReport      func(childComplexity int, domain string) int
-		InstanceMetrics           func(childComplexity int) int
-		InstancePeers             func(childComplexity int, limit *int) int
-		InstanceRelationships     func(childComplexity int, domain string) int
-		LinkTimeline              func(childComplexity int, url string, first *int, after *model.Cursor) int
-		List                      func(childComplexity int, id string) int
-		ListAccounts              func(childComplexity int, id string) int
-		Lists                     func(childComplexity int) int
-		Markers                   func(childComplexity int, timelines []model.MarkerTimeline) int
-		Media                     func(childComplexity int, id string) int
-		MediaLibrary              func(childComplexity int, filter *model.MediaFilterInput, first *int, after *model.Cursor) int
-		MediaStreamURL            func(childComplexity int, mediaID string) int
-		ModerationConsensus       func(childComplexity int, eventID string) int
-		ModerationDashboard       func(childComplexity int, filter *moderation.ModerationFilter) int
-		ModerationEffectiveness   func(childComplexity int, patternID string, period model.ModerationPeriod) int
-		ModerationHistory         func(childComplexity int, objectID string) int
-		ModerationPatterns        func(childComplexity int, active *bool, severity *model.ModerationSeverity, first *int, after *string) int
-		ModerationQueue           func(childComplexity int, first *int, after *model.Cursor) int
-		ModerationTrustScore      func(childComplexity int, actorID string) int
-		ModeratorActivity         func(childComplexity int, moderatorID string, period model.TimePeriod) int
-		MultiHashtagTimeline      func(childComplexity int, hashtags []string, mode model.HashtagMode, first *int, after *string) int
-		Mutes                     func(childComplexity int, first *int, after *model.Cursor) int
-		MyAgents                  func(childComplexity int) int
-		MyDrafts                  func(childComplexity int, contentType *model.ObjectType, status *model.DraftStatus, first *int, after *model.Cursor) int
-		MyDroneRequests           func(childComplexity int) int
-		MyDroneReviews            func(childComplexity int) int
-		MyPublications            func(childComplexity int) int
-		MySouls                   func(childComplexity int) int
-		Notification              func(childComplexity int, id string) int
-		Notifications             func(childComplexity int, types []string, excludeTypes []string, first *int, after *model.Cursor) int
-		Object                    func(childComplexity int, id string) int
-		PatternEffectiveness      func(childComplexity int, patternID string) int
-		PerformanceMetrics        func(childComplexity int, service model.ServiceCategory) int
-		PopularStreams            func(childComplexity int, first int, after *string) int
-		ProfileDirectory          func(childComplexity int, filters *model.DirectoryFiltersInput, first *int, after *model.Cursor) int
-		Publication               func(childComplexity int, id string) int
-		PublicationBySlug         func(childComplexity int, slug string) int
-		PushSubscription          func(childComplexity int) int
-		Relationship              func(childComplexity int, id string) int
-		Relationships             func(childComplexity int, ids []string) int
-		RemoveSuggestion          func(childComplexity int, accountID string) int
-		Reputation                func(childComplexity int, actorID string) int
-		Revision                  func(childComplexity int, objectID string, version int) int
-		Revisions                 func(childComplexity int, objectID string, first *int, after *model.Cursor) int
-		RootCategories            func(childComplexity int) int
-		ScheduledStatus           func(childComplexity int, id string) int
-		ScheduledStatuses         func(childComplexity int, first *int, after *model.Cursor) int
-		Search                    func(childComplexity int, query string, typeArg *string, first *int, after *model.Cursor) int
-		Series                    func(childComplexity int, id string) int
-		SeriesBySlug              func(childComplexity int, slug string) int
-		SeveredRelationships      func(childComplexity int, instance *string, first *int, after *string) int
-		SlowQueries               func(childComplexity int, threshold model.Duration) int
-		SoulBootstrap             func(childComplexity int, username string) int
-		StatusFavouritedBy        func(childComplexity int, id string, first *int, after *model.Cursor) int
-		StatusHistory             func(childComplexity int, id string, limit *int) int
-		StatusRebloggedBy         func(childComplexity int, id string, first *int, after *model.Cursor) int
-		StreamingAnalytics        func(childComplexity int, mediaID string) int
-		SuggestedHashtags         func(childComplexity int, limit *int) int
-		Suggestions               func(childComplexity int, limit *int) int
-		SupportedBitrates         func(childComplexity int, mediaID string) int
-		ThreadContext             func(childComplexity int, noteID string) int
-		Timeline                  func(childComplexity int, typeArg model.TimelineType, hashtag *string, listID *string, actorID *string, first *int, after *model.Cursor, mediaOnly *bool, excludeAgents *bool) int
-		TranslateStatus           func(childComplexity int, id string, targetLanguage *string) int
-		TranslationLanguages      func(childComplexity int) int
-		TrendingLinks             func(childComplexity int, limit *int) int
-		TrendingStatuses          func(childComplexity int, limit *int) int
-		TrendingTags              func(childComplexity int, limit *int) int
-		Trends                    func(childComplexity int, limit *int) int
-		TrustGraph                func(childComplexity int, actorID string, category *models.TrustCategory) int
-		UserPreferences           func(childComplexity int) int
-		Viewer                    func(childComplexity int) int
-		ViewerRole                func(childComplexity int) int
-		Vouches                   func(childComplexity int, actorID string) int
+		AccountQuotePermissions        func(childComplexity int, username string) int
+		Actor                          func(childComplexity int, id *string, username *string) int
+		AdminAccount                   func(childComplexity int, id string) int
+		AdminAccounts                  func(childComplexity int, first *int, after *model.Cursor) int
+		AdminAgentPolicy               func(childComplexity int) int
+		AdminDomainAllows              func(childComplexity int, first *int, after *model.Cursor) int
+		AdminDomainBlock               func(childComplexity int, id string) int
+		AdminDomainBlocks              func(childComplexity int, first *int, after *model.Cursor) int
+		AdminEmailDomainBlocks         func(childComplexity int, first *int, after *model.Cursor) int
+		AdminFederationInstance        func(childComplexity int, domain string) int
+		AdminFederationInstances       func(childComplexity int, first *int, after *model.Cursor) int
+		AdminFederationStatistics      func(childComplexity int, start *model.Time, end *model.Time) int
+		AdminInstanceConfig            func(childComplexity int) int
+		AdminModerationEvents          func(childComplexity int, filter *model.AdminModerationEventFilter, first *int, after *model.Cursor) int
+		AdminModerationReviewers       func(childComplexity int) int
+		AdminReport                    func(childComplexity int, id string) int
+		AdminReports                   func(childComplexity int, status *model.AdminReportStatus, first *int, after *model.Cursor) int
+		AdminStatus                    func(childComplexity int, id string) int
+		AdminStatuses                  func(childComplexity int, filter *model.AdminStatusFilter, first *int, after *model.Cursor) int
+		AdminTrustGraph                func(childComplexity int, limit *int) int
+		AffectedRelationships          func(childComplexity int, severedRelationshipID string) int
+		Agent                          func(childComplexity int, username string) int
+		AgentAccessLeases              func(childComplexity int, username string) int
+		AgentActivity                  func(childComplexity int, username string, first *int, after *model.Cursor) int
+		AgentMemorySearch              func(childComplexity int, query string, tags []string, dateRange *model.DateRangeInput, first *int, after *model.Cursor) int
+		AgentRuntimeSessions           func(childComplexity int, username string) int
+		Agents                         func(childComplexity int, first *int, after *model.Cursor, typeArg *model.AgentType, query *string, verified *bool, ownerUsername *string) int
+		AiAnalysis                     func(childComplexity int, objectID string) int
+		AiCapabilities                 func(childComplexity int) int
+		AiStats                        func(childComplexity int, period model.Period) int
+		AllSeries                      func(childComplexity int, authorID *string, first *int, after *model.Cursor) int
+		Announcements                  func(childComplexity int) int
+		Article                        func(childComplexity int, id string) int
+		ArticleBySlug                  func(childComplexity int, slug string) int
+		Articles                       func(childComplexity int, authorID *string, seriesID *string, categoryID *string, first *int, after *model.Cursor) int
+		BandwidthUsage                 func(childComplexity int, period model.TimePeriod) int
+		Blocks                         func(childComplexity int, first *int, after *model.Cursor) int
+		Bookmarks                      func(childComplexity int, first *int, after *model.Cursor) int
+		Categories                     func(childComplexity int, parentID *string) int
+		Category                       func(childComplexity int, id string) int
+		CategoryBySlug                 func(childComplexity int, slug string) int
+		CommunityNotesByAuthor         func(childComplexity int, username string, first *int, after *model.Cursor) int
+		Conversation                   func(childComplexity int, id string) int
+		ConversationMessages           func(childComplexity int, conversationID string, first *int, after *model.Cursor) int
+		Conversations                  func(childComplexity int, folder *model.ConversationFolder, first *int, after *model.Cursor) int
+		CostBreakdown                  func(childComplexity int, period *model.Period) int
+		CostProjections                func(childComplexity int, period model.Period) int
+		CustomEmojis                   func(childComplexity int) int
+		DomainBlocks                   func(childComplexity int, first *int, after *model.Cursor) int
+		Draft                          func(childComplexity int, id string) int
+		DraftPreview                   func(childComplexity int, id string) int
+		DroneWorkflow                  func(childComplexity int, username string) int
+		Endorsements                   func(childComplexity int) int
+		ExplainObject                  func(childComplexity int, id string) int
+		Export                         func(childComplexity int, id string) int
+		Exports                        func(childComplexity int, first *int, after *model.Cursor) int
+		Favourites                     func(childComplexity int, first *int, after *model.Cursor) int
+		FederationCosts                func(childComplexity int, first *int, after *string, orderBy *model.CostOrderBy) int
+		FederationFlow                 func(childComplexity int, period model.TimePeriod) int
+		FederationHealth               func(childComplexity int, threshold *float64) int
+		FederationLimits               func(childComplexity int, active *bool, first *int, after *string) int
+		FederationMap                  func(childComplexity int, depth *int) int
+		FederationStatus               func(childComplexity int, domain string) int
+		Filter                         func(childComplexity int, id string) int
+		Filters                        func(childComplexity int) int
+		FollowRequests                 func(childComplexity int, first *int, after *model.Cursor) int
+		FollowedHashtags               func(childComplexity int, first *int, after *string) int
+		Followers                      func(childComplexity int, username string, limit *int, cursor *model.Cursor) int
+		Following                      func(childComplexity int, username string, limit *int, cursor *model.Cursor) int
+		GroupedNotifications           func(childComplexity int, input *model.GroupedNotificationsInput) int
+		Hashtag                        func(childComplexity int, name string) int
+		HashtagTimeline                func(childComplexity int, hashtag string, first *int, after *string, mediaOnly *bool) int
+		Import                         func(childComplexity int, id string) int
+		Imports                        func(childComplexity int, first *int, after *model.Cursor) int
+		InfrastructureHealth           func(childComplexity int) int
+		Instance                       func(childComplexity int) int
+		InstanceActivity               func(childComplexity int, limit *int) int
+		InstanceBudgets                func(childComplexity int, exceeded *bool) int
+		InstanceDomainBlocks           func(childComplexity int, limit *int) int
+		InstanceHealthReport           func(childComplexity int, domain string) int
+		InstanceMetrics                func(childComplexity int) int
+		InstancePeers                  func(childComplexity int, limit *int) int
+		InstanceRelationships          func(childComplexity int, domain string) int
+		LinkTimeline                   func(childComplexity int, url string, first *int, after *model.Cursor) int
+		List                           func(childComplexity int, id string) int
+		ListAccounts                   func(childComplexity int, id string) int
+		ListHostedGenesisConversations func(childComplexity int, username string) int
+		Lists                          func(childComplexity int) int
+		Markers                        func(childComplexity int, timelines []model.MarkerTimeline) int
+		Media                          func(childComplexity int, id string) int
+		MediaLibrary                   func(childComplexity int, filter *model.MediaFilterInput, first *int, after *model.Cursor) int
+		MediaStreamURL                 func(childComplexity int, mediaID string) int
+		ModerationConsensus            func(childComplexity int, eventID string) int
+		ModerationDashboard            func(childComplexity int, filter *moderation.ModerationFilter) int
+		ModerationEffectiveness        func(childComplexity int, patternID string, period model.ModerationPeriod) int
+		ModerationHistory              func(childComplexity int, objectID string) int
+		ModerationPatterns             func(childComplexity int, active *bool, severity *model.ModerationSeverity, first *int, after *string) int
+		ModerationQueue                func(childComplexity int, first *int, after *model.Cursor) int
+		ModerationTrustScore           func(childComplexity int, actorID string) int
+		ModeratorActivity              func(childComplexity int, moderatorID string, period model.TimePeriod) int
+		MultiHashtagTimeline           func(childComplexity int, hashtags []string, mode model.HashtagMode, first *int, after *string) int
+		Mutes                          func(childComplexity int, first *int, after *model.Cursor) int
+		MyAgents                       func(childComplexity int) int
+		MyDrafts                       func(childComplexity int, contentType *model.ObjectType, status *model.DraftStatus, first *int, after *model.Cursor) int
+		MyDroneRequests                func(childComplexity int) int
+		MyDroneReviews                 func(childComplexity int) int
+		MyPublications                 func(childComplexity int) int
+		MySouls                        func(childComplexity int) int
+		Notification                   func(childComplexity int, id string) int
+		Notifications                  func(childComplexity int, types []string, excludeTypes []string, first *int, after *model.Cursor) int
+		Object                         func(childComplexity int, id string) int
+		PatternEffectiveness           func(childComplexity int, patternID string) int
+		PerformanceMetrics             func(childComplexity int, service model.ServiceCategory) int
+		PopularStreams                 func(childComplexity int, first int, after *string) int
+		ProfileDirectory               func(childComplexity int, filters *model.DirectoryFiltersInput, first *int, after *model.Cursor) int
+		Publication                    func(childComplexity int, id string) int
+		PublicationBySlug              func(childComplexity int, slug string) int
+		PushSubscription               func(childComplexity int) int
+		Relationship                   func(childComplexity int, id string) int
+		Relationships                  func(childComplexity int, ids []string) int
+		RemoveSuggestion               func(childComplexity int, accountID string) int
+		Reputation                     func(childComplexity int, actorID string) int
+		Revision                       func(childComplexity int, objectID string, version int) int
+		Revisions                      func(childComplexity int, objectID string, first *int, after *model.Cursor) int
+		RootCategories                 func(childComplexity int) int
+		ScheduledStatus                func(childComplexity int, id string) int
+		ScheduledStatuses              func(childComplexity int, first *int, after *model.Cursor) int
+		Search                         func(childComplexity int, query string, typeArg *string, first *int, after *model.Cursor) int
+		Series                         func(childComplexity int, id string) int
+		SeriesBySlug                   func(childComplexity int, slug string) int
+		SeveredRelationships           func(childComplexity int, instance *string, first *int, after *string) int
+		SlowQueries                    func(childComplexity int, threshold model.Duration) int
+		SoulBootstrap                  func(childComplexity int, username string) int
+		StatusFavouritedBy             func(childComplexity int, id string, first *int, after *model.Cursor) int
+		StatusHistory                  func(childComplexity int, id string, limit *int) int
+		StatusRebloggedBy              func(childComplexity int, id string, first *int, after *model.Cursor) int
+		StreamingAnalytics             func(childComplexity int, mediaID string) int
+		SuggestedHashtags              func(childComplexity int, limit *int) int
+		Suggestions                    func(childComplexity int, limit *int) int
+		SupportedBitrates              func(childComplexity int, mediaID string) int
+		ThreadContext                  func(childComplexity int, noteID string) int
+		Timeline                       func(childComplexity int, typeArg model.TimelineType, hashtag *string, listID *string, actorID *string, first *int, after *model.Cursor, mediaOnly *bool, excludeAgents *bool) int
+		TranslateStatus                func(childComplexity int, id string, targetLanguage *string) int
+		TranslationLanguages           func(childComplexity int) int
+		TrendingLinks                  func(childComplexity int, limit *int) int
+		TrendingStatuses               func(childComplexity int, limit *int) int
+		TrendingTags                   func(childComplexity int, limit *int) int
+		Trends                         func(childComplexity int, limit *int) int
+		TrustGraph                     func(childComplexity int, actorID string, category *models.TrustCategory) int
+		UserPreferences                func(childComplexity int) int
+		Viewer                         func(childComplexity int) int
+		ViewerRole                     func(childComplexity int) int
+		Vouches                        func(childComplexity int, actorID string) int
 	}
 
 	QueryPerformance struct {
@@ -3886,6 +3897,7 @@ type QueryResolver interface {
 	MyDroneReviews(ctx context.Context) ([]*model.ReviewDecisionCard, error)
 	DroneWorkflow(ctx context.Context, username string) (*model.AgentWorkflowSurface, error)
 	SoulBootstrap(ctx context.Context, username string) (*model.SoulBootstrapSurface, error)
+	ListHostedGenesisConversations(ctx context.Context, username string) ([]*model.HostedGenesisConversationSummary, error)
 }
 type QuoteContextResolver interface {
 	OriginalAuthor(ctx context.Context, obj *activitypub.QuoteContext) (*activitypub.Actor, error)
@@ -10456,6 +10468,55 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.HealthIssue.Type(childComplexity), true
+
+	case "HostedGenesisConversationSummary.conversationId":
+		if e.complexity.HostedGenesisConversationSummary.ConversationID == nil {
+			break
+		}
+
+		return e.complexity.HostedGenesisConversationSummary.ConversationID(childComplexity), true
+
+	case "HostedGenesisConversationSummary.createdAt":
+		if e.complexity.HostedGenesisConversationSummary.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.HostedGenesisConversationSummary.CreatedAt(childComplexity), true
+
+	case "HostedGenesisConversationSummary.latestTurnId":
+		if e.complexity.HostedGenesisConversationSummary.LatestTurnID == nil {
+			break
+		}
+
+		return e.complexity.HostedGenesisConversationSummary.LatestTurnID(childComplexity), true
+
+	case "HostedGenesisConversationSummary.messageCount":
+		if e.complexity.HostedGenesisConversationSummary.MessageCount == nil {
+			break
+		}
+
+		return e.complexity.HostedGenesisConversationSummary.MessageCount(childComplexity), true
+
+	case "HostedGenesisConversationSummary.registrationId":
+		if e.complexity.HostedGenesisConversationSummary.RegistrationID == nil {
+			break
+		}
+
+		return e.complexity.HostedGenesisConversationSummary.RegistrationID(childComplexity), true
+
+	case "HostedGenesisConversationSummary.status":
+		if e.complexity.HostedGenesisConversationSummary.Status == nil {
+			break
+		}
+
+		return e.complexity.HostedGenesisConversationSummary.Status(childComplexity), true
+
+	case "HostedGenesisConversationSummary.updatedAt":
+		if e.complexity.HostedGenesisConversationSummary.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.HostedGenesisConversationSummary.UpdatedAt(childComplexity), true
 
 	case "HourlyBandwidth.hour":
 		if e.complexity.HourlyBandwidth.Hour == nil {
@@ -17324,6 +17385,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.ListAccounts(childComplexity, args["id"].(string)), true
+
+	case "Query.listHostedGenesisConversations":
+		if e.complexity.Query.ListHostedGenesisConversations == nil {
+			break
+		}
+
+		args, err := ec.field_Query_listHostedGenesisConversations_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.ListHostedGenesisConversations(childComplexity, args["username"].(string)), true
 
 	case "Query.lists":
 		if e.complexity.Query.Lists == nil {
@@ -26092,6 +26165,17 @@ func (ec *executionContext) field_Query_listAccounts_args(ctx context.Context, r
 		return nil, err
 	}
 	args["id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_listHostedGenesisConversations_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "username", ec.unmarshalNString2string)
+	if err != nil {
+		return nil, err
+	}
+	args["username"] = arg0
 	return args, nil
 }
 
@@ -71184,6 +71268,302 @@ func (ec *executionContext) fieldContext_HealthIssue_impact(_ context.Context, f
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HostedGenesisConversationSummary_conversationId(ctx context.Context, field graphql.CollectedField, obj *model.HostedGenesisConversationSummary) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HostedGenesisConversationSummary_conversationId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ConversationID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HostedGenesisConversationSummary_conversationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HostedGenesisConversationSummary",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HostedGenesisConversationSummary_registrationId(ctx context.Context, field graphql.CollectedField, obj *model.HostedGenesisConversationSummary) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HostedGenesisConversationSummary_registrationId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RegistrationID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HostedGenesisConversationSummary_registrationId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HostedGenesisConversationSummary",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HostedGenesisConversationSummary_status(ctx context.Context, field graphql.CollectedField, obj *model.HostedGenesisConversationSummary) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HostedGenesisConversationSummary_status(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Status, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HostedGenesisConversationSummary_status(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HostedGenesisConversationSummary",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HostedGenesisConversationSummary_messageCount(ctx context.Context, field graphql.CollectedField, obj *model.HostedGenesisConversationSummary) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HostedGenesisConversationSummary_messageCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.MessageCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HostedGenesisConversationSummary_messageCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HostedGenesisConversationSummary",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HostedGenesisConversationSummary_latestTurnId(ctx context.Context, field graphql.CollectedField, obj *model.HostedGenesisConversationSummary) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HostedGenesisConversationSummary_latestTurnId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LatestTurnID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HostedGenesisConversationSummary_latestTurnId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HostedGenesisConversationSummary",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HostedGenesisConversationSummary_createdAt(ctx context.Context, field graphql.CollectedField, obj *model.HostedGenesisConversationSummary) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HostedGenesisConversationSummary_createdAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HostedGenesisConversationSummary_createdAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HostedGenesisConversationSummary",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HostedGenesisConversationSummary_updatedAt(ctx context.Context, field graphql.CollectedField, obj *model.HostedGenesisConversationSummary) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HostedGenesisConversationSummary_updatedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HostedGenesisConversationSummary_updatedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HostedGenesisConversationSummary",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
 		},
 	}
 	return fc, nil
@@ -120257,6 +120637,77 @@ func (ec *executionContext) fieldContext_Query_soulBootstrap(ctx context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_listHostedGenesisConversations(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_listHostedGenesisConversations(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().ListHostedGenesisConversations(rctx, fc.Args["username"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.HostedGenesisConversationSummary)
+	fc.Result = res
+	return ec.marshalNHostedGenesisConversationSummary2ᚕᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐHostedGenesisConversationSummaryᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_listHostedGenesisConversations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "conversationId":
+				return ec.fieldContext_HostedGenesisConversationSummary_conversationId(ctx, field)
+			case "registrationId":
+				return ec.fieldContext_HostedGenesisConversationSummary_registrationId(ctx, field)
+			case "status":
+				return ec.fieldContext_HostedGenesisConversationSummary_status(ctx, field)
+			case "messageCount":
+				return ec.fieldContext_HostedGenesisConversationSummary_messageCount(ctx, field)
+			case "latestTurnId":
+				return ec.fieldContext_HostedGenesisConversationSummary_latestTurnId(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_HostedGenesisConversationSummary_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_HostedGenesisConversationSummary_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type HostedGenesisConversationSummary", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_listHostedGenesisConversations_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query___type(ctx, field)
 	if err != nil {
@@ -167826,6 +168277,63 @@ func (ec *executionContext) _HealthIssue(ctx context.Context, sel ast.SelectionS
 	return out
 }
 
+var hostedGenesisConversationSummaryImplementors = []string{"HostedGenesisConversationSummary"}
+
+func (ec *executionContext) _HostedGenesisConversationSummary(ctx context.Context, sel ast.SelectionSet, obj *model.HostedGenesisConversationSummary) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, hostedGenesisConversationSummaryImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("HostedGenesisConversationSummary")
+		case "conversationId":
+			out.Values[i] = ec._HostedGenesisConversationSummary_conversationId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "registrationId":
+			out.Values[i] = ec._HostedGenesisConversationSummary_registrationId(ctx, field, obj)
+		case "status":
+			out.Values[i] = ec._HostedGenesisConversationSummary_status(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "messageCount":
+			out.Values[i] = ec._HostedGenesisConversationSummary_messageCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "latestTurnId":
+			out.Values[i] = ec._HostedGenesisConversationSummary_latestTurnId(ctx, field, obj)
+		case "createdAt":
+			out.Values[i] = ec._HostedGenesisConversationSummary_createdAt(ctx, field, obj)
+		case "updatedAt":
+			out.Values[i] = ec._HostedGenesisConversationSummary_updatedAt(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var hourlyBandwidthImplementors = []string{"HourlyBandwidth"}
 
 func (ec *executionContext) _HourlyBandwidth(ctx context.Context, sel ast.SelectionSet, obj *model.HourlyBandwidth) graphql.Marshaler {
@@ -178434,6 +178942,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_soulBootstrap(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "listHostedGenesisConversations":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_listHostedGenesisConversations(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 
@@ -189500,6 +190030,60 @@ func (ec *executionContext) unmarshalNHealthStatus2githubᚗcomᚋequaltoaiᚋle
 
 func (ec *executionContext) marshalNHealthStatus2githubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐHealthStatus(ctx context.Context, sel ast.SelectionSet, v model.HealthStatus) graphql.Marshaler {
 	return v
+}
+
+func (ec *executionContext) marshalNHostedGenesisConversationSummary2ᚕᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐHostedGenesisConversationSummaryᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.HostedGenesisConversationSummary) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNHostedGenesisConversationSummary2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐHostedGenesisConversationSummary(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNHostedGenesisConversationSummary2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐHostedGenesisConversationSummary(ctx context.Context, sel ast.SelectionSet, v *model.HostedGenesisConversationSummary) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._HostedGenesisConversationSummary(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNHourlyBandwidth2ᚕᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐHourlyBandwidthᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.HourlyBandwidth) graphql.Marshaler {

--- a/graph/generated.go
+++ b/graph/generated.go
@@ -2084,6 +2084,7 @@ type ComplexityRoot struct {
 		PrepareSoulBootstrapPrincipalDeclaration  func(childComplexity int, input model.PrepareSoulBootstrapPrincipalDeclarationInput) int
 		PublishDraft                              func(childComplexity int, id string) int
 		PublishHostedSoul                         func(childComplexity int, input model.PublishHostedSoulInput) int
+		RecoverHostedSoulGenesisTurn              func(childComplexity int, input model.RecoverHostedSoulGenesisTurnInput) int
 		RegisterAccount                           func(childComplexity int, input model.RegisterAccountInput) int
 		RegisterAgent                             func(childComplexity int, input model.RegisterAgentInput) int
 		RegisterPushSubscription                  func(childComplexity int, input model.RegisterPushSubscriptionInput) int
@@ -3715,6 +3716,7 @@ type MutationResolver interface {
 	StartHostedSoulBootstrap(ctx context.Context, input model.StartHostedSoulBootstrapInput) (*model.SoulBootstrapMutationPayload, error)
 	SendHostedSoulGenesisMessage(ctx context.Context, input model.SendHostedSoulGenesisMessageInput) (*model.SoulBootstrapMutationPayload, error)
 	CompleteHostedSoulGenesis(ctx context.Context, input model.CompleteHostedSoulGenesisInput) (*model.SoulBootstrapMutationPayload, error)
+	RecoverHostedSoulGenesisTurn(ctx context.Context, input model.RecoverHostedSoulGenesisTurnInput) (*model.SoulBootstrapMutationPayload, error)
 	PublishHostedSoul(ctx context.Context, input model.PublishHostedSoulInput) (*model.SoulBootstrapMutationPayload, error)
 	RestartSoulBootstrap(ctx context.Context, input model.RestartSoulBootstrapInput) (*model.SoulBootstrapMutationPayload, error)
 	BeginSoulBootstrap(ctx context.Context, input model.BeginSoulBootstrapInput) (*model.SoulBootstrapMutationPayload, error)
@@ -14130,6 +14132,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.PublishHostedSoul(childComplexity, args["input"].(model.PublishHostedSoulInput)), true
 
+	case "Mutation.recoverHostedSoulGenesisTurn":
+		if e.complexity.Mutation.RecoverHostedSoulGenesisTurn == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_recoverHostedSoulGenesisTurn_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.RecoverHostedSoulGenesisTurn(childComplexity, args["input"].(model.RecoverHostedSoulGenesisTurnInput)), true
+
 	case "Mutation.registerAccount":
 		if e.complexity.Mutation.RegisterAccount == nil {
 			break
@@ -22276,6 +22290,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputPushSubscriptionAlertsInput,
 		ec.unmarshalInputPushSubscriptionKeysInput,
 		ec.unmarshalInputReblogFilterInput,
+		ec.unmarshalInputRecoverHostedSoulGenesisTurnInput,
 		ec.unmarshalInputRegisterAccountInput,
 		ec.unmarshalInputRegisterAgentInput,
 		ec.unmarshalInputRegisterPushSubscriptionInput,
@@ -23786,6 +23801,17 @@ func (ec *executionContext) field_Mutation_publishHostedSoul_args(ctx context.Co
 	var err error
 	args := map[string]any{}
 	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNPublishHostedSoulInput2githubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐPublishHostedSoulInput)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_recoverHostedSoulGenesisTurn_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNRecoverHostedSoulGenesisTurnInput2githubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐRecoverHostedSoulGenesisTurnInput)
 	if err != nil {
 		return nil, err
 	}
@@ -100123,6 +100149,69 @@ func (ec *executionContext) fieldContext_Mutation_completeHostedSoulGenesis(ctx 
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_recoverHostedSoulGenesisTurn(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_recoverHostedSoulGenesisTurn(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().RecoverHostedSoulGenesisTurn(rctx, fc.Args["input"].(model.RecoverHostedSoulGenesisTurnInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.SoulBootstrapMutationPayload)
+	fc.Result = res
+	return ec.marshalNSoulBootstrapMutationPayload2ᚖgithubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐSoulBootstrapMutationPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_recoverHostedSoulGenesisTurn(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "bootstrap":
+				return ec.fieldContext_SoulBootstrapMutationPayload_bootstrap(ctx, field)
+			case "executable":
+				return ec.fieldContext_SoulBootstrapMutationPayload_executable(ctx, field)
+			case "error":
+				return ec.fieldContext_SoulBootstrapMutationPayload_error(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SoulBootstrapMutationPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_recoverHostedSoulGenesisTurn_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation_publishHostedSoul(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation_publishHostedSoul(ctx, field)
 	if err != nil {
@@ -154789,6 +154878,68 @@ func (ec *executionContext) unmarshalInputReblogFilterInput(ctx context.Context,
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputRecoverHostedSoulGenesisTurnInput(ctx context.Context, obj any) (model.RecoverHostedSoulGenesisTurnInput, error) {
+	var it model.RecoverHostedSoulGenesisTurnInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"username", "conversationId", "registrationId", "correlationKey", "idempotencyKey", "recoveryAttemptId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "username":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("username"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Username = data
+		case "conversationId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("conversationId"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ConversationID = data
+		case "registrationId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("registrationId"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.RegistrationID = data
+		case "correlationKey":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("correlationKey"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.CorrelationKey = data
+		case "idempotencyKey":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("idempotencyKey"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IdempotencyKey = data
+		case "recoveryAttemptId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("recoveryAttemptId"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.RecoveryAttemptID = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputRegisterAccountInput(ctx context.Context, obj any) (model.RegisterAccountInput, error) {
 	var it model.RegisterAccountInput
 	asMap := map[string]any{}
@@ -172970,6 +173121,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "completeHostedSoulGenesis":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_completeHostedSoulGenesis(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "recoverHostedSoulGenesisTurn":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_recoverHostedSoulGenesisTurn(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -192646,6 +192804,11 @@ func (ec *executionContext) marshalNReconnectionPayload2ᚖgithubᚗcomᚋequalt
 		return graphql.Null
 	}
 	return ec._ReconnectionPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNRecoverHostedSoulGenesisTurnInput2githubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐRecoverHostedSoulGenesisTurnInput(ctx context.Context, v any) (model.RecoverHostedSoulGenesisTurnInput, error) {
+	res, err := ec.unmarshalInputRecoverHostedSoulGenesisTurnInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalNRegisterAccountInput2githubᚗcomᚋequaltoaiᚋlesserᚋgraphᚋmodelᚐRegisterAccountInput(ctx context.Context, v any) (model.RegisterAccountInput, error) {

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -1542,6 +1542,16 @@ type HealthIssue struct {
 	Impact      string        `json:"impact"`
 }
 
+type HostedGenesisConversationSummary struct {
+	ConversationID string  `json:"conversationId"`
+	RegistrationID *string `json:"registrationId,omitempty"`
+	Status         string  `json:"status"`
+	MessageCount   int     `json:"messageCount"`
+	LatestTurnID   *string `json:"latestTurnId,omitempty"`
+	CreatedAt      *Time   `json:"createdAt,omitempty"`
+	UpdatedAt      *Time   `json:"updatedAt,omitempty"`
+}
+
 type HourlyBandwidth struct {
 	Hour     Time    `json:"hour"`
 	TotalGb  float64 `json:"totalGB"`

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -2410,6 +2410,15 @@ type ReconnectionPayload struct {
 	Errors              []string             `json:"errors,omitempty"`
 }
 
+type RecoverHostedSoulGenesisTurnInput struct {
+	Username          string  `json:"username"`
+	ConversationID    string  `json:"conversationId"`
+	RegistrationID    *string `json:"registrationId,omitempty"`
+	CorrelationKey    *string `json:"correlationKey,omitempty"`
+	IdempotencyKey    *string `json:"idempotencyKey,omitempty"`
+	RecoveryAttemptID *string `json:"recoveryAttemptId,omitempty"`
+}
+
 type RegisterAccountInput struct {
 	Username                 string      `json:"username"`
 	Locale                   *string     `json:"locale,omitempty"`

--- a/graph/soul_bootstrap_project51_test.go
+++ b/graph/soul_bootstrap_project51_test.go
@@ -938,3 +938,141 @@ func TestProject51RecoverHostedSoulGenesisTurnRequiresAuth(t *testing.T) {
 	)
 	require.Error(t, err)
 }
+
+func TestProject51ListHostedGenesisConversationsReturnsSummaries(t *testing.T) {
+	resolver, storageRepo := newRound12GraphResolver(t)
+	now := time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC)
+
+	const (
+		agentID        = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		registrationID = "hreg_p51_list"
+	)
+
+	var listCalls int
+	resolver.soulsClient = &stubSoulService{
+		beginHostedBootstrapFunc: func(_ context.Context, input soulservice.BootstrapBeginInput) (*soulservice.BootstrapBeginResult, error) {
+			return &soulservice.BootstrapBeginResult{
+				RegistrationID:     registrationID,
+				HostSoulAgentID:    agentID,
+				AuthorityModel:     soulservice.SoulAuthorityModelInstanceTrust,
+				AnchorState:        soulservice.SoulAnchorStateHostedOffchain,
+				RegistrationStatus: "pending",
+				HostRequestID:      "host-req-p51-list-begin",
+			}, nil
+		},
+		listHostedGenesisConversationsFunc: func(_ context.Context, agentIDArg string) ([]soulservice.HostedGenesisConversationSummary, error) {
+			listCalls++
+			require.Equal(t, agentID, agentIDArg)
+			return []soulservice.HostedGenesisConversationSummary{
+				{
+					ConversationID: "conv_list_001",
+					RegistrationID: registrationID,
+					Status:         "in_progress",
+					MessageCount:   2,
+					LatestTurnID:   "turn_001",
+					CreatedAt:      &now,
+					UpdatedAt:      &now,
+				},
+				{
+					ConversationID: "conv_list_002",
+					RegistrationID: registrationID,
+					Status:         "declaration_ready",
+					MessageCount:   4,
+					LatestTurnID:   "turn_004",
+				},
+			}, nil
+		},
+	}
+
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "owner",
+		DisplayName: "Owner",
+		Approved:    true,
+		CreatedAt:   now.Add(-48 * time.Hour),
+	}, nil)
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "drone-p51-list",
+		DisplayName: "Drone P51 List",
+		Approved:    true,
+		IsAgent:     true,
+		AgentOwner:  "@owner",
+		CreatedAt:   now.Add(-24 * time.Hour),
+	}, &storage.AgentGovernanceState{
+		Username:        "drone-p51-list",
+		DelegatedScopes: []string{auth.ScopeRead, auth.ScopeWrite},
+	})
+
+	started, err := (&mutationResolver{resolver}).StartHostedSoulBootstrap(
+		round13DroneAuthContext("owner", auth.ScopeWrite),
+		model.StartHostedSoulBootstrapInput{Username: "drone-p51-list"},
+	)
+	require.NoError(t, err)
+	require.Nil(t, started.Error)
+
+	summaries, err := (&queryResolver{resolver}).ListHostedGenesisConversations(
+		round13DroneAuthContext("owner", auth.ScopeRead),
+		"drone-p51-list",
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, listCalls)
+	require.Len(t, summaries, 2)
+
+	require.Equal(t, "conv_list_001", summaries[0].ConversationID)
+	require.Equal(t, "in_progress", summaries[0].Status)
+	require.Equal(t, 2, summaries[0].MessageCount)
+	require.NotNil(t, summaries[0].CreatedAt)
+	require.NotNil(t, summaries[0].UpdatedAt)
+
+	require.Equal(t, "conv_list_002", summaries[1].ConversationID)
+	require.Equal(t, "declaration_ready", summaries[1].Status)
+	require.Equal(t, 4, summaries[1].MessageCount)
+}
+
+func TestProject51ListHostedGenesisConversationsReturnsEmptyForNoAgentID(t *testing.T) {
+	resolver, storageRepo := newRound12GraphResolver(t)
+	now := time.Date(2026, 7, 2, 13, 0, 0, 0, time.UTC)
+
+	var listCalls int
+	resolver.soulsClient = &stubSoulService{
+		listHostedGenesisConversationsFunc: func(context.Context, string) ([]soulservice.HostedGenesisConversationSummary, error) {
+			listCalls++
+			return nil, nil
+		},
+	}
+
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "owner",
+		DisplayName: "Owner",
+		Approved:    true,
+		CreatedAt:   now.Add(-48 * time.Hour),
+	}, nil)
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "drone-p51-noagent",
+		DisplayName: "Drone NoAgent",
+		Approved:    true,
+		IsAgent:     true,
+		AgentOwner:  "@owner",
+		CreatedAt:   now.Add(-24 * time.Hour),
+	}, &storage.AgentGovernanceState{
+		Username:        "drone-p51-noagent",
+		DelegatedScopes: []string{auth.ScopeRead, auth.ScopeWrite},
+	})
+
+	summaries, err := (&queryResolver{resolver}).ListHostedGenesisConversations(
+		round13DroneAuthContext("owner", auth.ScopeRead),
+		"drone-p51-noagent",
+	)
+	require.NoError(t, err)
+	require.Empty(t, summaries)
+	require.Equal(t, 0, listCalls, "service must not be called when there is no agent ID")
+}
+
+func TestProject51ListHostedGenesisConversationsRequiresAuth(t *testing.T) {
+	resolver, _ := newRound12GraphResolver(t)
+
+	_, err := (&queryResolver{resolver}).ListHostedGenesisConversations(
+		context.Background(),
+		"drone-p51",
+	)
+	require.Error(t, err)
+}

--- a/graph/soul_bootstrap_project51_test.go
+++ b/graph/soul_bootstrap_project51_test.go
@@ -703,3 +703,238 @@ func TestProject51HostedTranscriptProjectionOmitsUnsafeHostCredentialMaterial(t 
 	require.NotContains(t, string(encoded), "do-not-project")
 	require.NotContains(t, string(encoded), "Bearer ")
 }
+
+func TestProject51RecoverHostedSoulGenesisTurnCallsHostRecoverWithoutUserMessage(t *testing.T) {
+	resolver, storageRepo := newRound12GraphResolver(t)
+	now := time.Date(2026, 7, 2, 10, 0, 0, 0, time.UTC)
+
+	const (
+		agentID        = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		registrationID = "hreg_p51_recover"
+		conversationID = "hconv_p51_recover"
+	)
+
+	var (
+		recoverCalls     int
+		sendMessageCalls int
+	)
+	resolver.soulsClient = &stubSoulService{
+		beginHostedBootstrapFunc: func(_ context.Context, input soulservice.BootstrapBeginInput) (*soulservice.BootstrapBeginResult, error) {
+			return &soulservice.BootstrapBeginResult{
+				RegistrationID:     registrationID,
+				HostSoulAgentID:    agentID,
+				AuthorityModel:     soulservice.SoulAuthorityModelInstanceTrust,
+				AnchorState:        soulservice.SoulAnchorStateHostedOffchain,
+				RegistrationStatus: "pending",
+				HostRequestID:      "host-req-p51-begin",
+			}, nil
+		},
+		sendBootstrapConversationFunc: func(_ context.Context, input soulservice.BootstrapConversationMessageInput) (*soulservice.BootstrapConversationMessageResult, error) {
+			sendMessageCalls++
+			require.Equal(t, "start genesis", input.Message)
+			return &soulservice.BootstrapConversationMessageResult{
+				RegistrationID:  registrationID,
+				HostSoulAgentID: agentID,
+				ConversationID:  conversationID,
+				Status:          "in_progress",
+				MessageCount:    1,
+				HostRequestID:   "host-req-p51-send",
+			}, nil
+		},
+		recoverHostedGenesisTurnFunc: func(_ context.Context, input soulservice.BootstrapConversationRecoverInput) (*soulservice.BootstrapConversationCompleteResult, error) {
+			recoverCalls++
+			require.Equal(t, registrationID, input.RegistrationID)
+			require.Equal(t, conversationID, input.ConversationID)
+			return &soulservice.BootstrapConversationCompleteResult{
+				RegistrationID:  registrationID,
+				HostSoulAgentID: agentID,
+				ConversationID:  conversationID,
+				Status:          "assistant_turn_ready",
+				LatestTurnID:    "turn_recovered",
+				MessageCount:    2,
+				HostRequestID:   "host-req-p51-recover",
+			}, nil
+		},
+	}
+
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "owner",
+		DisplayName: "Owner",
+		Approved:    true,
+		CreatedAt:   now.Add(-48 * time.Hour),
+		UpdatedAt:   now.Add(-24 * time.Hour),
+	}, nil)
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "drone-p51",
+		DisplayName: "Drone P51",
+		Approved:    true,
+		IsAgent:     true,
+		AgentOwner:  "@owner",
+		CreatedAt:   now.Add(-24 * time.Hour),
+		UpdatedAt:   now,
+	}, &storage.AgentGovernanceState{
+		Username:        "drone-p51",
+		DelegatedScopes: []string{auth.ScopeRead, auth.ScopeWrite},
+	})
+
+	started, err := (&mutationResolver{resolver}).StartHostedSoulBootstrap(
+		round13DroneAuthContext("owner", auth.ScopeWrite),
+		model.StartHostedSoulBootstrapInput{Username: "drone-p51"},
+	)
+	require.NoError(t, err)
+	require.Nil(t, started.Error)
+
+	sent, err := (&mutationResolver{resolver}).SendHostedSoulGenesisMessage(
+		round13DroneAuthContext("owner", auth.ScopeWrite),
+		model.SendHostedSoulGenesisMessageInput{
+			Username: "drone-p51",
+			Message:  "start genesis",
+		},
+	)
+	require.NoError(t, err)
+	require.Nil(t, sent.Error)
+	require.Equal(t, conversationID, derefString(sent.Bootstrap.State.HostConversationID))
+	require.Equal(t, 1, sendMessageCalls)
+
+	recovered, err := (&mutationResolver{resolver}).RecoverHostedSoulGenesisTurn(
+		round13DroneAuthContext("owner", auth.ScopeWrite),
+		model.RecoverHostedSoulGenesisTurnInput{
+			Username:       "drone-p51",
+			ConversationID: conversationID,
+		},
+	)
+	require.NoError(t, err)
+	require.Nil(t, recovered.Error)
+	require.Equal(t, 1, recoverCalls)
+	require.Equal(t, 1, sendMessageCalls, "recovery must not send a new user message")
+
+	require.Equal(t, model.SoulBootstrapPhaseConversation, recovered.Bootstrap.State.Phase)
+	require.Equal(t, workflow.SoulBootstrapStateConversationAssistantTurnReady, recovered.Bootstrap.State.State)
+	require.Equal(t, model.SoulBootstrapNextActionCompleteHostedSoulGenesis, recovered.Bootstrap.TypedNextAction)
+	require.Equal(t, "assistant_turn_ready", derefString(recovered.Bootstrap.State.HostConversationStatus))
+	require.Equal(t, 2, recovered.Bootstrap.State.HostedGenesisConversation.MessageCount)
+	require.Equal(t, "host-req-p51-recover", derefString(recovered.Bootstrap.State.LastHostRequestID))
+}
+
+func TestProject51RecoverHostedSoulGenesisTurnIsIdempotentForNonStuckSession(t *testing.T) {
+	resolver, storageRepo := newRound12GraphResolver(t)
+	now := time.Date(2026, 7, 2, 11, 0, 0, 0, time.UTC)
+
+	const (
+		agentID        = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		registrationID = "hreg_p51_idem"
+		conversationID = "hconv_p51_idem"
+	)
+
+	var recoverCalls int
+	resolver.soulsClient = &stubSoulService{
+		beginHostedBootstrapFunc: func(_ context.Context, input soulservice.BootstrapBeginInput) (*soulservice.BootstrapBeginResult, error) {
+			return &soulservice.BootstrapBeginResult{
+				RegistrationID:     registrationID,
+				HostSoulAgentID:    agentID,
+				AuthorityModel:     soulservice.SoulAuthorityModelInstanceTrust,
+				AnchorState:        soulservice.SoulAnchorStateHostedOffchain,
+				RegistrationStatus: "pending",
+				HostRequestID:      "host-req-p51-idem-begin",
+			}, nil
+		},
+		sendBootstrapConversationFunc: func(_ context.Context, input soulservice.BootstrapConversationMessageInput) (*soulservice.BootstrapConversationMessageResult, error) {
+			return &soulservice.BootstrapConversationMessageResult{
+				RegistrationID:  registrationID,
+				HostSoulAgentID: agentID,
+				ConversationID:  conversationID,
+				Status:          "in_progress",
+				MessageCount:    1,
+				HostRequestID:   "host-req-p51-idem-send",
+			}, nil
+		},
+		recoverHostedGenesisTurnFunc: func(_ context.Context, input soulservice.BootstrapConversationRecoverInput) (*soulservice.BootstrapConversationCompleteResult, error) {
+			recoverCalls++
+			return &soulservice.BootstrapConversationCompleteResult{
+				RegistrationID:  registrationID,
+				HostSoulAgentID: agentID,
+				ConversationID:  conversationID,
+				Status:          "in_progress",
+				LatestTurnID:    "turn_user_001",
+				MessageCount:    1,
+				HostRequestID:   "host-req-p51-idem-recover",
+			}, nil
+		},
+	}
+
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "owner",
+		DisplayName: "Owner",
+		Approved:    true,
+		CreatedAt:   now.Add(-48 * time.Hour),
+	}, nil)
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "drone-p51-idem",
+		DisplayName: "Drone P51 Idem",
+		Approved:    true,
+		IsAgent:     true,
+		AgentOwner:  "@owner",
+		CreatedAt:   now.Add(-24 * time.Hour),
+	}, &storage.AgentGovernanceState{
+		Username:        "drone-p51-idem",
+		DelegatedScopes: []string{auth.ScopeRead, auth.ScopeWrite},
+	})
+
+	started, err := (&mutationResolver{resolver}).StartHostedSoulBootstrap(
+		round13DroneAuthContext("owner", auth.ScopeWrite),
+		model.StartHostedSoulBootstrapInput{Username: "drone-p51-idem"},
+	)
+	require.NoError(t, err)
+	require.Nil(t, started.Error)
+
+	sent, err := (&mutationResolver{resolver}).SendHostedSoulGenesisMessage(
+		round13DroneAuthContext("owner", auth.ScopeWrite),
+		model.SendHostedSoulGenesisMessageInput{
+			Username: "drone-p51-idem",
+			Message:  "start genesis",
+		},
+	)
+	require.NoError(t, err)
+	require.Nil(t, sent.Error)
+
+	recovered, err := (&mutationResolver{resolver}).RecoverHostedSoulGenesisTurn(
+		round13DroneAuthContext("owner", auth.ScopeWrite),
+		model.RecoverHostedSoulGenesisTurnInput{
+			Username:       "drone-p51-idem",
+			ConversationID: conversationID,
+		},
+	)
+	require.NoError(t, err)
+	require.Nil(t, recovered.Error)
+	require.Equal(t, 1, recoverCalls)
+	require.Equal(t, model.SoulBootstrapPhaseConversation, recovered.Bootstrap.State.Phase)
+	require.Equal(t, workflow.SoulBootstrapStateConversationInProgress, recovered.Bootstrap.State.State)
+	require.Equal(t, "in_progress", derefString(recovered.Bootstrap.State.HostConversationStatus))
+	require.Equal(t, 1, recovered.Bootstrap.State.HostedGenesisConversation.MessageCount)
+}
+
+func TestProject51RecoverHostedSoulGenesisTurnRequiresWriteScope(t *testing.T) {
+	resolver, _ := newRound12GraphResolver(t)
+
+	_, err := (&mutationResolver{resolver}).RecoverHostedSoulGenesisTurn(
+		round13DroneAuthContext("owner", auth.ScopeRead),
+		model.RecoverHostedSoulGenesisTurnInput{
+			Username:       "drone-p51",
+			ConversationID: "conv_001",
+		},
+	)
+	require.Error(t, err)
+}
+
+func TestProject51RecoverHostedSoulGenesisTurnRequiresAuth(t *testing.T) {
+	resolver, _ := newRound12GraphResolver(t)
+
+	_, err := (&mutationResolver{resolver}).RecoverHostedSoulGenesisTurn(
+		context.Background(),
+		model.RecoverHostedSoulGenesisTurnInput{
+			Username:       "drone-p51",
+			ConversationID: "conv_001",
+		},
+	)
+	require.Error(t, err)
+}

--- a/graph/soul_bootstrap_resolvers.go
+++ b/graph/soul_bootstrap_resolvers.go
@@ -145,6 +145,43 @@ func (r *mutationResolver) CompleteHostedSoulGenesis(ctx context.Context, input 
 	})
 }
 
+func (r *mutationResolver) RecoverHostedSoulGenesisTurn(ctx context.Context, input model.RecoverHostedSoulGenesisTurnInput) (*model.SoulBootstrapMutationPayload, error) {
+	correlation := graphHostedBootstrapCorrelation(
+		input.CorrelationKey,
+		input.IdempotencyKey,
+		soulBootstrapCorrelationOpConversation,
+		input.RecoveryAttemptID,
+	)
+	return r.executeSoulBootstrapReviewMutation(ctx, input.Username, func(
+		ctx context.Context,
+		agentUser *storage.User,
+		_ *storage.AgentGovernanceState,
+		service soulBootstrapHostService,
+		existing *workflow.SoulBootstrapState,
+		now time.Time,
+	) (*workflow.SoulBootstrapState, error) {
+		registrationID, err := soulBootstrapRegistrationID(existing, input.RegistrationID)
+		if err != nil {
+			return soulBootstrapErrorState(agentUser, existing, correlation, err, now), nil
+		}
+		conversationID, err := soulBootstrapRequiredConversationID(existing, input.ConversationID)
+		if err != nil {
+			return soulBootstrapErrorState(agentUser, existing, correlation, err, now), nil
+		}
+		result, err := service.RecoverHostedGenesisTurn(ctx, soulservice.BootstrapConversationRecoverInput{
+			RegistrationID:  registrationID,
+			ConversationID:  conversationID,
+			CorrelationID:   derefString(input.CorrelationKey),
+			IdempotencyKey:  derefString(input.IdempotencyKey),
+			LesserRequestID: "",
+		})
+		if err != nil {
+			return soulBootstrapErrorState(agentUser, existing, correlation, err, now), nil
+		}
+		return soulBootstrapStateAfterHostedConversationSnapshot(agentUser, existing, correlation, result, now), nil
+	})
+}
+
 func (r *mutationResolver) PublishHostedSoul(ctx context.Context, input model.PublishHostedSoulInput) (*model.SoulBootstrapMutationPayload, error) {
 	correlation := graphHostedBootstrapCorrelation(
 		input.CorrelationKey,
@@ -495,6 +532,7 @@ type soulBootstrapHostService interface {
 	VerifyBootstrapPrincipalDeclaration(context.Context, soulservice.BootstrapPrincipalVerifyInput) (*soulservice.BootstrapPrincipalVerifyResult, error)
 	SendBootstrapConversationMessage(context.Context, soulservice.BootstrapConversationMessageInput) (*soulservice.BootstrapConversationMessageResult, error)
 	CompleteBootstrapConversation(context.Context, soulservice.BootstrapConversationCompleteInput) (*soulservice.BootstrapConversationCompleteResult, error)
+	RecoverHostedGenesisTurn(context.Context, soulservice.BootstrapConversationRecoverInput) (*soulservice.BootstrapConversationCompleteResult, error)
 	ReadBootstrapConversation(context.Context, soulservice.BootstrapConversationCompleteInput) (*soulservice.BootstrapConversationCompleteResult, error)
 	PrepareBootstrapFinalize(context.Context, soulservice.BootstrapFinalizePreflightInput) (*soulservice.BootstrapFinalizePreflightResult, error)
 	FinalizeBootstrap(context.Context, soulservice.BootstrapFinalizeInput) (*soulservice.BootstrapFinalizeResult, error)

--- a/graph/soul_bootstrap_resolvers.go
+++ b/graph/soul_bootstrap_resolvers.go
@@ -59,6 +59,60 @@ func (r *queryResolver) SoulBootstrap(ctx context.Context, username string) (*mo
 	return r.buildSoulBootstrapSurface(ctx, claims.Username, agentUser, governance, nil)
 }
 
+func (r *queryResolver) ListHostedGenesisConversations(ctx context.Context, username string) ([]*model.HostedGenesisConversationSummary, error) {
+	claims, err := r.requireAuthClaims(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireDroneReadScope(claims); err != nil {
+		return nil, err
+	}
+
+	agentUser, _, err := r.loadDroneAgent(ctx, username)
+	if err != nil {
+		return nil, err
+	}
+	workflowState, err := r.loadDroneWorkflowState(agentUser)
+	if err != nil {
+		return nil, apperrors.InternalWithCause(err, "failed to decode drone workflow metadata")
+	}
+	if !r.canAccessDroneReviewWorkflow(ctx, claims, agentUser, workflowState) {
+		return nil, apperrors.Forbidden("not authorized to view soul bootstrap")
+	}
+
+	agentID := ""
+	if workflowState != nil && workflowState.SoulBootstrap != nil {
+		agentID = strings.TrimSpace(workflowState.SoulBootstrap.HostSoulAgentID)
+	}
+	if agentID == "" {
+		return []*model.HostedGenesisConversationSummary{}, nil
+	}
+
+	service, err := r.soulBootstrapService()
+	if err != nil {
+		return nil, apperrors.InternalWithCause(err, "failed to initialize soul bootstrap service")
+	}
+
+	summaries, err := service.ListHostedGenesisConversations(ctx, agentID)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]*model.HostedGenesisConversationSummary, 0, len(summaries))
+	for _, summary := range summaries {
+		out = append(out, &model.HostedGenesisConversationSummary{
+			ConversationID: summary.ConversationID,
+			RegistrationID: optionalString(summary.RegistrationID),
+			Status:         summary.Status,
+			MessageCount:   summary.MessageCount,
+			LatestTurnID:   optionalString(summary.LatestTurnID),
+			CreatedAt:      graphTimePtr(summary.CreatedAt),
+			UpdatedAt:      graphTimePtr(summary.UpdatedAt),
+		})
+	}
+	return out, nil
+}
+
 func (r *mutationResolver) StartHostedSoulBootstrap(ctx context.Context, input model.StartHostedSoulBootstrapInput) (*model.SoulBootstrapMutationPayload, error) {
 	correlation := graphHostedBootstrapCorrelation(
 		input.CorrelationKey,
@@ -534,6 +588,7 @@ type soulBootstrapHostService interface {
 	CompleteBootstrapConversation(context.Context, soulservice.BootstrapConversationCompleteInput) (*soulservice.BootstrapConversationCompleteResult, error)
 	RecoverHostedGenesisTurn(context.Context, soulservice.BootstrapConversationRecoverInput) (*soulservice.BootstrapConversationCompleteResult, error)
 	ReadBootstrapConversation(context.Context, soulservice.BootstrapConversationCompleteInput) (*soulservice.BootstrapConversationCompleteResult, error)
+	ListHostedGenesisConversations(context.Context, string) ([]soulservice.HostedGenesisConversationSummary, error)
 	PrepareBootstrapFinalize(context.Context, soulservice.BootstrapFinalizePreflightInput) (*soulservice.BootstrapFinalizePreflightResult, error)
 	FinalizeBootstrap(context.Context, soulservice.BootstrapFinalizeInput) (*soulservice.BootstrapFinalizeResult, error)
 	PublishHostedBootstrap(context.Context, soulservice.HostedBootstrapPublishInput) (*soulservice.BootstrapFinalizeResult, error)

--- a/graph/souls_round12_test.go
+++ b/graph/souls_round12_test.go
@@ -27,6 +27,7 @@ type stubSoulService struct {
 	completeBootstrapConversationFunc func(context.Context, soulservice.BootstrapConversationCompleteInput) (*soulservice.BootstrapConversationCompleteResult, error)
 	recoverHostedGenesisTurnFunc     func(context.Context, soulservice.BootstrapConversationRecoverInput) (*soulservice.BootstrapConversationCompleteResult, error)
 	readBootstrapConversationFunc     func(context.Context, soulservice.BootstrapConversationCompleteInput) (*soulservice.BootstrapConversationCompleteResult, error)
+	listHostedGenesisConversationsFunc func(context.Context, string) ([]soulservice.HostedGenesisConversationSummary, error)
 	prepareBootstrapFinalizeFunc      func(context.Context, soulservice.BootstrapFinalizePreflightInput) (*soulservice.BootstrapFinalizePreflightResult, error)
 	finalizeBootstrapFunc             func(context.Context, soulservice.BootstrapFinalizeInput) (*soulservice.BootstrapFinalizeResult, error)
 	publishHostedBootstrapFunc        func(context.Context, soulservice.HostedBootstrapPublishInput) (*soulservice.BootstrapFinalizeResult, error)
@@ -114,6 +115,13 @@ func (s *stubSoulService) ReadBootstrapConversation(ctx context.Context, input s
 		return nil, errors.New("read bootstrap conversation not implemented")
 	}
 	return s.readBootstrapConversationFunc(ctx, input)
+}
+
+func (s *stubSoulService) ListHostedGenesisConversations(ctx context.Context, agentID string) ([]soulservice.HostedGenesisConversationSummary, error) {
+	if s.listHostedGenesisConversationsFunc == nil {
+		return nil, errors.New("list hosted genesis conversations not implemented")
+	}
+	return s.listHostedGenesisConversationsFunc(ctx, agentID)
 }
 
 func (s *stubSoulService) PrepareBootstrapFinalize(ctx context.Context, input soulservice.BootstrapFinalizePreflightInput) (*soulservice.BootstrapFinalizePreflightResult, error) {

--- a/graph/souls_round12_test.go
+++ b/graph/souls_round12_test.go
@@ -25,6 +25,7 @@ type stubSoulService struct {
 	verifyBootstrapPrincipalFunc      func(context.Context, soulservice.BootstrapPrincipalVerifyInput) (*soulservice.BootstrapPrincipalVerifyResult, error)
 	sendBootstrapConversationFunc     func(context.Context, soulservice.BootstrapConversationMessageInput) (*soulservice.BootstrapConversationMessageResult, error)
 	completeBootstrapConversationFunc func(context.Context, soulservice.BootstrapConversationCompleteInput) (*soulservice.BootstrapConversationCompleteResult, error)
+	recoverHostedGenesisTurnFunc     func(context.Context, soulservice.BootstrapConversationRecoverInput) (*soulservice.BootstrapConversationCompleteResult, error)
 	readBootstrapConversationFunc     func(context.Context, soulservice.BootstrapConversationCompleteInput) (*soulservice.BootstrapConversationCompleteResult, error)
 	prepareBootstrapFinalizeFunc      func(context.Context, soulservice.BootstrapFinalizePreflightInput) (*soulservice.BootstrapFinalizePreflightResult, error)
 	finalizeBootstrapFunc             func(context.Context, soulservice.BootstrapFinalizeInput) (*soulservice.BootstrapFinalizeResult, error)
@@ -99,6 +100,13 @@ func (s *stubSoulService) CompleteBootstrapConversation(ctx context.Context, inp
 		return nil, errors.New("complete bootstrap conversation not implemented")
 	}
 	return s.completeBootstrapConversationFunc(ctx, input)
+}
+
+func (s *stubSoulService) RecoverHostedGenesisTurn(ctx context.Context, input soulservice.BootstrapConversationRecoverInput) (*soulservice.BootstrapConversationCompleteResult, error) {
+	if s.recoverHostedGenesisTurnFunc == nil {
+		return nil, errors.New("recover hosted genesis turn not implemented")
+	}
+	return s.recoverHostedGenesisTurnFunc(ctx, input)
 }
 
 func (s *stubSoulService) ReadBootstrapConversation(ctx context.Context, input soulservice.BootstrapConversationCompleteInput) (*soulservice.BootstrapConversationCompleteResult, error) {

--- a/pkg/services/souls/bootstrap.go
+++ b/pkg/services/souls/bootstrap.go
@@ -707,11 +707,6 @@ func (s *Service) RecoverHostedGenesisTurn(ctx context.Context, input BootstrapC
 
 // ListHostedGenesisConversations calls Host's GET mint-conversations list
 // endpoint to return bounded conversation summaries for a given agent.
-//
-// TODO(host-dependency): Host's GET /api/v1/soul/instance/agents/{agentId}/
-// mint-conversations endpoint does not exist yet. It needs to be implemented on
-// lesser-host as a separate issue/PR. This Lesser service method is written to
-// call the expected endpoint shape and is tested with mocked Host responses.
 func (s *Service) ListHostedGenesisConversations(ctx context.Context, agentID string) ([]HostedGenesisConversationSummary, error) {
 	baseURL, _, instanceKey, err := s.hostBootstrapInputs(ctx)
 	if err != nil {

--- a/pkg/services/souls/bootstrap.go
+++ b/pkg/services/souls/bootstrap.go
@@ -212,6 +212,16 @@ type BootstrapConversationCompleteInput struct {
 	ConversationID string
 }
 
+// BootstrapConversationRecoverInput is the Lesser-local request for recovering a
+// stuck Host mint conversation turn without sending a new user message.
+type BootstrapConversationRecoverInput struct {
+	RegistrationID  string
+	ConversationID  string
+	CorrelationID   string
+	IdempotencyKey  string
+	LesserRequestID string
+}
+
 // BootstrapConversationCompleteResult contains Host completion state.
 type BootstrapConversationCompleteResult struct {
 	RegistrationID        string
@@ -604,6 +614,63 @@ func (s *Service) CompleteBootstrapConversation(ctx context.Context, input Boots
 	if version != "" && version != hostBootstrapVersion1 {
 		return nil, unsupportedHostConversationVersionError(
 			"Host conversation response",
+			requestID,
+			out.RequestID,
+		)
+	}
+	if err := validateHostConversationSnapshot(out, registrationID, true, requestID); err != nil {
+		return nil, err
+	}
+	result := bootstrapConversationCompleteResultFromHost(registrationID, out, hostConversationRequestID(requestID, out.RequestID))
+	if isHostedBootstrapTerminalDeclarationStatus(result.Status) {
+		if err := ValidateHostedBootstrapCompletionEvidence(result, conversationID); err != nil {
+			return nil, err
+		}
+		if compact, err := compactHostedBootstrapProducedDeclarations(result.ProducedDeclarations, result.HostRequestID); err == nil {
+			result.ProducedDeclarations = compact
+		}
+	}
+	return result, nil
+}
+
+// RecoverHostedGenesisTurn calls Host's POST /recover endpoint to re-run the
+// assistant turn for a stuck mint conversation without sending a new user
+// message. If the session is not stuck, Host returns the current conversation
+// state (idempotent). The response uses the same hostedGenesisConversationResponse
+// envelope as the GET conversation read route.
+func (s *Service) RecoverHostedGenesisTurn(ctx context.Context, input BootstrapConversationRecoverInput) (*BootstrapConversationCompleteResult, error) {
+	baseURL, _, instanceKey, err := s.hostBootstrapInputs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	registrationID, conversationID, err := requireBootstrapRegistrationConversation(input.RegistrationID, input.ConversationID)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := map[string]any{}
+	if correlationID := strings.TrimSpace(input.CorrelationID); correlationID != "" {
+		payload["correlation_id"] = correlationID
+	}
+	if idempotencyKey := strings.TrimSpace(input.IdempotencyKey); idempotencyKey != "" {
+		payload["idempotency_key"] = idempotencyKey
+	}
+	if lesserRequestID := strings.TrimSpace(input.LesserRequestID); lesserRequestID != "" {
+		payload["lesser_request_id"] = lesserRequestID
+	}
+
+	var raw json.RawMessage
+	requestID, err := s.doHostBootstrapJSON(ctx, http.MethodPost, baseURL, "/api/v1/soul/instance/agents/register/"+url.PathEscape(registrationID)+"/mint-conversation/"+url.PathEscape(conversationID)+"/recover", instanceKey, payload, http.StatusOK, http.StatusAccepted, &raw)
+	if err != nil {
+		return nil, err
+	}
+	out, version, err := parseHostConversationResponseEnvelope(raw, requestID)
+	if err != nil {
+		return nil, err
+	}
+	if version != "" && version != hostBootstrapVersion1 {
+		return nil, unsupportedHostConversationVersionError(
+			"Host conversation recovery response",
 			requestID,
 			out.RequestID,
 		)

--- a/pkg/services/souls/bootstrap.go
+++ b/pkg/services/souls/bootstrap.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -25,6 +26,7 @@ const (
 	hostConversationStatusDeclarationReady = "declaration_ready"
 	hostConversationMessageRoleUser        = "user"
 	hostConversationMessageRoleAssistant   = "assistant"
+	hostedGenesisConversationListMaxResults = 50
 
 	// SoulAuthorityModelWalletPrincipal is Host's wallet/principal authority model.
 	SoulAuthorityModelWalletPrincipal = "wallet_principal"
@@ -203,6 +205,19 @@ type BootstrapConversationMessage struct {
 	Order     int
 	CreatedAt *time.Time
 	Truncated bool
+}
+
+// HostedGenesisConversationSummary is a bounded summary of one Host mint
+// conversation for the genesis conversation list query. It carries no
+// transcript messages, signing material, or Host credentials.
+type HostedGenesisConversationSummary struct {
+	ConversationID  string
+	RegistrationID  string
+	Status          string
+	MessageCount    int
+	LatestTurnID    string
+	CreatedAt       *time.Time
+	UpdatedAt       *time.Time
 }
 
 // BootstrapConversationCompleteInput is the Lesser-local request for completing
@@ -688,6 +703,67 @@ func (s *Service) RecoverHostedGenesisTurn(ctx context.Context, input BootstrapC
 		}
 	}
 	return result, nil
+}
+
+// ListHostedGenesisConversations calls Host's GET mint-conversations list
+// endpoint to return bounded conversation summaries for a given agent.
+//
+// TODO(host-dependency): Host's GET /api/v1/soul/instance/agents/{agentId}/
+// mint-conversations endpoint does not exist yet. It needs to be implemented on
+// lesser-host as a separate issue/PR. This Lesser service method is written to
+// call the expected endpoint shape and is tested with mocked Host responses.
+func (s *Service) ListHostedGenesisConversations(ctx context.Context, agentID string) ([]HostedGenesisConversationSummary, error) {
+	baseURL, _, instanceKey, err := s.hostBootstrapInputs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return nil, &HostBootstrapError{Code: "HOST_AGENT_ID_REQUIRED", Message: "agent id is required", Source: "lesser", Err: ErrHostSigningPayloadUnsupported}
+	}
+
+	var raw json.RawMessage
+	_, err = s.doHostBootstrapJSON(ctx, http.MethodGet, baseURL, "/api/v1/soul/instance/agents/"+url.PathEscape(agentID)+"/mint-conversations", instanceKey, nil, http.StatusOK, &raw)
+	if err != nil {
+		return nil, err
+	}
+
+	var listResp hostMintConversationsListResponse
+	if err := json.Unmarshal(raw, &listResp); err != nil {
+		return nil, &HostBootstrapError{Code: "HOST_RESPONSE_INVALID", Message: "Host conversation list response is invalid.", Source: "host", Err: fmt.Errorf("%w: %v", ErrHostUnavailable, err)}
+	}
+
+	summaries := make([]HostedGenesisConversationSummary, 0, len(listResp.Conversations))
+	for _, conv := range listResp.Conversations {
+		summaries = append(summaries, HostedGenesisConversationSummary{
+			ConversationID:  strings.TrimSpace(conv.ConversationID),
+			RegistrationID:  strings.TrimSpace(conv.RegistrationID),
+			Status:          NormalizeHostedBootstrapConversationStatus(conv.Status),
+			MessageCount:    conv.MessageCount,
+			LatestTurnID:    strings.TrimSpace(conv.LatestTurnID),
+			CreatedAt:       parseHostTimePtr(conv.CreatedAt),
+			UpdatedAt:       parseHostTimePtr(conv.UpdatedAt),
+		})
+	}
+
+	sort.Slice(summaries, func(i, j int) bool {
+		if summaries[i].UpdatedAt == nil && summaries[j].UpdatedAt == nil {
+			return summaries[i].ConversationID < summaries[j].ConversationID
+		}
+		if summaries[i].UpdatedAt == nil {
+			return false
+		}
+		if summaries[j].UpdatedAt == nil {
+			return true
+		}
+		return summaries[i].UpdatedAt.After(*summaries[j].UpdatedAt)
+	})
+
+	if len(summaries) > hostedGenesisConversationListMaxResults {
+		summaries = summaries[:hostedGenesisConversationListMaxResults]
+	}
+
+	return summaries, nil
 }
 
 // ReadBootstrapConversation reads Host's private instance mint-conversation
@@ -2059,6 +2135,20 @@ type hostMintConversationReadResponse struct {
 	Version         string          `json:"version"`
 	RequestID       string          `json:"request_id"`
 	ConversationRaw json.RawMessage `json:"conversation"`
+}
+
+type hostMintConversationsListResponse struct {
+	Conversations []hostMintConversationSummary `json:"conversations"`
+}
+
+type hostMintConversationSummary struct {
+	ConversationID string `json:"conversation_id"`
+	RegistrationID string `json:"registration_id"`
+	Status         string `json:"status"`
+	MessageCount   int    `json:"message_count"`
+	LatestTurnID   string `json:"latest_turn_id"`
+	CreatedAt      string `json:"created_at"`
+	UpdatedAt      string `json:"updated_at"`
 }
 
 type hostConversationFailure struct {

--- a/pkg/services/souls/bootstrap_list_test.go
+++ b/pkg/services/souls/bootstrap_list_test.go
@@ -234,3 +234,184 @@ func TestService_ListHostedGenesisConversationsHandlesEmptyResponse(t *testing.T
 	require.NoError(t, err)
 	require.Empty(t, result)
 }
+
+func TestService_ListHostedGenesisConversationsHostHTTPErrorReturnsTypedError(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey = "host-instance-key"
+		agentID     = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-Id", "host-req-list-forbidden")
+		w.WriteHeader(http.StatusForbidden)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"code":        "soul_instance.boundary_violation",
+				"message":     "instance boundary violation",
+				"status_code": 403,
+				"request_id":  "host-req-list-forbidden",
+			},
+		}))
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	_, err := service.ListHostedGenesisConversations(context.Background(), agentID)
+	var hostErr *HostBootstrapError
+	require.ErrorAs(t, err, &hostErr)
+	require.Equal(t, "soul_instance.boundary_violation", hostErr.Code)
+	require.Equal(t, http.StatusForbidden, hostErr.StatusCode)
+}
+
+func TestService_ListHostedGenesisConversationsInvalidJSONReturnsTypedError(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey = "host-instance-key"
+		agentID     = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-Id", "host-req-list-bad-json")
+		w.WriteHeader(http.StatusOK)
+		// Valid JSON but conversations is a string, not an array —
+		// json.Unmarshal into hostMintConversationsListResponse will fail.
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"conversations": "not-an-array",
+		}))
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	_, err := service.ListHostedGenesisConversations(context.Background(), agentID)
+	var hostErr *HostBootstrapError
+	require.ErrorAs(t, err, &hostErr)
+	require.Equal(t, "HOST_RESPONSE_INVALID", hostErr.Code)
+}
+
+func TestService_ListHostedGenesisConversationsMisconfiguredServiceReturnsError(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{}
+	_, err := service.ListHostedGenesisConversations(context.Background(), "0xabc")
+	require.Error(t, err)
+}
+
+func TestService_ListHostedGenesisConversationsSortsMultipleNilUpdatedAtEntries(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey = "host-instance-key"
+		agentID     = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Two entries with nil UpdatedAt — exercises the both-nil tie-break branch.
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"conversations": []map[string]any{
+				{
+					"conversation_id": "conv_no_updated_b",
+					"status":          "in_progress",
+					"message_count":   1,
+				},
+				{
+					"conversation_id": "conv_no_updated_a",
+					"status":          "in_progress",
+					"message_count":   1,
+				},
+			},
+		}))
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	result, err := service.ListHostedGenesisConversations(context.Background(), agentID)
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	// Both have nil UpdatedAt — tie-break by conversation_id ascending.
+	require.Equal(t, "conv_no_updated_a", result[0].ConversationID)
+	require.Equal(t, "conv_no_updated_b", result[1].ConversationID)
+	require.Nil(t, result[0].UpdatedAt)
+	require.Nil(t, result[1].UpdatedAt)
+}
+
+func TestService_ListHostedGenesisConversationsSortsNonNilBeforeNilUpdatedAt(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey = "host-instance-key"
+		agentID     = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Three entries: first nil, then two non-nil — Go's insertion sort
+		// calls less(j, j-1) which triggers the summaries[j].UpdatedAt == nil
+		// branch when comparing a non-nil entry against a preceding nil entry.
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"conversations": []map[string]any{
+				{
+					"conversation_id": "conv_no_time_first",
+					"status":          "in_progress",
+					"message_count":   1,
+				},
+				{
+					"conversation_id": "conv_with_time_a",
+					"status":          "in_progress",
+					"message_count":   2,
+					"updated_at":      "2026-07-01T10:00:00Z",
+				},
+				{
+					"conversation_id": "conv_with_time_b",
+					"status":          "declaration_ready",
+					"message_count":   3,
+					"updated_at":      "2026-07-01T12:00:00Z",
+				},
+			},
+		}))
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	result, err := service.ListHostedGenesisConversations(context.Background(), agentID)
+	require.NoError(t, err)
+	require.Len(t, result, 3)
+	// Non-nil UpdatedAt entries sort before nil; among non-nil, newer first.
+	require.Equal(t, "conv_with_time_b", result[0].ConversationID)
+	require.Equal(t, "conv_with_time_a", result[1].ConversationID)
+	require.Equal(t, "conv_no_time_first", result[2].ConversationID)
+	require.NotNil(t, result[0].UpdatedAt)
+	require.NotNil(t, result[1].UpdatedAt)
+	require.Nil(t, result[2].UpdatedAt)
+}

--- a/pkg/services/souls/bootstrap_list_test.go
+++ b/pkg/services/souls/bootstrap_list_test.go
@@ -1,0 +1,236 @@
+package souls
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/config"
+	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestService_ListHostedGenesisConversationsCallsHostListEndpoint(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey = "host-instance-key"
+		agentID     = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	var (
+		sawMethod string
+		sawPath   string
+		sawAuth   string
+	)
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawMethod = r.Method
+		sawPath = r.URL.Path
+		sawAuth = r.Header.Get("Authorization")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-Id", "host-req-list-001")
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"conversations": []map[string]any{
+				{
+					"conversation_id": "conv_001",
+					"registration_id": "reg_001",
+					"status":          "in_progress",
+					"message_count":   2,
+					"latest_turn_id":  "turn_001",
+					"created_at":      "2026-07-01T10:00:00Z",
+					"updated_at":      "2026-07-01T11:00:00Z",
+				},
+				{
+					"conversation_id": "conv_002",
+					"registration_id": "reg_001",
+					"status":          "declaration_ready",
+					"message_count":   4,
+					"latest_turn_id":  "turn_004",
+					"created_at":      "2026-07-01T12:00:00Z",
+					"updated_at":      "2026-07-01T13:00:00Z",
+				},
+			},
+		}))
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	result, err := service.ListHostedGenesisConversations(context.Background(), agentID)
+	require.NoError(t, err)
+
+	require.Equal(t, http.MethodGet, sawMethod)
+	require.Equal(t, "/api/v1/soul/instance/agents/"+agentID+"/mint-conversations", sawPath)
+	require.Equal(t, "Bearer "+instanceKey, sawAuth)
+
+	require.Len(t, result, 2)
+	// Sorted by updated_at descending — conv_002 has the later updated_at.
+	require.Equal(t, "conv_002", result[0].ConversationID)
+	require.Equal(t, "declaration_ready", result[0].Status)
+	require.Equal(t, 4, result[0].MessageCount)
+	require.Equal(t, "turn_004", result[0].LatestTurnID)
+	require.NotNil(t, result[0].CreatedAt)
+	require.NotNil(t, result[0].UpdatedAt)
+
+	require.Equal(t, "conv_001", result[1].ConversationID)
+	require.Equal(t, "in_progress", result[1].Status)
+	require.Equal(t, 2, result[1].MessageCount)
+}
+
+func TestService_ListHostedGenesisConversationsSortedByUpdatedAtDescending(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey = "host-instance-key"
+		agentID     = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"conversations": []map[string]any{
+				{
+					"conversation_id": "conv_old",
+					"status":          "in_progress",
+					"message_count":   1,
+					"updated_at":      "2026-06-01T10:00:00Z",
+				},
+				{
+					"conversation_id": "conv_newest",
+					"status":          "declaration_ready",
+					"message_count":   3,
+					"updated_at":      "2026-07-02T14:00:00Z",
+				},
+				{
+					"conversation_id": "conv_mid",
+					"status":          "assistant_turn_ready",
+					"message_count":   2,
+					"updated_at":      "2026-06-15T12:00:00Z",
+				},
+				{
+					"conversation_id": "conv_no_updated",
+					"status":          "in_progress",
+					"message_count":   1,
+				},
+			},
+		}))
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	result, err := service.ListHostedGenesisConversations(context.Background(), agentID)
+	require.NoError(t, err)
+	require.Len(t, result, 4)
+
+	// Sorted by updated_at descending; nil updated_at entries go last.
+	require.Equal(t, "conv_newest", result[0].ConversationID)
+	require.Equal(t, "conv_mid", result[1].ConversationID)
+	require.Equal(t, "conv_old", result[2].ConversationID)
+	require.Equal(t, "conv_no_updated", result[3].ConversationID)
+	require.Nil(t, result[3].UpdatedAt)
+}
+
+func TestService_ListHostedGenesisConversationsBoundedTo50(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey = "host-instance-key"
+		agentID     = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		conversations := make([]map[string]any, 0, 60)
+		for i := 0; i < 60; i++ {
+			conversations = append(conversations, map[string]any{
+				"conversation_id": "conv_" + string(rune('a'+i)),
+				"status":          "in_progress",
+				"message_count":   i + 1,
+				"updated_at":      time.Date(2026, 7, 1, 0, i, 0, 0, time.UTC).Format(time.RFC3339),
+			})
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"conversations": conversations,
+		}))
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	result, err := service.ListHostedGenesisConversations(context.Background(), agentID)
+	require.NoError(t, err)
+	require.Len(t, result, 50, "list must be bounded to 50 results")
+	// The most recent 50 should be kept (sorted by updated_at descending).
+	require.Equal(t, 60, result[0].MessageCount)
+	require.Equal(t, 11, result[49].MessageCount)
+}
+
+func TestService_ListHostedGenesisConversationsRequiresAgentID(t *testing.T) {
+	t.Parallel()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: "https://host.example"}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: "key"},
+		zap.NewNop(),
+	)
+
+	_, err := service.ListHostedGenesisConversations(context.Background(), "")
+	var hostErr *HostBootstrapError
+	require.ErrorAs(t, err, &hostErr)
+	require.Equal(t, "HOST_AGENT_ID_REQUIRED", hostErr.Code)
+}
+
+func TestService_ListHostedGenesisConversationsHandlesEmptyResponse(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey = "host-instance-key"
+		agentID     = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"conversations": []any{},
+		}))
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	result, err := service.ListHostedGenesisConversations(context.Background(), agentID)
+	require.NoError(t, err)
+	require.Empty(t, result)
+}

--- a/pkg/services/souls/bootstrap_recover_test.go
+++ b/pkg/services/souls/bootstrap_recover_test.go
@@ -280,3 +280,218 @@ func TestService_RecoverHostedGenesisTurnRequiresRegistrationAndConversationIDs(
 	require.ErrorAs(t, err, &hostErr)
 	require.Equal(t, "HOST_CONVERSATION_ID_REQUIRED", hostErr.Code)
 }
+
+func TestService_RecoverHostedGenesisTurnHostHTTPErrorReturnsTypedError(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey    = "host-instance-key"
+		registrationID = "reg_recover_http_err"
+		conversationID = "conv_recover_http_err"
+	)
+
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-Id", "host-req-forbidden")
+		w.WriteHeader(http.StatusForbidden)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"code":        "soul_instance.boundary_violation",
+				"message":     "instance boundary violation",
+				"status_code": 403,
+				"request_id":  "host-req-forbidden",
+			},
+		}))
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	_, err := service.RecoverHostedGenesisTurn(context.Background(), BootstrapConversationRecoverInput{
+		RegistrationID: registrationID,
+		ConversationID: conversationID,
+	})
+	var hostErr *HostBootstrapError
+	require.ErrorAs(t, err, &hostErr)
+	require.Equal(t, "soul_instance.boundary_violation", hostErr.Code)
+	require.Equal(t, http.StatusForbidden, hostErr.StatusCode)
+	require.Equal(t, "host-req-forbidden", hostErr.HostRequestID)
+}
+
+func TestService_RecoverHostedGenesisTurnInvalidJSONResponseReturnsTypedError(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey    = "host-instance-key"
+		registrationID = "reg_recover_bad_json"
+		conversationID = "conv_recover_bad_json"
+	)
+
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-Id", "host-req-bad-json")
+		w.WriteHeader(http.StatusOK)
+		// Valid JSON wrapper but conversation field is a string, not an object —
+		// parseHostConversationEnvelope will fail unmarshaling into hostMintConversationResponse.
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"version":    "1",
+			"request_id": "host-req-bad-conv",
+			"conversation": "not-a-valid-conversation-object",
+		}))
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	_, err := service.RecoverHostedGenesisTurn(context.Background(), BootstrapConversationRecoverInput{
+		RegistrationID: registrationID,
+		ConversationID: conversationID,
+	})
+	var hostErr *HostBootstrapError
+	require.ErrorAs(t, err, &hostErr)
+	require.Equal(t, "HOST_RESPONSE_INVALID", hostErr.Code)
+}
+
+func TestService_RecoverHostedGenesisTurnInvalidSnapshotReturnsTypedError(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey    = "host-instance-key"
+		registrationID = "reg_recover_bad_snapshot"
+		conversationID = "conv_recover_bad_snapshot"
+	)
+
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-Id", "host-req-bad-snapshot")
+		w.WriteHeader(http.StatusOK)
+		// Missing status and conversation_id — validateHostConversationSnapshot will reject.
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"registration_id": registrationID,
+		}))
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	_, err := service.RecoverHostedGenesisTurn(context.Background(), BootstrapConversationRecoverInput{
+		RegistrationID: registrationID,
+		ConversationID: conversationID,
+	})
+	var hostErr *HostBootstrapError
+	require.ErrorAs(t, err, &hostErr)
+	require.Equal(t, "HOST_RESPONSE_INVALID", hostErr.Code)
+}
+
+func TestService_RecoverHostedGenesisTurnWithLesserRequestIDIncludesItInBody(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey    = "host-instance-key"
+		registrationID = "reg_recover_req_id"
+		conversationID = "conv_recover_req_id"
+		agentID        = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	var sawBody map[string]any
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&sawBody))
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-Id", "host-req-req-id")
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"registration_id": registrationID,
+			"agent_id":        agentID,
+			"conversation_id": conversationID,
+			"status":          "in_progress",
+			"message_count":   1,
+			"request_id":      "host-req-req-id",
+		}))
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	_, err := service.RecoverHostedGenesisTurn(context.Background(), BootstrapConversationRecoverInput{
+		RegistrationID:  registrationID,
+		ConversationID:  conversationID,
+		LesserRequestID: "lesser-req-001",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "lesser-req-001", sawBody["lesser_request_id"])
+}
+
+func TestService_RecoverHostedGenesisTurnMisconfiguredServiceReturnsError(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{}
+	_, err := service.RecoverHostedGenesisTurn(context.Background(), BootstrapConversationRecoverInput{
+		RegistrationID: "reg_001",
+		ConversationID: "conv_001",
+	})
+	require.Error(t, err)
+}
+
+func TestService_RecoverHostedGenesisTurnDeclarationReadyWithBadEvidenceReturnsError(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey    = "host-instance-key"
+		registrationID = "reg_recover_bad_evidence"
+		conversationID = "conv_recover_bad_evidence"
+		agentID        = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-Id", "host-req-bad-evidence")
+		w.WriteHeader(http.StatusOK)
+		// declaration_ready status but produced_declarations is empty —
+		// ValidateHostedBootstrapCompletionEvidence will reject.
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"registration_id": registrationID,
+			"agent_id":        agentID,
+			"conversation_id": conversationID,
+			"status":          "declaration_ready",
+			"message_count":   2,
+			"request_id":      "host-req-bad-evidence",
+		}))
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	_, err := service.RecoverHostedGenesisTurn(context.Background(), BootstrapConversationRecoverInput{
+		RegistrationID: registrationID,
+		ConversationID: conversationID,
+	})
+	var hostErr *HostBootstrapError
+	require.ErrorAs(t, err, &hostErr)
+	require.Equal(t, "HOST_RESPONSE_INVALID", hostErr.Code)
+	require.Contains(t, hostErr.Message, "produced declarations")
+}

--- a/pkg/services/souls/bootstrap_recover_test.go
+++ b/pkg/services/souls/bootstrap_recover_test.go
@@ -1,0 +1,282 @@
+package souls
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/config"
+	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestService_RecoverHostedGenesisTurnCallsHostRecoverWithoutUserMessage(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey    = "host-instance-key"
+		registrationID = "reg_recover_001"
+		conversationID = "conv_recover_001"
+		agentID        = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	var (
+		sawMethod     string
+		sawPath       string
+		sawAuth       string
+		sawBody       map[string]any
+		sawContentType string
+	)
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawMethod = r.Method
+		sawPath = r.URL.Path
+		sawAuth = r.Header.Get("Authorization")
+		sawContentType = r.Header.Get("Content-Type")
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&sawBody))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-Id", "host-req-recover-001")
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"registration_id": registrationID,
+			"agent_id":        agentID,
+			"conversation_id": conversationID,
+			"status":          "assistant_turn_ready",
+			"latest_turn_id":  "turn_assistant_recovered",
+			"message_count":   2,
+			"request_id":      "host-req-recover-001",
+		}))
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	result, err := service.RecoverHostedGenesisTurn(context.Background(), BootstrapConversationRecoverInput{
+		RegistrationID: registrationID,
+		ConversationID: conversationID,
+		CorrelationID:  "corr-001",
+		IdempotencyKey: "idem-001",
+	})
+	require.NoError(t, err)
+
+	// Verify the HTTP call hit the /recover endpoint with POST and instance-key auth.
+	require.Equal(t, http.MethodPost, sawMethod)
+	require.Equal(t, "/api/v1/soul/instance/agents/register/"+registrationID+"/mint-conversation/"+conversationID+"/recover", sawPath)
+	require.Equal(t, "Bearer "+instanceKey, sawAuth)
+	require.Equal(t, "application/json", sawContentType)
+
+	// Verify the request body includes correlation_id and idempotency_key but NO message.
+	require.Equal(t, "corr-001", sawBody["correlation_id"])
+	require.Equal(t, "idem-001", sawBody["idempotency_key"])
+	_, hasMessage := sawBody["message"]
+	require.False(t, hasMessage, "recovery request must not include a message field")
+	_, hasModel := sawBody["model"]
+	require.False(t, hasModel, "recovery request must not include a model field")
+
+	// Verify the response is mapped correctly.
+	require.Equal(t, registrationID, result.RegistrationID)
+	require.Equal(t, agentID, result.HostSoulAgentID)
+	require.Equal(t, conversationID, result.ConversationID)
+	require.Equal(t, "assistant_turn_ready", result.Status)
+	require.Equal(t, "turn_assistant_recovered", result.LatestTurnID)
+	require.Equal(t, 2, result.MessageCount)
+	require.Equal(t, "host-req-recover-001", result.HostRequestID)
+}
+
+func TestService_RecoverHostedGenesisTurnIsIdempotentForNonStuckSession(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey    = "host-instance-key"
+		registrationID = "reg_recover_002"
+		conversationID = "conv_recover_002"
+		agentID        = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	var callCount int
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/soul/instance/agents/register/"+registrationID+"/mint-conversation/"+conversationID+"/recover", r.URL.Path)
+		callCount++
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-Id", "host-req-recover-idem")
+		w.WriteHeader(http.StatusOK)
+		// Host returns current state (declaration_ready) — the session was not stuck.
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"registration_id": registrationID,
+			"agent_id":        agentID,
+			"conversation_id": conversationID,
+			"status":          "declaration_ready",
+			"latest_turn_id":  "turn_final",
+			"message_count":   4,
+			"request_id":      "host-req-recover-idem",
+			"produced_declarations": map[string]any{
+				"declaration_id":   "decl_001",
+				"declaration_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				"produced_at":      "2026-07-02T12:00:00Z",
+				"declarations": map[string]any{
+					"selfDescription": map[string]any{"summary": "recovered soul"},
+					"capabilities":    []any{},
+					"boundaries":      []any{},
+					"transparency":    map[string]any{},
+				},
+				"evidence": map[string]any{
+					"source":          "host_conversation",
+					"registration_id": registrationID,
+					"conversation_id": conversationID,
+					"agent_id":        agentID,
+					"message_count":   4,
+					"request_id":      "host-req-recover-idem",
+				},
+			},
+		}))
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	result, err := service.RecoverHostedGenesisTurn(context.Background(), BootstrapConversationRecoverInput{
+		RegistrationID: registrationID,
+		ConversationID: conversationID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, callCount)
+	require.Equal(t, "declaration_ready", result.Status)
+	require.Equal(t, 4, result.MessageCount)
+	require.Equal(t, "host-req-recover-idem", result.HostRequestID)
+	// The produced declarations should be compacted but present.
+	require.NotEmpty(t, result.ProducedDeclarations)
+	require.NotContains(t, result.ProducedDeclarations, "declaration_id")
+}
+
+func TestService_RecoverHostedGenesisTurnAcceptsHostWrapperEnvelope(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey    = "host-instance-key"
+		registrationID = "reg_recover_003"
+		conversationID = "conv_recover_003"
+		agentID        = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "Bearer "+instanceKey, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-Id", "host-req-header-ignored")
+		w.WriteHeader(http.StatusAccepted)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"version":    "1",
+			"request_id": "host-req-recover-wrapper",
+			"conversation": map[string]any{
+				"registration_id": registrationID,
+				"conversation_id": conversationID,
+				"agent_id":        agentID,
+				"status":          "in_progress",
+				"latest_turn_id":  "turn_recovered_001",
+				"message_count":   3,
+			},
+		}))
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	result, err := service.RecoverHostedGenesisTurn(context.Background(), BootstrapConversationRecoverInput{
+		RegistrationID: registrationID,
+		ConversationID: conversationID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, registrationID, result.RegistrationID)
+	require.Equal(t, agentID, result.HostSoulAgentID)
+	require.Equal(t, conversationID, result.ConversationID)
+	require.Equal(t, "in_progress", result.Status)
+	require.Equal(t, 3, result.MessageCount)
+	require.Equal(t, "host-req-recover-wrapper", result.HostRequestID)
+}
+
+func TestService_RecoverHostedGenesisTurnRejectsUnsupportedHostWrapperVersion(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey    = "host-instance-key"
+		registrationID = "reg_recover_004"
+		conversationID = "conv_recover_004"
+		agentID        = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"version":    "2",
+			"request_id": "host-req-recover-v2",
+			"conversation": map[string]any{
+				"registration_id": registrationID,
+				"conversation_id": conversationID,
+				"agent_id":        agentID,
+				"status":          "in_progress",
+				"message_count":   1,
+			},
+		}))
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	_, err := service.RecoverHostedGenesisTurn(context.Background(), BootstrapConversationRecoverInput{
+		RegistrationID: registrationID,
+		ConversationID: conversationID,
+	})
+	var hostErr *HostBootstrapError
+	require.ErrorAs(t, err, &hostErr)
+	require.Equal(t, "HOST_RESPONSE_INVALID", hostErr.Code)
+	require.Contains(t, hostErr.Message, "unsupported version")
+}
+
+func TestService_RecoverHostedGenesisTurnRequiresRegistrationAndConversationIDs(t *testing.T) {
+	t.Parallel()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: "https://host.example"}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: "key"},
+		zap.NewNop(),
+	)
+
+	_, err := service.RecoverHostedGenesisTurn(context.Background(), BootstrapConversationRecoverInput{
+		ConversationID: "conv_001",
+	})
+	var hostErr *HostBootstrapError
+	require.ErrorAs(t, err, &hostErr)
+	require.Equal(t, "HOST_REGISTRATION_ID_REQUIRED", hostErr.Code)
+
+	_, err = service.RecoverHostedGenesisTurn(context.Background(), BootstrapConversationRecoverInput{
+		RegistrationID: "reg_001",
+	})
+	require.ErrorAs(t, err, &hostErr)
+	require.Equal(t, "HOST_CONVERSATION_ID_REQUIRED", hostErr.Code)
+}


### PR DESCRIPTION
## Project 51 — Genesis Conversation v2: Close Upstream Gaps

Closes #1209
Closes #1210

### Summary

Sim's genesis conversation page (PR #234) is wired to real Lesser GraphQL but has two gaps that block deploy:

- **GAP-1 (Issue #1209):** Recovery used `sendHostedSoulGenesisMessage` with a `[recover]` marker, polluting the transcript with a fake user message. This PR adds a dedicated `recoverHostedSoulGenesisTurn` GraphQL mutation that calls Host's already-deployed `POST /recover` endpoint — no user message is sent.

- **GAP-2 (Issue #1210):** No conversation list existed. This PR adds a `listHostedGenesisConversations` GraphQL query field that calls Host's `GET /mint-conversations` list endpoint to return bounded conversation summaries sorted by `updated_at` descending.

### Commits

1. **`feat: add recoverHostedSoulGenesisTurn GraphQL mutation (Closes #1209)`**
   - New `RecoverHostedSoulGenesisTurnInput` GraphQL input type and mutation field
   - `BootstrapConversationRecoverInput` struct + `RecoverHostedGenesisTurn` service method in `pkg/services/souls/bootstrap.go`
   - POST to Host's `/api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}/recover`
   - Request body includes `correlation_id`, `idempotency_key`, `lesser_request_id` — NO message, NO model
   - Response parsed via same `hostedGenesisConversationResponse` envelope as GET
   - Resolver follows `CompleteHostedSoulGenesis` pattern (`executeSoulBootstrapReviewMutation` + `soulBootstrapStateAfterHostedConversationSnapshot`)
   - Tests: recovery calls Host /recover without adding user message, recovery is idempotent for non-stuck sessions, accepts host wrapper envelope, rejects unsupported version, requires registration + conversation IDs, requires write scope + auth

2. **`feat: add listHostedGenesisConversations GraphQL query (Closes #1210)`**
   - New `HostedGenesisConversationSummary` GraphQL type and `listHostedGenesisConversations` query field
   - `HostedGenesisConversationSummary` struct + `ListHostedGenesisConversations` service method in `pkg/services/souls/bootstrap.go`
   - GET to Host's `/api/v1/soul/instance/agents/{agentId}/mint-conversations` (instance-key bearer auth)
   - Results bounded to max 50, sorted by `updated_at` descending (nil timestamps sort last)
   - TODO comment noting Host endpoint dependency (endpoint not yet implemented on lesser-host)
   - Resolver follows `SoulBootstrap` query pattern (`requireAuthClaims` + `requireDroneReadScope` + `canAccessDroneReviewWorkflow`)
   - Returns empty list when no `HostSoulAgentID` in workflow state
   - Tests: list returns summaries, sorted by updated_at descending, bounded to 50, empty for no agent ID, requires auth

### Validation

- `go build ./cmd/lesser` — passes
- `go build ./graph/... ./pkg/services/souls/...` — passes
- `go vet ./graph/... ./pkg/services/souls/...` — clean
- `go run github.com/99designs/gqlgen@v0.17.78 generate` — codegen runs cleanly
- `./lesser generate schema` — contract regenerated
- `go test -short ./pkg/services/souls/...` — all pass
- `go test -short -run "Project51|Project49|Round12Souls|Round44|SoulBootstrap" ./graph/...` — all pass

### Schema note

Used `Time` scalar (not `DateTime`) for `createdAt`/`updatedAt` fields — `DateTime` is not a defined scalar in this schema; `Time` is the existing convention. Used `String`/`String!` for `conversationId`/`registrationId` per issue spec (functionally equivalent to `ID` in gqlgen Go codegen).

### Allowed write scope

All changes are within the allowed write scope: `graph/agents.graphql`, `graph/soul_bootstrap_resolvers.go`, `graph/model/` (generated), `pkg/services/souls/` (service + tests), `graph/soul_bootstrap_project51_test.go` (resolver tests), `graph/souls_round12_test.go` (stub update), `graph/generated.go` (codegen), `docs/contracts/graphql-schema.graphql` (contract). No sibling repo edits, no deploy, no opencode.json changes.