### PR TITLE
feat: P52 L3.1–L3.3 accept-then-poll genesis transport + state machine + contract snapshot

### DIFF
--- a/cmd/lesser/hosted_genesis_projection_contract_test.go
+++ b/cmd/lesser/hosted_genesis_projection_contract_test.go
@@ -286,3 +286,138 @@ func derefHostedGenesisString(value *string) string {
 	}
 	return *value
 }
+
+// TestHostedSoulGenesisAcceptSemanticsContract locks the P52 L3 accept-then-poll
+// transport + turn-state snapshot consumed by Greater for soul-bootstrap adapter
+// sync (G4). It verifies the machine-readable fixture at
+// docs/contracts/examples/hosted-soul-genesis-accept-semantics.example.json and
+// the corresponding markdown section in docs/contracts/hosted-soul-genesis-projection.md.
+// This is additive to the M1.2 projection table contract; no GraphQL schema,
+// status-vocabulary, or DynamoDB schema change.
+func TestHostedSoulGenesisAcceptSemanticsContract(t *testing.T) {
+	repoRoot, err := findRepoRoot()
+	require.NoError(t, err)
+
+	fixturePath := filepath.Join(repoRoot, "docs", "contracts", "examples", "hosted-soul-genesis-accept-semantics.example.json")
+	fixtureData, err := os.ReadFile(fixturePath)
+	require.NoError(t, err)
+
+	var contract acceptSemanticsContract
+	require.NoError(t, json.Unmarshal(fixtureData, &contract))
+	require.Equal(t, "lesser.hosted_soul_genesis_accept_semantics", contract.Kind)
+	require.Equal(t, 1, contract.SchemaVersion)
+	require.Equal(t, "p52-l3", contract.ContractVersion)
+
+	// Accept semantics: 202 is accepted-pending and never a full snapshot.
+	require.Len(t, contract.AcceptSemantics.Rows, 2)
+	var row202, row200 *acceptSemanticsRow
+	for i := range contract.AcceptSemantics.Rows {
+		switch contract.AcceptSemantics.Rows[i].HostHTTPStatus {
+		case 202:
+			row202 = &contract.AcceptSemantics.Rows[i]
+		case 200:
+			row200 = &contract.AcceptSemantics.Rows[i]
+		}
+	}
+	require.NotNil(t, row202, "fixture must document the 202 accepted-pending row")
+	require.NotNil(t, row200, "fixture must document the 200 synchronous snapshot row")
+	require.Equal(t, "in_progress", row202.LesserResultStatus)
+	require.False(t, row202.InlineAssistantMessages, "202 must not project inline assistant messages")
+	require.Equal(t, float64(0), row202.MessageCount, "202 must project messageCount 0") //nolint:all // any-typed fixture field
+	require.Equal(t, "REFRESH_STATE (poll)", row202.ClientNextAction)
+
+	// Turn-state surface: pending statuses route to poll, not send.
+	require.NotEmpty(t, contract.TurnStateSurface.Rows)
+	for _, row := range contract.TurnStateSurface.Rows {
+		switch row.LesserState {
+		case "conversation.in_progress":
+			require.Equal(t, "REFRESH_STATE", row.TypedNextAction, "in_progress must author REFRESH_STATE")
+			require.True(t, row.PollPrimary)
+			require.Contains(t, row.AvailableActions, "REFRESH_STATE")
+		case "conversation.declaration_extraction_pending":
+			require.Equal(t, "REFRESH_STATE", row.TypedNextAction, "declaration_extraction_pending must poll only")
+			require.True(t, row.PollPrimary)
+			require.NotContains(t, row.AvailableActions, "SEND_HOSTED_SOUL_GENESIS_MESSAGE",
+				"declaration_extraction_pending must not advertise SEND")
+		}
+	}
+
+	// Error routing: accept timeout must not map to RETRY_SAME_STEP.
+	require.False(t, contract.ErrorRouting.AcceptTimeout.RetrySameStep,
+		"accept timeout must not route to RETRY_SAME_STEP (G15)")
+	require.Equal(t, "REFRESH_STATE", contract.ErrorRouting.AcceptTimeout.TypedNextAction)
+	require.True(t, contract.ErrorRouting.HostAuthoredFailed.RetrySameStep,
+		"genuine Host-authored failed with retry_same_step still routes to RETRY_SAME_STEP")
+
+	// Greater sync: no GraphQL schema change.
+	require.False(t, contract.GreaterSync.GraphQLSchemaChange)
+
+	// Integration proof is BLOCKED on host lab evidence; the fixture must say so.
+	require.Contains(t, contract.IntegrationProofStatus, "BLOCKED")
+	require.Contains(t, contract.IntegrationProofStatus, "lesser-host#867")
+
+	// The markdown contract document must reference this fixture and contain
+	// the P52 section.
+	docData, err := os.ReadFile(filepath.Join(repoRoot, "docs", "contracts", "hosted-soul-genesis-projection.md"))
+	require.NoError(t, err)
+	doc := string(docData)
+	require.Contains(t, doc, "hosted-soul-genesis-accept-semantics.example.json")
+	require.Contains(t, doc, "P52 — MicroVM-only genesis: accept-then-poll transport + turn-state surface")
+	require.Contains(t, doc, "Accept semantics (transport)")
+	require.Contains(t, doc, "Turn-state surface (state machine)")
+}
+
+type acceptSemanticsContract struct {
+	Kind                   string                   `json:"kind"`
+	SchemaVersion          int                      `json:"schema_version"`
+	ContractVersion        string                   `json:"contract_version"`
+	AcceptSemantics        acceptSemanticsSection   `json:"accept_semantics"`
+	TurnStateSurface       acceptSemanticsTurnState `json:"turn_state_surface"`
+	ErrorRouting           acceptSemanticsErrors    `json:"error_routing"`
+	GreaterSync            acceptSemanticsGreater   `json:"greater_sync"`
+	IntegrationProofStatus string                   `json:"integration_proof_status"`
+}
+
+type acceptSemanticsSection struct {
+	Rows []acceptSemanticsRow `json:"rows"`
+}
+
+type acceptSemanticsRow struct {
+	HostHTTPStatus          int    `json:"host_http_status"`
+	LesserResultStatus      string `json:"lesser_result_status"`
+	InlineAssistantMessages bool   `json:"inline_assistant_messages"`
+	MessageCount            any    `json:"message_count"`
+	ClientNextAction        string `json:"client_next_action"`
+}
+
+type acceptSemanticsTurnState struct {
+	Rows []acceptSemanticsTurnStateRow `json:"rows"`
+}
+
+type acceptSemanticsTurnStateRow struct {
+	LesserState        string   `json:"lesser_state"`
+	TypedNextAction    string   `json:"typed_next_action"`
+	AvailableActions   []string `json:"available_actions"`
+	PollPrimary        bool     `json:"poll_primary"`
+}
+
+type acceptSemanticsErrors struct {
+	AcceptTimeout     acceptSemanticsErrorRow `json:"accept_timeout"`
+	HostAuthoredFailed acceptSemanticsFailedRow `json:"host_authored_failed"`
+}
+
+type acceptSemanticsErrorRow struct {
+	HostErrorCode     string `json:"host_error_code"`
+	TypedNextAction   string `json:"typed_next_action"`
+	RetrySameStep     bool   `json:"retry_same_step"`
+}
+
+type acceptSemanticsFailedRow struct {
+	HostErrorCode    string `json:"host_error_code"`
+	TypedNextAction  string `json:"typed_next_action"`
+	RetrySameStep    bool   `json:"retry_same_step"`
+}
+
+type acceptSemanticsGreater struct {
+	GraphQLSchemaChange bool `json:"graphql_schema_change"`
+}

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -29,6 +29,7 @@ running environment.
 
 - Hosted bound souls + x402 boundary contract: `docs/contracts/hosted-bound-souls-x402-boundary.md`
 - Hosted soul genesis GraphQL projection table: `docs/contracts/hosted-soul-genesis-projection.md`
+- Hosted soul genesis accept-then-poll transport + turn-state (P52): `docs/contracts/examples/hosted-soul-genesis-accept-semantics.example.json`
 
 ## Deploy And Release Contracts
 

--- a/docs/contracts/examples/hosted-soul-genesis-accept-semantics.example.json
+++ b/docs/contracts/examples/hosted-soul-genesis-accept-semantics.example.json
@@ -1,0 +1,103 @@
+{
+  "kind": "lesser.hosted_soul_genesis_accept_semantics",
+  "schema_version": 1,
+  "contract_version": "p52-l3",
+  "date": "2026-07-03",
+  "project": "P52 — MicroVM-only hosted genesis conversations",
+  "parent_issue": "https://github.com/equaltoai/lesser/issues/1213",
+  "host_dependency": "https://github.com/equaltoai/lesser-host/issues/867",
+  "factory_tracker": "https://github.com/equaltoai/factory/issues/8",
+  "depends_on": "lesser-host#867 H1.2 lab evidence for the integration proof",
+  "summary": "Lesser transport + state machine honor a 202-accepted-pending then poll contract for the MicroVM-dispatched genesis turn. Additive to the M1.2 projection table; no GraphQL schema, status-vocabulary, or DynamoDB schema change.",
+  "accept_semantics": {
+    "operation": "sendHostedSoulGenesisMessage",
+    "send_http_timeout": "defaultSoulBootstrapAcceptTimeout (<2s, sized for Host's 202 accept, not the turn)",
+    "read_poll_http_timeout": "defaultSoulHTTPTimeout (10s)",
+    "rows": [
+      {
+        "host_http_status": 202,
+        "lesser_transport_behavior": "accepted-pending; body is NOT parsed as a full conversation snapshot",
+        "lesser_result_status": "in_progress",
+        "inline_assistant_messages": false,
+        "message_count": 0,
+        "conversation_id": "persisted early: best-effort from minimal body (top-level or nested conversation), else caller's existing id",
+        "client_next_action": "REFRESH_STATE (poll)"
+      },
+      {
+        "host_http_status": 200,
+        "lesser_transport_behavior": "synchronous snapshot (legacy/non-MicroVM); parsed and validated as a full snapshot",
+        "lesser_result_status": "host-authored status from snapshot",
+        "inline_assistant_messages": true,
+        "message_count": "from snapshot",
+        "conversation_id": "from snapshot",
+        "client_next_action": "per M1.2 projection table for the snapshot status"
+      }
+    ]
+  },
+  "turn_state_surface": {
+    "notes": "Pending turn statuses route the client to poll (REFRESH_STATE), not re-send. Realigns the resolver with the M1.2 projection table.",
+    "rows": [
+      {
+        "lesser_state": "conversation.in_progress",
+        "host_status": ["in_progress", "created"],
+        "typed_next_action": "REFRESH_STATE",
+        "available_actions": ["REFRESH_STATE", "SEND_HOSTED_SOUL_GENESIS_MESSAGE"],
+        "poll_primary": true
+      },
+      {
+        "lesser_state": "conversation.declaration_extraction_pending",
+        "host_status": ["declaration_extraction_pending"],
+        "typed_next_action": "REFRESH_STATE",
+        "available_actions": ["REFRESH_STATE"],
+        "poll_primary": true
+      },
+      {
+        "lesser_state": "conversation.assistant_turn_ready",
+        "host_status": ["assistant_turn_ready"],
+        "typed_next_action": "COMPLETE_HOSTED_SOUL_GENESIS",
+        "available_actions": ["SEND_HOSTED_SOUL_GENESIS_MESSAGE", "COMPLETE_HOSTED_SOUL_GENESIS"],
+        "poll_primary": false
+      },
+      {
+        "lesser_state": "conversation.registration_active",
+        "host_status": ["registration_active_no_conversation"],
+        "typed_next_action": "SEND_HOSTED_SOUL_GENESIS_MESSAGE",
+        "available_actions": ["SEND_HOSTED_SOUL_GENESIS_MESSAGE"],
+        "poll_primary": false
+      }
+    ]
+  },
+  "error_routing": {
+    "accept_timeout": {
+      "host_error_code": "HOST_UNAVAILABLE",
+      "typed_next_action": "REFRESH_STATE",
+      "recovery_category": "REFRESH_STATE",
+      "recovery_action": "REFRESH_STATE",
+      "retryable": false,
+      "restart_required": false,
+      "retry_same_step": false,
+      "rationale": "An accept timeout must not instruct the client to re-issue the same blocking send. Host may have accepted the turn and be processing it asynchronously; poll reconciles via the read path."
+    },
+    "host_authored_failed": {
+      "host_error_code": "HOST_CONVERSATION_FAILED",
+      "host_recovery_action": "retry_same_step",
+      "typed_next_action": "RETRY_SAME_STEP",
+      "retry_same_step": true,
+      "rationale": "Genuine Host-authored failed conversations with a locked retry_same_step recovery action still route to RETRY_SAME_STEP (the failed row of the M1.2 table). The timeout->poll change is scoped to HOST_UNAVAILABLE."
+    }
+  },
+  "observability_no_silent_rewrites": {
+    "empty_host_status": "preserve existing state's status; fall back to in_progress only for a brand-new conversation",
+    "reconcile_host_read_error": "logged via resolver logger (best-effort, non-fatal); no longer silently swallowed",
+    "reconcile_service_resolution_error": "logged via resolver logger (best-effort, non-fatal); no longer silently swallowed",
+    "errored_to_send_retry_repair": "logged at both call sites; only reachable for genuine Host-authored retry_same_step"
+  },
+  "greater_sync": {
+    "greater_step": "G4",
+    "graphql_schema_change": false,
+    "surfaces": ["SoulBootstrapState", "SoulBootstrapHostedGenesisConversation", "SoulBootstrapNextAction enum"],
+    "adapter_work": "Pending turn (in_progress, declaration_extraction_pending) drives a poll/refresh UX rather than immediate re-send; accept-timeout error surfaces as polling state rather than re-send.",
+    "lesser_role": "produces this snapshot only"
+  },
+  "integration_proof_status": "BLOCKED on lesser-host#867 H1.2 lab evidence; unit proof ships with the L3.1/L3.2 commits"
+}

--- a/docs/contracts/hosted-soul-genesis-projection.md
+++ b/docs/contracts/hosted-soul-genesis-projection.md
@@ -276,3 +276,80 @@ correlation/request ids, evidence payloads, and publication evidence.
 - ActivityPub / federation: no actor, inbox/outbox, signing, WebFinger, object, collection, or delivery changes.
 - DynamoDB schema: no PK/SK/GSI/TableTheory-tag changes in M1.2.
 - Sibling consumers: Greater M1.3 and Sim must be able to represent every row before M3 resolver work ships.
+
+## P52 — MicroVM-only genesis: accept-then-poll transport + turn-state surface
+
+Project 52 (parent `equaltoai/lesser#1213`; host dependency `lesser-host#867` H1.2) makes the genesis
+turn a MicroVM-dispatched async operation. Host returns `202 Accepted-Pending` and processes the turn
+asynchronously; Lesser's transport and state machine honor a 202-then-poll contract. This section is the
+contract snapshot Greater consumes to sync soul-bootstrap adapters for the turn-state surface and accept
+semantics. It is additive to the M1.2 projection table above — no GraphQL schema change, no status-vocabulary
+change, no DynamoDB schema change.
+
+The machine-readable fixture for this section is checked in at
+`docs/contracts/examples/hosted-soul-genesis-accept-semantics.example.json`.
+
+### Accept semantics (transport)
+
+`sendHostedSoulGenesisMessage` relays one mint-conversation turn to Host's durable instance-key route.
+The HTTP status is transport state only:
+
+| Host HTTP status | Lesser transport behavior | Lesser result status | Inline assistant messages | Conversation id |
+| --- | --- | --- | --- | --- |
+| `202 Accepted` | Accepted-pending. The body is **not** parsed as a full conversation snapshot. | `in_progress` (canonical pending status) | None — `messages` is empty, `messageCount` is 0. | Persisted early: extracted best-effort from a minimal body (top-level or nested `conversation`), else the caller's existing id. |
+| `200 OK` | Synchronous snapshot (legacy / non-MicroVM path). Parsed and validated as a full snapshot. | Host-authored status from the snapshot. | Projected from the snapshot when Host supplies them. | From the snapshot. |
+
+The send POST is bounded by a short **accept timeout** (`defaultSoulBootstrapAcceptTimeout`, <2s), sized for
+Host's 202 accept — not for the turn to complete. Discovery and read/poll HTTP calls keep the longer
+`defaultSoulHTTPTimeout` (10s). A send that does not receive Host's accept in time surfaces `HOST_UNAVAILABLE`.
+
+### Turn-state surface (state machine)
+
+Pending turn statuses route the client to **poll** (`REFRESH_STATE`), not to re-send. This realigns the
+resolver with the M1.2 projection table; the code had drifted to `SEND` for pending statuses.
+
+| Lesser `state` | Host status | `typedNextAction` | `availableActions` | Notes |
+| --- | --- | --- | --- | --- |
+| `conversation.in_progress` | `in_progress` / `created` | `REFRESH_STATE` | `[REFRESH_STATE, SEND_HOSTED_SOUL_GENESIS_MESSAGE]` | Pending turn. Poll is primary; SEND remains an allowed alternative. |
+| `conversation.declaration_extraction_pending` | `declaration_extraction_pending` | `REFRESH_STATE` | `[REFRESH_STATE]` | Declaration extraction pending. Poll only — do not send again. |
+| `conversation.assistant_turn_ready` | `assistant_turn_ready` | `COMPLETE_HOSTED_SOUL_GENESIS` | `[SEND_HOSTED_SOUL_GENESIS_MESSAGE, COMPLETE_HOSTED_SOUL_GENESIS]` | Unchanged. |
+| `conversation.registration_active` | registration active, no conversation | `SEND_HOSTED_SOUL_GENESIS_MESSAGE` | `[SEND_HOSTED_SOUL_GENESIS_MESSAGE]` | Unchanged — no conversation yet. |
+
+### Error routing (accept timeout)
+
+An accept timeout (`HOST_UNAVAILABLE`) on the send POST routes the client to **poll** (`REFRESH_STATE`), never
+to `RETRY_SAME_STEP`. `RETRY_SAME_STEP` would instruct the client to re-issue the same blocking send — the
+binding constraint this project removes. Host may have accepted the turn and be processing it asynchronously;
+the safe forward motion is to poll, which reconciles via the read path and recovers the conversation id. A
+genuine Host-authored `failed` conversation with a `retry_same_step` recovery action still routes to
+`RETRY_SAME_STEP` (the `failed` row of the M1.2 table) — the timeout→poll change is scoped to
+`HOST_UNAVAILABLE`.
+
+### Observability (no silent rewrites)
+
+- An empty/unknown Host status is not silently coerced to `in_progress`; the existing state's status is
+  preserved, falling back to `in_progress` only for a brand-new conversation.
+- Reconcile logs Host read errors and service-resolution errors (best-effort, non-fatal) instead of silently
+  swallowing them.
+- The errored→send retry repair is logged at both call sites; it is only reachable for a genuine
+  Host-authored `retry_same_step`, not for accept timeouts.
+
+### Greater sync notes
+
+- No GraphQL schema change in P52; Greater adapters consume the existing `SoulBootstrapState` and
+  `SoulBootstrapHostedGenesisConversation` surfaces. The turn-state routing changes are observable through
+  `typedNextAction` / `availableActions` values, which are already in the `SoulBootstrapNextAction` enum.
+- Greater's step (G4) is to update soul-bootstrap adapters so a pending turn (`in_progress`,
+  `declaration_extraction_pending`) drives a poll/refresh UX rather than an immediate re-send, and so an
+  accept-timeout error surfaces as "polling state" rather than "re-send". Lesser only produces this snapshot.
+- Integration proof (send returns accepted in <2s while a >30s turn completes via poll) is BLOCKED on
+  `lesser-host#867` H1.2 lab evidence; the unit proof ships with this snapshot.
+
+## P52 contract audit (additive)
+
+- Mastodon REST: no impact; no `/api/v1/*` shape changes.
+- GraphQL: no schema change; `SoulBootstrapNextAction` already includes `REFRESH_STATE`. No regeneration.
+- ActivityPub / federation: no actor, inbox/outbox, signing, WebFinger, object, collection, or delivery changes.
+- DynamoDB schema: no PK/SK/GSI/TableTheory-tag changes.
+- Sibling consumers: Greater consumes this accept-semantics snapshot to sync soul-bootstrap adapters (G4).
+

--- a/graph/soul_bootstrap_project49_test.go
+++ b/graph/soul_bootstrap_project49_test.go
@@ -106,12 +106,17 @@ func TestProject49HostedInProgressPersistsConversationAndBlocksPublish(t *testin
 	require.Equal(t, model.SoulBootstrapPhaseConversation, sent.Bootstrap.State.Phase)
 	require.Equal(t, workflow.SoulBootstrapStateConversationInProgress, sent.Bootstrap.State.State)
 	require.Equal(t, workflow.SoulBootstrapHostConversationStatusInProgress, derefString(sent.Bootstrap.State.HostConversationStatus))
-	require.Equal(t, model.SoulBootstrapNextActionSendHostedSoulGenesisMessage, sent.Bootstrap.TypedNextAction)
+	// P52 L3.2 G14: in_progress is a pending turn — poll (REFRESH_STATE) is
+	// primary; SEND remains an allowed alternative.
+	require.Equal(t, model.SoulBootstrapNextActionRefreshState, sent.Bootstrap.TypedNextAction)
 	require.ElementsMatch(t, []model.SoulBootstrapNextAction{
+		model.SoulBootstrapNextActionRefreshState,
 		model.SoulBootstrapNextActionSendHostedSoulGenesisMessage,
 	}, sent.Bootstrap.AvailableActions)
-	require.Nil(t, sent.Bootstrap.State.RecoveryCategory)
-	require.Nil(t, sent.Bootstrap.State.RecoveryAction)
+	require.NotNil(t, sent.Bootstrap.State.RecoveryCategory)
+	require.Equal(t, model.SoulBootstrapRecoveryCategoryRefreshState, *sent.Bootstrap.State.RecoveryCategory)
+	require.NotNil(t, sent.Bootstrap.State.RecoveryAction)
+	require.Equal(t, model.SoulBootstrapRecoveryActionRefreshState, *sent.Bootstrap.State.RecoveryAction)
 	require.Equal(t, conversationID, derefString(sent.Bootstrap.State.HostConversationID))
 	require.Equal(t, "host-req-p49-turn-001", derefString(sent.Bootstrap.State.LastHostRequestID))
 	require.Empty(t, sent.Bootstrap.State.SigningCheckpoints)
@@ -312,7 +317,10 @@ func TestProject49GraphQLProjectionCoversLockedStatusTableRows(t *testing.T) {
 			},
 			wantPhase:  model.SoulBootstrapPhaseConversation,
 			wantState:  workflow.SoulBootstrapStateConversationInProgress,
-			wantAction: model.SoulBootstrapNextActionSendHostedSoulGenesisMessage,
+			// P52 L3.2 G14: in_progress is a pending turn — poll via REFRESH_STATE
+			// is primary, matching the locked projection table and the seeded
+			// NextAction.
+			wantAction: model.SoulBootstrapNextActionRefreshState,
 			wantHost:   workflow.SoulBootstrapHostConversationStatusInProgress,
 			wantGate:   "blocked:conversation_in_progress",
 		},
@@ -356,7 +364,10 @@ func TestProject49GraphQLProjectionCoversLockedStatusTableRows(t *testing.T) {
 			},
 			wantPhase:  model.SoulBootstrapPhaseConversation,
 			wantState:  workflow.SoulBootstrapStateConversationDeclarationExtractionPending,
-			wantAction: model.SoulBootstrapNextActionSendHostedSoulGenesisMessage,
+			// P52 L3.2 G14: declaration extraction is pending — poll only
+			// (REFRESH_STATE), matching the locked projection table and the
+			// seeded NextAction.
+			wantAction: model.SoulBootstrapNextActionRefreshState,
 			wantHost:   workflow.SoulBootstrapHostConversationStatusDeclarationExtractionPending,
 			wantGate:   "blocked:declaration_extraction_pending",
 		},

--- a/graph/soul_bootstrap_project51_test.go
+++ b/graph/soul_bootstrap_project51_test.go
@@ -492,13 +492,19 @@ func TestProject51HostedInProgressReadAdvertisesSendAndRelaysTranscript(t *testi
 	require.Equal(t, 1, readCalls)
 	require.Equal(t, workflow.SoulBootstrapStateConversationInProgress, surface.State.State)
 	require.Equal(t, workflow.SoulBootstrapHostConversationStatusInProgress, derefString(surface.State.HostConversationStatus))
-	require.Equal(t, model.SoulBootstrapNextActionSendHostedSoulGenesisMessage, surface.TypedNextAction)
+	// P52 L3.2 G14: in_progress is a pending turn — poll (REFRESH_STATE) is
+	// primary; SEND remains an allowed alternative. The read still relays the
+	// transcript (below); only the next-action routing changes.
+	require.Equal(t, model.SoulBootstrapNextActionRefreshState, surface.TypedNextAction)
 	require.ElementsMatch(t, []model.SoulBootstrapNextAction{
+		model.SoulBootstrapNextActionRefreshState,
 		model.SoulBootstrapNextActionSendHostedSoulGenesisMessage,
 	}, surface.AvailableActions)
 	require.ElementsMatch(t, surface.AvailableActions, surface.State.AvailableActions)
-	require.Nil(t, surface.State.RecoveryCategory)
-	require.Nil(t, surface.State.RecoveryAction)
+	require.NotNil(t, surface.State.RecoveryCategory)
+	require.Equal(t, model.SoulBootstrapRecoveryCategoryRefreshState, *surface.State.RecoveryCategory)
+	require.NotNil(t, surface.State.RecoveryAction)
+	require.Equal(t, model.SoulBootstrapRecoveryActionRefreshState, *surface.State.RecoveryAction)
 
 	require.NotNil(t, surface.State.HostedGenesisConversation)
 	conversation := surface.State.HostedGenesisConversation
@@ -535,19 +541,28 @@ func TestProject51HostedConversationAvailableActionsByStatus(t *testing.T) {
 			name:       "created",
 			hostStatus: workflow.SoulBootstrapHostConversationStatusCreated,
 			wantState:  workflow.SoulBootstrapStateConversationInProgress,
-			wantNext:   model.SoulBootstrapNextActionSendHostedSoulGenesisMessage,
+			// P52 L3.2 G14: created normalizes to in_progress — a pending turn.
+			// Poll (REFRESH_STATE) is primary; SEND remains an allowed alternative.
+			wantNext: model.SoulBootstrapNextActionRefreshState,
 			wantAvailable: []model.SoulBootstrapNextAction{
+				model.SoulBootstrapNextActionRefreshState,
 				model.SoulBootstrapNextActionSendHostedSoulGenesisMessage,
 			},
+			wantRecoveryKind: model.SoulBootstrapRecoveryCategoryRefreshState,
 		},
 		{
 			name:       "in_progress",
 			hostStatus: workflow.SoulBootstrapHostConversationStatusInProgress,
 			wantState:  workflow.SoulBootstrapStateConversationInProgress,
-			wantNext:   model.SoulBootstrapNextActionSendHostedSoulGenesisMessage,
+			// P52 L3.2 G14: in_progress is a pending turn — poll via REFRESH_STATE
+			// is primary; SEND remains an allowed alternative per the projection
+			// table.
+			wantNext: model.SoulBootstrapNextActionRefreshState,
 			wantAvailable: []model.SoulBootstrapNextAction{
+				model.SoulBootstrapNextActionRefreshState,
 				model.SoulBootstrapNextActionSendHostedSoulGenesisMessage,
 			},
+			wantRecoveryKind: model.SoulBootstrapRecoveryCategoryRefreshState,
 		},
 		{
 			name:       "assistant_turn_ready",
@@ -563,10 +578,13 @@ func TestProject51HostedConversationAvailableActionsByStatus(t *testing.T) {
 			name:       "declaration_extraction_pending",
 			hostStatus: workflow.SoulBootstrapHostConversationStatusDeclarationExtractionPending,
 			wantState:  workflow.SoulBootstrapStateConversationDeclarationExtractionPending,
-			wantNext:   model.SoulBootstrapNextActionSendHostedSoulGenesisMessage,
+			// P52 L3.2 G14: declaration extraction is pending — poll only. The
+			// projection table allows REFRESH_STATE only here.
+			wantNext: model.SoulBootstrapNextActionRefreshState,
 			wantAvailable: []model.SoulBootstrapNextAction{
-				model.SoulBootstrapNextActionSendHostedSoulGenesisMessage,
+				model.SoulBootstrapNextActionRefreshState,
 			},
+			wantRecoveryKind: model.SoulBootstrapRecoveryCategoryRefreshState,
 		},
 		{
 			name:       "declaration_ready",

--- a/graph/soul_bootstrap_project52_test.go
+++ b/graph/soul_bootstrap_project52_test.go
@@ -1,0 +1,273 @@
+package graph
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/graph/model"
+	workflow "github.com/equaltoai/lesser/pkg/agents"
+	"github.com/equaltoai/lesser/pkg/auth"
+	soulservice "github.com/equaltoai/lesser/pkg/services/souls"
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// TestP52_DeclarationExtractionPendingRoutesToPollNotSend proves L3.2 G14:
+// when Host status is declaration_extraction_pending, the state machine routes
+// the client to poll (REFRESH_STATE), never to send another message. This
+// realigns the resolver with the locked projection table. Covers both the
+// authored typedNextAction and availableActions.
+func TestP52_DeclarationExtractionPendingRoutesToPollNotSend(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 3, 11, 0, 0, 0, time.UTC)
+	agent := &storage.User{Username: "drone-p52-extraction"}
+	result := &soulservice.BootstrapConversationCompleteResult{
+		RegistrationID:  "reg_p52_extr",
+		HostSoulAgentID: "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+		ConversationID:  "conv_p52_extr",
+		Status:          workflow.SoulBootstrapHostConversationStatusDeclarationExtractionPending,
+		HostRequestID:   "host-req-p52-extr",
+	}
+
+	stored := soulBootstrapStateAfterHostedConversationSnapshot(agent, nil, nil, result, now)
+	projected := graphSoulBootstrapStoredStateModel(stored)
+
+	require.Equal(t, workflow.SoulBootstrapStateConversationDeclarationExtractionPending, projected.State)
+	require.Equal(t, model.SoulBootstrapNextActionRefreshState, projected.TypedNextAction,
+		"declaration_extraction_pending must route to REFRESH_STATE (poll), not SEND")
+	require.NotEqual(t, model.SoulBootstrapNextActionSendHostedSoulGenesisMessage, projected.TypedNextAction)
+	require.NotContains(t, projected.AvailableActions, model.SoulBootstrapNextActionSendHostedSoulGenesisMessage,
+		"declaration_extraction_pending must not advertise SEND at all")
+	require.Contains(t, projected.AvailableActions, model.SoulBootstrapNextActionRefreshState)
+}
+
+// TestP52_InProgressRoutesToPollPrimary proves L3.2 G14: in_progress is a
+// pending turn. Poll (REFRESH_STATE) is the authored typedNextAction; SEND
+// remains an allowed alternative per the projection table.
+func TestP52_InProgressRoutesToPollPrimary(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 3, 11, 0, 0, 0, time.UTC)
+	agent := &storage.User{Username: "drone-p52-inprogress"}
+	result := &soulservice.BootstrapConversationCompleteResult{
+		RegistrationID:  "reg_p52_inp",
+		HostSoulAgentID: "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+		ConversationID:  "conv_p52_inp",
+		Status:          workflow.SoulBootstrapHostConversationStatusInProgress,
+		HostRequestID:   "host-req-p52-inp",
+	}
+
+	stored := soulBootstrapStateAfterHostedConversationSnapshot(agent, nil, nil, result, now)
+	projected := graphSoulBootstrapStoredStateModel(stored)
+
+	require.Equal(t, workflow.SoulBootstrapStateConversationInProgress, projected.State)
+	require.Equal(t, model.SoulBootstrapNextActionRefreshState, projected.TypedNextAction,
+		"in_progress must author REFRESH_STATE (poll) as the primary next action")
+	require.Contains(t, projected.AvailableActions, model.SoulBootstrapNextActionSendHostedSoulGenesisMessage,
+		"in_progress may still advertise SEND as an alternative")
+	require.Contains(t, projected.AvailableActions, model.SoulBootstrapNextActionRefreshState)
+}
+
+// TestP52_HostUnavailableTimeoutRoutesToRefreshNotRetry proves L3.2 G15: a
+// HOST_UNAVAILABLE error (the accept-timeout mapping from L3.1) must NOT map
+// to RETRY_SAME_STEP. RETRY_SAME_STEP would instruct the client to re-issue the
+// same blocking send — the binding constraint this project removes. It must
+// route to REFRESH_STATE so the client polls and reconcile recovers.
+func TestP52_HostUnavailableTimeoutRoutesToRefreshNotRetry(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 3, 11, 0, 0, 0, time.UTC)
+	agent := &storage.User{Username: "drone-p52-timeout"}
+	hostErr := &soulservice.HostBootstrapError{
+		Code:    workflow.SoulBootstrapErrorHostUnavailable,
+		Message: "Host bootstrap endpoint is unavailable.",
+		Source:  "host",
+		Err:     errors.New("context deadline exceeded (client.Timeout exceeded while awaiting headers)"),
+	}
+
+	state := soulBootstrapErrorState(agent, nil, nil, hostErr, now)
+
+	require.Equal(t, workflow.SoulBootstrapPhaseError, state.Phase)
+	require.Equal(t, workflow.SoulBootstrapStateHostUnavailable, state.State)
+	// G15: the killer assertion — timeout must not instruct a blocking retry.
+	require.Equal(t, workflow.SoulBootstrapNextActionRefreshState, state.NextAction,
+		"HOST_UNAVAILABLE (accept timeout) must route to REFRESH_STATE (poll), not RETRY_SAME_STEP")
+	require.NotEqual(t, workflow.SoulBootstrapNextActionRetrySameStep, state.NextAction)
+	require.Equal(t, workflow.SoulBootstrapRecoveryCategoryRefreshState, state.RecoveryCategory)
+	require.Equal(t, workflow.SoulBootstrapRecoveryActionRefreshState, state.RecoveryAction)
+	require.False(t, state.Retryable, "accept timeout must not be flagged as a blocking retryable re-issue")
+	require.False(t, state.RestartRequired)
+	// And the retry-repair gate must not fire for a timeout (only genuine
+	// Host-authored retry_same_step qualifies), closing the G15 loop.
+	require.False(t, soulBootstrapHostedGenesisMessageRetryRequired(state),
+		"accept-timeout state must not qualify for the retry_same_step send repair")
+}
+
+// TestP52_HostAuthoredFailedStillRoutesToRetry proves the G15 change is scoped
+// to HOST_UNAVAILABLE only: a genuine Host-authored `failed` conversation with
+// a `retry_same_step` recovery action still routes to RETRY_SAME_STEP (the
+// failed row of the projection table). G15 does not regress the failed path.
+func TestP52_HostAuthoredFailedStillRoutesToRetry(t *testing.T) {
+	t.Parallel()
+
+	plan := soulBootstrapRecoveryForError(workflow.SoulBootstrapErrorHostConversationFailed, 0, "")
+	require.Equal(t, workflow.SoulBootstrapRecoveryCategoryRetrySameStep, plan.Category)
+	require.Equal(t, workflow.SoulBootstrapNextActionRetrySameStep, plan.NextAction)
+}
+
+// TestP52_EmptyHostStatusDoesNotSilentlyCoerceToInProgress proves L3.2 G16: an
+// empty/unknown Host status is no longer silently coerced to in_progress. When
+// a prior state exists, its status is preserved instead of inventing progress.
+func TestP52_EmptyHostStatusDoesNotSilentlyCoerceToInProgress(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 3, 11, 0, 0, 0, time.UTC)
+	agent := &storage.User{Username: "drone-p52-empty"}
+	// Existing state is assistant_turn_ready — a non-progress step.
+	existing := &workflow.SoulBootstrapState{
+		Username:           "drone-p52-empty",
+		BodyID:             "drone-p52-empty",
+		HostRegistrationID: "reg_p52_empty",
+		HostConversationID: "conv_p52_empty",
+		BootstrapMode:      workflow.SoulBootstrapModeHosted,
+		Phase:              workflow.SoulBootstrapPhaseConversation,
+		State:              workflow.SoulBootstrapStateConversationAssistantTurnReady,
+		NextAction:         workflow.SoulBootstrapNextActionCompleteHostedGenesis,
+	}
+	// A result with an unrecognized status that would previously have been
+	// silently coerced to in_progress (progress), masking the gap.
+	result := &soulservice.BootstrapConversationCompleteResult{
+		RegistrationID: "reg_p52_empty",
+		ConversationID: "conv_p52_empty",
+		Status:         "totally_unknown_status",
+	}
+
+	stored := soulBootstrapStateAfterHostedConversationSnapshot(agent, existing, nil, result, now)
+	// The prior assistant_turn_ready status is preserved rather than silently
+	// rewritten to in_progress.
+	require.Equal(t, workflow.SoulBootstrapStateConversationAssistantTurnReady, stored.State,
+		"empty/unknown Host status must preserve the existing state, not silently coerce to in_progress")
+}
+
+// TestP52_EmptyHostStatusNoPriorStateDefaultsToInProgress proves the honest
+// fallback: a brand-new conversation with no prior status and an empty Host
+// status defaults to in_progress (the only defensible default for a new
+// conversation), rather than inventing a more specific state.
+func TestP52_EmptyHostStatusNoPriorStateDefaultsToInProgress(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 3, 11, 0, 0, 0, time.UTC)
+	agent := &storage.User{Username: "drone-p52-new"}
+	result := &soulservice.BootstrapConversationCompleteResult{
+		RegistrationID: "reg_p52_new",
+		ConversationID: "conv_p52_new",
+		Status:         "",
+	}
+
+	stored := soulBootstrapStateAfterHostedConversationSnapshot(agent, nil, nil, result, now)
+	require.Equal(t, workflow.SoulBootstrapStateConversationInProgress, stored.State,
+		"empty Host status with no prior state defaults honestly to in_progress for a new conversation")
+}
+
+// TestP52_ReconcileLogsHostReadErrorNotSilent proves L3.2 G16: reconcile no
+// longer silently swallows Host read errors. The error is surfaced via the
+// resolver logger (observed here) while reconcile stays best-effort (the
+// SoulBootstrap query still succeeds). Exercised through the real query entry
+// point that invokes reconcileHostedSoulBootstrapState.
+func TestP52_ReconcileLogsHostReadErrorNotSilent(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 3, 11, 0, 0, 0, time.UTC)
+	core, recorded := observer.New(zap.WarnLevel)
+	resolver, storageRepo := newRound12GraphResolver(t)
+	resolver.Logger = zap.New(core)
+
+	const (
+		registrationID = "reg_p52_rec"
+		conversationID = "conv_p52_rec"
+		agentID        = "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	)
+
+	metadata, err := workflow.SetDroneWorkflowMetadata(nil, &workflow.DroneWorkflowState{
+		SoulBootstrap: &workflow.SoulBootstrapState{
+			Username:           "drone-p52-rec",
+			BodyID:             "drone-p52-rec",
+			HostRegistrationID: registrationID,
+			HostConversationID: conversationID,
+			HostSoulAgentID:    agentID,
+			BootstrapMode:      workflow.SoulBootstrapModeHosted,
+			AuthorityModel:     workflow.SoulBootstrapAuthorityModelInstanceTrust,
+			AnchorState:        workflow.SoulBootstrapAnchorStateHostedOffchain,
+			AssuranceState:     workflow.SoulBootstrapAnchorStateHostedOffchain,
+			Phase:              workflow.SoulBootstrapPhaseConversation,
+			State:              workflow.SoulBootstrapStateConversationInProgress,
+			NextAction:         workflow.SoulBootstrapNextActionRefreshState,
+			RecoveryCategory:   workflow.SoulBootstrapRecoveryCategoryRefreshState,
+			RecoveryAction:     workflow.SoulBootstrapRecoveryActionRefreshState,
+			UpdatedAt:          &now,
+		},
+	})
+	require.NoError(t, err)
+
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "owner",
+		DisplayName: "Owner",
+		Approved:    true,
+		CreatedAt:   now.Add(-48 * time.Hour),
+		UpdatedAt:   now.Add(-24 * time.Hour),
+	}, nil)
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "drone-p52-rec",
+		DisplayName: "Drone P52 Rec",
+		Approved:    true,
+		IsAgent:     true,
+		AgentOwner:  "@owner",
+		Metadata:    metadata,
+		CreatedAt:   now.Add(-24 * time.Hour),
+		UpdatedAt:   now,
+	}, &storage.AgentGovernanceState{
+		Username:        "drone-p52-rec",
+		DelegatedScopes: []string{auth.ScopeRead, auth.ScopeWrite},
+	})
+
+	resolver.soulsClient = &stubSoulService{
+		readBootstrapConversationFunc: func(_ context.Context, _ soulservice.BootstrapConversationCompleteInput) (*soulservice.BootstrapConversationCompleteResult, error) {
+			return nil, &soulservice.HostBootstrapError{Code: workflow.SoulBootstrapErrorHostUnavailable, Message: "transient host read failure", Source: "host"}
+		},
+	}
+
+	// The SoulBootstrap query invokes reconcile. Reconcile read-repairs the
+	// in_progress hosted state by calling Host's read endpoint, which here
+	// fails. The query must still succeed (best-effort reconcile) AND the
+	// previously-swallowed error must now be logged.
+	surface, err := (&queryResolver{resolver}).SoulBootstrap(round13DroneAuthContext("owner", auth.ScopeRead), "drone-p52-rec")
+	require.NoError(t, err, "reconcile must stay best-effort (non-fatal) on Host read error")
+	require.NotNil(t, surface)
+
+	found := false
+	for _, e := range recorded.All() {
+		if e.Message == "hosted soul bootstrap reconcile Host read failed" {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "reconcile must log the Host read error instead of silently swallowing it")
+}
+
+// TestP52_ReconcileNilLoggerDoesNotPanic proves the G16 logging helper is
+// nil-safe so best-effort reconcile paths never panic when no logger is wired.
+func TestP52_ReconcileNilLoggerDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	require.NotPanics(t, func() {
+		soulBootstrapReconcileLog(nil, "nil resolver must not panic", errors.New("x"))
+	})
+	require.NotPanics(t, func() {
+		soulBootstrapReconcileLog(&Resolver{}, "nil logger must not panic", errors.New("x"))
+	})
+}

--- a/graph/soul_bootstrap_resolvers.go
+++ b/graph/soul_bootstrap_resolvers.go
@@ -17,6 +17,7 @@ import (
 	soulservice "github.com/equaltoai/lesser/pkg/services/souls"
 	"github.com/equaltoai/lesser/pkg/storage"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
+	"go.uber.org/zap"
 )
 
 const (
@@ -129,6 +130,18 @@ func (r *mutationResolver) StartHostedSoulBootstrap(ctx context.Context, input m
 		now time.Time,
 	) (*workflow.SoulBootstrapState, error) {
 		if recoveryState, handled := soulBootstrapHostedGenesisMessageRetryState(agentUser, existing, correlation, now); handled {
+			// G16 (P52 L3.2): the retry repair rewrites an errored
+			// retry_same_step state back to conversation.registration_active /
+			// send_hosted_soul_genesis_message. This is intentional for a
+			// genuine Host-authored retry_same_step (the failed row of the
+			// projection table), not for accept-timeouts (which L3.2 G15 routes
+			// to REFRESH_STATE). Log the rewrite so it is observable rather
+			// than silent.
+			soulBootstrapReconcileLog(r.Resolver, "hosted soul bootstrap retry repair rewrote errored state to send",
+				errors.New("retry_same_step repair applied"),
+				zap.String("username", agentUser.Username),
+				zap.String("prior_state", soulBootstrapPriorStateName(existing)),
+			)
 			return recoveryState, nil
 		}
 		if replayState, handled := soulBootstrapHostedBeginReplayState(agentUser, existing, correlation, now); handled {
@@ -744,6 +757,34 @@ func (r *Resolver) soulBootstrapService() (soulBootstrapHostService, error) {
 	return bootstrap, nil
 }
 
+// soulBootstrapReconcileLog emits a best-effort reconcile diagnostic when a
+// non-nil resolver logger is configured. It never panics on a nil resolver or
+// logger so reconcile/read paths stay best-effort. Used by G16 (P52 L3.2) to
+// surface previously-swallowed errors and silent state rewrites.
+func soulBootstrapReconcileLog(r *Resolver, msg string, cause error, fields ...zap.Field) {
+	if r == nil || r.Logger == nil {
+		return
+	}
+	fields = append(fields, zap.Error(cause))
+	r.Logger.Warn(msg, fields...)
+}
+
+// soulBootstrapPriorStateName returns a non-empty label for the state being
+// rewritten by a retry repair, for diagnostic logging. Falls back to "unknown"
+// so a log line is always emitted with context.
+func soulBootstrapPriorStateName(state *workflow.SoulBootstrapState) string {
+	if state == nil {
+		return "unknown"
+	}
+	if v := strings.TrimSpace(state.State); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(state.Phase); v != "" {
+		return v
+	}
+	return "unknown"
+}
+
 func (r *Resolver) reconcileHostedSoulBootstrapState(
 	ctx context.Context,
 	viewerUsername string,
@@ -757,6 +798,14 @@ func (r *Resolver) reconcileHostedSoulBootstrapState(
 	if !soulBootstrapShouldReadRepairHostedState(state) {
 		now := time.Now().UTC()
 		if recoveryState, handled := soulBootstrapHostedGenesisMessageRetryState(agentUser, state, state.Correlation, now); handled {
+			// G16 (P52 L3.2): log the silent errored→send retry rewrite so it is
+			// observable. Only reachable for a genuine Host-authored
+			// retry_same_step (accept-timeouts route to REFRESH_STATE via G15).
+			soulBootstrapReconcileLog(r, "hosted soul bootstrap reconcile retry repair rewrote errored state to send",
+				errors.New("retry_same_step repair applied"),
+				zap.String("username", agentUser.Username),
+				zap.String("prior_state", soulBootstrapPriorStateName(state)),
+			)
 			workflowState.SoulBootstrap = workflow.NormalizeSoulBootstrap(recoveryState, agentUser.Username)
 			applySoulBootstrapWorkflowProjection(ctx, r, viewerUsername, agentUser, workflowState, workflowState.SoulBootstrap, now)
 			workflowState.UpdatedAt = &now
@@ -768,6 +817,10 @@ func (r *Resolver) reconcileHostedSoulBootstrapState(
 	}
 	service, err := r.soulBootstrapService()
 	if err != nil {
+		// G16 (P52 L3.2): surface the swallowed read-repair setup error instead
+		// of silently dropping it. Reconcile is best-effort, so we still return
+		// nil to avoid failing the read, but the error is logged for operators.
+		soulBootstrapReconcileLog(r, "hosted soul bootstrap reconcile could not resolve service", err, zap.String("username", agentUser.Username))
 		return nil
 	}
 	result, err := service.ReadBootstrapConversation(ctx, soulservice.BootstrapConversationCompleteInput{
@@ -775,6 +828,15 @@ func (r *Resolver) reconcileHostedSoulBootstrapState(
 		ConversationID: state.HostConversationID,
 	})
 	if err != nil {
+		// G16 (P52 L3.2): surface the swallowed Host read error instead of
+		// silently dropping it. Reconcile is best-effort (a transient Host read
+		// failure must not fail the GraphQL read), but the error is logged so a
+		// persistent Host bridge failure is observable rather than invisible.
+		soulBootstrapReconcileLog(r, "hosted soul bootstrap reconcile Host read failed", err,
+			zap.String("username", agentUser.Username),
+			zap.String("host_registration_id", state.HostRegistrationID),
+			zap.String("host_conversation_id", state.HostConversationID),
+		)
 		return nil
 	}
 
@@ -1081,7 +1143,19 @@ func soulBootstrapStateAfterHostedConversationSnapshot(
 		status = soulservice.NormalizeHostedBootstrapConversationStatus(result.Status)
 	}
 	if status == "" {
-		status = workflow.SoulBootstrapHostConversationStatusInProgress
+		// G16 (P52 L3.2): do not silently coerce an empty/unknown Host status
+		// to in_progress — that would mask a Host regression as progress.
+		// Prefer the existing state's status; only fall back to in_progress
+		// when there is no prior status (an honest default for a brand-new
+		// conversation). The transport guarantees in_progress for a 202
+		// (L3.1) and validateHostConversationSnapshot rejects empty status for
+		// a 200/recover/complete, so reaching here with result != nil and no
+		// prior status signals an unexpected caller, not silent progress.
+		if prior := graphSoulBootstrapHostConversationStatus(state); prior != "" {
+			status = prior
+		} else {
+			status = workflow.SoulBootstrapHostConversationStatusInProgress
+		}
 	}
 	if result != nil && strings.TrimSpace(result.RegistrationID) != "" {
 		state.HostRegistrationID = strings.TrimSpace(result.RegistrationID)
@@ -1096,11 +1170,19 @@ func soulBootstrapStateAfterHostedConversationSnapshot(
 
 	switch status {
 	case workflow.SoulBootstrapHostConversationStatusInProgress:
+		// G14 (P52 L3.2): in_progress is a pending turn — Host has accepted
+		// the message (202) and is processing it. The client must poll via
+		// REFRESH_STATE rather than immediately re-sending (which would
+		// re-issue a blocking turn Host is already running). The locked
+		// projection table permits SEND as an alternative action for in_progress,
+		// so availableActions keeps SEND; the authored typedNextAction is
+		// REFRESH_STATE. This realigns the resolver with the contract and with
+		// the 202-accepted-pending transport (L3.1).
 		state.Phase = workflow.SoulBootstrapPhaseConversation
 		state.State = workflow.SoulBootstrapStateConversationInProgress
-		state.NextAction = workflow.SoulBootstrapNextActionSendHostedGenesisMessage
-		state.RecoveryCategory = ""
-		state.RecoveryAction = ""
+		state.NextAction = workflow.SoulBootstrapNextActionRefreshState
+		state.RecoveryCategory = workflow.SoulBootstrapRecoveryCategoryRefreshState
+		state.RecoveryAction = workflow.SoulBootstrapRecoveryActionRefreshState
 		state.Retryable = false
 		state.RestartRequired = false
 		state.SigningCheckpoints = nil
@@ -1116,11 +1198,17 @@ func soulBootstrapStateAfterHostedConversationSnapshot(
 		state.SigningCheckpoints = nil
 		state.Error = nil
 	case workflow.SoulBootstrapHostConversationStatusDeclarationExtractionPending:
+		// G14 (P52 L3.2): while Host is still extracting the declaration, the
+		// turn is pending — the client must poll (REFRESH_STATE), not send
+		// another message. Sending again would re-issue a blocking turn Host
+		// is already processing. This realigns the resolver with the locked
+		// projection table (docs/contracts/hosted-soul-genesis-projection.md),
+		// which routes declaration_extraction_pending to REFRESH_STATE.
 		state.Phase = workflow.SoulBootstrapPhaseConversation
 		state.State = workflow.SoulBootstrapStateConversationDeclarationExtractionPending
-		state.NextAction = workflow.SoulBootstrapNextActionSendHostedGenesisMessage
-		state.RecoveryCategory = ""
-		state.RecoveryAction = ""
+		state.NextAction = workflow.SoulBootstrapNextActionRefreshState
+		state.RecoveryCategory = workflow.SoulBootstrapRecoveryCategoryRefreshState
+		state.RecoveryAction = workflow.SoulBootstrapRecoveryActionRefreshState
 		state.Retryable = false
 		state.RestartRequired = false
 		state.SigningCheckpoints = nil
@@ -1975,6 +2063,20 @@ func soulBootstrapRecoveryForError(code string, statusCode int, message string) 
 		}
 	}
 	switch strings.TrimSpace(code) {
+	case workflow.SoulBootstrapErrorHostUnavailable:
+		// G15 (P52 L3.2): a Host unavailable / accept-timeout on the send POST
+		// must NOT map to RETRY_SAME_STEP. RETRY_SAME_STEP would instruct the
+		// client to re-issue the same blocking send — the binding constraint
+		// this project removes. Under the MicroVM-only contract, Host may have
+		// accepted the turn and be processing it asynchronously; the safe
+		// forward motion is to poll state (REFRESH_STATE), which reconciles via
+		// the read path and recovers the conversation id. Not Retryable as a
+		// blocking re-issue; RestartRequired stays false.
+		return soulBootstrapRecoveryPlan{
+			Category:   workflow.SoulBootstrapRecoveryCategoryRefreshState,
+			Action:     workflow.SoulBootstrapRecoveryActionRefreshState,
+			NextAction: workflow.SoulBootstrapNextActionRefreshState,
+		}
 	case workflow.SoulBootstrapErrorHostTrustNotConfigured,
 		workflow.SoulBootstrapErrorHostInstanceKeyMissing,
 		workflow.SoulBootstrapErrorHostInstanceKeyUnavailable,
@@ -2766,11 +2868,23 @@ func graphSoulBootstrapHostedConversationAvailableActions(state *workflow.SoulBo
 		return nil
 	}
 	switch strings.TrimSpace(state.State) {
-	case workflow.SoulBootstrapStateConversationRegistrationActive,
-		workflow.SoulBootstrapStateConversationInProgress,
-		workflow.SoulBootstrapStateConversationDeclarationExtractionPending:
+	case workflow.SoulBootstrapStateConversationRegistrationActive:
 		return []model.SoulBootstrapNextAction{
 			model.SoulBootstrapNextActionSendHostedSoulGenesisMessage,
+		}
+	case workflow.SoulBootstrapStateConversationInProgress:
+		// G14 (P52 L3.2): in_progress is a pending turn. Poll (REFRESH_STATE)
+		// is primary; the locked projection table permits SEND as an
+		// alternative, so both are advertised with REFRESH_STATE first.
+		return []model.SoulBootstrapNextAction{
+			model.SoulBootstrapNextActionRefreshState,
+			model.SoulBootstrapNextActionSendHostedSoulGenesisMessage,
+		}
+	case workflow.SoulBootstrapStateConversationDeclarationExtractionPending:
+		// G14 (P52 L3.2): declaration extraction is pending — poll only.
+		// The locked projection table allows REFRESH_STATE only here.
+		return []model.SoulBootstrapNextAction{
+			model.SoulBootstrapNextActionRefreshState,
 		}
 	case workflow.SoulBootstrapStateConversationAssistantTurnReady:
 		return []model.SoulBootstrapNextAction{

--- a/graph/soul_bootstrap_round44_test.go
+++ b/graph/soul_bootstrap_round44_test.go
@@ -857,7 +857,11 @@ func TestRound44CompleteHostedSoulGenesisRequiresTerminalDeclarationEvidence(t *
 	require.NoError(t, err)
 	require.Nil(t, payload.Error)
 	require.Equal(t, workflow.SoulBootstrapStateConversationInProgress, payload.Bootstrap.State.State)
-	require.Equal(t, model.SoulBootstrapNextActionSendHostedSoulGenesisMessage, payload.Bootstrap.TypedNextAction)
+	// P52 L3.2 G14: in_progress is a pending turn. The client must poll
+	// (REFRESH_STATE), not re-send. This realigns with the locked projection
+	// table (hosted-soul-genesis-projection.md), which routes in_progress to
+	// REFRESH_STATE as the example action.
+	require.Equal(t, model.SoulBootstrapNextActionRefreshState, payload.Bootstrap.TypedNextAction)
 	require.NotEqual(t, model.SoulBootstrapNextActionPublishHostedSoul, payload.Bootstrap.TypedNextAction)
 	require.Empty(t, payload.Bootstrap.State.SigningCheckpoints)
 	require.Nil(t, payload.Bootstrap.Workflow.Declaration)

--- a/pkg/services/souls/bootstrap.go
+++ b/pkg/services/souls/bootstrap.go
@@ -545,8 +545,25 @@ func (s *Service) VerifyBootstrapPrincipalDeclaration(ctx context.Context, input
 }
 
 // SendBootstrapConversationMessage relays one mint-conversation turn to Host's
-// durable JSON instance-key route. HTTP 200/202 is transport success only; the
-// returned Host status drives Lesser's local projection.
+// durable JSON instance-key route. Under the MicroVM-only genesis contract
+// (P52 / lesser-host#867) Host returns 202 Accepted-Pending and dispatches the
+// turn to a MicroVM asynchronously; Lesser therefore bounds this call with
+// defaultSoulBootstrapAcceptTimeout (sized for the 202 accept, not the turn).
+//
+// HTTP status is transport state only (G12):
+//   - 202 Accepted: the turn was accepted and is pending. The response body is
+//     NOT a full conversation snapshot — Lesser never parses it as one (G12)
+//     and never projects inline assistant messages from it (G13). Host may
+//     optionally supply conversation/agent ids in a minimal body; otherwise the
+//     caller's existing conversation id is preserved. The returned status is
+//     the canonical pending status "in_progress" so the state machine routes
+//     the client to poll (REFRESH_STATE), not to re-send.
+//   - 200 OK: Host returned a complete synchronous snapshot (the legacy /
+//     non-MicroVM path). It is parsed and validated as a full snapshot, as
+//     before.
+//
+// A timeout maps to HOST_UNAVAILABLE; the resolver routes that to REFRESH_STATE
+// (poll), never to RETRY_SAME_STEP (G15).
 func (s *Service) SendBootstrapConversationMessage(ctx context.Context, input BootstrapConversationMessageInput) (*BootstrapConversationMessageResult, error) {
 	baseURL, _, instanceKey, err := s.hostBootstrapInputs(ctx)
 	if err != nil {
@@ -571,11 +588,19 @@ func (s *Service) SendBootstrapConversationMessage(ctx context.Context, input Bo
 		payload["model"] = model
 	}
 
+	// Read the body as raw bytes so 202 can be handled as accepted-pending
+	// without unmarshaling it into a full snapshot. The accept timeout bounds
+	// the call; reads/poll use the longer default timeout.
 	var raw json.RawMessage
-	requestID, err := s.doHostBootstrapJSON(ctx, http.MethodPost, baseURL, "/api/v1/soul/instance/agents/register/"+url.PathEscape(registrationID)+"/mint-conversation", instanceKey, payload, http.StatusOK, http.StatusAccepted, &raw)
+	requestID, statusCode, err := s.doHostBootstrapJSONWithStatus(ctx, defaultSoulBootstrapAcceptTimeout, http.MethodPost, baseURL, "/api/v1/soul/instance/agents/register/"+url.PathEscape(registrationID)+"/mint-conversation", instanceKey, payload, http.StatusOK, http.StatusAccepted, &raw)
 	if err != nil {
 		return nil, err
 	}
+
+	if statusCode == http.StatusAccepted {
+		return s.bootstrapConversationMessageAcceptedPending(registrationID, input.ConversationID, raw, requestID), nil
+	}
+
 	out, version, err := parseHostConversationResponseEnvelope(raw, requestID)
 	if err != nil {
 		return nil, err
@@ -600,6 +625,65 @@ func (s *Service) SendBootstrapConversationMessage(ctx context.Context, input Bo
 		}
 	}
 	return result, nil
+}
+
+// bootstrapConversationMessageAcceptedPending projects a 202 Accepted-Pending
+// response into a pending turn result. It never treats the 202 body as a full
+// conversation snapshot (G12) and never surfaces inline assistant messages
+// (G13): Messages is nil and MessageCount is 0. Host may optionally carry
+// conversation/agent/registration ids — either at the top level or nested
+// under a durable `conversation` envelope — and those are extracted
+// best-effort so Lesser can persist host_conversation_id early (projection
+// invariant #2); they fall back to the caller's existing conversation id. The
+// status is the canonical pending status "in_progress" so the state machine
+// routes the client to poll.
+func (s *Service) bootstrapConversationMessageAcceptedPending(registrationID, inputConversationID string, raw json.RawMessage, requestID string) *BootstrapConversationMessageResult {
+	result := &BootstrapConversationMessageResult{
+		RegistrationID: registrationID,
+		ConversationID: strings.TrimSpace(inputConversationID),
+		Status:         NormalizeHostedBootstrapConversationStatus("in_progress"),
+		HostRequestID:  strings.TrimSpace(requestID),
+	}
+	// Best-effort id extraction only. A missing/empty body is valid for
+	// accepted-pending; any parse failure is ignored so a pending accept is
+	// never turned into a HOST_RESPONSE_INVALID. Messages, status validation,
+	// and produced-declaration evidence are intentionally NOT read here — the
+	// 202 is not a snapshot.
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return result
+	}
+	var envelope struct {
+		RegistrationID string `json:"registration_id"`
+		AgentID        string `json:"agent_id"`
+		ConversationID string `json:"conversation_id"`
+		RequestID      string `json:"request_id"`
+		Conversation   struct {
+			RegistrationID string `json:"registration_id"`
+			AgentID        string `json:"agent_id"`
+			ConversationID string `json:"conversation_id"`
+			RequestID      string `json:"request_id"`
+		} `json:"conversation"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return result
+	}
+	regID := firstNonEmpty(strings.TrimSpace(envelope.RegistrationID), strings.TrimSpace(envelope.Conversation.RegistrationID))
+	if regID != "" {
+		result.RegistrationID = regID
+	}
+	agentID := firstNonEmpty(strings.TrimSpace(envelope.AgentID), strings.TrimSpace(envelope.Conversation.AgentID))
+	if agentID != "" {
+		result.HostSoulAgentID = strings.ToLower(agentID)
+	}
+	convID := firstNonEmpty(strings.TrimSpace(envelope.ConversationID), strings.TrimSpace(envelope.Conversation.ConversationID))
+	if convID != "" {
+		result.ConversationID = convID
+	}
+	bodyRequestID := firstNonEmpty(strings.TrimSpace(envelope.RequestID), strings.TrimSpace(envelope.Conversation.RequestID))
+	if bodyRequestID != "" {
+		result.HostRequestID = hostConversationRequestID(requestID, bodyRequestID)
+	}
+	return result
 }
 
 // CompleteBootstrapConversation completes a Host mint conversation and returns
@@ -1093,10 +1177,26 @@ func (s *Service) hostBootstrapInputs(ctx context.Context) (string, string, stri
 	return baseURL, instanceDomain, strings.TrimSpace(instanceKey), nil
 }
 
+// doHostBootstrapJSON issues a Host bootstrap JSON request, validates the
+// response status against expectedStatuses, and unmarshals the body into the
+// trailing pointer argument when one is supplied. It uses the default
+// discovery/read timeout and discards the HTTP status code. Callers that need
+// the propagated status (the send POST, to distinguish 200 from 202) or a
+// per-call timeout (the send POST accept timeout) must use
+// doHostBootstrapJSONWithStatus.
 func (s *Service) doHostBootstrapJSON(ctx context.Context, method string, baseURL string, path string, instanceKey string, payload any, expectedStatuses ...any) (string, error) {
+	requestID, _, err := s.doHostBootstrapJSONWithStatus(ctx, defaultSoulHTTPTimeout, method, baseURL, path, instanceKey, payload, expectedStatuses...)
+	return requestID, err
+}
+
+// doHostBootstrapJSONWithStatus is the status-propagating, timeout-aware core
+// of doHostBootstrapJSON. It returns the Host request id, the HTTP status code
+// of the response (propagated so callers can distinguish 200 from 202 — see
+// G12), and any error. A timeout <= 0 falls back to defaultSoulHTTPTimeout.
+func (s *Service) doHostBootstrapJSONWithStatus(ctx context.Context, timeout time.Duration, method string, baseURL string, path string, instanceKey string, payload any, expectedStatuses ...any) (string, int, error) {
 	endpoint, err := hostBootstrapURL(baseURL, path)
 	if err != nil {
-		return "", &HostBootstrapError{Code: "HOST_UNAVAILABLE", Message: "Host bootstrap endpoint is unavailable.", Source: "host", Err: fmt.Errorf("%w: %v", ErrHostUnavailable, err)}
+		return "", 0, &HostBootstrapError{Code: "HOST_UNAVAILABLE", Message: "Host bootstrap endpoint is unavailable.", Source: "host", Err: fmt.Errorf("%w: %v", ErrHostUnavailable, err)}
 	}
 	expected, out := splitHostBootstrapJSONExpectedStatuses(expectedStatuses...)
 
@@ -1104,14 +1204,14 @@ func (s *Service) doHostBootstrapJSON(ctx context.Context, method string, baseUR
 	if payload != nil {
 		encoded, err := json.Marshal(payload)
 		if err != nil {
-			return "", err
+			return "", 0, err
 		}
 		body = bytes.NewReader(encoded)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, endpoint, body)
 	if err != nil {
-		return "", &HostBootstrapError{Code: "HOST_UNAVAILABLE", Message: "Host bootstrap endpoint is unavailable.", Source: "host", Err: fmt.Errorf("%w: %v", ErrHostUnavailable, err)}
+		return "", 0, &HostBootstrapError{Code: "HOST_UNAVAILABLE", Message: "Host bootstrap endpoint is unavailable.", Source: "host", Err: fmt.Errorf("%w: %v", ErrHostUnavailable, err)}
 	}
 	req.Header.Set("Accept", "application/json")
 	if payload != nil {
@@ -1119,35 +1219,55 @@ func (s *Service) doHostBootstrapJSON(ctx context.Context, method string, baseUR
 	}
 	req.Header.Set("Authorization", "Bearer "+instanceKey)
 
+	// A per-call timeout > 0 bounds this request without disturbing a
+	// test-configured client's transport (see WithHTTPClient). The send POST
+	// passes defaultSoulBootstrapAcceptTimeout so it does not block on a full
+	// MicroVM turn; reads/discovery pass defaultSoulHTTPTimeout. We honor an
+	// already-shorter caller context deadline.
+	if timeout > 0 {
+		if deadline, ok := ctx.Deadline(); !ok || time.Until(deadline) > timeout {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, timeout)
+			defer cancel()
+			req = req.WithContext(ctx)
+		}
+	}
+
 	client := s.httpClient
 	if client == nil {
 		client = &http.Client{Timeout: defaultSoulHTTPTimeout}
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", &HostBootstrapError{Code: "HOST_UNAVAILABLE", Message: "Host bootstrap endpoint is unavailable.", Source: "host", Err: fmt.Errorf("%w: %v", ErrHostUnavailable, err)}
+		return "", 0, &HostBootstrapError{Code: "HOST_UNAVAILABLE", Message: "Host bootstrap endpoint is unavailable.", Source: "host", Err: fmt.Errorf("%w: %v", ErrHostUnavailable, err)}
 	}
 	defer resp.Body.Close()
 
 	responseBody, truncated, err := common.ReadUntrustedHTTPResponseBody(resp.Body, hostBootstrapMaxResponseBytes)
 	if err != nil {
-		return requestIDFromHeaders(resp.Header), &HostBootstrapError{Code: "HOST_UNAVAILABLE", Message: "Host bootstrap response is unavailable.", Source: "host", Err: fmt.Errorf("%w: %v", ErrHostUnavailable, err)}
+		return requestIDFromHeaders(resp.Header), resp.StatusCode, &HostBootstrapError{Code: "HOST_UNAVAILABLE", Message: "Host bootstrap response is unavailable.", Source: "host", Err: fmt.Errorf("%w: %v", ErrHostUnavailable, err)}
 	}
 	requestID := requestIDFromHeaders(resp.Header)
 
 	if !hostBootstrapStatusAllowed(resp.StatusCode, expected) {
-		return requestID, hostBootstrapHTTPError(resp.StatusCode, resp.Header, responseBody, truncated, instanceKey)
+		return requestID, resp.StatusCode, hostBootstrapHTTPError(resp.StatusCode, resp.Header, responseBody, truncated, instanceKey)
 	}
 	if truncated {
-		return requestID, &HostBootstrapError{Code: "HOST_UNAVAILABLE", Message: "Host bootstrap response is too large.", Source: "host", StatusCode: resp.StatusCode, HostRequestID: requestID, Err: ErrHostUnavailable}
+		return requestID, resp.StatusCode, &HostBootstrapError{Code: "HOST_UNAVAILABLE", Message: "Host bootstrap response is too large.", Source: "host", StatusCode: resp.StatusCode, HostRequestID: requestID, Err: ErrHostUnavailable}
 	}
 	if out != nil {
-		if err := json.Unmarshal(responseBody, out); err != nil {
-			return requestID, &HostBootstrapError{Code: "HOST_RESPONSE_INVALID", Message: "Host bootstrap response is invalid.", Source: "host", StatusCode: resp.StatusCode, HostRequestID: requestID, Err: fmt.Errorf("%w: %v", ErrHostUnavailable, err)}
+		// An empty body is valid only for an accepted-pending (202) response;
+		// leave the out target zero in that case rather than failing on
+		// "unexpected end of JSON input". For any other status an empty body
+		// is a Host regression and must surface as HOST_RESPONSE_INVALID.
+		if resp.StatusCode == http.StatusAccepted && len(bytes.TrimSpace(responseBody)) == 0 {
+			// leave out zero
+		} else if err := json.Unmarshal(responseBody, out); err != nil {
+			return requestID, resp.StatusCode, &HostBootstrapError{Code: "HOST_RESPONSE_INVALID", Message: "Host bootstrap response is invalid.", Source: "host", StatusCode: resp.StatusCode, HostRequestID: requestID, Err: fmt.Errorf("%w: %v", ErrHostUnavailable, err)}
 		}
 	}
 
-	return requestID, nil
+	return requestID, resp.StatusCode, nil
 }
 
 func splitHostBootstrapJSONExpectedStatuses(values ...any) ([]int, any) {

--- a/pkg/services/souls/bootstrap_test.go
+++ b/pkg/services/souls/bootstrap_test.go
@@ -859,11 +859,17 @@ func TestProject51ServiceReplaysHostV106ConversationFixtures(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, "Bearer "+instanceKey, sawPostAuth)
+	// P52 L3.1: a 202 Accepted-Pending is transport success. The 202 body is
+	// NOT parsed as a full snapshot (G12) and never carries inline assistant
+	// messages (G13): MessageCount is 0 and Messages is empty. Host's
+	// conversation/agent ids are extracted best-effort so Lesser persists
+	// host_conversation_id early; status is the canonical pending status.
 	require.Equal(t, registrationID, sent.RegistrationID)
 	require.Equal(t, agentID, sent.HostSoulAgentID)
 	require.Equal(t, conversationID, sent.ConversationID)
 	require.Equal(t, "in_progress", sent.Status)
-	require.Equal(t, 1, sent.MessageCount)
+	require.Equal(t, 0, sent.MessageCount)
+	require.Empty(t, sent.Messages)
 	require.Equal(t, "req_hosted_genesis_01", sent.HostRequestID)
 	require.Empty(t, sent.ProducedDeclarations)
 
@@ -2598,4 +2604,204 @@ func TestService_BootstrapInvalidHostResponseIsTyped(t *testing.T) {
 	require.ErrorIs(t, err, ErrHostUnavailable)
 	require.Equal(t, "HOST_RESPONSE_INVALID", hostErr.Code)
 	require.Equal(t, "host-req-invalid-json", hostErr.HostRequestID)
+}
+
+// TestP52_SendBootstrapConversation202AcceptedPendingNotParsedAsSnapshot proves
+// L3.1 G12: a 202 Accepted-Pending response is never parsed as a full
+// conversation snapshot, and G13: it never surfaces inline assistant messages.
+// Host may carry transcript fields in the 202 body; Lesser must ignore them for
+// a pending accept and project MessageCount=0 / Messages=nil while still
+// persisting the conversation id early.
+func TestP52_SendBootstrapConversation202AcceptedPendingNotParsedAsSnapshot(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey    = "host-instance-key"
+		registrationID = "reg_p52_accept"
+		conversationID = "conv_p52_accept"
+		agentID        = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	)
+
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-Id", "host-req-accept-header")
+		w.WriteHeader(http.StatusAccepted)
+		// Host nests ids under a durable conversation envelope and — crucially
+		// — includes transcript fields Lesser must NOT project from a 202.
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"version":    "1",
+			"request_id": "host-req-accept-body",
+			"conversation": map[string]any{
+				"registration_id": registrationID,
+				"conversation_id": conversationID,
+				"agent_id":        agentID,
+				"status":          "in_progress",
+				"latest_turn_id":  "turn_should_not_project",
+				"message_count":   3,
+				"messages": []map[string]any{
+					{"role": "assistant", "content": "assistant message that must NOT be projected from a 202", "order": 1},
+					{"role": "user", "content": "user message that must NOT be projected from a 202", "order": 2},
+				},
+				"produced_declarations": map[string]any{"selfDescription": "must not appear"},
+			},
+		}))
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	sent, err := service.SendBootstrapConversationMessage(context.Background(), BootstrapConversationMessageInput{
+		RegistrationID: registrationID,
+		Message:        "start hosted genesis",
+	})
+	require.NoError(t, err, "202 Accepted-Pending is transport success")
+	// G12: 202 is not a snapshot. G13: no inline assistant messages.
+	require.Equal(t, "in_progress", sent.Status)
+	require.Equal(t, 0, sent.MessageCount, "202 must not project a snapshot message_count")
+	require.Empty(t, sent.Messages, "202 must not project inline assistant messages")
+	require.Empty(t, sent.LatestTurnID, "202 must not project a latest turn id")
+	require.Empty(t, sent.ProducedDeclarations, "202 must not project produced declarations")
+	// Ids are extracted best-effort so host_conversation_id persists early.
+	require.Equal(t, registrationID, sent.RegistrationID)
+	require.Equal(t, conversationID, sent.ConversationID)
+	require.Equal(t, agentID, sent.HostSoulAgentID)
+	require.Equal(t, "host-req-accept-body", sent.HostRequestID)
+}
+
+// TestP52_SendBootstrapConversation202EmptyBodyAcceptedPending proves a 202
+// with no body is still a valid accepted-pending: Lesser falls back to the
+// caller's existing conversation id and never errors with HOST_RESPONSE_INVALID.
+func TestP52_SendBootstrapConversation202EmptyBodyAcceptedPending(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey    = "host-instance-key"
+		registrationID = "reg_p52_empty"
+		conversationID = "conv_p52_existing"
+	)
+
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Request-Id", "host-req-empty-202")
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	sent, err := service.SendBootstrapConversationMessage(context.Background(), BootstrapConversationMessageInput{
+		RegistrationID: registrationID,
+		ConversationID: conversationID,
+		Message:        "start hosted genesis",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "in_progress", sent.Status)
+	require.Equal(t, 0, sent.MessageCount)
+	require.Empty(t, sent.Messages)
+	require.Equal(t, registrationID, sent.RegistrationID)
+	require.Equal(t, conversationID, sent.ConversationID, "empty 202 body preserves the caller conversation id")
+	require.Equal(t, "host-req-empty-202", sent.HostRequestID)
+}
+
+// TestP52_SendBootstrapConversation200ParsesFullSnapshot proves the legacy
+// synchronous 200 path still parses a complete snapshot with inline messages —
+// the 202-not-a-snapshot change is scoped to 202 only.
+func TestP52_SendBootstrapConversation200ParsesFullSnapshot(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey    = "host-instance-key"
+		registrationID = "reg_p52_200"
+		conversationID = "conv_p52_200"
+		agentID        = "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	)
+
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"version": "1",
+			"conversation": map[string]any{
+				"registration_id": registrationID,
+				"conversation_id": conversationID,
+				"agent_id":        agentID,
+				"status":          "assistant_turn_ready",
+				"latest_turn_id":  "turn_200",
+				"message_count":   2,
+				"messages": []map[string]any{
+					{"role": "user", "content": "hello", "order": 1},
+					{"role": "assistant", "content": "ready", "order": 2},
+				},
+			},
+		}))
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(host.Client())
+
+	sent, err := service.SendBootstrapConversationMessage(context.Background(), BootstrapConversationMessageInput{
+		RegistrationID: registrationID,
+		Message:        "start hosted genesis",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "assistant_turn_ready", sent.Status)
+	require.Equal(t, 2, sent.MessageCount, "200 full snapshot still carries message_count")
+	require.Len(t, sent.Messages, 2, "200 full snapshot still carries inline messages")
+	require.Equal(t, conversationID, sent.ConversationID)
+}
+
+// TestP52_SendBootstrapConversationAcceptTimeoutRoutesHostUnavailable proves
+// L3.1 G11 + L3.2 G15 setup: the send POST is bounded by the short accept
+// timeout (not the 10s turn wait). When Host does not acknowledge the turn in
+// time, Lesser surfaces HOST_UNAVAILABLE — which L3.2 routes to REFRESH_STATE
+// (poll), never to RETRY_SAME_STEP (re-issue the blocking call).
+func TestP52_SendBootstrapConversationAcceptTimeoutRoutesHostUnavailable(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceKey    = "host-instance-key"
+		registrationID = "reg_p52_timeout"
+	)
+
+	host := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Sleep past the accept timeout. Host never acknowledges the turn.
+		time.Sleep(defaultSoulBootstrapAcceptTimeout + 500*time.Millisecond)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer host.Close()
+
+	service := NewService(
+		&fakeAccountRepo{},
+		&fakeInstanceRepo{trust: &storageModels.EffectiveTrustConfig{TrustBaseURL: host.URL}},
+		&config.Config{Domain: "example.com", LesserHostInstanceKey: instanceKey},
+		zap.NewNop(),
+	).WithHTTPClient(&http.Client{Transport: http.DefaultTransport})
+
+	start := time.Now()
+	_, err := service.SendBootstrapConversationMessage(context.Background(), BootstrapConversationMessageInput{
+		RegistrationID: registrationID,
+		Message:        "start hosted genesis",
+	})
+	elapsed := time.Since(start)
+	require.Error(t, err)
+	var hostErr *HostBootstrapError
+	require.ErrorAs(t, err, &hostErr)
+	require.Equal(t, "HOST_UNAVAILABLE", hostErr.Code)
+	// The call must be bounded by the accept timeout, not the 10s turn wait.
+	require.Less(t, elapsed, defaultSoulHTTPTimeout, "send must use the short accept timeout, not the 10s turn wait")
 }

--- a/pkg/services/souls/service.go
+++ b/pkg/services/souls/service.go
@@ -41,7 +41,21 @@ var (
 	ErrTargetAgentAlreadyHasSoul = errors.New("target agent already has soul")
 )
 
+// defaultSoulHTTPTimeout bounds soul discovery (search/identity) and Host
+// bootstrap *read* (poll) HTTP calls — operations that return a complete
+// response body. It is deliberately longer than the accept timeout because a
+// poll reads a fully-formed snapshot.
 const defaultSoulHTTPTimeout = 10 * time.Second
+
+// defaultSoulBootstrapAcceptTimeout bounds the Host bootstrap *send* POST
+// (mint-conversation turn). Under the MicroVM-only genesis contract (P52 /
+// lesser-host#867) Host returns 202 Accepted-Pending and dispatches the turn
+// to a MicroVM asynchronously; Lesser must not block this call for the whole
+// turn. This timeout is sized for Host's 202 *accept*, not for the turn to
+// complete — it stays well under 2s. A timeout here means "Host did not
+// acknowledge the turn in time", which routes the client to poll (REFRESH_STATE),
+// never to re-issue the same blocking send (see G15).
+const defaultSoulBootstrapAcceptTimeout = 1500 * time.Millisecond
 
 const (
 	defaultSoulSearchPageLimit = 100


### PR DESCRIPTION
## Summary

P52 L3.1–L3.3 — lesser-internal transport + state machine for the MicroVM-only hosted genesis contract.

- **Parent:** #1213 (stays OPEN — integration proof gates closure)
- **Factory tracker:** equaltoai/factory#8
- **Host dependency:** lesser-host#867 H1.2 (integration proof BLOCKED on its lab evidence)
- **Branch:** `p52/l3-accept-then-poll` off `main`

Host is making the genesis turn a MicroVM-dispatched async operation that returns `202 Accepted-Pending` (host H1, lesser-host#867). Lesser today blocked the send mutation on one host POST bounded by `defaultSoulHTTPTimeout = 10s` — the binding constraint. This PR makes lesser's transport and state machine honor the 202-then-poll contract so the product path works end to end. **Lesser-internal; no Theory Cloud framework surface in scope; no GraphQL schema change (G17).**

## L3.1 — transport (G11, G12, G13)

- `defaultSoulBootstrapAcceptTimeout` (1.5s, <2s) bounds the send POST, sized for Host's 202 accept — not the turn. Discovery/read paths keep `defaultSoulHTTPTimeout` (10s). (G11)
- `doHostBootstrapJSONWithStatus` propagates HTTP status to callers. `SendBootstrapConversationMessage` treats `202` as accepted-pending and **never parses the 202 body as a full snapshot**; `200` still parses the synchronous snapshot (legacy/non-MicroVM path). (G12)
- A `202` pending result carries **no inline assistant messages** — `Messages` nil, `MessageCount` 0. Host conversation/agent ids are extracted best-effort (top-level or nested durable envelope) so `host_conversation_id` persists early; status is the canonical pending status `in_progress`. (G13)

## L3.2 — state machine (G14, G15, G16)

- `declaration_extraction_pending` → `REFRESH_STATE` (poll), not `SEND` — both `typedNextAction` and `availableActions`. `in_progress` authors `REFRESH_STATE` as primary and keeps `SEND` as an allowed alternative per the locked projection table. (G14)
- `HOST_UNAVAILABLE` (accept timeout) no longer maps to `RETRY_SAME_STEP`; it routes to `REFRESH_STATE` (poll) so reconcile recovers via the read path. The retry_same_step send-repair gate no longer fires for timeouts. Genuine Host-authored `failed` with `retry_same_step` still routes to `RETRY_SAME_STEP` — G15 is scoped to `HOST_UNAVAILABLE`. (G15)
- Silent rewrites/coercions logged or removed (G16): empty/unknown Host status preserves existing state instead of silently coercing to `in_progress`; reconcile logs Host read / service-resolution errors (nil-safe) instead of swallowing them; the errored→send retry repair is logged at both call sites.

## L3.3 — contract snapshot for greater (G4 is greater's step)

- New P52 section in `docs/contracts/hosted-soul-genesis-projection.md` + machine-readable fixture `docs/contracts/examples/hosted-soul-genesis-accept-semantics.example.json` locking accept semantics, turn-state surface, error routing, and observability. Additive to the M1.2 projection table.
- `TestHostedSoulGenesisAcceptSemanticsContract` locks the fixture + markdown section.

## Validation

- `go build ./...` ✅
- `go vet ./...` ✅ (clean)
- `go test -short ./...` ✅ (full repo green)
- Touched packages green: `pkg/services/souls`, `pkg/agents`, `graph`, `cmd/lesser`
- New unit tests prove each invariant:
  - transport: 202 not parsed as snapshot; empty 202 accepted-pending; 200 still parses full snapshot; accept timeout routes `HOST_UNAVAILABLE` under the 10s turn wait
  - state machine: `declaration_extraction_pending` → poll not SEND; `in_progress` → poll primary; `HOST_UNAVAILABLE` → `REFRESH_STATE` not `RETRY_SAME_STEP` (and retry-repair gate does not fire); genuine `failed` still → `RETRY_SAME_STEP`; empty status preserves existing state; reconcile logs Host read error (observed) + nil-safe logger

## Integration proof status

**BLOCKED** on `lesser-host#867` H1.2 lab evidence. The integration proof (send returns accepted in <2s while a >30s turn completes via poll) requires host MicroVM lab evidence that does not yet exist. The unit proof ships here; the integration proof is not faked. Parent #1213 stays OPEN.

## Non-goals / out of scope

- No GraphQL schema change (G17). No host/greater/sim/soul/body changes. No deploy. No merge (reviewer merges).
- No synchronous long-timeout POST or non-MicroVM fallback (program-level refusal).
- No DynamoDB schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)