### PR TITLE
feat: implement soul binding api

### DIFF
--- a/cmd/api/handlers/souls.go
+++ b/cmd/api/handlers/souls.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"crypto/subtle"
 	"errors"
 	"net/http"
 	"strings"
@@ -13,10 +14,18 @@ import (
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 )
 
+const (
+	soulBindingIntegrationCallerID = "lesser-body"
+	soulBindingAPIVersion          = "1"
+	soulBindingStateBound          = "bound"
+)
+
 type soulHandlerService interface {
 	ListMine(ctx context.Context, username string) ([]soulservice.Soul, error)
 	Incorporate(ctx context.Context, principalUsername string, targetAgentUsername string, soulAgentID string) (*soulservice.Soul, error)
 	ResolveBoundAgent(ctx context.Context, agentUsername string) (*soulservice.Soul, error)
+	BindSoulBody(ctx context.Context, input soulservice.BindSoulBodyInput) (*soulservice.SoulBindingProjection, error)
+	GetSoulBinding(ctx context.Context, agentID string, actorUsername string) (*soulservice.SoulBindingProjection, error)
 }
 
 // HandleGetMySoulsLift returns souls owned by the authenticated user's linked wallet(s) for this instance.
@@ -127,6 +136,150 @@ func (h *Handler) HandleIncorporateSoulLift(ctx *apptheory.Context) (*apptheory.
 	})
 }
 
+// HandleCreateSoulBindingLift handles POST /api/v1/souls/bindings.
+//
+// This is a server-to-server body/Ptah integration surface. It is intentionally
+// route-gate reachable so ordinary OAuth middleware does not misclassify the
+// dedicated integration bearer, but the handler fails closed unless the
+// deployment-scoped soul-binding credential matches.
+func (h *Handler) HandleCreateSoulBindingLift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	callerID, resp, err := h.authenticateSoulBindingIntegration(ctx)
+	if err != nil || resp != nil {
+		return resp, err
+	}
+
+	idempotencyKey := strings.TrimSpace(headerValue(ctx, "Idempotency-Key"))
+	if idempotencyKey == "" {
+		return respondSoulBindingError(
+			http.StatusBadRequest,
+			"Idempotency key is required",
+			"POST /api/v1/souls/bindings requires the Idempotency-Key header.",
+			"SOUL_BINDING_IDEMPOTENCY_KEY_REQUIRED",
+		)
+	}
+
+	req, bindErr := apptheory.BindRequest[apimodels.SoulBindingRequest](ctx, apptheory.BindConfig[apimodels.SoulBindingRequest]{
+		Body:       true,
+		StrictJSON: true,
+	})
+	if bindErr != nil {
+		return respondSoulBindingError(
+			http.StatusBadRequest,
+			"Invalid soul-binding request",
+			"Request body must be valid JSON matching the soul-binding contract.",
+			"SOUL_BINDING_INVALID_REQUEST",
+		)
+	}
+
+	svc := h.getSoulService()
+	if svc == nil {
+		return respondSoulBindingError(
+			http.StatusInternalServerError,
+			"Soul binding service is unavailable",
+			"Lesser could not initialize the soul-binding service.",
+			"SOUL_BINDING_INTERNAL",
+		)
+	}
+
+	projection, serviceErr := svc.BindSoulBody(ctx.Context(), soulservice.BindSoulBodyInput{
+		CallerID:             callerID,
+		IdempotencyKey:       idempotencyKey,
+		ActorUsername:        req.ActorUsername,
+		SoulAgentID:          req.SoulAgentID,
+		BodyActorID:          req.BodyActorID,
+		HostRegistrationID:   req.HostRegistrationID,
+		HostConversationID:   req.HostConversationID,
+		AuthorityModel:       req.AuthorityModel,
+		AnchorState:          req.AnchorState,
+		OperationalBinding:   req.OperationalBinding,
+		PrincipalAddressHint: req.PrincipalAddress,
+		Evidence: soulservice.SoulBindingEvidence{
+			Source:          req.Evidence.Source,
+			HostRequestID:   req.Evidence.HostRequestID,
+			DeclarationHash: req.Evidence.DeclarationHash,
+			IssuedAt:        req.Evidence.IssuedAt,
+		},
+	})
+	if serviceErr != nil {
+		return h.respondSoulBindingServiceError(ctx, serviceErr)
+	}
+
+	return okJSON(toAPISoulBindingResponse(projection, true))
+}
+
+// HandleGetSoulBindingLift handles GET /api/v1/souls/bindings/{agentId}.
+func (h *Handler) HandleGetSoulBindingLift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	if _, resp, err := h.authenticateSoulBindingIntegration(ctx); err != nil || resp != nil {
+		return resp, err
+	}
+
+	svc := h.getSoulService()
+	if svc == nil {
+		return respondSoulBindingError(
+			http.StatusInternalServerError,
+			"Soul binding service is unavailable",
+			"Lesser could not initialize the soul-binding service.",
+			"SOUL_BINDING_INTERNAL",
+		)
+	}
+
+	projection, serviceErr := svc.GetSoulBinding(
+		ctx.Context(),
+		strings.TrimSpace(ctx.Param("agentId")),
+		strings.TrimSpace(queryValue(ctx, "actor_username")),
+	)
+	if serviceErr != nil {
+		return h.respondSoulBindingServiceError(ctx, serviceErr)
+	}
+
+	return okJSON(toAPISoulBindingResponse(projection, false))
+}
+
+func (h *Handler) authenticateSoulBindingIntegration(ctx *apptheory.Context) (string, *apptheory.Response, error) {
+	if h == nil || h.cfg == nil {
+		resp, err := respondSoulBindingError(
+			http.StatusServiceUnavailable,
+			"Soul binding is unavailable",
+			"Soul-binding integration credential is not configured for this instance.",
+			"SOUL_BINDING_INTERNAL",
+		)
+		return "", resp, err
+	}
+
+	expected, err := h.cfg.ResolveSoulBindingIntegrationKey()
+	if err != nil || strings.TrimSpace(expected) == "" {
+		resp, respErr := respondSoulBindingError(
+			http.StatusServiceUnavailable,
+			"Soul binding is unavailable",
+			"Soul-binding integration credential is not configured for this instance.",
+			"SOUL_BINDING_INTERNAL",
+		)
+		return "", resp, respErr
+	}
+
+	token, err := common.ExtractBearerToken(headerValue(ctx, "Authorization"))
+	if err != nil || !constantTimeEqual(token, expected) {
+		resp, respErr := respondSoulBindingError(
+			http.StatusUnauthorized,
+			"Soul-binding credential is required",
+			"Provide the deployment-scoped body/Ptah soul-binding integration bearer credential.",
+			"SOUL_BINDING_AUTH_REQUIRED",
+		)
+		return "", resp, respErr
+	}
+
+	return soulBindingIntegrationCallerID, nil, nil
+}
+
+func constantTimeEqual(a string, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	if a == "" || b == "" || len(a) != len(b) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
 func (h *Handler) getSoulService() soulHandlerService {
 	if h == nil {
 		return nil
@@ -171,6 +324,155 @@ func (h *Handler) respondSoulServiceError(ctx *apptheory.Context, err error) (*a
 	}
 }
 
+func (h *Handler) respondSoulBindingServiceError(_ *apptheory.Context, err error) (*apptheory.Response, error) {
+	switch {
+	case errors.Is(err, soulservice.ErrSoulBindingIdempotencyKeyRequired):
+		return respondSoulBindingError(
+			http.StatusBadRequest,
+			"Idempotency key is required",
+			"POST /api/v1/souls/bindings requires the Idempotency-Key header.",
+			"SOUL_BINDING_IDEMPOTENCY_KEY_REQUIRED",
+		)
+	case errors.Is(err, soulservice.ErrSoulBindingInvalidRequest),
+		errors.Is(err, soulservice.ErrTargetAgentRequired):
+		return respondSoulBindingError(
+			http.StatusBadRequest,
+			"Invalid soul-binding request",
+			"Request fields must identify a local agent actor and hosted bound soul.",
+			"SOUL_BINDING_INVALID_REQUEST",
+		)
+	case errors.Is(err, soulservice.ErrSoulBindingAgentIDInvalid):
+		return respondSoulBindingError(
+			http.StatusBadRequest,
+			"Invalid soul agent ID",
+			"soul_agent_id must be canonical lowercase 0x plus 64 hexadecimal characters.",
+			"SOUL_BINDING_AGENT_ID_INVALID",
+		)
+	case errors.Is(err, soulservice.ErrTargetAgentNotFound):
+		return respondSoulBindingError(
+			http.StatusNotFound,
+			"Target local actor was not found",
+			"Lesser could not find the requested local agent actor.",
+			"SOUL_BINDING_ACTOR_NOT_FOUND",
+		)
+	case errors.Is(err, soulservice.ErrSoulBindingNotFound):
+		return respondSoulBindingError(
+			http.StatusNotFound,
+			"Soul binding was not found",
+			"No Lesser-local soul/body binding exists for the requested soul agent ID.",
+			"SOUL_BINDING_NOT_FOUND",
+		)
+	case errors.Is(err, soulservice.ErrSoulBindingIdempotencyMismatch):
+		return respondSoulBindingError(
+			http.StatusConflict,
+			"Idempotency key was reused with a different soul-binding request",
+			"Reuse the original request payload or send a new idempotency key for a new ceremony attempt.",
+			"SOUL_BINDING_IDEMPOTENCY_MISMATCH",
+		)
+	case errors.Is(err, soulservice.ErrSoulAlreadyBound):
+		return respondSoulBindingError(
+			http.StatusConflict,
+			"Soul is already bound to another local actor",
+			"The requested soul agent ID is already bound to a different local actor.",
+			"SOUL_BINDING_SOUL_CONFLICT",
+		)
+	case errors.Is(err, soulservice.ErrTargetAgentAlreadyHasSoul):
+		return respondSoulBindingError(
+			http.StatusConflict,
+			"Local actor is already bound to another soul",
+			"The requested local actor already has a different soul binding.",
+			"SOUL_BINDING_BODY_CONFLICT",
+		)
+	case errors.Is(err, soulservice.ErrSoulBindingActorMismatch):
+		return respondSoulBindingError(
+			http.StatusConflict,
+			"Soul binding is for a different local actor",
+			"The requested actor_username does not match the existing Lesser-local binding.",
+			"SOUL_BINDING_ACTOR_MISMATCH",
+		)
+	case errors.Is(err, soulservice.ErrTargetAgentMustBeAgent):
+		return respondSoulBindingError(
+			http.StatusUnprocessableEntity,
+			"Target local actor is not eligible for soul binding",
+			"The requested local actor exists but is not an agent account.",
+			"SOUL_BINDING_ACTOR_INVALID",
+		)
+	case errors.Is(err, soulservice.ErrSoulBindingHostRegistryRejected):
+		return respondSoulBindingError(
+			http.StatusUnprocessableEntity,
+			"Host registry did not confirm the requested soul binding",
+			"The requested soul was not active for this Lesser domain and local agent.",
+			"SOUL_BINDING_HOST_REGISTRY_REJECTED",
+		)
+	case errors.Is(err, soulservice.ErrSoulBindingHostRegistryUnavailable):
+		return respondSoulBindingError(
+			http.StatusServiceUnavailable,
+			"Host registry is unavailable",
+			"Lesser could not verify Host source truth for the requested hosted soul.",
+			"SOUL_BINDING_HOST_REGISTRY_UNAVAILABLE",
+		)
+	default:
+		return respondSoulBindingError(
+			http.StatusInternalServerError,
+			"Soul binding failed",
+			"Lesser encountered an unexpected error while processing the soul-binding request.",
+			"SOUL_BINDING_INTERNAL",
+		)
+	}
+}
+
+func respondSoulBindingError(status int, message string, description string, code string) (*apptheory.Response, error) {
+	return apptheory.JSON(status, common.StandardErrorResponse{
+		Error:       message,
+		Description: description,
+		Code:        code,
+	})
+}
+
+func toAPISoulBindingResponse(projection *soulservice.SoulBindingProjection, includeIdempotency bool) apimodels.SoulBindingResponse {
+	if projection == nil {
+		return apimodels.SoulBindingResponse{
+			Version:      soulBindingAPIVersion,
+			Status:       soulBindingStateBound,
+			BindingState: soulBindingStateBound,
+		}
+	}
+
+	soul := projection.Soul
+	out := apimodels.SoulBindingResponse{
+		Version:      soulBindingAPIVersion,
+		Status:       soulBindingStateBound,
+		BindingState: soulBindingStateBound,
+		Agent: apimodels.SoulBindingAgent{
+			AgentID:            soul.AgentID,
+			Domain:             soul.Domain,
+			LocalID:            soul.LocalID,
+			AuthorityModel:     soul.AuthorityModel,
+			AnchorState:        soul.AnchorState,
+			OperationalBinding: soul.OperationalBinding,
+			LifecycleStatus:    soul.LifecycleStatus,
+			PublishedVersion:   soul.PublishedVersion,
+		},
+		Binding: apimodels.SoulAgentBinding{
+			AgentUsername:    soul.BoundAgentUsername,
+			PrincipalAddress: soul.BoundPrincipalAddress,
+			BoundAt:          soul.BoundAt,
+			UpdatedAt:        soul.BoundUpdatedAt,
+		},
+	}
+	if includeIdempotency {
+		out.Idempotency = &apimodels.SoulBindingIdempotency{
+			Key:         projection.IdempotencyKey,
+			Replayed:    projection.Replayed,
+			PayloadHash: projection.PayloadHash,
+		}
+		out.Links = &apimodels.SoulBindingLinks{
+			Status: "/api/v1/souls/bindings/" + soul.AgentID,
+		}
+	}
+	return out
+}
+
 func toAPISoulInventoryItem(soul soulservice.Soul) apimodels.SoulInventoryItem {
 	var binding *apimodels.SoulAgentBinding
 	bindingState := "unbound"
@@ -193,6 +495,9 @@ func toAPISoulInventoryItem(soul soulservice.Soul) apimodels.SoulInventoryItem {
 			LocalID:                soul.LocalID,
 			ENSName:                soul.ENSName,
 			Wallet:                 soul.Wallet,
+			AuthorityModel:         soul.AuthorityModel,
+			AnchorState:            soul.AnchorState,
+			OperationalBinding:     soul.OperationalBinding,
 			TokenID:                soul.TokenID,
 			MetaURI:                soul.MetaURI,
 			Avatar:                 toAPISoulAvatar(soul.Avatar),
@@ -210,6 +515,7 @@ func toAPISoulInventoryItem(soul soulservice.Soul) apimodels.SoulInventoryItem {
 			MintTxHash:             soul.MintTxHash,
 			MintedAt:               soul.MintedAt,
 			UpdatedAt:              soul.UpdatedAt,
+			PublishedVersion:       soul.PublishedVersion,
 		},
 		BindingState:              bindingState,
 		AvailableForIncorporation: available,

--- a/cmd/api/handlers/souls_test.go
+++ b/cmd/api/handlers/souls_test.go
@@ -26,11 +26,17 @@ type stubSoulHandlerService struct {
 	listMineErr     error
 	incorporateOut  *soulservice.Soul
 	incorporateErr  error
+	bindOut         *soulservice.SoulBindingProjection
+	bindErr         error
+	getBindingOut   *soulservice.SoulBindingProjection
+	getBindingErr   error
 	resolveBoundOut *soulservice.Soul
 	resolveBoundErr error
 	lastUsername    string
 	lastSoulAgentID string
 	lastTargetAgent string
+	lastBindInput   soulservice.BindSoulBodyInput
+	lastGetAgentID  string
 }
 
 func (s *stubSoulHandlerService) ListMine(_ context.Context, username string) ([]soulservice.Soul, error) {
@@ -48,6 +54,17 @@ func (s *stubSoulHandlerService) Incorporate(_ context.Context, username string,
 func (s *stubSoulHandlerService) ResolveBoundAgent(_ context.Context, agentUsername string) (*soulservice.Soul, error) {
 	s.lastTargetAgent = agentUsername
 	return s.resolveBoundOut, s.resolveBoundErr
+}
+
+func (s *stubSoulHandlerService) BindSoulBody(_ context.Context, input soulservice.BindSoulBodyInput) (*soulservice.SoulBindingProjection, error) {
+	s.lastBindInput = input
+	return s.bindOut, s.bindErr
+}
+
+func (s *stubSoulHandlerService) GetSoulBinding(_ context.Context, agentID string, actorUsername string) (*soulservice.SoulBindingProjection, error) {
+	s.lastGetAgentID = agentID
+	s.lastTargetAgent = actorUsername
+	return s.getBindingOut, s.getBindingErr
 }
 
 type soulPrivateHostReadClientFunc func(*http.Request) (*http.Response, error)
@@ -1436,6 +1453,291 @@ func TestHandleIncorporateSoulLift_ReturnsInternalWhenServiceUnavailable(t *test
 	ctx.Params["agentId"] = agentID
 
 	requireStatus(t, http.StatusInternalServerError)(h.HandleIncorporateSoulLift(ctx))
+}
+
+func TestHandleCreateSoulBindingLift_BindsWithDedicatedIntegrationCredential(t *testing.T) {
+	t.Parallel()
+
+	const (
+		integrationKey = "body-to-lesser-binding-key"
+		agentID        = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	cfg := round10TestConfig()
+	cfg.SoulBindingIntegrationKey = integrationKey
+	service := &stubSoulHandlerService{bindOut: soulBindingHandlerProjection(agentID, "drone-ada", false)}
+	h := &Handler{cfg: cfg, logger: round10TestLogger(t), soulsService: service}
+
+	ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/souls/bindings", map[string]string{
+		"Authorization":   "Bearer " + integrationKey,
+		"Idempotency-Key": "bind-key-1",
+	}, nil, apimodels.SoulBindingRequest{
+		ActorUsername:      "drone-ada",
+		SoulAgentID:        agentID,
+		BodyActorID:        "body://ptah/drone-ada",
+		HostRegistrationID: "hreg_01JZPTHOSTREG",
+		HostConversationID: "hconv_01JZPTHOSTCONV",
+		AuthorityModel:     soulservice.SoulAuthorityModelInstanceTrust,
+		AnchorState:        soulservice.SoulAnchorStateHostedOffchain,
+		OperationalBinding: soulservice.SoulOperationalBindingHostedBound,
+		PrincipalAddress:   "0x2222222222222222222222222222222222222222",
+		Evidence: apimodels.SoulBindingEvidence{
+			Source:          "ptah",
+			HostRequestID:   "hreq_01JZPTHOSTREQ",
+			DeclarationHash: "sha256:4c5835f5c2c84bcaadc17af3c5a5700fdd7f39fb7f61305b02d1a02a0e6c7c56",
+			IssuedAt:        "2026-07-14T16:20:00Z",
+		},
+	})
+	require.NoError(t, err)
+
+	resp := requireStatus(t, http.StatusOK)(h.HandleCreateSoulBindingLift(ctx))
+
+	var body apimodels.SoulBindingResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Equal(t, "1", body.Version)
+	require.Equal(t, "bound", body.Status)
+	require.Equal(t, "bound", body.BindingState)
+	require.Equal(t, agentID, body.Agent.AgentID)
+	require.Equal(t, "example.com", body.Agent.Domain)
+	require.Equal(t, "drone-ada", body.Agent.LocalID)
+	require.Equal(t, soulservice.SoulAuthorityModelInstanceTrust, body.Agent.AuthorityModel)
+	require.Equal(t, soulservice.SoulAnchorStateHostedOffchain, body.Agent.AnchorState)
+	require.Equal(t, soulservice.SoulOperationalBindingHostedBound, body.Agent.OperationalBinding)
+	require.Equal(t, "active", body.Agent.LifecycleStatus)
+	require.Equal(t, 3, body.Agent.PublishedVersion)
+	require.Equal(t, "drone-ada", body.Binding.AgentUsername)
+	require.Equal(t, "0x1111111111111111111111111111111111111111", body.Binding.PrincipalAddress)
+	require.NotNil(t, body.Idempotency)
+	require.Equal(t, "bind-key-1", body.Idempotency.Key)
+	require.False(t, body.Idempotency.Replayed)
+	require.Equal(t, "sha256:handler-payload", body.Idempotency.PayloadHash)
+	require.NotNil(t, body.Links)
+	require.Equal(t, "/api/v1/souls/bindings/"+agentID, body.Links.Status)
+
+	require.Equal(t, soulBindingIntegrationCallerID, service.lastBindInput.CallerID)
+	require.Equal(t, "bind-key-1", service.lastBindInput.IdempotencyKey)
+	require.Equal(t, "drone-ada", service.lastBindInput.ActorUsername)
+	require.Equal(t, agentID, service.lastBindInput.SoulAgentID)
+	require.Equal(t, "body://ptah/drone-ada", service.lastBindInput.BodyActorID)
+	require.Equal(t, "hreg_01JZPTHOSTREG", service.lastBindInput.HostRegistrationID)
+	require.Equal(t, "hconv_01JZPTHOSTCONV", service.lastBindInput.HostConversationID)
+	require.Equal(t, soulservice.SoulAuthorityModelInstanceTrust, service.lastBindInput.AuthorityModel)
+	require.Equal(t, "0x2222222222222222222222222222222222222222", service.lastBindInput.PrincipalAddressHint)
+	require.Equal(t, "ptah", service.lastBindInput.Evidence.Source)
+}
+
+func TestHandleCreateSoulBindingLift_RejectsOrdinaryOAuthAndBadInputs(t *testing.T) {
+	t.Parallel()
+
+	const (
+		integrationKey = "body-to-lesser-binding-key"
+		agentID        = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	)
+
+	cfg := round10TestConfig()
+	cfg.SoulBindingIntegrationKey = integrationKey
+	oauthToken := round11SignToken(t, cfg.JWTSecret, "alice", []string{auth.ScopeWrite}, "ordinary-user")
+
+	tests := []struct {
+		name       string
+		headers    map[string]string
+		body       any
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "missing credential",
+			headers:    nil,
+			body:       apimodels.SoulBindingRequest{ActorUsername: "drone-ada", SoulAgentID: agentID},
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   "SOUL_BINDING_AUTH_REQUIRED",
+		},
+		{
+			name: "ordinary oauth token is not accepted",
+			headers: map[string]string{
+				"Authorization":   "Bearer " + oauthToken,
+				"Idempotency-Key": "bind-key-ordinary",
+			},
+			body:       apimodels.SoulBindingRequest{ActorUsername: "drone-ada", SoulAgentID: agentID},
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   "SOUL_BINDING_AUTH_REQUIRED",
+		},
+		{
+			name: "missing idempotency key",
+			headers: map[string]string{
+				"Authorization": "Bearer " + integrationKey,
+			},
+			body:       apimodels.SoulBindingRequest{ActorUsername: "drone-ada", SoulAgentID: agentID},
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "SOUL_BINDING_IDEMPOTENCY_KEY_REQUIRED",
+		},
+		{
+			name: "service is not reached without dedicated credential",
+			headers: map[string]string{
+				"Authorization":   "Bearer wrong-key",
+				"Idempotency-Key": "bind-key-wrong",
+			},
+			body:       apimodels.SoulBindingRequest{ActorUsername: "drone-ada", SoulAgentID: agentID},
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   "SOUL_BINDING_AUTH_REQUIRED",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			service := &stubSoulHandlerService{bindOut: soulBindingHandlerProjection(agentID, "drone-ada", false)}
+			h := &Handler{cfg: cfg, logger: round10TestLogger(t), soulsService: service}
+			ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/souls/bindings", tc.headers, nil, tc.body)
+			require.NoError(t, err)
+
+			resp := requireStatus(t, tc.wantStatus)(h.HandleCreateSoulBindingLift(ctx))
+			require.Equal(t, tc.wantCode, decodeStandardErrorResponse(t, resp).Code)
+			require.Empty(t, service.lastBindInput.CallerID, "handler must not call service after auth/input rejection")
+		})
+	}
+
+	t.Run("invalid body", func(t *testing.T) {
+		t.Parallel()
+
+		service := &stubSoulHandlerService{bindOut: soulBindingHandlerProjection(agentID, "drone-ada", false)}
+		h := &Handler{cfg: cfg, logger: round10TestLogger(t), soulsService: service}
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/api/v1/souls/bindings", map[string]string{
+			"Authorization":   "Bearer " + integrationKey,
+			"Idempotency-Key": "bind-key-invalid",
+		}, nil, []byte("{"))
+
+		resp := requireStatus(t, http.StatusBadRequest)(h.HandleCreateSoulBindingLift(ctx))
+		require.Equal(t, "SOUL_BINDING_INVALID_REQUEST", decodeStandardErrorResponse(t, resp).Code)
+		require.Empty(t, service.lastBindInput.CallerID)
+	})
+}
+
+func TestHandleSoulBindingLift_MapsServiceProjectionAndErrors(t *testing.T) {
+	t.Parallel()
+
+	const (
+		integrationKey = "body-to-lesser-binding-key"
+		agentID        = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	)
+
+	cfg := round10TestConfig()
+	cfg.SoulBindingIntegrationKey = integrationKey
+
+	t.Run("get returns status projection without idempotency block", func(t *testing.T) {
+		t.Parallel()
+
+		service := &stubSoulHandlerService{getBindingOut: soulBindingHandlerProjection(agentID, "drone-ada", false)}
+		h := &Handler{cfg: cfg, logger: round10TestLogger(t), soulsService: service}
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/souls/bindings/"+agentID, map[string]string{
+			"Authorization": "Bearer " + integrationKey,
+		}, map[string]string{"actor_username": "drone-ada"}, nil)
+		require.NoError(t, err)
+		ctx.Params["agentId"] = agentID
+
+		resp := requireStatus(t, http.StatusOK)(h.HandleGetSoulBindingLift(ctx))
+
+		var body apimodels.SoulBindingResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "bound", body.Status)
+		require.Equal(t, agentID, body.Agent.AgentID)
+		require.Nil(t, body.Idempotency)
+		require.Nil(t, body.Links)
+		require.Equal(t, agentID, service.lastGetAgentID)
+		require.Equal(t, "drone-ada", service.lastTargetAgent)
+	})
+
+	t.Run("actor mismatch maps to stable conflict code", func(t *testing.T) {
+		t.Parallel()
+
+		service := &stubSoulHandlerService{getBindingErr: soulservice.ErrSoulBindingActorMismatch}
+		h := &Handler{cfg: cfg, logger: round10TestLogger(t), soulsService: service}
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/souls/bindings/"+agentID, map[string]string{
+			"Authorization": "Bearer " + integrationKey,
+		}, map[string]string{"actor_username": "wrong-agent"}, nil)
+		require.NoError(t, err)
+		ctx.Params["agentId"] = agentID
+
+		resp := requireStatus(t, http.StatusConflict)(h.HandleGetSoulBindingLift(ctx))
+		require.Equal(t, "SOUL_BINDING_ACTOR_MISMATCH", decodeStandardErrorResponse(t, resp).Code)
+	})
+
+	t.Run("host unavailable fails closed", func(t *testing.T) {
+		t.Parallel()
+
+		service := &stubSoulHandlerService{getBindingErr: soulservice.ErrSoulBindingHostRegistryUnavailable}
+		h := &Handler{cfg: cfg, logger: round10TestLogger(t), soulsService: service}
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/souls/bindings/"+agentID, map[string]string{
+			"Authorization": "Bearer " + integrationKey,
+		}, nil, nil)
+		require.NoError(t, err)
+		ctx.Params["agentId"] = agentID
+
+		resp := requireStatus(t, http.StatusServiceUnavailable)(h.HandleGetSoulBindingLift(ctx))
+		require.Equal(t, "SOUL_BINDING_HOST_REGISTRY_UNAVAILABLE", decodeStandardErrorResponse(t, resp).Code)
+	})
+
+	t.Run("write conflict maps body conflict code", func(t *testing.T) {
+		t.Parallel()
+
+		service := &stubSoulHandlerService{bindErr: soulservice.ErrTargetAgentAlreadyHasSoul}
+		h := &Handler{cfg: cfg, logger: round10TestLogger(t), soulsService: service}
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/souls/bindings", map[string]string{
+			"Authorization":   "Bearer " + integrationKey,
+			"Idempotency-Key": "bind-key-conflict",
+		}, nil, apimodels.SoulBindingRequest{ActorUsername: "drone-ada", SoulAgentID: agentID})
+		require.NoError(t, err)
+
+		resp := requireStatus(t, http.StatusConflict)(h.HandleCreateSoulBindingLift(ctx))
+		require.Equal(t, "SOUL_BINDING_BODY_CONFLICT", decodeStandardErrorResponse(t, resp).Code)
+	})
+}
+
+func TestHandleSoulBindingLift_FailsClosedWhenIntegrationCredentialMissing(t *testing.T) {
+	t.Parallel()
+
+	cfg := round10TestConfig()
+	cfg.SoulBindingIntegrationKey = ""
+	h := &Handler{cfg: cfg, logger: round10TestLogger(t), soulsService: &stubSoulHandlerService{}}
+
+	ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/souls/bindings", map[string]string{
+		"Authorization":   "Bearer any-key",
+		"Idempotency-Key": "bind-key",
+	}, nil, apimodels.SoulBindingRequest{
+		ActorUsername: "drone-ada",
+		SoulAgentID:   "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	})
+	require.NoError(t, err)
+
+	resp := requireStatus(t, http.StatusServiceUnavailable)(h.HandleCreateSoulBindingLift(ctx))
+	require.Equal(t, "SOUL_BINDING_INTERNAL", decodeStandardErrorResponse(t, resp).Code)
+}
+
+func soulBindingHandlerProjection(agentID string, username string, replayed bool) *soulservice.SoulBindingProjection {
+	now := time.Date(2026, 7, 14, 16, 20, 2, 0, time.UTC)
+	return &soulservice.SoulBindingProjection{
+		Soul: soulservice.Soul{
+			AgentID:               agentID,
+			Domain:                "example.com",
+			LocalID:               username,
+			AuthorityModel:        soulservice.SoulAuthorityModelInstanceTrust,
+			AnchorState:           soulservice.SoulAnchorStateHostedOffchain,
+			OperationalBinding:    soulservice.SoulOperationalBindingHostedBound,
+			Status:                "active",
+			LifecycleStatus:       "active",
+			PublishedVersion:      3,
+			Bound:                 true,
+			BoundAgentUsername:    username,
+			BoundPrincipalAddress: "0x1111111111111111111111111111111111111111",
+			BoundAt:               now,
+			BoundUpdatedAt:        now,
+		},
+		IdempotencyKey: "bind-key-1",
+		PayloadHash:    "sha256:handler-payload",
+		Replayed:       replayed,
+	}
 }
 
 func TestSoulHandlerHelpers_ServiceResolutionAndErrorMapping(t *testing.T) {

--- a/cmd/api/models/souls.go
+++ b/cmd/api/models/souls.go
@@ -28,6 +28,9 @@ type SoulAgentIdentity struct {
 	LocalID                string           `json:"local_id"`
 	ENSName                *string          `json:"ens_name"`
 	Wallet                 string           `json:"wallet"`
+	AuthorityModel         string           `json:"authority_model,omitempty"`
+	AnchorState            string           `json:"anchor_state,omitempty"`
+	OperationalBinding     string           `json:"operational_binding,omitempty"`
 	TokenID                string           `json:"token_id,omitempty"`
 	MetaURI                string           `json:"meta_uri,omitempty"`
 	Avatar                 *SoulAgentAvatar `json:"avatar,omitempty"`
@@ -45,6 +48,7 @@ type SoulAgentIdentity struct {
 	MintTxHash             string           `json:"mint_tx_hash,omitempty"`
 	MintedAt               *time.Time       `json:"minted_at,omitempty"`
 	UpdatedAt              *time.Time       `json:"updated_at,omitempty"`
+	PublishedVersion       int              `json:"published_version,omitempty"`
 }
 
 // SoulAgentBinding represents a local soul -> agent incorporation binding.
@@ -74,6 +78,64 @@ type BoundSoulResponse struct {
 	Agent        SoulAgentIdentity `json:"agent"`
 	BindingState string            `json:"binding_state"`
 	Binding      SoulAgentBinding  `json:"binding"`
+}
+
+// SoulBindingEvidence carries body/Ptah correlation evidence. Lesser treats it
+// as a hint only; Host source truth remains authoritative.
+type SoulBindingEvidence struct {
+	Source          string `json:"source,omitempty"`
+	HostRequestID   string `json:"host_request_id,omitempty"`
+	DeclarationHash string `json:"declaration_hash,omitempty"`
+	IssuedAt        string `json:"issued_at,omitempty"`
+}
+
+// SoulBindingRequest represents POST /api/v1/souls/bindings.
+type SoulBindingRequest struct {
+	ActorUsername      string              `json:"actor_username"`
+	SoulAgentID        string              `json:"soul_agent_id"`
+	BodyActorID        string              `json:"body_actor_id,omitempty"`
+	HostRegistrationID string              `json:"host_registration_id,omitempty"`
+	HostConversationID string              `json:"host_conversation_id,omitempty"`
+	AuthorityModel     string              `json:"authority_model,omitempty"`
+	AnchorState        string              `json:"anchor_state,omitempty"`
+	OperationalBinding string              `json:"operational_binding,omitempty"`
+	PrincipalAddress   string              `json:"principal_address,omitempty"`
+	Evidence           SoulBindingEvidence `json:"evidence,omitempty"`
+}
+
+// SoulBindingAgent is the Host-refetched identity block used for binding responses.
+type SoulBindingAgent struct {
+	AgentID            string `json:"agent_id"`
+	Domain             string `json:"domain"`
+	LocalID            string `json:"local_id"`
+	AuthorityModel     string `json:"authority_model"`
+	AnchorState        string `json:"anchor_state"`
+	OperationalBinding string `json:"operational_binding"`
+	LifecycleStatus    string `json:"lifecycle_status"`
+	PublishedVersion   int    `json:"published_version,omitempty"`
+}
+
+// SoulBindingIdempotency describes the POST replay scope and canonical payload hash.
+type SoulBindingIdempotency struct {
+	Key         string `json:"key"`
+	Replayed    bool   `json:"replayed"`
+	PayloadHash string `json:"payload_hash"`
+}
+
+// SoulBindingLinks contains binding follow-up links.
+type SoulBindingLinks struct {
+	Status string `json:"status"`
+}
+
+// SoulBindingResponse represents POST/GET /api/v1/souls/bindings*.
+type SoulBindingResponse struct {
+	Version      string                  `json:"version"`
+	Status       string                  `json:"status"`
+	BindingState string                  `json:"binding_state"`
+	Agent        SoulBindingAgent        `json:"agent"`
+	Binding      SoulAgentBinding        `json:"binding"`
+	Idempotency  *SoulBindingIdempotency `json:"idempotency,omitempty"`
+	Links        *SoulBindingLinks       `json:"links,omitempty"`
 }
 
 // SoulMintConversationSummary represents compact mint-conversation metadata for self-scoped private reads.

--- a/cmd/api/public_surface_equivalence_test.go
+++ b/cmd/api/public_surface_equivalence_test.go
@@ -77,12 +77,15 @@ func TestPublicSurfacePackageMatchesLegacyGateDecision(t *testing.T) {
 		{"get skills resolve child remains prefix-public", http.MethodGet, "/api/v1/skills/resolve/child", true},
 		{"get search statuses prefix", http.MethodGet, "/api/v1/search/statuses/abc", true},
 		{"get notes prefix", http.MethodGet, "/api/v1/notes/abc", true},
+		{"get soul binding status", http.MethodGet, "/api/v1/souls/bindings/0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", true},
+		{"get soul binding child private", http.MethodGet, "/api/v1/souls/bindings/0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/audit", false},
 
 		// Exact POST allowlist.
 		{"post apps", http.MethodPost, "/api/v1/apps", true},
 		{"post oauth register", http.MethodPost, "/oauth/register", true},
 		{"post accounts", http.MethodPost, "/api/v1/accounts", true},
 		{"post notifications deliver", http.MethodPost, "/api/v1/notifications/deliver", true},
+		{"post soul bindings", http.MethodPost, "/api/v1/souls/bindings", true},
 		{"post oauth token", http.MethodPost, "/oauth/token", true},
 		{"post oauth revoke", http.MethodPost, "/oauth/revoke", true},
 		{"post oauth consent", http.MethodPost, "/oauth/consent", true},
@@ -119,6 +122,7 @@ func TestPublicSurfacePackageMatchesLegacyGateDecision(t *testing.T) {
 		{"get account pinned statuses private", http.MethodGet, "/api/v1/accounts/123/pinned_statuses", false},
 		{"get trust preview private", http.MethodGet, "/api/v1/trust/previews/abc", false},
 		{"post notifications private", http.MethodPost, "/api/v1/notifications", false},
+		{"post soul binding member private", http.MethodPost, "/api/v1/souls/bindings/0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false},
 		{"post apps child private", http.MethodPost, "/api/v1/apps/123", false},
 		{"put oauth token private", http.MethodPut, "/oauth/token", false},
 		{"delete status private", http.MethodDelete, "/api/v1/statuses/123", false},

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -402,6 +402,8 @@ func configureRoutes(app *apptheory.App) {
 	app.Get("/api/v1/souls/bound/me", apiHandler.HandleGetBoundSoulMeLift, requireReadOrWrite)
 	app.Get("/api/v1/souls/bound/me/mint-conversations", apiHandler.HandleListBoundSoulMintConversationsLift, requireRead)
 	app.Get("/api/v1/souls/bound/me/mint-conversations/{conversationId}", apiHandler.HandleGetBoundSoulMintConversationLift, requireRead)
+	app.Post("/api/v1/souls/bindings", apiHandler.HandleCreateSoulBindingLift)
+	app.Get("/api/v1/souls/bindings/{agentId}", apiHandler.HandleGetSoulBindingLift)
 	app.Get("/api/v1/souls/mine", apiHandler.HandleGetMySoulsLift, requireReadOrWrite)
 	app.Post("/api/v1/souls/{agentId}/incorporate", apiHandler.HandleIncorporateSoulLift, requireWrite)
 

--- a/cmd/api/testdata/auth_surface_exceptions.json
+++ b/cmd/api/testdata/auth_surface_exceptions.json
@@ -22,5 +22,21 @@
     "owner": "lesser-auth-surface-ssot",
     "expiry": "2026-09-01",
     "note": "Gate-reachable, handler-enforced (verified fail-closed) by internal instance-key bearer validation; gate-level backstop deferred as optional defense-in-depth."
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/souls/bindings",
+    "verdict": "failOpen",
+    "owner": "lesser-soul-binding-api",
+    "expiry": "2026-10-15",
+    "note": "Gate-reachable, handler-enforced (verified fail-closed) by dedicated body/Ptah soul-binding integration bearer; ordinary user OAuth is rejected."
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/souls/bindings/{agentId}",
+    "verdict": "overMark",
+    "owner": "lesser-soul-binding-api",
+    "expiry": "2026-10-15",
+    "note": "Gate-reachable, handler-enforced (verified fail-closed) by dedicated body/Ptah soul-binding integration bearer; OpenAPI advertises required integration security."
   }
 ]

--- a/cmd/api/testdata/auth_surface_golden.json
+++ b/cmd/api/testdata/auth_surface_golden.json
@@ -1491,6 +1491,20 @@
     "verdict": "agree"
   },
   {
+    "method": "POST",
+    "path": "/api/v1/souls/bindings",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "required",
+    "verdict": "failOpen"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/souls/bindings/{agentId}",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "required",
+    "verdict": "overMark"
+  },
+  {
     "method": "GET",
     "path": "/api/v1/souls/bound/me",
     "runtimePosture": "auth-required",

--- a/cmd/api/testdata/routes_manifest.txt
+++ b/cmd/api/testdata/routes_manifest.txt
@@ -116,6 +116,7 @@ GET /api/v1/skills/{skillId}
 GET /api/v1/skills/{skillId}/revisions
 GET /api/v1/skills/{skillId}/revisions/{revisionNumber}
 GET /api/v1/skills/{skillId}/revisions/{revisionNumber}/bundle
+GET /api/v1/souls/bindings/{agentId}
 GET /api/v1/souls/bound/me
 GET /api/v1/souls/bound/me/mint-conversations
 GET /api/v1/souls/bound/me/mint-conversations/{conversationId}
@@ -257,6 +258,7 @@ POST /api/v1/reputation/export
 POST /api/v1/reputation/import
 POST /api/v1/reputation/verify
 POST /api/v1/search/statuses
+POST /api/v1/souls/bindings
 POST /api/v1/souls/{agentId}/incorporate
 POST /api/v1/statuses
 POST /api/v1/statuses/{id}/bookmark

--- a/cmd/lesser/cdk.go
+++ b/cmd/lesser/cdk.go
@@ -105,17 +105,18 @@ func cdkDeployWithOutputs(ctx context.Context, repoRoot string, awsProfile strin
 	// Optional deployment configuration from environment variables.
 	// This keeps `lesser up` ergonomic while allowing one-off instance config without editing CDK code.
 	envContexts := map[string]string{
-		"lesserHostUrl":             strings.TrimSpace(os.Getenv("LESSER_HOST_URL")),
-		"lesserHostInstanceKeyArn":  strings.TrimSpace(os.Getenv("LESSER_HOST_INSTANCE_KEY_ARN")),
-		"lesserHostAttestationsUrl": strings.TrimSpace(os.Getenv("LESSER_HOST_ATTESTATIONS_URL")),
-		"bodyEnabled":               strings.TrimSpace(os.Getenv("BODY_ENABLED")),
-		"translationEnabled":        strings.TrimSpace(os.Getenv("TRANSLATION_ENABLED")),
-		"allowAgents":               strings.TrimSpace(os.Getenv("ALLOW_AGENTS")),
-		"allowAgentRegistration":    strings.TrimSpace(os.Getenv("ALLOW_AGENT_REGISTRATION")),
-		"tipEnabled":                strings.TrimSpace(os.Getenv("TIP_ENABLED")),
-		"tipChainId":                strings.TrimSpace(os.Getenv("TIP_CHAIN_ID")),
-		"tipContractAddress":        strings.TrimSpace(os.Getenv("TIP_CONTRACT_ADDRESS")),
-		"apiCorsAllowedOrigins":     firstNonEmpty(os.Getenv("API_CORS_ALLOWED_ORIGINS"), os.Getenv("CORS_ALLOWED_ORIGINS")),
+		"lesserHostUrl":                strings.TrimSpace(os.Getenv("LESSER_HOST_URL")),
+		"lesserHostInstanceKeyArn":     strings.TrimSpace(os.Getenv("LESSER_HOST_INSTANCE_KEY_ARN")),
+		"lesserHostAttestationsUrl":    strings.TrimSpace(os.Getenv("LESSER_HOST_ATTESTATIONS_URL")),
+		"soulBindingIntegrationKeyArn": strings.TrimSpace(os.Getenv("SOUL_BINDING_INTEGRATION_KEY_ARN")),
+		"bodyEnabled":                  strings.TrimSpace(os.Getenv("BODY_ENABLED")),
+		"translationEnabled":           strings.TrimSpace(os.Getenv("TRANSLATION_ENABLED")),
+		"allowAgents":                  strings.TrimSpace(os.Getenv("ALLOW_AGENTS")),
+		"allowAgentRegistration":       strings.TrimSpace(os.Getenv("ALLOW_AGENT_REGISTRATION")),
+		"tipEnabled":                   strings.TrimSpace(os.Getenv("TIP_ENABLED")),
+		"tipChainId":                   strings.TrimSpace(os.Getenv("TIP_CHAIN_ID")),
+		"tipContractAddress":           strings.TrimSpace(os.Getenv("TIP_CONTRACT_ADDRESS")),
+		"apiCorsAllowedOrigins":        firstNonEmpty(os.Getenv("API_CORS_ALLOWED_ORIGINS"), os.Getenv("CORS_ALLOWED_ORIGINS")),
 	}
 	normalizeContext := func(key, value string) string {
 		value = strings.TrimSpace(value)

--- a/docs/architecture/adr/0011-soul-binding-ceremony-api.md
+++ b/docs/architecture/adr/0011-soul-binding-ceremony-api.md
@@ -324,6 +324,7 @@ Binding-specific codes:
 | 409 | `SOUL_BINDING_IDEMPOTENCY_MISMATCH` | Same idempotency key was reused for a different payload. |
 | 409 | `SOUL_BINDING_SOUL_CONFLICT` | Soul agent ID is already bound to a different local actor. |
 | 409 | `SOUL_BINDING_BODY_CONFLICT` | Local actor is already bound to a different soul agent ID. |
+| 409 | `SOUL_BINDING_ACTOR_MISMATCH` | Status lookup supplied an `actor_username` that does not match the existing Lesser-local binding. |
 | 422 | `SOUL_BINDING_ACTOR_INVALID` | Target local actor exists but is not eligible for binding. |
 | 422 | `SOUL_BINDING_HOST_REGISTRY_REJECTED` | Host source truth does not prove the requested identity/binding. |
 | 503 | `SOUL_BINDING_HOST_REGISTRY_UNAVAILABLE` | Host registry could not be reached or returned a retryable failure. |
@@ -380,6 +381,16 @@ least:
 Lesser will use this Host projection as validation source truth before writing
 `SOUL_BODY_BINDING`. Body/Ptah-provided evidence can help find or correlate the
 Host record, but it cannot replace Host source truth.
+
+Implementation note for lesser#1153: Lesser uses Host's existing
+`GET /api/v1/soul/agents/{agentId}` projection under instance trust as the
+response `agent` block source truth and as the validation source before any local
+binding write. That projection is sufficient for lesser-host#696 when it returns
+the fields listed above; remaining Host-side work is limited to preserving that
+field set, active lifecycle semantics, publication evidence, and redacted
+machine-readable errors in every hosted deployment. Lesser fails closed with
+`SOUL_BINDING_HOST_REGISTRY_UNAVAILABLE` when the local binding row exists but
+Host source truth cannot currently be fetched.
 
 Later extension point: Host may add a callback, reservation, or richer registry
 attestation for ceremonies. Such extensions must still preserve the same

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -46,6 +46,11 @@ components:
             scheme: bearer
             bearerFormat: opaque
             description: 'Temporary setup session token: `Authorization: Bearer <setup_token>` (issued by `/setup/bootstrap/verify`).'
+        soulBindingBearer:
+            type: http
+            scheme: bearer
+            bearerFormat: opaque
+            description: Dedicated body/Ptah to Lesser soul-binding integration credential. User OAuth tokens are not accepted.
     schemas:
         Account:
             additionalProperties: false
@@ -6113,6 +6118,10 @@ components:
             properties:
                 agent_id:
                     type: string
+                anchor_state:
+                    type: string
+                authority_model:
+                    type: string
                 avatar:
                     anyOf:
                         - $ref: '#/components/schemas/SoulAgentAvatar'
@@ -6141,6 +6150,8 @@ components:
                     anyOf:
                         - $ref: '#/components/schemas/RFC3339DateTime'
                         - type: "null"
+                operational_binding:
+                    type: string
                 predecessor_agent_id:
                     type: string
                 principal_address:
@@ -6151,6 +6162,8 @@ components:
                     type: string
                 principal_signature:
                     type: string
+                published_version:
+                    type: integer
                 self_description_version:
                     anyOf:
                         - type: integer
@@ -6173,6 +6186,123 @@ components:
                 - local_id
                 - status
                 - wallet
+            type: object
+        SoulBindingAgent:
+            additionalProperties: false
+            properties:
+                agent_id:
+                    type: string
+                anchor_state:
+                    type: string
+                authority_model:
+                    type: string
+                domain:
+                    type: string
+                lifecycle_status:
+                    type: string
+                local_id:
+                    type: string
+                operational_binding:
+                    type: string
+                published_version:
+                    type: integer
+            required:
+                - agent_id
+                - anchor_state
+                - authority_model
+                - domain
+                - lifecycle_status
+                - local_id
+                - operational_binding
+            type: object
+        SoulBindingEvidence:
+            additionalProperties: false
+            properties:
+                declaration_hash:
+                    type: string
+                host_request_id:
+                    type: string
+                issued_at:
+                    type: string
+                source:
+                    type: string
+            type: object
+        SoulBindingIdempotency:
+            additionalProperties: false
+            properties:
+                key:
+                    type: string
+                payload_hash:
+                    type: string
+                replayed:
+                    type: boolean
+            required:
+                - key
+                - payload_hash
+                - replayed
+            type: object
+        SoulBindingLinks:
+            additionalProperties: false
+            properties:
+                status:
+                    type: string
+            required:
+                - status
+            type: object
+        SoulBindingRequest:
+            additionalProperties: false
+            properties:
+                actor_username:
+                    type: string
+                anchor_state:
+                    type: string
+                authority_model:
+                    type: string
+                body_actor_id:
+                    type: string
+                evidence:
+                    $ref: '#/components/schemas/SoulBindingEvidence'
+                host_conversation_id:
+                    type: string
+                host_registration_id:
+                    type: string
+                operational_binding:
+                    type: string
+                principal_address:
+                    type: string
+                soul_agent_id:
+                    type: string
+            required:
+                - actor_username
+                - soul_agent_id
+            type: object
+        SoulBindingResponse:
+            additionalProperties: false
+            properties:
+                agent:
+                    $ref: '#/components/schemas/SoulBindingAgent'
+                binding:
+                    $ref: '#/components/schemas/SoulAgentBinding'
+                binding_state:
+                    type: string
+                idempotency:
+                    anyOf:
+                        - $ref: '#/components/schemas/SoulBindingIdempotency'
+                        - type: "null"
+                links:
+                    anyOf:
+                        - $ref: '#/components/schemas/SoulBindingLinks'
+                        - type: "null"
+                status:
+                    type: string
+                version:
+                    type: string
+            required:
+                - agent
+                - binding
+                - binding_state
+                - status
+                - version
             type: object
         SoulBodyBinding:
             additionalProperties: false
@@ -17246,6 +17376,98 @@ paths:
                 - cmd/api/routes.go
             x-oauth-scopes:
                 - write
+    /api/v1/souls/bindings:
+        post:
+            operationId: post_api_v1_souls_bindings
+            description: 'Create or confirm a Lesser-local hosted soul/body binding for body/Ptah. The endpoint is server-to-server only: it requires the dedicated soul-binding integration bearer, rejects user OAuth tokens, refetches Host source truth, and writes only through Lesser''s SOUL_BODY_BINDING repository path.'
+            tags:
+                - souls
+            security:
+                - soulBindingBearer: []
+            parameters:
+                - name: Idempotency-Key
+                  in: header
+                  required: true
+                  description: Caller-scoped idempotency key for this binding attempt. Reusing the same key with a different canonical payload returns SOUL_BINDING_IDEMPOTENCY_MISMATCH.
+                  schema:
+                    type: string
+                    minLength: 1
+                    maxLength: 200
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/SoulBindingResponse'
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "401":
+                    $ref: '#/components/responses/Unauthorized'
+                "403":
+                    $ref: '#/components/responses/Forbidden'
+                "404":
+                    $ref: '#/components/responses/NotFound'
+                "409":
+                    $ref: '#/components/responses/Conflict'
+                "422":
+                    $ref: '#/components/responses/UnprocessableEntity'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+                "503":
+                    $ref: '#/components/responses/ServiceUnavailable'
+            x-lesser-handler: HandleCreateSoulBindingLift
+            x-lesser-lambda: api
+            x-lesser-routeSources:
+                - cmd/api/routes.go
+    /api/v1/souls/bindings/{agentId}:
+        get:
+            operationId: get_api_v1_souls_bindings_by_agentId
+            description: Return the authenticated body/Ptah status projection for a Lesser-local hosted soul/body binding. Lesser fails closed if the local binding exists but Host source truth cannot currently prove the hosted active identity.
+            tags:
+                - souls
+            security:
+                - soulBindingBearer: []
+            parameters:
+                - name: agentId
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: actor_username
+                  in: query
+                  description: Optional local actor username assertion. A mismatch with the stored binding returns SOUL_BINDING_ACTOR_MISMATCH.
+                  schema:
+                    type: string
+                    minLength: 1
+                    maxLength: 64
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/SoulBindingResponse'
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "401":
+                    $ref: '#/components/responses/Unauthorized'
+                "403":
+                    $ref: '#/components/responses/Forbidden'
+                "404":
+                    $ref: '#/components/responses/NotFound'
+                "409":
+                    $ref: '#/components/responses/Conflict'
+                "422":
+                    $ref: '#/components/responses/UnprocessableEntity'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+                "503":
+                    $ref: '#/components/responses/ServiceUnavailable'
+            x-lesser-handler: HandleGetSoulBindingLift
+            x-lesser-lambda: api
+            x-lesser-routeSources:
+                - cmd/api/routes.go
     /api/v1/souls/bound/me:
         get:
             operationId: get_api_v1_souls_bound_me

--- a/docs/security-public-surface.md
+++ b/docs/security-public-surface.md
@@ -122,6 +122,8 @@ The `tools/authsurface_doc` Go test asserts that the committed section matches t
 | POST | exact | `/api/v1/agents/auth/token` | self-sovereign agent token exchange using signed challenge proof |
 | POST | agent_access_lease_proof | `/api/v1/agents/` | agent access-lease session and renewal proof exchanges; handlers enforce lease/challenge signatures |
 | POST | exact | `/api/v1/notifications/deliver` | gate-reachable notification delivery; handler enforces internal instance key |
+| POST | exact | `/api/v1/souls/bindings` | gate-reachable soul-binding write; handler enforces body/Ptah integration credential |
+| GET/HEAD | single_segment | `/api/v1/souls/bindings/` | gate-reachable soul-binding status read; handler enforces body/Ptah integration credential |
 | POST | exact | `/oauth/token` | OAuth token exchange |
 | POST | exact | `/oauth/revoke` | OAuth token revocation |
 | POST | exact | `/oauth/consent` | OAuth consent submission |
@@ -148,6 +150,8 @@ These routes are intentionally gate-reachable but are **not** anonymous in the g
 | POST | `/setup/admin` | `setup_bearer` | setup-session bearer token enforced in handler |
 | POST | `/setup/finalize` | `bearer_required` | OAuth bearer/admin setup finalization enforced in handler |
 | POST | `/api/v1/notifications/deliver` | `internal_only` | internal instance-key bearer validation enforced in handler |
+| POST | `/api/v1/souls/bindings` | `soul_binding_integration` | body/Ptah soul-binding integration bearer validation enforced in handler |
+| GET | `/api/v1/souls/bindings/{agentId}` | `soul_binding_integration` | body/Ptah soul-binding integration bearer validation enforced in handler |
 <!-- END GENERATED PUBLICSURFACE -->
 
 ### Auth (user-scoped)

--- a/docs/specs/graphql_coverage.yaml
+++ b/docs/specs/graphql_coverage.yaml
@@ -67,9 +67,11 @@ exemptions:
             - /api/v1/admin/soul/well-known
             - /api/v1/notifications/deliver
     - id: lesser_body_mcp
-      reason: lesser-body MCP runtime-agent self-verification endpoints are REST-only support APIs.
+      reason: lesser-body/Ptah integration and MCP runtime-agent self-verification endpoints are REST-only support APIs.
       match:
         exact:
+            - /api/v1/souls/bindings
+            - /api/v1/souls/bindings/{agentId}
             - /api/v1/souls/bound/me
             - /api/v1/souls/bound/me/mint-conversations
             - /api/v1/souls/bound/me/mint-conversations/{conversationId}
@@ -1271,6 +1273,14 @@ routes:
       path: /api/v1/skills/{skillId}/revisions/{revisionNumber}/bundle
       policy: rest_only
       exemptedBy: canonical_skill_authority
+    - method: GET
+      path: /api/v1/souls/bindings/{agentId}
+      policy: rest_only
+      exemptedBy: lesser_body_mcp
+    - method: POST
+      path: /api/v1/souls/bindings
+      policy: rest_only
+      exemptedBy: lesser_body_mcp
     - method: GET
       path: /api/v1/souls/bound/me
       policy: rest_only

--- a/infra/cdk/constructs/lambda_functions.go
+++ b/infra/cdk/constructs/lambda_functions.go
@@ -195,6 +195,11 @@ func CreateLambdaFunctions(stack awscdk.Stack, props *LambdaFunctionsProps) *Lam
 	if v := getConfigString("lesserHostAttestationsUrl"); v != "" {
 		commonEnv["LESSER_HOST_ATTESTATIONS_URL"] = jsii.String(v)
 	}
+	// NOTE: Dedicated body/Ptah -> Lesser binding credential ARN; the ARN is non-secret,
+	// but the resolved value must remain server-side only.
+	if v := getConfigString("soulBindingIntegrationKeyArn"); v != "" {
+		commonEnv["SOUL_BINDING_INTEGRATION_KEY_ARN"] = jsii.String(v)
+	}
 
 	// Optional tables
 	if props.StreamEventsTable != nil {

--- a/infra/cdk/main.go
+++ b/infra/cdk/main.go
@@ -117,6 +117,7 @@ func main() {
 			"lesserHostUrl",
 			"lesserHostInstanceKeyArn",
 			"lesserHostAttestationsUrl",
+			"soulBindingIntegrationKeyArn",
 			"bodyEnabled",
 			"soulEnabled",
 			"translationEnabled",

--- a/infra/cdk/stacks/configured_secret_permissions.go
+++ b/infra/cdk/stacks/configured_secret_permissions.go
@@ -12,6 +12,7 @@ import (
 
 var configuredSecretARNContextKeys = []string{
 	"lesserHostInstanceKeyArn",
+	"soulBindingIntegrationKeyArn",
 	"vapidSecretArn",
 }
 

--- a/pkg/auth/publicsurface/publicsurface.go
+++ b/pkg/auth/publicsurface/publicsurface.go
@@ -58,6 +58,9 @@ const (
 	ContractAuthBearerRequired ContractAuthClass = "bearer_required"
 	// ContractAuthInternalOnly is handler-enforced with internal instance keys.
 	ContractAuthInternalOnly ContractAuthClass = "internal_only"
+	// ContractAuthSoulBindingIntegration is handler-enforced with the dedicated
+	// body/Ptah -> Lesser soul-binding integration bearer credential.
+	ContractAuthSoulBindingIntegration ContractAuthClass = "soul_binding_integration"
 )
 
 // ContractAuthRule is one handler-enforced contract-auth override for a route
@@ -412,6 +415,18 @@ var publicRules = []PublicRule{
 	},
 	{
 		Methods:     []string{http.MethodPost},
+		Path:        "/api/v1/souls/bindings",
+		Match:       RuleMatchExact,
+		Description: "gate-reachable soul-binding write; handler enforces body/Ptah integration credential",
+	},
+	{
+		Methods:     []string{http.MethodGet, http.MethodHead},
+		Path:        "/api/v1/souls/bindings/",
+		Match:       RuleMatchSingleSegment,
+		Description: "gate-reachable soul-binding status read; handler enforces body/Ptah integration credential",
+	},
+	{
+		Methods:     []string{http.MethodPost},
 		Path:        "/oauth/token",
 		Match:       RuleMatchExact,
 		Description: "OAuth token exchange",
@@ -526,6 +541,18 @@ var contractAuthRules = []ContractAuthRule{
 		Path:        "/api/v1/notifications/deliver",
 		Class:       ContractAuthInternalOnly,
 		Description: "internal instance-key bearer validation enforced in handler",
+	},
+	{
+		Method:      http.MethodPost,
+		Path:        "/api/v1/souls/bindings",
+		Class:       ContractAuthSoulBindingIntegration,
+		Description: "body/Ptah soul-binding integration bearer validation enforced in handler",
+	},
+	{
+		Method:      http.MethodGet,
+		Path:        "/api/v1/souls/bindings/{agentId}",
+		Class:       ContractAuthSoulBindingIntegration,
+		Description: "body/Ptah soul-binding integration bearer validation enforced in handler",
 	},
 }
 

--- a/pkg/auth/publicsurface/publicsurface_test.go
+++ b/pkg/auth/publicsurface/publicsurface_test.go
@@ -11,24 +11,40 @@ func TestContractAuthOverrides(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name  string
-		route string
-		want  ContractAuthClass
+		name   string
+		method string
+		route  string
+		want   ContractAuthClass
 	}{
 		{
-			name:  "setup admin uses setup bearer",
-			route: "/setup/admin",
-			want:  ContractAuthSetupBearer,
+			name:   "setup admin uses setup bearer",
+			method: http.MethodPost,
+			route:  "/setup/admin",
+			want:   ContractAuthSetupBearer,
 		},
 		{
-			name:  "setup finalize preserves oauth bearer contract",
-			route: "/setup/finalize",
-			want:  ContractAuthBearerRequired,
+			name:   "setup finalize preserves oauth bearer contract",
+			method: http.MethodPost,
+			route:  "/setup/finalize",
+			want:   ContractAuthBearerRequired,
 		},
 		{
-			name:  "notification delivery is internal only",
-			route: "/api/v1/notifications/deliver",
-			want:  ContractAuthInternalOnly,
+			name:   "notification delivery is internal only",
+			method: http.MethodPost,
+			route:  "/api/v1/notifications/deliver",
+			want:   ContractAuthInternalOnly,
+		},
+		{
+			name:   "soul binding write uses dedicated integration bearer",
+			method: http.MethodPost,
+			route:  "/api/v1/souls/bindings",
+			want:   ContractAuthSoulBindingIntegration,
+		},
+		{
+			name:   "soul binding read uses dedicated integration bearer",
+			method: http.MethodGet,
+			route:  "/api/v1/souls/bindings/{agentId}",
+			want:   ContractAuthSoulBindingIntegration,
 		},
 	}
 
@@ -37,10 +53,10 @@ func TestContractAuthOverrides(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, ok := ContractAuth(http.MethodPost, tc.route)
+			got, ok := ContractAuth(tc.method, tc.route)
 			require.True(t, ok)
 			require.Equal(t, tc.want, got)
-			require.True(t, IsPublic(http.MethodPost, tc.route), "contract metadata must not change gate reachability")
+			require.True(t, IsPublic(tc.method, tc.route), "contract metadata must not change gate reachability")
 		})
 	}
 }
@@ -51,6 +67,17 @@ func TestContractAuthDoesNotClassifyNormalPublicRoutes(t *testing.T) {
 	_, ok := ContractAuth(http.MethodGet, "/api/v1/custom_emojis")
 	require.False(t, ok)
 	require.True(t, IsPublic(http.MethodGet, "/api/v1/custom_emojis"))
+}
+
+func TestSoulBindingRoutesAreGateReachableButNotOrdinaryPublicSiblings(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, IsPublic(http.MethodPost, "/api/v1/souls/bindings"))
+	require.True(t, IsPublic(http.MethodGet, "/api/v1/souls/bindings/0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+
+	require.False(t, IsPublic(http.MethodPost, "/api/v1/souls/bindings/0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+	require.False(t, IsPublic(http.MethodGet, "/api/v1/souls/bindings/0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/audit"))
+	require.False(t, IsPublic(http.MethodGet, "/api/v1/souls/private"))
 }
 
 func TestAgentRegistrationAndAuthProofRoutesArePublic(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,6 +82,10 @@ type Config struct {
 	LesserHostInstanceKeyARN  string // ARN pointing to stored instance key (optional)
 	LesserHostAttestationsURL string // Optional override for public attestations/JWKS base URL
 
+	// Dedicated body/Ptah -> Lesser integration credential for server-side soul-binding.
+	SoulBindingIntegrationKey    string // Optional value or Secrets Manager resolved secret
+	SoulBindingIntegrationKeyARN string // ARN pointing to stored binding integration key (optional)
+
 	// Privacy Configuration
 	PrivacyMasterKey     string // Master key for privacy hashing (required for audit privacy)
 	EnablePrivacyHashing bool   // Enable privacy-preserving hashing in audit logs
@@ -305,6 +309,7 @@ func (c *Config) Redacted() *Config {
 	cp.PrivacyMasterKey = RedactedSecretSentinel
 	cp.InstanceAPIKey = RedactedSecretSentinel
 	cp.LesserHostInstanceKey = RedactedSecretSentinel
+	cp.SoulBindingIntegrationKey = RedactedSecretSentinel
 	cp.CloudFrontPrivateKeyPath = RedactedSecretSentinel
 	cp.DynamoDBEncryptionKey = RedactedSecretSentinel
 	cp.ActorPrivateKeyEncryption = RedactedSecretSentinel
@@ -360,21 +365,23 @@ func loadConfig() *Config {
 		ReputationTableName:     getEnvOrDefault("REPUTATION_TABLE_NAME", "lesser-reputation"),
 		AWSAccountID:            getEnvOrDefault("AWS_ACCOUNT_ID", ""),
 
-		JWTSecret:                 strings.TrimSpace(getEnvOrDefault("JWT_SECRET", "")),
-		JWTSecretARN:              strings.TrimSpace(getEnvOrDefault("JWT_SECRET_ARN", "")),
-		KMSKeyID:                  getEnvOrDefault("KMS_KEY_ID", ""), // Optional - defaults to AWS managed key
-		ReputationPrivateKey:      getEnvOrDefault("REPUTATION_PRIVATE_KEY", ""),
-		VAPIDPublicKey:            getEnvOrDefault("VAPID_PUBLIC_KEY", ""),
-		VAPIDSecretARN:            getEnvOrDefault("VAPID_SECRET_ARN", ""),
-		VAPIDSubject:              getEnvOrDefault("VAPID_SUBJECT", ""),
-		AdminUsername:             getEnvOrDefault("ADMIN_USERNAME", ""),
-		SystemActorPublicKey:      getEnvOrDefault("SYSTEM_ACTOR_PUBLIC_KEY", ""),
-		InstanceAPIKey:            strings.TrimSpace(getEnvOrDefault("INSTANCE_API_KEY", "")),
-		InstanceAPIKeyARN:         strings.TrimSpace(getEnvOrDefault("INSTANCE_API_KEY_ARN", "")),
-		LesserHostURL:             strings.TrimRight(strings.TrimSpace(getEnvOrDefault("LESSER_HOST_URL", "")), "/"),
-		LesserHostInstanceKey:     strings.TrimSpace(getEnvOrDefault("LESSER_HOST_INSTANCE_KEY", "")),
-		LesserHostInstanceKeyARN:  strings.TrimSpace(getEnvOrDefault("LESSER_HOST_INSTANCE_KEY_ARN", "")),
-		LesserHostAttestationsURL: strings.TrimRight(strings.TrimSpace(getEnvOrDefault("LESSER_HOST_ATTESTATIONS_URL", "")), "/"),
+		JWTSecret:                    strings.TrimSpace(getEnvOrDefault("JWT_SECRET", "")),
+		JWTSecretARN:                 strings.TrimSpace(getEnvOrDefault("JWT_SECRET_ARN", "")),
+		KMSKeyID:                     getEnvOrDefault("KMS_KEY_ID", ""), // Optional - defaults to AWS managed key
+		ReputationPrivateKey:         getEnvOrDefault("REPUTATION_PRIVATE_KEY", ""),
+		VAPIDPublicKey:               getEnvOrDefault("VAPID_PUBLIC_KEY", ""),
+		VAPIDSecretARN:               getEnvOrDefault("VAPID_SECRET_ARN", ""),
+		VAPIDSubject:                 getEnvOrDefault("VAPID_SUBJECT", ""),
+		AdminUsername:                getEnvOrDefault("ADMIN_USERNAME", ""),
+		SystemActorPublicKey:         getEnvOrDefault("SYSTEM_ACTOR_PUBLIC_KEY", ""),
+		InstanceAPIKey:               strings.TrimSpace(getEnvOrDefault("INSTANCE_API_KEY", "")),
+		InstanceAPIKeyARN:            strings.TrimSpace(getEnvOrDefault("INSTANCE_API_KEY_ARN", "")),
+		LesserHostURL:                strings.TrimRight(strings.TrimSpace(getEnvOrDefault("LESSER_HOST_URL", "")), "/"),
+		LesserHostInstanceKey:        strings.TrimSpace(getEnvOrDefault("LESSER_HOST_INSTANCE_KEY", "")),
+		LesserHostInstanceKeyARN:     strings.TrimSpace(getEnvOrDefault("LESSER_HOST_INSTANCE_KEY_ARN", "")),
+		LesserHostAttestationsURL:    strings.TrimRight(strings.TrimSpace(getEnvOrDefault("LESSER_HOST_ATTESTATIONS_URL", "")), "/"),
+		SoulBindingIntegrationKey:    strings.TrimSpace(getEnvOrDefault("SOUL_BINDING_INTEGRATION_KEY", "")),
+		SoulBindingIntegrationKeyARN: strings.TrimSpace(getEnvOrDefault("SOUL_BINDING_INTEGRATION_KEY_ARN", "")),
 
 		// Privacy configuration
 		PrivacyMasterKey:     getEnvOrDefault("PRIVACY_MASTER_KEY", ""),
@@ -655,6 +662,16 @@ func (c *Config) ResolveLesserHostInstanceKey() (string, error) {
 		return "", nil
 	}
 	return resolveOptionalSecretValue(c.LesserHostInstanceKey, c.LesserHostInstanceKeyARN)
+}
+
+// ResolveSoulBindingIntegrationKey returns the configured dedicated body/Ptah
+// -> Lesser soul-binding integration credential, resolving the optional Secrets
+// Manager ARN lazily when needed.
+func (c *Config) ResolveSoulBindingIntegrationKey() (string, error) {
+	if c == nil {
+		return "", nil
+	}
+	return resolveOptionalSecretValue(c.SoulBindingIntegrationKey, c.SoulBindingIntegrationKeyARN)
 }
 
 // ResolveOptionalSecretValue returns value when set, otherwise resolves arn

--- a/pkg/config/validator.go
+++ b/pkg/config/validator.go
@@ -31,6 +31,7 @@ var secretEnvVarNames = map[string]bool{
 	"PRIVACY_MASTER_KEY":           true,
 	"INSTANCE_API_KEY":             true,
 	"LESSER_HOST_INSTANCE_KEY":     true,
+	"SOUL_BINDING_INTEGRATION_KEY": true,
 	"CLOUDFRONT_PRIVATE_KEY_PATH":  true,
 	"DYNAMODB_ENCRYPTION_KEY":      true,
 	"ACTOR_PRIVATE_KEY_ENCRYPTION": true,

--- a/pkg/services/souls/binding_api.go
+++ b/pkg/services/souls/binding_api.go
@@ -1,0 +1,421 @@
+package souls
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
+	storageRepos "github.com/equaltoai/lesser/pkg/storage/repositories"
+	"go.uber.org/zap"
+)
+
+const soulBindingReceiptTTL = 24 * time.Hour
+
+var (
+	// ErrSoulBindingInvalidRequest indicates the binding intent failed local grammar validation.
+	ErrSoulBindingInvalidRequest = errors.New("soul binding request invalid")
+	// ErrSoulBindingAgentIDInvalid indicates the soul agent ID is not canonical.
+	ErrSoulBindingAgentIDInvalid = errors.New("soul binding agent id invalid")
+	// ErrSoulBindingIdempotencyKeyRequired indicates a POST omitted the required idempotency key.
+	ErrSoulBindingIdempotencyKeyRequired = errors.New("soul binding idempotency key required")
+	// ErrSoulBindingIdempotencyMismatch indicates the same caller/key was reused for a different payload.
+	ErrSoulBindingIdempotencyMismatch = errors.New("soul binding idempotency mismatch")
+	// ErrSoulBindingNotFound indicates no Lesser-local binding row exists for the requested soul.
+	ErrSoulBindingNotFound = errors.New("soul binding not found")
+	// ErrSoulBindingActorMismatch indicates a GET actor_username filter conflicts with the stored binding.
+	ErrSoulBindingActorMismatch = errors.New("soul binding actor mismatch")
+	// ErrSoulBindingHostRegistryRejected indicates Host source truth did not confirm the requested binding.
+	ErrSoulBindingHostRegistryRejected = errors.New("soul binding host registry rejected")
+	// ErrSoulBindingHostRegistryUnavailable indicates Host source truth could not be checked.
+	ErrSoulBindingHostRegistryUnavailable = errors.New("soul binding host registry unavailable")
+)
+
+// SoulBindingEvidence carries caller-provided correlation evidence. It is never
+// authority for the binding; Host source truth is re-fetched before writes.
+type SoulBindingEvidence struct {
+	Source          string
+	HostRequestID   string
+	DeclarationHash string
+	IssuedAt        string
+}
+
+// BindSoulBodyInput is the server-to-server binding intent accepted from body/Ptah.
+type BindSoulBodyInput struct {
+	CallerID             string
+	IdempotencyKey       string
+	ActorUsername        string
+	SoulAgentID          string
+	BodyActorID          string
+	HostRegistrationID   string
+	HostConversationID   string
+	AuthorityModel       string
+	AnchorState          string
+	OperationalBinding   string
+	PrincipalAddressHint string
+	Evidence             SoulBindingEvidence
+}
+
+// SoulBindingProjection returns the current Lesser-local binding plus the
+// Host-refetched identity projection used to validate it.
+type SoulBindingProjection struct {
+	Soul           Soul
+	IdempotencyKey string
+	PayloadHash    string
+	Replayed       bool
+}
+
+// BindSoulBody validates a body/Ptah binding intent and writes the local
+// SOUL_BODY_BINDING rows only through InstanceRepository.BindSoulBody.
+func (s *Service) BindSoulBody(ctx context.Context, input BindSoulBodyInput) (*SoulBindingProjection, error) {
+	if s == nil || s.instanceRepo == nil {
+		return nil, fmt.Errorf("soul service misconfigured")
+	}
+	callerID := normalizeSoulBindingCaller(input.CallerID)
+	if callerID == "" {
+		return nil, ErrSoulBindingInvalidRequest
+	}
+	input.CallerID = callerID
+	if strings.TrimSpace(input.IdempotencyKey) == "" {
+		return nil, ErrSoulBindingIdempotencyKeyRequired
+	}
+
+	normalizedAgentID, err := validateAgentID(input.SoulAgentID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrSoulBindingAgentIDInvalid, err)
+	}
+	if err := validateSoulBindingIntentHints(input); err != nil {
+		return nil, err
+	}
+
+	targetAgent, err := s.resolveHostedTargetAgent(ctx, input.ActorUsername)
+	if err != nil {
+		return nil, err
+	}
+	input.ActorUsername = targetAgent.Username
+	input.SoulAgentID = normalizedAgentID
+
+	payloadHash, err := hashSoulBindingPayload(input)
+	if err != nil {
+		return nil, err
+	}
+	receipt, replayed, err := s.reserveSoulBindingReceipt(ctx, input, payloadHash)
+	if err != nil {
+		return nil, err
+	}
+
+	identity, err := s.fetchAndValidateHostedSoulBindingIdentity(ctx, normalizedAgentID, targetAgent.Username)
+	if err != nil {
+		s.updateSoulBindingReceiptState(ctx, receipt, soulBindingReceiptStatusForError(err), "")
+		return nil, err
+	}
+
+	binding, err := s.instanceRepo.BindSoulBody(ctx, identity.AgentID, targetAgent.Username, canonicalOwnerAddress(identity))
+	if err != nil {
+		mapped := mapSoulBindingWriteError(err)
+		s.updateSoulBindingReceiptState(ctx, receipt, soulBindingReceiptStatusForError(mapped), "")
+		return nil, mapped
+	}
+	s.updateSoulBindingReceiptState(ctx, receipt, "bound", "bound")
+
+	soul := soulFromIdentity(identity, binding)
+	return &SoulBindingProjection{
+		Soul:           soul,
+		IdempotencyKey: strings.TrimSpace(input.IdempotencyKey),
+		PayloadHash:    payloadHash,
+		Replayed:       replayed,
+	}, nil
+}
+
+// GetSoulBinding returns the authenticated body/Ptah status projection for a local binding.
+func (s *Service) GetSoulBinding(ctx context.Context, agentID string, actorUsername string) (*SoulBindingProjection, error) {
+	if s == nil || s.instanceRepo == nil {
+		return nil, fmt.Errorf("soul service misconfigured")
+	}
+
+	normalizedAgentID, err := validateAgentID(agentID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrSoulBindingAgentIDInvalid, err)
+	}
+
+	binding, err := s.instanceRepo.GetSoulBodyBinding(ctx, normalizedAgentID)
+	if err != nil {
+		return nil, err
+	}
+	if binding == nil {
+		return nil, ErrSoulBindingNotFound
+	}
+
+	if strings.TrimSpace(actorUsername) != "" && !strings.EqualFold(strings.TrimSpace(actorUsername), binding.Username) {
+		return nil, ErrSoulBindingActorMismatch
+	}
+
+	identity, err := s.fetchAndValidateHostedSoulBindingIdentity(ctx, normalizedAgentID, binding.Username)
+	if err != nil {
+		return nil, err
+	}
+	soul := soulFromIdentity(identity, binding)
+	return &SoulBindingProjection{Soul: soul}, nil
+}
+
+func validateSoulBindingIntentHints(input BindSoulBodyInput) error {
+	if hint := strings.TrimSpace(input.AuthorityModel); hint != "" && hint != SoulAuthorityModelInstanceTrust {
+		return fmt.Errorf("%w: authority_model must be %s", ErrSoulBindingInvalidRequest, SoulAuthorityModelInstanceTrust)
+	}
+	if hint := strings.TrimSpace(input.AnchorState); hint != "" && hint != SoulAnchorStateHostedOffchain {
+		return fmt.Errorf("%w: anchor_state must be %s", ErrSoulBindingInvalidRequest, SoulAnchorStateHostedOffchain)
+	}
+	if hint := strings.TrimSpace(input.OperationalBinding); hint != "" && hint != SoulOperationalBindingHostedBound {
+		return fmt.Errorf("%w: operational_binding must be %s", ErrSoulBindingInvalidRequest, SoulOperationalBindingHostedBound)
+	}
+	return nil
+}
+
+func (s *Service) reserveSoulBindingReceipt(ctx context.Context, input BindSoulBodyInput, payloadHash string) (*storageModels.InstanceSoulBindingIdempotencyReceipt, bool, error) {
+	existing, err := s.instanceRepo.GetSoulBindingIdempotencyReceipt(ctx, input.CallerID, input.IdempotencyKey)
+	if err != nil {
+		return nil, false, err
+	}
+	if existing != nil {
+		if strings.TrimSpace(existing.PayloadHash) != payloadHash {
+			return existing, true, ErrSoulBindingIdempotencyMismatch
+		}
+		return existing, true, nil
+	}
+
+	receipt := storageModels.NewInstanceSoulBindingIdempotencyReceipt(
+		input.CallerID,
+		input.IdempotencyKey,
+		payloadHash,
+		input.SoulAgentID,
+		input.ActorUsername,
+		time.Now().UTC().Add(soulBindingReceiptTTL),
+	)
+	receipt.BodyActorID = strings.TrimSpace(input.BodyActorID)
+	if err := receipt.UpdateKeys(); err != nil {
+		return nil, false, err
+	}
+
+	err = s.instanceRepo.CreateSoulBindingIdempotencyReceipt(ctx, receipt)
+	if err == nil {
+		return receipt, false, nil
+	}
+
+	existing, getErr := s.instanceRepo.GetSoulBindingIdempotencyReceipt(ctx, input.CallerID, input.IdempotencyKey)
+	if getErr != nil {
+		return nil, false, getErr
+	}
+	if existing != nil {
+		if strings.TrimSpace(existing.PayloadHash) != payloadHash {
+			return existing, true, ErrSoulBindingIdempotencyMismatch
+		}
+		return existing, true, nil
+	}
+	return nil, false, err
+}
+
+func (s *Service) updateSoulBindingReceiptState(ctx context.Context, receipt *storageModels.InstanceSoulBindingIdempotencyReceipt, status string, bindingState string) {
+	if s == nil || s.instanceRepo == nil || receipt == nil {
+		return
+	}
+	status = strings.TrimSpace(status)
+	if status == "" {
+		return
+	}
+	receipt.Status = status
+	receipt.BindingState = strings.TrimSpace(bindingState)
+	receipt.UpdatedAt = time.Now().UTC()
+	if err := s.instanceRepo.UpdateSoulBindingIdempotencyReceipt(ctx, receipt); err != nil && s.logger != nil {
+		s.logger.Warn("failed to update soul binding idempotency receipt",
+			zap.String("status", status),
+			zap.String("agent_id", receipt.AgentID),
+			zap.String("actor_username", receipt.ActorUsername),
+			zap.Error(err))
+	}
+}
+
+func (s *Service) fetchAndValidateHostedSoulBindingIdentity(ctx context.Context, agentID string, actorUsername string) (*hostSoulIdentity, error) {
+	baseURL, instanceDomain, instanceKey, err := s.hostBootstrapInputs(ctx)
+	if err != nil {
+		return nil, mapSoulBindingHostError(err)
+	}
+
+	var out hostSoulAgentResponse
+	_, err = s.doHostBootstrapJSON(
+		ctx,
+		http.MethodGet,
+		baseURL,
+		"/api/v1/soul/agents/"+url.PathEscape(agentID),
+		instanceKey,
+		nil,
+		http.StatusOK,
+		&out,
+	)
+	if err != nil {
+		return nil, mapSoulBindingHostError(err)
+	}
+
+	identity := &out.Agent
+	normalizedAgentID, err := validateAgentID(identity.AgentID)
+	if err != nil {
+		return nil, ErrSoulBindingHostRegistryUnavailable
+	}
+	identity.AgentID = normalizedAgentID
+
+	if !strings.EqualFold(identity.AgentID, agentID) {
+		return nil, ErrSoulBindingHostRegistryRejected
+	}
+	if !domainMatches(identity.Domain, instanceDomain) {
+		return nil, ErrSoulBindingHostRegistryRejected
+	}
+	if !strings.EqualFold(strings.TrimSpace(identity.LocalID), strings.TrimSpace(actorUsername)) {
+		return nil, ErrSoulBindingHostRegistryRejected
+	}
+	if strings.TrimSpace(identity.AuthorityModel) != SoulAuthorityModelInstanceTrust {
+		return nil, ErrSoulBindingHostRegistryRejected
+	}
+	if strings.TrimSpace(identity.AnchorState) != SoulAnchorStateHostedOffchain {
+		return nil, ErrSoulBindingHostRegistryRejected
+	}
+	if strings.TrimSpace(identity.OperationalBinding) != SoulOperationalBindingHostedBound {
+		return nil, ErrSoulBindingHostRegistryRejected
+	}
+	if !identityIsActive(identity) {
+		return nil, ErrSoulBindingHostRegistryRejected
+	}
+	if !hostSoulIdentityHasPublicationEvidence(identity) {
+		return nil, ErrSoulBindingHostRegistryRejected
+	}
+	if canonicalOwnerAddress(identity) == "" {
+		return nil, ErrSoulBindingHostRegistryRejected
+	}
+
+	return identity, nil
+}
+
+func hostSoulIdentityHasPublicationEvidence(identity *hostSoulIdentity) bool {
+	if identity == nil {
+		return false
+	}
+	if identity.PublishedVersion > 0 {
+		return true
+	}
+	return identity.SelfDescriptionVersion != nil && *identity.SelfDescriptionVersion > 0
+}
+
+func hashSoulBindingPayload(input BindSoulBodyInput) (string, error) {
+	payload := normalizedSoulBindingPayload{
+		ActorUsername:      strings.TrimSpace(input.ActorUsername),
+		SoulAgentID:        strings.ToLower(strings.TrimSpace(input.SoulAgentID)),
+		BodyActorID:        strings.TrimSpace(input.BodyActorID),
+		HostRegistrationID: strings.TrimSpace(input.HostRegistrationID),
+		HostConversationID: strings.TrimSpace(input.HostConversationID),
+		AuthorityModel:     strings.TrimSpace(input.AuthorityModel),
+		AnchorState:        strings.TrimSpace(input.AnchorState),
+		OperationalBinding: strings.TrimSpace(input.OperationalBinding),
+		PrincipalAddress:   strings.ToLower(strings.TrimSpace(input.PrincipalAddressHint)),
+		Evidence: normalizedSoulBindingEvidence{
+			Source:          strings.TrimSpace(input.Evidence.Source),
+			HostRequestID:   strings.TrimSpace(input.Evidence.HostRequestID),
+			DeclarationHash: strings.TrimSpace(input.Evidence.DeclarationHash),
+			IssuedAt:        strings.TrimSpace(input.Evidence.IssuedAt),
+		},
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(encoded)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+type normalizedSoulBindingPayload struct {
+	ActorUsername      string                        `json:"actor_username"`
+	SoulAgentID        string                        `json:"soul_agent_id"`
+	BodyActorID        string                        `json:"body_actor_id,omitempty"`
+	HostRegistrationID string                        `json:"host_registration_id,omitempty"`
+	HostConversationID string                        `json:"host_conversation_id,omitempty"`
+	AuthorityModel     string                        `json:"authority_model,omitempty"`
+	AnchorState        string                        `json:"anchor_state,omitempty"`
+	OperationalBinding string                        `json:"operational_binding,omitempty"`
+	PrincipalAddress   string                        `json:"principal_address,omitempty"`
+	Evidence           normalizedSoulBindingEvidence `json:"evidence,omitempty"`
+}
+
+type normalizedSoulBindingEvidence struct {
+	Source          string `json:"source,omitempty"`
+	HostRequestID   string `json:"host_request_id,omitempty"`
+	DeclarationHash string `json:"declaration_hash,omitempty"`
+	IssuedAt        string `json:"issued_at,omitempty"`
+}
+
+func mapSoulBindingWriteError(err error) error {
+	switch {
+	case errors.Is(err, storageRepos.ErrSoulBodyBindingAlreadyExists):
+		return ErrSoulAlreadyBound
+	case errors.Is(err, storageRepos.ErrSoulBodyAlreadyHasBinding):
+		return ErrTargetAgentAlreadyHasSoul
+	default:
+		return err
+	}
+}
+
+func mapSoulBindingHostError(err error) error {
+	var hostErr *HostBootstrapError
+	if errors.As(err, &hostErr) {
+		switch {
+		case errors.Is(hostErr.Err, ErrHostTrustNotConfigured),
+			errors.Is(hostErr.Err, ErrHostInstanceKeyMissing),
+			errors.Is(hostErr.Err, ErrHostInstanceKeyUnavailable),
+			errors.Is(hostErr.Err, ErrHostUnavailable):
+			switch hostErr.StatusCode {
+			case http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusUnprocessableEntity:
+				return ErrSoulBindingHostRegistryRejected
+			default:
+				return ErrSoulBindingHostRegistryUnavailable
+			}
+		default:
+			return ErrSoulBindingHostRegistryUnavailable
+		}
+	}
+	if errors.Is(err, ErrSoulNotAvailable) {
+		return ErrSoulBindingHostRegistryRejected
+	}
+	return ErrSoulBindingHostRegistryUnavailable
+}
+
+func soulBindingReceiptStatusForError(err error) string {
+	switch {
+	case errors.Is(err, ErrSoulBindingHostRegistryUnavailable):
+		return "host_unavailable"
+	case errors.Is(err, ErrSoulAlreadyBound),
+		errors.Is(err, ErrTargetAgentAlreadyHasSoul),
+		errors.Is(err, ErrSoulBindingIdempotencyMismatch),
+		errors.Is(err, ErrSoulBindingActorMismatch):
+		return "conflict"
+	case err != nil:
+		return "rejected"
+	default:
+		return ""
+	}
+}
+
+func normalizeSoulBindingCaller(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func firstPositiveInt(values ...int) int {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
+	}
+	return 0
+}

--- a/pkg/services/souls/binding_api_test.go
+++ b/pkg/services/souls/binding_api_test.go
@@ -1,0 +1,289 @@
+package souls
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/config"
+	"github.com/equaltoai/lesser/pkg/storage"
+	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+const (
+	testBindingSoulAgentID = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	testBindingPrincipal   = "0x1111111111111111111111111111111111111111"
+	testBindingInstanceKey = "host-instance-key"
+)
+
+func TestService_BindSoulBody_SuccessReplayAndStatusProjection(t *testing.T) {
+	var hostCalls int
+	host := newSoulBindingHost(t, func(w http.ResponseWriter, r *http.Request) {
+		hostCalls++
+		require.Equal(t, "Bearer "+testBindingInstanceKey, r.Header.Get("Authorization"))
+		require.Equal(t, "/api/v1/soul/agents/"+testBindingSoulAgentID, r.URL.Path)
+		writeSoulBindingHostIdentity(t, w, testBindingSoulAgentID, "drone-ada", http.StatusOK)
+	})
+	defer host.Close()
+
+	repo := newSoulBindingFakeRepo(host.URL)
+	svc := newSoulBindingTestService(repo)
+	input := testSoulBindingInput("bind-key-1")
+
+	first, err := svc.BindSoulBody(context.Background(), input)
+	require.NoError(t, err)
+	require.False(t, first.Replayed)
+	require.Equal(t, "active", first.Soul.Status)
+	require.True(t, first.Soul.Bound)
+	require.Equal(t, testBindingSoulAgentID, first.Soul.AgentID)
+	require.Equal(t, "drone-ada", first.Soul.BoundAgentUsername)
+	require.Equal(t, testBindingPrincipal, first.Soul.BoundPrincipalAddress)
+	require.Equal(t, SoulAuthorityModelInstanceTrust, first.Soul.AuthorityModel)
+	require.Equal(t, SoulAnchorStateHostedOffchain, first.Soul.AnchorState)
+	require.Equal(t, SoulOperationalBindingHostedBound, first.Soul.OperationalBinding)
+	require.Equal(t, 1, first.Soul.PublishedVersion)
+	require.True(t, strings.HasPrefix(first.PayloadHash, "sha256:"))
+	require.Equal(t, 1, repo.bindCalls, "service must write only through BindSoulBody")
+
+	second, err := svc.BindSoulBody(context.Background(), input)
+	require.NoError(t, err)
+	require.True(t, second.Replayed)
+	require.Equal(t, first.PayloadHash, second.PayloadHash)
+	require.Equal(t, 2, repo.bindCalls, "same-key replay still resolves through Lesser-owned binding writer")
+
+	status, err := svc.GetSoulBinding(context.Background(), testBindingSoulAgentID, "drone-ada")
+	require.NoError(t, err)
+	require.NotNil(t, status, "projection should be non-nil")
+	require.Equal(t, "active", status.Soul.Status)
+	require.Equal(t, "drone-ada", status.Soul.BoundAgentUsername)
+	require.GreaterOrEqual(t, hostCalls, 3, "POST and GET re-fetch Host source truth")
+}
+
+func TestService_BindSoulBody_IdempotencyMismatch(t *testing.T) {
+	host := newSoulBindingHost(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSoulBindingHostIdentity(t, w, testBindingSoulAgentID, "drone-ada", http.StatusOK)
+	})
+	defer host.Close()
+
+	repo := newSoulBindingFakeRepo(host.URL)
+	svc := newSoulBindingTestService(repo)
+
+	input := testSoulBindingInput("same-key")
+	_, err := svc.BindSoulBody(context.Background(), input)
+	require.NoError(t, err)
+
+	input.BodyActorID = "body://ptah/other-correlation"
+	_, err = svc.BindSoulBody(context.Background(), input)
+	require.ErrorIs(t, err, ErrSoulBindingIdempotencyMismatch)
+}
+
+func TestService_BindSoulBody_SamePairAfterReceiptExpiry(t *testing.T) {
+	host := newSoulBindingHost(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSoulBindingHostIdentity(t, w, testBindingSoulAgentID, "drone-ada", http.StatusOK)
+	})
+	defer host.Close()
+
+	repo := newSoulBindingFakeRepo(host.URL)
+	repo.bindingsByAgent[testBindingSoulAgentID] = soulBindingTestBinding(testBindingSoulAgentID, "drone-ada")
+	repo.bindingsByUser["drone-ada"] = repo.bindingsByAgent[testBindingSoulAgentID]
+	svc := newSoulBindingTestService(repo)
+
+	projection, err := svc.BindSoulBody(context.Background(), testSoulBindingInput("receipt-expired-new-key"))
+	require.NoError(t, err)
+	require.False(t, projection.Replayed, "new idempotency receipt should be reserved, but existing binding is still same-pair idempotent")
+	require.True(t, projection.Soul.Bound)
+	require.Equal(t, "drone-ada", projection.Soul.BoundAgentUsername)
+	require.Equal(t, 1, repo.bindCalls, "same-pair replay after receipt expiry must still resolve through Lesser-owned binding writer")
+}
+
+func TestService_BindSoulBody_ConflictCases(t *testing.T) {
+	host := newSoulBindingHost(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSoulBindingHostIdentity(t, w, testBindingSoulAgentID, "drone-ada", http.StatusOK)
+	})
+	defer host.Close()
+
+	t.Run("soul already bound to different body", func(t *testing.T) {
+		repo := newSoulBindingFakeRepo(host.URL)
+		repo.bindingsByAgent[testBindingSoulAgentID] = soulBindingTestBinding(testBindingSoulAgentID, "other-agent")
+		svc := newSoulBindingTestService(repo)
+
+		_, err := svc.BindSoulBody(context.Background(), testSoulBindingInput("conflict-soul"))
+		require.ErrorIs(t, err, ErrSoulAlreadyBound)
+	})
+
+	t.Run("body already bound to different soul", func(t *testing.T) {
+		repo := newSoulBindingFakeRepo(host.URL)
+		otherSoul := "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+		repo.bindingsByUser["drone-ada"] = soulBindingTestBinding(otherSoul, "drone-ada")
+		svc := newSoulBindingTestService(repo)
+
+		_, err := svc.BindSoulBody(context.Background(), testSoulBindingInput("conflict-body"))
+		require.ErrorIs(t, err, ErrTargetAgentAlreadyHasSoul)
+	})
+}
+
+func TestService_GetSoulBinding_ActorMismatchAndHostUnavailable(t *testing.T) {
+	t.Run("actor mismatch has stable error", func(t *testing.T) {
+		host := newSoulBindingHost(t, func(w http.ResponseWriter, r *http.Request) {
+			writeSoulBindingHostIdentity(t, w, testBindingSoulAgentID, "drone-ada", http.StatusOK)
+		})
+		defer host.Close()
+
+		repo := newSoulBindingFakeRepo(host.URL)
+		repo.bindingsByAgent[testBindingSoulAgentID] = soulBindingTestBinding(testBindingSoulAgentID, "drone-ada")
+		svc := newSoulBindingTestService(repo)
+
+		_, err := svc.GetSoulBinding(context.Background(), testBindingSoulAgentID, "other-agent")
+		require.ErrorIs(t, err, ErrSoulBindingActorMismatch)
+	})
+
+	t.Run("local row plus unavailable host fails closed", func(t *testing.T) {
+		host := newSoulBindingHost(t, func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "host unavailable", http.StatusInternalServerError)
+		})
+		defer host.Close()
+
+		repo := newSoulBindingFakeRepo(host.URL)
+		repo.bindingsByAgent[testBindingSoulAgentID] = soulBindingTestBinding(testBindingSoulAgentID, "drone-ada")
+		svc := newSoulBindingTestService(repo)
+
+		_, err := svc.GetSoulBinding(context.Background(), testBindingSoulAgentID, "drone-ada")
+		require.ErrorIs(t, err, ErrSoulBindingHostRegistryUnavailable)
+	})
+}
+
+func TestService_BindSoulBody_LocalAndHostRejections(t *testing.T) {
+	t.Run("actor must exist", func(t *testing.T) {
+		host := newSoulBindingHost(t, func(w http.ResponseWriter, r *http.Request) {
+			writeSoulBindingHostIdentity(t, w, testBindingSoulAgentID, "drone-ada", http.StatusOK)
+		})
+		defer host.Close()
+		repo := newSoulBindingFakeRepo(host.URL)
+		repoAccount := &fakeAccountRepo{usersByUsername: map[string]*storage.User{}}
+		svc := NewService(repoAccount, repo, &config.Config{Domain: "example.com", LesserHostInstanceKey: testBindingInstanceKey}, zap.NewNop())
+
+		_, err := svc.BindSoulBody(context.Background(), testSoulBindingInput("missing-actor"))
+		require.ErrorIs(t, err, ErrTargetAgentNotFound)
+	})
+
+	t.Run("actor must be agent", func(t *testing.T) {
+		host := newSoulBindingHost(t, func(w http.ResponseWriter, r *http.Request) {
+			writeSoulBindingHostIdentity(t, w, testBindingSoulAgentID, "drone-ada", http.StatusOK)
+		})
+		defer host.Close()
+		repo := newSoulBindingFakeRepo(host.URL)
+		repoAccount := &fakeAccountRepo{usersByUsername: map[string]*storage.User{"drone-ada": {Username: "drone-ada", IsAgent: false}}}
+		svc := NewService(repoAccount, repo, &config.Config{Domain: "example.com", LesserHostInstanceKey: testBindingInstanceKey}, zap.NewNop())
+
+		_, err := svc.BindSoulBody(context.Background(), testSoulBindingInput("not-agent"))
+		require.ErrorIs(t, err, ErrTargetAgentMustBeAgent)
+	})
+
+	t.Run("host registry rejection writes no binding", func(t *testing.T) {
+		host := newSoulBindingHost(t, func(w http.ResponseWriter, r *http.Request) {
+			writeSoulBindingHostIdentity(t, w, testBindingSoulAgentID, "other-agent", http.StatusOK)
+		})
+		defer host.Close()
+		repo := newSoulBindingFakeRepo(host.URL)
+		svc := newSoulBindingTestService(repo)
+
+		_, err := svc.BindSoulBody(context.Background(), testSoulBindingInput("host-reject"))
+		require.ErrorIs(t, err, ErrSoulBindingHostRegistryRejected)
+		require.Nil(t, repo.bindingsByAgent[testBindingSoulAgentID])
+		require.Equal(t, 0, repo.bindCalls)
+	})
+}
+
+func newSoulBindingFakeRepo(hostURL string) *fakeInstanceRepo {
+	return &fakeInstanceRepo{
+		trust: &storageModels.EffectiveTrustConfig{
+			TrustBaseURL: hostURL,
+		},
+		bindingsByAgent: map[string]*storageModels.InstanceSoulBodyBinding{},
+		bindingsByUser:  map[string]*storageModels.InstanceSoulBodyBinding{},
+		receipts:        map[string]*storageModels.InstanceSoulBindingIdempotencyReceipt{},
+	}
+}
+
+func newSoulBindingTestService(repo *fakeInstanceRepo) *Service {
+	accountRepo := &fakeAccountRepo{usersByUsername: map[string]*storage.User{
+		"drone-ada": {Username: "drone-ada", IsAgent: true},
+	}}
+	return NewService(accountRepo, repo, &config.Config{Domain: "example.com", LesserHostInstanceKey: testBindingInstanceKey}, zap.NewNop())
+}
+
+func testSoulBindingInput(idempotencyKey string) BindSoulBodyInput {
+	return BindSoulBodyInput{
+		CallerID:             "lesser-body",
+		IdempotencyKey:       idempotencyKey,
+		ActorUsername:        "drone-ada",
+		SoulAgentID:          testBindingSoulAgentID,
+		BodyActorID:          "body://ptah/drone-ada",
+		HostRegistrationID:   "hreg_01JZPTHOSTREG",
+		HostConversationID:   "hconv_01JZPTHOSTCONV",
+		AuthorityModel:       SoulAuthorityModelInstanceTrust,
+		AnchorState:          SoulAnchorStateHostedOffchain,
+		OperationalBinding:   SoulOperationalBindingHostedBound,
+		PrincipalAddressHint: "0x2222222222222222222222222222222222222222",
+		Evidence: SoulBindingEvidence{
+			Source:          "ptah",
+			HostRequestID:   "hreq_01JZPTHOSTREQ",
+			DeclarationHash: "sha256:4c5835f5c2c84bcaadc17af3c5a5700fdd7f39fb7f61305b02d1a02a0e6c7c56",
+			IssuedAt:        "2026-07-14T16:20:00Z",
+		},
+	}
+}
+
+func newSoulBindingHost(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/api/v1/soul/agents/") {
+			http.NotFound(w, r)
+			return
+		}
+		handler(w, r)
+	}))
+}
+
+func writeSoulBindingHostIdentity(t *testing.T, w http.ResponseWriter, agentID string, localID string, status int) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if status != http.StatusOK {
+		return
+	}
+	require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+		"version": "1",
+		"agent": map[string]any{
+			"agent_id":                 agentID,
+			"domain":                   "example.com",
+			"local_id":                 localID,
+			"wallet":                   testBindingPrincipal,
+			"principal_address":        testBindingPrincipal,
+			"status":                   "active",
+			"lifecycle_status":         "active",
+			"authority_model":          SoulAuthorityModelInstanceTrust,
+			"anchor_state":             SoulAnchorStateHostedOffchain,
+			"operational_binding":      SoulOperationalBindingHostedBound,
+			"published_version":        1,
+			"self_description_version": 1,
+		},
+	}))
+}
+
+func soulBindingTestBinding(agentID string, username string) *storageModels.InstanceSoulBodyBinding {
+	binding := &storageModels.InstanceSoulBodyBinding{
+		AgentID:          strings.ToLower(strings.TrimSpace(agentID)),
+		Username:         strings.TrimSpace(username),
+		PrincipalAddress: testBindingPrincipal,
+	}
+	if err := binding.UpdateKeys(); err != nil {
+		panic(err)
+	}
+	return binding
+}

--- a/pkg/services/souls/service.go
+++ b/pkg/services/souls/service.go
@@ -66,6 +66,9 @@ type Soul struct {
 	LocalID                string
 	ENSName                *string
 	Wallet                 string
+	AuthorityModel         string
+	AnchorState            string
+	OperationalBinding     string
 	TokenID                string
 	MetaURI                string
 	Avatar                 *SoulAvatar
@@ -83,6 +86,7 @@ type Soul struct {
 	MintTxHash             string
 	MintedAt               *time.Time
 	UpdatedAt              *time.Time
+	PublishedVersion       int
 	Bound                  bool
 	BoundAgentUsername     string
 	BoundPrincipalAddress  string
@@ -263,6 +267,7 @@ func (s *Service) BindHostedBootstrap(ctx context.Context, targetAgentUsername s
 		AnchorState:        result.AgentAnchorState,
 		OperationalBinding: result.AgentOperationalBinding,
 		UpdatedAt:          result.Publication.PublishedAt,
+		PublishedVersion:   firstPositiveInt(result.PublishedVersion, result.Publication.PublishedVersion),
 	}
 	soul := soulFromIdentity(identity, binding)
 	return &soul, nil
@@ -689,6 +694,9 @@ func soulFromIdentity(identity *hostSoulIdentity, binding *storageModels.Instanc
 		LocalID:                strings.TrimSpace(identity.LocalID),
 		ENSName:                normalizedOptionalString(identity.ENSName),
 		Wallet:                 strings.ToLower(strings.TrimSpace(identity.Wallet)),
+		AuthorityModel:         strings.TrimSpace(identity.AuthorityModel),
+		AnchorState:            strings.TrimSpace(identity.AnchorState),
+		OperationalBinding:     strings.TrimSpace(identity.OperationalBinding),
 		TokenID:                strings.TrimSpace(identity.TokenID),
 		MetaURI:                strings.TrimSpace(identity.MetaURI),
 		Avatar:                 cloneSoulAvatar(identity.Avatar),
@@ -706,6 +714,7 @@ func soulFromIdentity(identity *hostSoulIdentity, binding *storageModels.Instanc
 		MintTxHash:             strings.TrimSpace(identity.MintTxHash),
 		MintedAt:               identity.MintedAt,
 		UpdatedAt:              identity.UpdatedAt,
+		PublishedVersion:       identity.PublishedVersion,
 	}
 	if binding != nil {
 		soul.Bound = true
@@ -777,6 +786,7 @@ type hostSoulIdentity struct {
 	AuthorityModel         string          `json:"authority_model"`
 	AnchorState            string          `json:"anchor_state"`
 	OperationalBinding     string          `json:"operational_binding"`
+	PublishedVersion       int             `json:"published_version"`
 	TokenID                string          `json:"token_id"`
 	MetaURI                string          `json:"meta_uri"`
 	Avatar                 *hostSoulAvatar `json:"avatar"`
@@ -823,4 +833,7 @@ type instanceRepository interface {
 	GetSoulBodyBinding(ctx context.Context, agentID string) (*storageModels.InstanceSoulBodyBinding, error)
 	GetSoulBodyBindingByUsername(ctx context.Context, username string) (*storageModels.InstanceSoulBodyBinding, error)
 	BindSoulBody(ctx context.Context, agentID string, username string, principalAddress string) (*storageModels.InstanceSoulBodyBinding, error)
+	GetSoulBindingIdempotencyReceipt(ctx context.Context, callerID string, idempotencyKey string) (*storageModels.InstanceSoulBindingIdempotencyReceipt, error)
+	CreateSoulBindingIdempotencyReceipt(ctx context.Context, receipt *storageModels.InstanceSoulBindingIdempotencyReceipt) error
+	UpdateSoulBindingIdempotencyReceipt(ctx context.Context, receipt *storageModels.InstanceSoulBindingIdempotencyReceipt) error
 }

--- a/pkg/services/souls/service_test.go
+++ b/pkg/services/souls/service_test.go
@@ -52,7 +52,9 @@ type fakeInstanceRepo struct {
 	trustErr        error
 	bindingsByAgent map[string]*storageModels.InstanceSoulBodyBinding
 	bindingsByUser  map[string]*storageModels.InstanceSoulBodyBinding
+	receipts        map[string]*storageModels.InstanceSoulBindingIdempotencyReceipt
 	bindErr         error
+	bindCalls       int
 }
 
 func (f *fakeInstanceRepo) EffectiveTrustConfig(_ context.Context) (*storageModels.EffectiveTrustConfig, error) {
@@ -77,6 +79,7 @@ func (f *fakeInstanceRepo) GetSoulBodyBindingByUsername(_ context.Context, usern
 }
 
 func (f *fakeInstanceRepo) BindSoulBody(_ context.Context, agentID string, username string, principalAddress string) (*storageModels.InstanceSoulBodyBinding, error) {
+	f.bindCalls++
 	if f.bindErr != nil {
 		return nil, f.bindErr
 	}
@@ -119,6 +122,43 @@ func (f *fakeInstanceRepo) BindSoulBody(_ context.Context, agentID string, usern
 	f.bindingsByAgent[normalizedAgentID] = binding
 	f.bindingsByUser[normalizedUsername] = binding
 	return binding, nil
+}
+
+func (f *fakeInstanceRepo) GetSoulBindingIdempotencyReceipt(_ context.Context, callerID string, idempotencyKey string) (*storageModels.InstanceSoulBindingIdempotencyReceipt, error) {
+	if f == nil || f.receipts == nil {
+		return nil, nil
+	}
+	return f.receipts[f.receiptKey(callerID, idempotencyKey)], nil
+}
+
+func (f *fakeInstanceRepo) CreateSoulBindingIdempotencyReceipt(_ context.Context, receipt *storageModels.InstanceSoulBindingIdempotencyReceipt) error {
+	if f.receipts == nil {
+		f.receipts = map[string]*storageModels.InstanceSoulBindingIdempotencyReceipt{}
+	}
+	key := f.receiptKey(receipt.CallerID, receipt.IdempotencyKeyHash)
+	if _, ok := f.receipts[key]; ok {
+		return storageRepos.ErrSoulBodyBindingAlreadyExists
+	}
+	cp := *receipt
+	f.receipts[key] = &cp
+	return nil
+}
+
+func (f *fakeInstanceRepo) UpdateSoulBindingIdempotencyReceipt(_ context.Context, receipt *storageModels.InstanceSoulBindingIdempotencyReceipt) error {
+	if f.receipts == nil {
+		f.receipts = map[string]*storageModels.InstanceSoulBindingIdempotencyReceipt{}
+	}
+	cp := *receipt
+	f.receipts[f.receiptKey(receipt.CallerID, receipt.IdempotencyKeyHash)] = &cp
+	return nil
+}
+
+func (f *fakeInstanceRepo) receiptKey(callerID string, idempotencyKeyOrHash string) string {
+	key := strings.TrimSpace(idempotencyKeyOrHash)
+	if len(key) != 64 {
+		key = storageModels.SoulBindingIdempotencyKeyHash(key)
+	}
+	return strings.ToLower(strings.TrimSpace(callerID)) + "|" + strings.ToLower(key)
 }
 
 type errorRoundTripper struct {

--- a/pkg/storage/models/instance_soul_binding_idempotency_receipt.go
+++ b/pkg/storage/models/instance_soul_binding_idempotency_receipt.go
@@ -1,0 +1,154 @@
+package models
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	// PKSoulBindingIdempotencyPrefix scopes soul-binding idempotency receipts by authenticated caller.
+	PKSoulBindingIdempotencyPrefix = "SOUL_BINDING_IDEMPOTENCY#"
+	// SKSoulBindingIdempotencyKeyPrefix scopes one idempotency key receipt under a caller partition.
+	SKSoulBindingIdempotencyKeyPrefix = "KEY#"
+)
+
+// InstanceSoulBindingIdempotencyReceipt stores TTL-scoped replay evidence for
+// server-side soul-binding requests. It is control-plane evidence only; the
+// terminal binding truth remains the SOUL_BODY_BINDING rows.
+type InstanceSoulBindingIdempotencyReceipt struct {
+	_ struct{} `theorydb:"naming:camelCase"`
+
+	PK string `theorydb:"pk,attr:PK" json:"-"`
+	SK string `theorydb:"sk,attr:SK" json:"-"`
+
+	CallerID           string    `theorydb:"attr:callerId" json:"caller_id"`
+	IdempotencyKeyHash string    `theorydb:"attr:idempotencyKeyHash" json:"idempotency_key_hash"`
+	PayloadHash        string    `theorydb:"attr:payloadHash" json:"payload_hash"`
+	AgentID            string    `theorydb:"attr:agentId" json:"agent_id"`
+	ActorUsername      string    `theorydb:"attr:actorUsername" json:"actor_username"`
+	BodyActorID        string    `theorydb:"attr:bodyActorId,omitempty" json:"body_actor_id,omitempty"`
+	Status             string    `theorydb:"attr:status" json:"status"`
+	BindingState       string    `theorydb:"attr:bindingState,omitempty" json:"binding_state,omitempty"`
+	CreatedAt          time.Time `theorydb:"attr:createdAt" json:"created_at"`
+	UpdatedAt          time.Time `theorydb:"attr:updatedAt" json:"updated_at"`
+	TTL                int64     `theorydb:"ttl,attr:ttl" json:"ttl,omitempty"`
+	Version            int       `theorydb:"version,attr:version" json:"version"`
+}
+
+// TableName returns the DynamoDB table backing InstanceSoulBindingIdempotencyReceipt.
+func (InstanceSoulBindingIdempotencyReceipt) TableName() string {
+	return MainTableName
+}
+
+// UpdateKeys updates the DynamoDB keys.
+func (r *InstanceSoulBindingIdempotencyReceipt) UpdateKeys() error {
+	if r == nil {
+		return fmt.Errorf("soul binding idempotency receipt is nil")
+	}
+
+	r.CallerID = normalizeSoulBindingReceiptCaller(r.CallerID)
+	r.IdempotencyKeyHash = normalizeSoulBindingReceiptHash(r.IdempotencyKeyHash)
+	r.PayloadHash = strings.TrimSpace(r.PayloadHash)
+	r.AgentID = strings.ToLower(strings.TrimSpace(r.AgentID))
+	r.ActorUsername = strings.TrimSpace(r.ActorUsername)
+	r.BodyActorID = strings.TrimSpace(r.BodyActorID)
+	r.Status = strings.TrimSpace(r.Status)
+	r.BindingState = strings.TrimSpace(r.BindingState)
+
+	if r.CallerID == "" {
+		return fmt.Errorf("caller id is required")
+	}
+	if r.IdempotencyKeyHash == "" {
+		return fmt.Errorf("idempotency key hash is required")
+	}
+	if r.PayloadHash == "" {
+		return fmt.Errorf("payload hash is required")
+	}
+	if r.AgentID == "" {
+		return fmt.Errorf("agent id is required")
+	}
+	if r.ActorUsername == "" {
+		return fmt.Errorf("actor username is required")
+	}
+	if r.Status == "" {
+		r.Status = "received"
+	}
+
+	now := time.Now().UTC()
+	if r.CreatedAt.IsZero() {
+		r.CreatedAt = now
+	}
+	if r.UpdatedAt.IsZero() {
+		r.UpdatedAt = r.CreatedAt
+	}
+
+	r.PK = SoulBindingIdempotencyPartitionKey(r.CallerID)
+	r.SK = SoulBindingIdempotencySortKeyFromHash(r.IdempotencyKeyHash)
+	return nil
+}
+
+// GetPK returns the partition key.
+func (r *InstanceSoulBindingIdempotencyReceipt) GetPK() string {
+	return r.PK
+}
+
+// GetSK returns the sort key.
+func (r *InstanceSoulBindingIdempotencyReceipt) GetSK() string {
+	return r.SK
+}
+
+// NewInstanceSoulBindingIdempotencyReceipt creates a new TTL-scoped soul-binding receipt.
+func NewInstanceSoulBindingIdempotencyReceipt(callerID string, idempotencyKey string, payloadHash string, agentID string, actorUsername string, ttl time.Time) *InstanceSoulBindingIdempotencyReceipt {
+	now := time.Now().UTC()
+	receipt := &InstanceSoulBindingIdempotencyReceipt{
+		CallerID:           callerID,
+		IdempotencyKeyHash: SoulBindingIdempotencyKeyHash(idempotencyKey),
+		PayloadHash:        strings.TrimSpace(payloadHash),
+		AgentID:            strings.ToLower(strings.TrimSpace(agentID)),
+		ActorUsername:      strings.TrimSpace(actorUsername),
+		Status:             "received",
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	if !ttl.IsZero() {
+		receipt.TTL = ttl.UTC().Unix()
+	}
+	_ = receipt.UpdateKeys()
+	return receipt
+}
+
+// SoulBindingIdempotencyPartitionKey returns the caller-scoped receipt partition.
+func SoulBindingIdempotencyPartitionKey(callerID string) string {
+	return PKSoulBindingIdempotencyPrefix + hashSoulBindingReceiptValue(normalizeSoulBindingReceiptCaller(callerID))
+}
+
+// SoulBindingIdempotencySortKey returns the key-scoped receipt sort key.
+func SoulBindingIdempotencySortKey(idempotencyKey string) string {
+	return SoulBindingIdempotencySortKeyFromHash(SoulBindingIdempotencyKeyHash(idempotencyKey))
+}
+
+// SoulBindingIdempotencySortKeyFromHash returns the key-scoped receipt sort key from a precomputed hash.
+func SoulBindingIdempotencySortKeyFromHash(idempotencyKeyHash string) string {
+	return SKSoulBindingIdempotencyKeyPrefix + normalizeSoulBindingReceiptHash(idempotencyKeyHash)
+}
+
+// SoulBindingIdempotencyKeyHash hashes the caller-supplied idempotency key before storage.
+func SoulBindingIdempotencyKeyHash(idempotencyKey string) string {
+	return hashSoulBindingReceiptValue(strings.TrimSpace(idempotencyKey))
+}
+
+func normalizeSoulBindingReceiptCaller(callerID string) string {
+	return strings.ToLower(strings.TrimSpace(callerID))
+}
+
+func normalizeSoulBindingReceiptHash(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func hashSoulBindingReceiptValue(value string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(value)))
+	return hex.EncodeToString(sum[:])
+}

--- a/pkg/storage/models/instance_soul_binding_idempotency_receipt_test.go
+++ b/pkg/storage/models/instance_soul_binding_idempotency_receipt_test.go
@@ -1,0 +1,144 @@
+package models
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstanceSoulBindingIdempotencyReceipt_ConstructsHashedTTLKeys(t *testing.T) {
+	t.Parallel()
+
+	ttl := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	receipt := NewInstanceSoulBindingIdempotencyReceipt(
+		" Lesser-Body ",
+		" Bind-Key ",
+		" sha256:payload ",
+		" 0XAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA ",
+		" Drone-Ada ",
+		ttl,
+	)
+
+	require.Equal(t, "lesser-body", receipt.CallerID)
+	require.Equal(t, testSoulBindingReceiptHash("Bind-Key"), receipt.IdempotencyKeyHash)
+	require.Equal(t, "sha256:payload", receipt.PayloadHash)
+	require.Equal(t, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", receipt.AgentID)
+	require.Equal(t, "Drone-Ada", receipt.ActorUsername)
+	require.Equal(t, "received", receipt.Status)
+	require.Equal(t, ttl.Unix(), receipt.TTL)
+	require.False(t, receipt.CreatedAt.IsZero())
+	require.False(t, receipt.UpdatedAt.IsZero())
+	require.Equal(t, SoulBindingIdempotencyPartitionKey("lesser-body"), receipt.GetPK())
+	require.Equal(t, SoulBindingIdempotencySortKey("Bind-Key"), receipt.GetSK())
+	require.Equal(t, MainTableName, receipt.TableName())
+}
+
+func TestSoulBindingIdempotencyKeyHelpersNormalizeAndHash(t *testing.T) {
+	t.Parallel()
+
+	keyHash := testSoulBindingReceiptHash("bind-key")
+	callerHash := testSoulBindingReceiptHash("lesser-body")
+
+	require.Equal(t, PKSoulBindingIdempotencyPrefix+callerHash, SoulBindingIdempotencyPartitionKey(" Lesser-Body "))
+	require.Equal(t, keyHash, SoulBindingIdempotencyKeyHash(" bind-key "))
+	require.Equal(t, SKSoulBindingIdempotencyKeyPrefix+keyHash, SoulBindingIdempotencySortKey(" bind-key "))
+	require.Equal(t, SKSoulBindingIdempotencyKeyPrefix+keyHash, SoulBindingIdempotencySortKeyFromHash(" "+strings.ToUpper(keyHash)+" "))
+	require.Equal(t, "lesser-body", normalizeSoulBindingReceiptCaller(" Lesser-Body "))
+	require.Equal(t, keyHash, normalizeSoulBindingReceiptHash(" "+strings.ToUpper(keyHash)+" "))
+	require.Equal(t, testSoulBindingReceiptHash("payload"), hashSoulBindingReceiptValue(" payload "))
+
+	withoutTTL := NewInstanceSoulBindingIdempotencyReceipt(
+		"lesser-body",
+		"bind-key",
+		"sha256:payload",
+		"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"drone-ada",
+		time.Time{},
+	)
+	require.Zero(t, withoutTTL.TTL)
+}
+
+func TestInstanceSoulBindingIdempotencyReceipt_UpdateKeysDefaultsAndValidates(t *testing.T) {
+	t.Parallel()
+
+	var nilReceipt *InstanceSoulBindingIdempotencyReceipt
+	require.Error(t, nilReceipt.UpdateKeys())
+
+	receipt := validSoulBindingIdempotencyReceipt()
+	receipt.BodyActorID = " body://ptah/drone-ada "
+	receipt.Status = " "
+	receipt.BindingState = " bound "
+	require.NoError(t, receipt.UpdateKeys())
+	require.Equal(t, "received", receipt.Status)
+	require.Equal(t, "bound", receipt.BindingState)
+	require.Equal(t, "body://ptah/drone-ada", receipt.BodyActorID)
+	require.False(t, receipt.CreatedAt.IsZero())
+	require.Equal(t, receipt.CreatedAt, receipt.UpdatedAt)
+	require.NotEmpty(t, receipt.PK)
+	require.NotEmpty(t, receipt.SK)
+
+	testCases := []struct {
+		name   string
+		mutate func(*InstanceSoulBindingIdempotencyReceipt)
+	}{
+		{
+			name: "caller id is required",
+			mutate: func(receipt *InstanceSoulBindingIdempotencyReceipt) {
+				receipt.CallerID = " "
+			},
+		},
+		{
+			name: "idempotency key hash is required",
+			mutate: func(receipt *InstanceSoulBindingIdempotencyReceipt) {
+				receipt.IdempotencyKeyHash = " "
+			},
+		},
+		{
+			name: "payload hash is required",
+			mutate: func(receipt *InstanceSoulBindingIdempotencyReceipt) {
+				receipt.PayloadHash = " "
+			},
+		},
+		{
+			name: "agent id is required",
+			mutate: func(receipt *InstanceSoulBindingIdempotencyReceipt) {
+				receipt.AgentID = " "
+			},
+		},
+		{
+			name: "actor username is required",
+			mutate: func(receipt *InstanceSoulBindingIdempotencyReceipt) {
+				receipt.ActorUsername = " "
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			receipt := validSoulBindingIdempotencyReceipt()
+			tc.mutate(receipt)
+			require.ErrorContains(t, receipt.UpdateKeys(), tc.name)
+		})
+	}
+}
+
+func validSoulBindingIdempotencyReceipt() *InstanceSoulBindingIdempotencyReceipt {
+	return &InstanceSoulBindingIdempotencyReceipt{
+		CallerID:           "lesser-body",
+		IdempotencyKeyHash: SoulBindingIdempotencyKeyHash("bind-key"),
+		PayloadHash:        "sha256:payload",
+		AgentID:            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		ActorUsername:      "drone-ada",
+	}
+}
+
+func testSoulBindingReceiptHash(value string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(value)))
+	return hex.EncodeToString(sum[:])
+}

--- a/pkg/storage/repositories/instance_repository.go
+++ b/pkg/storage/repositories/instance_repository.go
@@ -34,6 +34,7 @@ type InstanceRepository struct {
 	soulENSChannelRepo           *BaseRepository[*models.InstanceSoulENSChannel]
 	soulBodyBindingRepo          *BaseRepository[*models.InstanceSoulBodyBinding]
 	soulBodyBindingUsernameRepo  *BaseRepository[*models.InstanceSoulBodyBindingUsername]
+	soulBindingReceiptRepo       *BaseRepository[*models.InstanceSoulBindingIdempotencyReceipt]
 	transactWriteFn              func(ctx context.Context, fn func(core.TransactionBuilder) error) error
 	logger                       *zap.Logger
 
@@ -122,6 +123,7 @@ func NewInstanceRepository(db core.DB, tableName string, logger *zap.Logger) *In
 		soulENSChannelRepo:           NewBaseRepository[*models.InstanceSoulENSChannel](db, tableName, logger),
 		soulBodyBindingRepo:          NewBaseRepository[*models.InstanceSoulBodyBinding](db, tableName, logger),
 		soulBodyBindingUsernameRepo:  NewBaseRepository[*models.InstanceSoulBodyBindingUsername](db, tableName, logger),
+		soulBindingReceiptRepo:       NewBaseRepository[*models.InstanceSoulBindingIdempotencyReceipt](db, tableName, logger),
 		transactWriteFn:              newInstanceTransactWriteFn(db),
 		logger:                       logger,
 	}
@@ -153,6 +155,7 @@ func NewInstanceRepositoryWithCostTracking(db core.DB, tableName string, logger 
 		soulENSChannelRepo:           NewBaseRepositoryWithCostTracking[*models.InstanceSoulENSChannel](db, tableName, logger, costService, "instance_soul_ens_channel"),
 		soulBodyBindingRepo:          NewBaseRepositoryWithCostTracking[*models.InstanceSoulBodyBinding](db, tableName, logger, costService, "instance_soul_body_binding"),
 		soulBodyBindingUsernameRepo:  NewBaseRepositoryWithCostTracking[*models.InstanceSoulBodyBindingUsername](db, tableName, logger, costService, "instance_soul_body_binding_username"),
+		soulBindingReceiptRepo:       NewBaseRepositoryWithCostTracking[*models.InstanceSoulBindingIdempotencyReceipt](db, tableName, logger, costService, "instance_soul_binding_idempotency_receipt"),
 		transactWriteFn:              newInstanceTransactWriteFn(db),
 		logger:                       logger,
 	}

--- a/pkg/storage/repositories/instance_repository_soul_binding_receipt.go
+++ b/pkg/storage/repositories/instance_repository_soul_binding_receipt.go
@@ -1,0 +1,57 @@
+package repositories
+
+import (
+	"context"
+	"strings"
+
+	appErrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+)
+
+// GetSoulBindingIdempotencyReceipt returns a soul-binding idempotency receipt, or (nil, nil) when absent.
+func (r *InstanceRepository) GetSoulBindingIdempotencyReceipt(ctx context.Context, callerID string, idempotencyKey string) (*models.InstanceSoulBindingIdempotencyReceipt, error) {
+	if r == nil || r.soulBindingReceiptRepo == nil {
+		return nil, nil
+	}
+
+	callerID = strings.TrimSpace(callerID)
+	idempotencyKey = strings.TrimSpace(idempotencyKey)
+	if callerID == "" || idempotencyKey == "" {
+		return nil, nil
+	}
+
+	receipt := &models.InstanceSoulBindingIdempotencyReceipt{}
+	err := r.soulBindingReceiptRepo.Get(
+		ctx,
+		models.SoulBindingIdempotencyPartitionKey(callerID),
+		models.SoulBindingIdempotencySortKey(idempotencyKey),
+		receipt,
+	)
+	if err != nil {
+		if appErrors.HasCode(err, appErrors.CodeNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	if strings.TrimSpace(receipt.PK) == "" || strings.TrimSpace(receipt.SK) == "" {
+		return nil, nil
+	}
+	return receipt, nil
+}
+
+// CreateSoulBindingIdempotencyReceipt creates a new receipt if the key is not already reserved.
+func (r *InstanceRepository) CreateSoulBindingIdempotencyReceipt(ctx context.Context, receipt *models.InstanceSoulBindingIdempotencyReceipt) error {
+	if r == nil || r.soulBindingReceiptRepo == nil {
+		return nil
+	}
+	return r.soulBindingReceiptRepo.CreateIfNotExists(ctx, receipt)
+}
+
+// UpdateSoulBindingIdempotencyReceipt updates an existing soul-binding idempotency receipt.
+func (r *InstanceRepository) UpdateSoulBindingIdempotencyReceipt(ctx context.Context, receipt *models.InstanceSoulBindingIdempotencyReceipt) error {
+	if r == nil || r.soulBindingReceiptRepo == nil {
+		return nil
+	}
+	return r.soulBindingReceiptRepo.Update(ctx, receipt)
+}

--- a/pkg/storage/repositories/instance_repository_soul_binding_receipt_test.go
+++ b/pkg/storage/repositories/instance_repository_soul_binding_receipt_test.go
@@ -1,0 +1,147 @@
+package repositories
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	dynamormerrors "github.com/theory-cloud/tabletheory/v2/pkg/errors"
+	dynamormmocks "github.com/theory-cloud/tabletheory/v2/pkg/mocks"
+	"go.uber.org/zap"
+)
+
+func TestInstanceRepository_GetSoulBindingIdempotencyReceipt(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+	setupMockDB(db, q)
+
+	q.On("First", mock.AnythingOfType("*models.InstanceSoulBindingIdempotencyReceipt")).Run(func(args mock.Arguments) {
+		out := args.Get(0).(*models.InstanceSoulBindingIdempotencyReceipt)
+		out.PK = models.SoulBindingIdempotencyPartitionKey("lesser-body")
+		out.SK = models.SoulBindingIdempotencySortKey("bind-key")
+		out.CallerID = "lesser-body"
+		out.IdempotencyKeyHash = models.SoulBindingIdempotencyKeyHash("bind-key")
+		out.PayloadHash = "sha256:payload"
+		out.AgentID = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		out.ActorUsername = "drone-ada"
+		out.Status = "received"
+	}).Return(nil).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	receipt, err := repo.GetSoulBindingIdempotencyReceipt(ctx, " Lesser-Body ", " bind-key ")
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
+	require.Equal(t, "lesser-body", receipt.CallerID)
+	require.Equal(t, "sha256:payload", receipt.PayloadHash)
+}
+
+func TestInstanceRepository_GetSoulBindingIdempotencyReceipt_ReturnsNilForEmptyMissingAndBlankRows(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	var nilRepo *InstanceRepository
+	receipt, err := nilRepo.GetSoulBindingIdempotencyReceipt(ctx, "lesser-body", "bind-key")
+	require.NoError(t, err)
+	require.Nil(t, receipt)
+
+	repoWithNoReceiptStore := &InstanceRepository{}
+	receipt, err = repoWithNoReceiptStore.GetSoulBindingIdempotencyReceipt(ctx, "lesser-body", "bind-key")
+	require.NoError(t, err)
+	require.Nil(t, receipt)
+
+	repoWithDB := NewInstanceRepository(new(dynamormmocks.MockDB), "test-table", zap.NewNop())
+	receipt, err = repoWithDB.GetSoulBindingIdempotencyReceipt(ctx, " ", "bind-key")
+	require.NoError(t, err)
+	require.Nil(t, receipt)
+	receipt, err = repoWithDB.GetSoulBindingIdempotencyReceipt(ctx, "lesser-body", " ")
+	require.NoError(t, err)
+	require.Nil(t, receipt)
+
+	t.Run("missing row", func(t *testing.T) {
+		t.Parallel()
+
+		db := new(dynamormmocks.MockDB)
+		q := new(dynamormmocks.MockQuery)
+		setupMockDB(db, q)
+		q.On("First", mock.AnythingOfType("*models.InstanceSoulBindingIdempotencyReceipt")).Return(dynamormerrors.ErrItemNotFound).Once()
+
+		repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+		receipt, err := repo.GetSoulBindingIdempotencyReceipt(ctx, "lesser-body", "bind-key")
+		require.NoError(t, err)
+		require.Nil(t, receipt)
+	})
+
+	t.Run("blank persisted row", func(t *testing.T) {
+		t.Parallel()
+
+		db := new(dynamormmocks.MockDB)
+		q := new(dynamormmocks.MockQuery)
+		setupMockDB(db, q)
+		q.On("First", mock.AnythingOfType("*models.InstanceSoulBindingIdempotencyReceipt")).Return(nil).Once()
+
+		repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+		receipt, err := repo.GetSoulBindingIdempotencyReceipt(ctx, "lesser-body", "bind-key")
+		require.NoError(t, err)
+		require.Nil(t, receipt)
+	})
+}
+
+func TestInstanceRepository_GetSoulBindingIdempotencyReceipt_PropagatesReadError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+	setupMockDB(db, q)
+	q.On("First", mock.AnythingOfType("*models.InstanceSoulBindingIdempotencyReceipt")).Return(errors.New("read failed")).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	receipt, err := repo.GetSoulBindingIdempotencyReceipt(ctx, "lesser-body", "bind-key")
+	require.Error(t, err)
+	require.Nil(t, receipt)
+}
+
+func TestInstanceRepository_CreateAndUpdateSoulBindingIdempotencyReceipt(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	receipt := models.NewInstanceSoulBindingIdempotencyReceipt(
+		"lesser-body",
+		"bind-key",
+		"sha256:payload",
+		"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"drone-ada",
+		testSoulBindingReceiptTTL(),
+	)
+
+	var nilRepo *InstanceRepository
+	require.NoError(t, nilRepo.CreateSoulBindingIdempotencyReceipt(ctx, receipt))
+	require.NoError(t, nilRepo.UpdateSoulBindingIdempotencyReceipt(ctx, receipt))
+	require.NoError(t, (&InstanceRepository{}).CreateSoulBindingIdempotencyReceipt(ctx, receipt))
+	require.NoError(t, (&InstanceRepository{}).UpdateSoulBindingIdempotencyReceipt(ctx, receipt))
+
+	db := new(dynamormmocks.MockDB)
+	q := new(dynamormmocks.MockQuery)
+	setupMockDB(db, q)
+	q.On("IfNotExists").Return(q).Once()
+	q.On("Create").Return(nil).Once()
+	q.On("Update", mock.Anything).Return(nil).Once()
+
+	repo := NewInstanceRepository(db, "test-table", zap.NewNop())
+	require.NoError(t, repo.CreateSoulBindingIdempotencyReceipt(ctx, receipt))
+
+	receipt.Status = "bound"
+	receipt.BindingState = "bound"
+	require.NoError(t, repo.UpdateSoulBindingIdempotencyReceipt(ctx, receipt))
+}
+
+func testSoulBindingReceiptTTL() time.Time {
+	return time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+}

--- a/tools/openapi/main.go
+++ b/tools/openapi/main.go
@@ -158,6 +158,7 @@ const (
 	authModeBearerRequired authMode = "bearer_required"
 	authModeBearerOptional authMode = "bearer_optional"
 	authModeSetupBearer    authMode = "setup_bearer"
+	authModeSoulBinding    authMode = "soul_binding_bearer"
 )
 
 const (
@@ -336,6 +337,15 @@ func ensureFoundationComponents(spec *openAPISpec) {
 			Scheme:       "bearer",
 			BearerFormat: "opaque",
 			Description:  "Temporary setup session token: `Authorization: Bearer <setup_token>` (issued by `/setup/bootstrap/verify`).",
+		}
+	}
+
+	if _, ok := spec.Components.SecuritySchemes["soulBindingBearer"]; !ok {
+		spec.Components.SecuritySchemes["soulBindingBearer"] = securityScheme{
+			Type:         "http",
+			Scheme:       "bearer",
+			BearerFormat: "opaque",
+			Description:  "Dedicated body/Ptah to Lesser soul-binding integration credential. User OAuth tokens are not accepted.",
 		}
 	}
 
@@ -1287,6 +1297,8 @@ func lambdaPriority(lambda string) int {
 
 func authPriority(mode authMode) int {
 	switch mode {
+	case authModeSoulBinding:
+		return 40
 	case authModeSetupBearer:
 		return 40
 	case authModeBearerRequired:
@@ -1355,6 +1367,8 @@ func applyAuthDefaults(op *operation, route routeDef) {
 		op.Security = []map[string][]string{{}, {"bearerAuth": {}}}
 	case authModeSetupBearer:
 		op.Security = []map[string][]string{{"setupBearer": {}}}
+	case authModeSoulBinding:
+		op.Security = []map[string][]string{{"soulBindingBearer": {}}}
 	case authModePublic:
 		op.Security = nil
 	default:
@@ -1376,7 +1390,7 @@ func ensureStandardResponses(op *operation, route routeDef) {
 		ensureResponseRef(op.Responses, "429", "TooManyRequests")
 	}
 
-	if route.Auth == authModeBearerRequired || route.Auth == authModeBearerOptional || route.Auth == authModeSetupBearer {
+	if route.Auth == authModeBearerRequired || route.Auth == authModeBearerOptional || route.Auth == authModeSetupBearer || route.Auth == authModeSoulBinding {
 		ensureResponseRef(op.Responses, "401", "Unauthorized")
 		ensureResponseRef(op.Responses, "403", "Forbidden")
 	}
@@ -2159,6 +2173,8 @@ func authModeFromPublicSurfaceContract(class publicsurface.ContractAuthClass) au
 	switch class {
 	case publicsurface.ContractAuthSetupBearer:
 		return authModeSetupBearer
+	case publicsurface.ContractAuthSoulBindingIntegration:
+		return authModeSoulBinding
 	case publicsurface.ContractAuthBearerRequired, publicsurface.ContractAuthInternalOnly:
 		return authModeBearerRequired
 	default:

--- a/tools/openapi/operation_overrides.go
+++ b/tools/openapi/operation_overrides.go
@@ -79,17 +79,27 @@ func applySoulOverrides(op *operation, route routeDef) {
 		return
 	}
 
-	if route.Method != methodGET {
-		return
-	}
-
 	switch route.Path {
 	case "/api/v1/souls/bound/me":
-		applyBoundSoulMeOverride(op)
+		if route.Method == methodGET {
+			applyBoundSoulMeOverride(op)
+		}
 	case "/api/v1/souls/bound/me/mint-conversations":
-		applyBoundSoulMintConversationsOverride(op)
+		if route.Method == methodGET {
+			applyBoundSoulMintConversationsOverride(op)
+		}
 	case "/api/v1/souls/bound/me/mint-conversations/{conversationId}":
-		applyBoundSoulMintConversationOverride(op)
+		if route.Method == methodGET {
+			applyBoundSoulMintConversationOverride(op)
+		}
+	case "/api/v1/souls/bindings":
+		if route.Method == methodPOST {
+			applySoulBindingCreateOverride(op)
+		}
+	case "/api/v1/souls/bindings/{agentId}":
+		if route.Method == methodGET {
+			applySoulBindingGetOverride(op)
+		}
 	}
 }
 
@@ -153,6 +163,50 @@ func ensureSoulMintConversationErrorResponses(op *operation) {
 			},
 		}
 	}
+}
+
+func applySoulBindingCreateOverride(op *operation) {
+	op.Description = "Create or confirm a Lesser-local hosted soul/body binding for body/Ptah. The endpoint is server-to-server only: it requires the dedicated soul-binding integration bearer, rejects user OAuth tokens, refetches Host source truth, and writes only through Lesser's SOUL_BODY_BINDING repository path."
+	ensureQueryParam(op, parameter{
+		Name:        "Idempotency-Key",
+		In:          "header",
+		Required:    true,
+		Description: "Caller-scoped idempotency key for this binding attempt. Reusing the same key with a different canonical payload returns SOUL_BINDING_IDEMPOTENCY_MISMATCH.",
+		Schema: schemaRef{
+			Type:      "string",
+			MinLength: intPtr(1),
+			MaxLength: intPtr(200),
+		},
+	})
+	ensureSoulBindingErrorResponses(op)
+	ensureJSONResponseSchema(op, "200", "SoulBindingResponse")
+}
+
+func applySoulBindingGetOverride(op *operation) {
+	op.Description = "Return the authenticated body/Ptah status projection for a Lesser-local hosted soul/body binding. Lesser fails closed if the local binding exists but Host source truth cannot currently prove the hosted active identity."
+	ensureQueryParam(op, parameter{
+		Name:        "actor_username",
+		In:          "query",
+		Required:    false,
+		Description: "Optional local actor username assertion. A mismatch with the stored binding returns SOUL_BINDING_ACTOR_MISMATCH.",
+		Schema: schemaRef{
+			Type:      "string",
+			MinLength: intPtr(1),
+			MaxLength: intPtr(64),
+		},
+	})
+	ensureSoulBindingErrorResponses(op)
+	ensureJSONResponseSchema(op, "200", "SoulBindingResponse")
+}
+
+func ensureSoulBindingErrorResponses(op *operation) {
+	if op.Responses == nil {
+		op.Responses = map[string]response{}
+	}
+	ensureResponseRef(op.Responses, "404", "NotFound")
+	ensureResponseRef(op.Responses, "409", "Conflict")
+	ensureResponseRef(op.Responses, "422", "UnprocessableEntity")
+	ensureResponseRef(op.Responses, "503", "ServiceUnavailable")
 }
 
 func applyGraphQLOverrides(op *operation, route routeDef) {

--- a/tools/openapi/route_auth_test.go
+++ b/tools/openapi/route_auth_test.go
@@ -171,6 +171,20 @@ func TestResolveContractAuthModeUsesPublicSurfaceFailClosed(t *testing.T) {
 			want:   authModeBearerRequired,
 		},
 		{
+			name:   "soul binding write uses dedicated integration bearer",
+			method: methodPOST,
+			path:   "/api/v1/souls/bindings",
+			lambda: lambdaAPI,
+			want:   authModeSoulBinding,
+		},
+		{
+			name:   "soul binding read uses dedicated integration bearer",
+			method: methodGET,
+			path:   "/api/v1/souls/bindings/{agentId}",
+			lambda: lambdaAPI,
+			want:   authModeSoulBinding,
+		},
+		{
 			name:   "streaming health remains public",
 			method: methodGET,
 			path:   "/api/v1/streaming/health",

--- a/tools/openapi/strict_verify.go
+++ b/tools/openapi/strict_verify.go
@@ -207,6 +207,16 @@ func validateStrictOperationSecurity(op *operation, route routeDef) error {
 		if _, ok := op.Responses["403"]; !ok {
 			return errors.New("missing 403 response for authenticated operation")
 		}
+	case authModeSoulBinding:
+		if !isSoulBindingBearerSecurity(op.Security) {
+			return errors.New("expected soulBindingBearer required security")
+		}
+		if _, ok := op.Responses["401"]; !ok {
+			return errors.New("missing 401 response for authenticated operation")
+		}
+		if _, ok := op.Responses["403"]; !ok {
+			return errors.New("missing 403 response for authenticated operation")
+		}
 	default:
 		return fmt.Errorf("unknown auth mode %q", route.Auth)
 	}
@@ -383,6 +393,14 @@ func isSetupBearerSecurity(security []map[string][]string) bool {
 		return false
 	}
 	_, ok := security[0]["setupBearer"]
+	return ok
+}
+
+func isSoulBindingBearerSecurity(security []map[string][]string) bool {
+	if len(security) != 1 {
+		return false
+	}
+	_, ok := security[0]["soulBindingBearer"]
 	return ok
 }
 


### PR DESCRIPTION
## Summary

Closes #1153.

Implements the M7/L4 soul-binding ceremony API from ADR 0011 while keeping Lesser as the sole writer of `SOUL_BODY_BINDING` records:

- `POST /api/v1/souls/bindings` and `GET /api/v1/souls/bindings/{agentId}`
- dedicated server-to-server `SOUL_BINDING_INTEGRATION_KEY(_ARN)` authorization
- Host source-truth validation before Lesser writes binding state
- TTL idempotency receipts and same-pair replay/conflict handling
- OpenAPI/public-surface/auth-surface/CDK/config documentation updates

## Publication note

Factory is publishing the completed lesser steward delegate commit through the GitHub API because the governed small-file commit path rejected the generated OpenAPI artifact (`docs/contracts/openapi.yaml`, ~792 KiB). Per operator guidance, generated artifacts are excluded from the substantive progress/count blocker; they remain part of the PR artifact. No child implementation was authored by Factory during publication.

Local steward commit: `2eb3b46aa2ac564d60e283aad06e6b0cfb56aa41`
Remote API commit: `87d069a57ac6e8b0f6ed32c35b6909829965ea01`

## Review already completed before publication

Factory ran Claude adversarial review against the local steward commit before publication and received ACCEPT. Checked invariants included:

- Lesser remains the sole writer of `SOUL_BODY_BINDING`
- dedicated integration credential gate
- Host validation before writes
- idempotency/conflict behavior
- stable GET errors and hosted agent-block handling
- OpenAPI/auth/public-surface consistency

Non-blocking review notes: POST replay during Host outage returns 503 even if already bound; optional explicit Host-5xx no-write test; runtime accepts long `Idempotency-Key` while OpenAPI documents maxLength 200.

## Validation

Reported by lesser steward delegate before publication:

- targeted service/handler tests for success, replay, conflict, Host unavailable fail-closed behavior, and OAuth rejection
- generated OpenAPI/public-surface/auth-surface evidence updated
- focused Go validation completed by delegate

Factory follow-up will run a short PR/tree-equivalence review before approval/merge.
