### PR TITLE
fix: harden review grants, reach, and websocket expiry

### DIFF
--- a/cmd/api/handlers/interactions.go
+++ b/cmd/api/handlers/interactions.go
@@ -590,7 +590,7 @@ func (h *Handler) HandleReblogLift(ctx *apptheory.Context) (*apptheory.Response,
 		objectID = fmt.Sprintf("%s/objects/%s", h.cfg.BaseURL(), statusID)
 	}
 
-	return h.createQuoteBoostLift(ctx, statusID, objectID, *req.Comment, req.Visibility, actor)
+	return h.createQuoteBoostLift(ctx, claims.Username, statusID, objectID, *req.Comment, req.Visibility, actor)
 }
 
 // HandleUnreblogLift handles POST /api/v1/statuses/:id/unreblog

--- a/cmd/api/handlers/service_registry.go
+++ b/cmd/api/handlers/service_registry.go
@@ -123,6 +123,7 @@ type NotesService interface {
 	GetLikers(ctx context.Context, query *notes.GetLikersQuery) (*notes.UsersResult, error)
 	GetNote(ctx context.Context, statusID string) (*storagemodels.Status, error)
 	GetNoteWithViewer(ctx context.Context, query *notes.GetNoteQuery) (*storagemodels.Status, error)
+	ResolveQuoteTarget(ctx context.Context, viewerID, rawQuoteTarget string) (*storagemodels.Status, error)
 	GetRebloggers(ctx context.Context, query *notes.GetRebloggersQuery) (*notes.UsersResult, error)
 	GetSearchSuggestions(ctx context.Context, query *notes.GetSearchSuggestionsQuery) (*notes.GetSearchSuggestionsResult, error)
 	GetUpdateHistory(ctx context.Context, query *notes.GetUpdateHistoryQuery) (*notes.GetUpdateHistoryResult, error)

--- a/cmd/api/handlers/service_registry_stubs_test.go
+++ b/cmd/api/handlers/service_registry_stubs_test.go
@@ -459,6 +459,7 @@ type NotesServiceStub struct {
 	GetLikersFunc                 func(ctx context.Context, query *notes.GetLikersQuery) (*notes.UsersResult, error)
 	GetNoteFunc                   func(ctx context.Context, statusID string) (*storagemodels.Status, error)
 	GetNoteWithViewerFunc         func(ctx context.Context, query *notes.GetNoteQuery) (*storagemodels.Status, error)
+	ResolveQuoteTargetFunc        func(ctx context.Context, viewerID, rawQuoteTarget string) (*storagemodels.Status, error)
 	GetRebloggersFunc             func(ctx context.Context, query *notes.GetRebloggersQuery) (*notes.UsersResult, error)
 	GetSearchSuggestionsFunc      func(ctx context.Context, query *notes.GetSearchSuggestionsQuery) (*notes.GetSearchSuggestionsResult, error)
 	GetUpdateHistoryFunc          func(ctx context.Context, query *notes.GetUpdateHistoryQuery) (*notes.GetUpdateHistoryResult, error)
@@ -587,6 +588,13 @@ func (s *NotesServiceStub) GetNoteWithViewer(ctx context.Context, query *notes.G
 		return s.GetNoteWithViewerFunc(ctx, query)
 	}
 	return nil, missingStub("NotesService.GetNoteWithViewer")
+}
+
+func (s *NotesServiceStub) ResolveQuoteTarget(ctx context.Context, viewerID, rawQuoteTarget string) (*storagemodels.Status, error) {
+	if s != nil && s.ResolveQuoteTargetFunc != nil {
+		return s.ResolveQuoteTargetFunc(ctx, viewerID, rawQuoteTarget)
+	}
+	return nil, missingStub("NotesService.ResolveQuoteTarget")
 }
 
 func (s *NotesServiceStub) GetRebloggers(ctx context.Context, query *notes.GetRebloggersQuery) (*notes.UsersResult, error) {

--- a/cmd/api/handlers/statuses_unified_boost.go
+++ b/cmd/api/handlers/statuses_unified_boost.go
@@ -14,7 +14,9 @@ import (
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/common"
+	commonerrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/security/htmlsafe"
+	"github.com/equaltoai/lesser/pkg/services/notes"
 	"github.com/equaltoai/lesser/pkg/storage"
 	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/transformations"
@@ -63,7 +65,7 @@ func (h *Handler) HandleUnifiedBoostLift(ctx *apptheory.Context) (*apptheory.Res
 	// Check if this is a quote boost
 	if req.Comment != nil && *req.Comment != "" {
 		// Create a quote boost
-		return h.createQuoteBoostLift(ctx, statusID, objectID, *req.Comment, req.Visibility, actor)
+		return h.createQuoteBoostLift(ctx, username, statusID, objectID, *req.Comment, req.Visibility, actor)
 	}
 
 	// Traditional boost - create Announce activity
@@ -217,13 +219,43 @@ func (h *Handler) extractContentFromObject(obj any) string {
 }
 
 // createQuoteBoostLift creates a new status with a quote relationship
-func (h *Handler) createQuoteBoostLift(ctx *apptheory.Context, statusID, objectID, comment, visibility string, actor *activitypub.Actor) (*apptheory.Response, error) {
+func (h *Handler) createQuoteBoostLift(ctx *apptheory.Context, username, statusID, objectID, comment, visibility string, actor *activitypub.Actor) (*apptheory.Response, error) {
 	// Validate and default visibility if not specified
 	if err := common.ValidateVisibility(visibility); err != nil {
 		return common.RespondUnprocessableEntity(ctx, err.Error())
 	}
 	if visibility == "" {
 		visibility = storageModels.VisibilityPublic
+	}
+
+	if h.registry == nil {
+		h.logger.Error("service registry unavailable while resolving quote target")
+		return common.RespondInternalServerError(ctx)
+	}
+	notesService := h.registry.Notes()
+	if notesService == nil {
+		h.logger.Error("notes service unavailable while resolving quote target")
+		return common.RespondInternalServerError(ctx)
+	}
+	quoteTarget, err := notesService.ResolveQuoteTarget(ctx.Context(), username, statusID)
+	if err != nil {
+		h.logger.Warn("quote target rejected",
+			zap.String("status_id", statusID),
+			zap.String("viewer", username),
+			zap.Error(err))
+		if appErr, ok := commonerrors.AsAppError(err); ok {
+			return common.RespondWithAppError(ctx, appErr)
+		}
+		return common.RespondInternalServerError(ctx)
+	}
+	if err := notes.ValidateChildReach("quote", quoteTarget, visibility); err != nil {
+		if appErr, ok := commonerrors.AsAppError(err); ok {
+			return common.RespondWithAppError(ctx, appErr)
+		}
+		return common.RespondInternalServerError(ctx)
+	}
+	if quoteTarget.Note != nil && strings.TrimSpace(quoteTarget.Note.ID) != "" {
+		objectID = strings.TrimSpace(quoteTarget.Note.ID)
 	}
 
 	// Generate note ID

--- a/cmd/api/handlers/statuses_unified_boost_round11_test.go
+++ b/cmd/api/handlers/statuses_unified_boost_round11_test.go
@@ -1,12 +1,14 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/equaltoai/lesser/cmd/api/models"
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/services/notes"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/require"
 )
@@ -55,7 +57,16 @@ func TestUnifiedBoostHandlers_Round11(t *testing.T) {
 		},
 	}
 
-	handler, _, _ := round11NewHandler(t, cfg, state)
+	handler, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{NotesSvc: &NotesServiceStub{
+		ResolveQuoteTargetFunc: func(_ context.Context, viewerID, rawQuoteTarget string) (*storagemodels.Status, error) {
+			require.Equal(t, "alice", viewerID)
+			require.Equal(t, "status-1", rawQuoteTarget)
+			return quoteBoostTarget("status-1", objectID, storagemodels.VisibilityPublic), nil
+		},
+		ReblogNoteFunc: func(_ context.Context, cmd *notes.ReblogNoteCommand) (*notes.LikeResult, error) {
+			return &notes.LikeResult{Status: &storagemodels.Status{StatusID: cmd.StatusID}}, nil
+		},
+	}})
 	writeToken := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{"write"})
 	headers := map[string]string{"Authorization": "Bearer " + writeToken}
 

--- a/cmd/api/handlers/statuses_unified_boost_round12_coverage_test.go
+++ b/cmd/api/handlers/statuses_unified_boost_round12_coverage_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/equaltoai/lesser/cmd/api/models"
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/common"
+	commonerrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/services/notes"
 	"github.com/equaltoai/lesser/pkg/storage"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
@@ -82,6 +83,11 @@ func TestHandleReblogLift_UsesUnifiedBoostParserOnLiveRoute(t *testing.T) {
 		}
 		h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{
 			NotesSvc: &NotesServiceStub{
+				ResolveQuoteTargetFunc: func(_ context.Context, viewerID, rawQuoteTarget string) (*storagemodels.Status, error) {
+					require.Equal(t, "alice", viewerID)
+					require.Equal(t, "status-1", rawQuoteTarget)
+					return quoteBoostTarget("status-1", objectID, storagemodels.VisibilityPublic), nil
+				},
 				ReblogNoteFunc: func(context.Context, *notes.ReblogNoteCommand) (*notes.LikeResult, error) {
 					t.Fatal("pure reblog service should not be called for quote comments")
 					return nil, nil
@@ -210,7 +216,16 @@ func TestUnifiedBoostRound12_Coverage(t *testing.T) {
 				"ACTOR#bob#PROFILE": true,
 			},
 		}
-		h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{})
+		h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{NotesSvc: &NotesServiceStub{
+			ResolveQuoteTargetFunc: func(_ context.Context, viewerID, rawQuoteTarget string) (*storagemodels.Status, error) {
+				require.Equal(t, "alice", viewerID)
+				require.Equal(t, "status-1", rawQuoteTarget)
+				return quoteBoostTarget("status-1", objectID, storagemodels.VisibilityPublic), nil
+			},
+			ReblogNoteFunc: func(_ context.Context, cmd *notes.ReblogNoteCommand) (*notes.LikeResult, error) {
+				return &notes.LikeResult{Status: &storagemodels.Status{StatusID: cmd.StatusID}}, nil
+			},
+		}})
 
 		token := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{"write"})
 		headers := map[string]string{"Authorization": "Bearer " + token}
@@ -356,4 +371,112 @@ func TestUnifiedBoostRound12_Coverage(t *testing.T) {
 			Timestamp:    time.Now().Add(-1 * time.Minute),
 		})
 	})
+}
+
+func quoteBoostTarget(statusID, objectID, visibility string) *storagemodels.Status {
+	now := time.Now().UTC()
+	return &storagemodels.Status{
+		StatusID:       statusID,
+		AuthorID:       "https://remote.example/users/bob",
+		AuthorUsername: "bob@remote.example",
+		Visibility:     visibility,
+		PublishedAt:    now,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		ModifiedAt:     now,
+		Note: &activitypub.Note{
+			BaseObject:   activitypub.BaseObject{ID: objectID, Type: activitypub.NoteType},
+			AttributedTo: "https://remote.example/users/bob",
+			Content:      "original",
+			Visibility:   visibility,
+		},
+	}
+}
+
+func TestHandleReblogLift_EnforcesQuoteReachAndViewerAccess(t *testing.T) {
+	cfg := round11TestConfig()
+	token := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{"write"})
+	headers := map[string]string{"Authorization": "Bearer " + token}
+	comment := "bounded quote"
+
+	newQuoteHandler := func(t *testing.T, target *storagemodels.Status, resolveErr error) *Handler {
+		t.Helper()
+		state := &round10QueryState{
+			actorsByUser: map[string]storagemodels.Actor{
+				"alice": {Username: "alice", Actor: &activitypub.Actor{
+					BaseObject:        activitypub.BaseObject{ID: cfg.ActorURL("alice"), Type: "Person"},
+					PreferredUsername: "alice",
+					Followers:         cfg.ActorURL("alice") + "/followers",
+				}},
+			},
+		}
+		if target != nil && target.Note != nil {
+			state.objectsByID = map[string]storagemodels.Object{
+				target.Note.ID: {
+					ID:           target.Note.ID,
+					Type:         activitypub.NoteType,
+					Content:      target.Content,
+					AttributedTo: target.AuthorID,
+					Published:    target.PublishedAt,
+				},
+			}
+		}
+		h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{NotesSvc: &NotesServiceStub{
+			ResolveQuoteTargetFunc: func(_ context.Context, viewerID, rawQuoteTarget string) (*storagemodels.Status, error) {
+				require.Equal(t, "alice", viewerID)
+				require.Equal(t, "status-1", rawQuoteTarget)
+				return target, resolveErr
+			},
+		}})
+		return h
+	}
+
+	for _, targetVisibility := range []string{storagemodels.VisibilityPrivate, storagemodels.VisibilityDirect} {
+		t.Run(targetVisibility+" target cannot be publicly quoted", func(t *testing.T) {
+			target := quoteBoostTarget("status-1", cfg.BaseURL()+"/objects/status-1", targetVisibility)
+			h := newQuoteHandler(t, target, nil)
+			ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses/status-1/reblog", headers, nil, models.ReblogRequest{
+				Comment:    &comment,
+				Visibility: storagemodels.VisibilityPublic,
+			})
+			require.NoError(t, err)
+			ctx.Params["id"] = "status-1"
+
+			resp := requireStatus(t, http.StatusUnprocessableEntity)(h.HandleReblogLift(ctx))
+			var body common.StandardErrorResponse
+			require.NoError(t, json.Unmarshal(resp.Body, &body))
+			require.Equal(t, string(commonerrors.CodeUnprocessableEntity), body.Code)
+		})
+	}
+
+	t.Run("unviewable target remains indistinguishable from not found", func(t *testing.T) {
+		h := newQuoteHandler(t, nil, notes.ErrStatusNotFound)
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses/status-1/reblog", headers, nil, models.ReblogRequest{Comment: &comment})
+		require.NoError(t, err)
+		ctx.Params["id"] = "status-1"
+		requireStatus(t, http.StatusNotFound)(h.HandleReblogLift(ctx))
+	})
+
+	tests := []struct {
+		name             string
+		targetVisibility string
+		quoteVisibility  string
+	}{
+		{name: "equal public", targetVisibility: storagemodels.VisibilityPublic, quoteVisibility: storagemodels.VisibilityPublic},
+		{name: "narrower private", targetVisibility: storagemodels.VisibilityPublic, quoteVisibility: storagemodels.VisibilityPrivate},
+		{name: "equal followers", targetVisibility: storagemodels.VisibilityPrivate, quoteVisibility: storagemodels.VisibilityPrivate},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := quoteBoostTarget("status-1", cfg.BaseURL()+"/objects/status-1", tt.targetVisibility)
+			h := newQuoteHandler(t, target, nil)
+			ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses/status-1/reblog", headers, nil, models.ReblogRequest{
+				Comment:    &comment,
+				Visibility: tt.quoteVisibility,
+			})
+			require.NoError(t, err)
+			ctx.Params["id"] = "status-1"
+			requireStatus(t, http.StatusOK)(h.HandleReblogLift(ctx))
+		})
+	}
 }

--- a/cmd/graphql-ws/anonymous_init_authz_test.go
+++ b/cmd/graphql-ws/anonymous_init_authz_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
 	"github.com/equaltoai/lesser/pkg/streaming"
 	"github.com/equaltoai/lesser/pkg/testing/inmemory"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 	appTheory "github.com/theory-cloud/apptheory/v2/runtime"
 	"github.com/vektah/gqlparser/v2/gqlerror"
@@ -433,7 +434,11 @@ func TestAuthenticatedConnectionStillStreamsGatedSubscription(t *testing.T) {
 	exec := executor.New(graph.NewExecutableSchema(graph.Config{Resolvers: resolver}))
 	configureGraphQLExecutor(exec, &appconfig.Config{})
 
-	validator := &fakeTokenValidator{claims: &auth.Claims{Username: "alice", Scopes: []string{"read"}}}
+	validator := &fakeTokenValidator{claims: &auth.Claims{
+		RegisteredClaims: jwt.RegisteredClaims{ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour))},
+		Username:         "alice",
+		Scopes:           []string{"read"},
+	}}
 	server := newServer(validator, resolver, exec, zap.NewNop(), &fakeConnRepo{}, nil, &fakeInstanceRepo{state: &models.InstanceState{}})
 	server.connections["authenticated-conn"] = &connectionState{subscriptions: map[string]*subscriptionState{}}
 	messages := make(chan responseEnvelope, 10)

--- a/cmd/graphql-ws/credential_expiry_test.go
+++ b/cmd/graphql-ws/credential_expiry_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+	appTheory "github.com/theory-cloud/apptheory/v2/runtime"
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+	"go.uber.org/zap"
+)
+
+func TestSubscribeRechecksCredentialExpiryPerOperation(t *testing.T) {
+	newOperationServer := func(t *testing.T, claims *auth.Claims) (*wsServer, *fakeGraphQLExecutor, <-chan responseEnvelope) {
+		t.Helper()
+		exec := &fakeGraphQLExecutor{create: func(context.Context, *graphql.RawParams) (*graphql.OperationContext, gqlerror.List) {
+			return &graphql.OperationContext{Operation: &ast.OperationDefinition{Operation: ast.Subscription}}, nil
+		}}
+		server := newServer(nil, nil, exec, zap.NewNop(), &fakeConnRepo{}, nil, &fakeInstanceRepo{state: &models.InstanceState{}})
+		server.connections["c1"] = &connectionState{
+			username:      "alice",
+			claims:        claims,
+			initialized:   true,
+			subscriptions: map[string]*subscriptionState{},
+		}
+		messages := make(chan responseEnvelope, 10)
+		server.sendJSONMessage = func(_ *appTheory.WebSocketContext, payload any) error {
+			raw, err := json.Marshal(payload)
+			require.NoError(t, err)
+			var envelope responseEnvelope
+			require.NoError(t, json.Unmarshal(raw, &envelope))
+			messages <- envelope
+			return nil
+		}
+		return server, exec, messages
+	}
+
+	t.Run("expired credential is refused with a distinct code", func(t *testing.T) {
+		server, exec, messages := newOperationServer(t, &auth.Claims{
+			RegisteredClaims: jwt.RegisteredClaims{ExpiresAt: jwt.NewNumericDate(time.Now().Add(-time.Minute))},
+			Username:         "alice",
+		})
+		server.handleSubscribe(context.Background(), wsMessage{
+			ID:      "expired",
+			Type:    "subscribe",
+			Payload: json.RawMessage(`{"query":"subscription { timelineUpdates(type: HOME) { id } }"}`),
+		}, &appTheory.WebSocketContext{ConnectionID: "c1"})
+
+		message := receiveWSMessage(t, messages)
+		require.Equal(t, "error", message.Type)
+		require.Equal(t, wsCodeCredentialExpired, graphQLErrorExtensionCode(t, message.Payload))
+		require.Zero(t, atomic.LoadInt32(&exec.createCalls), "expired credentials must be refused before operation creation")
+	})
+
+	t.Run("unexpired credential proceeds", func(t *testing.T) {
+		server, exec, messages := newOperationServer(t, &auth.Claims{
+			RegisteredClaims: jwt.RegisteredClaims{ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour))},
+			Username:         "alice",
+		})
+		server.handleSubscribe(context.Background(), wsMessage{
+			ID:      "valid",
+			Type:    "subscribe",
+			Payload: json.RawMessage(`{"query":"subscription { timelineUpdates(type: HOME) { id } }"}`),
+		}, &appTheory.WebSocketContext{ConnectionID: "c1"})
+
+		require.Eventually(t, func() bool { return atomic.LoadInt32(&exec.createCalls) == 1 }, time.Second, 10*time.Millisecond)
+		require.Equal(t, "complete", receiveWSMessage(t, messages).Type)
+	})
+}
+
+func TestGetConnectionRehydratesCredentialExpiry(t *testing.T) {
+	expiresAt := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+	repo := &fakeConnRepo{getConnection: &models.WebSocketConnection{
+		ConnectionID: "c1",
+		UserID:       "alice",
+		Username:     "alice",
+		Info: models.ConnectionInfo{CustomHeaders: map[string]string{
+			"scopes":                    "read",
+			wsCredentialExpiresAtHeader: fmt.Sprintf("%d", expiresAt.Unix()),
+		}},
+	}}
+	server := newServer(nil, nil, nil, zap.NewNop(), repo, nil, nil)
+
+	state, err := server.getConnection(context.Background(), "c1")
+	require.NoError(t, err)
+	require.NotNil(t, state.claims)
+	require.NotNil(t, state.claims.ExpiresAt)
+	require.Equal(t, expiresAt, state.claims.ExpiresAt.Time)
+}

--- a/cmd/graphql-ws/credential_expiry_test.go
+++ b/cmd/graphql-ws/credential_expiry_test.go
@@ -95,4 +95,41 @@ func TestGetConnectionRehydratesCredentialExpiry(t *testing.T) {
 	require.NotNil(t, state.claims)
 	require.NotNil(t, state.claims.ExpiresAt)
 	require.Equal(t, expiresAt, state.claims.ExpiresAt.Time)
+	require.False(t, state.credentialExpiryUnavailable)
+}
+
+func TestLegacyConnectionWithoutCredentialExpiryFailsClosedOnNextOperation(t *testing.T) {
+	exec := &fakeGraphQLExecutor{create: func(context.Context, *graphql.RawParams) (*graphql.OperationContext, gqlerror.List) {
+		return &graphql.OperationContext{Operation: &ast.OperationDefinition{Operation: ast.Subscription}}, nil
+	}}
+	repo := &fakeConnRepo{getConnection: &models.WebSocketConnection{
+		ConnectionID: "legacy",
+		UserID:       "alice",
+		Username:     "alice",
+		Info: models.ConnectionInfo{
+			AuthMethod:    "oauth",
+			CustomHeaders: map[string]string{"scopes": "read"},
+		},
+	}}
+	server := newServer(nil, nil, exec, zap.NewNop(), repo, nil, &fakeInstanceRepo{state: &models.InstanceState{}})
+	messages := make(chan responseEnvelope, 1)
+	server.sendJSONMessage = func(_ *appTheory.WebSocketContext, payload any) error {
+		raw, err := json.Marshal(payload)
+		require.NoError(t, err)
+		var envelope responseEnvelope
+		require.NoError(t, json.Unmarshal(raw, &envelope))
+		messages <- envelope
+		return nil
+	}
+
+	server.handleSubscribe(context.Background(), wsMessage{
+		ID:      "legacy-operation",
+		Type:    "subscribe",
+		Payload: json.RawMessage(`{"query":"subscription { timelineUpdates(type: HOME) { id } }"}`),
+	}, &appTheory.WebSocketContext{ConnectionID: "legacy"})
+
+	message := receiveWSMessage(t, messages)
+	require.Equal(t, "error", message.Type)
+	require.Equal(t, wsCodeCredentialExpired, graphQLErrorExtensionCode(t, message.Payload))
+	require.Zero(t, atomic.LoadInt32(&exec.createCalls), "legacy authenticated rows without persisted expiry must force re-authentication before operation creation")
 }

--- a/cmd/graphql-ws/main.go
+++ b/cmd/graphql-ws/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -31,6 +32,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/storage/repositories"
 	"github.com/equaltoai/lesser/pkg/storage/theorydb"
 	"github.com/equaltoai/lesser/pkg/streaming"
+	"github.com/golang-jwt/jwt/v5"
 	appstreamer "github.com/theory-cloud/apptheory/v2/pkg/streamer"
 	apptheory "github.com/theory-cloud/apptheory/v2/runtime"
 	dynamormCore "github.com/theory-cloud/tabletheory/v2/pkg/core"
@@ -42,6 +44,8 @@ import (
 const graphqlWSName = "graphql-ws"
 const graphqlTransportWSSubprotocol = "graphql-transport-ws"
 const wsCodeUnauthenticated = "UNAUTHENTICATED"
+const wsCodeCredentialExpired = "TOKEN_EXPIRED"
+const wsCredentialExpiresAtHeader = "token_expires_at"
 const protocolErrorID = "protocol-error"
 
 const (
@@ -331,6 +335,9 @@ func (s *wsServer) registerConnection(ctx context.Context, connectionID, usernam
 			if claims != nil && len(claims.Scopes) > 0 {
 				connectionRecord.Info.CustomHeaders["scopes"] = strings.Join(claims.Scopes, " ")
 			}
+			if claims != nil && claims.ExpiresAt != nil {
+				connectionRecord.Info.CustomHeaders[wsCredentialExpiresAtHeader] = strconv.FormatInt(claims.ExpiresAt.Unix(), 10)
+			}
 			connectionRecord.LastActivity = time.Now()
 			connectionRecord.Established = time.Now()
 			connectionRecord.UpdateState(models.ConnectionStateConnected)
@@ -473,6 +480,16 @@ func (s *wsServer) getConnection(ctx context.Context, connectionID string) (*con
 		claims = &auth.Claims{
 			Username: connection.Username,
 			Scopes:   scopes,
+		}
+		if connection.Info.CustomHeaders != nil {
+			rawExpiresAt := strings.TrimSpace(connection.Info.CustomHeaders[wsCredentialExpiresAtHeader])
+			if rawExpiresAt != "" {
+				expiresAt, parseErr := strconv.ParseInt(rawExpiresAt, 10, 64)
+				if parseErr != nil {
+					return nil, fmt.Errorf("invalid persisted graphql credential expiry: %w", parseErr)
+				}
+				claims.ExpiresAt = jwt.NewNumericDate(time.Unix(expiresAt, 0).UTC())
+			}
 		}
 	}
 
@@ -1022,6 +1039,10 @@ func (s *wsServer) handleSubscribe(ctx context.Context, msg wsMessage, wsCtx *ap
 		s.sendError(wsCtx, msg.ID, "unauthorized", "connection_init has not been acknowledged")
 		return
 	}
+	if connectionCredentialExpired(state, time.Now()) {
+		s.sendOperationCredentialExpiredError(wsCtx, msg.ID)
+		return
+	}
 
 	if s.exec == nil {
 		s.logger.Error("graphql executor not initialized")
@@ -1191,6 +1212,20 @@ func (s *wsServer) sendOperationAuthenticationError(wsCtx *apptheory.WebSocketCo
 		Message:    message,
 		Extensions: map[string]any{"code": wsCodeUnauthenticated},
 	}})
+}
+
+func (s *wsServer) sendOperationCredentialExpiredError(wsCtx *apptheory.WebSocketContext, id string) {
+	s.sendGraphQLErrors(wsCtx, id, gqlerror.List{&gqlerror.Error{
+		Message:    "credential expired; re-authentication required",
+		Extensions: map[string]any{"code": wsCodeCredentialExpired},
+	}})
+}
+
+func connectionCredentialExpired(state *connectionState, now time.Time) bool {
+	if state == nil || state.claims == nil || state.claims.ExpiresAt == nil {
+		return false
+	}
+	return !now.Before(state.claims.ExpiresAt.Time)
 }
 
 func (s *wsServer) sendGraphQLErrors(wsCtx *apptheory.WebSocketContext, id string, errs gqlerror.List) {

--- a/cmd/graphql-ws/main.go
+++ b/cmd/graphql-ws/main.go
@@ -55,10 +55,11 @@ const (
 )
 
 type connectionState struct {
-	username      string
-	claims        *auth.Claims
-	initialized   bool
-	subscriptions map[string]*subscriptionState
+	username                    string
+	claims                      *auth.Claims
+	initialized                 bool
+	credentialExpiryUnavailable bool
+	subscriptions               map[string]*subscriptionState
 }
 
 type subscriptionState struct {
@@ -361,10 +362,11 @@ func (s *wsServer) registerConnection(ctx context.Context, connectionID, usernam
 		subscriptions = existing.subscriptions
 	}
 	s.connections[connectionID] = &connectionState{
-		username:      username,
-		claims:        claims,
-		initialized:   true,
-		subscriptions: subscriptions,
+		username:                    username,
+		claims:                      claims,
+		initialized:                 true,
+		credentialExpiryUnavailable: claims != nil && claims.ExpiresAt == nil,
+		subscriptions:               subscriptions,
 	}
 	s.mu.Unlock()
 
@@ -476,6 +478,7 @@ func (s *wsServer) getConnection(ctx context.Context, connectionID string) (*con
 	}
 
 	var claims *auth.Claims
+	credentialExpiryUnavailable := false
 	if connection.Username != "" {
 		claims = &auth.Claims{
 			Username: connection.Username,
@@ -489,15 +492,20 @@ func (s *wsServer) getConnection(ctx context.Context, connectionID string) (*con
 					return nil, fmt.Errorf("invalid persisted graphql credential expiry: %w", parseErr)
 				}
 				claims.ExpiresAt = jwt.NewNumericDate(time.Unix(expiresAt, 0).UTC())
+			} else {
+				credentialExpiryUnavailable = true
 			}
+		} else {
+			credentialExpiryUnavailable = true
 		}
 	}
 
 	state = &connectionState{
-		username:      connection.Username,
-		claims:        claims,
-		initialized:   connection.Username != "" || connection.Info.AuthMethod == "anonymous",
-		subscriptions: make(map[string]*subscriptionState),
+		username:                    connection.Username,
+		claims:                      claims,
+		initialized:                 connection.Username != "" || connection.Info.AuthMethod == "anonymous",
+		credentialExpiryUnavailable: credentialExpiryUnavailable,
+		subscriptions:               make(map[string]*subscriptionState),
 	}
 
 	s.mu.Lock()
@@ -1222,7 +1230,13 @@ func (s *wsServer) sendOperationCredentialExpiredError(wsCtx *apptheory.WebSocke
 }
 
 func connectionCredentialExpired(state *connectionState, now time.Time) bool {
-	if state == nil || state.claims == nil || state.claims.ExpiresAt == nil {
+	if state == nil || state.claims == nil {
+		return false
+	}
+	if state.credentialExpiryUnavailable {
+		return true
+	}
+	if state.claims.ExpiresAt == nil {
 		return false
 	}
 	return !now.Before(state.claims.ExpiresAt.Time)

--- a/cmd/graphql-ws/round12_additional_test.go
+++ b/cmd/graphql-ws/round12_additional_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"sync/atomic"
 	"testing"
@@ -17,6 +18,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/streaming"
 	pkgtesting "github.com/equaltoai/lesser/pkg/testing"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 	apptheory "github.com/theory-cloud/apptheory/v2/runtime"
 	dynamormCore "github.com/theory-cloud/tabletheory/v2/pkg/core"
@@ -77,6 +79,7 @@ type fakeConnRepo struct {
 	deleteSubCalls      int32
 	lastDeleteSubConn   string
 	lastDeleteSubStream string
+	getConnection       *models.WebSocketConnection
 }
 
 func (f *fakeConnRepo) WriteConnection(_ context.Context, connectionID string, userID string, username string, streams []string) (*models.WebSocketConnection, error) {
@@ -112,6 +115,9 @@ func (f *fakeConnRepo) GetConnection(_ context.Context, _ string) (*models.WebSo
 	atomic.AddInt32(&f.getConnCalls, 1)
 	if f.getConnErr != nil {
 		return nil, f.getConnErr
+	}
+	if f.getConnection != nil {
+		return f.getConnection, nil
 	}
 	return &models.WebSocketConnection{
 		ConnectionID: "c1",
@@ -175,8 +181,13 @@ func setDummyAWSEnv(t *testing.T) {
 func TestRegisterConnection_PersistsAndStoresState(t *testing.T) {
 	repo := &fakeConnRepo{updateErr: errors.New("update failed")}
 	s := newServer(nil, nil, nil, zap.NewNop(), repo, nil, nil)
+	expiresAt := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
 
-	err := s.registerConnection(context.Background(), "c1", "user", &auth.Claims{Username: "user", Scopes: []string{"read"}})
+	err := s.registerConnection(context.Background(), "c1", "user", &auth.Claims{
+		RegisteredClaims: jwt.RegisteredClaims{ExpiresAt: jwt.NewNumericDate(expiresAt)},
+		Username:         "user",
+		Scopes:           []string{"read"},
+	})
 	require.Error(t, err)
 	require.Equal(t, int32(1), atomic.LoadInt32(&repo.writeCalls))
 	require.Equal(t, int32(1), atomic.LoadInt32(&repo.updateCalls))
@@ -184,6 +195,7 @@ func TestRegisterConnection_PersistsAndStoresState(t *testing.T) {
 	require.Equal(t, "graphql-ws", repo.lastUpdated.Info.Protocol)
 	require.Equal(t, "oauth", repo.lastUpdated.Info.AuthMethod)
 	require.Equal(t, "read", repo.lastUpdated.Info.CustomHeaders["scopes"])
+	require.Equal(t, fmt.Sprintf("%d", expiresAt.Unix()), repo.lastUpdated.Info.CustomHeaders[wsCredentialExpiresAtHeader])
 
 	state, err2 := s.getConnection(context.Background(), "c1")
 	require.NoError(t, err2)

--- a/docs/security/hardened-auth-visibility-rollout.md
+++ b/docs/security/hardened-auth-visibility-rollout.md
@@ -8,6 +8,13 @@ with the generated REST contract (`docs/contracts/openapi.yaml`) and generated G
 
 - REST write APIs and non-public GraphQL fields require OAuth bearer authentication.
 - GraphQL anonymous reads are limited to the documented public-read subset and only expose public/unlisted content.
+- GraphQL WebSocket authentication is rechecked when each `subscribe` operation starts. An authenticated connection whose
+  JWT is expired receives `extensions.code=TOKEN_EXPIRED`; anonymous access to a gated operation remains
+  `extensions.code=UNAUTHENTICATED`. Expiry is not rechecked continuously or while delivering an already-established
+  subscription, so token expiry does not tear down an in-flight operation.
+- Authenticated WebSocket connection rows without a persisted `token_expires_at` fail closed on their next operation and
+  receive `TOKEN_EXPIRED`, forcing one reconnect/re-authentication. This includes rows created before expiry persistence
+  was introduced; anonymous rows remain unaffected.
 - Device-code authorization is disabled by default. When enabled, `client_class=cli` tokens are governed by the CLI
   automation rails in `docs/configuration.md` regardless of account type.
 - Browser CORS is fail-closed by default to the instance origin unless the operator configures an explicit trusted origin
@@ -18,10 +25,18 @@ with the generated REST contract (`docs/contracts/openapi.yaml`) and generated G
 - Public/unlisted objects may be returned by anonymous public-read surfaces.
 - Private/followers/direct content requires an authenticated viewer and the same visibility and participant checks used
   by REST handlers.
-- Reply and quote reach is non-widening: `public > unlisted > private/followers > direct`. An explicit child visibility
-  wider than the parent status is rejected with the structured `UNPROCESSABLE_ENTITY` error; mutation inputs whose quote
-  visibility is optional inherit the parent status visibility when omitted. Lesser never silently clamps an explicit
-  author choice.
+- Reply and quote reach is ordered `public < unlisted < private/followers < direct`, from widest to narrowest audience.
+  REST status replies, GraphQL note/quote mutations, and `POST /api/v1/statuses/{id}/reblog` quote requests with a
+  non-empty `comment` reject a child visibility wider than the referenced status with the structured
+  `UNPROCESSABLE_ENTITY` error. GraphQL quote inputs whose visibility is omitted inherit the target visibility; the REST
+  reblog-quote request retains its documented public default, which is therefore rejected when it would widen reach.
+  These paths never silently clamp an explicit author choice.
+- GraphQL quote mutations and REST reblog-quotes resolve the target storage-first, fetch and materialize a canonical
+  remote ActivityPub Note when absent locally, and then apply viewer-access and reach checks. Deleted or inaccessible
+  targets remain indistinguishable from missing statuses. The separate lesser-exclusive
+  `POST /api/v1/statuses/{id}/quote` extension still requires a locally materialized target and is not the
+  Mastodon-compatible reblog-quote creation path described above.
+- `UpdateStatus` does not accept or propagate a visibility field, so an existing status cannot be widened by editing it.
 - Direct messages are 1:1 in v1. `POST /api/v1/statuses` with `visibility=direct` must include exactly one resolvable
   local or remote `@mention`; group DMs are not accepted.
 - Once a direct message is stored, ActivityPub addressing fields (`to`, `cc`, `bto`, `bcc` and their stored status
@@ -43,6 +58,11 @@ Before promoting a release beyond `dev`, validate the behaviors that changed in 
 6. Lambda-optimized TableTheory clients retain the configured timeout safety buffer when a Lambda context deadline is
    applied.
 7. DM conversation backfill ignores message-text mentions and uses stored recipient fields.
+8. A pre-expiry-persistence authenticated GraphQL WebSocket row is refused with `TOKEN_EXPIRED` on its next subscribe
+   operation, while a newly authenticated row with an unexpired JWT can subscribe and anonymous public subscriptions are
+   unchanged.
+9. REST and GraphQL quotes can materialize a previously unseen remote target, reject inaccessible targets, and reject
+   public quotes of private/followers/direct targets without changing empty-comment reblog behavior.
 
 The release path remains `dev -> staging -> live` (with staging where the deployment uses it). Soak is evidence-based:
 check API auth behavior, anonymous public-read visibility, direct-message visibility, federation delivery/receipt,

--- a/docs/security/hardened-auth-visibility-rollout.md
+++ b/docs/security/hardened-auth-visibility-rollout.md
@@ -18,6 +18,10 @@ with the generated REST contract (`docs/contracts/openapi.yaml`) and generated G
 - Public/unlisted objects may be returned by anonymous public-read surfaces.
 - Private/followers/direct content requires an authenticated viewer and the same visibility and participant checks used
   by REST handlers.
+- Reply and quote reach is non-widening: `public > unlisted > private/followers > direct`. An explicit child visibility
+  wider than the parent status is rejected with the structured `UNPROCESSABLE_ENTITY` error; mutation inputs whose quote
+  visibility is optional inherit the parent status visibility when omitted. Lesser never silently clamps an explicit
+  author choice.
 - Direct messages are 1:1 in v1. `POST /api/v1/statuses` with `visibility=direct` must include exactly one resolvable
   local or remote `@mention`; group DMs are not accepted.
 - Once a direct message is stored, ActivityPub addressing fields (`to`, `cc`, `bto`, `bcc` and their stored status

--- a/graph/draft_review_cursor_test.go
+++ b/graph/draft_review_cursor_test.go
@@ -105,13 +105,14 @@ func TestDraftReviewResolversTreatWhitespaceCursorAsAbsent(t *testing.T) {
 	})
 
 	t.Run("SharedDraftReviews", func(t *testing.T) {
-		resolver, drafts := newDraftReviewCursorResolver(t)
+		resolver, _ := newDraftReviewCursorResolver(t)
 		after := model.Cursor(" \t\n ")
 
 		result, err := resolver.Query().SharedDraftReviews(round12AuthContext("reviewer"), nil, &after)
 		require.NoError(t, err)
 		require.NotNil(t, result.PageInfo)
+		// This is the resolver-sensitive assertion: the service independently trims
+		// its cursor, so asserting the repository's captured cursor would be vacuous.
 		require.False(t, result.PageInfo.HasPreviousPage)
-		require.Empty(t, drafts.sharedDraftReviewsCursor, "SharedDraftReviews must pass the trimmed cursor downstream")
 	})
 }

--- a/graph/mutation_resolvers_notes.go
+++ b/graph/mutation_resolvers_notes.go
@@ -38,6 +38,22 @@ func (r *mutationResolver) CreateNote(ctx context.Context, input model.CreateNot
 	if err != nil {
 		return nil, err
 	}
+	service := r.Registry.Notes()
+	if service == nil {
+		return nil, errors.New("notes service is not available")
+	}
+	if quoteTargetID != "" {
+		quoteTarget, err := service.GetNoteWithViewer(ctx, &notes.GetNoteQuery{
+			StatusID: quoteTargetID,
+			ViewerID: username,
+		})
+		if err != nil {
+			return nil, errors.Join(errors.New("failed to load quote target"), err)
+		}
+		if err := validateMutationChildReach("quote", quoteTarget, cmd.Visibility); err != nil {
+			return nil, err
+		}
+	}
 
 	if claims, ok := ctx.Value(common.ContextKeyClaims).(*auth.Claims); ok && claims != nil && claims.IsAgent {
 		attribution, err := r.buildAgentPostAttribution(ctx, claims, input.AgentAttribution)
@@ -60,7 +76,7 @@ func (r *mutationResolver) CreateNote(ctx context.Context, input model.CreateNot
 
 	// Create note using service
 	serviceStart := time.Now()
-	result, err := r.Registry.Notes().CreateNote(ctx, cmd)
+	result, err := service.CreateNote(ctx, cmd)
 	if err != nil {
 		r.Logger.Error("Failed to create note",
 			zap.String("user", username),
@@ -323,7 +339,7 @@ func (r *mutationResolver) buildCreateNoteCommand(username string, input model.C
 	cmd := &notes.CreateNoteCommand{
 		AuthorID:   username,
 		Content:    input.Content,
-		Visibility: strings.ToLower(input.Visibility.String()),
+		Visibility: postingVisibilityFromGraphQL(input.Visibility),
 		Sensitive:  input.Sensitive != nil && *input.Sensitive,
 	}
 
@@ -537,11 +553,26 @@ func (r *mutationResolver) CreateQuoteNote(ctx context.Context, input model.Crea
 		return nil, err
 	}
 
-	// Set default visibility if not provided
-	// Convert GraphQL enum (PUBLIC, UNLISTED, etc.) to lowercase (public, unlisted, etc.)
-	visibility := "public"
+	service := r.Registry.Notes()
+	if service == nil {
+		return nil, errors.New("notes service is not available")
+	}
+	quoteTarget, err := service.GetNoteWithViewer(ctx, &notes.GetNoteQuery{
+		StatusID: strings.TrimSpace(input.QuoteURL),
+		ViewerID: username,
+	})
+	if err != nil {
+		return nil, errors.Join(errors.New("failed to load quote target"), err)
+	}
+
+	// Omitted visibility inherits the target's effective reach. An explicit
+	// visibility remains author-controlled as long as it does not widen reach.
+	visibility := quoteTarget.Visibility
 	if input.Visibility != nil {
-		visibility = strings.ToLower(string(*input.Visibility))
+		visibility = postingVisibilityFromGraphQL(*input.Visibility)
+	}
+	if err := validateMutationChildReach("quote", quoteTarget, visibility); err != nil {
+		return nil, err
 	}
 
 	// Create the quote note using the notes service
@@ -558,7 +589,7 @@ func (r *mutationResolver) CreateQuoteNote(ctx context.Context, input model.Crea
 		cmd.SpoilerText = *input.SpoilerText
 	}
 
-	result, err := r.Registry.Notes().CreateNote(ctx, cmd)
+	result, err := service.CreateNote(ctx, cmd)
 	if err != nil {
 		return nil, errors.Join(errors.New("failed to create quote note"), err)
 	}
@@ -571,4 +602,55 @@ func (r *mutationResolver) CreateQuoteNote(ctx context.Context, input model.Crea
 	return &model.CreateNotePayload{
 		Object: r.convertStatusToObject(ctx, result.Note),
 	}, nil
+}
+
+func validateMutationChildReach(relationship string, parent *models.Status, requestedVisibility string) error {
+	if parent == nil {
+		return apperrors.NewAppError(
+			apperrors.CodeUnprocessableEntity,
+			apperrors.CategoryValidation,
+			"parent status is not usable",
+		)
+	}
+
+	parentRank, parentOK := mutationVisibilityRank(parent.Visibility)
+	requestedRank, requestedOK := mutationVisibilityRank(requestedVisibility)
+	if !parentOK || !requestedOK {
+		return apperrors.NewAppError(
+			apperrors.CodeUnprocessableEntity,
+			apperrors.CategoryValidation,
+			"status visibility is not supported for this relationship",
+		).
+			WithMetadata("relationship", relationship).
+			WithMetadata("parent_visibility", parent.Visibility).
+			WithMetadata("requested_visibility", requestedVisibility)
+	}
+	if requestedRank < parentRank {
+		return apperrors.NewAppError(
+			apperrors.CodeUnprocessableEntity,
+			apperrors.CategoryValidation,
+			"requested visibility exceeds parent reach",
+		).
+			WithMetadata("relationship", relationship).
+			WithMetadata("parent_id", parent.StatusID).
+			WithMetadata("parent_visibility", parent.Visibility).
+			WithMetadata("requested_visibility", requestedVisibility)
+	}
+
+	return nil
+}
+
+func mutationVisibilityRank(visibility string) (int, bool) {
+	switch strings.ToLower(strings.TrimSpace(visibility)) {
+	case models.VisibilityPublic:
+		return 0, true
+	case models.VisibilityUnlisted:
+		return 1, true
+	case models.VisibilityPrivate:
+		return 2, true
+	case models.VisibilityDirect:
+		return 3, true
+	default:
+		return 0, false
+	}
 }

--- a/graph/mutation_resolvers_notes.go
+++ b/graph/mutation_resolvers_notes.go
@@ -43,10 +43,7 @@ func (r *mutationResolver) CreateNote(ctx context.Context, input model.CreateNot
 		return nil, errors.New("notes service is not available")
 	}
 	if quoteTargetID != "" {
-		quoteTarget, err := service.GetNoteWithViewer(ctx, &notes.GetNoteQuery{
-			StatusID: quoteTargetID,
-			ViewerID: username,
-		})
+		quoteTarget, err := service.ResolveQuoteTarget(ctx, username, quoteTargetID)
 		if err != nil {
 			return nil, errors.Join(errors.New("failed to load quote target"), err)
 		}
@@ -557,10 +554,7 @@ func (r *mutationResolver) CreateQuoteNote(ctx context.Context, input model.Crea
 	if service == nil {
 		return nil, errors.New("notes service is not available")
 	}
-	quoteTarget, err := service.GetNoteWithViewer(ctx, &notes.GetNoteQuery{
-		StatusID: strings.TrimSpace(input.QuoteURL),
-		ViewerID: username,
-	})
+	quoteTarget, err := service.ResolveQuoteTarget(ctx, username, strings.TrimSpace(input.QuoteURL))
 	if err != nil {
 		return nil, errors.Join(errors.New("failed to load quote target"), err)
 	}
@@ -605,52 +599,5 @@ func (r *mutationResolver) CreateQuoteNote(ctx context.Context, input model.Crea
 }
 
 func validateMutationChildReach(relationship string, parent *models.Status, requestedVisibility string) error {
-	if parent == nil {
-		return apperrors.NewAppError(
-			apperrors.CodeUnprocessableEntity,
-			apperrors.CategoryValidation,
-			"parent status is not usable",
-		)
-	}
-
-	parentRank, parentOK := mutationVisibilityRank(parent.Visibility)
-	requestedRank, requestedOK := mutationVisibilityRank(requestedVisibility)
-	if !parentOK || !requestedOK {
-		return apperrors.NewAppError(
-			apperrors.CodeUnprocessableEntity,
-			apperrors.CategoryValidation,
-			"status visibility is not supported for this relationship",
-		).
-			WithMetadata("relationship", relationship).
-			WithMetadata("parent_visibility", parent.Visibility).
-			WithMetadata("requested_visibility", requestedVisibility)
-	}
-	if requestedRank < parentRank {
-		return apperrors.NewAppError(
-			apperrors.CodeUnprocessableEntity,
-			apperrors.CategoryValidation,
-			"requested visibility exceeds parent reach",
-		).
-			WithMetadata("relationship", relationship).
-			WithMetadata("parent_id", parent.StatusID).
-			WithMetadata("parent_visibility", parent.Visibility).
-			WithMetadata("requested_visibility", requestedVisibility)
-	}
-
-	return nil
-}
-
-func mutationVisibilityRank(visibility string) (int, bool) {
-	switch strings.ToLower(strings.TrimSpace(visibility)) {
-	case models.VisibilityPublic:
-		return 0, true
-	case models.VisibilityUnlisted:
-		return 1, true
-	case models.VisibilityPrivate:
-		return 2, true
-	case models.VisibilityDirect:
-		return 3, true
-	default:
-		return 0, false
-	}
+	return notes.ValidateChildReach(relationship, parent, requestedVisibility)
 }

--- a/graph/mutation_resolvers_reach_test.go
+++ b/graph/mutation_resolvers_reach_test.go
@@ -1,0 +1,140 @@
+package graph
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/graph/model"
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	apperrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+)
+
+func seedMutationReachParent(t *testing.T, statusRepo interface {
+	CreateStatus(context.Context, *models.Status) error
+}, id, visibility string) {
+	t.Helper()
+
+	now := time.Now().UTC()
+	require.NoError(t, statusRepo.CreateStatus(context.Background(), &models.Status{
+		StatusID:       id,
+		AuthorID:       "https://localhost/users/alice",
+		AuthorUsername: "alice",
+		Content:        "parent " + id,
+		Visibility:     visibility,
+		PublishedAt:    now,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		ModifiedAt:     now,
+		Note: &activitypub.Note{
+			BaseObject: activitypub.BaseObject{
+				ID:   fmt.Sprintf("https://localhost/users/alice/statuses/%s", id),
+				Type: activitypub.NoteType,
+			},
+			Content:      "parent " + id,
+			AttributedTo: "https://localhost/users/alice",
+			Visibility:   visibility,
+		},
+	}))
+}
+
+func requireStructuredReachRefusal(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	appErr, ok := apperrors.AsAppError(err)
+	require.True(t, ok, "reach refusals must retain a structured application error")
+	require.Equal(t, apperrors.CodeUnprocessableEntity, appErr.Code)
+}
+
+func TestCreateNoteRejectsReplyReachWidening(t *testing.T) {
+	tests := []struct {
+		name             string
+		parentVisibility string
+	}{
+		{name: "direct parent", parentVisibility: models.VisibilityDirect},
+		{name: "followers-only parent", parentVisibility: models.VisibilityPrivate},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver, storageRepo := newRound12GraphResolver(t)
+			seedMutationReachParent(t, storageRepo.Status(), "parent", tt.parentVisibility)
+			parentID := "parent"
+
+			_, err := resolver.Mutation().CreateNote(round12AuthContext("alice"), model.CreateNoteInput{
+				Content:     "wider reply",
+				InReplyToID: &parentID,
+				Visibility:  model.VisibilityPublic,
+			})
+			requireStructuredReachRefusal(t, err)
+		})
+	}
+}
+
+func TestCreateNoteAcceptsEqualAndNarrowerReplyReach(t *testing.T) {
+	tests := []struct {
+		name             string
+		parentVisibility string
+		requested        model.Visibility
+	}{
+		{name: "equal followers-only", parentVisibility: models.VisibilityPrivate, requested: model.VisibilityFollowers},
+		{name: "narrower followers-only", parentVisibility: models.VisibilityPublic, requested: model.VisibilityFollowers},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver, storageRepo := newRound12GraphResolver(t)
+			seedMutationReachParent(t, storageRepo.Status(), "parent", tt.parentVisibility)
+			parentID := "parent"
+
+			payload, err := resolver.Mutation().CreateNote(round12AuthContext("alice"), model.CreateNoteInput{
+				Content:     "bounded reply",
+				InReplyToID: &parentID,
+				Visibility:  tt.requested,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, payload)
+			require.NotNil(t, payload.Object)
+			require.Equal(t, tt.requested, payload.Object.Visibility)
+		})
+	}
+}
+
+func TestCreateNoteRejectsQuoteReachWidening(t *testing.T) {
+	resolver, storageRepo := newRound12GraphResolver(t)
+	seedMutationReachParent(t, storageRepo.Status(), "parent", models.VisibilityPrivate)
+	quoteID := "parent"
+
+	_, err := resolver.Mutation().CreateNote(round12AuthContext("alice"), model.CreateNoteInput{
+		Content:    "wider quote",
+		QuoteID:    &quoteID,
+		Visibility: model.VisibilityPublic,
+	})
+	requireStructuredReachRefusal(t, err)
+}
+
+func TestCreateQuoteNoteInheritsReachAndRejectsWidening(t *testing.T) {
+	resolver, storageRepo := newRound12GraphResolver(t)
+	seedMutationReachParent(t, storageRepo.Status(), "parent", models.VisibilityPrivate)
+
+	_, err := resolver.Mutation().CreateQuoteNote(round12AuthContext("alice"), model.CreateQuoteNoteInput{
+		Content:    "wider quote",
+		QuoteURL:   "parent",
+		Visibility: ptrVisibility(model.VisibilityPublic),
+	})
+	requireStructuredReachRefusal(t, err)
+
+	payload, err := resolver.Mutation().CreateQuoteNote(round12AuthContext("alice"), model.CreateQuoteNoteInput{
+		Content:  "inherited quote",
+		QuoteURL: "parent",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, payload)
+	require.NotNil(t, payload.Object)
+	require.Equal(t, model.VisibilityFollowers, payload.Object.Visibility)
+}
+
+func ptrVisibility(v model.Visibility) *model.Visibility { return &v }

--- a/pkg/federation/remotenotes/reply_parent_resolver.go
+++ b/pkg/federation/remotenotes/reply_parent_resolver.go
@@ -324,21 +324,6 @@ func validateReplyParentVisibility(status *models.Status, requestedVisibility st
 	return notes.ValidateChildReach("reply", status, requestedVisibility)
 }
 
-func replyVisibilityRank(visibility string) (int, bool) {
-	switch strings.TrimSpace(visibility) {
-	case models.VisibilityPublic:
-		return 0, true
-	case models.VisibilityUnlisted:
-		return 1, true
-	case models.VisibilityPrivate:
-		return 2, true
-	case models.VisibilityDirect:
-		return 3, true
-	default:
-		return 0, false
-	}
-}
-
 func replyParentResultFromStatus(status *models.Status, fetched bool, localDomain string) *notes.ResolvedReplyParent {
 	if status == nil {
 		return nil

--- a/pkg/federation/remotenotes/reply_parent_resolver.go
+++ b/pkg/federation/remotenotes/reply_parent_resolver.go
@@ -86,15 +86,38 @@ func (r *Resolver) ResolveReplyParent(
 	rawInReplyTo string,
 	requestedVisibility string,
 ) (*notes.ResolvedReplyParent, error) {
+	return r.resolveStatusReference(ctx, author, rawInReplyTo, requestedVisibility, true)
+}
+
+// ResolveQuoteTarget reuses the reply path's storage-first, authorized remote
+// fetch and materialization flow. Viewer access and quote reach are enforced by
+// the notes service after the target has a stable local projection.
+func (r *Resolver) ResolveQuoteTarget(
+	ctx context.Context,
+	author *storage.Account,
+	rawQuoteTarget string,
+) (*notes.ResolvedReplyParent, error) {
+	return r.resolveStatusReference(ctx, author, rawQuoteTarget, "", false)
+}
+
+func (r *Resolver) resolveStatusReference(
+	ctx context.Context,
+	author *storage.Account,
+	rawInReplyTo string,
+	requestedVisibility string,
+	validateReach bool,
+) (*notes.ResolvedReplyParent, error) {
 	rawInReplyTo = strings.TrimSpace(rawInReplyTo)
 	if rawInReplyTo == "" {
 		return nil, nil
 	}
 
 	if status, err := r.resolveStoredParent(ctx, rawInReplyTo); err == nil && status != nil {
-		if err := validateReplyParentVisibility(status, requestedVisibility); err != nil {
-			r.logOutcome("visibility_rejected", rawInReplyTo, status, false, err)
-			return nil, err
+		if validateReach {
+			if err := validateReplyParentVisibility(status, requestedVisibility); err != nil {
+				r.logOutcome("visibility_rejected", rawInReplyTo, status, false, err)
+				return nil, err
+			}
 		}
 		r.logOutcome("stored", rawInReplyTo, status, false, nil)
 		return replyParentResultFromStatus(status, false, r.localDomain), nil
@@ -111,7 +134,7 @@ func (r *Resolver) ResolveReplyParent(
 		return nil, invalidReplyParentReference(rawInReplyTo, err)
 	}
 
-	if requestedVisibility == models.VisibilityDirect {
+	if validateReach && requestedVisibility == models.VisibilityDirect {
 		return nil, unusableReplyParent(parentURL, "direct replies are handled by conversations")
 	}
 
@@ -145,9 +168,11 @@ func (r *Resolver) ResolveReplyParent(
 		return nil, mappedErr
 	}
 
-	if err := validateReplyParentVisibility(status, requestedVisibility); err != nil {
-		r.logOutcome("visibility_rejected", rawInReplyTo, status, true, err)
-		return nil, err
+	if validateReach {
+		if err := validateReplyParentVisibility(status, requestedVisibility); err != nil {
+			r.logOutcome("visibility_rejected", rawInReplyTo, status, true, err)
+			return nil, err
+		}
 	}
 
 	r.logOutcome("materialized", rawInReplyTo, status, true, nil)
@@ -296,21 +321,7 @@ func fetchedReplyParentNote(obj any) (*activitypub.Note, error) {
 }
 
 func validateReplyParentVisibility(status *models.Status, requestedVisibility string) error {
-	if status == nil {
-		return unusableReplyParent("", "reply parent is unavailable")
-	}
-
-	parentRank, parentOK := replyVisibilityRank(status.Visibility)
-	requestedRank, requestedOK := replyVisibilityRank(requestedVisibility)
-	if !parentOK || !requestedOK {
-		return unusableReplyParent(status.StatusID, "reply visibility is unsupported")
-	}
-
-	if requestedRank < parentRank {
-		return unusableReplyParent(status.StatusID, "reply visibility cannot broaden beyond the parent")
-	}
-
-	return nil
+	return notes.ValidateChildReach("reply", status, requestedVisibility)
 }
 
 func replyVisibilityRank(visibility string) (int, bool) {

--- a/pkg/federation/remotenotes/reply_parent_resolver_helpers_test.go
+++ b/pkg/federation/remotenotes/reply_parent_resolver_helpers_test.go
@@ -304,27 +304,6 @@ func TestResolveStoredParentAndFetchGuards(t *testing.T) {
 }
 
 func TestReplyParentVisibilityAndFailureHelpers(t *testing.T) {
-	t.Run("maps supported visibility levels and rejects unknown values", func(t *testing.T) {
-		rank, ok := replyVisibilityRank(models.VisibilityPublic)
-		require.True(t, ok)
-		assert.Equal(t, 0, rank)
-
-		rank, ok = replyVisibilityRank(models.VisibilityUnlisted)
-		require.True(t, ok)
-		assert.Equal(t, 1, rank)
-
-		rank, ok = replyVisibilityRank(models.VisibilityPrivate)
-		require.True(t, ok)
-		assert.Equal(t, 2, rank)
-
-		rank, ok = replyVisibilityRank(models.VisibilityDirect)
-		require.True(t, ok)
-		assert.Equal(t, 3, rank)
-
-		_, ok = replyVisibilityRank("followers")
-		assert.False(t, ok)
-	})
-
 	t.Run("normalizes parent domains and materialize failure mapping", func(t *testing.T) {
 		assert.Equal(t, "remote.example", replyParentDomain("https://remote.example/users/steward/statuses/seed-1"))
 		assert.Empty(t, replyParentDomain("not-a-url"))

--- a/pkg/federation/remotenotes/reply_parent_resolver_test.go
+++ b/pkg/federation/remotenotes/reply_parent_resolver_test.go
@@ -310,6 +310,35 @@ func TestReplyParentResolver_ResolveReplyParent(t *testing.T) {
 	})
 }
 
+func TestReplyParentResolver_ResolveQuoteTargetMaterializesRemoteStatus(t *testing.T) {
+	parentURL := "https://remote.example/users/steward/statuses/fresh-quote"
+	statusRepo := &stubStatusRepo{}
+	objectRepo := &stubObjectRepo{}
+	fetcher := &stubFetcher{obj: remoteNoteObject(parentURL, models.VisibilityPrivate)}
+	resolver := NewReplyParentResolver(
+		statusRepo,
+		objectRepo,
+		&stubDomainBlockRepo{},
+		fetcher,
+		"example.com",
+		zap.NewNop(),
+	)
+
+	result, err := resolver.ResolveQuoteTarget(context.Background(), localAuthorAccount("alice"), parentURL)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Status)
+	require.Len(t, objectRepo.created, 1)
+	assert.True(t, result.Fetched)
+	assert.True(t, result.Remote)
+	assert.Equal(t, models.VisibilityPrivate, result.Status.Visibility)
+	assert.Equal(t, parentURL, result.CanonicalObjectURL)
+	assert.Equal(t, parentURL, fetcher.gotURL)
+	require.NotNil(t, fetcher.gotActor)
+	assert.Equal(t, "alice", fetcher.gotActor.PreferredUsername)
+	assert.Same(t, result.Status, statusRepo.byURL[parentURL], "the fetched quote target must be materialized before caller-side access evaluation")
+}
+
 func localAuthorAccount(username string) *storage.Account {
 	actorID := "https://example.com/users/" + username
 	return &storage.Account{

--- a/pkg/services/notes/reach.go
+++ b/pkg/services/notes/reach.go
@@ -1,0 +1,62 @@
+package notes
+
+import (
+	"strings"
+
+	apperrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+)
+
+// ValidateChildReach rejects reply and quote visibility that would broaden the
+// audience beyond the referenced status. Callers retain the author's requested
+// visibility; this helper never clamps it.
+func ValidateChildReach(relationship string, parent *models.Status, requestedVisibility string) error {
+	if parent == nil {
+		return apperrors.NewAppError(
+			apperrors.CodeUnprocessableEntity,
+			apperrors.CategoryValidation,
+			"parent status is not usable",
+		)
+	}
+
+	parentRank, parentOK := childReachVisibilityRank(parent.Visibility)
+	requestedRank, requestedOK := childReachVisibilityRank(requestedVisibility)
+	if !parentOK || !requestedOK {
+		return apperrors.NewAppError(
+			apperrors.CodeUnprocessableEntity,
+			apperrors.CategoryValidation,
+			"status visibility is not supported for this relationship",
+		).
+			WithMetadata("relationship", relationship).
+			WithMetadata("parent_visibility", parent.Visibility).
+			WithMetadata("requested_visibility", requestedVisibility)
+	}
+	if requestedRank < parentRank {
+		return apperrors.NewAppError(
+			apperrors.CodeUnprocessableEntity,
+			apperrors.CategoryValidation,
+			"requested visibility exceeds parent reach",
+		).
+			WithMetadata("relationship", relationship).
+			WithMetadata("parent_id", parent.StatusID).
+			WithMetadata("parent_visibility", parent.Visibility).
+			WithMetadata("requested_visibility", requestedVisibility)
+	}
+
+	return nil
+}
+
+func childReachVisibilityRank(visibility string) (int, bool) {
+	switch strings.ToLower(strings.TrimSpace(visibility)) {
+	case models.VisibilityPublic:
+		return 0, true
+	case models.VisibilityUnlisted:
+		return 1, true
+	case models.VisibilityPrivate:
+		return 2, true
+	case models.VisibilityDirect:
+		return 3, true
+	default:
+		return 0, false
+	}
+}

--- a/pkg/services/notes/service.go
+++ b/pkg/services/notes/service.go
@@ -125,6 +125,7 @@ type FederationService interface {
 // ReplyParentResolver resolves and materializes reply parents for note creation.
 type ReplyParentResolver interface {
 	ResolveReplyParent(ctx context.Context, author *storage.Account, rawInReplyTo string, requestedVisibility string) (*ResolvedReplyParent, error)
+	ResolveQuoteTarget(ctx context.Context, author *storage.Account, rawQuoteTarget string) (*ResolvedReplyParent, error)
 }
 
 // ResolvedReplyParent describes a reply parent resolved for a single create-note request.
@@ -674,6 +675,44 @@ func (s *Service) resolveCreateReplyParent(ctx context.Context, author *storage.
 		Visibility:         parent.Visibility,
 		Remote:             !s.replyParentIsLocal(parent),
 	}, nil
+}
+
+// ResolveQuoteTarget resolves and, when necessary, materializes a quote target
+// before applying the normal viewer-aware status access checks. Quote creation
+// must not turn an unviewable status reference into an existence oracle.
+func (s *Service) ResolveQuoteTarget(ctx context.Context, viewerID, rawQuoteTarget string) (*models.Status, error) {
+	if err := common.ValidateRequiredParam("quote_target", strings.TrimSpace(rawQuoteTarget)); err != nil {
+		return nil, ErrStatusIDRequired
+	}
+	if err := common.ValidateRequiredParam("viewer_id", strings.TrimSpace(viewerID)); err != nil {
+		return nil, ErrStatusNotFound
+	}
+
+	lookupID := strings.TrimSpace(rawQuoteTarget)
+	if s.replyParents != nil {
+		author, err := s.accountRepo.GetAccount(ctx, viewerID)
+		if err != nil {
+			return nil, ErrGetAuthorAccount
+		}
+
+		resolved, err := s.replyParents.ResolveQuoteTarget(ctx, author, lookupID)
+		if err != nil {
+			return nil, err
+		}
+		if resolved != nil {
+			switch {
+			case strings.TrimSpace(resolved.CanonicalStatusID) != "":
+				lookupID = strings.TrimSpace(resolved.CanonicalStatusID)
+			case resolved.Status != nil && strings.TrimSpace(resolved.Status.StatusID) != "":
+				lookupID = strings.TrimSpace(resolved.Status.StatusID)
+			}
+		}
+	}
+
+	return s.GetNoteWithViewer(ctx, &GetNoteQuery{
+		StatusID: lookupID,
+		ViewerID: viewerID,
+	})
 }
 
 func replyConversationID(cmd *CreateNoteCommand, parent *models.Status) string {

--- a/pkg/services/notes/service_internal_test.go
+++ b/pkg/services/notes/service_internal_test.go
@@ -9,10 +9,12 @@ import (
 	"time"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	apperrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/services/notifications"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/streaming"
+	testinginmemory "github.com/equaltoai/lesser/pkg/testing/inmemory"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -548,6 +550,81 @@ type stubReplyParentResolver struct {
 	resolved map[string]*ResolvedReplyParent
 	err      error
 	calls    []replyParentResolutionCall
+}
+
+func (s *stubReplyParentResolver) ResolveQuoteTarget(_ context.Context, author *storage.Account, rawQuoteTarget string) (*ResolvedReplyParent, error) {
+	call := replyParentResolutionCall{raw: rawQuoteTarget}
+	if author != nil {
+		if author.User != nil {
+			call.username = author.User.Username
+		}
+		if author.Actor != nil {
+			call.authorID = author.Actor.ID
+		}
+	}
+	s.calls = append(s.calls, call)
+
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.resolved != nil {
+		return s.resolved[rawQuoteTarget], nil
+	}
+	return nil, nil
+}
+
+func TestResolveQuoteTargetAppliesViewerAccessAfterResolution(t *testing.T) {
+	ctx := context.Background()
+	statusRepo := testinginmemory.NewStatusRepository()
+	now := time.Now().UTC()
+	target := &models.Status{
+		StatusID:       "remote-direct",
+		AuthorID:       "https://remote.example/users/bob",
+		AuthorUsername: "bob@remote.example",
+		Visibility:     models.VisibilityDirect,
+		ToRecipients:   []string{"https://example.com/users/carol"},
+		PublishedAt:    now,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		ModifiedAt:     now,
+		Note: &activitypub.Note{
+			BaseObject:   activitypub.BaseObject{ID: "https://remote.example/users/bob/statuses/direct", Type: activitypub.NoteType},
+			AttributedTo: "https://remote.example/users/bob",
+			Visibility:   models.VisibilityDirect,
+		},
+	}
+	require.NoError(t, statusRepo.CreateStatus(ctx, target))
+
+	resolver := &stubReplyParentResolver{resolved: map[string]*ResolvedReplyParent{
+		target.Note.ID: {
+			Status:             target,
+			CanonicalStatusID:  target.StatusID,
+			CanonicalObjectURL: target.Note.ID,
+			Visibility:         target.Visibility,
+			Fetched:            true,
+			Remote:             true,
+		},
+	}}
+	service := &Service{
+		noteRepo:     statusRepo,
+		accountRepo:  &stubAccountRepo{domain: "example.com"},
+		replyParents: resolver,
+		domainName:   "example.com",
+		logger:       zap.NewNop(),
+	}
+
+	_, err := service.ResolveQuoteTarget(ctx, "alice", target.Note.ID)
+	appErr, ok := apperrors.AsAppError(err)
+	require.True(t, ok)
+	require.Equal(t, apperrors.CodeNotFound, appErr.Code)
+	require.Len(t, resolver.calls, 1)
+	require.Equal(t, "alice", resolver.calls[0].username)
+
+	target.ToRecipients = []string{"https://example.com/users/alice"}
+	require.NoError(t, statusRepo.UpdateStatus(ctx, target))
+	visible, err := service.ResolveQuoteTarget(ctx, "alice", target.Note.ID)
+	require.NoError(t, err)
+	require.Equal(t, target.StatusID, visible.StatusID)
 }
 
 func (s *stubReplyParentResolver) ResolveReplyParent(_ context.Context, author *storage.Account, rawInReplyTo string, requestedVisibility string) (*ResolvedReplyParent, error) {

--- a/pkg/storage/repositories/draft_repository.go
+++ b/pkg/storage/repositories/draft_repository.go
@@ -174,7 +174,7 @@ func (r *DraftRepository) CreateDraftReviewGrant(ctx context.Context, grant *mod
 	if err := grant.UpdateKeys(); err != nil {
 		return err
 	}
-	return r.db.WithContext(ctx).Model(grant).Create()
+	return r.db.WithContext(ctx).Model(grant).IfNotExists().Create()
 }
 
 // RegrantDraftReviewGrant clears revocation and restores the sparse queue keys.

--- a/pkg/storage/repositories/draft_review_repository_test.go
+++ b/pkg/storage/repositories/draft_review_repository_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/models"
@@ -52,7 +53,48 @@ func TestDraftRepositoryCreateDraftReviewGrantUsesCreateBuilder(t *testing.T) {
 
 	require.Len(t, client.putInputs, 1, "first-time grants must use TableTheory's create path")
 	require.Empty(t, client.updateInputs, "first-time grants must not use the version-conditioned update path")
-	require.Nil(t, client.putInputs[0].ConditionExpression, "the create path must remain an unconditional PutItem")
+	require.Contains(t, aws.ToString(client.putInputs[0].ConditionExpression), "attribute_not_exists",
+		"first-time grants must use a conditional PutItem")
+	require.Contains(t, client.putInputs[0].ExpressionAttributeNames, "#n1")
+	require.Equal(t, "PK", client.putInputs[0].ExpressionAttributeNames["#n1"])
+}
+
+func TestDraftRepositoryCreateDraftReviewGrantRejectsStaleCreateAfterRevoke(t *testing.T) {
+	ctx := context.Background()
+	db, err := tabletheory.NewWithClient(session.Config{Region: "us-east-1"}, fakedb.New())
+	require.NoError(t, err)
+	require.NoError(t, db.CreateTable(&models.DraftReviewGrant{}))
+	repo := NewDraftRepository(db, "test-table", zap.NewNop(), nil)
+
+	// This stale grant represents caller A after its Get observed no grant.
+	staleGrant := &models.DraftReviewGrant{
+		OwnerID:   "owner",
+		DraftID:   "draft-1",
+		Reviewer:  "reviewer",
+		GrantedAt: time.Now().UTC().Add(-time.Minute),
+	}
+
+	// Caller B creates and then completes a revocation before A reaches Create.
+	grant := &models.DraftReviewGrant{
+		OwnerID:   staleGrant.OwnerID,
+		DraftID:   staleGrant.DraftID,
+		Reviewer:  staleGrant.Reviewer,
+		GrantedAt: staleGrant.GrantedAt,
+	}
+	require.NoError(t, repo.CreateDraftReviewGrant(ctx, grant))
+	revokedAt := time.Now().UTC()
+	grant.RevokedAt = &revokedAt
+	require.NoError(t, repo.RevokeDraftReviewGrant(ctx, grant))
+
+	err = repo.CreateDraftReviewGrant(ctx, staleGrant)
+	require.Error(t, err, "a stale create must fail instead of resurrecting a revoked grant")
+	require.ErrorIs(t, err, dynamormerrors.ErrConditionFailed)
+
+	persisted, getErr := repo.GetDraftReviewGrant(ctx, grant.OwnerID, grant.DraftID, grant.Reviewer)
+	require.NoError(t, getErr)
+	require.NotNil(t, persisted.RevokedAt, "the completed revocation must remain persisted")
+	require.Empty(t, persisted.GSI2PK, "the revoked grant must stay out of the reviewer queue")
+	require.Empty(t, persisted.GSI2SK, "the revoked grant must stay out of the reviewer queue")
 }
 
 func TestDraftRepositoryGetDraftReviewGrantMapsNotFoundSentinel(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up wrap-up batch, stream A: Lesser hardening for `#1292`, `#1291`, `#1295`, and `#1299`, plus bounded rework for the adversarial findings on review `pullrequestreview-4834822610`.

- remove the vacuous shared-review repository-cursor assertion while retaining the resolver-sensitive `HasPreviousPage` check
- make first-time draft-review grant creation conditional so a stale create cannot overwrite a completed revocation
- enforce non-widening reply and quote reach with structured client errors
- resolve, authorize, and when necessary fetch/materialize quote targets before quote creation
- persist and recheck JWT expiry for each GraphQL WebSocket subscribe operation; legacy authenticated rows without persisted expiry now fail closed

Refs #1292
Refs #1291
Refs #1295
Refs #1299

## Contract and trust review

- **#1292:** `TestDraftReviewResolversTreatWhitespaceCursorAsAbsent` still proves resolver behavior with `HasPreviousPage == false`. The decorative SharedDraftReviews repository-cursor assertion was removed; the downstream MyDrafts assertion remains.
- **#1291:** TableTheory remains pinned at `v2.0.5`. Its supported `Query.IfNotExists().Create()` path emits a conditional put; no dependency bump or framework patch was made. The regression interleave proves a stale create returns `dynamormerrors.ErrConditionFailed`, preserves `RevokedAt`, and does not restore GSI2 grant keys.
- **#1295:** Effective reach is ordered `public < unlisted < followers/private < direct`. GraphQL replies and quotes and REST `POST /api/v1/statuses/{id}/reblog` with a non-empty `comment` resolve the parent/target, apply viewer-aware authorization, and reject wider child reach with `UNPROCESSABLE_ENTITY`; no silent clamp occurs. Omitted GraphQL quote visibility inherits the target reach. A non-empty REST reblog comment retains its REST default of public, which is rejected when that would widen reach. Remote targets not yet stored locally are fetched, materialized, then authorized and evaluated.
- **#1299:** Authenticated connection state carries token expiry across Lambda invocations. Each new subscribe operation rechecks `exp`; expired credentials return `TOKEN_EXPIRED`, while anonymous gated-operation behavior remains `UNAUTHENTICATED`. Existing subscriptions are not interrupted mid-delivery.

## Adversarial rework disposition

- **HIGH — REST quote reach widening: fixed.** The non-empty-comment reblog path now uses the reply resolver's storage-first/fetch-and-materialize flow, performs viewer-aware target access control, and applies the same shared reach validator as GraphQL before any object, activity, or fanout write. Followers/private and direct targets cannot be publicly quoted. Equal or narrower quotes pass. The empty-comment pure-reblog path is unchanged.
- **MEDIUM — remote quote materialization: fixed for the reviewed paths.** GraphQL quote creation and REST reblog-quotes now fetch and materialize unseen remote targets before access and reach checks. Explicit residue: the separate lesser-exclusive `POST /api/v1/statuses/{id}/quote` endpoint still requires a locally materialized target; it is not the reviewed reblog-quote path and is documented as such.
- **MEDIUM — legacy WebSocket expiry: fail closed.** Authenticated rows without `token_expires_at` return `TOKEN_EXPIRED` on the next subscribe and require one reconnect. This avoids preserving an up-to-connection-TTL pre-deploy authorization window; a reconnect self-heals the row, and anonymous connections remain unaffected.
- **LOW — rollout documentation omitted WebSocket semantics: fixed.** The rollout document now states per-operation timing, error codes, legacy-row behavior, and the fact that already-running subscriptions are not torn down.
- **LOW — conditional grant error is opaque: rebutted for this bounded rework.** The conditional race already fails loudly and preserves revocation. Automatically rereading/regranting or collapsing the condition failure to success could obscure a concurrent revocation. Translating the raw persistence error into a domain conflict may improve ergonomics, but does not change the proven security invariant and is outside the requested quote/WS/doc scope.

## Regression evidence

- REST reblog-quote: followers/private-to-public and direct-to-public rejected; equal/narrower accepted; inaccessible target hidden; unseen remote target fetched/materialized/evaluated; empty-comment reblog unchanged
- GraphQL quote creation: unseen remote target fetched/materialized and viewer authorization applied
- WebSocket: legacy authenticated connection without persisted expiry fails closed on next operation; valid, expired, and anonymous behavior remains distinct
- Original #1291, #1292, #1295, and #1299 regressions remain green

## Documentation truthfulness

`docs/security/hardened-auth-visibility-rollout.md` now names the enforcing GraphQL and REST paths, target materialization and viewer checks, structured rejection/no-clamp semantics, REST default-public behavior, deleted/inaccessible target handling, `UpdateStatus`'s lack of a visibility mutation field, WebSocket legacy-row handling, and the local-materialization residue of the separate lesser-exclusive quote endpoint.

## Validation

- `go test ./cmd/api/handlers ./cmd/graphql-ws ./graph ./pkg/federation/remotenotes ./pkg/services/notes -count=1`
- `go vet ./...`
- gofmt check across every changed Go file (empty)
- `./lesser verify ci` (green: lint, security, supply chain, verify suite, strict contracts, and overall/pkg/cmd coverage gates; overall 87.630%, pkg 90.004%, cmd 90.004%)
- DCO trailers verified for every commit in `staging..HEAD`

## Rollout and consumers

No deployment or cloud mutation was performed.

- [ ] dev rollout and observable soak
- [ ] staging rollout and observable soak
- [ ] live rollout with explicit operator authorization

After landing, consumers should handle `UNPROCESSABLE_ENTITY` for widened reach and `TOKEN_EXPIRED` for expired or legacy expiry-less authenticated WebSocket rows.

## Risks / review focus

- Verify that no write/federation side effect precedes quote target authorization and reach validation.
- Verify storage-first and freshly fetched/materialized remote targets receive identical viewer-access and reach checks.
- Verify missing persisted WebSocket expiry fails closed only for authenticated legacy rows and does not alter anonymous behavior.
- Please have Claude adversarially re-review the new head; the implementing client for this bounded rework is Codex.