### PR TITLE
fix(cms): bind draft-review approvals to approved content hash (#1293)

### DIFF
--- a/docs/contracts/graphql-schema.graphql
+++ b/docs/contracts/graphql-schema.graphql
@@ -2446,6 +2446,7 @@ type DraftReviewGrant {
 type DraftReviewVerdictRecord {
   verdict: DraftReviewVerdict!
   notes: String
+  contentHash: String
   reviewer: Actor!
   recordedAt: Time!
 }

--- a/graph/cms_converters.go
+++ b/graph/cms_converters.go
@@ -533,7 +533,13 @@ func (r *Resolver) convertCMSDraftReview(ctx context.Context, draft *models.Draf
 		if v == nil {
 			continue
 		}
-		out = append(out, &model.DraftReviewVerdictRecord{Verdict: model.DraftReviewVerdict(v.Verdict), Notes: cmsOptionalString(v.Notes), Reviewer: r.resolveActorByID(ctx, v.Reviewer), RecordedAt: model.Time(v.RecordedAt)})
+		out = append(out, &model.DraftReviewVerdictRecord{
+			Verdict:     model.DraftReviewVerdict(v.Verdict),
+			Notes:       cmsOptionalString(v.Notes),
+			ContentHash: cmsOptionalString(v.ContentHash),
+			Reviewer:    r.resolveActorByID(ctx, v.Reviewer),
+			RecordedAt:  model.Time(v.RecordedAt),
+		})
 	}
 	return &model.DraftReview{DraftID: draft.ID, Title: cmsOptionalString(draft.Title), ContentFormat: cmsContentFormatFromStorage(draft.ContentFormat), Status: cmsDraftStatusFromStorage(draft.Status), ScheduledAt: scheduledAt, UpdatedAt: model.Time(draft.UpdatedAt), CreatedAt: model.Time(draft.CreatedAt), GeneratedBy: r.resolveActorByID(ctx, draft.GeneratedBy), ReviewedBy: r.resolveActorByID(ctx, draft.ReviewedBy), ReviewStatus: cmsOptionalString(draft.ReviewStatus), EditorNotes: cmsOptionalString(draft.EditorNotes), Grant: reviewGrant, Verdicts: out}
 }

--- a/graph/generated.go
+++ b/graph/generated.go
@@ -1215,10 +1215,11 @@ type ComplexityRoot struct {
 	}
 
 	DraftReviewVerdictRecord struct {
-		Notes      func(childComplexity int) int
-		RecordedAt func(childComplexity int) int
-		Reviewer   func(childComplexity int) int
-		Verdict    func(childComplexity int) int
+		ContentHash func(childComplexity int) int
+		Notes       func(childComplexity int) int
+		RecordedAt  func(childComplexity int) int
+		Reviewer    func(childComplexity int) int
+		Verdict     func(childComplexity int) int
 	}
 
 	Driver struct {
@@ -9391,6 +9392,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.DraftReviewGrant.Reviewer(childComplexity), true
+
+	case "DraftReviewVerdictRecord.contentHash":
+		if e.complexity.DraftReviewVerdictRecord.ContentHash == nil {
+			break
+		}
+
+		return e.complexity.DraftReviewVerdictRecord.ContentHash(childComplexity), true
 
 	case "DraftReviewVerdictRecord.notes":
 		if e.complexity.DraftReviewVerdictRecord.Notes == nil {
@@ -63700,6 +63708,8 @@ func (ec *executionContext) fieldContext_DraftReview_verdicts(_ context.Context,
 				return ec.fieldContext_DraftReviewVerdictRecord_verdict(ctx, field)
 			case "notes":
 				return ec.fieldContext_DraftReviewVerdictRecord_notes(ctx, field)
+			case "contentHash":
+				return ec.fieldContext_DraftReviewVerdictRecord_contentHash(ctx, field)
 			case "reviewer":
 				return ec.fieldContext_DraftReviewVerdictRecord_reviewer(ctx, field)
 			case "recordedAt":
@@ -64186,6 +64196,47 @@ func (ec *executionContext) _DraftReviewVerdictRecord_notes(ctx context.Context,
 }
 
 func (ec *executionContext) fieldContext_DraftReviewVerdictRecord_notes(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DraftReviewVerdictRecord",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DraftReviewVerdictRecord_contentHash(ctx context.Context, field graphql.CollectedField, obj *model.DraftReviewVerdictRecord) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DraftReviewVerdictRecord_contentHash(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ContentHash, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DraftReviewVerdictRecord_contentHash(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "DraftReviewVerdictRecord",
 		Field:      field,
@@ -168650,6 +168701,8 @@ func (ec *executionContext) _DraftReviewVerdictRecord(ctx context.Context, sel a
 			}
 		case "notes":
 			out.Values[i] = ec._DraftReviewVerdictRecord_notes(ctx, field, obj)
+		case "contentHash":
+			out.Values[i] = ec._DraftReviewVerdictRecord_contentHash(ctx, field, obj)
 		case "reviewer":
 			out.Values[i] = ec._DraftReviewVerdictRecord_reviewer(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -1229,10 +1229,11 @@ type DraftReviewGrant struct {
 }
 
 type DraftReviewVerdictRecord struct {
-	Verdict    DraftReviewVerdict `json:"verdict"`
-	Notes      *string            `json:"notes,omitempty"`
-	Reviewer   *activitypub.Actor `json:"reviewer"`
-	RecordedAt Time               `json:"recordedAt"`
+	Verdict     DraftReviewVerdict `json:"verdict"`
+	Notes       *string            `json:"notes,omitempty"`
+	ContentHash *string            `json:"contentHash,omitempty"`
+	Reviewer    *activitypub.Actor `json:"reviewer"`
+	RecordedAt  Time               `json:"recordedAt"`
 }
 
 type DroneWorkflowMutationPayload struct {

--- a/graph/phase1.graphql
+++ b/graph/phase1.graphql
@@ -133,6 +133,7 @@ type DraftReviewGrant {
 type DraftReviewVerdictRecord {
   verdict: DraftReviewVerdict!
   notes: String
+  contentHash: String
   reviewer: Actor!
   recordedAt: Time!
 }

--- a/pkg/services/cms/draft_review.go
+++ b/pkg/services/cms/draft_review.go
@@ -3,8 +3,9 @@ package cms
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
 	"errors"
-	"fmt"
 	"strings"
 	"time"
 
@@ -18,11 +19,20 @@ const (
 	DraftReviewChangesRequested = "CHANGES_REQUESTED"
 )
 
-// draftReviewContentHash excludes slug, metadata, autosave state, and timestamps
-// because only format, title, and content are reviewed.
+// draftReviewContentHash binds every field that changes the published article's
+// reviewed content or permalink. Each field is length-prefixed so field
+// boundaries remain unambiguous even when values contain control characters.
+// Metadata, autosave state, and timestamps do not reach the published article
+// and are intentionally excluded.
 func draftReviewContentHash(d *models.Draft) string {
-	canonical := d.ContentFormat + "\x00" + d.Title + "\x00" + d.Content
-	return fmt.Sprintf("%x", sha256.Sum256([]byte(canonical)))
+	h := sha256.New()
+	var length [8]byte
+	for _, field := range []string{d.ContentFormat, d.Slug, d.Title, d.Content} {
+		binary.BigEndian.PutUint64(length[:], uint64(len(field)))
+		_, _ = h.Write(length[:])
+		_, _ = h.Write([]byte(field))
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 var (
@@ -48,6 +58,10 @@ type draftReviewRepository interface {
 	ListDraftReviewGrants(context.Context, string, string) ([]*models.DraftReviewGrant, error)
 	CreateDraftReviewVerdict(context.Context, *models.DraftReviewVerdict) error
 	ListDraftReviewVerdicts(context.Context, string, string) ([]*models.DraftReviewVerdict, error)
+}
+
+type draftReviewFieldUpdater interface {
+	UpdateDraftReviewFields(context.Context, string, *models.Draft) error
 }
 
 func (s *DraftService) reviewRepository() (draftReviewRepository, error) {
@@ -213,6 +227,10 @@ func (s *DraftService) SubmitDraftReview(ctx context.Context, caller, owner, dra
 	if err != nil {
 		return nil, err
 	}
+	fieldUpdater, ok := s.draftRepo.(draftReviewFieldUpdater)
+	if !ok || fieldUpdater == nil {
+		return nil, errDraftReviewStorageUnavailable
+	}
 	d, err := s.draftRepo.GetDraft(ctx, owner, draftID)
 	if err != nil {
 		return nil, err
@@ -232,7 +250,7 @@ func (s *DraftService) SubmitDraftReview(ctx context.Context, caller, owner, dra
 	d.ReviewedBy = caller
 	d.ReviewStatus = verdict
 	d.EditorNotes = v.Notes
-	if err := s.draftRepo.UpdateDraft(ctx, owner, d); err != nil {
+	if err := fieldUpdater.UpdateDraftReviewFields(ctx, owner, d); err != nil {
 		return nil, err
 	}
 	return v, nil
@@ -266,7 +284,7 @@ type draftReviewApprovalState struct {
 	latest map[string]*models.DraftReviewVerdict
 }
 
-func (s *DraftService) draftReviewApprovalState(ctx context.Context, owner, draftID string) (*draftReviewApprovalState, error) {
+func (s *DraftService) draftReviewApprovalState(ctx context.Context, owner, draftID string, draft *models.Draft) (*draftReviewApprovalState, error) {
 	repo, err := s.reviewRepository()
 	if err != nil {
 		return nil, err
@@ -281,13 +299,20 @@ func (s *DraftService) draftReviewApprovalState(ctx context.Context, owner, draf
 			active[grant.Reviewer] = grant
 		}
 	}
+	if len(active) == 0 {
+		return &draftReviewApprovalState{active: active, latest: map[string]*models.DraftReviewVerdict{}}, nil
+	}
 	verdicts, err := repo.ListDraftReviewVerdicts(ctx, owner, draftID)
 	if err != nil {
 		return nil, err
 	}
-	draft, err := s.draftRepo.GetDraft(ctx, owner, draftID)
-	if err != nil {
-		return nil, err
+	if draft == nil {
+		// Public approval helpers may not already have the draft snapshot. Fetch
+		// exactly once, and only when an active grant makes the hash relevant.
+		draft, err = s.draftRepo.GetDraft(ctx, owner, draftID)
+		if err != nil {
+			return nil, err
+		}
 	}
 	currentHash := draftReviewContentHash(draft)
 	latest := make(map[string]*models.DraftReviewVerdict, len(active))
@@ -298,7 +323,7 @@ func (s *DraftService) draftReviewApprovalState(ctx context.Context, owner, draf
 		grant := active[verdict.Reviewer]
 		// A re-grant deliberately requires a verdict recorded after the new grant.
 		if grant != nil && verdict.RecordedAt.After(grant.GrantedAt) &&
-			verdict.ContentHash != "" && verdict.ContentHash == currentHash {
+			verdict.ContentHash == currentHash {
 			if current := latest[verdict.Reviewer]; current == nil || verdict.RecordedAt.After(current.RecordedAt) {
 				latest[verdict.Reviewer] = verdict
 			}
@@ -322,7 +347,11 @@ func allActiveReviewersApproved(state *draftReviewApprovalState) bool {
 // HasUnanimousActiveApproval applies the all-invited-reviewers rule. With no
 // active grants the result is vacuously true, preserving human draft behavior.
 func (s *DraftService) HasUnanimousActiveApproval(ctx context.Context, owner, draftID string) (bool, error) {
-	state, err := s.draftReviewApprovalState(ctx, owner, draftID)
+	return s.hasUnanimousActiveApproval(ctx, owner, draftID, nil)
+}
+
+func (s *DraftService) hasUnanimousActiveApproval(ctx context.Context, owner, draftID string, draft *models.Draft) (bool, error) {
+	state, err := s.draftReviewApprovalState(ctx, owner, draftID, draft)
 	if err != nil {
 		if errors.Is(err, errDraftReviewStorageUnavailable) {
 			// A repository without review support cannot contain active grants;
@@ -336,11 +365,15 @@ func (s *DraftService) HasUnanimousActiveApproval(ctx context.Context, owner, dr
 
 // HasPrincipalApproval applies the additional generated-content principal rule.
 func (s *DraftService) HasPrincipalApproval(ctx context.Context, owner, draftID string) (bool, error) {
+	return s.hasPrincipalApproval(ctx, owner, draftID, nil)
+}
+
+func (s *DraftService) hasPrincipalApproval(ctx context.Context, owner, draftID string, draft *models.Draft) (bool, error) {
 	principal, err := s.instancePrincipal(ctx)
 	if err != nil {
 		return false, err
 	}
-	state, err := s.draftReviewApprovalState(ctx, owner, draftID)
+	state, err := s.draftReviewApprovalState(ctx, owner, draftID, draft)
 	if err != nil {
 		return false, err
 	}
@@ -352,9 +385,18 @@ func (s *DraftService) HasPrincipalApproval(ctx context.Context, owner, draftID 
 // HasActiveApproval preserves the combined generated-draft gate for callers
 // that need both unanimous active-reviewer and principal approval.
 func (s *DraftService) HasActiveApproval(ctx context.Context, owner, draftID string) (bool, error) {
-	approved, err := s.HasUnanimousActiveApproval(ctx, owner, draftID)
-	if err != nil || !approved {
-		return approved, err
+	state, err := s.draftReviewApprovalState(ctx, owner, draftID, nil)
+	if err != nil {
+		return false, err
 	}
-	return s.HasPrincipalApproval(ctx, owner, draftID)
+	if !allActiveReviewersApproved(state) {
+		return false, nil
+	}
+	principal, err := s.instancePrincipal(ctx)
+	if err != nil {
+		return false, err
+	}
+	grant := state.active[principal]
+	verdict := state.latest[principal]
+	return grant != nil && verdict != nil && verdict.Verdict == DraftReviewApproved, nil
 }

--- a/pkg/services/cms/draft_review.go
+++ b/pkg/services/cms/draft_review.go
@@ -23,7 +23,10 @@ const (
 // reviewed content or permalink. Each field is length-prefixed so field
 // boundaries remain unambiguous even when values contain control characters.
 // Metadata, autosave state, and timestamps do not reach the published article
-// and are intentionally excluded.
+// and are intentionally excluded. GeneratedBy is also excluded because
+// cmsApplyDraftRequestAttribution in graph/mutation_resolvers_cms.go only sets
+// and never clears it; that invariant is load-bearing because GeneratedBy
+// enables the principal-approval gate.
 func draftReviewContentHash(d *models.Draft) string {
 	h := sha256.New()
 	var length [8]byte
@@ -342,6 +345,42 @@ func allActiveReviewersApproved(state *draftReviewApprovalState) bool {
 		}
 	}
 	return true
+}
+
+// draftReviewGateApprovals derives the approval snapshot once for the publish
+// and schedule gates, then answers both the unanimous-reviewer and conditional
+// principal requirements from that same snapshot.
+func (s *DraftService) draftReviewGateApprovals(ctx context.Context, owner, draftID string, draft *models.Draft) (bool, bool, error) {
+	state, err := s.draftReviewApprovalState(ctx, owner, draftID, draft)
+	if err != nil {
+		if !errors.Is(err, errDraftReviewStorageUnavailable) {
+			return false, false, err
+		}
+		if strings.TrimSpace(draft.GeneratedBy) == "" {
+			// A repository without review support cannot contain active grants;
+			// preserve the pre-review behavior for human-authored drafts.
+			return true, true, nil
+		}
+		// Preserve the generated-draft error ordering: principal resolution ran
+		// before its independent approval-state derivation on the former path.
+		if _, principalErr := s.instancePrincipal(ctx); principalErr != nil {
+			return false, false, principalErr
+		}
+		return false, false, err
+	}
+	if !allActiveReviewersApproved(state) {
+		return false, false, nil
+	}
+	if strings.TrimSpace(draft.GeneratedBy) == "" {
+		return true, true, nil
+	}
+	principal, err := s.instancePrincipal(ctx)
+	if err != nil {
+		return false, false, err
+	}
+	grant := state.active[principal]
+	verdict := state.latest[principal]
+	return true, grant != nil && verdict != nil && verdict.Verdict == DraftReviewApproved, nil
 }
 
 // HasUnanimousActiveApproval applies the all-invited-reviewers rule. With no

--- a/pkg/services/cms/draft_review.go
+++ b/pkg/services/cms/draft_review.go
@@ -325,6 +325,8 @@ func (s *DraftService) draftReviewApprovalState(ctx context.Context, owner, draf
 		}
 		grant := active[verdict.Reviewer]
 		// A re-grant deliberately requires a verdict recorded after the new grant.
+		// Pre-deploy approvals have no hash and deliberately revert to unapproved;
+		// the fail-closed/no-backfill rollout requires re-review.
 		if grant != nil && verdict.RecordedAt.After(grant.GrantedAt) &&
 			verdict.ContentHash == currentHash {
 			if current := latest[verdict.Reviewer]; current == nil || verdict.RecordedAt.After(current.RecordedAt) {
@@ -351,6 +353,15 @@ func allActiveReviewersApproved(state *draftReviewApprovalState) bool {
 // and schedule gates, then answers both the unanimous-reviewer and conditional
 // principal requirements from that same snapshot.
 func (s *DraftService) draftReviewGateApprovals(ctx context.Context, owner, draftID string, draft *models.Draft) (bool, bool, error) {
+	if draft == nil {
+		// Callers without a snapshot fetch it exactly once before deriving both
+		// approval answers from that same content.
+		var err error
+		draft, err = s.draftRepo.GetDraft(ctx, owner, draftID)
+		if err != nil {
+			return false, false, err
+		}
+	}
 	state, err := s.draftReviewApprovalState(ctx, owner, draftID, draft)
 	if err != nil {
 		if !errors.Is(err, errDraftReviewStorageUnavailable) {

--- a/pkg/services/cms/draft_review.go
+++ b/pkg/services/cms/draft_review.go
@@ -2,7 +2,9 @@ package cms
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -15,6 +17,13 @@ const (
 	DraftReviewApproved         = "APPROVED"
 	DraftReviewChangesRequested = "CHANGES_REQUESTED"
 )
+
+// draftReviewContentHash excludes slug, metadata, autosave state, and timestamps
+// because only format, title, and content are reviewed.
+func draftReviewContentHash(d *models.Draft) string {
+	canonical := d.ContentFormat + "\x00" + d.Title + "\x00" + d.Content
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(canonical)))
+}
 
 var (
 	// ErrDraftReviewApprovalRequired means an active reviewer is missing a current approval.
@@ -204,12 +213,20 @@ func (s *DraftService) SubmitDraftReview(ctx context.Context, caller, owner, dra
 	if err != nil {
 		return nil, err
 	}
-	v := &models.DraftReviewVerdict{OwnerID: owner, DraftID: strings.TrimSpace(draftID), Reviewer: caller, Verdict: verdict, Notes: strings.TrimSpace(notes), RecordedAt: time.Now().UTC()}
-	if err := repo.CreateDraftReviewVerdict(ctx, v); err != nil {
-		return nil, err
-	}
 	d, err := s.draftRepo.GetDraft(ctx, owner, draftID)
 	if err != nil {
+		return nil, err
+	}
+	v := &models.DraftReviewVerdict{
+		OwnerID:     owner,
+		DraftID:     strings.TrimSpace(draftID),
+		Reviewer:    caller,
+		Verdict:     verdict,
+		Notes:       strings.TrimSpace(notes),
+		ContentHash: draftReviewContentHash(d),
+		RecordedAt:  time.Now().UTC(),
+	}
+	if err := repo.CreateDraftReviewVerdict(ctx, v); err != nil {
 		return nil, err
 	}
 	d.ReviewedBy = caller
@@ -268,11 +285,20 @@ func (s *DraftService) draftReviewApprovalState(ctx context.Context, owner, draf
 	if err != nil {
 		return nil, err
 	}
+	draft, err := s.draftRepo.GetDraft(ctx, owner, draftID)
+	if err != nil {
+		return nil, err
+	}
+	currentHash := draftReviewContentHash(draft)
 	latest := make(map[string]*models.DraftReviewVerdict, len(active))
 	for _, verdict := range verdicts {
+		if verdict == nil {
+			continue
+		}
 		grant := active[verdict.Reviewer]
 		// A re-grant deliberately requires a verdict recorded after the new grant.
-		if grant != nil && verdict.RecordedAt.After(grant.GrantedAt) {
+		if grant != nil && verdict.RecordedAt.After(grant.GrantedAt) &&
+			verdict.ContentHash != "" && verdict.ContentHash == currentHash {
 			if current := latest[verdict.Reviewer]; current == nil || verdict.RecordedAt.After(current.RecordedAt) {
 				latest[verdict.Reviewer] = verdict
 			}

--- a/pkg/services/cms/draft_review_test.go
+++ b/pkg/services/cms/draft_review_test.go
@@ -405,6 +405,45 @@ func TestHumanDraftWithoutReviewersSkipsApprovalDetailReads(t *testing.T) {
 	require.Zero(t, repo.getDraftCalls, "zero active grants must return before loading draft content")
 }
 
+func TestDraftReviewApprovalStateRejectsLegacyHashlessVerdict(t *testing.T) {
+	svc, repo := newReviewService(t)
+	ctx := context.Background()
+	grant, err := svc.ShareDraftForReview(ctx, "owner", "d1", "reviewer")
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateDraftReviewVerdict(ctx, &models.DraftReviewVerdict{
+		OwnerID:    "owner",
+		DraftID:    "d1",
+		Reviewer:   "reviewer",
+		Verdict:    DraftReviewApproved,
+		RecordedAt: grant.GrantedAt.Add(time.Nanosecond),
+	}))
+
+	draft, err := repo.GetDraft(ctx, "owner", "d1")
+	require.NoError(t, err)
+	state, err := svc.draftReviewApprovalState(ctx, "owner", "d1", draft)
+	require.NoError(t, err)
+	require.Contains(t, state.active, "reviewer")
+	require.NotContains(t, state.latest, "reviewer",
+		"a pre-migration verdict without a content hash must require re-review")
+	require.False(t, allActiveReviewersApproved(state))
+}
+
+func TestDraftReviewGateApprovalsAcceptsNilDraftSnapshot(t *testing.T) {
+	svc, repo := newReviewService(t)
+	ctx := context.Background()
+	_, err := svc.ShareDraftForReview(ctx, "owner", "d1", "principal")
+	require.NoError(t, err)
+	_, err = svc.SubmitDraftReview(ctx, "principal", "owner", "d1", DraftReviewApproved, "operator approval")
+	require.NoError(t, err)
+
+	repo.getDraftCalls = 0
+	unanimous, principal, err := svc.draftReviewGateApprovals(ctx, "owner", "d1", nil)
+	require.NoError(t, err)
+	require.True(t, unanimous)
+	require.True(t, principal)
+	require.Equal(t, 1, repo.getDraftCalls, "a nil snapshot must trigger exactly one draft read")
+}
+
 func TestGeneratedDraftGateDerivesApprovalStateOnce(t *testing.T) {
 	for _, operation := range []string{"schedule", "publish"} {
 		t.Run(operation, func(t *testing.T) {

--- a/pkg/services/cms/draft_review_test.go
+++ b/pkg/services/cms/draft_review_test.go
@@ -169,6 +169,177 @@ func TestDraftReviewGateRequiresAllActiveReviewersAndPrincipal(t *testing.T) {
 	require.False(t, approved, "latest verdict supersedes per reviewer")
 }
 
+func TestDraftReviewContentHashUsesCanonicalReviewedFields(t *testing.T) {
+	draft := &models.Draft{
+		ContentFormat: "markdown",
+		Title:         "Review draft",
+		Content:       "draft",
+		Slug:          "first-slug",
+		MetadataJSON:  `{"version":1}`,
+	}
+	require.Equal(t, "7c9933a0acf8c08f480f19136b164da3491ff943ba29a3a872c895fb403136ce", draftReviewContentHash(draft))
+
+	draft.Slug = "renamed"
+	draft.MetadataJSON = `{"version":2}`
+	draft.AutosaveVersion++
+	draft.UpdatedAt = time.Now().UTC()
+	require.Equal(t, "7c9933a0acf8c08f480f19136b164da3491ff943ba29a3a872c895fb403136ce", draftReviewContentHash(draft))
+}
+
+func TestDraftReviewApprovalBindsToCurrentContent(t *testing.T) {
+	testCases := map[string]func(*models.Draft){
+		"title": func(draft *models.Draft) { draft.Title = "Edited title" },
+		"content": func(draft *models.Draft) {
+			draft.Content = "edited content"
+		},
+		"format": func(draft *models.Draft) { draft.ContentFormat = "html" },
+	}
+
+	for name, edit := range testCases {
+		t.Run(name, func(t *testing.T) {
+			svc, repo := newReviewService(t)
+			ctx := context.Background()
+			draft, err := repo.GetDraft(ctx, "owner", "d1")
+			require.NoError(t, err)
+			draft.GeneratedBy = ""
+			require.NoError(t, repo.UpdateDraft(ctx, "owner", draft))
+
+			_, err = svc.ShareDraftForReview(ctx, "owner", "d1", "reviewer")
+			require.NoError(t, err)
+			verdict, err := svc.SubmitDraftReview(ctx, "reviewer", "owner", "d1", DraftReviewApproved, "ready")
+			require.NoError(t, err)
+			require.NotEmpty(t, verdict.ContentHash)
+
+			approved, err := svc.HasUnanimousActiveApproval(ctx, "owner", "d1")
+			require.NoError(t, err)
+			require.True(t, approved, "an approval at the current content hash must count")
+
+			draft, err = repo.GetDraft(ctx, "owner", "d1")
+			require.NoError(t, err)
+			edit(draft)
+			require.NoError(t, repo.UpdateDraft(ctx, "owner", draft))
+
+			approved, err = svc.HasUnanimousActiveApproval(ctx, "owner", "d1")
+			require.NoError(t, err)
+			require.False(t, approved, "an edit to reviewed content must invalidate the approval")
+			require.ErrorIs(t, svc.ScheduleDraft(ctx, "owner", "d1", time.Now().Add(time.Hour)), ErrDraftReviewApprovalRequired)
+			_, err = svc.PublishDraft(ctx, "owner", "d1")
+			require.ErrorIs(t, err, ErrDraftReviewApprovalRequired)
+		})
+	}
+}
+
+func TestDraftReviewAfterContentEditRestoresApproval(t *testing.T) {
+	svc, repo := newReviewService(t)
+	ctx := context.Background()
+	draft, err := repo.GetDraft(ctx, "owner", "d1")
+	require.NoError(t, err)
+	draft.GeneratedBy = ""
+	require.NoError(t, repo.UpdateDraft(ctx, "owner", draft))
+	_, err = svc.ShareDraftForReview(ctx, "owner", "d1", "reviewer")
+	require.NoError(t, err)
+	first, err := svc.SubmitDraftReview(ctx, "reviewer", "owner", "d1", DraftReviewApproved, "ready")
+	require.NoError(t, err)
+
+	draft, err = repo.GetDraft(ctx, "owner", "d1")
+	require.NoError(t, err)
+	draft.Content = "revised draft"
+	require.NoError(t, repo.UpdateDraft(ctx, "owner", draft))
+	approved, err := svc.HasUnanimousActiveApproval(ctx, "owner", "d1")
+	require.NoError(t, err)
+	require.False(t, approved)
+
+	time.Sleep(time.Millisecond)
+	second, err := svc.SubmitDraftReview(ctx, "reviewer", "owner", "d1", DraftReviewApproved, "re-reviewed")
+	require.NoError(t, err)
+	require.NotEqual(t, first.ContentHash, second.ContentHash)
+	approved, err = svc.HasUnanimousActiveApproval(ctx, "owner", "d1")
+	require.NoError(t, err)
+	require.True(t, approved)
+}
+
+func TestDraftReviewChangesRequestedAtCurrentHashBlocks(t *testing.T) {
+	svc, _ := newReviewService(t)
+	ctx := context.Background()
+	_, err := svc.ShareDraftForReview(ctx, "owner", "d1", "reviewer")
+	require.NoError(t, err)
+	verdict, err := svc.SubmitDraftReview(ctx, "reviewer", "owner", "d1", DraftReviewChangesRequested, "revise")
+	require.NoError(t, err)
+	require.NotEmpty(t, verdict.ContentHash)
+
+	approved, err := svc.HasUnanimousActiveApproval(ctx, "owner", "d1")
+	require.NoError(t, err)
+	require.False(t, approved)
+}
+
+func TestDraftReviewVerdictWithoutContentHashNeverCounts(t *testing.T) {
+	svc, repo := newReviewService(t)
+	ctx := context.Background()
+	grant, err := svc.ShareDraftForReview(ctx, "owner", "d1", "reviewer")
+	require.NoError(t, err)
+	require.NoError(t, repo.CreateDraftReviewVerdict(ctx, &models.DraftReviewVerdict{
+		OwnerID:    "owner",
+		DraftID:    "d1",
+		Reviewer:   "reviewer",
+		Verdict:    DraftReviewApproved,
+		RecordedAt: grant.GrantedAt.Add(time.Second),
+	}))
+
+	approved, err := svc.HasUnanimousActiveApproval(ctx, "owner", "d1")
+	require.NoError(t, err)
+	require.False(t, approved, "a pre-migration verdict must fail closed")
+}
+
+func TestDraftReviewDraftFetchFailuresFailClosed(t *testing.T) {
+	svc, repo := newReviewService(t)
+	ctx := context.Background()
+	_, err := svc.ShareDraftForReview(ctx, "owner", "d1", "reviewer")
+	require.NoError(t, err)
+	require.NoError(t, repo.DeleteDraft(ctx, "owner", "d1"))
+
+	_, err = svc.SubmitDraftReview(ctx, "reviewer", "owner", "d1", DraftReviewApproved, "ready")
+	require.Error(t, err)
+	require.Empty(t, repo.verdicts, "a missing draft must not leave an unbound verdict")
+
+	approved, err := svc.HasUnanimousActiveApproval(ctx, "owner", "d1")
+	require.Error(t, err)
+	require.False(t, approved)
+}
+
+func TestDraftReviewPrincipalApprovalBindsToCurrentContent(t *testing.T) {
+	svc, repo := newReviewService(t)
+	ctx := context.Background()
+	_, err := svc.ShareDraftForReview(ctx, "owner", "d1", "principal")
+	require.NoError(t, err)
+	_, err = svc.SubmitDraftReview(ctx, "principal", "owner", "d1", DraftReviewApproved, "operator approval")
+	require.NoError(t, err)
+
+	approved, err := svc.HasPrincipalApproval(ctx, "owner", "d1")
+	require.NoError(t, err)
+	require.True(t, approved)
+
+	draft, err := repo.GetDraft(ctx, "owner", "d1")
+	require.NoError(t, err)
+	draft.Title = "edited after principal approval"
+	require.NoError(t, repo.UpdateDraft(ctx, "owner", draft))
+	approved, err = svc.HasPrincipalApproval(ctx, "owner", "d1")
+	require.NoError(t, err)
+	require.False(t, approved)
+}
+
+func TestDraftReviewNoActiveGrantsRemainsVacuouslyApproved(t *testing.T) {
+	svc, repo := newReviewService(t)
+	ctx := context.Background()
+	draft, err := repo.GetDraft(ctx, "owner", "d1")
+	require.NoError(t, err)
+	draft.GeneratedBy = ""
+	require.NoError(t, repo.UpdateDraft(ctx, "owner", draft))
+
+	approved, err := svc.HasUnanimousActiveApproval(ctx, "owner", "d1")
+	require.NoError(t, err)
+	require.True(t, approved)
+}
+
 func TestHumanDraftWithActiveReviewsRequiresUnanimousApproval(t *testing.T) {
 	svc, repo := newReviewService(t)
 	ctx := context.Background()

--- a/pkg/services/cms/draft_review_test.go
+++ b/pkg/services/cms/draft_review_test.go
@@ -25,10 +25,33 @@ type reviewMemRepo struct {
 	revokeGrantCalls        int
 	getGrantErr             error
 	callLog                 []string
+	getDraftCalls           int
+	afterGetDraft           func(int)
+	afterCreateVerdict      func()
 }
 
 func newReviewMemRepo() *reviewMemRepo {
 	return &reviewMemRepo{memDraftRepo: newMemDraftRepo(), grants: map[string]*models.DraftReviewGrant{}}
+}
+
+func (r *reviewMemRepo) GetDraft(ctx context.Context, owner, draftID string) (*models.Draft, error) {
+	r.getDraftCalls++
+	draft, err := r.memDraftRepo.GetDraft(ctx, owner, draftID)
+	if r.afterGetDraft != nil {
+		r.afterGetDraft(r.getDraftCalls)
+	}
+	return draft, err
+}
+
+func (r *reviewMemRepo) UpdateDraftReviewFields(_ context.Context, owner string, draft *models.Draft) error {
+	stored, ok := r.items[r.key(owner, draft.ID)]
+	if !ok {
+		return storage.ErrNotFound
+	}
+	stored.ReviewedBy = draft.ReviewedBy
+	stored.ReviewStatus = draft.ReviewStatus
+	stored.EditorNotes = draft.EditorNotes
+	return nil
 }
 func reviewKey(owner, draft, reviewer string) string { return owner + "|" + draft + "|" + reviewer }
 func (r *reviewMemRepo) storeGrant(g *models.DraftReviewGrant) error {
@@ -116,6 +139,9 @@ func (r *reviewMemRepo) CreateDraftReviewVerdict(_ context.Context, v *models.Dr
 	}
 	copy := *v
 	r.verdicts = append(r.verdicts, &copy)
+	if r.afterCreateVerdict != nil {
+		r.afterCreateVerdict()
+	}
 	return nil
 }
 func (r *reviewMemRepo) ListDraftReviewVerdicts(_ context.Context, owner, draft string) ([]*models.DraftReviewVerdict, error) {
@@ -177,13 +203,21 @@ func TestDraftReviewContentHashUsesCanonicalReviewedFields(t *testing.T) {
 		Slug:          "first-slug",
 		MetadataJSON:  `{"version":1}`,
 	}
-	require.Equal(t, "7c9933a0acf8c08f480f19136b164da3491ff943ba29a3a872c895fb403136ce", draftReviewContentHash(draft))
+	original := draftReviewContentHash(draft)
+	require.Len(t, original, 64)
 
 	draft.Slug = "renamed"
+	require.NotEqual(t, original, draftReviewContentHash(draft), "the published permalink requires re-review")
+	draft.Slug = "first-slug"
 	draft.MetadataJSON = `{"version":2}`
 	draft.AutosaveVersion++
 	draft.UpdatedAt = time.Now().UTC()
-	require.Equal(t, "7c9933a0acf8c08f480f19136b164da3491ff943ba29a3a872c895fb403136ce", draftReviewContentHash(draft))
+	require.Equal(t, original, draftReviewContentHash(draft))
+
+	left := &models.Draft{ContentFormat: "a\x00b", Slug: "c"}
+	right := &models.Draft{ContentFormat: "a", Slug: "b\x00c"}
+	require.NotEqual(t, draftReviewContentHash(left), draftReviewContentHash(right),
+		"length prefixes must keep control characters from crossing field boundaries")
 }
 
 func TestDraftReviewApprovalBindsToCurrentContent(t *testing.T) {
@@ -193,6 +227,7 @@ func TestDraftReviewApprovalBindsToCurrentContent(t *testing.T) {
 			draft.Content = "edited content"
 		},
 		"format": func(draft *models.Draft) { draft.ContentFormat = "html" },
+		"slug":   func(draft *models.Draft) { draft.Slug = "edited-slug" },
 	}
 
 	for name, edit := range testCases {
@@ -272,24 +307,6 @@ func TestDraftReviewChangesRequestedAtCurrentHashBlocks(t *testing.T) {
 	require.False(t, approved)
 }
 
-func TestDraftReviewVerdictWithoutContentHashNeverCounts(t *testing.T) {
-	svc, repo := newReviewService(t)
-	ctx := context.Background()
-	grant, err := svc.ShareDraftForReview(ctx, "owner", "d1", "reviewer")
-	require.NoError(t, err)
-	require.NoError(t, repo.CreateDraftReviewVerdict(ctx, &models.DraftReviewVerdict{
-		OwnerID:    "owner",
-		DraftID:    "d1",
-		Reviewer:   "reviewer",
-		Verdict:    DraftReviewApproved,
-		RecordedAt: grant.GrantedAt.Add(time.Second),
-	}))
-
-	approved, err := svc.HasUnanimousActiveApproval(ctx, "owner", "d1")
-	require.NoError(t, err)
-	require.False(t, approved, "a pre-migration verdict must fail closed")
-}
-
 func TestDraftReviewDraftFetchFailuresFailClosed(t *testing.T) {
 	svc, repo := newReviewService(t)
 	ctx := context.Background()
@@ -304,6 +321,92 @@ func TestDraftReviewDraftFetchFailuresFailClosed(t *testing.T) {
 	approved, err := svc.HasUnanimousActiveApproval(ctx, "owner", "d1")
 	require.Error(t, err)
 	require.False(t, approved)
+}
+
+func TestDraftReviewGateHashesTheSnapshotBeingScheduledOrPublished(t *testing.T) {
+	for _, operation := range []string{"schedule", "publish"} {
+		t.Run(operation, func(t *testing.T) {
+			svc, repo := newReviewService(t)
+			ctx := context.Background()
+			draft, err := repo.GetDraft(ctx, "owner", "d1")
+			require.NoError(t, err)
+			draft.GeneratedBy = ""
+			draft.Content = "approved content"
+			require.NoError(t, repo.UpdateDraft(ctx, "owner", draft))
+			_, err = svc.ShareDraftForReview(ctx, "owner", "d1", "reviewer")
+			require.NoError(t, err)
+			_, err = svc.SubmitDraftReview(ctx, "reviewer", "owner", "d1", DraftReviewApproved, "ready")
+			require.NoError(t, err)
+
+			draft, err = repo.GetDraft(ctx, "owner", "d1")
+			require.NoError(t, err)
+			draft.Content = "unapproved payload"
+			require.NoError(t, repo.UpdateDraft(ctx, "owner", draft))
+
+			repo.getDraftCalls = 0
+			repo.afterGetDraft = func(call int) {
+				if call == 1 {
+					// Simulate the owner reverting storage to the approved content
+					// after the operation loaded the unapproved snapshot.
+					repo.items[repo.key("owner", "d1")].Content = "approved content"
+				}
+			}
+
+			if operation == "schedule" {
+				err = svc.ScheduleDraft(ctx, "owner", "d1", time.Now().Add(time.Hour))
+				require.ErrorIs(t, err, ErrDraftReviewApprovalRequired)
+			} else {
+				_, err = svc.PublishDraft(ctx, "owner", "d1")
+				require.ErrorIs(t, err, ErrDraftReviewApprovalRequired)
+				require.Empty(t, svc.articleService.(*memArticleService).items)
+			}
+			require.Equal(t, 1, repo.getDraftCalls, "the gate must reuse the operation's loaded snapshot")
+		})
+	}
+}
+
+func TestHumanDraftWithoutReviewersHasNoApprovalGateRead(t *testing.T) {
+	svc, repo := newReviewService(t)
+	ctx := context.Background()
+	draft, err := repo.GetDraft(ctx, "owner", "d1")
+	require.NoError(t, err)
+	draft.GeneratedBy = ""
+	require.NoError(t, repo.UpdateDraft(ctx, "owner", draft))
+
+	repo.getDraftCalls = 0
+	require.NoError(t, svc.ScheduleDraft(ctx, "owner", "d1", time.Now().Add(time.Hour)))
+	require.Equal(t, 1, repo.getDraftCalls, "schedule must load the draft only once")
+}
+
+func TestSubmitDraftReviewPreservesConcurrentOwnerEdit(t *testing.T) {
+	svc, repo := newReviewService(t)
+	ctx := context.Background()
+	draft, err := repo.GetDraft(ctx, "owner", "d1")
+	require.NoError(t, err)
+	draft.GeneratedBy = ""
+	draft.Content = "reviewed body"
+	require.NoError(t, repo.UpdateDraft(ctx, "owner", draft))
+	_, err = svc.ShareDraftForReview(ctx, "owner", "d1", "reviewer")
+	require.NoError(t, err)
+
+	repo.afterCreateVerdict = func() {
+		stored := repo.items[repo.key("owner", "d1")]
+		stored.Content = "owner late edit"
+	}
+	verdict, err := svc.SubmitDraftReview(ctx, "reviewer", "owner", "d1", DraftReviewApproved, "ready")
+	require.NoError(t, err)
+
+	stored, err := repo.GetDraft(ctx, "owner", "d1")
+	require.NoError(t, err)
+	require.Equal(t, "owner late edit", stored.Content, "review summary must not clobber owner content")
+	require.Equal(t, "reviewer", stored.ReviewedBy)
+	require.Equal(t, DraftReviewApproved, stored.ReviewStatus)
+	require.Equal(t, "ready", stored.EditorNotes)
+	require.NotEqual(t, verdict.ContentHash, draftReviewContentHash(stored),
+		"the verdict must remain bound to the snapshot the reviewer saw")
+	approved, err := svc.HasUnanimousActiveApproval(ctx, "owner", "d1")
+	require.NoError(t, err)
+	require.False(t, approved, "the concurrent owner edit must fail closed until re-review")
 }
 
 func TestDraftReviewPrincipalApprovalBindsToCurrentContent(t *testing.T) {

--- a/pkg/services/cms/draft_review_test.go
+++ b/pkg/services/cms/draft_review_test.go
@@ -26,6 +26,8 @@ type reviewMemRepo struct {
 	getGrantErr             error
 	callLog                 []string
 	getDraftCalls           int
+	listGrantCalls          int
+	listVerdictCalls        int
 	afterGetDraft           func(int)
 	afterCreateVerdict      func()
 }
@@ -124,6 +126,7 @@ func (r *reviewMemRepo) CountActiveDraftReviewGrants(_ context.Context, reviewer
 	return count, nil
 }
 func (r *reviewMemRepo) ListDraftReviewGrants(_ context.Context, owner, draft string) ([]*models.DraftReviewGrant, error) {
+	r.listGrantCalls++
 	out := []*models.DraftReviewGrant{}
 	for _, g := range r.grants {
 		if g.OwnerID == owner && g.DraftID == draft {
@@ -145,6 +148,7 @@ func (r *reviewMemRepo) CreateDraftReviewVerdict(_ context.Context, v *models.Dr
 	return nil
 }
 func (r *reviewMemRepo) ListDraftReviewVerdicts(_ context.Context, owner, draft string) ([]*models.DraftReviewVerdict, error) {
+	r.listVerdictCalls++
 	out := []*models.DraftReviewVerdict{}
 	for _, v := range r.verdicts {
 		if v.OwnerID == owner && v.DraftID == draft {
@@ -376,6 +380,54 @@ func TestHumanDraftWithoutReviewersHasNoApprovalGateRead(t *testing.T) {
 	repo.getDraftCalls = 0
 	require.NoError(t, svc.ScheduleDraft(ctx, "owner", "d1", time.Now().Add(time.Hour)))
 	require.Equal(t, 1, repo.getDraftCalls, "schedule must load the draft only once")
+}
+
+func TestHumanDraftWithoutReviewersSkipsApprovalDetailReads(t *testing.T) {
+	svc, repo := newReviewService(t)
+	ctx := context.Background()
+	draft, err := repo.GetDraft(ctx, "owner", "d1")
+	require.NoError(t, err)
+	draft.GeneratedBy = ""
+	require.NoError(t, repo.UpdateDraft(ctx, "owner", draft))
+
+	repo.getDraftCalls = 0
+	repo.listGrantCalls = 0
+	repo.listVerdictCalls = 0
+	repo.afterGetDraft = func(int) {
+		panic("zero-grant approval must not reload the draft")
+	}
+
+	approved, err := svc.HasUnanimousActiveApproval(ctx, "owner", "d1")
+	require.NoError(t, err)
+	require.True(t, approved)
+	require.Equal(t, 1, repo.listGrantCalls)
+	require.Zero(t, repo.listVerdictCalls, "zero active grants make verdict history irrelevant")
+	require.Zero(t, repo.getDraftCalls, "zero active grants must return before loading draft content")
+}
+
+func TestGeneratedDraftGateDerivesApprovalStateOnce(t *testing.T) {
+	for _, operation := range []string{"schedule", "publish"} {
+		t.Run(operation, func(t *testing.T) {
+			svc, repo := newReviewService(t)
+			ctx := context.Background()
+			_, err := svc.ShareDraftForReview(ctx, "owner", "d1", "principal")
+			require.NoError(t, err)
+			_, err = svc.SubmitDraftReview(ctx, "principal", "owner", "d1", DraftReviewApproved, "operator approval")
+			require.NoError(t, err)
+
+			repo.listGrantCalls = 0
+			repo.listVerdictCalls = 0
+			if operation == "schedule" {
+				err = svc.ScheduleDraft(ctx, "owner", "d1", time.Now().Add(time.Hour))
+				require.NoError(t, err)
+			} else {
+				_, err = svc.PublishDraft(ctx, "owner", "d1")
+				require.NoError(t, err)
+			}
+			require.Equal(t, 1, repo.listGrantCalls, "the gate must derive active grants once")
+			require.Equal(t, 1, repo.listVerdictCalls, "the gate must derive current verdicts once")
+		})
+	}
 }
 
 func TestSubmitDraftReviewPreservesConcurrentOwnerEdit(t *testing.T) {

--- a/pkg/services/cms/draft_service.go
+++ b/pkg/services/cms/draft_service.go
@@ -208,7 +208,7 @@ func (s *DraftService) ScheduleDraft(ctx context.Context, authorID, draftID stri
 		return err
 	}
 
-	approved, approvalErr := s.HasUnanimousActiveApproval(ctx, authorID, draftID)
+	approved, approvalErr := s.hasUnanimousActiveApproval(ctx, authorID, draftID, draft)
 	if approvalErr != nil {
 		return approvalErr
 	}
@@ -216,7 +216,7 @@ func (s *DraftService) ScheduleDraft(ctx context.Context, authorID, draftID stri
 		return ErrDraftReviewApprovalRequired
 	}
 	if strings.TrimSpace(draft.GeneratedBy) != "" {
-		principalApproved, principalErr := s.HasPrincipalApproval(ctx, authorID, draftID)
+		principalApproved, principalErr := s.hasPrincipalApproval(ctx, authorID, draftID, draft)
 		if principalErr != nil {
 			return principalErr
 		}
@@ -248,7 +248,7 @@ func (s *DraftService) PublishDraft(ctx context.Context, authorID, draftID strin
 	if !strings.EqualFold(strings.TrimSpace(draft.ContentType), activitypub.ArticleType) {
 		return nil, stdErrors.New("only article drafts can be published")
 	}
-	approved, approvalErr := s.HasUnanimousActiveApproval(ctx, authorID, draftID)
+	approved, approvalErr := s.hasUnanimousActiveApproval(ctx, authorID, draftID, draft)
 	if approvalErr != nil {
 		return nil, approvalErr
 	}
@@ -256,7 +256,7 @@ func (s *DraftService) PublishDraft(ctx context.Context, authorID, draftID strin
 		return nil, ErrDraftReviewApprovalRequired
 	}
 	if strings.TrimSpace(draft.GeneratedBy) != "" {
-		principalApproved, principalErr := s.HasPrincipalApproval(ctx, authorID, draftID)
+		principalApproved, principalErr := s.hasPrincipalApproval(ctx, authorID, draftID, draft)
 		if principalErr != nil {
 			return nil, principalErr
 		}

--- a/pkg/services/cms/draft_service.go
+++ b/pkg/services/cms/draft_service.go
@@ -208,21 +208,15 @@ func (s *DraftService) ScheduleDraft(ctx context.Context, authorID, draftID stri
 		return err
 	}
 
-	approved, approvalErr := s.hasUnanimousActiveApproval(ctx, authorID, draftID, draft)
+	approved, principalApproved, approvalErr := s.draftReviewGateApprovals(ctx, authorID, draftID, draft)
 	if approvalErr != nil {
 		return approvalErr
 	}
 	if !approved {
 		return ErrDraftReviewApprovalRequired
 	}
-	if strings.TrimSpace(draft.GeneratedBy) != "" {
-		principalApproved, principalErr := s.hasPrincipalApproval(ctx, authorID, draftID, draft)
-		if principalErr != nil {
-			return principalErr
-		}
-		if !principalApproved {
-			return ErrDraftReviewPrincipalApprovalRequired
-		}
+	if !principalApproved {
+		return ErrDraftReviewPrincipalApprovalRequired
 	}
 	draft.ScheduledAt = &scheduledAt
 	draft.Status = draftStatusScheduled
@@ -248,21 +242,15 @@ func (s *DraftService) PublishDraft(ctx context.Context, authorID, draftID strin
 	if !strings.EqualFold(strings.TrimSpace(draft.ContentType), activitypub.ArticleType) {
 		return nil, stdErrors.New("only article drafts can be published")
 	}
-	approved, approvalErr := s.hasUnanimousActiveApproval(ctx, authorID, draftID, draft)
+	approved, principalApproved, approvalErr := s.draftReviewGateApprovals(ctx, authorID, draftID, draft)
 	if approvalErr != nil {
 		return nil, approvalErr
 	}
 	if !approved {
 		return nil, ErrDraftReviewApprovalRequired
 	}
-	if strings.TrimSpace(draft.GeneratedBy) != "" {
-		principalApproved, principalErr := s.hasPrincipalApproval(ctx, authorID, draftID, draft)
-		if principalErr != nil {
-			return nil, principalErr
-		}
-		if !principalApproved {
-			return nil, ErrDraftReviewPrincipalApprovalRequired
-		}
+	if !principalApproved {
+		return nil, ErrDraftReviewPrincipalApprovalRequired
 	}
 
 	if s.isPublishedDraftCleanup(draft) {

--- a/pkg/storage/models/draft_review.go
+++ b/pkg/storage/models/draft_review.go
@@ -45,15 +45,16 @@ func (g *DraftReviewGrant) UpdateKeys() error {
 
 // DraftReviewVerdict is an immutable review decision audit record.
 type DraftReviewVerdict struct {
-	PK         string    `theorydb:"pk,attr:PK"`
-	SK         string    `theorydb:"sk,attr:SK"`
-	OwnerID    string    `theorydb:"attr:ownerID"`
-	DraftID    string    `theorydb:"attr:draftID"`
-	Reviewer   string    `theorydb:"attr:reviewer"`
-	Verdict    string    `theorydb:"attr:verdict"`
-	Notes      string    `theorydb:"attr:notes,omitempty"`
-	RecordedAt time.Time `theorydb:"attr:recordedAt"`
-	Version    int       `theorydb:"version,attr:version"`
+	PK          string    `theorydb:"pk,attr:PK"`
+	SK          string    `theorydb:"sk,attr:SK"`
+	OwnerID     string    `theorydb:"attr:ownerID"`
+	DraftID     string    `theorydb:"attr:draftID"`
+	Reviewer    string    `theorydb:"attr:reviewer"`
+	Verdict     string    `theorydb:"attr:verdict"`
+	Notes       string    `theorydb:"attr:notes,omitempty"`
+	ContentHash string    `theorydb:"attr:contentHash,omitempty" json:"content_hash,omitempty"`
+	RecordedAt  time.Time `theorydb:"attr:recordedAt"`
+	Version     int       `theorydb:"version,attr:version"`
 }
 
 // TableName returns the table for a review verdict.

--- a/pkg/storage/models/draft_review_test.go
+++ b/pkg/storage/models/draft_review_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -40,4 +41,8 @@ func TestDraftReviewVerdictUpdateKeys(t *testing.T) {
 	require.False(t, implicitTime.RecordedAt.IsZero())
 	require.Error(t, (&DraftReviewVerdict{}).UpdateKeys())
 	require.Equal(t, MainTableName, verdict.TableName())
+	field, ok := reflect.TypeOf(*verdict).FieldByName("ContentHash")
+	require.True(t, ok)
+	require.Equal(t, "attr:contentHash,omitempty", field.Tag.Get("theorydb"))
+	require.Equal(t, "content_hash,omitempty", field.Tag.Get("json"))
 }

--- a/pkg/storage/repositories/draft_repository.go
+++ b/pkg/storage/repositories/draft_repository.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -82,6 +83,36 @@ func (r *DraftRepository) UpdateDraft(ctx context.Context, authorID string, draf
 	}
 
 	return r.db.WithContext(ctx).Model(draft).Update()
+}
+
+// UpdateDraftReviewFields atomically updates only the mutable review summary.
+// Content and other owner-controlled fields are deliberately excluded so a
+// concurrent owner edit cannot be overwritten by review submission.
+func (r *DraftRepository) UpdateDraftReviewFields(ctx context.Context, authorID string, draft *models.Draft) error {
+	if err := validateDraftWriteOwner(authorID, draft); err != nil {
+		return err
+	}
+	if err := draft.UpdateKeys(); err != nil {
+		return err
+	}
+
+	builder := r.db.WithContext(ctx).
+		Model(draft).
+		Where("PK", "=", draft.PK).
+		Where("SK", "=", draft.SK).
+		UpdateBuilder()
+	builder.Set("ReviewedBy", draft.ReviewedBy)
+	builder.Set("ReviewStatus", draft.ReviewStatus)
+	builder.Set("EditorNotes", draft.EditorNotes)
+	builder.ConditionExists("PK")
+	if err := builder.Execute(); err != nil {
+		if dynamormerrors.IsConditionFailed(err) {
+			return apperrors.ItemNotFoundWithID("draft", draft.ID).
+				WithInternalError(errors.Join(err, storage.ErrNotFound))
+		}
+		return ErrorHandler.HandleUpdateError(err, "draft", draft.ID)
+	}
+	return nil
 }
 
 // DeleteDraft deletes a draft

--- a/pkg/storage/repositories/draft_review_repository_test.go
+++ b/pkg/storage/repositories/draft_review_repository_test.go
@@ -27,6 +27,55 @@ type draftReviewRecordingDynamo struct {
 	updateInputs []*dynamodb.UpdateItemInput
 }
 
+func TestDraftRepositoryUpdateDraftReviewFieldsDoesNotClobberOwnerContent(t *testing.T) {
+	ctx := context.Background()
+	client := &draftReviewRecordingDynamo{Fake: fakedb.New()}
+	db, err := tabletheory.NewWithClient(session.Config{Region: "us-east-1"}, client)
+	require.NoError(t, err)
+	require.NoError(t, db.CreateTable(&models.Draft{}))
+
+	persisted := &models.Draft{
+		AuthorID:      "owner",
+		ID:            "draft-1",
+		ContentType:   "Article",
+		Title:         "owner title",
+		Slug:          "owner-slug",
+		Content:       "owner late edit",
+		ContentFormat: "markdown",
+		Status:        "draft",
+		CreatedAt:     time.Now().UTC(),
+		UpdatedAt:     time.Now().UTC(),
+	}
+	require.NoError(t, persisted.UpdateKeys())
+	require.NoError(t, db.WithContext(ctx).Model(persisted).Create())
+
+	staleReviewSnapshot := *persisted
+	staleReviewSnapshot.Title = "stale title"
+	staleReviewSnapshot.Slug = "stale-slug"
+	staleReviewSnapshot.Content = "stale reviewed body"
+	staleReviewSnapshot.ReviewedBy = "reviewer"
+	staleReviewSnapshot.ReviewStatus = "APPROVED"
+	staleReviewSnapshot.EditorNotes = "ready"
+
+	repo := NewDraftRepository(db, "test-table", zap.NewNop(), nil)
+	require.NoError(t, repo.UpdateDraftReviewFields(ctx, "owner", &staleReviewSnapshot))
+
+	got, err := repo.GetDraft(ctx, "owner", "draft-1")
+	require.NoError(t, err)
+	require.Equal(t, "owner title", got.Title)
+	require.Equal(t, "owner-slug", got.Slug)
+	require.Equal(t, "owner late edit", got.Content)
+	require.Equal(t, "reviewer", got.ReviewedBy)
+	require.Equal(t, "APPROVED", got.ReviewStatus)
+	require.Equal(t, "ready", got.EditorNotes)
+	require.Len(t, client.updateInputs, 1)
+	require.Contains(t, aws.ToString(client.updateInputs[0].ConditionExpression), "attribute_exists")
+
+	missing := staleReviewSnapshot
+	missing.ID = "missing"
+	require.ErrorIs(t, repo.UpdateDraftReviewFields(ctx, "owner", &missing), storage.ErrNotFound)
+}
+
 func (d *draftReviewRecordingDynamo) PutItem(ctx context.Context, input *dynamodb.PutItemInput, opts ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
 	d.putInputs = append(d.putInputs, input)
 	return d.Fake.PutItem(ctx, input, opts...)


### PR DESCRIPTION
Closes #1293.

## What
Draft-review approvals bind to the **approved content hash** (operator ruling: any post-approval content edit invalidates; no minor-edit allowance; fail-closed everywhere).

- `DraftReviewVerdict.ContentHash` stamped in `SubmitDraftReview` — sha256 over a length-prefixed canonical form of the reviewed fields (`ContentFormat`, `Title`, `Content`, `Slug`; slug included because it sets the published permalink). Length-prefixing makes the encoding injective.
- `draftReviewApprovalState`: a verdict counts only when it post-dates the grant AND matches the current draft hash (hashless pre-migration verdicts never count by construction). Publish/schedule gates hash the SAME loaded snapshot the article is built from — no second read, no TOCTOU window.
- `SubmitDraftReview` updates only review fields (`ReviewedBy`/`ReviewStatus`/`EditorNotes`) via a conditional TableTheory partial update — concurrent owner edits survive and invalidate the hash.
- Zero-reviewer human drafts do no extra draft read; generated-draft publish derives approval state once (1× ListGrants + 1× ListVerdicts, pinned by count tests).
- GraphQL `DraftReviewVerdictRecord.contentHash: String` exposed (null for legacy verdicts); `make gqlgen` + `make schema` regenerated.

## Rollout note
Approvals recorded **before this deploy** carry no content hash and revert to unapproved on deploy — affected drafts require re-review. This is the operator-settled fail-closed/no-backfill ruling, not an oversight.

## Evidence
Three adversarial review rounds (claude, comment-only; reviews 4837314830, 4837441837, 4837560594): round 1 — 6 findings (HIGH TOCTOU, write-back clobber, extra draft read, non-injective join, slug unhashed, dead guard), all fixed and mutation-tested; round 2 — all six RESOLVED plus 2 LOW (unpinned early return, double derivation), fixed in 9ebca8a2b with discriminating panic/count tests; round 3 — all RESOLVED (14-case differential on the unified derivation, 12/12 mutants killed) plus 2 non-blocking (nil-contract alignment, hashless-verdict pin) addressed in the final commit. Reviewer-verified: `go test ./...` 0 FAIL; `verify ci` all gates, 90.021% cmd coverage; govulncheck 0 called vulns.

Branch stacked on the #1316 head (now merged); diff vs staging is only this feature's commits.

Implementing client: codex. Adversarial review: claude (cross-client rule).