### PR TITLE
fix: guard GraphQL list timelines (auth + ListID wiring)

### DIFF
--- a/graph/query_resolvers_notes.go
+++ b/graph/query_resolvers_notes.go
@@ -96,7 +96,11 @@ func applyTimelineTypeFilter(username string, timelineType model.TimelineType, h
 		if err := common.ValidateRequiredParam("listID", *listID); err != nil {
 			return ErrListIDParameterRequired
 		}
+		if err := common.ValidateRequiredParam("username", username); err != nil {
+			return ErrAuthenticationRequired
+		}
 		query.TimelineType = TimelineTypeList
+		query.ListID = *listID
 		// List timeline is handled differently - need to get list members
 		// and fetch their posts
 	case model.TimelineTypeDirect:

--- a/graph/query_resolvers_notes_round12_test.go
+++ b/graph/query_resolvers_notes_round12_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/equaltoai/lesser/graph/model"
 	"github.com/equaltoai/lesser/pkg/config"
+	pkgerrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/services/search"
 	"github.com/equaltoai/lesser/pkg/storage"
 	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
@@ -54,6 +55,50 @@ func TestRound12QueryResolvers_Notes_ObjectTimelineSearch(t *testing.T) {
 	result, err := q.Search(context.Background(), "alice", nil, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, result)
+}
+
+func TestQueryResolverTimeline_ListRequiresAuthAndWiresListID(t *testing.T) {
+	resolver, _ := newRound12GraphResolver(t)
+	query := resolver.Query()
+	listID := "list-1"
+
+	t.Run("anonymous list matches authenticated timeline error shape", func(t *testing.T) {
+		_, err := query.Timeline(context.Background(), model.TimelineTypeList, nil, &listID, nil, nil, nil, nil, nil)
+		require.ErrorIs(t, err, ErrAuthenticationRequired)
+
+		for _, timelineType := range []model.TimelineType{model.TimelineTypeHome, model.TimelineTypeDirect} {
+			_, siblingErr := query.Timeline(context.Background(), timelineType, nil, nil, nil, nil, nil, nil, nil)
+			require.Error(t, siblingErr)
+			require.Equal(t, pkgerrors.GetErrorCode(siblingErr), pkgerrors.GetErrorCode(err))
+			require.Equal(t, pkgerrors.GetErrorCategory(siblingErr), pkgerrors.GetErrorCategory(err))
+			require.Equal(t, pkgerrors.GetHTTPStatus(siblingErr), pkgerrors.GetHTTPStatus(err))
+		}
+	})
+
+	t.Run("list ID validation precedes authentication", func(t *testing.T) {
+		emptyListID := ""
+		for _, test := range []struct {
+			name   string
+			listID *string
+		}{
+			{name: "missing"},
+			{name: "empty", listID: &emptyListID},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				_, err := query.Timeline(context.Background(), model.TimelineTypeList, nil, test.listID, nil, nil, nil, nil, nil)
+				require.ErrorIs(t, err, ErrListIDParameterRequired)
+			})
+		}
+	})
+
+	t.Run("authenticated list reaches notes service with list ID", func(t *testing.T) {
+		connection, err := query.Timeline(
+			round12AuthContext("alice"), model.TimelineTypeList, nil, &listID, nil, nil, nil, nil, nil,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, connection)
+		require.Empty(t, connection.Edges)
+	})
 }
 
 func TestRound12QueryResolvers_Notes_ThreadContext_StorageNil(t *testing.T) {

--- a/graph/query_resolvers_notes_round12_test.go
+++ b/graph/query_resolvers_notes_round12_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/equaltoai/lesser/graph/model"
 	"github.com/equaltoai/lesser/pkg/config"
 	pkgerrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/services/notes"
 	"github.com/equaltoai/lesser/pkg/services/search"
 	"github.com/equaltoai/lesser/pkg/storage"
 	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
@@ -91,13 +92,23 @@ func TestQueryResolverTimeline_ListRequiresAuthAndWiresListID(t *testing.T) {
 		}
 	})
 
-	t.Run("authenticated list reaches notes service with list ID", func(t *testing.T) {
-		connection, err := query.Timeline(
-			round12AuthContext("alice"), model.TimelineTypeList, nil, &listID, nil, nil, nil, nil, nil,
-		)
-		require.NoError(t, err)
-		require.NotNil(t, connection)
-		require.Empty(t, connection.Edges)
+	t.Run("authenticated list preserves caller list ID", func(t *testing.T) {
+		for _, requestedListID := range []string{"list-alpha", "list-beta"} {
+			t.Run(requestedListID, func(t *testing.T) {
+				serviceQuery := &notes.ListNotesQuery{}
+				require.NoError(t, applyTimelineTypeFilter(
+					"alice", model.TimelineTypeList, nil, &requestedListID, nil, serviceQuery,
+				))
+				require.Equal(t, requestedListID, serviceQuery.ListID)
+
+				connection, err := query.Timeline(
+					round12AuthContext("alice"), model.TimelineTypeList, nil, &requestedListID, nil, nil, nil, nil, nil,
+				)
+				require.NoError(t, err)
+				require.NotNil(t, connection)
+				require.Empty(t, connection.Edges)
+			})
+		}
 	})
 }
 

--- a/pkg/services/notes/service.go
+++ b/pkg/services/notes/service.go
@@ -4543,6 +4543,11 @@ func (s *Service) unmuteStatus(ctx context.Context, userID, statusID string) err
 // getDirectTimeline retrieves the direct message timeline for a user
 func (s *Service) getListTimeline(_ context.Context, query *ListNotesQuery) (*Result, error) {
 	// For now, we'll just return an empty list since we don't have list service integration
+	// The eventual implementation MUST delegate to lists.Service.GetListTimeline, which
+	// enforces ViewerID == list.Username before returning statuses. When this stub is
+	// implemented, revisit TestService_round15_view_permissions_and_timelines: its
+	// viewer "bob" and "list-1" pair needs an ownership fixture before it can exercise
+	// the implemented list timeline path.
 	// In a complete implementation, this would:
 	// 1. Get the list membership
 	// 2. Query statuses from list members


### PR DESCRIPTION
Closes #1301.

## What
Anonymous GraphQL queries could reach `applyTimelineTypeFilter`'s LIST arm (the anonymous field allowlist admits `timeline` without argument inspection; viewer is `optionalAuth`). Doubly defused today — the arm never copied `query.ListID` (service always rejected with `ErrListTimelineRequiresListID`) and `getListTimeline` is an empty stub — but the hole activated the day the stub lands. This lands the guard first, per the kimi audit posted on the issue:

- LIST arm now requires an authenticated viewer with the exact HOME/DIRECT idiom (`ErrAuthenticationRequired`), preserving listID-before-auth validation order.
- `query.ListID = *listID` wired through, matching the hashtag/actor arms.

No behavior change for any successful caller (no LIST query can succeed through GraphQL today); anonymous LIST now fails with the correct auth-required error instead of a wrapped service error. Out of scope by design: implementing `getListTimeline` (must delegate to the ownership-enforcing `lists.Service.GetListTimeline` when picked up) and the anonymous field allowlist.

## Contract note (explicit, per adversarial review round 1, finding F1)

One client-visible change IS made explicit here rather than landing silently: an **authenticated** GraphQL LIST query now returns HTTP 200 with an **empty connection** (the `getListTimeline` stub's pre-existing behavior, already blessed for service-level callers by `pkg/services/notes/service_round15_mainline_test.go:1882-1888`), where it previously errored (`ErrListTimelineRequiresListID`). This empty-page success is the unimplemented-feature contract, not a statement that the list is empty; the eventual implementation must replace the stub by delegating to the ownership-enforcing `lists.Service.GetListTimeline` and revisit the round15 fixture with an ownership relation (also now stated in the stub's own comment). Anonymous behavior is unchanged in kind — still an error, now the correct auth-required one.

## Review decisions (round 1, review 4837747492 — security fix CONFIRMED correct, zero blocking findings)

- **F2 (fixed in round 2):** propagation test made discriminating — two distinct caller list IDs (`list-alpha`/`list-beta`) asserted at the filter boundary by direct unit call; hard-coding a wrong ID (or a swapped variable) in the wiring now fails the suite. The filter is the single assignment site and `Timeline` passes the query through to `ListNotes` unmutated (verified in review round 2).
- **F4 (fixed in round 2):** `getListTimeline` stub comment now carries the ownership requirement and the delegation mandate.
- **F3 (declined, recorded):** the generic `ErrAuthenticationRequired` sentinel stays — code/category/status match the HOME/DIRECT arms and the caller supplied the timelineType, so the message difference is no oracle. Sibling-specific sentinels would add surface without closing anything.

## Evidence
Fault injection both halves: guard removed → anonymous test fails (request reaches stub, returns nil); `ListID` wiring removed → authenticated test fails with `ErrListTimelineRequiresListID`; hard-coded wrong list ID → both propagation subtests fail with expected/actual mismatch; restored → green. Tests: `graph/query_resolvers_notes_round12_test.go:60-112` (anonymous auth-error parity with HOME/DIRECT, missing/empty listID precedence, authenticated ListID propagation). `go test ./graph/... ./pkg/services/notes/... ./pkg/services/lists/...` green; `go build ./...` exit 0.

Implementing client: codex. Adversarial review: claude (cross-client rule).

