### PR TITLE
chore: ignore remaining materialized agent roots (.kimi-code, .theorymcp)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,8 @@ INCOMPLETE_IMPLEMENTATIONS.md
 .agents/
 .claude/
 .codex/
+.kimi-code/
+.theorymcp/
 .mcp/
 .mcp.json
 GEMINI.md


### PR DESCRIPTION
.kimi-code/ and .theorymcp/ join the existing untracked materialized roots per the fleet convention of 2026-08-01; nothing materialized was tracked in this repo, so this is .gitignore-only.

Cherry-picked from the local-only commit 8cae458e7 found on the factory checkout's local staging (authored 2026-08-01 after namespace publish v16); upstreaming per the operator's standing approval of materialization .gitignore changes.

Does not gate v1.5.34 — safe to land whenever.

Signed-off-by: Aron Price <aron23@gmail.com>