### PR TITLE
feat(graphql): route keyed timeline subscriptions (ACTOR/HASHTAG/LIST)

### DIFF
--- a/cmd/graphql-ws/anonymous_init_authz_test.go
+++ b/cmd/graphql-ws/anonymous_init_authz_test.go
@@ -337,7 +337,7 @@ func TestAnonymousSubscriptionOperationAuthorization(t *testing.T) {
 	anonymousSafe := map[string]string{
 		"PUBLIC":  "timelineUpdates(type: PUBLIC) { id }",
 		"LOCAL":   "timelineUpdates(type: LOCAL) { id }",
-		"ACTOR":   `timelineUpdates(type: ACTOR, actorId: "alice") { id }`,
+		"ACTOR":   `timelineUpdates(type: ACTOR, actorUsername: "alice") { id }`,
 		"HASHTAG": `timelineUpdates(type: HASHTAG, hashtag: "golang") { id }`,
 	}
 	for name, field := range anonymousSafe {
@@ -471,7 +471,7 @@ func TestAuthenticatedConnectionStreamsTimelineAuthorizationSet(t *testing.T) {
 	authenticated := map[string]string{
 		"HOME":    "timelineUpdates(type: HOME) { id }",
 		"DIRECT":  "timelineUpdates(type: DIRECT) { id }",
-		"ACTOR":   `timelineUpdates(type: ACTOR, actorId: "alice") { id }`,
+		"ACTOR":   `timelineUpdates(type: ACTOR, actorUsername: "alice") { id }`,
 		"HASHTAG": `timelineUpdates(type: HASHTAG, hashtag: "golang") { id }`,
 		"LIST":    `timelineUpdates(type: LIST, listId: "list-1") { id }`,
 	}

--- a/cmd/graphql-ws/anonymous_init_authz_test.go
+++ b/cmd/graphql-ws/anonymous_init_authz_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -333,16 +334,24 @@ func TestAnonymousSubscriptionOperationAuthorization(t *testing.T) {
 	exec := executor.New(graph.NewExecutableSchema(graph.Config{Resolvers: resolver}))
 	configureGraphQLExecutor(exec, &appconfig.Config{})
 
-	for _, timelineType := range []string{"PUBLIC", "LOCAL"} {
-		t.Run(timelineType, func(t *testing.T) {
-			connectionID := "safe-conn-" + timelineType
-			subscriptionID := "safe-" + timelineType
+	anonymousSafe := map[string]string{
+		"PUBLIC":  "timelineUpdates(type: PUBLIC) { id }",
+		"LOCAL":   "timelineUpdates(type: LOCAL) { id }",
+		"ACTOR":   `timelineUpdates(type: ACTOR, actorId: "alice") { id }`,
+		"HASHTAG": `timelineUpdates(type: HASHTAG, hashtag: "golang") { id }`,
+	}
+	for name, field := range anonymousSafe {
+		t.Run(name, func(t *testing.T) {
+			connectionID := "safe-conn-" + name
+			subscriptionID := "safe-" + name
 			server, messages := newAnonymousOperationTestServer(t, resolver, exec, connectionID)
 			wsCtx := &appTheory.WebSocketContext{ConnectionID: connectionID}
+			payload, err := json.Marshal(subscribePayload{Query: "subscription { " + field + " }"})
+			require.NoError(t, err)
 			server.handleSubscribe(context.Background(), wsMessage{
 				ID:      subscriptionID,
 				Type:    "subscribe",
-				Payload: json.RawMessage(`{"query":"subscription { timelineUpdates(type: ` + timelineType + `) { id } }"}`),
+				Payload: payload,
 			}, wsCtx)
 
 			require.Eventually(t, func() bool {
@@ -362,9 +371,7 @@ func TestAnonymousSubscriptionOperationAuthorization(t *testing.T) {
 	}
 
 	gated := map[string]string{
-		"ACTOR timeline":            "timelineUpdates(type: ACTOR) { id }",
 		"HOME timeline":             "timelineUpdates(type: HOME) { id }",
-		"HASHTAG timeline":          "timelineUpdates(type: HASHTAG) { id }",
 		"LIST timeline":             `timelineUpdates(type: LIST, listId: "list-1") { id }`,
 		"DIRECT timeline":           "timelineUpdates(type: DIRECT) { id }",
 		"activity stream":           "activityStream { __typename }",
@@ -419,7 +426,7 @@ func TestAnonymousSubscriptionOperationAuthorization(t *testing.T) {
 	}
 }
 
-func TestAuthenticatedConnectionStillStreamsGatedSubscription(t *testing.T) {
+func TestAuthenticatedConnectionStreamsTimelineAuthorizationSet(t *testing.T) {
 	manager := graph.NewSubscriptionManager(
 		inmemory.NewStreamingConnectionRepository(),
 		streaming.NewMockPublisher(),
@@ -461,19 +468,33 @@ func TestAuthenticatedConnectionStillStreamsGatedSubscription(t *testing.T) {
 	require.Equal(t, "connection_ack", ack.Type)
 	require.True(t, connectionACKAuthenticated(t, ack.Payload))
 
-	server.handleSubscribe(context.Background(), wsMessage{
-		ID:      "home-subscription",
-		Type:    "subscribe",
-		Payload: json.RawMessage(`{"query":"subscription { timelineUpdates(type: HOME) { id } }"}`),
-	}, wsCtx)
-	require.Eventually(t, func() bool {
-		server.mu.RLock()
-		defer server.mu.RUnlock()
-		_, ok := server.connections["authenticated-conn"].subscriptions["home-subscription"]
-		return ok
-	}, time.Second, 10*time.Millisecond)
-	require.True(t, server.cancelSubscription(context.Background(), "authenticated-conn", "home-subscription"))
-	require.Equal(t, "complete", receiveWSMessage(t, messages).Type)
+	authenticated := map[string]string{
+		"HOME":    "timelineUpdates(type: HOME) { id }",
+		"DIRECT":  "timelineUpdates(type: DIRECT) { id }",
+		"ACTOR":   `timelineUpdates(type: ACTOR, actorId: "alice") { id }`,
+		"HASHTAG": `timelineUpdates(type: HASHTAG, hashtag: "golang") { id }`,
+		"LIST":    `timelineUpdates(type: LIST, listId: "list-1") { id }`,
+	}
+	for name, field := range authenticated {
+		t.Run(name, func(t *testing.T) {
+			subscriptionID := strings.ToLower(name) + "-subscription"
+			payload, marshalErr := json.Marshal(subscribePayload{Query: "subscription { " + field + " }"})
+			require.NoError(t, marshalErr)
+			server.handleSubscribe(context.Background(), wsMessage{
+				ID:      subscriptionID,
+				Type:    "subscribe",
+				Payload: payload,
+			}, wsCtx)
+			require.Eventually(t, func() bool {
+				server.mu.RLock()
+				defer server.mu.RUnlock()
+				_, ok := server.connections["authenticated-conn"].subscriptions[subscriptionID]
+				return ok
+			}, time.Second, 10*time.Millisecond)
+			require.True(t, server.cancelSubscription(context.Background(), "authenticated-conn", subscriptionID))
+			require.Equal(t, "complete", receiveWSMessage(t, messages).Type)
+		})
+	}
 }
 
 func TestAuthenticatedNonAdminAuthorizationFailureIsTerminalError(t *testing.T) {

--- a/cmd/inbox/internal/routing/inbox.go
+++ b/cmd/inbox/internal/routing/inbox.go
@@ -700,6 +700,9 @@ func (ih *InboxHandler) handlePostInbox(ctx *apptheory.Context) (*apptheory.Resp
 	if err := ih.verifyAuthentication(ctx, req); err != nil {
 		return nil, err
 	}
+	if err := ih.verifyCreateAuthorization(req.Activity); err != nil {
+		return nil, err
+	}
 	if err := ih.validateActorInboxAddressingAndPrivacy(req); err != nil {
 		return nil, err
 	}
@@ -709,6 +712,29 @@ func (ih *InboxHandler) handlePostInbox(ctx *apptheory.Context) (*apptheory.Resp
 
 	ih.recordSuccessAndComplete(ctx, req)
 	return apptheory.Text(http.StatusAccepted, ""), nil
+}
+
+// verifyCreateAuthorization binds an embedded object's attribution to the
+// Activity actor whose key authenticated the request. It must run only after
+// verifyAuthentication so activity.Actor represents the verified signer.
+func (ih *InboxHandler) verifyCreateAuthorization(activity *activitypub.Activity) error {
+	if activity == nil || activity.Type != activitypub.CreateType {
+		return nil
+	}
+
+	object, ok := activity.Object.(map[string]any)
+	if !ok {
+		return nil
+	}
+	attributedTo, ok := object["attributedTo"].(string)
+	if !ok || strings.TrimSpace(attributedTo) == "" {
+		return nil
+	}
+	if !common.SameCanonicalActorID(activity.Actor, attributedTo) {
+		return errors.InsufficientPermissions("create object attribution")
+	}
+
+	return nil
 }
 
 // validateRequestBody validates the request body size and content

--- a/cmd/inbox/internal/routing/inbox.go
+++ b/cmd/inbox/internal/routing/inbox.go
@@ -3402,12 +3402,11 @@ func (ih *InboxHandler) processRemoteUpdateActivity(ctx context.Context, activit
 	objType, _ := objMap["type"].(string)
 	switch strings.TrimSpace(objType) {
 	case activitypub.NoteType:
-		// Store edit history before updating supported Note objects.
-		if err := ih.storeEditHistory(ctx, objectID, existingObject, activity.Actor); err != nil {
-			log.Error("failed to store edit history",
-				zap.String("object_id", objectID),
-				zap.Error(err))
-			// Continue even if history storage fails
+		// Updates carry a complete Note just like Creates. Validate before edit
+		// history or object writes so missing attribution cannot blank the author.
+		if err := common.ValidateActivityPubNote(objMap); err != nil {
+			log.Warn("invalid note object in update activity", zap.Error(err))
+			return invalidNoteError()
 		}
 
 		// Convert to Note object
@@ -3419,6 +3418,19 @@ func (ih *InboxHandler) processRemoteUpdateActivity(ctx context.Context, activit
 		var note activitypub.Note
 		if err := common.ParseActivityPubObject(objJSON, &note); err != nil {
 			return err
+		}
+		// Remote projection owns the local-author invariant for every ingestion
+		// route. Check it before mutating the stored object or edit history.
+		if ih.buildCanonicalRemoteStatus(&note) == nil {
+			return invalidNoteError()
+		}
+
+		// Store edit history before updating supported Note objects.
+		if err := ih.storeEditHistory(ctx, objectID, existingObject, activity.Actor); err != nil {
+			log.Error("failed to store edit history",
+				zap.String("object_id", objectID),
+				zap.Error(err))
+			// Continue even if history storage fails
 		}
 
 		// Set updated timestamp
@@ -4682,7 +4694,7 @@ func (ih *InboxHandler) verifyUpdateAuthorization(_ context.Context, activity *a
 	}
 
 	// Only the object owner can update it
-	if activity.Actor != objectOwner {
+	if !common.SameCanonicalActorID(activity.Actor, objectOwner) {
 		return unauthorizedUpdateError()
 	}
 
@@ -4797,7 +4809,7 @@ func (ih *InboxHandler) verifyDeleteAuthorization(_ context.Context, activity *a
 	}
 
 	// Only the object owner can delete it
-	if activity.Actor != objectOwner {
+	if !common.SameCanonicalActorID(activity.Actor, objectOwner) {
 		return unauthorizedDeleteError()
 	}
 

--- a/cmd/inbox/internal/routing/more_branches_round10_coverage_test.go
+++ b/cmd/inbox/internal/routing/more_branches_round10_coverage_test.go
@@ -3,6 +3,7 @@ package routing
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
@@ -224,6 +225,8 @@ func TestInboxHandler_Round10_HelperCoverageExpansion(t *testing.T) {
 
 		updateActivity.Actor = owner
 		require.NoError(t, env.handler.verifyUpdateAuthorization(context.Background(), updateActivity, note))
+		updateActivity.Actor = strings.ToUpper("https://remote.example") + "/users/bob/"
+		require.NoError(t, env.handler.verifyUpdateAuthorization(context.Background(), updateActivity, note))
 		require.NoError(t, env.handler.verifyUpdateAuthorization(context.Background(), updateActivity, &activitypub.Article{
 			Note: activitypub.Note{AttributedTo: owner},
 		}))
@@ -233,6 +236,8 @@ func TestInboxHandler_Round10_HelperCoverageExpansion(t *testing.T) {
 		require.Error(t, env.handler.verifyDeleteAuthorization(context.Background(), deleteActivity, note))
 
 		deleteActivity.Actor = owner
+		require.NoError(t, env.handler.verifyDeleteAuthorization(context.Background(), deleteActivity, note))
+		deleteActivity.Actor = strings.ToUpper("https://remote.example") + "/users/bob/"
 		require.NoError(t, env.handler.verifyDeleteAuthorization(context.Background(), deleteActivity, note))
 		require.NoError(t, env.handler.verifyDeleteAuthorization(context.Background(), deleteActivity, &activitypub.Article{
 			Note: activitypub.Note{AttributedTo: owner},

--- a/cmd/inbox/internal/routing/pipeline_more_round10_coverage_test.go
+++ b/cmd/inbox/internal/routing/pipeline_more_round10_coverage_test.go
@@ -576,7 +576,7 @@ func TestInboxHandler_Round10_RemoteCreateUpdateDelete_ErrorBranches(t *testing.
 				"id":           noteID,
 				"type":         activitypub.NoteType,
 				"content":      "forged local author",
-				"attributedTo": env.local.ID,
+				"attributedTo": env.local.ID + "?x=1",
 				"to":           []any{activitypub.PublicAddress},
 			},
 		}

--- a/cmd/inbox/internal/routing/pipeline_more_round10_coverage_test.go
+++ b/cmd/inbox/internal/routing/pipeline_more_round10_coverage_test.go
@@ -595,6 +595,49 @@ func TestInboxHandler_Round10_RemoteCreateUpdateDelete_ErrorBranches(t *testing.
 		require.Equal(t, env.remoteActorID, storedNote.AttributedTo)
 	})
 
+	t.Run("create then honest update preserves remote attribution", func(t *testing.T) {
+		objectRepo := inmemory.NewObjectRepository()
+		statusRepo := &recordingStatusRepository{}
+		handler := *env.handler
+		handler.objectRepository = objectRepo
+		handler.statusRepository = statusRepo
+
+		noteID := "https://remote.example/objects/honest-update"
+		create := &activitypub.Activity{
+			BaseObject: activitypub.BaseObject{Type: activitypub.CreateType, ID: "https://remote.example/activities/honest-create"},
+			Actor:      env.remoteActorID,
+			Object: map[string]any{
+				"@context":     []any{"https://www.w3.org/ns/activitystreams"},
+				"id":           noteID,
+				"type":         activitypub.NoteType,
+				"content":      "before honest update",
+				"attributedTo": env.remoteActorID,
+				"to":           []any{activitypub.PublicAddress},
+			},
+		}
+		require.NoError(t, handler.processRemoteCreateActivity(ctx, create, env.local))
+		require.Len(t, statusRepo.created, 1)
+
+		update := &activitypub.Activity{
+			BaseObject: activitypub.BaseObject{Type: activitypub.UpdateType, ID: "https://remote.example/activities/honest-update"},
+			Actor:      env.remoteActorID,
+			Object: map[string]any{
+				"@context":     []any{"https://www.w3.org/ns/activitystreams"},
+				"id":           noteID,
+				"type":         activitypub.NoteType,
+				"content":      "after honest update",
+				"attributedTo": env.remoteActorID,
+				"to":           []any{activitypub.PublicAddress},
+			},
+		}
+
+		require.NoError(t, handler.processRemoteUpdateActivity(ctx, update, env.local))
+		require.Len(t, statusRepo.updated, 1)
+		require.Equal(t, env.remoteActorID, statusRepo.updated[0].AuthorID)
+		require.Equal(t, "bob@remote.example", statusRepo.updated[0].AuthorUsername)
+		require.Equal(t, "after honest update", statusRepo.updated[0].Content)
+	})
+
 	t.Run("update note requires complete ActivityPub attribution", func(t *testing.T) {
 		noteID := "https://remote.example/users/bob/statuses/update-missing-attribution"
 		objectRepo := inmemory.NewObjectRepository()

--- a/cmd/inbox/internal/routing/pipeline_more_round10_coverage_test.go
+++ b/cmd/inbox/internal/routing/pipeline_more_round10_coverage_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -545,54 +546,64 @@ func TestInboxHandler_Round10_RemoteCreateUpdateDelete_ErrorBranches(t *testing.
 	})
 
 	t.Run("create then update cannot reattribute remote status to local actor", func(t *testing.T) {
-		objectRepo := inmemory.NewObjectRepository()
-		statusRepo := &recordingStatusRepository{}
-		handler := *env.handler
-		handler.objectRepository = objectRepo
-		handler.statusRepository = statusRepo
+		localHostAndPath := strings.TrimPrefix(strings.TrimPrefix(env.local.ID, "http://"), "https://")
+		for _, attributedTo := range []string{
+			env.local.ID + "?x=1",
+			"HTTP://" + localHostAndPath,
+			"HTTPS://" + localHostAndPath,
+			"HttPs://" + localHostAndPath,
+		} {
+			t.Run(attributedTo, func(t *testing.T) {
+				objectRepo := inmemory.NewObjectRepository()
+				statusRepo := &recordingStatusRepository{}
+				handler := *env.handler
+				handler.objectRepository = objectRepo
+				handler.statusRepository = statusRepo
 
-		noteID := "https://remote.example/objects/reattribution-attack"
-		create := &activitypub.Activity{
-			BaseObject: activitypub.BaseObject{Type: activitypub.CreateType, ID: "https://remote.example/activities/reattribution-create"},
-			Actor:      env.remoteActorID,
-			Object: map[string]any{
-				"@context":     []any{"https://www.w3.org/ns/activitystreams"},
-				"id":           noteID,
-				"type":         activitypub.NoteType,
-				"content":      "honest remote create",
-				"attributedTo": env.remoteActorID,
-				"to":           []any{activitypub.PublicAddress},
-			},
+				noteID := "https://remote.example/objects/reattribution-attack"
+				create := &activitypub.Activity{
+					BaseObject: activitypub.BaseObject{Type: activitypub.CreateType, ID: "https://remote.example/activities/reattribution-create"},
+					Actor:      env.remoteActorID,
+					Object: map[string]any{
+						"@context":     []any{"https://www.w3.org/ns/activitystreams"},
+						"id":           noteID,
+						"type":         activitypub.NoteType,
+						"content":      "honest remote create",
+						"attributedTo": env.remoteActorID,
+						"to":           []any{activitypub.PublicAddress},
+					},
+				}
+				require.NoError(t, handler.processRemoteCreateActivity(ctx, create, env.local))
+				require.Len(t, statusRepo.created, 1)
+				require.Equal(t, env.remoteActorID, statusRepo.created[0].AuthorID)
+
+				update := &activitypub.Activity{
+					BaseObject: activitypub.BaseObject{Type: activitypub.UpdateType, ID: "https://remote.example/activities/reattribution-update"},
+					Actor:      env.remoteActorID,
+					Object: map[string]any{
+						"@context":     []any{"https://www.w3.org/ns/activitystreams"},
+						"id":           noteID,
+						"type":         activitypub.NoteType,
+						"content":      "forged local author",
+						"attributedTo": attributedTo,
+						"to":           []any{activitypub.PublicAddress},
+					},
+				}
+
+				require.Error(t, handler.processRemoteUpdateActivity(ctx, update, env.local))
+				// A status write is the DynamoDB Streams trigger for public:actor:alice and
+				// user:alice. Refusing the write proves neither stream can receive the attack.
+				require.Empty(t, statusRepo.updated)
+				require.Len(t, statusRepo.created, 1)
+				require.Equal(t, env.remoteActorID, statusRepo.created[0].AuthorID)
+
+				stored, err := objectRepo.GetObject(ctx, noteID)
+				require.NoError(t, err)
+				storedNote, ok := stored.(*activitypub.Note)
+				require.True(t, ok)
+				require.Equal(t, env.remoteActorID, storedNote.AttributedTo)
+			})
 		}
-		require.NoError(t, handler.processRemoteCreateActivity(ctx, create, env.local))
-		require.Len(t, statusRepo.created, 1)
-		require.Equal(t, env.remoteActorID, statusRepo.created[0].AuthorID)
-
-		update := &activitypub.Activity{
-			BaseObject: activitypub.BaseObject{Type: activitypub.UpdateType, ID: "https://remote.example/activities/reattribution-update"},
-			Actor:      env.remoteActorID,
-			Object: map[string]any{
-				"@context":     []any{"https://www.w3.org/ns/activitystreams"},
-				"id":           noteID,
-				"type":         activitypub.NoteType,
-				"content":      "forged local author",
-				"attributedTo": env.local.ID + "?x=1",
-				"to":           []any{activitypub.PublicAddress},
-			},
-		}
-
-		require.Error(t, handler.processRemoteUpdateActivity(ctx, update, env.local))
-		// A status write is the DynamoDB Streams trigger for public:actor:alice and
-		// user:alice. Refusing the write proves neither stream can receive the attack.
-		require.Empty(t, statusRepo.updated)
-		require.Len(t, statusRepo.created, 1)
-		require.Equal(t, env.remoteActorID, statusRepo.created[0].AuthorID)
-
-		stored, err := objectRepo.GetObject(ctx, noteID)
-		require.NoError(t, err)
-		storedNote, ok := stored.(*activitypub.Note)
-		require.True(t, ok)
-		require.Equal(t, env.remoteActorID, storedNote.AttributedTo)
 	})
 
 	t.Run("create then honest update preserves remote attribution", func(t *testing.T) {

--- a/cmd/inbox/internal/routing/pipeline_more_round10_coverage_test.go
+++ b/cmd/inbox/internal/routing/pipeline_more_round10_coverage_test.go
@@ -544,6 +544,91 @@ func TestInboxHandler_Round10_RemoteCreateUpdateDelete_ErrorBranches(t *testing.
 		assert.Equal(t, noteID, status.Note.ID)
 	})
 
+	t.Run("create then update cannot reattribute remote status to local actor", func(t *testing.T) {
+		objectRepo := inmemory.NewObjectRepository()
+		statusRepo := &recordingStatusRepository{}
+		handler := *env.handler
+		handler.objectRepository = objectRepo
+		handler.statusRepository = statusRepo
+
+		noteID := "https://remote.example/objects/reattribution-attack"
+		create := &activitypub.Activity{
+			BaseObject: activitypub.BaseObject{Type: activitypub.CreateType, ID: "https://remote.example/activities/reattribution-create"},
+			Actor:      env.remoteActorID,
+			Object: map[string]any{
+				"@context":     []any{"https://www.w3.org/ns/activitystreams"},
+				"id":           noteID,
+				"type":         activitypub.NoteType,
+				"content":      "honest remote create",
+				"attributedTo": env.remoteActorID,
+				"to":           []any{activitypub.PublicAddress},
+			},
+		}
+		require.NoError(t, handler.processRemoteCreateActivity(ctx, create, env.local))
+		require.Len(t, statusRepo.created, 1)
+		require.Equal(t, env.remoteActorID, statusRepo.created[0].AuthorID)
+
+		update := &activitypub.Activity{
+			BaseObject: activitypub.BaseObject{Type: activitypub.UpdateType, ID: "https://remote.example/activities/reattribution-update"},
+			Actor:      env.remoteActorID,
+			Object: map[string]any{
+				"@context":     []any{"https://www.w3.org/ns/activitystreams"},
+				"id":           noteID,
+				"type":         activitypub.NoteType,
+				"content":      "forged local author",
+				"attributedTo": env.local.ID,
+				"to":           []any{activitypub.PublicAddress},
+			},
+		}
+
+		require.Error(t, handler.processRemoteUpdateActivity(ctx, update, env.local))
+		// A status write is the DynamoDB Streams trigger for public:actor:alice and
+		// user:alice. Refusing the write proves neither stream can receive the attack.
+		require.Empty(t, statusRepo.updated)
+		require.Len(t, statusRepo.created, 1)
+		require.Equal(t, env.remoteActorID, statusRepo.created[0].AuthorID)
+
+		stored, err := objectRepo.GetObject(ctx, noteID)
+		require.NoError(t, err)
+		storedNote, ok := stored.(*activitypub.Note)
+		require.True(t, ok)
+		require.Equal(t, env.remoteActorID, storedNote.AttributedTo)
+	})
+
+	t.Run("update note requires complete ActivityPub attribution", func(t *testing.T) {
+		noteID := "https://remote.example/users/bob/statuses/update-missing-attribution"
+		objectRepo := inmemory.NewObjectRepository()
+		require.NoError(t, objectRepo.CreateObject(ctx, &activitypub.Note{
+			BaseObject:   activitypub.BaseObject{ID: noteID, Type: activitypub.NoteType},
+			AttributedTo: env.remoteActorID,
+			Content:      "before",
+		}))
+		statusRepo := &recordingStatusRepository{}
+		handler := *env.handler
+		handler.objectRepository = objectRepo
+		handler.statusRepository = statusRepo
+
+		update := &activitypub.Activity{
+			BaseObject: activitypub.BaseObject{Type: activitypub.UpdateType, ID: "https://remote.example/activities/update-missing-attribution"},
+			Actor:      env.remoteActorID,
+			Object: map[string]any{
+				"@context": []any{"https://www.w3.org/ns/activitystreams"},
+				"id":       noteID,
+				"type":     activitypub.NoteType,
+				"content":  "after",
+				"to":       []any{activitypub.PublicAddress},
+			},
+		}
+
+		require.Error(t, handler.processRemoteUpdateActivity(ctx, update, env.local))
+		require.Empty(t, statusRepo.updated)
+		stored, err := objectRepo.GetObject(ctx, noteID)
+		require.NoError(t, err)
+		storedNote, ok := stored.(*activitypub.Note)
+		require.True(t, ok)
+		require.Equal(t, env.remoteActorID, storedNote.AttributedTo)
+	})
+
 	t.Run("update note preserves tombstone metadata", func(t *testing.T) {
 		noteID := "https://remote.example/users/bob/statuses/update-deleted-123"
 		deletedAt := time.Date(2025, 12, 28, 11, 0, 0, 0, time.UTC)

--- a/cmd/inbox/internal/routing/post_pipeline_round10_coverage_test.go
+++ b/cmd/inbox/internal/routing/post_pipeline_round10_coverage_test.go
@@ -243,10 +243,12 @@ func TestInboxHandler_Round10_ProcessorSweep(t *testing.T) {
 			},
 			Actor: env.remoteActorID,
 			Object: map[string]any{
+				"@context":     []any{"https://www.w3.org/ns/activitystreams"},
 				"id":           objectID,
 				"type":         activitypub.NoteType,
 				"attributedTo": env.remoteActorID,
 				"content":      "updated content",
+				"to":           []any{activitypub.PublicAddress},
 			},
 		}
 		require.NoError(t, env.handler.processRemoteUpdateActivity(ctx, update, env.local))

--- a/cmd/inbox/internal/routing/post_pipeline_round10_coverage_test.go
+++ b/cmd/inbox/internal/routing/post_pipeline_round10_coverage_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	costpkg "github.com/equaltoai/lesser/pkg/cost"
+	pkgErrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/federation"
 	"github.com/stretchr/testify/require"
 	apptheory "github.com/theory-cloud/apptheory/v3/runtime"
@@ -97,6 +98,50 @@ func TestInboxHandler_Round10_PostPipeline_CreateActivity(t *testing.T) {
 	resp, err := env.handler.handlePostInbox(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 202, resp.Status)
+}
+
+func TestInboxHandler_CreateAttributionMustMatchVerifiedSigner(t *testing.T) {
+	env := newInboxTestEnv(t)
+	setRunAsyncSynchronous(t)
+
+	targetActor, err := env.handler.actorRepository.GetActorByUsername(context.Background(), "alice")
+	require.NoError(t, err)
+
+	activity := map[string]any{
+		"@context": activitypub.Context,
+		"type":     activitypub.CreateType,
+		"id":       "https://remote.example/activities/forged-local-attribution",
+		"actor":    env.remoteActorID,
+		"to":       []string{targetActor.ID},
+		"object": map[string]any{
+			"@context":     activitypub.Context,
+			"id":           "https://remote.example/objects/forged-local-attribution",
+			"type":         activitypub.NoteType,
+			"attributedTo": targetActor.ID,
+			"content":      "forged local author",
+			"to":           []string{targetActor.ID},
+			"cc":           []string{},
+		},
+	}
+	body, err := json.Marshal(activity)
+	require.NoError(t, err)
+
+	ctx := newAppTheoryContext("POST", "/users/alice/inbox", map[string]string{
+		"Host":            "localhost",
+		"Content-Type":    "application/activity+json",
+		"User-Agent":      "Mastodon/4.0.0",
+		"X-Forwarded-For": "203.0.113.10",
+	}, nil, body)
+	ctx.Params["username"] = "alice"
+
+	// The request is cryptographically signed by the remote actor. The forged
+	// local attributedTo must still be rejected after signature verification.
+	signAppTheoryRequest(t, env, ctx, body)
+
+	resp, err := env.handler.handlePostInbox(ctx)
+	require.Nil(t, resp)
+	require.Error(t, err)
+	require.True(t, pkgErrors.HasCode(err, pkgErrors.CodeForbidden), "unexpected error: %v", err)
 }
 
 func TestInboxHandler_Round10_ProcessorSweep(t *testing.T) {

--- a/cmd/inbox/internal/routing/process_activity_by_type_round10_coverage_test.go
+++ b/cmd/inbox/internal/routing/process_activity_by_type_round10_coverage_test.go
@@ -87,10 +87,12 @@ func TestInboxHandler_Round10_ProcessActivityByType_AllCases(t *testing.T) {
 				BaseObject: activitypub.BaseObject{Context: activitypub.Context, Type: activitypub.UpdateType, ID: env.cfg.BaseURL() + "/activities/update-bytype"},
 				Actor:      env.remoteActorID,
 				Object: map[string]any{
+					"@context":     "https://www.w3.org/ns/activitystreams",
 					"id":           objectID,
 					"type":         activitypub.NoteType,
 					"attributedTo": env.remoteActorID,
 					"content":      "updated bytype",
+					"to":           []any{activitypub.PublicAddress},
 				},
 			},
 		},

--- a/cmd/inbox/internal/routing/shared_inbox_ingress.go
+++ b/cmd/inbox/internal/routing/shared_inbox_ingress.go
@@ -34,6 +34,9 @@ func (ih *InboxHandler) handlePostSharedInbox(ctx *apptheory.Context) (*apptheor
 	if err := ih.verifyAuthentication(ctx, req); err != nil {
 		return nil, err
 	}
+	if err := ih.verifyCreateAuthorization(req.Activity); err != nil {
+		return nil, err
+	}
 	if err := ih.validateSharedInboxAddressingAndPrivacy(req); err != nil {
 		return nil, err
 	}

--- a/cmd/inbox/internal/routing/shared_inbox_ingress_test.go
+++ b/cmd/inbox/internal/routing/shared_inbox_ingress_test.go
@@ -76,6 +76,83 @@ func TestInboxHandler_SharedInboxPublicCreateResolvesFollowerTargets(t *testing.
 	require.Equal(t, env.remoteActorID, stored.Actor)
 }
 
+func TestInboxHandler_SharedInboxCreateAttributionMustMatchVerifiedSigner(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		slug          string
+		attributedTo  func(*inboxTestEnv) string
+		wantForbidden bool
+	}{
+		{
+			name:         "honest remote attribution",
+			slug:         "honest",
+			attributedTo: func(env *inboxTestEnv) string { return env.remoteActorID },
+		},
+		{
+			name:          "forged local attribution",
+			slug:          "forged-local",
+			attributedTo:  func(env *inboxTestEnv) string { return env.local.ID },
+			wantForbidden: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newInboxTestEnv(t)
+			setRunAsyncSynchronous(t)
+
+			relationshipRepo := inmemory.NewRelationshipRepository()
+			require.NoError(t, relationshipRepo.CreateRelationship(context.Background(), "alice", "bob@remote.example", env.remoteActorID+"/activities/follow"))
+			require.NoError(t, relationshipRepo.AcceptFollowRequest(context.Background(), "alice", "bob@remote.example"))
+			env.handler.relationshipRepository = relationshipRepo
+			env.handler.activityRepository = inmemory.NewActivityRepository()
+
+			activityID := "https://remote.example/activities/shared-attribution-" + tc.slug
+			activity := map[string]any{
+				"@context": activitypub.Context,
+				"type":     activitypub.CreateType,
+				"id":       activityID,
+				"actor":    env.remoteActorID,
+				"to":       []string{activitypub.PublicAddress},
+				"cc":       []string{env.remoteActorID + "/followers"},
+				"object": map[string]any{
+					"@context":     activitypub.Context,
+					"id":           "https://remote.example/objects/shared-attribution-" + tc.slug,
+					"type":         activitypub.NoteType,
+					"attributedTo": tc.attributedTo(env),
+					"content":      "shared inbox attribution check",
+					"to":           []string{activitypub.PublicAddress},
+					"cc":           []string{env.remoteActorID + "/followers"},
+				},
+			}
+			body, err := json.Marshal(activity)
+			require.NoError(t, err)
+
+			ctx := newAppTheoryContext(http.MethodPost, "/inbox", map[string]string{
+				"Host":         "localhost",
+				"Content-Type": "application/activity+json",
+				"User-Agent":   "Mastodon/4.0.0",
+			}, nil, body)
+			signAppTheoryRequest(t, env, ctx, body)
+
+			resp, err := env.handler.handlePostSharedInbox(ctx)
+			if tc.wantForbidden {
+				require.Nil(t, resp)
+				require.Error(t, err)
+				require.True(t, apperrors.HasCode(err, apperrors.CodeForbidden), "unexpected error: %v", err)
+				_, storedErr := env.handler.activityRepository.GetActivity(context.Background(), activityID)
+				require.Error(t, storedErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.Equal(t, http.StatusAccepted, resp.Status)
+			stored, err := env.handler.activityRepository.GetActivity(context.Background(), activityID)
+			require.NoError(t, err)
+			require.Equal(t, env.remoteActorID, stored.Actor)
+		})
+	}
+}
+
 func TestInboxHandler_SharedInboxFollowersOnlyCreateResolvesFollowerTargets(t *testing.T) {
 	env := newInboxTestEnv(t)
 	setRunAsyncSynchronous(t)

--- a/cmd/stream-router/main.go
+++ b/cmd/stream-router/main.go
@@ -1763,15 +1763,11 @@ func (h *StreamRouterHandler) broadcastDeletionToStreams(ctx context.Context, re
 		}
 		h.appendStreamEvent(ctx, requestID, streaming.PublicLocalStream, "delete", objectID)
 
-		// Public actor streams mirror create fanout: only public objects from a
-		// local author may reach the anonymous per-actor key. Older tombstones may
-		// lack AttributedTo, so use the authorized deleter as a compatibility
-		// fallback while keeping missing IsPublic fail-closed.
+		// Public actor streams mirror create fanout: only public objects with an
+		// explicitly recorded local author may reach the anonymous per-actor key.
+		// DeletedBy identifies the deleter and is never an author fallback.
 		if tombstone.IsPublic {
 			authorID := strings.TrimSpace(tombstone.AttributedTo)
-			if authorID == "" {
-				authorID = strings.TrimSpace(tombstone.DeletedBy)
-			}
 			if h.isLocalActorID(authorID) {
 				username, err := common.ActorUsernameFromID(authorID)
 				if err != nil {
@@ -1786,7 +1782,6 @@ func (h *StreamRouterHandler) broadcastDeletionToStreams(ctx context.Context, re
 							zap.String("stream", actorStream),
 							zap.Error(err))
 					}
-					h.appendStreamEvent(ctx, requestID, actorStream, "delete", objectID)
 				}
 			}
 		}

--- a/cmd/stream-router/main.go
+++ b/cmd/stream-router/main.go
@@ -1733,8 +1733,15 @@ func (h *StreamRouterHandler) processTombstoneEvent(ctx context.Context, request
 		// Don't return error - this is not critical
 	}
 
-	// Remove the object from user timelines (followers of the deleter)
-	if err := h.removeFromFollowerTimelines(ctx, requestID, tombstone.DeletedBy, tombstone.ID); err != nil {
+	// Remove the object from the author's followers' home timelines. DeletedBy
+	// identifies the deleter (possibly a moderator) and is never an author
+	// fallback; without an explicitly recorded author we fail closed and skip
+	// this leg rather than guess.
+	authorID := strings.TrimSpace(tombstone.AttributedTo)
+	if authorID == "" {
+		logger.Warn("skipping follower timeline removal for deletion without attributed author",
+			zap.String("object_id", tombstone.ID))
+	} else if err := h.removeFromFollowerTimelines(ctx, requestID, authorID, tombstone.ID); err != nil {
 		logger.Warn("failed to remove from follower timelines", zap.Error(err))
 	}
 

--- a/cmd/stream-router/main.go
+++ b/cmd/stream-router/main.go
@@ -781,17 +781,28 @@ func (h *StreamRouterHandler) buildWebSocketStatusStreams(status *models.Status)
 	}
 
 	streams := make([]string, 0, 5+len(status.Hashtags))
+	seen := make(map[string]struct{}, cap(streams))
+	add := func(stream string) {
+		if stream == "" {
+			return
+		}
+		if _, exists := seen[stream]; exists {
+			return
+		}
+		seen[stream] = struct{}{}
+		streams = append(streams, stream)
+	}
 	if status.Visibility == models.VisibilityPublic {
-		streams = append(streams, streaming.PublicStream)
+		add(streaming.PublicStream)
 
 		isLocalAuthor := h.isLocalActorID(status.AuthorID)
 		if isLocalAuthor {
-			streams = append(streams, streaming.PublicLocalStream)
+			add(streaming.PublicLocalStream)
 			if status.AuthorUsername != "" {
-				streams = append(streams, streaming.PublicActorStreamName(status.AuthorUsername))
+				add(streaming.PublicActorStreamName(status.AuthorUsername))
 			}
 		} else {
-			streams = append(streams, streaming.PublicRemoteStream)
+			add(streaming.PublicRemoteStream)
 		}
 
 		for _, hashtag := range status.Hashtags {
@@ -802,14 +813,14 @@ func (h *StreamRouterHandler) buildWebSocketStatusStreams(status *models.Status)
 					zap.Error(err))
 				continue
 			}
-			streams = append(streams, streaming.HashtagStreamName(normalized))
+			add(streaming.HashtagStreamName(normalized))
 		}
 	}
 
 	// The author receives all of their own statuses, including non-public ones,
 	// on the private user stream.
 	if status.AuthorUsername != "" {
-		streams = append(streams, streaming.UserStreamName(status.AuthorUsername))
+		add(streaming.UserStreamName(status.AuthorUsername))
 	}
 
 	return streams

--- a/cmd/stream-router/main.go
+++ b/cmd/stream-router/main.go
@@ -1640,16 +1640,20 @@ func (h *StreamRouterHandler) processTombstoneEvent(ctx context.Context, request
 
 	// Unmarshal the tombstone record
 	var recordModel struct {
-		ID               string    `json:"ID"`
-		IDLegacy         string    `json:"id"`
-		Type             string    `json:"Type"`
-		TypeLegacy       string    `json:"type"`
-		FormerType       string    `json:"FormerType"`
-		FormerTypeLegacy string    `json:"formerType"`
-		Deleted          time.Time `json:"Deleted"`
-		DeletedLegacy    time.Time `json:"deleted"`
-		DeletedBy        string    `json:"DeletedBy"`
-		DeletedByLegacy  string    `json:"deletedBy"`
+		ID                 string    `json:"ID"`
+		IDLegacy           string    `json:"id"`
+		Type               string    `json:"Type"`
+		TypeLegacy         string    `json:"type"`
+		FormerType         string    `json:"FormerType"`
+		FormerTypeLegacy   string    `json:"formerType"`
+		Deleted            time.Time `json:"Deleted"`
+		DeletedLegacy      time.Time `json:"deleted"`
+		DeletedBy          string    `json:"DeletedBy"`
+		DeletedByLegacy    string    `json:"deletedBy"`
+		AttributedTo       string    `json:"AttributedTo"`
+		AttributedToLegacy string    `json:"attributedTo"`
+		IsPublic           bool      `json:"IsPublic"`
+		IsPublicLegacy     bool      `json:"isPublic"`
 	}
 
 	if err := stream.UnmarshalItem(record, &recordModel); err != nil {
@@ -1677,13 +1681,19 @@ func (h *StreamRouterHandler) processTombstoneEvent(ctx context.Context, request
 	if deletedBy == "" {
 		deletedBy = recordModel.DeletedByLegacy
 	}
+	attributedTo := recordModel.AttributedTo
+	if attributedTo == "" {
+		attributedTo = recordModel.AttributedToLegacy
+	}
 
 	tombstone := models.Tombstone{
-		ID:         objectID,
-		Type:       objectType,
-		FormerType: formerType,
-		Deleted:    deletedAt,
-		DeletedBy:  deletedBy,
+		ID:           objectID,
+		Type:         objectType,
+		FormerType:   formerType,
+		Deleted:      deletedAt,
+		DeletedBy:    deletedBy,
+		AttributedTo: attributedTo,
+		IsPublic:     recordModel.IsPublic || recordModel.IsPublicLegacy,
 	}
 
 	if tombstone.ID == "" || tombstone.DeletedBy == "" || tombstone.FormerType == "" || tombstone.Deleted.IsZero() {
@@ -1752,6 +1762,34 @@ func (h *StreamRouterHandler) broadcastDeletionToStreams(ctx context.Context, re
 			h.logger.Warn("failed to broadcast deletion to local stream", zap.Error(err))
 		}
 		h.appendStreamEvent(ctx, requestID, streaming.PublicLocalStream, "delete", objectID)
+
+		// Public actor streams mirror create fanout: only public objects from a
+		// local author may reach the anonymous per-actor key. Older tombstones may
+		// lack AttributedTo, so use the authorized deleter as a compatibility
+		// fallback while keeping missing IsPublic fail-closed.
+		if tombstone.IsPublic {
+			authorID := strings.TrimSpace(tombstone.AttributedTo)
+			if authorID == "" {
+				authorID = strings.TrimSpace(tombstone.DeletedBy)
+			}
+			if h.isLocalActorID(authorID) {
+				username, err := common.ActorUsernameFromID(authorID)
+				if err != nil {
+					h.logger.Warn("failed to extract local actor username for deletion fanout",
+						zap.String("actor_id", authorID),
+						zap.Error(err))
+				} else {
+					actorStream := streaming.PublicActorStreamName(username)
+					message.Stream = actorStream
+					if err := h.broadcastMessage(ctx, requestID, message); err != nil {
+						h.logger.Warn("failed to broadcast deletion to public actor stream",
+							zap.String("stream", actorStream),
+							zap.Error(err))
+					}
+					h.appendStreamEvent(ctx, requestID, actorStream, "delete", objectID)
+				}
+			}
+		}
 
 		// Hashtag streams - extract hashtags from the deleted object if available
 		if err := h.removeFromHashtagStreams(ctx, requestID, objectID); err != nil {

--- a/cmd/stream-router/main.go
+++ b/cmd/stream-router/main.go
@@ -736,18 +736,10 @@ func (h *StreamRouterHandler) processStatusEvent(ctx context.Context, requestID 
 		return FailedToMarshalStatus(err)
 	}
 
-	// Route to appropriate streams based on visibility
-	wsStreams := []string{}
-
-	// Public timelines
-	if status.Visibility == "public" {
-		wsStreams = append(wsStreams, streaming.PublicStream, streaming.PublicLocalStream)
-	}
-
-	// User stream for the author
-	if status.AuthorUsername != "" {
-		wsStreams = append(wsStreams, streaming.UserStreamName(status.AuthorUsername))
-	}
+	// Route to appropriate streams based on visibility. The public actor and
+	// hashtag streams are populated only inside the public-visibility guard;
+	// the private user stream remains separate and authenticated/self-only.
+	wsStreams := h.buildWebSocketStatusStreams(&status)
 
 	// Send to all relevant streams
 	eventType := streamEventUpdate
@@ -781,6 +773,46 @@ func (h *StreamRouterHandler) processStatusEvent(ctx context.Context, requestID 
 	}
 
 	return nil
+}
+
+func (h *StreamRouterHandler) buildWebSocketStatusStreams(status *models.Status) []string {
+	if status == nil {
+		return []string{}
+	}
+
+	streams := make([]string, 0, 5+len(status.Hashtags))
+	if status.Visibility == models.VisibilityPublic {
+		streams = append(streams, streaming.PublicStream)
+
+		isLocalAuthor := h.isLocalActorID(status.AuthorID)
+		if isLocalAuthor {
+			streams = append(streams, streaming.PublicLocalStream)
+			if status.AuthorUsername != "" {
+				streams = append(streams, streaming.PublicActorStreamName(status.AuthorUsername))
+			}
+		} else {
+			streams = append(streams, streaming.PublicRemoteStream)
+		}
+
+		for _, hashtag := range status.Hashtags {
+			normalized, err := streaming.NormalizeHashtagStreamValue(hashtag)
+			if err != nil {
+				h.logger.Warn("skipping invalid hashtag stream value",
+					zap.String("hashtag", hashtag),
+					zap.Error(err))
+				continue
+			}
+			streams = append(streams, streaming.HashtagStreamName(normalized))
+		}
+	}
+
+	// The author receives all of their own statuses, including non-public ones,
+	// on the private user stream.
+	if status.AuthorUsername != "" {
+		streams = append(streams, streaming.UserStreamName(status.AuthorUsername))
+	}
+
+	return streams
 }
 
 // processNotificationEvent processes notification events using TableTheory stream utilities

--- a/cmd/stream-router/round12_stream_router_test.go
+++ b/cmd/stream-router/round12_stream_router_test.go
@@ -767,10 +767,11 @@ func TestStreamRouterHandler_ProcessTombstoneEvent_ErrorBranches_Round12(t *test
 		EventName: eventNameInsert,
 		Change: events.DynamoDBStreamRecord{
 			NewImage: map[string]events.DynamoDBAttributeValue{
-				"ID":         events.NewStringAttribute("1"),
-				"FormerType": events.NewStringAttribute("Follow"),
-				"Deleted":    events.NewStringAttribute(time.Now().UTC().Format(time.RFC3339)),
-				"DeletedBy":  events.NewStringAttribute("https://example.com/users/alice"),
+				"ID":           events.NewStringAttribute("1"),
+				"FormerType":   events.NewStringAttribute("Follow"),
+				"Deleted":      events.NewStringAttribute(time.Now().UTC().Format(time.RFC3339)),
+				"DeletedBy":    events.NewStringAttribute("https://example.com/users/alice"),
+				"AttributedTo": events.NewStringAttribute("https://example.com/users/alice"),
 			},
 		},
 	}

--- a/cmd/stream-router/timeline_fanout_authz_test.go
+++ b/cmd/stream-router/timeline_fanout_authz_test.go
@@ -82,7 +82,11 @@ func TestBuildWebSocketStatusStreamsKeepsAnonymousAndPrivateKeysDisjoint(t *test
 
 	remoteStatus := publicStatus
 	remoteStatus.AuthorID = "https://remote.example/users/alice"
-	remoteStatus.AuthorUsername = "alice@remote.example"
+	// Remote status projection stores the bare actor-path username, so a remote
+	// alice collides with local alice unless AuthorID locality remains in the
+	// authorization guard.
+	remoteStatus.AuthorUsername = "alice"
+	require.Equal(t, publicStatus.AuthorUsername, remoteStatus.AuthorUsername)
 	remoteStreams := handler.buildWebSocketStatusStreams(&remoteStatus)
 	require.Contains(t, remoteStreams, streaming.PublicRemoteStream)
 	require.NotContains(t, remoteStreams, streaming.PublicLocalStream)

--- a/cmd/stream-router/timeline_fanout_authz_test.go
+++ b/cmd/stream-router/timeline_fanout_authz_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/equaltoai/lesser/pkg/streaming"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestPublicActorAndHashtagSubscribersReceiveOnlyPublicStatuses(t *testing.T) {
+	const (
+		anonymousActorConnection   = "anonymous-actor"
+		anonymousHashtagConnection = "anonymous-hashtag"
+		authorConnection           = "author-self"
+	)
+
+	streamRepo := &fakeStreamRepo{
+		subsByStream: map[string][]models.WebSocketSubscription{
+			streaming.PublicActorStreamName("alice"): {{ConnectionID: anonymousActorConnection}},
+			streaming.HashtagStreamName("golang"):    {{ConnectionID: anonymousHashtagConnection}},
+			streaming.UserStreamName("alice"):        {{ConnectionID: authorConnection}},
+		},
+		getConnErrByID: make(map[string]error),
+	}
+	client := &fakeStreamerClient{}
+	handler := &StreamRouterHandler{
+		logger:        zap.NewNop(),
+		apiClient:     client,
+		streamingRepo: streamRepo,
+		accountRepo:   fakeFollowerRepo{},
+		domain:        "example.com",
+	}
+
+	publicRecord := newStatusInsertRecord(eventNameInsert)
+	require.NoError(t, handler.processStatusEvent(context.Background(), "public", publicRecord))
+	require.Equal(t, 1, connectionCallCount(client.postCalls, anonymousActorConnection))
+	require.Equal(t, 1, connectionCallCount(client.postCalls, anonymousHashtagConnection))
+	require.Equal(t, 1, connectionCallCount(client.postCalls, authorConnection))
+
+	followersOnlyRecord := statusRecordWithVisibility(publicRecord, models.VisibilityPrivate)
+	require.NoError(t, handler.processStatusEvent(context.Background(), "followers-only", followersOnlyRecord))
+	directRecord := statusRecordWithVisibility(publicRecord, models.VisibilityDirect)
+	require.NoError(t, handler.processStatusEvent(context.Background(), "direct", directRecord))
+	require.NoError(t, handler.processNotificationEvent(context.Background(), "notification", newNotificationInsertRecord("alice")))
+
+	// The anonymous streams receive no followers-only status, direct status, or
+	// notification fanout. Those events remain confined to private user streams.
+	require.Equal(t, 1, connectionCallCount(client.postCalls, anonymousActorConnection))
+	require.Equal(t, 1, connectionCallCount(client.postCalls, anonymousHashtagConnection))
+	require.Greater(t, connectionCallCount(client.postCalls, authorConnection), 1)
+}
+
+func TestBuildWebSocketStatusStreamsKeepsAnonymousAndPrivateKeysDisjoint(t *testing.T) {
+	handler := &StreamRouterHandler{logger: zap.NewNop(), domain: "example.com"}
+	base := &models.Status{
+		AuthorID:       "https://example.com/users/alice",
+		AuthorUsername: "alice",
+		Hashtags:       []string{"#GoLang"},
+	}
+
+	publicStatus := *base
+	publicStatus.Visibility = models.VisibilityPublic
+	publicStreams := handler.buildWebSocketStatusStreams(&publicStatus)
+	require.ElementsMatch(t, []string{
+		streaming.PublicStream,
+		streaming.PublicLocalStream,
+		streaming.PublicActorStreamName("alice"),
+		streaming.HashtagStreamName("golang"),
+		streaming.UserStreamName("alice"),
+	}, publicStreams)
+	require.NotEqual(t, streaming.PublicActorStreamName("alice"), streaming.UserStreamName("alice"))
+
+	for _, visibility := range []string{models.VisibilityUnlisted, models.VisibilityPrivate, models.VisibilityDirect} {
+		status := *base
+		status.Visibility = visibility
+		require.Equal(t, []string{streaming.UserStreamName("alice")}, handler.buildWebSocketStatusStreams(&status))
+	}
+
+	remoteStatus := publicStatus
+	remoteStatus.AuthorID = "https://remote.example/users/alice"
+	remoteStatus.AuthorUsername = "alice@remote.example"
+	remoteStreams := handler.buildWebSocketStatusStreams(&remoteStatus)
+	require.Contains(t, remoteStreams, streaming.PublicRemoteStream)
+	require.NotContains(t, remoteStreams, streaming.PublicLocalStream)
+	require.NotContains(t, remoteStreams, streaming.PublicActorStreamName("alice"))
+}
+
+func statusRecordWithVisibility(record events.DynamoDBEventRecord, visibility string) events.DynamoDBEventRecord {
+	record.Change.NewImage["visibility"] = events.NewStringAttribute(visibility)
+	return record
+}
+
+func connectionCallCount(calls []string, connectionID string) int {
+	count := 0
+	for _, call := range calls {
+		if call == connectionID {
+			count++
+		}
+	}
+	return count
+}

--- a/cmd/stream-router/timeline_fanout_authz_test.go
+++ b/cmd/stream-router/timeline_fanout_authz_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/equaltoai/lesser/pkg/storage/models"
@@ -91,6 +92,61 @@ func TestBuildWebSocketStatusStreamsKeepsAnonymousAndPrivateKeysDisjoint(t *test
 	require.Contains(t, remoteStreams, streaming.PublicRemoteStream)
 	require.NotContains(t, remoteStreams, streaming.PublicLocalStream)
 	require.NotContains(t, remoteStreams, streaming.PublicActorStreamName("alice"))
+}
+
+func TestPublicActorDeletionFanoutRequiresPublicLocalAuthor(t *testing.T) {
+	const actorConnection = "anonymous-actor"
+
+	streamRepo := &fakeStreamRepo{
+		subsByStream: map[string][]models.WebSocketSubscription{
+			streaming.PublicActorStreamName("alice"): {{ConnectionID: actorConnection}},
+		},
+		getConnErrByID: make(map[string]error),
+	}
+	client := &fakeStreamerClient{}
+	handler := &StreamRouterHandler{
+		logger:        zap.NewNop(),
+		apiClient:     client,
+		streamingRepo: streamRepo,
+		accountRepo:   fakeFollowerRepo{},
+		statusRepo: fakeStatusRepo{statusByID: map[string]*models.Status{
+			"local-public":  {StatusID: "local-public"},
+			"local-private": {StatusID: "local-private"},
+			"remote-public": {StatusID: "remote-public"},
+		}},
+		domain: "example.com",
+	}
+
+	deletedAt := time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+	localPublic := newTombstoneRecord("local-public", "https://example.com/users/alice", true, deletedAt)
+	require.NoError(t, handler.processTombstoneEvent(context.Background(), "local-public", localPublic))
+	require.Equal(t, 1, connectionCallCount(client.postCalls, actorConnection))
+
+	// Both remote and local projections use the bare username "alice". The
+	// remote actor ID must keep its deletion off public:actor:alice.
+	remotePublic := newTombstoneRecord("remote-public", "https://remote.example/users/alice", true, deletedAt)
+	require.NoError(t, handler.processTombstoneEvent(context.Background(), "remote-public", remotePublic))
+	require.Equal(t, 1, connectionCallCount(client.postCalls, actorConnection))
+
+	localPrivate := newTombstoneRecord("local-private", "https://example.com/users/alice", false, deletedAt)
+	require.NoError(t, handler.processTombstoneEvent(context.Background(), "local-private", localPrivate))
+	require.Equal(t, 1, connectionCallCount(client.postCalls, actorConnection))
+}
+
+func newTombstoneRecord(id, authorID string, isPublic bool, deletedAt time.Time) events.DynamoDBEventRecord {
+	return events.DynamoDBEventRecord{
+		EventID:   "tombstone-" + id,
+		EventName: eventNameInsert,
+		Change: events.DynamoDBStreamRecord{NewImage: map[string]events.DynamoDBAttributeValue{
+			"id":           events.NewStringAttribute(id),
+			"type":         events.NewStringAttribute("Tombstone"),
+			"formerType":   events.NewStringAttribute("Note"),
+			"deleted":      events.NewStringAttribute(deletedAt.Format(time.RFC3339)),
+			"deletedBy":    events.NewStringAttribute(authorID),
+			"attributedTo": events.NewStringAttribute(authorID),
+			"isPublic":     events.NewBooleanAttribute(isPublic),
+		}},
+	}
 }
 
 func statusRecordWithVisibility(record events.DynamoDBEventRecord, visibility string) events.DynamoDBEventRecord {

--- a/cmd/stream-router/timeline_fanout_authz_test.go
+++ b/cmd/stream-router/timeline_fanout_authz_test.go
@@ -149,6 +149,72 @@ func TestPublicActorDeletionFanoutRequiresPublicLocalAuthor(t *testing.T) {
 	require.Equal(t, 1, connectionCallCount(client.postCalls, actorConnection))
 }
 
+// followerRepoByUser returns distinct follower sets per username so tests can
+// tell the author's followers apart from the deleter's.
+type followerRepoByUser map[string][]*activitypub.Actor
+
+func (r followerRepoByUser) GetFollowers(_ context.Context, username string, _ int, _ string) ([]*activitypub.Actor, string, error) {
+	return r[username], "", nil
+}
+
+func TestTombstoneFollowerRemovalTargetsAuthorNotDeleter(t *testing.T) {
+	const (
+		aliceFollowerConnection = "carol-home"
+		modFollowerConnection   = "dave-home"
+	)
+
+	streamRepo := &fakeStreamRepo{
+		subsByStream: map[string][]models.WebSocketSubscription{
+			streaming.UserStreamName("carol"): {{ConnectionID: aliceFollowerConnection}},
+			streaming.UserStreamName("dave"):  {{ConnectionID: modFollowerConnection}},
+		},
+		getConnErrByID: make(map[string]error),
+	}
+	client := &fakeStreamerClient{}
+	handler := &StreamRouterHandler{
+		logger:        zap.NewNop(),
+		apiClient:     client,
+		streamingRepo: streamRepo,
+		accountRepo: followerRepoByUser{
+			"alice": {{BaseObject: activitypub.BaseObject{ID: "https://example.com/users/carol"}}},
+			"mod":   {{BaseObject: activitypub.BaseObject{ID: "https://example.com/users/dave"}}},
+		},
+		statusRepo: fakeStatusRepo{statusByID: map[string]*models.Status{
+			"alice-status":   {StatusID: "alice-status"},
+			"missing-author": {StatusID: "missing-author"},
+		}},
+		domain: "example.com",
+	}
+
+	deletedAt := time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC)
+
+	// A moderator deleting alice's status retracts it from alice's followers'
+	// home timelines, not the moderator's.
+	moderated := newTombstoneRecordWithActors(
+		"alice-status",
+		"https://example.com/users/alice",
+		"https://example.com/users/mod",
+		true,
+		deletedAt,
+	)
+	require.NoError(t, handler.processTombstoneEvent(context.Background(), "moderated", moderated))
+	require.Equal(t, 1, connectionCallCount(client.postCalls, aliceFollowerConnection))
+	require.Equal(t, 0, connectionCallCount(client.postCalls, modFollowerConnection))
+
+	// Without an explicitly recorded author the follower-removal leg fails
+	// closed: no follower stream is touched and processing does not fail.
+	missingAuthor := newTombstoneRecordWithActors(
+		"missing-author",
+		"",
+		"https://example.com/users/mod",
+		true,
+		deletedAt,
+	)
+	require.NoError(t, handler.processTombstoneEvent(context.Background(), "missing-author", missingAuthor))
+	require.Equal(t, 1, connectionCallCount(client.postCalls, aliceFollowerConnection))
+	require.Equal(t, 0, connectionCallCount(client.postCalls, modFollowerConnection))
+}
+
 func newTombstoneRecord(id, authorID string, isPublic bool, deletedAt time.Time) events.DynamoDBEventRecord {
 	return newTombstoneRecordWithActors(id, authorID, authorID, isPublic, deletedAt)
 }

--- a/cmd/stream-router/timeline_fanout_authz_test.go
+++ b/cmd/stream-router/timeline_fanout_authz_test.go
@@ -59,7 +59,7 @@ func TestBuildWebSocketStatusStreamsKeepsAnonymousAndPrivateKeysDisjoint(t *test
 	base := &models.Status{
 		AuthorID:       "https://example.com/users/alice",
 		AuthorUsername: "alice",
-		Hashtags:       []string{"#GoLang"},
+		Hashtags:       []string{"#GoLang", "golang"},
 	}
 
 	publicStatus := *base

--- a/cmd/stream-router/timeline_fanout_authz_test.go
+++ b/cmd/stream-router/timeline_fanout_authz_test.go
@@ -6,9 +6,12 @@ import (
 	"time"
 
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/equaltoai/lesser/pkg/streaming"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	dynamormmocks "github.com/theory-cloud/tabletheory/v3/pkg/mocks"
 	"go.uber.org/zap"
 )
 
@@ -110,9 +113,10 @@ func TestPublicActorDeletionFanoutRequiresPublicLocalAuthor(t *testing.T) {
 		streamingRepo: streamRepo,
 		accountRepo:   fakeFollowerRepo{},
 		statusRepo: fakeStatusRepo{statusByID: map[string]*models.Status{
-			"local-public":  {StatusID: "local-public"},
-			"local-private": {StatusID: "local-private"},
-			"remote-public": {StatusID: "remote-public"},
+			"local-public":   {StatusID: "local-public"},
+			"local-private":  {StatusID: "local-private"},
+			"remote-public":  {StatusID: "remote-public"},
+			"missing-author": {StatusID: "missing-author"},
 		}},
 		domain: "example.com",
 	}
@@ -131,9 +135,25 @@ func TestPublicActorDeletionFanoutRequiresPublicLocalAuthor(t *testing.T) {
 	localPrivate := newTombstoneRecord("local-private", "https://example.com/users/alice", false, deletedAt)
 	require.NoError(t, handler.processTombstoneEvent(context.Background(), "local-private", localPrivate))
 	require.Equal(t, 1, connectionCallCount(client.postCalls, actorConnection))
+
+	// DeletedBy identifies the deleter, not necessarily the author. A public
+	// tombstone without attribution must not guess an actor stream from it.
+	missingAuthor := newTombstoneRecordWithActors(
+		"missing-author",
+		"",
+		"https://example.com/users/alice",
+		true,
+		deletedAt,
+	)
+	require.NoError(t, handler.processTombstoneEvent(context.Background(), "missing-author", missingAuthor))
+	require.Equal(t, 1, connectionCallCount(client.postCalls, actorConnection))
 }
 
 func newTombstoneRecord(id, authorID string, isPublic bool, deletedAt time.Time) events.DynamoDBEventRecord {
+	return newTombstoneRecordWithActors(id, authorID, authorID, isPublic, deletedAt)
+}
+
+func newTombstoneRecordWithActors(id, attributedTo, deletedBy string, isPublic bool, deletedAt time.Time) events.DynamoDBEventRecord {
 	return events.DynamoDBEventRecord{
 		EventID:   "tombstone-" + id,
 		EventName: eventNameInsert,
@@ -142,11 +162,41 @@ func newTombstoneRecord(id, authorID string, isPublic bool, deletedAt time.Time)
 			"type":         events.NewStringAttribute("Tombstone"),
 			"formerType":   events.NewStringAttribute("Note"),
 			"deleted":      events.NewStringAttribute(deletedAt.Format(time.RFC3339)),
-			"deletedBy":    events.NewStringAttribute(authorID),
-			"attributedTo": events.NewStringAttribute(authorID),
+			"deletedBy":    events.NewStringAttribute(deletedBy),
+			"attributedTo": events.NewStringAttribute(attributedTo),
 			"isPublic":     events.NewBooleanAttribute(isPublic),
 		}},
 	}
+}
+
+func TestPublicActorDeletionDoesNotWriteUnconsumableSSEEvent(t *testing.T) {
+	t.Setenv("STREAM_EVENTS_TABLE_NAME", "stream-events")
+
+	db := new(dynamormmocks.MockDB)
+	query := new(dynamormmocks.MockQuery)
+	db.On("WithContext", mock.Anything).Return(db).Twice()
+	db.On("Model", mock.Anything).Return(query).Twice()
+	query.On("Create").Return(nil).Twice()
+
+	handler := &StreamRouterHandler{
+		logger:         zap.NewNop(),
+		apiClient:      &fakeStreamerClient{},
+		streamingRepo:  &fakeStreamRepo{},
+		statusRepo:     fakeStatusRepo{statusByID: map[string]*models.Status{"local-public": {StatusID: "local-public"}}},
+		streamEventLog: streaming.NewStreamEventLog(db, time.Hour),
+		domain:         "example.com",
+	}
+	tombstone := &models.Tombstone{
+		ID:           "local-public",
+		FormerType:   activitypub.NoteType,
+		AttributedTo: "https://example.com/users/alice",
+		DeletedBy:    "https://example.com/users/alice",
+		IsPublic:     true,
+	}
+
+	require.NoError(t, handler.broadcastDeletionToStreams(context.Background(), "sse-delete", tombstone, StreamMessage{}))
+	db.AssertExpectations(t)
+	query.AssertExpectations(t)
 }
 
 func statusRecordWithVisibility(record events.DynamoDBEventRecord, visibility string) events.DynamoDBEventRecord {

--- a/cmd/streaming/main.go
+++ b/cmd/streaming/main.go
@@ -28,6 +28,7 @@ import (
 	dynamormCore "github.com/theory-cloud/tabletheory/v3/pkg/core"
 	"go.uber.org/zap"
 
+	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
@@ -751,6 +752,13 @@ func (sh *StreamingHandler) resolveCanonicalStreamSubscription(ctx context.Conte
 	case "public":
 		if stream == streaming.PublicStream || stream == streaming.PublicLocalStream || stream == streaming.PublicRemoteStream {
 			return stream, nil
+		}
+		if len(parts) == 3 && parts[1] == "actor" {
+			username := strings.TrimSpace(parts[2])
+			if err := activitypub.ValidateUsername(username); err != nil {
+				return "", pkgErrors.StreamingInvalidStream()
+			}
+			return streaming.PublicActorStreamName(username), nil
 		}
 		return "", pkgErrors.StreamingInvalidStream()
 	case streaming.HashtagStreamPrefix:

--- a/cmd/streaming/round16_streaming_more_coverage_test.go
+++ b/cmd/streaming/round16_streaming_more_coverage_test.go
@@ -66,6 +66,11 @@ func TestResolveCanonicalStreamSubscription_Round16(t *testing.T) {
 	cases := []tc{
 		{name: "empty stream", conn: authed, stream: " ", wantCode: apperrors.CodeBadRequest},
 		{name: "public ok", conn: authed, stream: streaming.PublicStream, want: streaming.PublicStream},
+		{name: "public actor anonymous ok", conn: noAuth, stream: "public:actor:Alice", want: streaming.PublicActorStreamName("alice")},
+		{name: "public actor trims username", conn: authed, stream: "public:actor: alice ", want: streaming.PublicActorStreamName("alice")},
+		{name: "public actor missing username", conn: authed, stream: "public:actor:", wantCode: apperrors.CodeBadRequest},
+		{name: "public actor invalid username", conn: authed, stream: "public:actor:alice!", wantCode: apperrors.CodeBadRequest},
+		{name: "public actor extra segment", conn: authed, stream: "public:actor:alice:extra", wantCode: apperrors.CodeBadRequest},
 		{name: "public invalid suffix", conn: authed, stream: "public:unknown", wantCode: apperrors.CodeBadRequest},
 		{name: "hashtag missing tag", conn: authed, stream: "hashtag", wantCode: apperrors.CodeBadRequest},
 		{name: "hashtag empty tag", conn: authed, stream: "hashtag: ", wantCode: apperrors.CodeBadRequest},

--- a/docs/contracts/graphql-schema.graphql
+++ b/docs/contracts/graphql-schema.graphql
@@ -1474,7 +1474,8 @@ type UploadMediaPayload {
 type Subscription {
   # Activity streams
   activityStream(types: [ActivityType!]): Activity!
-  timelineUpdates(type: TimelineType!, actorId: ID, hashtag: String, listId: ID): Object!
+  # ACTOR uses a local actor username and publishes public statuses only.
+  timelineUpdates(type: TimelineType!, actorUsername: String, hashtag: String, listId: ID): Object!
   
   # Notification stream
   notificationStream(types: [String!]): Notification!

--- a/docs/contracts/graphql-schema.graphql
+++ b/docs/contracts/graphql-schema.graphql
@@ -1474,7 +1474,7 @@ type UploadMediaPayload {
 type Subscription {
   # Activity streams
   activityStream(types: [ActivityType!]): Activity!
-  timelineUpdates(type: TimelineType!, listId: ID): Object!
+  timelineUpdates(type: TimelineType!, actorId: ID, hashtag: String, listId: ID): Object!
   
   # Notification stream
   notificationStream(types: [String!]): Notification!

--- a/graph/core.graphql
+++ b/graph/core.graphql
@@ -1471,7 +1471,8 @@ type UploadMediaPayload {
 type Subscription {
   # Activity streams
   activityStream(types: [ActivityType!]): Activity!
-  timelineUpdates(type: TimelineType!, actorId: ID, hashtag: String, listId: ID): Object!
+  # ACTOR uses a local actor username and publishes public statuses only.
+  timelineUpdates(type: TimelineType!, actorUsername: String, hashtag: String, listId: ID): Object!
   
   # Notification stream
   notificationStream(types: [String!]): Notification!

--- a/graph/core.graphql
+++ b/graph/core.graphql
@@ -1471,7 +1471,7 @@ type UploadMediaPayload {
 type Subscription {
   # Activity streams
   activityStream(types: [ActivityType!]): Activity!
-  timelineUpdates(type: TimelineType!, listId: ID): Object!
+  timelineUpdates(type: TimelineType!, actorId: ID, hashtag: String, listId: ID): Object!
   
   # Notification stream
   notificationStream(types: [String!]): Notification!

--- a/graph/errors.go
+++ b/graph/errors.go
@@ -20,6 +20,7 @@ var (
 	ErrHashtagParameterRequired   = errors.NewValidationError("hashtag", "parameter required for hashtag timeline")
 	ErrListIDParameterRequired    = errors.NewValidationError("listId", "parameter required for list timeline")
 	ErrActorIDParameterRequired   = errors.NewValidationError("actorId", "parameter required for ACTOR timeline")
+	ErrActorUsernameRequired      = errors.NewValidationError("actorUsername", "parameter required for ACTOR timeline updates")
 	ErrTrusteeIDRequired          = errors.NewValidationError("trustee_id", "required")
 	ErrObjectIDRequired           = errors.NewValidationError("objectId", "required")
 	ErrReasonRequired             = errors.NewValidationError("reason", "required")

--- a/graph/generated.go
+++ b/graph/generated.go
@@ -3298,7 +3298,7 @@ type ComplexityRoot struct {
 		QuoteActivity           func(childComplexity int, noteID string) int
 		RelationshipUpdates     func(childComplexity int, actorID *string) int
 		ThreatIntelligence      func(childComplexity int) int
-		TimelineUpdates         func(childComplexity int, typeArg model.TimelineType, listID *string) int
+		TimelineUpdates         func(childComplexity int, typeArg model.TimelineType, actorID *string, hashtag *string, listID *string) int
 		TrustUpdates            func(childComplexity int, actorID string) int
 	}
 
@@ -3963,7 +3963,7 @@ type QuoteContextResolver interface {
 }
 type SubscriptionResolver interface {
 	ActivityStream(ctx context.Context, types []model.ActivityType) (<-chan *activitypub.Activity, error)
-	TimelineUpdates(ctx context.Context, typeArg model.TimelineType, listID *string) (<-chan *model.Object, error)
+	TimelineUpdates(ctx context.Context, typeArg model.TimelineType, actorID *string, hashtag *string, listID *string) (<-chan *model.Object, error)
 	NotificationStream(ctx context.Context, types []string) (<-chan *model.Notification, error)
 	ConversationUpdates(ctx context.Context) (<-chan *model.Conversation, error)
 	ListUpdates(ctx context.Context, listID string) (<-chan *model.ListUpdate, error)
@@ -21673,7 +21673,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Subscription.TimelineUpdates(childComplexity, args["type"].(model.TimelineType), args["listId"].(*string)), true
+		return e.complexity.Subscription.TimelineUpdates(childComplexity, args["type"].(model.TimelineType), args["actorId"].(*string), args["hashtag"].(*string), args["listId"].(*string)), true
 
 	case "Subscription.trustUpdates":
 		if e.complexity.Subscription.TrustUpdates == nil {
@@ -27622,11 +27622,21 @@ func (ec *executionContext) field_Subscription_timelineUpdates_args(ctx context.
 		return nil, err
 	}
 	args["type"] = arg0
-	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "listId", ec.unmarshalOID2ᚖstring)
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "actorId", ec.unmarshalOID2ᚖstring)
 	if err != nil {
 		return nil, err
 	}
-	args["listId"] = arg1
+	args["actorId"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "hashtag", ec.unmarshalOString2ᚖstring)
+	if err != nil {
+		return nil, err
+	}
+	args["hashtag"] = arg2
+	arg3, err := graphql.ProcessArgField(ctx, rawArgs, "listId", ec.unmarshalOID2ᚖstring)
+	if err != nil {
+		return nil, err
+	}
+	args["listId"] = arg3
 	return args, nil
 }
 
@@ -143477,7 +143487,7 @@ func (ec *executionContext) _Subscription_timelineUpdates(ctx context.Context, f
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Subscription().TimelineUpdates(rctx, fc.Args["type"].(model.TimelineType), fc.Args["listId"].(*string))
+		return ec.resolvers.Subscription().TimelineUpdates(rctx, fc.Args["type"].(model.TimelineType), fc.Args["actorId"].(*string), fc.Args["hashtag"].(*string), fc.Args["listId"].(*string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/graph/generated.go
+++ b/graph/generated.go
@@ -3298,7 +3298,7 @@ type ComplexityRoot struct {
 		QuoteActivity           func(childComplexity int, noteID string) int
 		RelationshipUpdates     func(childComplexity int, actorID *string) int
 		ThreatIntelligence      func(childComplexity int) int
-		TimelineUpdates         func(childComplexity int, typeArg model.TimelineType, actorID *string, hashtag *string, listID *string) int
+		TimelineUpdates         func(childComplexity int, typeArg model.TimelineType, actorUsername *string, hashtag *string, listID *string) int
 		TrustUpdates            func(childComplexity int, actorID string) int
 	}
 
@@ -3963,7 +3963,7 @@ type QuoteContextResolver interface {
 }
 type SubscriptionResolver interface {
 	ActivityStream(ctx context.Context, types []model.ActivityType) (<-chan *activitypub.Activity, error)
-	TimelineUpdates(ctx context.Context, typeArg model.TimelineType, actorID *string, hashtag *string, listID *string) (<-chan *model.Object, error)
+	TimelineUpdates(ctx context.Context, typeArg model.TimelineType, actorUsername *string, hashtag *string, listID *string) (<-chan *model.Object, error)
 	NotificationStream(ctx context.Context, types []string) (<-chan *model.Notification, error)
 	ConversationUpdates(ctx context.Context) (<-chan *model.Conversation, error)
 	ListUpdates(ctx context.Context, listID string) (<-chan *model.ListUpdate, error)
@@ -21673,7 +21673,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Subscription.TimelineUpdates(childComplexity, args["type"].(model.TimelineType), args["actorId"].(*string), args["hashtag"].(*string), args["listId"].(*string)), true
+		return e.complexity.Subscription.TimelineUpdates(childComplexity, args["type"].(model.TimelineType), args["actorUsername"].(*string), args["hashtag"].(*string), args["listId"].(*string)), true
 
 	case "Subscription.trustUpdates":
 		if e.complexity.Subscription.TrustUpdates == nil {
@@ -27622,11 +27622,11 @@ func (ec *executionContext) field_Subscription_timelineUpdates_args(ctx context.
 		return nil, err
 	}
 	args["type"] = arg0
-	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "actorId", ec.unmarshalOID2ᚖstring)
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "actorUsername", ec.unmarshalOString2ᚖstring)
 	if err != nil {
 		return nil, err
 	}
-	args["actorId"] = arg1
+	args["actorUsername"] = arg1
 	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "hashtag", ec.unmarshalOString2ᚖstring)
 	if err != nil {
 		return nil, err
@@ -143487,7 +143487,7 @@ func (ec *executionContext) _Subscription_timelineUpdates(ctx context.Context, f
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Subscription().TimelineUpdates(rctx, fc.Args["type"].(model.TimelineType), fc.Args["actorId"].(*string), fc.Args["hashtag"].(*string), fc.Args["listId"].(*string))
+		return ec.resolvers.Subscription().TimelineUpdates(rctx, fc.Args["type"].(model.TimelineType), fc.Args["actorUsername"].(*string), fc.Args["hashtag"].(*string), fc.Args["listId"].(*string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/graph/subscription_authz_audit_test.go
+++ b/graph/subscription_authz_audit_test.go
@@ -18,28 +18,20 @@ func TestSubscriptionResolvers_AnonymousAuthorizationMatrix(t *testing.T) {
 	listID := "list-1"
 
 	gated := map[string]func() error{
-		"actor timeline": func() error {
-			_, err := resolver.Subscription().TimelineUpdates(ctx, model.TimelineTypeActor, nil)
-			return err
-		},
 		"activity stream": func() error {
 			_, err := resolver.Subscription().ActivityStream(ctx, nil)
 			return err
 		},
 		"home timeline": func() error {
-			_, err := resolver.Subscription().TimelineUpdates(ctx, model.TimelineTypeHome, nil)
-			return err
-		},
-		"hashtag timeline": func() error {
-			_, err := resolver.Subscription().TimelineUpdates(ctx, model.TimelineTypeHashtag, nil)
+			_, err := resolver.Subscription().TimelineUpdates(ctx, model.TimelineTypeHome, nil, nil, nil)
 			return err
 		},
 		"list timeline": func() error {
-			_, err := resolver.Subscription().TimelineUpdates(ctx, model.TimelineTypeList, &listID)
+			_, err := resolver.Subscription().TimelineUpdates(ctx, model.TimelineTypeList, nil, nil, &listID)
 			return err
 		},
 		"direct timeline": func() error {
-			_, err := resolver.Subscription().TimelineUpdates(ctx, model.TimelineTypeDirect, nil)
+			_, err := resolver.Subscription().TimelineUpdates(ctx, model.TimelineTypeDirect, nil, nil, nil)
 			return err
 		},
 		"notification stream": func() error {
@@ -144,11 +136,20 @@ func TestTimelineUpdates_AnonymousSafeTypesStream(t *testing.T) {
 	require.NoError(t, manager.Start(ctx))
 	t.Cleanup(func() { _ = manager.Stop() })
 
-	for _, timelineType := range []model.TimelineType{
-		model.TimelineTypePublic,
-		model.TimelineTypeLocal,
+	actorID := " alice "
+	hashtag := " #GoLang "
+	for _, test := range []struct {
+		timelineType model.TimelineType
+		actorID      *string
+		hashtag      *string
+		wantStream   string
+	}{
+		{timelineType: model.TimelineTypePublic, wantStream: StreamNamePublic},
+		{timelineType: model.TimelineTypeLocal, wantStream: streaming.PublicLocalStream},
+		{timelineType: model.TimelineTypeActor, actorID: &actorID, wantStream: streaming.UserStreamName("alice")},
+		{timelineType: model.TimelineTypeHashtag, hashtag: &hashtag, wantStream: streaming.HashtagStreamName("golang")},
 	} {
-		t.Run(string(timelineType), func(t *testing.T) {
+		t.Run(string(test.timelineType), func(t *testing.T) {
 			manager.manager.subscriptionsMux.RLock()
 			before := make(map[string]struct{}, len(manager.manager.subscriptions))
 			for id := range manager.manager.subscriptions {
@@ -156,7 +157,7 @@ func TestTimelineUpdates_AnonymousSafeTypesStream(t *testing.T) {
 			}
 			manager.manager.subscriptionsMux.RUnlock()
 
-			updates, err := resolver.Subscription().TimelineUpdates(ctx, timelineType, nil)
+			updates, err := resolver.Subscription().TimelineUpdates(ctx, test.timelineType, test.actorID, test.hashtag, nil)
 			require.NoError(t, err)
 			require.NotNil(t, updates)
 
@@ -170,10 +171,11 @@ func TestTimelineUpdates_AnonymousSafeTypesStream(t *testing.T) {
 			}
 			manager.manager.subscriptionsMux.RUnlock()
 			require.NotNil(t, subscription)
+			require.Equal(t, []string{test.wantStream}, subscription.Streams)
 
 			objectChannel, ok := subscription.OutputChannel.(chan *model.Object)
 			require.True(t, ok)
-			want := &model.Object{ID: "object-" + string(timelineType), Type: model.ObjectTypeNote}
+			want := &model.Object{ID: "object-" + string(test.timelineType), Type: model.ObjectTypeNote}
 			objectChannel <- want
 
 			select {
@@ -194,25 +196,25 @@ func TestSubscribeToTimeline_RoutesOnlyImplementedStreams(t *testing.T) {
 	require.NoError(t, manager.Start(ctx))
 	t.Cleanup(func() { _ = manager.Stop() })
 
-	_, err := manager.SubscribeToTimeline(ctx, "", model.TimelineTypePublic)
+	_, err := manager.SubscribeToTimeline(ctx, "", model.TimelineTypePublic, nil, nil, nil)
 	require.NoError(t, err)
 	publicSubscriptions, err := connRepo.GetSubscriptionsForStream(ctx, StreamNamePublic)
 	require.NoError(t, err)
 	require.Len(t, publicSubscriptions, 1)
 
-	_, err = manager.SubscribeToTimeline(ctx, "", model.TimelineTypeLocal)
+	_, err = manager.SubscribeToTimeline(ctx, "", model.TimelineTypeLocal, nil, nil, nil)
 	require.NoError(t, err)
 	localSubscriptions, err := connRepo.GetSubscriptionsForStream(ctx, "public:local")
 	require.NoError(t, err)
 	require.Len(t, localSubscriptions, 1)
 
-	_, err = manager.SubscribeToTimeline(ctx, "", model.TimelineTypeActor)
+	_, err = manager.SubscribeToTimeline(ctx, "", model.TimelineTypeActor, nil, nil, nil)
 	require.Error(t, err)
 	emptyUserSubscriptions, err := connRepo.GetSubscriptionsForStream(ctx, "user:")
 	require.NoError(t, err)
 	require.Empty(t, emptyUserSubscriptions)
 
-	_, err = manager.SubscribeToTimeline(ctx, "alice", model.TimelineTypeHome)
+	_, err = manager.SubscribeToTimeline(ctx, "alice", model.TimelineTypeHome, nil, nil, nil)
 	require.NoError(t, err)
 	homeSubscriptions, err := connRepo.GetSubscriptionsForStream(ctx, "user:alice")
 	require.NoError(t, err)
@@ -229,7 +231,7 @@ func TestSubscribeToTimeline_RoutesOnlyImplementedStreams(t *testing.T) {
 		{name: "direct spaces", username: "   ", typeValue: model.TimelineTypeDirect, streamName: "direct:   "},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, subscribeErr := manager.SubscribeToTimeline(ctx, tc.username, tc.typeValue)
+			_, subscribeErr := manager.SubscribeToTimeline(ctx, tc.username, tc.typeValue, nil, nil, nil)
 			require.ErrorIs(t, subscribeErr, ErrUsernameCannotBeEmpty)
 			subscriptions, lookupErr := connRepo.GetSubscriptionsForStream(ctx, tc.streamName)
 			require.NoError(t, lookupErr)

--- a/graph/subscription_authz_audit_test.go
+++ b/graph/subscription_authz_audit_test.go
@@ -136,17 +136,17 @@ func TestTimelineUpdates_AnonymousSafeTypesStream(t *testing.T) {
 	require.NoError(t, manager.Start(ctx))
 	t.Cleanup(func() { _ = manager.Stop() })
 
-	actorID := " alice "
+	actorUsername := " alice "
 	hashtag := " #GoLang "
 	for _, test := range []struct {
-		timelineType model.TimelineType
-		actorID      *string
-		hashtag      *string
-		wantStream   string
+		timelineType  model.TimelineType
+		actorUsername *string
+		hashtag       *string
+		wantStream    string
 	}{
 		{timelineType: model.TimelineTypePublic, wantStream: StreamNamePublic},
 		{timelineType: model.TimelineTypeLocal, wantStream: streaming.PublicLocalStream},
-		{timelineType: model.TimelineTypeActor, actorID: &actorID, wantStream: streaming.UserStreamName("alice")},
+		{timelineType: model.TimelineTypeActor, actorUsername: &actorUsername, wantStream: streaming.PublicActorStreamName("alice")},
 		{timelineType: model.TimelineTypeHashtag, hashtag: &hashtag, wantStream: streaming.HashtagStreamName("golang")},
 	} {
 		t.Run(string(test.timelineType), func(t *testing.T) {
@@ -157,7 +157,7 @@ func TestTimelineUpdates_AnonymousSafeTypesStream(t *testing.T) {
 			}
 			manager.manager.subscriptionsMux.RUnlock()
 
-			updates, err := resolver.Subscription().TimelineUpdates(ctx, test.timelineType, test.actorID, test.hashtag, nil)
+			updates, err := resolver.Subscription().TimelineUpdates(ctx, test.timelineType, test.actorUsername, test.hashtag, nil)
 			require.NoError(t, err)
 			require.NotNil(t, updates)
 
@@ -186,6 +186,13 @@ func TestTimelineUpdates_AnonymousSafeTypesStream(t *testing.T) {
 			}
 		})
 	}
+
+	actorSubscriptions, err := connRepo.GetSubscriptionsForStream(ctx, streaming.PublicActorStreamName("alice"))
+	require.NoError(t, err)
+	require.Len(t, actorSubscriptions, 1)
+	privateUserSubscriptions, err := connRepo.GetSubscriptionsForStream(ctx, streaming.UserStreamName("alice"))
+	require.NoError(t, err)
+	require.Empty(t, privateUserSubscriptions)
 }
 
 func TestSubscribeToTimeline_RoutesOnlyImplementedStreams(t *testing.T) {

--- a/graph/subscription_manager.go
+++ b/graph/subscription_manager.go
@@ -395,7 +395,7 @@ func (sm *GraphQLSubscriptionManager) SubscribeToTimeline(
 	ctx context.Context,
 	username string,
 	timelineType model.TimelineType,
-	actorID *string,
+	actorUsername *string,
 	hashtag *string,
 	listID *string,
 ) (<-chan *model.Object, error) {
@@ -404,9 +404,9 @@ func (sm *GraphQLSubscriptionManager) SubscribeToTimeline(
 	}
 
 	streamName, err := timelineStreamName(username, timelineType, timelineRoutingInputs{
-		actorID: actorID,
-		hashtag: hashtag,
-		listID:  listID,
+		actorUsername: actorUsername,
+		hashtag:       hashtag,
+		listID:        listID,
 	})
 	if err != nil {
 		return nil, err

--- a/graph/subscription_manager.go
+++ b/graph/subscription_manager.go
@@ -3,7 +3,6 @@ package graph
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -392,32 +391,25 @@ func (sm *GraphQLSubscriptionManager) createGenericSubscription(
 }
 
 // SubscribeToTimeline subscribes to timeline updates via DynamoDB-backed subscriptions
-func (sm *GraphQLSubscriptionManager) SubscribeToTimeline(ctx context.Context, username string, timelineType model.TimelineType) (<-chan *model.Object, error) {
+func (sm *GraphQLSubscriptionManager) SubscribeToTimeline(
+	ctx context.Context,
+	username string,
+	timelineType model.TimelineType,
+	actorID *string,
+	hashtag *string,
+	listID *string,
+) (<-chan *model.Object, error) {
 	if !sm.IsRunning() {
 		return nil, ErrSubscriptionManagerNotRunning
 	}
 
-	// Determine stream name based on timeline type
-	var streamName string
-	switch timelineType {
-	case model.TimelineTypeHome:
-		username = strings.TrimSpace(username)
-		if err := common.ValidateRequiredParam("username", username); err != nil {
-			return nil, ErrUsernameCannotBeEmpty
-		}
-		streamName = fmt.Sprintf("user:%s", username)
-	case model.TimelineTypePublic:
-		streamName = StreamNamePublic
-	case model.TimelineTypeLocal:
-		streamName = "public:local"
-	case model.TimelineTypeDirect:
-		username = strings.TrimSpace(username)
-		if err := common.ValidateRequiredParam("username", username); err != nil {
-			return nil, ErrUsernameCannotBeEmpty
-		}
-		streamName = fmt.Sprintf("direct:%s", username)
-	default:
-		return nil, ErrUnsupportedTimelineTypeWithValue(timelineType)
+	streamName, err := timelineStreamName(username, timelineType, timelineRoutingInputs{
+		actorID: actorID,
+		hashtag: hashtag,
+		listID:  listID,
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	streams := []string{streamName}

--- a/graph/subscription_manager_round12_test.go
+++ b/graph/subscription_manager_round12_test.go
@@ -68,7 +68,7 @@ func TestGraphQLSubscriptionManager_SubscribeVariantsAndCleanup(t *testing.T) {
 	sm := NewGraphQLSubscriptionManager(connRepo, pub, zap.NewNop())
 
 	// Not running guards.
-	_, err := sm.SubscribeToTimeline(context.Background(), "alice", model.TimelineTypeHome)
+	_, err := sm.SubscribeToTimeline(context.Background(), "alice", model.TimelineTypeHome, nil, nil, nil)
 	require.ErrorIs(t, err, ErrSubscriptionManagerNotRunning)
 	_, err = sm.SubscribeToHashtagActivity(context.Background(), "alice", nil)
 	require.ErrorIs(t, err, ErrSubscriptionManagerNotRunning)
@@ -81,15 +81,15 @@ func TestGraphQLSubscriptionManager_SubscribeVariantsAndCleanup(t *testing.T) {
 	ctx = WithConnectionID(ctx, "conn-1")
 
 	// Exercise stream selection branches.
-	_, err = sm.SubscribeToTimeline(ctx, "alice", model.TimelineTypeHome)
+	_, err = sm.SubscribeToTimeline(ctx, "alice", model.TimelineTypeHome, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = sm.SubscribeToTimeline(ctx, "alice", model.TimelineTypePublic)
+	_, err = sm.SubscribeToTimeline(ctx, "alice", model.TimelineTypePublic, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = sm.SubscribeToTimeline(ctx, "alice", model.TimelineTypeLocal)
+	_, err = sm.SubscribeToTimeline(ctx, "alice", model.TimelineTypeLocal, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = sm.SubscribeToTimeline(ctx, "alice", model.TimelineTypeDirect)
+	_, err = sm.SubscribeToTimeline(ctx, "alice", model.TimelineTypeDirect, nil, nil, nil)
 	require.NoError(t, err)
-	_, err = sm.SubscribeToTimeline(ctx, "alice", model.TimelineTypeActor)
+	_, err = sm.SubscribeToTimeline(ctx, "alice", model.TimelineTypeActor, nil, nil, nil)
 	require.Error(t, err)
 
 	// Various subscription types.

--- a/graph/subscription_resolvers_round12_test.go
+++ b/graph/subscription_resolvers_round12_test.go
@@ -34,9 +34,9 @@ func TestRound12SubscriptionResolvers_ManagerGuardsAndTimelineValidation(t *test
 	require.False(t, ok)
 
 	// Timeline validations.
-	_, err = resolver.Subscription().TimelineUpdates(ctx, model.TimelineTypeHome, nil)
+	_, err = resolver.Subscription().TimelineUpdates(ctx, model.TimelineTypeHome, nil, nil, nil)
 	require.Error(t, err)
-	_, err = resolver.Subscription().TimelineUpdates(context.Background(), model.TimelineTypeList, nil)
+	_, err = resolver.Subscription().TimelineUpdates(context.Background(), model.TimelineTypeList, nil, nil, nil)
 	require.Error(t, err)
 }
 
@@ -59,7 +59,7 @@ func TestRound12SubscriptionResolvers_SuccessPaths(t *testing.T) {
 	_, err := resolver.Subscription().ActivityStream(authCtx, nil)
 	require.NoError(t, err)
 
-	_, err = resolver.Subscription().TimelineUpdates(authCtx, model.TimelineTypeHome, nil)
+	_, err = resolver.Subscription().TimelineUpdates(authCtx, model.TimelineTypeHome, nil, nil, nil)
 	require.NoError(t, err)
 
 	_, err = resolver.Subscription().RelationshipUpdates(authCtx, nil)

--- a/graph/subscription_resolvers_timelines.go
+++ b/graph/subscription_resolvers_timelines.go
@@ -58,12 +58,20 @@ func (r *subscriptionResolver) ActivityStream(ctx context.Context, types []model
 }
 
 // TimelineUpdates is the resolver for the timelineUpdates field.
-func (r *subscriptionResolver) TimelineUpdates(ctx context.Context, timelineType model.TimelineType, listID *string) (<-chan *model.Object, error) {
+func (r *subscriptionResolver) TimelineUpdates(
+	ctx context.Context,
+	timelineType model.TimelineType,
+	actorID *string,
+	hashtag *string,
+	listID *string,
+) (<-chan *model.Object, error) {
 	username := r.optionalAuth(ctx)
+	inputs := timelineRoutingInputs{actorID: actorID, hashtag: hashtag, listID: listID}
 
-	// Validate request
-	if timelineType == model.TimelineTypeList && listID == nil {
-		return nil, ErrListIDParameterRequired
+	// Validate routing before authorization so malformed operations fail closed
+	// without being mistaken for a credential problem.
+	if _, err := validateTimelineRoutingInputs(timelineType, inputs); err != nil {
+		return nil, err
 	}
 	if !timelineAllowsAnonymous(timelineType) && username == "" {
 		return nil, ErrAuthenticationRequired
@@ -92,7 +100,7 @@ func (r *subscriptionResolver) TimelineUpdates(ctx context.Context, timelineType
 	// Ensure the WebSocket connection ID is attached so DynamoDB subscription records can be created.
 	ctx = WithConnectionID(ctx, r.getConnectionID(ctx))
 
-	timelineChan, err := sm.SubscribeToTimelineUpdates(ctx, username, timelineType)
+	timelineChan, err := sm.SubscribeToTimelineUpdates(ctx, username, timelineType, actorID, hashtag, listID)
 	if err != nil {
 		r.Logger.Error("failed to create timeline subscription",
 			zap.String("user", username),
@@ -110,7 +118,7 @@ func (r *subscriptionResolver) TimelineUpdates(ctx context.Context, timelineType
 
 func timelineAllowsAnonymous(timelineType model.TimelineType) bool {
 	switch timelineType {
-	case model.TimelineTypePublic, model.TimelineTypeLocal:
+	case model.TimelineTypePublic, model.TimelineTypeLocal, model.TimelineTypeActor, model.TimelineTypeHashtag:
 		return true
 	default:
 		return false

--- a/graph/subscription_resolvers_timelines.go
+++ b/graph/subscription_resolvers_timelines.go
@@ -2,9 +2,11 @@ package graph
 
 import (
 	"context"
+	"strings"
 
 	"github.com/equaltoai/lesser/graph/model"
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/services/lists"
 	"go.uber.org/zap"
 )
 
@@ -61,12 +63,12 @@ func (r *subscriptionResolver) ActivityStream(ctx context.Context, types []model
 func (r *subscriptionResolver) TimelineUpdates(
 	ctx context.Context,
 	timelineType model.TimelineType,
-	actorID *string,
+	actorUsername *string,
 	hashtag *string,
 	listID *string,
 ) (<-chan *model.Object, error) {
 	username := r.optionalAuth(ctx)
-	inputs := timelineRoutingInputs{actorID: actorID, hashtag: hashtag, listID: listID}
+	inputs := timelineRoutingInputs{actorUsername: actorUsername, hashtag: hashtag, listID: listID}
 
 	// Validate routing before authorization so malformed operations fail closed
 	// without being mistaken for a credential problem.
@@ -75,6 +77,17 @@ func (r *subscriptionResolver) TimelineUpdates(
 	}
 	if !timelineAllowsAnonymous(timelineType) && username == "" {
 		return nil, ErrAuthenticationRequired
+	}
+	if timelineType == model.TimelineTypeList {
+		if r.Registry == nil || r.Registry.Lists() == nil {
+			return nil, ErrListNotFoundOrAccessDenied
+		}
+		if _, err := r.Registry.Lists().GetList(ctx, &lists.GetListQuery{
+			ListID:   strings.TrimSpace(*listID),
+			ViewerID: username,
+		}); err != nil {
+			return nil, ErrListNotFoundOrAccessDenied
+		}
 	}
 
 	r.Logger.Info("Timeline updates subscription started",
@@ -100,7 +113,7 @@ func (r *subscriptionResolver) TimelineUpdates(
 	// Ensure the WebSocket connection ID is attached so DynamoDB subscription records can be created.
 	ctx = WithConnectionID(ctx, r.getConnectionID(ctx))
 
-	timelineChan, err := sm.SubscribeToTimelineUpdates(ctx, username, timelineType, actorID, hashtag, listID)
+	timelineChan, err := sm.SubscribeToTimelineUpdates(ctx, username, timelineType, actorUsername, hashtag, listID)
 	if err != nil {
 		r.Logger.Error("failed to create timeline subscription",
 			zap.String("user", username),

--- a/graph/subscriptions.go
+++ b/graph/subscriptions.go
@@ -108,11 +108,11 @@ func (sm *SubscriptionManager) SubscribeToTimelineUpdates(
 	ctx context.Context,
 	username string,
 	timelineType model.TimelineType,
-	actorID *string,
+	actorUsername *string,
 	hashtag *string,
 	listID *string,
 ) (<-chan *model.Object, error) {
-	return sm.manager.SubscribeToTimeline(ctx, username, timelineType, actorID, hashtag, listID)
+	return sm.manager.SubscribeToTimeline(ctx, username, timelineType, actorUsername, hashtag, listID)
 }
 
 // SubscribeToCostUpdates creates a channel for cost updates using event bus

--- a/graph/subscriptions.go
+++ b/graph/subscriptions.go
@@ -56,7 +56,7 @@ func (sm *SubscriptionManager) IsRunning() bool {
 // NOTE: This method creates ActivityPub activities, not GraphQL Objects
 func (sm *SubscriptionManager) SubscribeToActivityStream(ctx context.Context, username string, activityTypes []model.ActivityType) (<-chan *activitypub.Activity, error) {
 	// For now, convert timeline subscription to activities
-	objectsCh, err := sm.manager.SubscribeToTimeline(ctx, username, model.TimelineTypeHome)
+	objectsCh, err := sm.manager.SubscribeToTimeline(ctx, username, model.TimelineTypeHome, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -104,8 +104,15 @@ func (sm *SubscriptionManager) SubscribeToActivityStream(ctx context.Context, us
 }
 
 // SubscribeToTimelineUpdates creates a channel for timeline updates using event bus
-func (sm *SubscriptionManager) SubscribeToTimelineUpdates(ctx context.Context, username string, timelineType model.TimelineType) (<-chan *model.Object, error) {
-	return sm.manager.SubscribeToTimeline(ctx, username, timelineType)
+func (sm *SubscriptionManager) SubscribeToTimelineUpdates(
+	ctx context.Context,
+	username string,
+	timelineType model.TimelineType,
+	actorID *string,
+	hashtag *string,
+	listID *string,
+) (<-chan *model.Object, error) {
+	return sm.manager.SubscribeToTimeline(ctx, username, timelineType, actorID, hashtag, listID)
 }
 
 // SubscribeToCostUpdates creates a channel for cost updates using event bus

--- a/graph/subscriptions_wrapper_round12_test.go
+++ b/graph/subscriptions_wrapper_round12_test.go
@@ -27,7 +27,7 @@ func TestRound12SubscriptionManagerWrapper_StartStopAndDelegates(t *testing.T) {
 
 	ctx = WithConnectionID(ctx, "conn-1")
 
-	_, err := sm.SubscribeToTimelineUpdates(ctx, "alice", model.TimelineTypeHome)
+	_, err := sm.SubscribeToTimelineUpdates(ctx, "alice", model.TimelineTypeHome, nil, nil, nil)
 	require.NoError(t, err)
 
 	threshold := 10

--- a/graph/timeline_subscription_routing.go
+++ b/graph/timeline_subscription_routing.go
@@ -8,26 +8,25 @@ import (
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/common"
 	apperrors "github.com/equaltoai/lesser/pkg/errors"
-	"github.com/equaltoai/lesser/pkg/mastodon"
 	"github.com/equaltoai/lesser/pkg/streaming"
 )
 
 const (
-	timelineInputActorID = "actorId"
-	timelineInputHashtag = "hashtag"
-	timelineInputListID  = "listId"
+	timelineInputActorUsername = "actorUsername"
+	timelineInputHashtag       = "hashtag"
+	timelineInputListID        = "listId"
 )
 
 type timelineRoutingInputs struct {
-	actorID *string
-	hashtag *string
-	listID  *string
+	actorUsername *string
+	hashtag       *string
+	listID        *string
 }
 
 type validatedTimelineRoute struct {
-	actorID string
-	hashtag string
-	listID  string
+	actorUsername string
+	hashtag       string
+	listID        string
 }
 
 func validateTimelineRoutingInputs(timelineType model.TimelineType, inputs timelineRoutingInputs) (validatedTimelineRoute, error) {
@@ -37,20 +36,20 @@ func validateTimelineRoutingInputs(timelineType model.TimelineType, inputs timel
 
 	switch timelineType {
 	case model.TimelineTypeActor:
-		if inputs.actorID == nil {
-			return validatedTimelineRoute{}, ErrActorIDParameterRequired
+		if inputs.actorUsername == nil {
+			return validatedTimelineRoute{}, ErrActorUsernameRequired
 		}
-		actorID := strings.TrimSpace(*inputs.actorID)
-		if err := activitypub.ValidateUsername(actorID); err != nil {
-			return validatedTimelineRoute{}, invalidTimelineRoutingInput(timelineInputActorID, timelineType, "a valid actor stream username", err)
+		actorUsername := strings.TrimSpace(*inputs.actorUsername)
+		if err := activitypub.ValidateUsername(actorUsername); err != nil {
+			return validatedTimelineRoute{}, invalidTimelineRoutingInput(timelineInputActorUsername, timelineType, "a valid local actor username", err)
 		}
-		return validatedTimelineRoute{actorID: actorID}, nil
+		return validatedTimelineRoute{actorUsername: actorUsername}, nil
 	case model.TimelineTypeHashtag:
 		if inputs.hashtag == nil {
 			return validatedTimelineRoute{}, ErrHashtagParameterRequired
 		}
-		hashtag := mastodon.NormalizeHashtag(strings.TrimSpace(*inputs.hashtag))
-		if err := common.ValidateHashtag(hashtag); err != nil {
+		hashtag, err := streaming.NormalizeHashtagStreamValue(*inputs.hashtag)
+		if err != nil {
 			return validatedTimelineRoute{}, invalidTimelineRoutingInput(timelineInputHashtag, timelineType, "a valid hashtag", err)
 		}
 		return validatedTimelineRoute{hashtag: hashtag}, nil
@@ -74,7 +73,7 @@ func rejectUnexpectedTimelineRoutingInputs(timelineType model.TimelineType, inpu
 	expected := ""
 	switch timelineType {
 	case model.TimelineTypeActor:
-		expected = timelineInputActorID
+		expected = timelineInputActorUsername
 	case model.TimelineTypeHashtag:
 		expected = timelineInputHashtag
 	case model.TimelineTypeList:
@@ -89,7 +88,7 @@ func rejectUnexpectedTimelineRoutingInputs(timelineType model.TimelineType, inpu
 		name  string
 		value *string
 	}{
-		{name: timelineInputActorID, value: inputs.actorID},
+		{name: timelineInputActorUsername, value: inputs.actorUsername},
 		{name: timelineInputHashtag, value: inputs.hashtag},
 		{name: timelineInputListID, value: inputs.listID},
 	} {
@@ -130,7 +129,7 @@ func timelineStreamName(username string, timelineType model.TimelineType, inputs
 		}
 		return streaming.DirectStreamName(username), nil
 	case model.TimelineTypeActor:
-		return streaming.UserStreamName(route.actorID), nil
+		return streaming.PublicActorStreamName(route.actorUsername), nil
 	case model.TimelineTypeHashtag:
 		return streaming.HashtagStreamName(route.hashtag), nil
 	case model.TimelineTypeList:

--- a/graph/timeline_subscription_routing.go
+++ b/graph/timeline_subscription_routing.go
@@ -1,0 +1,141 @@
+package graph
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/equaltoai/lesser/graph/model"
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/common"
+	apperrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/mastodon"
+	"github.com/equaltoai/lesser/pkg/streaming"
+)
+
+const (
+	timelineInputActorID = "actorId"
+	timelineInputHashtag = "hashtag"
+	timelineInputListID  = "listId"
+)
+
+type timelineRoutingInputs struct {
+	actorID *string
+	hashtag *string
+	listID  *string
+}
+
+type validatedTimelineRoute struct {
+	actorID string
+	hashtag string
+	listID  string
+}
+
+func validateTimelineRoutingInputs(timelineType model.TimelineType, inputs timelineRoutingInputs) (validatedTimelineRoute, error) {
+	if err := rejectUnexpectedTimelineRoutingInputs(timelineType, inputs); err != nil {
+		return validatedTimelineRoute{}, err
+	}
+
+	switch timelineType {
+	case model.TimelineTypeActor:
+		if inputs.actorID == nil {
+			return validatedTimelineRoute{}, ErrActorIDParameterRequired
+		}
+		actorID := strings.TrimSpace(*inputs.actorID)
+		if err := activitypub.ValidateUsername(actorID); err != nil {
+			return validatedTimelineRoute{}, invalidTimelineRoutingInput(timelineInputActorID, timelineType, "a valid actor stream username", err)
+		}
+		return validatedTimelineRoute{actorID: actorID}, nil
+	case model.TimelineTypeHashtag:
+		if inputs.hashtag == nil {
+			return validatedTimelineRoute{}, ErrHashtagParameterRequired
+		}
+		hashtag := mastodon.NormalizeHashtag(strings.TrimSpace(*inputs.hashtag))
+		if err := common.ValidateHashtag(hashtag); err != nil {
+			return validatedTimelineRoute{}, invalidTimelineRoutingInput(timelineInputHashtag, timelineType, "a valid hashtag", err)
+		}
+		return validatedTimelineRoute{hashtag: hashtag}, nil
+	case model.TimelineTypeList:
+		if inputs.listID == nil {
+			return validatedTimelineRoute{}, ErrListIDParameterRequired
+		}
+		listID := strings.TrimSpace(*inputs.listID)
+		if err := common.ValidateStatusID(listID); err != nil {
+			return validatedTimelineRoute{}, invalidTimelineRoutingInput(timelineInputListID, timelineType, "a valid list ID", err)
+		}
+		return validatedTimelineRoute{listID: listID}, nil
+	case model.TimelineTypePublic, model.TimelineTypeLocal, model.TimelineTypeHome, model.TimelineTypeDirect:
+		return validatedTimelineRoute{}, nil
+	default:
+		return validatedTimelineRoute{}, ErrUnsupportedTimelineTypeWithValue(timelineType)
+	}
+}
+
+func rejectUnexpectedTimelineRoutingInputs(timelineType model.TimelineType, inputs timelineRoutingInputs) error {
+	expected := ""
+	switch timelineType {
+	case model.TimelineTypeActor:
+		expected = timelineInputActorID
+	case model.TimelineTypeHashtag:
+		expected = timelineInputHashtag
+	case model.TimelineTypeList:
+		expected = timelineInputListID
+	case model.TimelineTypePublic, model.TimelineTypeLocal, model.TimelineTypeHome, model.TimelineTypeDirect:
+		// These established routes do not accept an identifying input.
+	default:
+		return ErrUnsupportedTimelineTypeWithValue(timelineType)
+	}
+
+	for _, input := range []struct {
+		name  string
+		value *string
+	}{
+		{name: timelineInputActorID, value: inputs.actorID},
+		{name: timelineInputHashtag, value: inputs.hashtag},
+		{name: timelineInputListID, value: inputs.listID},
+	} {
+		if input.value != nil && input.name != expected {
+			return apperrors.NewValidationError(input.name, fmt.Sprintf("not allowed for %s timeline", timelineType))
+		}
+	}
+
+	return nil
+}
+
+func invalidTimelineRoutingInput(field string, timelineType model.TimelineType, requirement string, cause error) error {
+	return apperrors.NewValidationError(field, fmt.Sprintf("must be %s for %s timeline", requirement, timelineType)).
+		WithInternalError(cause)
+}
+
+func timelineStreamName(username string, timelineType model.TimelineType, inputs timelineRoutingInputs) (string, error) {
+	route, err := validateTimelineRoutingInputs(timelineType, inputs)
+	if err != nil {
+		return "", err
+	}
+
+	switch timelineType {
+	case model.TimelineTypeHome:
+		username = strings.TrimSpace(username)
+		if err := common.ValidateRequiredParam("username", username); err != nil {
+			return "", ErrUsernameCannotBeEmpty
+		}
+		return streaming.UserStreamName(username), nil
+	case model.TimelineTypePublic:
+		return StreamNamePublic, nil
+	case model.TimelineTypeLocal:
+		return streaming.PublicLocalStream, nil
+	case model.TimelineTypeDirect:
+		username = strings.TrimSpace(username)
+		if err := common.ValidateRequiredParam("username", username); err != nil {
+			return "", ErrUsernameCannotBeEmpty
+		}
+		return streaming.DirectStreamName(username), nil
+	case model.TimelineTypeActor:
+		return streaming.UserStreamName(route.actorID), nil
+	case model.TimelineTypeHashtag:
+		return streaming.HashtagStreamName(route.hashtag), nil
+	case model.TimelineTypeList:
+		return streaming.ListStreamName(route.listID), nil
+	default:
+		return "", ErrUnsupportedTimelineTypeWithValue(timelineType)
+	}
+}

--- a/graph/timeline_subscription_routing_test.go
+++ b/graph/timeline_subscription_routing_test.go
@@ -27,10 +27,10 @@ func TestValidateTimelineRoutingInputsFailsClosed(t *testing.T) {
 		wantField    string
 		wantMessage  string
 	}{
-		{name: "actor missing", timelineType: model.TimelineTypeActor, wantField: "actorId", wantMessage: "parameter required"},
-		{name: "actor blank", timelineType: model.TimelineTypeActor, inputs: timelineRoutingInputs{actorID: &empty}, wantField: "actorId", wantMessage: "valid actor stream username"},
-		{name: "actor malformed", timelineType: model.TimelineTypeActor, inputs: timelineRoutingInputs{actorID: &invalidActor}, wantField: "actorId", wantMessage: "valid actor stream username"},
-		{name: "actor extra hashtag", timelineType: model.TimelineTypeActor, inputs: timelineRoutingInputs{actorID: &actor, hashtag: &hashtag}, wantField: "hashtag", wantMessage: "not allowed for ACTOR timeline"},
+		{name: "actor missing", timelineType: model.TimelineTypeActor, wantField: "actorUsername", wantMessage: "parameter required"},
+		{name: "actor blank", timelineType: model.TimelineTypeActor, inputs: timelineRoutingInputs{actorUsername: &empty}, wantField: "actorUsername", wantMessage: "valid local actor username"},
+		{name: "actor malformed", timelineType: model.TimelineTypeActor, inputs: timelineRoutingInputs{actorUsername: &invalidActor}, wantField: "actorUsername", wantMessage: "valid local actor username"},
+		{name: "actor extra hashtag", timelineType: model.TimelineTypeActor, inputs: timelineRoutingInputs{actorUsername: &actor, hashtag: &hashtag}, wantField: "hashtag", wantMessage: "not allowed for ACTOR timeline"},
 		{name: "hashtag missing", timelineType: model.TimelineTypeHashtag, wantField: "hashtag", wantMessage: "parameter required"},
 		{name: "hashtag blank", timelineType: model.TimelineTypeHashtag, inputs: timelineRoutingInputs{hashtag: &empty}, wantField: "hashtag", wantMessage: "valid hashtag"},
 		{name: "hashtag malformed", timelineType: model.TimelineTypeHashtag, inputs: timelineRoutingInputs{hashtag: &invalidHashtag}, wantField: "hashtag", wantMessage: "valid hashtag"},
@@ -38,11 +38,11 @@ func TestValidateTimelineRoutingInputsFailsClosed(t *testing.T) {
 		{name: "list missing", timelineType: model.TimelineTypeList, wantField: "listId", wantMessage: "parameter required"},
 		{name: "list blank", timelineType: model.TimelineTypeList, inputs: timelineRoutingInputs{listID: &empty}, wantField: "listId", wantMessage: "valid list ID"},
 		{name: "list malformed", timelineType: model.TimelineTypeList, inputs: timelineRoutingInputs{listID: &invalidList}, wantField: "listId", wantMessage: "valid list ID"},
-		{name: "list extra actor", timelineType: model.TimelineTypeList, inputs: timelineRoutingInputs{actorID: &actor, listID: &listID}, wantField: "actorId", wantMessage: "not allowed for LIST timeline"},
-		{name: "public extra actor", timelineType: model.TimelineTypePublic, inputs: timelineRoutingInputs{actorID: &actor}, wantField: "actorId", wantMessage: "not allowed for PUBLIC timeline"},
+		{name: "list extra actor", timelineType: model.TimelineTypeList, inputs: timelineRoutingInputs{actorUsername: &actor, listID: &listID}, wantField: "actorUsername", wantMessage: "not allowed for LIST timeline"},
+		{name: "public extra actor", timelineType: model.TimelineTypePublic, inputs: timelineRoutingInputs{actorUsername: &actor}, wantField: "actorUsername", wantMessage: "not allowed for PUBLIC timeline"},
 		{name: "local extra hashtag", timelineType: model.TimelineTypeLocal, inputs: timelineRoutingInputs{hashtag: &hashtag}, wantField: "hashtag", wantMessage: "not allowed for LOCAL timeline"},
 		{name: "home extra list", timelineType: model.TimelineTypeHome, inputs: timelineRoutingInputs{listID: &listID}, wantField: "listId", wantMessage: "not allowed for HOME timeline"},
-		{name: "direct extra actor", timelineType: model.TimelineTypeDirect, inputs: timelineRoutingInputs{actorID: &actor}, wantField: "actorId", wantMessage: "not allowed for DIRECT timeline"},
+		{name: "direct extra actor", timelineType: model.TimelineTypeDirect, inputs: timelineRoutingInputs{actorUsername: &actor}, wantField: "actorUsername", wantMessage: "not allowed for DIRECT timeline"},
 	}
 
 	for _, test := range tests {
@@ -70,7 +70,7 @@ func TestTimelineStreamNameCanonicalizesNewRoutingInputs(t *testing.T) {
 		inputs       timelineRoutingInputs
 		want         string
 	}{
-		{name: "actor", timelineType: model.TimelineTypeActor, inputs: timelineRoutingInputs{actorID: &actor}, want: streaming.UserStreamName("alice-1")},
+		{name: "actor", timelineType: model.TimelineTypeActor, inputs: timelineRoutingInputs{actorUsername: &actor}, want: streaming.PublicActorStreamName("alice-1")},
 		{name: "hashtag", timelineType: model.TimelineTypeHashtag, inputs: timelineRoutingInputs{hashtag: &hashtag}, want: streaming.HashtagStreamName("golang")},
 		{name: "list", timelineType: model.TimelineTypeList, inputs: timelineRoutingInputs{listID: &listID}, want: streaming.ListStreamName("list_123")},
 	}
@@ -101,7 +101,7 @@ func TestSubscribeToTimelinePersistsNewCanonicalRoutes(t *testing.T) {
 		inputs       timelineRoutingInputs
 		wantStream   string
 	}{
-		{name: "actor", timelineType: model.TimelineTypeActor, inputs: timelineRoutingInputs{actorID: &actor}, wantStream: streaming.UserStreamName("alice")},
+		{name: "actor", timelineType: model.TimelineTypeActor, inputs: timelineRoutingInputs{actorUsername: &actor}, wantStream: streaming.PublicActorStreamName("alice")},
 		{name: "hashtag", timelineType: model.TimelineTypeHashtag, inputs: timelineRoutingInputs{hashtag: &hashtag}, wantStream: streaming.HashtagStreamName("golang")},
 		{name: "list", timelineType: model.TimelineTypeList, inputs: timelineRoutingInputs{listID: &listID}, wantStream: streaming.ListStreamName("list-1")},
 	}
@@ -109,7 +109,7 @@ func TestSubscribeToTimelinePersistsNewCanonicalRoutes(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			updates, err := manager.SubscribeToTimeline(
-				ctx, "alice", test.timelineType, test.inputs.actorID, test.inputs.hashtag, test.inputs.listID,
+				ctx, "alice", test.timelineType, test.inputs.actorUsername, test.inputs.hashtag, test.inputs.listID,
 			)
 			require.NoError(t, err)
 			require.NotNil(t, updates)
@@ -131,6 +131,7 @@ func TestSubscribeToTimelineRejectsMalformedRoutesBeforePersistence(t *testing.T
 
 	invalidActor := "alice:admin"
 	invalidHashtag := "go:lang"
+	doublePrefixHashtag := "##golang"
 	invalidList := "list:private"
 	tests := []struct {
 		name          string
@@ -138,15 +139,16 @@ func TestSubscribeToTimelineRejectsMalformedRoutesBeforePersistence(t *testing.T
 		inputs        timelineRoutingInputs
 		forbiddenName string
 	}{
-		{name: "actor", timelineType: model.TimelineTypeActor, inputs: timelineRoutingInputs{actorID: &invalidActor}, forbiddenName: "user:alice:admin"},
+		{name: "actor", timelineType: model.TimelineTypeActor, inputs: timelineRoutingInputs{actorUsername: &invalidActor}, forbiddenName: "public:actor:alice:admin"},
 		{name: "hashtag", timelineType: model.TimelineTypeHashtag, inputs: timelineRoutingInputs{hashtag: &invalidHashtag}, forbiddenName: "hashtag:go:lang"},
+		{name: "hashtag double prefix", timelineType: model.TimelineTypeHashtag, inputs: timelineRoutingInputs{hashtag: &doublePrefixHashtag}, forbiddenName: "hashtag:#golang"},
 		{name: "list", timelineType: model.TimelineTypeList, inputs: timelineRoutingInputs{listID: &invalidList}, forbiddenName: "list:list:private"},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := manager.SubscribeToTimeline(
-				ctx, "alice", test.timelineType, test.inputs.actorID, test.inputs.hashtag, test.inputs.listID,
+				ctx, "alice", test.timelineType, test.inputs.actorUsername, test.inputs.hashtag, test.inputs.listID,
 			)
 			require.Error(t, err)
 
@@ -170,6 +172,15 @@ func TestTimelineUpdatesListIsAuthenticatedOnly(t *testing.T) {
 
 	listID := " list-1 "
 	_, err := resolver.Subscription().TimelineUpdates(
+		WithConnectionID(round12AuthContext("mallory"), "non-owner-list"), model.TimelineTypeList, nil, nil, &listID,
+	)
+	require.ErrorIs(t, err, ErrListNotFoundOrAccessDenied)
+
+	subscriptions, err := connRepo.GetSubscriptionsForStream(ctx, streaming.ListStreamName("list-1"))
+	require.NoError(t, err)
+	require.Empty(t, subscriptions)
+
+	_, err = resolver.Subscription().TimelineUpdates(
 		WithConnectionID(context.Background(), "anonymous-list"), model.TimelineTypeList, nil, nil, &listID,
 	)
 	require.ErrorIs(t, err, ErrAuthenticationRequired)
@@ -180,7 +191,7 @@ func TestTimelineUpdatesListIsAuthenticatedOnly(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, updates)
 
-	subscriptions, err := connRepo.GetSubscriptionsForStream(ctx, streaming.ListStreamName("list-1"))
+	subscriptions, err = connRepo.GetSubscriptionsForStream(ctx, streaming.ListStreamName("list-1"))
 	require.NoError(t, err)
 	require.Len(t, subscriptions, 1)
 }

--- a/graph/timeline_subscription_routing_test.go
+++ b/graph/timeline_subscription_routing_test.go
@@ -60,7 +60,7 @@ func TestValidateTimelineRoutingInputsFailsClosed(t *testing.T) {
 }
 
 func TestTimelineStreamNameCanonicalizesNewRoutingInputs(t *testing.T) {
-	actor := " alice-1 "
+	actor := " Alice-1 "
 	hashtag := " #GoLang "
 	listID := " list_123 "
 

--- a/graph/timeline_subscription_routing_test.go
+++ b/graph/timeline_subscription_routing_test.go
@@ -1,0 +1,186 @@
+package graph
+
+import (
+	"context"
+	"testing"
+
+	"github.com/equaltoai/lesser/graph/model"
+	apperrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/streaming"
+	"github.com/equaltoai/lesser/pkg/testing/inmemory"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateTimelineRoutingInputsFailsClosed(t *testing.T) {
+	actor := "alice"
+	hashtag := "golang"
+	listID := "list-1"
+	empty := " \t "
+	invalidActor := "alice:admin"
+	invalidHashtag := "go:lang"
+	invalidList := "list:1"
+
+	tests := []struct {
+		name         string
+		timelineType model.TimelineType
+		inputs       timelineRoutingInputs
+		wantField    string
+		wantMessage  string
+	}{
+		{name: "actor missing", timelineType: model.TimelineTypeActor, wantField: "actorId", wantMessage: "parameter required"},
+		{name: "actor blank", timelineType: model.TimelineTypeActor, inputs: timelineRoutingInputs{actorID: &empty}, wantField: "actorId", wantMessage: "valid actor stream username"},
+		{name: "actor malformed", timelineType: model.TimelineTypeActor, inputs: timelineRoutingInputs{actorID: &invalidActor}, wantField: "actorId", wantMessage: "valid actor stream username"},
+		{name: "actor extra hashtag", timelineType: model.TimelineTypeActor, inputs: timelineRoutingInputs{actorID: &actor, hashtag: &hashtag}, wantField: "hashtag", wantMessage: "not allowed for ACTOR timeline"},
+		{name: "hashtag missing", timelineType: model.TimelineTypeHashtag, wantField: "hashtag", wantMessage: "parameter required"},
+		{name: "hashtag blank", timelineType: model.TimelineTypeHashtag, inputs: timelineRoutingInputs{hashtag: &empty}, wantField: "hashtag", wantMessage: "valid hashtag"},
+		{name: "hashtag malformed", timelineType: model.TimelineTypeHashtag, inputs: timelineRoutingInputs{hashtag: &invalidHashtag}, wantField: "hashtag", wantMessage: "valid hashtag"},
+		{name: "hashtag extra list", timelineType: model.TimelineTypeHashtag, inputs: timelineRoutingInputs{hashtag: &hashtag, listID: &listID}, wantField: "listId", wantMessage: "not allowed for HASHTAG timeline"},
+		{name: "list missing", timelineType: model.TimelineTypeList, wantField: "listId", wantMessage: "parameter required"},
+		{name: "list blank", timelineType: model.TimelineTypeList, inputs: timelineRoutingInputs{listID: &empty}, wantField: "listId", wantMessage: "valid list ID"},
+		{name: "list malformed", timelineType: model.TimelineTypeList, inputs: timelineRoutingInputs{listID: &invalidList}, wantField: "listId", wantMessage: "valid list ID"},
+		{name: "list extra actor", timelineType: model.TimelineTypeList, inputs: timelineRoutingInputs{actorID: &actor, listID: &listID}, wantField: "actorId", wantMessage: "not allowed for LIST timeline"},
+		{name: "public extra actor", timelineType: model.TimelineTypePublic, inputs: timelineRoutingInputs{actorID: &actor}, wantField: "actorId", wantMessage: "not allowed for PUBLIC timeline"},
+		{name: "local extra hashtag", timelineType: model.TimelineTypeLocal, inputs: timelineRoutingInputs{hashtag: &hashtag}, wantField: "hashtag", wantMessage: "not allowed for LOCAL timeline"},
+		{name: "home extra list", timelineType: model.TimelineTypeHome, inputs: timelineRoutingInputs{listID: &listID}, wantField: "listId", wantMessage: "not allowed for HOME timeline"},
+		{name: "direct extra actor", timelineType: model.TimelineTypeDirect, inputs: timelineRoutingInputs{actorID: &actor}, wantField: "actorId", wantMessage: "not allowed for DIRECT timeline"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := validateTimelineRoutingInputs(test.timelineType, test.inputs)
+			require.Error(t, err)
+			require.True(t, apperrors.HasCode(err, apperrors.CodeValidationFailed), "unexpected error: %v", err)
+			require.ErrorContains(t, err, test.wantMessage)
+
+			var appErr *apperrors.AppError
+			require.ErrorAs(t, err, &appErr)
+			require.Equal(t, test.wantField, appErr.Metadata["field"])
+		})
+	}
+}
+
+func TestTimelineStreamNameCanonicalizesNewRoutingInputs(t *testing.T) {
+	actor := " alice-1 "
+	hashtag := " #GoLang "
+	listID := " list_123 "
+
+	tests := []struct {
+		name         string
+		timelineType model.TimelineType
+		inputs       timelineRoutingInputs
+		want         string
+	}{
+		{name: "actor", timelineType: model.TimelineTypeActor, inputs: timelineRoutingInputs{actorID: &actor}, want: streaming.UserStreamName("alice-1")},
+		{name: "hashtag", timelineType: model.TimelineTypeHashtag, inputs: timelineRoutingInputs{hashtag: &hashtag}, want: streaming.HashtagStreamName("golang")},
+		{name: "list", timelineType: model.TimelineTypeList, inputs: timelineRoutingInputs{listID: &listID}, want: streaming.ListStreamName("list_123")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := timelineStreamName("", test.timelineType, test.inputs)
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestSubscribeToTimelinePersistsNewCanonicalRoutes(t *testing.T) {
+	connRepo := inmemory.NewStreamingConnectionRepository()
+	manager := NewGraphQLSubscriptionManager(connRepo, streaming.NewMockPublisher(), nil)
+	ctx, cancel := context.WithCancel(WithConnectionID(context.Background(), "routing-inputs-conn"))
+	t.Cleanup(cancel)
+	require.NoError(t, manager.Start(ctx))
+	t.Cleanup(func() { _ = manager.Stop() })
+
+	actor := " alice "
+	hashtag := " #GoLang "
+	listID := " list-1 "
+	tests := []struct {
+		name         string
+		timelineType model.TimelineType
+		inputs       timelineRoutingInputs
+		wantStream   string
+	}{
+		{name: "actor", timelineType: model.TimelineTypeActor, inputs: timelineRoutingInputs{actorID: &actor}, wantStream: streaming.UserStreamName("alice")},
+		{name: "hashtag", timelineType: model.TimelineTypeHashtag, inputs: timelineRoutingInputs{hashtag: &hashtag}, wantStream: streaming.HashtagStreamName("golang")},
+		{name: "list", timelineType: model.TimelineTypeList, inputs: timelineRoutingInputs{listID: &listID}, wantStream: streaming.ListStreamName("list-1")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			updates, err := manager.SubscribeToTimeline(
+				ctx, "alice", test.timelineType, test.inputs.actorID, test.inputs.hashtag, test.inputs.listID,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, updates)
+
+			subscriptions, err := connRepo.GetSubscriptionsForStream(ctx, test.wantStream)
+			require.NoError(t, err)
+			require.Len(t, subscriptions, 1)
+		})
+	}
+}
+
+func TestSubscribeToTimelineRejectsMalformedRoutesBeforePersistence(t *testing.T) {
+	connRepo := inmemory.NewStreamingConnectionRepository()
+	manager := NewGraphQLSubscriptionManager(connRepo, streaming.NewMockPublisher(), nil)
+	ctx, cancel := context.WithCancel(WithConnectionID(context.Background(), "invalid-routing-conn"))
+	t.Cleanup(cancel)
+	require.NoError(t, manager.Start(ctx))
+	t.Cleanup(func() { _ = manager.Stop() })
+
+	invalidActor := "alice:admin"
+	invalidHashtag := "go:lang"
+	invalidList := "list:private"
+	tests := []struct {
+		name          string
+		timelineType  model.TimelineType
+		inputs        timelineRoutingInputs
+		forbiddenName string
+	}{
+		{name: "actor", timelineType: model.TimelineTypeActor, inputs: timelineRoutingInputs{actorID: &invalidActor}, forbiddenName: "user:alice:admin"},
+		{name: "hashtag", timelineType: model.TimelineTypeHashtag, inputs: timelineRoutingInputs{hashtag: &invalidHashtag}, forbiddenName: "hashtag:go:lang"},
+		{name: "list", timelineType: model.TimelineTypeList, inputs: timelineRoutingInputs{listID: &invalidList}, forbiddenName: "list:list:private"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := manager.SubscribeToTimeline(
+				ctx, "alice", test.timelineType, test.inputs.actorID, test.inputs.hashtag, test.inputs.listID,
+			)
+			require.Error(t, err)
+
+			subscriptions, lookupErr := connRepo.GetSubscriptionsForStream(ctx, test.forbiddenName)
+			require.NoError(t, lookupErr)
+			require.Empty(t, subscriptions)
+		})
+	}
+}
+
+func TestTimelineUpdatesListIsAuthenticatedOnly(t *testing.T) {
+	resolver, _ := newRound12GraphResolver(t)
+	connRepo := inmemory.NewStreamingConnectionRepository()
+	manager := NewSubscriptionManager(connRepo, streaming.NewMockPublisher(), nil)
+	resolver.SubscriptionManager = manager
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	require.NoError(t, manager.Start(ctx))
+	t.Cleanup(func() { _ = manager.Stop() })
+
+	listID := " list-1 "
+	_, err := resolver.Subscription().TimelineUpdates(
+		WithConnectionID(context.Background(), "anonymous-list"), model.TimelineTypeList, nil, nil, &listID,
+	)
+	require.ErrorIs(t, err, ErrAuthenticationRequired)
+
+	updates, err := resolver.Subscription().TimelineUpdates(
+		WithConnectionID(round12AuthContext("alice"), "authenticated-list"), model.TimelineTypeList, nil, nil, &listID,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, updates)
+
+	subscriptions, err := connRepo.GetSubscriptionsForStream(ctx, streaming.ListStreamName("list-1"))
+	require.NoError(t, err)
+	require.Len(t, subscriptions, 1)
+}

--- a/pkg/federation/remote_note_materialization.go
+++ b/pkg/federation/remote_note_materialization.go
@@ -36,6 +36,10 @@ func MaterializeRemoteNote(
 	if note == nil {
 		return nil, fmt.Errorf("remote note is required")
 	}
+	status := BuildCanonicalRemoteStatus(note, localDomain)
+	if status == nil {
+		return nil, fmt.Errorf("canonical remote status payload is invalid")
+	}
 
 	if objectRepo != nil {
 		if err := objectRepo.CreateObject(ctx, note); err != nil && !dynamormerrors.IsConditionFailed(err) && !stdErrors.Is(err, storage.ErrAlreadyExists) {
@@ -43,10 +47,6 @@ func MaterializeRemoteNote(
 		}
 	}
 
-	status := BuildCanonicalRemoteStatus(note, localDomain)
-	if status == nil {
-		return nil, fmt.Errorf("canonical remote status payload is invalid")
-	}
 	if err := status.UpdateKeys(); err != nil {
 		return nil, err
 	}

--- a/pkg/federation/remote_note_status_projection.go
+++ b/pkg/federation/remote_note_status_projection.go
@@ -1,6 +1,7 @@
 package federation
 
 import (
+	"net/url"
 	"strings"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
@@ -14,7 +15,13 @@ func BuildCanonicalRemoteStatus(note *activitypub.Note, localDomain string) *mod
 	if note == nil {
 		return nil
 	}
-	if remoteNoteAttributionIsLocal(note.AttributedTo, localDomain) {
+	local := remoteNoteLocalDomain(localDomain)
+	if local == "" {
+		// Fail closed: a projection with no valid local domain anchor is never
+		// safe, because the local-author rejection below cannot be evaluated.
+		return nil
+	}
+	if remoteNoteAttributionIsLocal(note.AttributedTo, local) {
 		return nil
 	}
 	statusID := models.CanonicalStatusIDForDomain(note.ID, localDomain)
@@ -41,20 +48,30 @@ func BuildCanonicalRemoteStatus(note *activitypub.Note, localDomain string) *mod
 	return status
 }
 
-// remoteNoteAttributionIsLocal applies the canonical actor-URL rules used by
-// inbox origin binding before comparing the attributed actor's host with this
-// instance. Remote projection is never a valid entry point for local actors.
-func remoteNoteAttributionIsLocal(attributedTo, localDomain string) bool {
-	canonicalActorID, err := common.CanonicalActorID(attributedTo)
-	if err != nil {
-		return false
-	}
-	if _, err := common.ActorUsernameFromID(canonicalActorID); err != nil {
-		return false
-	}
+// remoteNoteAttributionIsLocal compares the attributed actor's host with this
+// instance using the same lenient host extraction the fanout consumers apply
+// (url.Parse host, case-insensitive, agnostic to path shape, query, fragment,
+// userinfo, and port). Guard and consumer must agree by construction: any
+// actor ID the stream router treats as local must be rejected here. Remote
+// actors with non-canonical path shapes (/profile/<name>, /actor, etc.) still
+// project — their host is not local, so they cannot reach local stream keys.
+func remoteNoteAttributionIsLocal(attributedTo, normalizedLocalDomain string) bool {
+	actorDomain := normalizeActorDomain(common.ExtractDomainFromActorID(strings.TrimSpace(attributedTo)))
+	return actorDomain != "" && actorDomain == normalizedLocalDomain
+}
 
-	actorDomain := normalizeActorDomain(common.ExtractDomainFromActorID(canonicalActorID))
-	return actorDomain != "" && actorDomain == normalizeActorDomain(localDomain)
+// remoteNoteLocalDomain normalizes the configured local domain (with or
+// without scheme) and fails closed on any value that cannot be a valid host.
+func remoteNoteLocalDomain(localDomain string) string {
+	local := normalizeActorDomain(localDomain)
+	if local == "" {
+		return ""
+	}
+	u, err := url.Parse("https://" + local)
+	if err != nil || u.Hostname() != local {
+		return ""
+	}
+	return local
 }
 
 func remoteStatusAuthorUsername(note *activitypub.Note, localDomain string) string {

--- a/pkg/federation/remote_note_status_projection.go
+++ b/pkg/federation/remote_note_status_projection.go
@@ -48,16 +48,46 @@ func BuildCanonicalRemoteStatus(note *activitypub.Note, localDomain string) *mod
 	return status
 }
 
-// remoteNoteAttributionIsLocal compares the attributed actor's host with this
-// instance using the same lenient host extraction the fanout consumers apply
-// (url.Parse host, case-insensitive, agnostic to path shape, query, fragment,
-// userinfo, and port). Guard and consumer must agree by construction: any
-// actor ID the stream router treats as local must be rejected here. Remote
-// actors with non-canonical path shapes (/profile/<name>, /actor, etc.) still
+// remoteNoteAttributionIsLocal decides whether an attributed actor must be
+// treated as local, in which case the note must never be projected from a
+// remote-fed object.
+//
+// The primary test parses with net/url — the same parser family the fanout
+// consumer (StreamRouterHandler.isLocalActorID) parses with, including its
+// scheme lowercasing, Hostname() extraction with Host fallback, and
+// case-insensitive host compare. On top of that the guard trims surrounding
+// whitespace, fails closed on parse errors and empty input, and adds an
+// additive canonical branch, so the guard rejects a strict superset of the
+// IDs the consumer treats as local: consumer-local always implies
+// guard-local. The remaining divergence is therefore one-directional in the
+// safe direction only (e.g. a whitespace-padded or unparseable ID is local
+// here but not to the consumer).
+//
+// The canonical branch is independent defense: CanonicalActorID normalizes
+// the scheme, so it covers case-variant schemes even if the primary parse
+// ever diverged from the consumer again. A canonicalization failure
+// contributes no rejection and falls through to the host compare, so honest
+// remote path shapes (/profile/<name>, /actor, /api/v1/accounts/<name>) still
 // project — their host is not local, so they cannot reach local stream keys.
 func remoteNoteAttributionIsLocal(attributedTo, normalizedLocalDomain string) bool {
-	actorDomain := normalizeActorDomain(common.ExtractDomainFromActorID(strings.TrimSpace(attributedTo)))
-	return actorDomain != "" && actorDomain == normalizedLocalDomain
+	if canonical, err := common.CanonicalActorID(attributedTo); err == nil {
+		if domain := normalizeActorDomain(common.ExtractDomainFromActorID(canonical)); domain != "" && domain == normalizedLocalDomain {
+			return true
+		}
+	}
+	trimmed := strings.TrimSpace(attributedTo)
+	if trimmed == "" {
+		return true // no attribution is never safe to project
+	}
+	u, err := url.Parse(trimmed)
+	if err != nil {
+		return true // fail closed
+	}
+	host := u.Hostname()
+	if host == "" {
+		host = u.Host
+	}
+	return strings.EqualFold(strings.TrimSpace(host), normalizedLocalDomain)
 }
 
 // remoteNoteLocalDomain normalizes the configured local domain (with or

--- a/pkg/federation/remote_note_status_projection.go
+++ b/pkg/federation/remote_note_status_projection.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 )
 
@@ -13,7 +14,9 @@ func BuildCanonicalRemoteStatus(note *activitypub.Note, localDomain string) *mod
 	if note == nil {
 		return nil
 	}
-
+	if remoteNoteAttributionIsLocal(note.AttributedTo, localDomain) {
+		return nil
+	}
 	statusID := models.CanonicalStatusIDForDomain(note.ID, localDomain)
 	if statusID == "" {
 		return nil
@@ -36,6 +39,22 @@ func BuildCanonicalRemoteStatus(note *activitypub.Note, localDomain string) *mod
 	}
 
 	return status
+}
+
+// remoteNoteAttributionIsLocal applies the canonical actor-URL rules used by
+// inbox origin binding before comparing the attributed actor's host with this
+// instance. Remote projection is never a valid entry point for local actors.
+func remoteNoteAttributionIsLocal(attributedTo, localDomain string) bool {
+	canonicalActorID, err := common.CanonicalActorID(attributedTo)
+	if err != nil {
+		return false
+	}
+	if _, err := common.ActorUsernameFromID(canonicalActorID); err != nil {
+		return false
+	}
+
+	actorDomain := normalizeActorDomain(common.ExtractDomainFromActorID(canonicalActorID))
+	return actorDomain != "" && actorDomain == normalizeActorDomain(localDomain)
 }
 
 func remoteStatusAuthorUsername(note *activitypub.Note, localDomain string) string {

--- a/pkg/federation/remote_note_status_projection_test.go
+++ b/pkg/federation/remote_note_status_projection_test.go
@@ -51,6 +51,9 @@ func TestBuildCanonicalRemoteStatus_RejectsRemoteProjectionOfLocalAuthors(t *tes
 		"https://local.example/users/admin/alice",
 		"https://local.example/api/v1/accounts/alice",
 		"https://local.example/alice",
+		"HTTP://local.example/users/alice",
+		"HTTPS://local.example/users/alice",
+		"HttPs://local.example/users/alice",
 	} {
 		t.Run(attributedTo, func(t *testing.T) {
 			note := &activitypub.Note{

--- a/pkg/federation/remote_note_status_projection_test.go
+++ b/pkg/federation/remote_note_status_projection_test.go
@@ -39,19 +39,27 @@ func TestBuildCanonicalRemoteStatus(t *testing.T) {
 	assert.Equal(t, "hello world", note.Content)
 }
 
-func TestBuildCanonicalRemoteStatus_LocalAndInvalidInputs(t *testing.T) {
-	localNote := &activitypub.Note{
-		BaseObject: activitypub.BaseObject{
-			ID:   "https://remote.example/users/alice/statuses/2",
-			Type: activitypub.NoteType,
-		},
-		AttributedTo: "https://local.example/users/alice",
+func TestBuildCanonicalRemoteStatus_RejectsRemoteProjectionOfLocalAuthors(t *testing.T) {
+	for _, attributedTo := range []string{
+		"https://local.example/users/alice",
+		"https://LOCAL.EXAMPLE/users/Alice/",
+		"https://local.example:443/@alice",
+	} {
+		t.Run(attributedTo, func(t *testing.T) {
+			note := &activitypub.Note{
+				BaseObject: activitypub.BaseObject{
+					ID:   "https://remote.example/users/mallory/statuses/2",
+					Type: activitypub.NoteType,
+				},
+				AttributedTo: attributedTo,
+			}
+
+			assert.Nil(t, BuildCanonicalRemoteStatus(note, "https://local.example"))
+		})
 	}
+}
 
-	status := BuildCanonicalRemoteStatus(localNote, "local.example")
-	require.NotNil(t, status)
-	assert.Equal(t, "alice", status.AuthorUsername)
-
+func TestBuildCanonicalRemoteStatus_InvalidInputs(t *testing.T) {
 	assert.Nil(t, BuildCanonicalRemoteStatus(nil, "local.example"))
 	assert.Nil(t, BuildCanonicalRemoteStatus(&activitypub.Note{}, "local.example"))
 }

--- a/pkg/federation/remote_note_status_projection_test.go
+++ b/pkg/federation/remote_note_status_projection_test.go
@@ -44,6 +44,13 @@ func TestBuildCanonicalRemoteStatus_RejectsRemoteProjectionOfLocalAuthors(t *tes
 		"https://local.example/users/alice",
 		"https://LOCAL.EXAMPLE/users/Alice/",
 		"https://local.example:443/@alice",
+		"https://local.example/users/alice?x=1",
+		"https://local.example/users/alice#fragment",
+		"https://user@local.example/users/alice",
+		"https://local.example/foo/alice",
+		"https://local.example/users/admin/alice",
+		"https://local.example/api/v1/accounts/alice",
+		"https://local.example/alice",
 	} {
 		t.Run(attributedTo, func(t *testing.T) {
 			note := &activitypub.Note{
@@ -59,9 +66,51 @@ func TestBuildCanonicalRemoteStatus_RejectsRemoteProjectionOfLocalAuthors(t *tes
 	}
 }
 
+func TestBuildCanonicalRemoteStatus_AllowsHonestRemoteActorPaths(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		attributedTo   string
+		authorUsername string
+	}{
+		{name: "bob", attributedTo: "https://remote.example/users/bob", authorUsername: "bob@remote.example"},
+		{name: "remote username collision", attributedTo: "https://remote.example/users/alice", authorUsername: "alice@remote.example"},
+		{name: "profile path", attributedTo: "https://remote.example/profile/carol", authorUsername: "carol@remote.example"},
+		{name: "actor path", attributedTo: "https://remote.example/actor", authorUsername: "actor@remote.example"},
+		{name: "api account path", attributedTo: "https://remote.example/api/v1/accounts/dave", authorUsername: "dave@remote.example"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			note := &activitypub.Note{
+				BaseObject: activitypub.BaseObject{
+					ID:   "https://remote.example/objects/remote-path-control",
+					Type: activitypub.NoteType,
+				},
+				AttributedTo: test.attributedTo,
+			}
+
+			status := BuildCanonicalRemoteStatus(note, "https://local.example")
+			require.NotNil(t, status)
+			assert.Equal(t, test.attributedTo, status.AuthorID)
+			assert.Equal(t, test.authorUsername, status.AuthorUsername)
+		})
+	}
+}
+
 func TestBuildCanonicalRemoteStatus_InvalidInputs(t *testing.T) {
 	assert.Nil(t, BuildCanonicalRemoteStatus(nil, "local.example"))
 	assert.Nil(t, BuildCanonicalRemoteStatus(&activitypub.Note{}, "local.example"))
+
+	note := &activitypub.Note{
+		BaseObject: activitypub.BaseObject{
+			ID:   "https://remote.example/objects/missing-domain-anchor",
+			Type: activitypub.NoteType,
+		},
+		AttributedTo: "https://remote.example/users/bob",
+	}
+	for _, localDomain := range []string{"", " ", "://", "not a domain"} {
+		t.Run("local domain "+localDomain, func(t *testing.T) {
+			assert.Nil(t, BuildCanonicalRemoteStatus(note, localDomain))
+		})
+	}
 }
 
 func TestRemoteNoteStatusProjectionHelpers(t *testing.T) {

--- a/pkg/federation/remotenotes/reply_parent_resolver_test.go
+++ b/pkg/federation/remotenotes/reply_parent_resolver_test.go
@@ -181,6 +181,9 @@ func TestReplyParentResolver_ResolveReplyParent(t *testing.T) {
 			"https://example.com/users/alice",
 			"https://example.com/users/alice?x=1",
 			"https://example.com/foo/alice",
+			"HTTP://example.com/users/alice",
+			"HTTPS://example.com/users/alice",
+			"HttPs://example.com/users/alice",
 		} {
 			t.Run(attributedTo, func(t *testing.T) {
 				parentURL := "https://evil.example/objects/forged-parent"

--- a/pkg/federation/remotenotes/reply_parent_resolver_test.go
+++ b/pkg/federation/remotenotes/reply_parent_resolver_test.go
@@ -176,6 +176,31 @@ func TestReplyParentResolver_ResolveReplyParent(t *testing.T) {
 		assert.Equal(t, "https://example.com/users/alice", fetcher.gotActor.ID)
 	})
 
+	t.Run("rejects fetched remote parent attributed to a local actor", func(t *testing.T) {
+		parentURL := "https://evil.example/objects/forged-parent"
+		statusRepo := &stubStatusRepo{}
+		objectRepo := &stubObjectRepo{}
+		forged := remoteNoteObject(parentURL, models.VisibilityPublic)
+		forged["attributedTo"] = "https://example.com/users/alice"
+		resolver := NewReplyParentResolver(
+			statusRepo,
+			objectRepo,
+			&stubDomainBlockRepo{},
+			&stubFetcher{obj: forged},
+			"example.com",
+			zap.NewNop(),
+		)
+
+		_, err := resolver.ResolveReplyParent(context.Background(), localAuthorAccount("alice"), parentURL, models.VisibilityPublic)
+		require.Error(t, err)
+		appErr, ok := commonerrors.AsAppError(err)
+		require.True(t, ok)
+		assert.Equal(t, commonerrors.CodeExternalServiceUnavailable, appErr.Code)
+		assert.Empty(t, objectRepo.created)
+		assert.Empty(t, statusRepo.byID)
+		assert.Empty(t, statusRepo.byURL)
+	})
+
 	t.Run("timeout maps to 408", func(t *testing.T) {
 		parentURL := "https://remote.example/users/steward/statuses/slow"
 		resolver := NewReplyParentResolver(

--- a/pkg/federation/remotenotes/reply_parent_resolver_test.go
+++ b/pkg/federation/remotenotes/reply_parent_resolver_test.go
@@ -177,28 +177,36 @@ func TestReplyParentResolver_ResolveReplyParent(t *testing.T) {
 	})
 
 	t.Run("rejects fetched remote parent attributed to a local actor", func(t *testing.T) {
-		parentURL := "https://evil.example/objects/forged-parent"
-		statusRepo := &stubStatusRepo{}
-		objectRepo := &stubObjectRepo{}
-		forged := remoteNoteObject(parentURL, models.VisibilityPublic)
-		forged["attributedTo"] = "https://example.com/users/alice"
-		resolver := NewReplyParentResolver(
-			statusRepo,
-			objectRepo,
-			&stubDomainBlockRepo{},
-			&stubFetcher{obj: forged},
-			"example.com",
-			zap.NewNop(),
-		)
+		for _, attributedTo := range []string{
+			"https://example.com/users/alice",
+			"https://example.com/users/alice?x=1",
+			"https://example.com/foo/alice",
+		} {
+			t.Run(attributedTo, func(t *testing.T) {
+				parentURL := "https://evil.example/objects/forged-parent"
+				statusRepo := &stubStatusRepo{}
+				objectRepo := &stubObjectRepo{}
+				forged := remoteNoteObject(parentURL, models.VisibilityPublic)
+				forged["attributedTo"] = attributedTo
+				resolver := NewReplyParentResolver(
+					statusRepo,
+					objectRepo,
+					&stubDomainBlockRepo{},
+					&stubFetcher{obj: forged},
+					"example.com",
+					zap.NewNop(),
+				)
 
-		_, err := resolver.ResolveReplyParent(context.Background(), localAuthorAccount("alice"), parentURL, models.VisibilityPublic)
-		require.Error(t, err)
-		appErr, ok := commonerrors.AsAppError(err)
-		require.True(t, ok)
-		assert.Equal(t, commonerrors.CodeExternalServiceUnavailable, appErr.Code)
-		assert.Empty(t, objectRepo.created)
-		assert.Empty(t, statusRepo.byID)
-		assert.Empty(t, statusRepo.byURL)
+				_, err := resolver.ResolveReplyParent(context.Background(), localAuthorAccount("alice"), parentURL, models.VisibilityPublic)
+				require.Error(t, err)
+				appErr, ok := commonerrors.AsAppError(err)
+				require.True(t, ok)
+				assert.Equal(t, commonerrors.CodeExternalServiceUnavailable, appErr.Code)
+				assert.Empty(t, objectRepo.created)
+				assert.Empty(t, statusRepo.byID)
+				assert.Empty(t, statusRepo.byURL)
+			})
+		}
 	})
 
 	t.Run("timeout maps to 408", func(t *testing.T) {

--- a/pkg/services/hashtags/service.go
+++ b/pkg/services/hashtags/service.go
@@ -482,7 +482,9 @@ func (s *Service) relatedHashtags(ctx context.Context, hashtag string, limit int
 	return result
 }
 
-// publishUserEvent notifies websocket clients about hashtag follow-related operations.
+// publishUserEvent notifies only the user who changed their hashtag settings.
+// Follow, unfollow, and mute state is private and must not be published onto
+// the shared hashtag stream used by anonymous timeline subscribers.
 func (s *Service) publishUserEvent(ctx context.Context, eventType, userID, hashtag string) {
 	if s.publisher == nil {
 		return
@@ -498,14 +500,6 @@ func (s *Service) publishUserEvent(ctx context.Context, eventType, userID, hasht
 		s.logger.Warn("failed to publish user hashtag event",
 			zap.String("type", eventType),
 			zap.String("user_id", userID),
-			zap.String("hashtag", hashtag),
-			zap.Error(err))
-	}
-
-	// Broadcast to hashtag stream as well so hashtag timelines receive updates.
-	if err := s.publisher.PublishToStream(ctx, streaming.HashtagStreamName(hashtag), event); err != nil {
-		s.logger.Debug("failed to publish hashtag stream event",
-			zap.String("type", eventType),
 			zap.String("hashtag", hashtag),
 			zap.Error(err))
 	}

--- a/pkg/services/hashtags/service_round31_more_coverage_test.go
+++ b/pkg/services/hashtags/service_round31_more_coverage_test.go
@@ -143,18 +143,18 @@ func TestUniqueNormalizedHashtags_DedupesAndNormalizes(t *testing.T) {
 	assert.Equal(t, []string{"golang", "testing"}, out)
 }
 
-func TestService_publishUserEvent_HandlesPublisherErrors(t *testing.T) {
+func TestService_publishUserEvent_RemainsUserScopedOnPublisherError(t *testing.T) {
 	t.Parallel()
 
 	publisher := new(mockPublisher)
 	service := NewService(nil, nil, nil, publisher, zap.NewNop())
 
 	publisher.On("PublishToUser", mock.Anything, "alice", mock.Anything).Return(errors.New("user publish failed")).Once()
-	publisher.On("PublishToStream", mock.Anything, streaming.HashtagStreamName("golang"), mock.Anything).Return(errors.New("stream publish failed")).Once()
 
 	service.publishUserEvent(context.Background(), streaming.HashtagFollowed, "alice", "golang")
 
 	publisher.AssertExpectations(t)
+	publisher.AssertNotCalled(t, "PublishToStream", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestService_publishInternalHashtagEvent_SkipsWithoutPublisher(t *testing.T) {

--- a/pkg/services/hashtags/service_test.go
+++ b/pkg/services/hashtags/service_test.go
@@ -216,11 +216,8 @@ func TestFollowHashtag(t *testing.T) {
 		return event != nil && event.Type == streaming.HashtagFollowed
 	})).Return(nil).Once()
 	publisher.On("PublishToStream", mock.Anything, streaming.HashtagStreamName("golang"), mock.MatchedBy(func(event *streaming.Event) bool {
-		if event == nil {
-			return false
-		}
-		return event.Type == streaming.HashtagFollowed || event.Type == string(streaming.EventTypeHashtagUpdate)
-	})).Return(nil).Twice()
+		return event != nil && event.Type == string(streaming.EventTypeHashtagUpdate)
+	})).Return(nil).Once()
 
 	service := newTestService(repo, publisher)
 
@@ -237,6 +234,9 @@ func TestFollowHashtag(t *testing.T) {
 
 	repo.AssertExpectations(t)
 	publisher.AssertExpectations(t)
+	publisher.AssertNotCalled(t, "PublishToStream", mock.Anything, streaming.HashtagStreamName("golang"), mock.MatchedBy(func(event *streaming.Event) bool {
+		return event != nil && event.Type == streaming.HashtagFollowed
+	}))
 }
 
 func TestUnfollowHashtag(t *testing.T) {
@@ -267,11 +267,8 @@ func TestUnfollowHashtag(t *testing.T) {
 		return event != nil && event.Type == "hashtag.unfollowed"
 	})).Return(nil).Once()
 	publisher.On("PublishToStream", mock.Anything, streaming.HashtagStreamName("golang"), mock.MatchedBy(func(event *streaming.Event) bool {
-		if event == nil {
-			return false
-		}
-		return event.Type == "hashtag.unfollowed" || event.Type == string(streaming.EventTypeHashtagUpdate)
-	})).Return(nil).Twice()
+		return event != nil && event.Type == string(streaming.EventTypeHashtagUpdate)
+	})).Return(nil).Once()
 
 	service := newTestService(repo, publisher)
 
@@ -283,6 +280,9 @@ func TestUnfollowHashtag(t *testing.T) {
 
 	repo.AssertExpectations(t)
 	publisher.AssertExpectations(t)
+	publisher.AssertNotCalled(t, "PublishToStream", mock.Anything, streaming.HashtagStreamName("golang"), mock.MatchedBy(func(event *streaming.Event) bool {
+		return event != nil && event.Type == "hashtag.unfollowed"
+	}))
 }
 
 func TestGetFollowedHashtags(t *testing.T) {
@@ -369,11 +369,8 @@ func TestMuteHashtag(t *testing.T) {
 		return event != nil && event.Type == "hashtag.muted"
 	})).Return(nil).Once()
 	publisher.On("PublishToStream", mock.Anything, streaming.HashtagStreamName("golang"), mock.MatchedBy(func(event *streaming.Event) bool {
-		if event == nil {
-			return false
-		}
-		return event.Type == "hashtag.muted" || event.Type == string(streaming.EventTypeHashtagUpdate)
-	})).Return(nil).Twice()
+		return event != nil && event.Type == string(streaming.EventTypeHashtagUpdate)
+	})).Return(nil).Once()
 
 	service := newTestService(repo, publisher)
 	result, err := service.MuteHashtag(ctx, "alice", "golang", nil)
@@ -383,6 +380,9 @@ func TestMuteHashtag(t *testing.T) {
 
 	repo.AssertExpectations(t)
 	publisher.AssertExpectations(t)
+	publisher.AssertNotCalled(t, "PublishToStream", mock.Anything, streaming.HashtagStreamName("golang"), mock.MatchedBy(func(event *streaming.Event) bool {
+		return event != nil && event.Type == "hashtag.muted"
+	}))
 }
 
 // TestGetHashtagActivity verifies the deprecated GetHashtagActivity method returns empty channel

--- a/pkg/storage/models/tabletheory_v3_registration_test.go
+++ b/pkg/storage/models/tabletheory_v3_registration_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestArticleRegistersWithSingleCreatedAtMapping(t *testing.T) {
+	// TableTheory v2 persisted embedded Object.CreatedAt under the createdAt attribute.
 	registry := tablemodel.NewRegistry()
 	require.NoError(t, registry.Register(&Article{}))
 
@@ -27,6 +28,7 @@ func TestArticleRegistersWithSingleCreatedAtMapping(t *testing.T) {
 }
 
 func TestDNSCacheRegistersWithV2TTLPrecedence(t *testing.T) {
+	// TableTheory v2 persisted ExpiresAt under the ttl attribute; ExpiresAt won over the Go TTL field.
 	registry := tablemodel.NewRegistry()
 	require.NoError(t, registry.Register(&DNSCache{}))
 

--- a/pkg/streaming/events.go
+++ b/pkg/streaming/events.go
@@ -93,9 +93,10 @@ const (
 // Stream name constants following Mastodon streaming API
 const (
 	// Public Streams
-	PublicStream       = "public"        // All public posts
-	PublicLocalStream  = "public:local"  // Local public posts only
-	PublicRemoteStream = "public:remote" // Remote public posts only
+	PublicStream            = "public"        // All public posts
+	PublicLocalStream       = "public:local"  // Local public posts only
+	PublicRemoteStream      = "public:remote" // Remote public posts only
+	PublicActorStreamPrefix = "public:actor"  // Public posts by one local actor
 
 	// User Streams
 	UserStream             = "user"              // User's home timeline and notifications
@@ -342,6 +343,33 @@ func UserNotificationStreamName(userID string) string {
 	return fmt.Sprintf("%s:%s", UserNotificationStream, userID)
 }
 
+// PublicActorStreamName returns the public-only stream name for a local actor.
+// Unlike UserStreamName, this stream must never carry home, notification, or
+// non-public status fanout.
+func PublicActorStreamName(username string) string {
+	return fmt.Sprintf("%s:%s", PublicActorStreamPrefix, username)
+}
+
+// NormalizeHashtagStreamValue normalizes and validates the exact hashtag value
+// used in a stream key. One boundary '#' is accepted; any residual '#' is
+// rejected rather than constructing a dead hashtag stream.
+func NormalizeHashtagStreamValue(hashtag string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(hashtag))
+	normalized = strings.TrimPrefix(normalized, "#")
+
+	if err := common.ValidateHashtag(normalized); err != nil {
+		return "", err
+	}
+	if !common.HashtagPattern.MatchString(normalized) {
+		return "", common.ValidationError{
+			Field:   "hashtag",
+			Message: "can only contain letters, numbers, and underscores",
+		}
+	}
+
+	return normalized, nil
+}
+
 // HashtagStreamName returns the hashtag stream name for a specific hashtag
 func HashtagStreamName(hashtag string) string {
 	return fmt.Sprintf("%s:%s", HashtagStreamPrefix, hashtag)
@@ -422,6 +450,7 @@ func IsValidStreamName(streamName string) bool {
 
 	// Check prefixes (streams with IDs)
 	prefixes := []string{
+		PublicActorStreamPrefix + ":",
 		HashtagStreamPrefix + ":",
 		ListStreamPrefix + ":",
 		UserStream + ":",

--- a/pkg/streaming/events.go
+++ b/pkg/streaming/events.go
@@ -347,7 +347,7 @@ func UserNotificationStreamName(userID string) string {
 // Unlike UserStreamName, this stream must never carry home, notification, or
 // non-public status fanout.
 func PublicActorStreamName(username string) string {
-	return fmt.Sprintf("%s:%s", PublicActorStreamPrefix, username)
+	return fmt.Sprintf("%s:%s", PublicActorStreamPrefix, strings.ToLower(strings.TrimSpace(username)))
 }
 
 // NormalizeHashtagStreamValue normalizes and validates the exact hashtag value

--- a/pkg/streaming/events_test.go
+++ b/pkg/streaming/events_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEventBuilder_NewEvent(t *testing.T) {
@@ -233,6 +234,23 @@ func TestUserNotificationStreamName(t *testing.T) {
 func TestHashtagStreamName(t *testing.T) {
 	assert.Equal(t, "hashtag:golang", HashtagStreamName("golang"))
 	assert.Equal(t, "hashtag:activitypub", HashtagStreamName("activitypub"))
+}
+
+func TestNormalizeHashtagStreamValueValidatesExactKeyMaterial(t *testing.T) {
+	value, err := NormalizeHashtagStreamValue(" #GoLang ")
+	require.NoError(t, err)
+	require.Equal(t, "golang", value)
+
+	_, err = NormalizeHashtagStreamValue("##golang")
+	require.Error(t, err)
+	_, err = NormalizeHashtagStreamValue("go:lang")
+	require.Error(t, err)
+}
+
+func TestPublicActorStreamNameIsDistinctFromPrivateUserStream(t *testing.T) {
+	require.Equal(t, "public:actor:alice", PublicActorStreamName("alice"))
+	require.NotEqual(t, UserStreamName("alice"), PublicActorStreamName("alice"))
+	require.True(t, IsValidStreamName(PublicActorStreamName("alice")))
 }
 
 func TestListStreamName(t *testing.T) {

--- a/pkg/streaming/events_test.go
+++ b/pkg/streaming/events_test.go
@@ -249,6 +249,7 @@ func TestNormalizeHashtagStreamValueValidatesExactKeyMaterial(t *testing.T) {
 
 func TestPublicActorStreamNameIsDistinctFromPrivateUserStream(t *testing.T) {
 	require.Equal(t, "public:actor:alice", PublicActorStreamName("alice"))
+	require.Equal(t, "public:actor:alice", PublicActorStreamName(" Alice "))
 	require.NotEqual(t, UserStreamName("alice"), PublicActorStreamName("alice"))
 	require.True(t, IsValidStreamName(PublicActorStreamName("alice")))
 }


### PR DESCRIPTION
## Summary

Adds the additive subscription arguments `actorId`, `hashtag`, `listId` to `timelineUpdates` with exact per-type routing, so the three timeline types that could not be honestly routed since #1298 now can be:

- `ACTOR` requires `actorId` — anonymous-safe, matching its query-side read
- `HASHTAG` requires `hashtag` — anonymous-safe, matching its query-side read
- `LIST` requires `listId` — authenticated-only, pending the ownership investigation in the companion issue (pre-existing LIST query-side exposure)

`PUBLIC`/`LOCAL`/`HOME`/`DIRECT` reject identifying inputs and retain existing routing. Missing, malformed, blank, or unexpected inputs **fail closed** with field-specific validation errors. Stream-key construction reuses the publisher/subscriber symmetric validators #1298 established (`activitypub.ValidateUsername`, `mastodon.NormalizeHashtag` + `common.ValidateHashtag`, `common.ValidateStatusID`).

**Authorization disclosure:** anonymous realtime set becomes `PUBLIC | LOCAL | ACTOR | HASHTAG`; authenticated realtime set is `HOME | DIRECT | LIST`.

Also folded in: the #1322 round-2 review nit — `tabletheory_v3_registration_test.go` and the DNSCache sibling now carry comments stating the v2 baselines explicitly (Article: embedded `Object.CreatedAt` persisted as `createdAt`; DNSCache: `ExpiresAt` persisted as `ttl`, winning over Go `TTL`). Comments only, assertions unchanged.

## Security hardening landed through adversarial review (r2–r5)

The keyed routes exposed pre-existing stream-key attribution weaknesses; the review rounds pinned and fixed them in this PR rather than deferring:

- **Origin binding on remote Create/Update ingestion.** Shared-inbox and actor-inbox Creates are bound to the signature-verified actor (`verifyCreateAuthorization`), and — the root fix — the remote→status projection layer (`BuildCanonicalRemoteStatus`) rejects any remote-sourced Note whose attributed actor's **host is local**, parsing with the same net/url parser family the stream fanout uses (including scheme lowercasing), failing closed on empty or unparseable attribution, plus an additive canonical branch — the guard rejects a strict superset of consumer-local IDs, so any residual divergence is fail-safe (query, fragment, userinfo, case-variant schemes, and non-`/users/` path shapes cannot bypass it). The projection also fails closed when the configured local domain is empty or unparseable — a projection with no domain anchor is never projected. Because every remote ingestion route (Create, Update, reply-parent fetch, future envelopes) funnels through that projection, a forged remote Note can no longer re-attribute authorship to a local account via host-comparison divergence — verified exhaustively (363,000 combinations, 0 inputs where the consumer treats an ID as local and the guard does not reject). One pre-existing lane outside this invariant remains: degenerate hosts that parse but resolve to no domain (`[::1]`, `[::ffff:127.0.0.1]`, port-only `:8443`/`:0`/`:`) still yield a bare local-shaped `AuthorUsername` reaching `user:<victim>` (present byte-identically at base `cd172a0c`, proven by fault injection; this PR opens nothing and closes twenty-plus shapes). That lane fails closed in the combined follow-up PR (#1296/#1317/#1318 carrier), which extends the same guard to "not resolvable to a domain" using the username-derivation normalizer. Honest remote actors with non-canonical path shapes (`/profile/<name>`, `/actor`, …) still project — their hosts are not local and cannot reach local stream keys. Update activities additionally validate the complete Note before edit-history or object writes, so a partial Update cannot blank authorship. Update/Delete ownership comparisons use `common.SameCanonicalActorID`.
- **Public actor stream-key canonicalization.** Anonymous `public:actor:<name>` keys are canonicalized so `Alice`/`alice` cannot collide or diverge between publisher and subscriber; remote actors are isolated off local actor keys.
- **Hashtag lane isolation.** User-scope events no longer land on shared hashtag streams.
- **Public actor deletion retraction.** Deletes of public notes from local authors retract from the anonymous per-actor key (WebSocket lane), symmetric with creates. The `DeletedBy` deleter-is-author fallback was removed in both lanes: fanout requires an explicitly recorded local `AttributedTo`, and follower-timeline removal targets the tombstone's **author** (a moderator deleting another actor's status retracts it from the author's followers, not the moderator's); missing attribution is fail-closed skip in both lanes.
- **SSE lane decision (documented asymmetry).** `public:actor:*` has no SSE/stream-event consumer — it is reachable through GraphQL subscriptions and Mastodon-compatible WebSockets only (verified against the SSE route table). The SSE `appendStreamEvent` write for actor-stream deletes was removed rather than writing unconsumable events; WebSocket fanout is retained.

## Behavior notes and known residuals

- **Stream-key mapping.** `PUBLIC` maps to the `"public"` stream — the full firehose **including remote statuses**; `LOCAL` maps to `"public:local"` (local-only). `ACTOR` maps to the anonymous per-actor key; no subscription type maps to `public:remote`.
- **`public:remote` consumption.** There is no GraphQL `TimelineType` mapping for `public:remote` (the enum claim is scoped to GraphQL); remote-only realtime **is** consumable today via the SSE route `/api/v1/streaming/public/remote`.
- **Edit retraction residual (pre-existing).** A public→non-public visibility *edit* does not retract the note from shared streams; Delete remains the only retraction mechanism. This predates this PR and is not made worse by it.
- **Canonicalization case-sensitivity.** The projection guard compares host only (case-insensitive); case-sensitivity is confined to `common.SameCanonicalActorID` in the inbox origin gates, where a canonicalization mismatch is a rejection (fail-closed).

## Consumer coordination (downstream, not in this PR)

Additive schema change; existing consumers unaffected. contentus `docs/consumption/timeline-contract.md` currently records ACTOR realtime as explicitly `unsupported` — that note flips when contentus M6 adopts this release; sim and greater timeline components pick up the arguments on their next contract refresh.

## Contract snapshot

Regenerated through `make gqlgen` + `./lesser schema`; `./lesser verify schema` confirms the committed snapshot is current:

```graphql
timelineUpdates(
  type: TimelineType!
  actorId: ID
  hashtag: String
  listId: ID
): Object!
```

## Validation (at head `781721849ab0e2d2f273214561f7eac1c817150d`)

- Targeted `go test` across `graph`, `cmd/graphql-ws`, `cmd/inbox`, `cmd/stream-router`, `pkg/federation`, `pkg/storage/models`: **PASS** — happy-path, malformed-input, fault-injection regressions (guard-removal and polarity-revert both proven red), seven-shape local-host bypass table, shared-inbox origin binding, reply-parent fetch guard, author-follower retraction, SSE write-count pinning
- `./lesser verify ci`: **PASS** — coverage 90.030% cmd
- `./lesser verify schema`: PASS; gofmt clean; `git diff --check` clean
- All commits GPG-verified, DCO trailers, `Refs #1300`

Closes #1300

