### PR TITLE
feat(api): implement the Quote Posts REST surface

### DIFF
--- a/cmd/api/handlers/quotes.go
+++ b/cmd/api/handlers/quotes.go
@@ -17,8 +17,8 @@ import (
 )
 
 const (
-	quoteListPageSize   = 80
-	quoteListMaxScanned = 10080
+	quoteListPageSize       = 80
+	quoteListScanMultiplier = 4
 )
 
 // HandleCreateQuotePostLift handles POST /api/v1/statuses/:id/quote.
@@ -336,10 +336,15 @@ func (h *Handler) listVisibleQuoteSummaries(ctx context.Context, notesService No
 	cursor := ""
 	visible := 0
 	scanned := 0
+	maxScanned := limit * quoteListScanMultiplier
 	seenCursors := map[string]struct{}{}
 
-	for scanned < quoteListMaxScanned && len(items) < limit {
-		page, err := quotesService.GetQuoteRelationshipsForStatus(ctx, statusID, quoteListPageSize, cursor)
+	for scanned < maxScanned && len(items) < limit {
+		pageLimit := quoteListPageSize
+		if remaining := maxScanned - scanned; remaining < pageLimit {
+			pageLimit = remaining
+		}
+		page, err := quotesService.GetQuoteRelationshipsForStatus(ctx, statusID, pageLimit, cursor)
 		if err != nil {
 			return nil, err
 		}
@@ -348,10 +353,13 @@ func (h *Handler) listVisibleQuoteSummaries(ctx context.Context, notesService No
 		}
 
 		for _, relationship := range page.Relationships {
-			if relationship == nil || scanned >= quoteListMaxScanned {
-				continue
+			if scanned >= maxScanned {
+				break
 			}
 			scanned++
+			if relationship == nil {
+				continue
+			}
 			summary, isVisible, err := visibleQuoteSummary(ctx, notesService, relationship, viewer)
 			if err != nil {
 				return nil, err

--- a/cmd/api/handlers/quotes.go
+++ b/cmd/api/handlers/quotes.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -120,9 +121,13 @@ func (h *Handler) HandleGetQuotesOfStatusLift(ctx *apptheory.Context) (*apptheor
 	if err != nil {
 		return common.RespondValidationError(ctx, err)
 	}
-	offset, err := common.ParseAndValidateIntWithBounds("offset", queryValue(ctx, "offset"), -1, 10000, 0)
+	maxOffset := quoteListMaxOffset(limit)
+	offset, err := common.ParseAndValidateIntWithBounds("offset", queryValue(ctx, "offset"), -1, int(^uint(0)>>1), 0)
 	if err != nil {
 		return common.RespondValidationError(ctx, err)
+	}
+	if offset > maxOffset {
+		return common.RespondUnprocessableEntity(ctx, fmt.Sprintf("offset cannot be greater than %d for limit %d", maxOffset, limit))
 	}
 
 	if h.registry == nil || h.registry.Notes() == nil || h.registry.Quotes() == nil {
@@ -145,6 +150,10 @@ func (h *Handler) HandleGetQuotesOfStatusLift(ctx *apptheory.Context) (*apptheor
 		return h.respondVisibleQuoteStatusError(ctx, statusID, viewer, err)
 	}
 	return okJSON(items)
+}
+
+func quoteListMaxOffset(limit int) int {
+	return limit*quoteListScanMultiplier - 1
 }
 
 // HandleDeleteQuotePostLift handles DELETE /api/v1/statuses/:id/quote/:quote_id.

--- a/cmd/api/handlers/quotes.go
+++ b/cmd/api/handlers/quotes.go
@@ -65,6 +65,9 @@ func (h *Handler) HandleCreateQuotePostLift(ctx *apptheory.Context) (*apptheory.
 	if err := notes.ValidateChildReach("quote", quoteTarget, statusRequest.Visibility); err != nil {
 		return respondQuoteAppError(ctx, err)
 	}
+	if !common.IsPubliclyVisible(quoteTarget.Visibility) {
+		return common.RespondUnprocessableEntity(ctx, quotes.ErrTargetStatusNotQuotable.Message)
+	}
 
 	quotesService := h.registry.Quotes()
 	allowed, err := quotesService.CheckQuotePermissions(ctx.Context(), claims.Username, quoteTarget)

--- a/cmd/api/handlers/quotes.go
+++ b/cmd/api/handlers/quotes.go
@@ -1,84 +1,150 @@
 package handlers
 
 import (
-	"net/http"
+	"context"
 	"strings"
+	"time"
 
 	apimodels "github.com/equaltoai/lesser/cmd/api/models"
 	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/common"
-	pkgErrors "github.com/equaltoai/lesser/pkg/errors"
+	commonerrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/services/notes"
+	"github.com/equaltoai/lesser/pkg/services/quotes"
 	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
 	apptheory "github.com/theory-cloud/apptheory/v3/runtime"
 	"go.uber.org/zap"
 )
 
-// HandleCreateQuotePostLift handles POST /api/v1/statuses/:id/quote
-// Creates a quote post of an existing status
+const (
+	quoteListPageSize   = 80
+	quoteListMaxScanned = 10080
+)
+
+// HandleCreateQuotePostLift handles POST /api/v1/statuses/:id/quote.
+// It uses the same Notes.CreateNote -> QuoteService.AttachQuoteToStatus path as
+// GraphQL quote creation, including the notes service's persistence, streaming,
+// and federation fanout.
 func (h *Handler) HandleCreateQuotePostLift(ctx *apptheory.Context) (*apptheory.Response, error) {
 	statusID := ctx.Param("id")
 	if err := common.ValidateStatusParamID(statusID); err != nil {
 		return common.RespondValidationError(ctx, err)
 	}
 
-	// Authenticate user
-	_, err := h.authenticateUser(ctx, []string{"write:statuses", auth.ScopeWrite})
+	claims, err := h.authenticateWithAnyScope(ctx, "write:statuses", auth.ScopeWrite)
 	if err != nil {
-		if isInsufficientScopeError(err) {
-			return common.RespondForbidden(ctx, err.Error())
-		}
-		return common.RespondUnauthorized(ctx)
+		return respondQuoteAuthError(ctx, err)
 	}
 
-	// Parse request body
 	var params apimodels.CreateQuotePostRequest
-
 	if err := common.ParseRequestWithFallback(ctx, &params); err != nil {
 		return common.RespondBadRequest(ctx, "invalid request body")
 	}
 
-	// Validate quote content
-	if params.Status != "" {
-		if err := common.ValidateStatusContent(params.Status); err != nil {
-			return common.RespondValidationError(ctx, err)
-		}
+	statusRequest := quoteStatusRequest(params)
+	if statusRequest.Visibility == "" {
+		statusRequest.Visibility = storageModels.VisibilityPublic
+	}
+	if resp, err := validateCreateStatusRequest(ctx, &statusRequest); resp != nil || err != nil {
+		return resp, err
 	}
 
-	// The routed extension is intentionally inert until quote authorization,
-	// persistence, and federation are implemented. Return before looking up the
-	// target so existent, private, and missing IDs remain indistinguishable.
-	return apptheory.JSON(http.StatusNotImplemented, common.StandardErrorResponse{
-		Error: "quote endpoint is not implemented",
-	})
+	if h.registry == nil || h.registry.Notes() == nil || h.registry.Quotes() == nil {
+		h.logger.Error("quote services unavailable")
+		return common.RespondInternalServerError(ctx)
+	}
+
+	notesService := h.registry.Notes()
+	quoteTarget, err := notesService.ResolveQuoteTarget(ctx.Context(), claims.Username, statusID)
+	if err != nil {
+		return h.respondQuoteTargetError(ctx, statusID, claims.Username, err)
+	}
+	if quoteTarget == nil {
+		return common.RespondStatusNotFound(ctx)
+	}
+	if err := notes.ValidateChildReach("quote", quoteTarget, statusRequest.Visibility); err != nil {
+		return respondQuoteAppError(ctx, err)
+	}
+
+	quotesService := h.registry.Quotes()
+	allowed, err := quotesService.CheckQuotePermissions(ctx.Context(), claims.Username, quoteTarget)
+	if err != nil {
+		h.logger.Error("failed to check quote permissions",
+			zap.String("viewer", claims.Username),
+			zap.String("target_status_id", quoteTarget.StatusID),
+			zap.Error(err))
+		return common.RespondWithAppError(ctx, quotes.ErrCheckQuotePermissions(err))
+	}
+	if !allowed {
+		return common.RespondWithAppError(ctx, quotes.ErrNotAuthorizedToQuote)
+	}
+
+	agentAttribution, resp, err := h.prepareAgentStatusCreate(ctx, claims, &statusRequest)
+	if resp != nil || err != nil {
+		return resp, err
+	}
+
+	result, err := notesService.CreateNote(ctx.Context(), createNoteCommandFromStatusRequest(claims, &statusRequest, agentAttribution))
+	if err != nil {
+		h.logger.Error("failed to create quote status", zap.Error(err))
+		return respondQuoteAppError(ctx, err)
+	}
+	if result == nil || result.Note == nil {
+		h.logger.Error("notes service returned no quote status")
+		return common.RespondInternalServerError(ctx)
+	}
+
+	if _, err := quotesService.AttachQuoteToStatus(ctx.Context(), result.Note, quoteTarget.StatusID); err != nil {
+		h.logger.Error("failed to attach quote status",
+			zap.String("quote_status_id", result.Note.StatusID),
+			zap.String("target_status_id", quoteTarget.StatusID),
+			zap.Error(err))
+		return respondQuoteAppError(ctx, err)
+	}
+
+	return okJSON(quoteStatusSummary(result.Note))
 }
 
-// HandleGetQuotesOfStatusLift handles GET /api/v1/statuses/:id/quotes
-// Returns a list of quote posts for a given status
+// HandleGetQuotesOfStatusLift handles GET /api/v1/statuses/:id/quotes.
+// The target and every returned quote are checked through Notes.GetNoteWithViewer.
 func (h *Handler) HandleGetQuotesOfStatusLift(ctx *apptheory.Context) (*apptheory.Response, error) {
 	statusID := ctx.Param("id")
 	if err := common.ValidateStatusParamID(statusID); err != nil {
 		return common.RespondValidationError(ctx, err)
 	}
 
-	// Parse pagination parameters
-	if _, err := common.ParseFollowLimit(queryValue(ctx, "limit")); err != nil {
+	limit, err := common.ParseFollowLimit(queryValue(ctx, "limit"))
+	if err != nil {
+		return common.RespondValidationError(ctx, err)
+	}
+	offset, err := common.ParseAndValidateIntWithBounds("offset", queryValue(ctx, "offset"), -1, 10000, 0)
+	if err != nil {
 		return common.RespondValidationError(ctx, err)
 	}
 
-	if _, err := common.ParseAndValidateIntWithBounds("offset", queryValue(ctx, "offset"), -1, 10000, 0); err != nil {
-		return common.RespondValidationError(ctx, err)
+	if h.registry == nil || h.registry.Notes() == nil || h.registry.Quotes() == nil {
+		h.logger.Error("quote services unavailable")
+		return common.RespondInternalServerError(ctx)
 	}
 
-	// Quote rows are not yet backed by real status projections. Return before
-	// storage access so the response cannot disclose a target's existence or
-	// the number of quote relationships associated with it.
-	return apptheory.JSON(http.StatusNotImplemented, common.StandardErrorResponse{
-		Error: "quotes endpoint is not implemented",
-	})
+	viewer := h.getOptionalAuthenticatedUser(ctx)
+	notesService := h.registry.Notes()
+	target, err := notesService.GetNoteWithViewer(ctx.Context(), &notes.GetNoteQuery{StatusID: statusID, ViewerID: viewer})
+	if err != nil {
+		return h.respondVisibleQuoteStatusError(ctx, statusID, viewer, err)
+	}
+	if target == nil {
+		return common.RespondStatusNotFound(ctx)
+	}
+
+	items, err := h.listVisibleQuoteSummaries(ctx.Context(), notesService, h.registry.Quotes(), statusID, viewer, limit, offset)
+	if err != nil {
+		return h.respondVisibleQuoteStatusError(ctx, statusID, viewer, err)
+	}
+	return okJSON(items)
 }
 
-// HandleDeleteQuotePostLift handles DELETE /api/v1/statuses/:id/quote/:quote_id
-// Deletes a quote post (removes the quote relationship)
+// HandleDeleteQuotePostLift handles DELETE /api/v1/statuses/:id/quote/:quote_id.
 func (h *Handler) HandleDeleteQuotePostLift(ctx *apptheory.Context) (*apptheory.Response, error) {
 	statusID := ctx.Param("id")
 	quoteID := ctx.Param("quote_id")
@@ -89,7 +155,6 @@ func (h *Handler) HandleDeleteQuotePostLift(ctx *apptheory.Context) (*apptheory.
 		return common.RespondValidationError(ctx, err)
 	}
 
-	// Authenticate user
 	username, err := h.authenticateUser(ctx, []string{"write:statuses", auth.ScopeWrite})
 	if err != nil {
 		if isInsufficientScopeError(err) {
@@ -98,13 +163,11 @@ func (h *Handler) HandleDeleteQuotePostLift(ctx *apptheory.Context) (*apptheory.
 		return common.RespondUnauthorized(ctx)
 	}
 
-	// Verify user owns the quote
 	quote, err := h.getQuoteRelationship(ctx, quoteID, statusID)
 	if err != nil {
 		h.logger.Error("failed to get quote relationship", zap.Error(err))
 		return common.RespondFailedToGet(ctx, "quote")
 	}
-
 	if quote == nil {
 		return common.RespondNotFound(ctx, "quote")
 	}
@@ -114,14 +177,10 @@ func (h *Handler) HandleDeleteQuotePostLift(ctx *apptheory.Context) (*apptheory.
 		ownedByUser = quote.QuoterID == common.GenerateActorID(h.cfg.Domain, username)
 	}
 	if !ownedByUser {
-		// Do not disclose that a quote relationship exists when the caller does
-		// not own it; missing and non-owned relationships share one response.
 		return common.RespondNotFound(ctx, "quote")
 	}
 
-	// Delete the quote relationship
-	err = h.deleteQuoteRelationship(ctx, quote)
-	if err != nil {
+	if err := h.deleteQuoteRelationship(ctx, quote); err != nil {
 		h.logger.Error("failed to delete quote relationship", zap.Error(err))
 		return common.RespondFailedToDelete(ctx, "quote")
 	}
@@ -129,54 +188,278 @@ func (h *Handler) HandleDeleteQuotePostLift(ctx *apptheory.Context) (*apptheory.
 	return okJSON(apimodels.MessageResponse{Message: "quote deleted"})
 }
 
-// HandleGetQuotePermissionsLift handles GET /api/v1/accounts/:id/quote_permissions
-// Returns quote permissions for a user
+// HandleGetQuotePermissionsLift handles GET /api/v1/accounts/:id/quote_permissions.
+// Authentication happens before account resolution. Only the authenticated
+// account may read its policy; other and missing accounts share a 404 so the
+// block list is not exposed and the route does not become an account oracle.
 func (h *Handler) HandleGetQuotePermissionsLift(ctx *apptheory.Context) (*apptheory.Response, error) {
 	accountID := ctx.Param("id")
 	if err := common.ValidateRequiredParam("account_id", accountID); err != nil {
 		return common.RespondValidationError(ctx, err)
 	}
 
-	// Permission persistence is not implemented. Return before storage access so
-	// existent and missing account IDs remain indistinguishable and clients are
-	// never given fabricated all-permissive settings.
-	return apptheory.JSON(http.StatusNotImplemented, common.StandardErrorResponse{
-		Error: "quote permissions endpoint is not implemented",
-	})
-}
-
-// HandleUpdateQuotePermissionsLift handles PUT /api/v1/accounts/quote_permissions
-// Updates quote permissions for the authenticated user
-func (h *Handler) HandleUpdateQuotePermissionsLift(ctx *apptheory.Context) (*apptheory.Response, error) {
-	// Authenticate user
-	_, err := h.authenticateUser(ctx, []string{"write:accounts", auth.ScopeWrite})
+	claims, err := h.authenticateWithAnyScope(ctx, "read:accounts", auth.ScopeRead)
 	if err != nil {
-		if isInsufficientScopeError(err) {
-			return common.RespondForbidden(ctx, err.Error())
-		}
-		return common.RespondUnauthorized(ctx)
+		return respondQuoteAuthError(ctx, err)
+	}
+	if h.registry == nil || h.registry.Accounts() == nil || h.registry.Quotes() == nil {
+		h.logger.Error("quote permission services unavailable")
+		return common.RespondInternalServerError(ctx)
 	}
 
-	// Parse request body
-	var params apimodels.UpdateQuotePermissionsRequest
+	actor, err := h.resolveAccountIDFull(ctx.Context(), accountID)
+	if err != nil || actor == nil || !h.actorAppearsLocal(actor) || strings.TrimSpace(actor.PreferredUsername) == "" {
+		if err != nil && !commonerrors.HasCode(err, commonerrors.CodeNotFound) {
+			h.logger.Error("failed to resolve quote permission account", zap.String("account_id", accountID), zap.Error(err))
+			return common.RespondInternalServerError(ctx)
+		}
+		return common.RespondNotFound(ctx, "account")
+	}
+	if !strings.EqualFold(actor.PreferredUsername, claims.Username) {
+		return common.RespondNotFound(ctx, "account")
+	}
 
+	permissions, err := h.registry.Quotes().GetQuotePermissions(ctx.Context(), claims.Username)
+	if err != nil {
+		h.logger.Error("failed to get quote permissions", zap.String("account_id", accountID), zap.Error(err))
+		return common.RespondInternalServerError(ctx)
+	}
+	return okJSON(quotePermissionsResponse(permissions))
+}
+
+// HandleUpdateQuotePermissionsLift handles PUT /api/v1/accounts/quote_permissions.
+func (h *Handler) HandleUpdateQuotePermissionsLift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	claims, err := h.authenticateWithAnyScope(ctx, "write:accounts", auth.ScopeWrite)
+	if err != nil {
+		return respondQuoteAuthError(ctx, err)
+	}
+
+	var params apimodels.UpdateQuotePermissionsRequest
 	if err := common.ParseRequestWithFallback(ctx, &params); err != nil {
 		return common.RespondBadRequest(ctx, "invalid request body")
 	}
+	blockList, err := normalizeQuoteBlockList(params.BlockList)
+	if err != nil {
+		return common.RespondValidationError(ctx, err)
+	}
 
-	// Persistence is not implemented. Refuse the update rather than echoing
-	// request values as though they were saved.
-	return apptheory.JSON(http.StatusNotImplemented, common.StandardErrorResponse{
-		Error: "quote permission updates are not implemented",
-	})
+	if h.registry == nil || h.registry.Quotes() == nil {
+		h.logger.Error("quote permission service unavailable")
+		return common.RespondInternalServerError(ctx)
+	}
+	quotesService := h.registry.Quotes()
+	permissions, err := quotesService.GetQuotePermissions(ctx.Context(), claims.Username)
+	if err != nil {
+		h.logger.Error("failed to load quote permissions", zap.String("username", claims.Username), zap.Error(err))
+		return common.RespondInternalServerError(ctx)
+	}
+	if permissions == nil {
+		permissions = &storageModels.QuotePermissions{Username: claims.Username}
+		permissions.SetDefaults()
+	}
+
+	if params.AllowPublic != nil {
+		permissions.AllowPublic = *params.AllowPublic
+	}
+	if params.AllowFollowers != nil {
+		permissions.AllowFollowers = *params.AllowFollowers
+	}
+	if params.AllowMentioned != nil {
+		permissions.AllowMentioned = *params.AllowMentioned
+	}
+	if params.BlockList != nil {
+		permissions.BlockList = blockList
+	}
+	if permissions.BlockList == nil {
+		permissions.BlockList = []string{}
+	}
+	permissions.Username = claims.Username
+
+	if err := quotesService.UpdateQuotePermissions(ctx.Context(), permissions); err != nil {
+		h.logger.Error("failed to save quote permissions", zap.String("username", claims.Username), zap.Error(err))
+		return common.RespondInternalServerError(ctx)
+	}
+	return okJSON(quotePermissionsResponse(permissions))
 }
 
-// Helper methods
+func quoteStatusRequest(params apimodels.CreateQuotePostRequest) apimodels.CreateStatusRequest {
+	return apimodels.CreateStatusRequest{
+		Status:      params.Status,
+		Visibility:  params.Visibility,
+		SpoilerText: params.SpoilerText,
+		Sensitive:   params.Sensitive,
+		Language:    params.Language,
+	}
+}
+
+func respondQuoteAuthError(ctx *apptheory.Context, err error) (*apptheory.Response, error) {
+	if isInsufficientScopeError(err) {
+		return common.RespondForbidden(ctx, err.Error())
+	}
+	return common.RespondUnauthorized(ctx)
+}
+
+func respondQuoteAppError(ctx *apptheory.Context, err error) (*apptheory.Response, error) {
+	if appErr, ok := commonerrors.AsAppError(err); ok {
+		return common.RespondWithAppError(ctx, appErr)
+	}
+	return common.RespondInternalServerError(ctx)
+}
+
+func (h *Handler) respondQuoteTargetError(ctx *apptheory.Context, statusID, viewer string, err error) (*apptheory.Response, error) {
+	h.logger.Warn("quote target rejected",
+		zap.String("status_id", statusID),
+		zap.String("viewer", viewer),
+		zap.Error(err))
+	if commonerrors.HasCode(err, commonerrors.CodeNotFound) {
+		return common.RespondStatusNotFound(ctx)
+	}
+	return respondQuoteAppError(ctx, err)
+}
+
+func (h *Handler) respondVisibleQuoteStatusError(ctx *apptheory.Context, statusID, viewer string, err error) (*apptheory.Response, error) {
+	if commonerrors.HasCode(err, commonerrors.CodeNotFound) {
+		return common.RespondStatusNotFound(ctx)
+	}
+	h.logger.Error("failed to list visible quotes",
+		zap.String("status_id", statusID),
+		zap.String("viewer", viewer),
+		zap.Error(err))
+	return respondQuoteAppError(ctx, err)
+}
+
+func (h *Handler) listVisibleQuoteSummaries(ctx context.Context, notesService NotesService, quotesService QuotesService, statusID, viewer string, limit, offset int) ([]apimodels.QuoteStatusSummary, error) {
+	items := make([]apimodels.QuoteStatusSummary, 0, limit)
+	cursor := ""
+	visible := 0
+	scanned := 0
+	seenCursors := map[string]struct{}{}
+
+	for scanned < quoteListMaxScanned && len(items) < limit {
+		page, err := quotesService.GetQuoteRelationshipsForStatus(ctx, statusID, quoteListPageSize, cursor)
+		if err != nil {
+			return nil, err
+		}
+		if page == nil {
+			return nil, commonerrors.Internal("quote relationship page is unavailable")
+		}
+
+		for _, relationship := range page.Relationships {
+			if relationship == nil || scanned >= quoteListMaxScanned {
+				continue
+			}
+			scanned++
+			status, err := notesService.GetNoteWithViewer(ctx, &notes.GetNoteQuery{
+				StatusID: relationship.QuoterNoteID,
+				ViewerID: viewer,
+			})
+			if err != nil {
+				if commonerrors.HasCode(err, commonerrors.CodeNotFound) {
+					continue
+				}
+				return nil, err
+			}
+			if status == nil {
+				continue
+			}
+			if visible < offset {
+				visible++
+				continue
+			}
+			visible++
+			items = append(items, quoteStatusSummary(status))
+			if len(items) == limit {
+				break
+			}
+		}
+
+		next := strings.TrimSpace(page.NextCursor)
+		if next == "" {
+			break
+		}
+		if _, repeated := seenCursors[next]; repeated {
+			return nil, commonerrors.Internal("quote relationship cursor repeated")
+		}
+		seenCursors[next] = struct{}{}
+		cursor = next
+	}
+
+	return items, nil
+}
+
+func quoteStatusSummary(status *storageModels.Status) apimodels.QuoteStatusSummary {
+	createdAt := status.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = status.PublishedAt
+	}
+	createdAtText := ""
+	if !createdAt.IsZero() {
+		createdAtText = createdAt.UTC().Format(time.RFC3339Nano)
+	}
+
+	accountID := strings.TrimSpace(status.AuthorID)
+	username := strings.TrimSpace(status.AuthorUsername)
+	if accountID == "" {
+		accountID = username
+	}
+	var usernamePtr *string
+	if username != "" {
+		usernameCopy := username
+		usernamePtr = &usernameCopy
+	}
+
+	return apimodels.QuoteStatusSummary{
+		ID:        status.StatusID,
+		CreatedAt: createdAtText,
+		Account: apimodels.QuoteStatusAccount{
+			ID:       accountID,
+			Username: usernamePtr,
+		},
+		Content: status.Content,
+	}
+}
+
+func quotePermissionsResponse(permissions *storageModels.QuotePermissions) apimodels.QuotePermissionsResponse {
+	blockList := []string{}
+	if permissions != nil && permissions.BlockList != nil {
+		blockList = append(blockList, permissions.BlockList...)
+	}
+	if permissions == nil {
+		return apimodels.QuotePermissionsResponse{BlockList: blockList}
+	}
+	return apimodels.QuotePermissionsResponse{
+		AllowPublic:    permissions.AllowPublic,
+		AllowFollowers: permissions.AllowFollowers,
+		AllowMentioned: permissions.AllowMentioned,
+		BlockList:      blockList,
+	}
+}
+
+func normalizeQuoteBlockList(raw []string) ([]string, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	normalized := make([]string, 0, len(raw))
+	seen := make(map[string]struct{}, len(raw))
+	for _, value := range raw {
+		username := strings.TrimPrefix(strings.TrimSpace(value), "@")
+		if err := common.ValidateUsername(username); err != nil {
+			return nil, err
+		}
+		key := strings.ToLower(username)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		normalized = append(normalized, username)
+	}
+	return normalized, nil
+}
 
 func (h *Handler) getQuoteRelationship(ctx *apptheory.Context, quoteStatusID string, targetStatusID string) (*storageModels.QuoteRelationship, error) {
 	relationship, err := h.repos.Quote().GetQuoteRelationship(ctx.Context(), quoteStatusID, targetStatusID)
 	if err != nil {
-		if pkgErrors.HasCode(err, pkgErrors.CodeNotFound) || strings.Contains(strings.ToLower(err.Error()), "not found") {
+		if commonerrors.HasCode(err, commonerrors.CodeNotFound) || strings.Contains(strings.ToLower(err.Error()), "not found") {
 			return nil, nil
 		}
 		return nil, err

--- a/cmd/api/handlers/quotes.go
+++ b/cmd/api/handlers/quotes.go
@@ -337,17 +337,16 @@ func (h *Handler) listVisibleQuoteSummaries(ctx context.Context, notesService No
 	visible := 0
 	scanned := 0
 	maxScanned := limit * quoteListScanMultiplier
+	maxFetches := (maxScanned + quoteListPageSize - 1) / quoteListPageSize
+	fetches := 0
 	seenCursors := map[string]struct{}{}
 
-	for scanned < maxScanned && len(items) < limit {
-		pageLimit := quoteListPageSize
-		if remaining := maxScanned - scanned; remaining < pageLimit {
-			pageLimit = remaining
-		}
-		page, err := quotesService.GetQuoteRelationshipsForStatus(ctx, statusID, pageLimit, cursor)
+	for fetches < maxFetches && scanned < maxScanned && len(items) < limit {
+		page, err := quotesService.GetQuoteRelationshipsForStatus(ctx, statusID, quoteListPageSize, cursor)
 		if err != nil {
 			return nil, err
 		}
+		fetches++
 		if page == nil {
 			return nil, commonerrors.Internal("quote relationship page is unavailable")
 		}

--- a/cmd/api/handlers/quotes.go
+++ b/cmd/api/handlers/quotes.go
@@ -349,17 +349,11 @@ func (h *Handler) listVisibleQuoteSummaries(ctx context.Context, notesService No
 				continue
 			}
 			scanned++
-			status, err := notesService.GetNoteWithViewer(ctx, &notes.GetNoteQuery{
-				StatusID: relationship.QuoterNoteID,
-				ViewerID: viewer,
-			})
+			summary, isVisible, err := visibleQuoteSummary(ctx, notesService, relationship, viewer)
 			if err != nil {
-				if commonerrors.HasCode(err, commonerrors.CodeNotFound) {
-					continue
-				}
 				return nil, err
 			}
-			if status == nil {
+			if !isVisible {
 				continue
 			}
 			if visible < offset {
@@ -367,7 +361,7 @@ func (h *Handler) listVisibleQuoteSummaries(ctx context.Context, notesService No
 				continue
 			}
 			visible++
-			items = append(items, quoteStatusSummary(status))
+			items = append(items, summary)
 			if len(items) == limit {
 				break
 			}
@@ -385,6 +379,23 @@ func (h *Handler) listVisibleQuoteSummaries(ctx context.Context, notesService No
 	}
 
 	return items, nil
+}
+
+func visibleQuoteSummary(ctx context.Context, notesService NotesService, relationship *storageModels.QuoteRelationship, viewer string) (apimodels.QuoteStatusSummary, bool, error) {
+	status, err := notesService.GetNoteWithViewer(ctx, &notes.GetNoteQuery{
+		StatusID: relationship.QuoterNoteID,
+		ViewerID: viewer,
+	})
+	if err != nil {
+		if commonerrors.HasCode(err, commonerrors.CodeNotFound) {
+			return apimodels.QuoteStatusSummary{}, false, nil
+		}
+		return apimodels.QuoteStatusSummary{}, false, err
+	}
+	if status == nil {
+		return apimodels.QuoteStatusSummary{}, false, nil
+	}
+	return quoteStatusSummary(status), true, nil
 }
 
 func quoteStatusSummary(status *storageModels.Status) apimodels.QuoteStatusSummary {

--- a/cmd/api/handlers/quotes.go
+++ b/cmd/api/handlers/quotes.go
@@ -352,10 +352,7 @@ func (h *Handler) listVisibleQuoteSummaries(ctx context.Context, notesService No
 			return nil, commonerrors.Internal("quote relationship page is unavailable")
 		}
 
-		for _, relationship := range page.Relationships {
-			if scanned >= maxScanned {
-				break
-			}
+		for _, relationship := range boundedQuoteRelationships(page.Relationships, maxScanned-scanned) {
 			scanned++
 			if relationship == nil {
 				continue
@@ -390,6 +387,16 @@ func (h *Handler) listVisibleQuoteSummaries(ctx context.Context, notesService No
 	}
 
 	return items, nil
+}
+
+func boundedQuoteRelationships(relationships []*storageModels.QuoteRelationship, remaining int) []*storageModels.QuoteRelationship {
+	if remaining <= 0 {
+		return nil
+	}
+	if len(relationships) > remaining {
+		return relationships[:remaining]
+	}
+	return relationships
 }
 
 func visibleQuoteSummary(ctx context.Context, notesService NotesService, relationship *storageModels.QuoteRelationship, viewer string) (apimodels.QuoteStatusSummary, bool, error) {

--- a/cmd/api/handlers/quotes.go
+++ b/cmd/api/handlers/quotes.go
@@ -20,6 +20,7 @@ import (
 const (
 	quoteListPageSize       = 80
 	quoteListScanMultiplier = 4
+	restTargetNotQuotable   = "target status is not quotable"
 )
 
 // HandleCreateQuotePostLift handles POST /api/v1/statuses/:id/quote.
@@ -67,7 +68,7 @@ func (h *Handler) HandleCreateQuotePostLift(ctx *apptheory.Context) (*apptheory.
 		return respondQuoteAppError(ctx, err)
 	}
 	if !common.IsPubliclyVisible(quoteTarget.Visibility) {
-		return common.RespondUnprocessableEntity(ctx, quotes.ErrTargetStatusNotQuotable.Message)
+		return common.RespondUnprocessableEntity(ctx, restTargetNotQuotable)
 	}
 
 	quotesService := h.registry.Quotes()

--- a/cmd/api/handlers/quotes_round12_coverage_test.go
+++ b/cmd/api/handlers/quotes_round12_coverage_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"encoding/json"
 	stdErrors "errors"
 	"net/http"
 	"strings"
@@ -97,33 +96,6 @@ func TestQuotes_Round12_CreateQuotePost_Coverage(t *testing.T) {
 		requireStatus(t, http.StatusBadRequest)(handler.HandleCreateQuotePostLift(ctx))
 	})
 
-	t.Run("auth_header_fallback_paths", func(t *testing.T) {
-		writeToken := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{"write:statuses"})
-
-		handler, _, _ := round11NewHandler(t, cfg, &round10QueryState{
-			statusByID: map[string]storagemodels.Status{"s1": {StatusID: "s1"}},
-		})
-
-		ctxLower, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses/s1/quote", map[string]string{"authorization": "Bearer " + writeToken}, nil, apimodels.CreateQuotePostRequest{Status: "hi"})
-		require.NoError(t, err)
-		ctxLower.Params["id"] = "s1"
-		requireStatus(t, http.StatusNotImplemented)(handler.HandleCreateQuotePostLift(ctxLower))
-
-		ctxDirect, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses/s1/quote", map[string]string{"Authorization": "Bearer " + writeToken}, nil, apimodels.CreateQuotePostRequest{Status: "hi"})
-		require.NoError(t, err)
-		ctxDirect.Params["id"] = "s1"
-		ctxDirect.Request.Headers = nil
-
-		requireStatus(t, http.StatusUnauthorized)(handler.HandleCreateQuotePostLift(ctxDirect))
-
-		ctxDirectLower, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses/s1/quote", map[string]string{"authorization": "Bearer " + writeToken}, nil, apimodels.CreateQuotePostRequest{Status: "hi"})
-		require.NoError(t, err)
-		ctxDirectLower.Params["id"] = "s1"
-		ctxDirectLower.Request.Headers = nil
-
-		requireStatus(t, http.StatusUnauthorized)(handler.HandleCreateQuotePostLift(ctxDirectLower))
-	})
-
 	t.Run("request_body_fallback_uses_request_request_body", func(t *testing.T) {
 		writeToken := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{"write:statuses"})
 		headers := map[string]string{
@@ -142,118 +114,6 @@ func TestQuotes_Round12_CreateQuotePost_Coverage(t *testing.T) {
 		requireStatus(t, http.StatusBadRequest)(handler.HandleCreateQuotePostLift(ctx))
 	})
 
-	t.Run("status_not_found", func(t *testing.T) {
-		writeToken := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{"write:statuses"})
-		headers := map[string]string{"Authorization": "Bearer " + writeToken}
-
-		state := &round10QueryState{notFoundPKs: map[string]bool{"status#missing": true}}
-		handler, _, _ := round11NewHandler(t, cfg, state)
-
-		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses/missing/quote", headers, nil, apimodels.CreateQuotePostRequest{Status: "hi"})
-		require.NoError(t, err)
-		ctx.Params["id"] = "missing"
-
-		requireStatus(t, http.StatusNotImplemented)(handler.HandleCreateQuotePostLift(ctx))
-	})
-
-	t.Run("ok", func(t *testing.T) {
-		writeToken := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{"write:statuses"})
-		headers := map[string]string{"Authorization": "Bearer " + writeToken}
-
-		handler, _, _ := round11NewHandler(t, cfg, &round10QueryState{
-			statusByID: map[string]storagemodels.Status{"s1": {StatusID: "s1", Content: "original"}},
-		})
-		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses/s1/quote", headers, nil, apimodels.CreateQuotePostRequest{Status: "hi"})
-		require.NoError(t, err)
-		ctx.Params["id"] = "s1"
-
-		requireStatus(t, http.StatusNotImplemented)(handler.HandleCreateQuotePostLift(ctx))
-	})
-}
-
-func TestCreateQuotePostReturnsNotImplementedWithoutStatusLookup(t *testing.T) {
-	cfg := round11TestConfig()
-	writeToken := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{"write:statuses"})
-	headers := map[string]string{"Authorization": "Bearer " + writeToken}
-
-	tests := []struct {
-		name   string
-		id     string
-		status *storagemodels.Status
-	}{
-		{name: "existent", id: "public", status: &storagemodels.Status{StatusID: "public", Visibility: storagemodels.VisibilityPublic}},
-		{name: "followers only", id: "followers", status: &storagemodels.Status{StatusID: "followers", Visibility: storagemodels.VisibilityPrivate}},
-		{name: "nonexistent", id: "missing"},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			state := &round10QueryState{statusByID: map[string]storagemodels.Status{}}
-			if tt.status != nil {
-				state.statusByID[tt.id] = *tt.status
-			}
-			handler, _, _ := round11NewHandler(t, cfg, state)
-			ctx, err := round10NewLiftContext(
-				http.MethodPost,
-				"/api/v1/statuses/"+tt.id+"/quote",
-				headers,
-				nil,
-				apimodels.CreateQuotePostRequest{Status: "quote text"},
-			)
-			require.NoError(t, err)
-			ctx.Params["id"] = tt.id
-
-			resp, err := handler.HandleCreateQuotePostLift(ctx)
-			require.NoError(t, err)
-			require.Equal(t, http.StatusNotImplemented, resp.Status)
-
-			var body map[string]any
-			require.NoError(t, json.Unmarshal(resp.Body, &body))
-			require.Equal(t, "quote endpoint is not implemented", body["error"])
-			require.NotContains(t, body, "id")
-			require.NotContains(t, body, "content")
-			require.NotContains(t, body, "quoted_status")
-
-			for _, where := range state.wheres {
-				require.NotEqual(t, "status#"+tt.id, where.value, "501 path must not look up the target status")
-			}
-		})
-	}
-}
-
-func TestGetQuotePermissionsReturnsNotImplementedWithoutStorageLookup(t *testing.T) {
-	tests := []struct {
-		name string
-		id   string
-	}{
-		{name: "existent account shape", id: "alice"},
-		{name: "nonexistent account", id: "definitely-not-a-real-account-9f2b"},
-		{name: "path traversal text", id: "../../root"},
-		{name: "sql injection text", id: "'; DROP--"},
-	}
-
-	var expectedBody []byte
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			state := &round10QueryState{}
-			handler, _, _ := round11NewHandler(t, round11TestConfig(), state)
-			ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/accounts/alice/quote_permissions", nil, nil, nil)
-			require.NoError(t, err)
-			ctx.Params["id"] = tt.id
-
-			resp, err := handler.HandleGetQuotePermissionsLift(ctx)
-			require.NoError(t, err)
-			require.Equal(t, http.StatusNotImplemented, resp.Status)
-			if expectedBody == nil {
-				expectedBody = append([]byte(nil), resp.Body...)
-			} else {
-				require.Equal(t, expectedBody, resp.Body, "all account IDs must receive an identical response")
-			}
-			require.JSONEq(t, `{"error":"quote permissions endpoint is not implemented"}`, string(resp.Body))
-			require.Empty(t, state.wheres, "501 path must not perform a storage query")
-		})
-	}
 }
 
 func TestDeleteQuoteAcceptsOnlyCanonicalOrLegacyOwnerIdentity(t *testing.T) {
@@ -360,52 +220,6 @@ func TestQuotes_Round12_GetQuotesOfStatus_Coverage(t *testing.T) {
 
 		requireStatus(t, http.StatusBadRequest)(handler.HandleGetQuotesOfStatusLift(ctx))
 	})
-}
-
-func TestGetQuotesReturnsNotImplementedWithoutStorageRead(t *testing.T) {
-	cfg := round11TestConfig()
-	tests := []struct {
-		name   string
-		id     string
-		status *storagemodels.Status
-	}{
-		{name: "existent", id: "public", status: &storagemodels.Status{StatusID: "public", Visibility: storagemodels.VisibilityPublic}},
-		{name: "followers only", id: "followers", status: &storagemodels.Status{StatusID: "followers", Visibility: storagemodels.VisibilityPrivate}},
-		{name: "nonexistent", id: "missing"},
-	}
-
-	var contractBody []byte
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			state := &round10QueryState{statusByID: map[string]storagemodels.Status{}}
-			if tt.status != nil {
-				state.statusByID[tt.id] = *tt.status
-			}
-			handler, _, _ := round11NewHandler(t, cfg, state)
-			ctx, err := round10NewLiftContext(
-				http.MethodGet,
-				"/api/v1/statuses/"+tt.id+"/quotes",
-				nil,
-				map[string]string{"limit": "10", "offset": "0"},
-				nil,
-			)
-			require.NoError(t, err)
-			ctx.Params["id"] = tt.id
-
-			resp := requireStatus(t, http.StatusNotImplemented)(handler.HandleGetQuotesOfStatusLift(ctx))
-			var body map[string]any
-			require.NoError(t, json.Unmarshal(resp.Body, &body))
-			require.Equal(t, "quotes endpoint is not implemented", body["error"])
-			require.Empty(t, state.wheres, "501 path must not perform a storage query")
-
-			if contractBody == nil {
-				contractBody = append([]byte(nil), resp.Body...)
-			} else {
-				require.Equal(t, contractBody, resp.Body, "all valid target IDs must have the same 501 body")
-			}
-		})
-	}
 }
 
 func TestQuotes_Round12_DeleteAndPermissions_Coverage(t *testing.T) {
@@ -534,13 +348,13 @@ func TestQuotes_Round12_DeleteAndPermissions_Coverage(t *testing.T) {
 		requireStatus(t, http.StatusInternalServerError)(handlerDel.HandleDeleteQuotePostLift(ctxDel))
 	})
 
-	t.Run("get_quote_permissions_validation_and_not_implemented", func(t *testing.T) {
+	t.Run("get_quote_permissions_validation", func(t *testing.T) {
 		ctxMissing, err := round10NewLiftContext(http.MethodGet, "/api/v1/accounts//quote_permissions", nil, nil, nil)
 		require.NoError(t, err)
 		requireStatus(t, http.StatusBadRequest)(handler.HandleGetQuotePermissionsLift(ctxMissing))
 	})
 
-	t.Run("update_quote_permissions_auth_validation_and_not_implemented", func(t *testing.T) {
+	t.Run("update_quote_permissions_auth_validation", func(t *testing.T) {
 		ctx, err := round10NewLiftContext(http.MethodPut, "/api/v1/accounts/quote_permissions", nil, nil, apimodels.UpdateQuotePermissionsRequest{})
 		require.NoError(t, err)
 		requireStatus(t, http.StatusUnauthorized)(handler.HandleUpdateQuotePermissionsLift(ctx))
@@ -555,24 +369,6 @@ func TestQuotes_Round12_DeleteAndPermissions_Coverage(t *testing.T) {
 		ctxBad := round10NewLiftContextWithBodyBytes(http.MethodPut, "/api/v1/accounts/quote_permissions", headers, nil, []byte(`{invalid}`))
 		requireStatus(t, http.StatusBadRequest)(handler.HandleUpdateQuotePermissionsLift(ctxBad))
 
-		allowPublic := true
-		allowFollowers := false
-		allowMentioned := true
-		ctx3, err := round10NewLiftContext(http.MethodPut, "/api/v1/accounts/quote_permissions", headers, nil, apimodels.UpdateQuotePermissionsRequest{
-			AllowPublic:    &allowPublic,
-			AllowFollowers: &allowFollowers,
-			AllowMentioned: &allowMentioned,
-			BlockList:      []string{"bob"},
-		})
-		require.NoError(t, err)
-		requireStatus(t, http.StatusNotImplemented)(handler.HandleUpdateQuotePermissionsLift(ctx3))
-
-		ctx4 := round10NewLiftContextWithBodyBytes(http.MethodPut, "/api/v1/accounts/quote_permissions",
-			map[string]string{"Authorization": "Bearer " + writeToken, "Content-Type": "application/x-www-form-urlencoded"},
-			nil,
-			[]byte(`{"allow_followers":true,"allow_mentioned":false}`),
-		)
-		requireStatus(t, http.StatusNotImplemented)(handler.HandleUpdateQuotePermissionsLift(ctx4))
 	})
 
 	t.Run("helper_functions", func(t *testing.T) {

--- a/cmd/api/handlers/round11_quotes_test.go
+++ b/cmd/api/handlers/round11_quotes_test.go
@@ -11,6 +11,7 @@ import (
 	apimodels "github.com/equaltoai/lesser/cmd/api/models"
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/common"
 	commonerrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/services/notes"
 	"github.com/equaltoai/lesser/pkg/services/quotes"
@@ -319,6 +320,18 @@ func TestQuotePostRESTListRoundTrip(t *testing.T) {
 	require.NoError(t, json.Unmarshal(resp.Body, &body))
 	require.Len(t, body, 1)
 	require.Equal(t, "quote-2", body[0].ID)
+
+	t.Run("offset beyond the servable scan bound is rejected", func(t *testing.T) {
+		boundedCtx, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/target-1/quotes", nil, map[string]string{"limit": "1", "offset": "4"}, nil)
+		require.NoError(t, err)
+		boundedCtx.Params["id"] = "target-1"
+
+		boundedResponse := requireStatus(t, http.StatusUnprocessableEntity)(handler.HandleGetQuotesOfStatusLift(boundedCtx))
+		var errorBody common.StandardErrorResponse
+		require.NoError(t, json.Unmarshal(boundedResponse.Body, &errorBody))
+		require.Contains(t, errorBody.Error, "3")
+		require.Equal(t, string(commonerrors.CodeUnprocessableEntity), errorBody.Code)
+	})
 
 	t.Run("missing and invisible targets have one 404 shape", func(t *testing.T) {
 		var expectedBody []byte

--- a/cmd/api/handlers/round11_quotes_test.go
+++ b/cmd/api/handlers/round11_quotes_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -247,7 +248,7 @@ func TestQuotePostRESTListRoundTrip(t *testing.T) {
 		QuotesSvc: &QuotesServiceStub{
 			GetQuoteRelationshipsForStatusFunc: func(_ context.Context, statusID string, limit int, cursor string) (*quotes.QuoteRelationshipPage, error) {
 				require.Equal(t, "target-1", statusID)
-				require.Equal(t, quoteListPageSize, limit)
+				require.Equal(t, quoteListScanMultiplier, limit)
 				require.Empty(t, cursor)
 				return &quotes.QuoteRelationshipPage{Relationships: []*storagemodels.QuoteRelationship{
 					{QuoterNoteID: "quote-hidden"},
@@ -299,6 +300,47 @@ func TestQuotePostRESTListRoundTrip(t *testing.T) {
 				}
 			})
 		}
+	})
+
+	t.Run("scan stops at bounded multiple when all quotes are hidden", func(t *testing.T) {
+		const requestedLimit = 2
+		quoteReads := 0
+		listCalls := 0
+		boundedRegistry := &RegistryStub{
+			NotesSvc: &NotesServiceStub{
+				GetNoteWithViewerFunc: func(_ context.Context, query *notes.GetNoteQuery) (*storagemodels.Status, error) {
+					if query.StatusID == "target-1" {
+						return target, nil
+					}
+					quoteReads++
+					return nil, notes.ErrStatusNotFound
+				},
+			},
+			QuotesSvc: &QuotesServiceStub{
+				GetQuoteRelationshipsForStatusFunc: func(_ context.Context, statusID string, limit int, cursor string) (*quotes.QuoteRelationshipPage, error) {
+					listCalls++
+					require.Equal(t, "target-1", statusID)
+					require.Equal(t, requestedLimit*quoteListScanMultiplier, limit)
+					require.Empty(t, cursor)
+					relationships := make([]*storagemodels.QuoteRelationship, limit)
+					for i := range relationships {
+						relationships[i] = &storagemodels.QuoteRelationship{QuoterNoteID: fmt.Sprintf("hidden-%d", i)}
+					}
+					return &quotes.QuoteRelationshipPage{Relationships: relationships, NextCursor: "more-relationships-exist"}, nil
+				},
+			},
+		}
+		boundedHandler, _, _ := round11NewHandler(t, cfg, boundedRegistry)
+		boundedCtx, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/target-1/quotes", nil, map[string]string{"limit": "2"}, nil)
+		require.NoError(t, err)
+		boundedCtx.Params["id"] = "target-1"
+
+		boundedResponse := requireStatus(t, http.StatusOK)(boundedHandler.HandleGetQuotesOfStatusLift(boundedCtx))
+		var boundedBody []apimodels.QuoteStatusSummary
+		require.NoError(t, json.Unmarshal(boundedResponse.Body, &boundedBody))
+		require.Empty(t, boundedBody)
+		require.Equal(t, requestedLimit*quoteListScanMultiplier, quoteReads)
+		require.Equal(t, 1, listCalls)
 	})
 
 	t.Run("relationship storage errors fail closed", func(t *testing.T) {

--- a/cmd/api/handlers/round11_quotes_test.go
+++ b/cmd/api/handlers/round11_quotes_test.go
@@ -16,7 +16,11 @@ import (
 	"github.com/equaltoai/lesser/pkg/services/quotes"
 	"github.com/equaltoai/lesser/pkg/storage"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
+	testinginmemory "github.com/equaltoai/lesser/pkg/testing/inmemory"
+	testingmocks "github.com/equaltoai/lesser/pkg/testing/mocks"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestQuotePostRESTCreateRoundTrip(t *testing.T) {
@@ -86,19 +90,63 @@ func TestQuotePostRESTCreateRoundTrip(t *testing.T) {
 
 	t.Run("missing and invisible targets have one 404 shape and no write", func(t *testing.T) {
 		var expectedBody []byte
-		for _, name := range []string{"missing", "invisible"} {
-			t.Run(name, func(t *testing.T) {
-				createCalls := 0
+		for _, test := range []struct {
+			name          string
+			seedInvisible bool
+		}{
+			{name: "missing"},
+			{name: "invisible", seedInvisible: true},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				statusRepo := testinginmemory.NewStatusRepository()
+				relationshipRepo := testingmocks.NewMockRelationshipRepository()
+				if test.seedInvisible {
+					now := time.Now().UTC()
+					relationshipRepo.On("IsFollowing", mock.Anything, "alice", "bob").Return(false, nil).Once()
+					require.NoError(t, statusRepo.CreateStatus(context.Background(), &storagemodels.Status{
+						StatusID:       "target-1",
+						AuthorID:       cfg.ActorURL("bob"),
+						AuthorUsername: "bob",
+						Visibility:     storagemodels.VisibilityPrivate,
+						ToRecipients:   []string{cfg.ActorURL("bob") + "/followers"},
+						PublishedAt:    now,
+						CreatedAt:      now,
+						UpdatedAt:      now,
+						ModifiedAt:     now,
+						Note: &activitypub.Note{
+							BaseObject: activitypub.BaseObject{
+								ID:   cfg.ActorURL("bob") + "/statuses/target-1",
+								Type: activitypub.NoteType,
+							},
+							AttributedTo: cfg.ActorURL("bob"),
+							Visibility:   storagemodels.VisibilityPrivate,
+						},
+					}))
+				}
+				notesService := notes.NewService(
+					statusRepo,
+					nil,
+					nil,
+					relationshipRepo,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					zap.NewNop(),
+					cfg.Domain,
+				)
 				reg := &RegistryStub{
-					NotesSvc: &NotesServiceStub{
-						ResolveQuoteTargetFunc: func(context.Context, string, string) (*storagemodels.Status, error) {
-							return nil, notes.ErrStatusNotFound
-						},
-						CreateNoteFunc: func(context.Context, *notes.CreateNoteCommand) (*notes.NoteResult, error) {
-							createCalls++
-							return nil, nil
-						},
-					},
+					NotesSvc:  notesService,
 					QuotesSvc: &QuotesServiceStub{},
 				}
 				handler, _, _ := round11NewHandler(t, cfg, reg)
@@ -107,12 +155,15 @@ func TestQuotePostRESTCreateRoundTrip(t *testing.T) {
 				ctx.Params["id"] = "target-1"
 
 				resp := requireStatus(t, http.StatusNotFound)(handler.HandleCreateQuotePostLift(ctx))
-				require.Zero(t, createCalls)
 				if expectedBody == nil {
 					expectedBody = append([]byte(nil), resp.Body...)
 				} else {
 					require.Equal(t, expectedBody, resp.Body)
 				}
+				createdCount, countErr := statusRepo.CountStatusesByAuthor(context.Background(), "alice")
+				require.NoError(t, countErr)
+				require.Zero(t, createdCount)
+				relationshipRepo.AssertExpectations(t)
 			})
 		}
 	})

--- a/cmd/api/handlers/round11_quotes_test.go
+++ b/cmd/api/handlers/round11_quotes_test.go
@@ -222,7 +222,10 @@ func TestQuotePostRESTCreateRoundTrip(t *testing.T) {
 		ctx.Params["id"] = "target-1"
 
 		resp := requireStatus(t, http.StatusUnprocessableEntity)(handler.HandleCreateQuotePostLift(ctx))
-		require.Contains(t, string(resp.Body), string(commonerrors.CodeUnprocessableEntity))
+		var errorBody common.StandardErrorResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &errorBody))
+		require.Equal(t, restTargetNotQuotable, errorBody.Error)
+		require.Equal(t, string(commonerrors.CodeUnprocessableEntity), errorBody.Code)
 		require.Zero(t, permissionCalls)
 		require.Zero(t, createCalls)
 	})

--- a/cmd/api/handlers/round11_quotes_test.go
+++ b/cmd/api/handlers/round11_quotes_test.go
@@ -436,3 +436,31 @@ func TestQuotePermissionsRESTRoundTrips(t *testing.T) {
 		requireStatus(t, http.StatusInternalServerError)(failedHandler.HandleUpdateQuotePermissionsLift(ctx))
 	})
 }
+
+func TestQuoteRESTUnavailableServicesFailClosed(t *testing.T) {
+	cfg := round11TestConfig()
+	writeStatuses := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{"write:statuses"})
+	readAccounts := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{"read:accounts"})
+	writeAccounts := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{"write:accounts"})
+	handler, _, _ := round11NewHandler(t, cfg, &RegistryStub{})
+	handler.registry = &RegistryStub{}
+
+	createCtx, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses/target-1/quote", map[string]string{"Authorization": "Bearer " + writeStatuses}, nil, apimodels.CreateQuotePostRequest{Status: "quote"})
+	require.NoError(t, err)
+	createCtx.Params["id"] = "target-1"
+	requireStatus(t, http.StatusInternalServerError)(handler.HandleCreateQuotePostLift(createCtx))
+
+	listCtx, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/target-1/quotes", nil, nil, nil)
+	require.NoError(t, err)
+	listCtx.Params["id"] = "target-1"
+	requireStatus(t, http.StatusInternalServerError)(handler.HandleGetQuotesOfStatusLift(listCtx))
+
+	readCtx, err := round10NewLiftContext(http.MethodGet, "/api/v1/accounts/alice/quote_permissions", map[string]string{"Authorization": "Bearer " + readAccounts}, nil, nil)
+	require.NoError(t, err)
+	readCtx.Params["id"] = "alice"
+	requireStatus(t, http.StatusInternalServerError)(handler.HandleGetQuotePermissionsLift(readCtx))
+
+	updateCtx, err := round10NewLiftContext(http.MethodPut, "/api/v1/accounts/quote_permissions", map[string]string{"Authorization": "Bearer " + writeAccounts}, nil, apimodels.UpdateQuotePermissionsRequest{})
+	require.NoError(t, err)
+	requireStatus(t, http.StatusInternalServerError)(handler.HandleUpdateQuotePermissionsLift(updateCtx))
+}

--- a/cmd/api/handlers/round11_quotes_test.go
+++ b/cmd/api/handlers/round11_quotes_test.go
@@ -161,6 +161,28 @@ func TestQuotePostRESTCreateRoundTrip(t *testing.T) {
 		requireStatus(t, http.StatusInternalServerError)(handler.HandleCreateQuotePostLift(ctx))
 		require.Zero(t, createCalls)
 	})
+
+	t.Run("target storage errors fail closed before note creation", func(t *testing.T) {
+		createCalls := 0
+		reg := &RegistryStub{
+			NotesSvc: &NotesServiceStub{
+				ResolveQuoteTargetFunc: func(context.Context, string, string) (*storagemodels.Status, error) {
+					return nil, commonerrors.Internal("target storage failed")
+				},
+				CreateNoteFunc: func(context.Context, *notes.CreateNoteCommand) (*notes.NoteResult, error) {
+					createCalls++
+					return nil, nil
+				},
+			},
+			QuotesSvc: &QuotesServiceStub{},
+		}
+		handler, _, _ := round11NewHandler(t, cfg, reg)
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses/target-1/quote", headers, nil, apimodels.CreateQuotePostRequest{Status: "Quote text"})
+		require.NoError(t, err)
+		ctx.Params["id"] = "target-1"
+		requireStatus(t, http.StatusInternalServerError)(handler.HandleCreateQuotePostLift(ctx))
+		require.Zero(t, createCalls)
+	})
 }
 
 func TestQuotePostRESTListRoundTrip(t *testing.T) {
@@ -241,6 +263,26 @@ func TestQuotePostRESTListRoundTrip(t *testing.T) {
 				}
 			})
 		}
+	})
+
+	t.Run("relationship storage errors fail closed", func(t *testing.T) {
+		failedRegistry := &RegistryStub{
+			NotesSvc: &NotesServiceStub{
+				GetNoteWithViewerFunc: func(context.Context, *notes.GetNoteQuery) (*storagemodels.Status, error) {
+					return target, nil
+				},
+			},
+			QuotesSvc: &QuotesServiceStub{
+				GetQuoteRelationshipsForStatusFunc: func(context.Context, string, int, string) (*quotes.QuoteRelationshipPage, error) {
+					return nil, commonerrors.Internal("relationship storage failed")
+				},
+			},
+		}
+		failedHandler, _, _ := round11NewHandler(t, cfg, failedRegistry)
+		failedCtx, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/target-1/quotes", nil, nil, nil)
+		require.NoError(t, err)
+		failedCtx.Params["id"] = "target-1"
+		requireStatus(t, http.StatusInternalServerError)(failedHandler.HandleGetQuotesOfStatusLift(failedCtx))
 	})
 }
 
@@ -354,5 +396,43 @@ func TestQuotePermissionsRESTRoundTrips(t *testing.T) {
 		require.NoError(t, err)
 		requireStatus(t, http.StatusBadRequest)(handler.HandleUpdateQuotePermissionsLift(ctx))
 		require.Nil(t, updated)
+	})
+
+	t.Run("permission storage errors fail closed", func(t *testing.T) {
+		failedRegistry := &RegistryStub{
+			AccountsSvc: reg.AccountsSvc,
+			QuotesSvc: &QuotesServiceStub{
+				GetQuotePermissionsFunc: func(context.Context, string) (*storagemodels.QuotePermissions, error) {
+					return nil, commonerrors.Internal("permission storage failed")
+				},
+			},
+		}
+		failedHandler, _, _ := round11NewHandler(t, cfg, failedRegistry)
+
+		readCtx, err := round10NewLiftContext(http.MethodGet, "/api/v1/accounts/alice/quote_permissions", map[string]string{"Authorization": "Bearer " + readToken}, nil, nil)
+		require.NoError(t, err)
+		readCtx.Params["id"] = "alice"
+		requireStatus(t, http.StatusInternalServerError)(failedHandler.HandleGetQuotePermissionsLift(readCtx))
+
+		updateCtx, err := round10NewLiftContext(http.MethodPut, "/api/v1/accounts/quote_permissions", map[string]string{"Authorization": "Bearer " + writeToken}, nil, apimodels.UpdateQuotePermissionsRequest{})
+		require.NoError(t, err)
+		requireStatus(t, http.StatusInternalServerError)(failedHandler.HandleUpdateQuotePermissionsLift(updateCtx))
+	})
+
+	t.Run("permission save errors fail closed", func(t *testing.T) {
+		failedRegistry := &RegistryStub{
+			QuotesSvc: &QuotesServiceStub{
+				GetQuotePermissionsFunc: func(context.Context, string) (*storagemodels.QuotePermissions, error) {
+					return stored["alice"], nil
+				},
+				UpdateQuotePermissionsFunc: func(context.Context, *storagemodels.QuotePermissions) error {
+					return commonerrors.Internal("permission save failed")
+				},
+			},
+		}
+		failedHandler, _, _ := round11NewHandler(t, cfg, failedRegistry)
+		ctx, err := round10NewLiftContext(http.MethodPut, "/api/v1/accounts/quote_permissions", map[string]string{"Authorization": "Bearer " + writeToken}, nil, apimodels.UpdateQuotePermissionsRequest{})
+		require.NoError(t, err)
+		requireStatus(t, http.StatusInternalServerError)(failedHandler.HandleUpdateQuotePermissionsLift(ctx))
 	})
 }

--- a/cmd/api/handlers/round11_quotes_test.go
+++ b/cmd/api/handlers/round11_quotes_test.go
@@ -299,7 +299,7 @@ func TestQuotePostRESTListRoundTrip(t *testing.T) {
 		QuotesSvc: &QuotesServiceStub{
 			GetQuoteRelationshipsForStatusFunc: func(_ context.Context, statusID string, limit int, cursor string) (*quotes.QuoteRelationshipPage, error) {
 				require.Equal(t, "target-1", statusID)
-				require.Equal(t, quoteListScanMultiplier, limit)
+				require.Equal(t, quoteListPageSize, limit)
 				require.Empty(t, cursor)
 				return &quotes.QuoteRelationshipPage{Relationships: []*storagemodels.QuoteRelationship{
 					{QuoterNoteID: "quote-hidden"},
@@ -371,9 +371,9 @@ func TestQuotePostRESTListRoundTrip(t *testing.T) {
 				GetQuoteRelationshipsForStatusFunc: func(_ context.Context, statusID string, limit int, cursor string) (*quotes.QuoteRelationshipPage, error) {
 					listCalls++
 					require.Equal(t, "target-1", statusID)
-					require.Equal(t, requestedLimit*quoteListScanMultiplier, limit)
+					require.Equal(t, quoteListPageSize, limit)
 					require.Empty(t, cursor)
-					relationships := make([]*storagemodels.QuoteRelationship, limit)
+					relationships := make([]*storagemodels.QuoteRelationship, requestedLimit*quoteListScanMultiplier)
 					for i := range relationships {
 						relationships[i] = &storagemodels.QuoteRelationship{QuoterNoteID: fmt.Sprintf("hidden-%d", i)}
 					}
@@ -392,6 +392,49 @@ func TestQuotePostRESTListRoundTrip(t *testing.T) {
 		require.Empty(t, boundedBody)
 		require.Equal(t, requestedLimit*quoteListScanMultiplier, quoteReads)
 		require.Equal(t, 1, listCalls)
+	})
+
+	t.Run("withdrawn relationship pages terminate at the fetch cap", func(t *testing.T) {
+		const requestedLimit = 80
+		fetchCap := (requestedLimit*quoteListScanMultiplier + quoteListPageSize - 1) / quoteListPageSize
+		listCalls := 0
+		withdrawnRegistry := &RegistryStub{
+			NotesSvc: &NotesServiceStub{
+				GetNoteWithViewerFunc: func(_ context.Context, query *notes.GetNoteQuery) (*storagemodels.Status, error) {
+					require.Empty(t, query.ViewerID, "the termination path must remain safe for unauthenticated callers")
+					if query.StatusID == "target-1" {
+						return target, nil
+					}
+					t.Fatalf("withdrawn relationships must not reach visibility projection: %s", query.StatusID)
+					return nil, nil
+				},
+			},
+			QuotesSvc: &QuotesServiceStub{
+				GetQuoteRelationshipsForStatusFunc: func(_ context.Context, statusID string, limit int, cursor string) (*quotes.QuoteRelationshipPage, error) {
+					listCalls++
+					require.Equal(t, "target-1", statusID)
+					require.Equal(t, quoteListPageSize, limit)
+					if listCalls == 1 {
+						require.Empty(t, cursor)
+					} else {
+						require.Equal(t, fmt.Sprintf("withdrawn-page-%d", listCalls-1), cursor)
+					}
+					// QuoteRepository filters withdrawn rows after each raw storage page,
+					// so the handler sees no survivors alongside a live cursor.
+					return &quotes.QuoteRelationshipPage{NextCursor: fmt.Sprintf("withdrawn-page-%d", listCalls)}, nil
+				},
+			},
+		}
+		withdrawnHandler, _, _ := round11NewHandler(t, cfg, withdrawnRegistry)
+		withdrawnCtx, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/target-1/quotes", nil, map[string]string{"limit": "80"}, nil)
+		require.NoError(t, err)
+		withdrawnCtx.Params["id"] = "target-1"
+
+		withdrawnResponse := requireStatus(t, http.StatusOK)(withdrawnHandler.HandleGetQuotesOfStatusLift(withdrawnCtx))
+		var withdrawnBody []apimodels.QuoteStatusSummary
+		require.NoError(t, json.Unmarshal(withdrawnResponse.Body, &withdrawnBody))
+		require.Empty(t, withdrawnBody)
+		require.Equal(t, fetchCap, listCalls)
 	})
 
 	t.Run("relationship storage errors fail closed", func(t *testing.T) {

--- a/cmd/api/handlers/round11_quotes_test.go
+++ b/cmd/api/handlers/round11_quotes_test.go
@@ -335,15 +335,66 @@ func TestQuotePostRESTListRoundTrip(t *testing.T) {
 
 	t.Run("missing and invisible targets have one 404 shape", func(t *testing.T) {
 		var expectedBody []byte
-		for _, name := range []string{"missing", "invisible"} {
-			t.Run(name, func(t *testing.T) {
+		for _, test := range []struct {
+			name          string
+			seedInvisible bool
+		}{
+			{name: "missing"},
+			{name: "invisible", seedInvisible: true},
+		} {
+			t.Run(test.name, func(t *testing.T) {
 				listCalls := 0
-				deniedRegistry := &RegistryStub{
-					NotesSvc: &NotesServiceStub{
-						GetNoteWithViewerFunc: func(context.Context, *notes.GetNoteQuery) (*storagemodels.Status, error) {
-							return nil, notes.ErrStatusNotFound
+				statusRepo := testinginmemory.NewStatusRepository()
+				relationshipRepo := testingmocks.NewMockRelationshipRepository()
+				if test.seedInvisible {
+					now := time.Now().UTC()
+					require.NoError(t, statusRepo.CreateStatus(context.Background(), &storagemodels.Status{
+						StatusID:       "target-1",
+						AuthorID:       cfg.ActorURL("bob"),
+						AuthorUsername: "bob",
+						Visibility:     storagemodels.VisibilityPrivate,
+						ToRecipients:   []string{cfg.ActorURL("bob") + "/followers"},
+						PublishedAt:    now,
+						CreatedAt:      now,
+						UpdatedAt:      now,
+						ModifiedAt:     now,
+						Note: &activitypub.Note{
+							BaseObject: activitypub.BaseObject{
+								ID:   cfg.ActorURL("bob") + "/statuses/target-1",
+								Type: activitypub.NoteType,
+							},
+							AttributedTo: cfg.ActorURL("bob"),
+							Visibility:   storagemodels.VisibilityPrivate,
 						},
-					},
+					}))
+					seeded, seedErr := statusRepo.GetStatus(context.Background(), "target-1")
+					require.NoError(t, seedErr)
+					require.NotNil(t, seeded, "the invisible fixture must genuinely exist")
+				}
+				notesService := notes.NewService(
+					statusRepo,
+					nil,
+					nil,
+					relationshipRepo,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					nil,
+					zap.NewNop(),
+					cfg.Domain,
+				)
+				deniedRegistry := &RegistryStub{
+					NotesSvc: notesService,
 					QuotesSvc: &QuotesServiceStub{
 						GetQuoteRelationshipsForStatusFunc: func(context.Context, string, int, string) (*quotes.QuoteRelationshipPage, error) {
 							listCalls++
@@ -362,6 +413,7 @@ func TestQuotePostRESTListRoundTrip(t *testing.T) {
 				} else {
 					require.Equal(t, expectedBody, deniedResponse.Body)
 				}
+				relationshipRepo.AssertExpectations(t)
 			})
 		}
 	})

--- a/cmd/api/handlers/round11_quotes_test.go
+++ b/cmd/api/handlers/round11_quotes_test.go
@@ -1,65 +1,358 @@
 package handlers
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 
 	apimodels "github.com/equaltoai/lesser/cmd/api/models"
+	"github.com/equaltoai/lesser/pkg/activitypub"
+	"github.com/equaltoai/lesser/pkg/auth"
+	commonerrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/services/notes"
+	"github.com/equaltoai/lesser/pkg/services/quotes"
+	"github.com/equaltoai/lesser/pkg/storage"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/require"
 )
 
-func TestQuotesHandlers(t *testing.T) {
+func TestQuotePostRESTCreateRoundTrip(t *testing.T) {
 	cfg := round11TestConfig()
-	state := &round10QueryState{
-		statusByID: map[string]storagemodels.Status{
-			"123": {StatusID: "123", AuthorUsername: "bob"},
+	writeToken := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{"write:statuses"})
+	headers := map[string]string{"Authorization": "Bearer " + writeToken}
+	target := &storagemodels.Status{
+		StatusID:       "target-1",
+		AuthorID:       cfg.ActorURL("bob"),
+		AuthorUsername: "bob",
+		Visibility:     storagemodels.VisibilityPublic,
+	}
+	created := &storagemodels.Status{
+		StatusID:       "quote-1",
+		AuthorID:       cfg.ActorURL("alice"),
+		AuthorUsername: "alice",
+		Content:        "Quote text",
+		Visibility:     storagemodels.VisibilityPublic,
+		CreatedAt:      time.Date(2026, time.August, 4, 12, 0, 0, 0, time.UTC),
+	}
+
+	t.Run("happy path uses notes creation and quote attachment", func(t *testing.T) {
+		var createCalls, attachCalls int
+		reg := &RegistryStub{
+			NotesSvc: &NotesServiceStub{
+				ResolveQuoteTargetFunc: func(_ context.Context, viewerID, rawTarget string) (*storagemodels.Status, error) {
+					require.Equal(t, "alice", viewerID)
+					require.Equal(t, "target-1", rawTarget)
+					return target, nil
+				},
+				CreateNoteFunc: func(_ context.Context, cmd *notes.CreateNoteCommand) (*notes.NoteResult, error) {
+					createCalls++
+					require.Equal(t, "alice", cmd.AuthorID)
+					require.Equal(t, "Quote text", cmd.Content)
+					require.Equal(t, storagemodels.VisibilityPublic, cmd.Visibility)
+					return &notes.NoteResult{Note: created}, nil
+				},
+			},
+			QuotesSvc: &QuotesServiceStub{
+				CheckQuotePermissionsFunc: func(_ context.Context, quoter string, gotTarget *storagemodels.Status) (bool, error) {
+					require.Equal(t, "alice", quoter)
+					require.Same(t, target, gotTarget)
+					return true, nil
+				},
+				AttachQuoteToStatusFunc: func(_ context.Context, quoteStatus *storagemodels.Status, targetID string) (*quotes.QuotePostResult, error) {
+					attachCalls++
+					require.Same(t, created, quoteStatus)
+					require.Equal(t, "target-1", targetID)
+					return &quotes.QuotePostResult{QuoteStatus: created, TargetStatus: target}, nil
+				},
+			},
+		}
+		handler, _, _ := round11NewHandler(t, cfg, reg)
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses/target-1/quote", headers, nil, apimodels.CreateQuotePostRequest{Status: "Quote text"})
+		require.NoError(t, err)
+		ctx.Params["id"] = "target-1"
+
+		resp := requireStatus(t, http.StatusOK)(handler.HandleCreateQuotePostLift(ctx))
+		require.Equal(t, 1, createCalls)
+		require.Equal(t, 1, attachCalls)
+		var body apimodels.QuoteStatusSummary
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, "quote-1", body.ID)
+		require.Equal(t, "Quote text", body.Content)
+		require.Equal(t, cfg.ActorURL("alice"), body.Account.ID)
+	})
+
+	t.Run("missing and invisible targets have one 404 shape and no write", func(t *testing.T) {
+		var expectedBody []byte
+		for _, name := range []string{"missing", "invisible"} {
+			t.Run(name, func(t *testing.T) {
+				createCalls := 0
+				reg := &RegistryStub{
+					NotesSvc: &NotesServiceStub{
+						ResolveQuoteTargetFunc: func(context.Context, string, string) (*storagemodels.Status, error) {
+							return nil, notes.ErrStatusNotFound
+						},
+						CreateNoteFunc: func(context.Context, *notes.CreateNoteCommand) (*notes.NoteResult, error) {
+							createCalls++
+							return nil, nil
+						},
+					},
+					QuotesSvc: &QuotesServiceStub{},
+				}
+				handler, _, _ := round11NewHandler(t, cfg, reg)
+				ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses/target-1/quote", headers, nil, apimodels.CreateQuotePostRequest{Status: "Quote text"})
+				require.NoError(t, err)
+				ctx.Params["id"] = "target-1"
+
+				resp := requireStatus(t, http.StatusNotFound)(handler.HandleCreateQuotePostLift(ctx))
+				require.Zero(t, createCalls)
+				if expectedBody == nil {
+					expectedBody = append([]byte(nil), resp.Body...)
+				} else {
+					require.Equal(t, expectedBody, resp.Body)
+				}
+			})
+		}
+	})
+
+	t.Run("quoteability denial happens before note creation", func(t *testing.T) {
+		createCalls := 0
+		reg := &RegistryStub{
+			NotesSvc: &NotesServiceStub{
+				ResolveQuoteTargetFunc: func(context.Context, string, string) (*storagemodels.Status, error) { return target, nil },
+				CreateNoteFunc: func(context.Context, *notes.CreateNoteCommand) (*notes.NoteResult, error) {
+					createCalls++
+					return nil, nil
+				},
+			},
+			QuotesSvc: &QuotesServiceStub{
+				CheckQuotePermissionsFunc: func(context.Context, string, *storagemodels.Status) (bool, error) { return false, nil },
+			},
+		}
+		handler, _, _ := round11NewHandler(t, cfg, reg)
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses/target-1/quote", headers, nil, apimodels.CreateQuotePostRequest{Status: "Quote text"})
+		require.NoError(t, err)
+		ctx.Params["id"] = "target-1"
+		requireStatus(t, http.StatusForbidden)(handler.HandleCreateQuotePostLift(ctx))
+		require.Zero(t, createCalls)
+	})
+
+	t.Run("quoteability storage errors fail closed before note creation", func(t *testing.T) {
+		createCalls := 0
+		reg := &RegistryStub{
+			NotesSvc: &NotesServiceStub{
+				ResolveQuoteTargetFunc: func(context.Context, string, string) (*storagemodels.Status, error) { return target, nil },
+				CreateNoteFunc: func(context.Context, *notes.CreateNoteCommand) (*notes.NoteResult, error) {
+					createCalls++
+					return nil, nil
+				},
+			},
+			QuotesSvc: &QuotesServiceStub{
+				CheckQuotePermissionsFunc: func(context.Context, string, *storagemodels.Status) (bool, error) {
+					return false, commonerrors.Internal("permission storage failed")
+				},
+			},
+		}
+		handler, _, _ := round11NewHandler(t, cfg, reg)
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses/target-1/quote", headers, nil, apimodels.CreateQuotePostRequest{Status: "Quote text"})
+		require.NoError(t, err)
+		ctx.Params["id"] = "target-1"
+		requireStatus(t, http.StatusInternalServerError)(handler.HandleCreateQuotePostLift(ctx))
+		require.Zero(t, createCalls)
+	})
+}
+
+func TestQuotePostRESTListRoundTrip(t *testing.T) {
+	cfg := round11TestConfig()
+	target := &storagemodels.Status{StatusID: "target-1", Visibility: storagemodels.VisibilityPublic}
+	visibleOne := &storagemodels.Status{StatusID: "quote-1", AuthorID: cfg.ActorURL("alice"), AuthorUsername: "alice", Content: "one", CreatedAt: time.Now()}
+	visibleTwo := &storagemodels.Status{StatusID: "quote-2", AuthorID: cfg.ActorURL("carol"), AuthorUsername: "carol", Content: "two", CreatedAt: time.Now()}
+
+	reg := &RegistryStub{
+		NotesSvc: &NotesServiceStub{
+			GetNoteWithViewerFunc: func(_ context.Context, query *notes.GetNoteQuery) (*storagemodels.Status, error) {
+				switch query.StatusID {
+				case "target-1":
+					return target, nil
+				case "quote-hidden":
+					return nil, notes.ErrStatusNotFound
+				case "quote-1":
+					return visibleOne, nil
+				case "quote-2":
+					return visibleTwo, nil
+				default:
+					return nil, notes.ErrStatusNotFound
+				}
+			},
+		},
+		QuotesSvc: &QuotesServiceStub{
+			GetQuoteRelationshipsForStatusFunc: func(_ context.Context, statusID string, limit int, cursor string) (*quotes.QuoteRelationshipPage, error) {
+				require.Equal(t, "target-1", statusID)
+				require.Equal(t, quoteListPageSize, limit)
+				require.Empty(t, cursor)
+				return &quotes.QuoteRelationshipPage{Relationships: []*storagemodels.QuoteRelationship{
+					{QuoterNoteID: "quote-hidden"},
+					{QuoterNoteID: "quote-1"},
+					{QuoterNoteID: "quote-2"},
+				}}, nil
+			},
 		},
 	}
-	handler, _, _ := round11NewHandler(t, cfg, state)
-
-	token := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{"write:statuses", "read"})
-	headers := map[string]string{"Authorization": "Bearer " + token}
-
-	ctxCreate, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses/123/quote", headers, nil, apimodels.CreateQuotePostRequest{Status: "Quote text"})
+	handler, _, _ := round11NewHandler(t, cfg, reg)
+	ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/target-1/quotes", nil, map[string]string{"limit": "1", "offset": "1"}, nil)
 	require.NoError(t, err)
-	ctxCreate.Params["id"] = "123"
-	requireStatus(t, http.StatusNotImplemented)(handler.HandleCreateQuotePostLift(ctxCreate))
+	ctx.Params["id"] = "target-1"
 
-	ctxList, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/123/quotes", nil, map[string]string{"limit": "2", "offset": "0"}, nil)
-	require.NoError(t, err)
-	ctxList.Params["id"] = "123"
-	requireStatus(t, http.StatusNotImplemented)(handler.HandleGetQuotesOfStatusLift(ctxList))
+	resp := requireStatus(t, http.StatusOK)(handler.HandleGetQuotesOfStatusLift(ctx))
+	var body []apimodels.QuoteStatusSummary
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Len(t, body, 1)
+	require.Equal(t, "quote-2", body[0].ID)
 
-	ctxDelete, err := round10NewLiftContext(http.MethodDelete, "/api/v1/statuses/123/quote/q1", headers, nil, nil)
-	require.NoError(t, err)
-	ctxDelete.Params["id"] = "123"
-	ctxDelete.Params["quote_id"] = "q1"
-	requireStatus(t, http.StatusNotFound)(handler.HandleDeleteQuotePostLift(ctxDelete))
+	t.Run("missing and invisible targets have one 404 shape", func(t *testing.T) {
+		var expectedBody []byte
+		for _, name := range []string{"missing", "invisible"} {
+			t.Run(name, func(t *testing.T) {
+				listCalls := 0
+				deniedRegistry := &RegistryStub{
+					NotesSvc: &NotesServiceStub{
+						GetNoteWithViewerFunc: func(context.Context, *notes.GetNoteQuery) (*storagemodels.Status, error) {
+							return nil, notes.ErrStatusNotFound
+						},
+					},
+					QuotesSvc: &QuotesServiceStub{
+						GetQuoteRelationshipsForStatusFunc: func(context.Context, string, int, string) (*quotes.QuoteRelationshipPage, error) {
+							listCalls++
+							return nil, nil
+						},
+					},
+				}
+				deniedHandler, _, _ := round11NewHandler(t, cfg, deniedRegistry)
+				deniedCtx, err := round10NewLiftContext(http.MethodGet, "/api/v1/statuses/target-1/quotes", nil, nil, nil)
+				require.NoError(t, err)
+				deniedCtx.Params["id"] = "target-1"
+				deniedResponse := requireStatus(t, http.StatusNotFound)(deniedHandler.HandleGetQuotesOfStatusLift(deniedCtx))
+				require.Zero(t, listCalls)
+				if expectedBody == nil {
+					expectedBody = append([]byte(nil), deniedResponse.Body...)
+				} else {
+					require.Equal(t, expectedBody, deniedResponse.Body)
+				}
+			})
+		}
+	})
 }
 
-func TestQuotesPermissions(t *testing.T) {
+func TestQuotePermissionsRESTRoundTrips(t *testing.T) {
 	cfg := round11TestConfig()
-	handler, _, _ := round11NewHandler(t, cfg, &round10QueryState{})
-
-	ctxGet, err := round10NewLiftContext(http.MethodGet, "/api/v1/accounts/alice/quote_permissions", nil, nil, nil)
-	require.NoError(t, err)
-	ctxGet.Params["id"] = "alice"
-	requireStatus(t, http.StatusNotImplemented)(handler.HandleGetQuotePermissionsLift(ctxGet))
-
-	updateToken := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{"write:accounts"})
-	headers := map[string]string{"Authorization": "Bearer " + updateToken}
-	updateReq := apimodels.UpdateQuotePermissionsRequest{
-		AllowPublic:    boolPtr(true),
-		AllowFollowers: boolPtr(false),
-		AllowMentioned: boolPtr(true),
-		BlockList:      []string{"bob"},
+	readToken := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{"read:accounts"})
+	writeToken := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{"write:accounts"})
+	actors := map[string]*activitypub.Actor{
+		"alice": {BaseObject: activitypub.BaseObject{ID: cfg.ActorURL("alice")}, PreferredUsername: "alice"},
+		"bob":   {BaseObject: activitypub.BaseObject{ID: cfg.ActorURL("bob")}, PreferredUsername: "bob"},
 	}
-	ctxUpdate, err := round10NewLiftContext(http.MethodPut, "/api/v1/accounts/quote_permissions", headers, nil, updateReq)
-	require.NoError(t, err)
-	requireStatus(t, http.StatusNotImplemented)(handler.HandleUpdateQuotePermissionsLift(ctxUpdate))
-}
+	stored := map[string]*storagemodels.QuotePermissions{
+		"alice": {Username: "alice", AllowPublic: true, AllowFollowers: true, AllowMentioned: true, BlockList: []string{}},
+		"bob":   {Username: "bob", AllowFollowers: true, BlockList: []string{"mallory"}},
+	}
+	var updated *storagemodels.QuotePermissions
+	var readUsernames []string
+	reg := &RegistryStub{
+		AccountsSvc: &AccountsServiceStub{
+			GetAccountFunc: func(_ context.Context, username string) (*storage.Account, error) {
+				actor := actors[username]
+				if actor == nil {
+					return nil, commonerrors.NotFound("account")
+				}
+				return &storage.Account{Actor: actor}, nil
+			},
+		},
+		QuotesSvc: &QuotesServiceStub{
+			GetQuotePermissionsFunc: func(_ context.Context, username string) (*storagemodels.QuotePermissions, error) {
+				readUsernames = append(readUsernames, username)
+				return stored[username], nil
+			},
+			UpdateQuotePermissionsFunc: func(_ context.Context, permissions *storagemodels.QuotePermissions) error {
+				copy := *permissions
+				copy.BlockList = append([]string(nil), permissions.BlockList...)
+				updated = &copy
+				return nil
+			},
+		},
+	}
+	handler, _, _ := round11NewHandler(t, cfg, reg)
 
-func boolPtr(v bool) *bool {
-	return &v
+	t.Run("authenticated self read uses persisted policy", func(t *testing.T) {
+		readUsernames = nil
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/accounts/alice/quote_permissions", map[string]string{"Authorization": "Bearer " + readToken}, nil, nil)
+		require.NoError(t, err)
+		ctx.Params["id"] = "alice"
+		resp := requireStatus(t, http.StatusOK)(handler.HandleGetQuotePermissionsLift(ctx))
+		var body apimodels.QuotePermissionsResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, stored["alice"].AllowFollowers, body.AllowFollowers)
+		require.Equal(t, stored["alice"].BlockList, body.BlockList)
+		require.Equal(t, []string{"alice"}, readUsernames)
+	})
+
+	t.Run("other and missing accounts have one 404 shape without policy reads", func(t *testing.T) {
+		readUsernames = nil
+		var expectedBody []byte
+		for _, accountID := range []string{"bob", "missing"} {
+			ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/accounts/"+accountID+"/quote_permissions", map[string]string{"Authorization": "Bearer " + readToken}, nil, nil)
+			require.NoError(t, err)
+			ctx.Params["id"] = accountID
+			resp := requireStatus(t, http.StatusNotFound)(handler.HandleGetQuotePermissionsLift(ctx))
+			if expectedBody == nil {
+				expectedBody = append([]byte(nil), resp.Body...)
+			} else {
+				require.Equal(t, expectedBody, resp.Body)
+			}
+		}
+		require.Empty(t, readUsernames)
+	})
+
+	t.Run("permission read requires authentication and read scope", func(t *testing.T) {
+		ctx, err := round10NewLiftContext(http.MethodGet, "/api/v1/accounts/alice/quote_permissions", nil, nil, nil)
+		require.NoError(t, err)
+		ctx.Params["id"] = "alice"
+		requireStatus(t, http.StatusUnauthorized)(handler.HandleGetQuotePermissionsLift(ctx))
+
+		onlyWrite := round11SignAccessToken(t, cfg.JWTSecret, "alice", []string{auth.ScopeWrite})
+		ctx, err = round10NewLiftContext(http.MethodGet, "/api/v1/accounts/alice/quote_permissions", map[string]string{"Authorization": "Bearer " + onlyWrite}, nil, nil)
+		require.NoError(t, err)
+		ctx.Params["id"] = "alice"
+		requireStatus(t, http.StatusForbidden)(handler.HandleGetQuotePermissionsLift(ctx))
+	})
+
+	t.Run("update validates and persists the full arm set", func(t *testing.T) {
+		allowPublic := false
+		allowFollowers := true
+		allowMentioned := true
+		ctx, err := round10NewLiftContext(http.MethodPut, "/api/v1/accounts/quote_permissions", map[string]string{"Authorization": "Bearer " + writeToken}, nil, apimodels.UpdateQuotePermissionsRequest{
+			AllowPublic:    &allowPublic,
+			AllowFollowers: &allowFollowers,
+			AllowMentioned: &allowMentioned,
+			BlockList:      []string{" @bob ", "bob", "carol"},
+		})
+		require.NoError(t, err)
+		resp := requireStatus(t, http.StatusOK)(handler.HandleUpdateQuotePermissionsLift(ctx))
+		require.NotNil(t, updated)
+		require.False(t, updated.AllowPublic)
+		require.True(t, updated.AllowFollowers)
+		require.True(t, updated.AllowMentioned)
+		require.Equal(t, []string{"bob", "carol"}, updated.BlockList)
+		var body apimodels.QuotePermissionsResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.Equal(t, updated.BlockList, body.BlockList)
+	})
+
+	t.Run("invalid block-list member fails before persistence", func(t *testing.T) {
+		updated = nil
+		ctx, err := round10NewLiftContext(http.MethodPut, "/api/v1/accounts/quote_permissions", map[string]string{"Authorization": "Bearer " + writeToken}, nil, apimodels.UpdateQuotePermissionsRequest{BlockList: []string{"../../root"}})
+		require.NoError(t, err)
+		requireStatus(t, http.StatusBadRequest)(handler.HandleUpdateQuotePermissionsLift(ctx))
+		require.Nil(t, updated)
+	})
 }

--- a/cmd/api/handlers/round11_quotes_test.go
+++ b/cmd/api/handlers/round11_quotes_test.go
@@ -138,6 +138,42 @@ func TestQuotePostRESTCreateRoundTrip(t *testing.T) {
 		require.Zero(t, createCalls)
 	})
 
+	t.Run("non-public target fails with 422 before note creation", func(t *testing.T) {
+		createCalls := 0
+		permissionCalls := 0
+		followersOnlyTarget := *target
+		followersOnlyTarget.Visibility = storagemodels.VisibilityPrivate
+		reg := &RegistryStub{
+			NotesSvc: &NotesServiceStub{
+				ResolveQuoteTargetFunc: func(context.Context, string, string) (*storagemodels.Status, error) {
+					return &followersOnlyTarget, nil
+				},
+				CreateNoteFunc: func(context.Context, *notes.CreateNoteCommand) (*notes.NoteResult, error) {
+					createCalls++
+					return nil, nil
+				},
+			},
+			QuotesSvc: &QuotesServiceStub{
+				CheckQuotePermissionsFunc: func(context.Context, string, *storagemodels.Status) (bool, error) {
+					permissionCalls++
+					return true, nil
+				},
+			},
+		}
+		handler, _, _ := round11NewHandler(t, cfg, reg)
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses/target-1/quote", headers, nil, apimodels.CreateQuotePostRequest{
+			Status:     "Quote text",
+			Visibility: storagemodels.VisibilityPrivate,
+		})
+		require.NoError(t, err)
+		ctx.Params["id"] = "target-1"
+
+		resp := requireStatus(t, http.StatusUnprocessableEntity)(handler.HandleCreateQuotePostLift(ctx))
+		require.Contains(t, string(resp.Body), string(commonerrors.CodeUnprocessableEntity))
+		require.Zero(t, permissionCalls)
+		require.Zero(t, createCalls)
+	})
+
 	t.Run("quoteability storage errors fail closed before note creation", func(t *testing.T) {
 		createCalls := 0
 		reg := &RegistryStub{

--- a/cmd/api/handlers/service_registry.go
+++ b/cmd/api/handlers/service_registry.go
@@ -142,9 +142,14 @@ type NotesService interface {
 	UnreblogNote(ctx context.Context, cmd *notes.UnreblogNoteCommand) (*notes.LikeResult, error)
 }
 
-// QuotesService defines the quote authorization operation shared with GraphQL quote creation.
+// QuotesService defines quote operations shared with GraphQL quote creation and
+// account quote-permission storage.
 type QuotesService interface {
+	AttachQuoteToStatus(ctx context.Context, quoteStatus *storagemodels.Status, targetStatusID string) (*quotes.QuotePostResult, error)
 	CheckQuotePermissions(ctx context.Context, quoterUsername string, targetStatus *storagemodels.Status) (bool, error)
+	GetQuotePermissions(ctx context.Context, username string) (*storagemodels.QuotePermissions, error)
+	GetQuoteRelationshipsForStatus(ctx context.Context, statusID string, limit int, cursor string) (*quotes.QuoteRelationshipPage, error)
+	UpdateQuotePermissions(ctx context.Context, permissions *storagemodels.QuotePermissions) error
 }
 
 var _ QuotesService = (*quotes.QuoteService)(nil)

--- a/cmd/api/handlers/service_registry_stubs_test.go
+++ b/cmd/api/handlers/service_registry_stubs_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/services/media"
 	"github.com/equaltoai/lesser/pkg/services/notes"
 	"github.com/equaltoai/lesser/pkg/services/notifications"
+	"github.com/equaltoai/lesser/pkg/services/quotes"
 	"github.com/equaltoai/lesser/pkg/services/relationships"
 	"github.com/equaltoai/lesser/pkg/services/scheduled"
 	"github.com/equaltoai/lesser/pkg/services/search"
@@ -53,6 +54,51 @@ func (r *RegistryStub) Quotes() QuotesService               { return r.QuotesSvc
 func (r *RegistryStub) Relationships() RelationshipsService { return r.RelationshipsSvc }
 func (r *RegistryStub) Scheduled() ScheduledService         { return r.ScheduledSvc }
 func (r *RegistryStub) Search() SearchService               { return r.SearchSvc }
+
+type QuotesServiceStub struct {
+	AttachQuoteToStatusFunc            func(ctx context.Context, quoteStatus *storagemodels.Status, targetStatusID string) (*quotes.QuotePostResult, error)
+	CheckQuotePermissionsFunc          func(ctx context.Context, quoterUsername string, targetStatus *storagemodels.Status) (bool, error)
+	GetQuotePermissionsFunc            func(ctx context.Context, username string) (*storagemodels.QuotePermissions, error)
+	GetQuoteRelationshipsForStatusFunc func(ctx context.Context, statusID string, limit int, cursor string) (*quotes.QuoteRelationshipPage, error)
+	UpdateQuotePermissionsFunc         func(ctx context.Context, permissions *storagemodels.QuotePermissions) error
+}
+
+var _ QuotesService = (*QuotesServiceStub)(nil)
+
+func (s *QuotesServiceStub) AttachQuoteToStatus(ctx context.Context, quoteStatus *storagemodels.Status, targetStatusID string) (*quotes.QuotePostResult, error) {
+	if s != nil && s.AttachQuoteToStatusFunc != nil {
+		return s.AttachQuoteToStatusFunc(ctx, quoteStatus, targetStatusID)
+	}
+	return nil, missingStub("QuotesService.AttachQuoteToStatus")
+}
+
+func (s *QuotesServiceStub) CheckQuotePermissions(ctx context.Context, quoterUsername string, targetStatus *storagemodels.Status) (bool, error) {
+	if s != nil && s.CheckQuotePermissionsFunc != nil {
+		return s.CheckQuotePermissionsFunc(ctx, quoterUsername, targetStatus)
+	}
+	return false, missingStub("QuotesService.CheckQuotePermissions")
+}
+
+func (s *QuotesServiceStub) GetQuotePermissions(ctx context.Context, username string) (*storagemodels.QuotePermissions, error) {
+	if s != nil && s.GetQuotePermissionsFunc != nil {
+		return s.GetQuotePermissionsFunc(ctx, username)
+	}
+	return nil, missingStub("QuotesService.GetQuotePermissions")
+}
+
+func (s *QuotesServiceStub) GetQuoteRelationshipsForStatus(ctx context.Context, statusID string, limit int, cursor string) (*quotes.QuoteRelationshipPage, error) {
+	if s != nil && s.GetQuoteRelationshipsForStatusFunc != nil {
+		return s.GetQuoteRelationshipsForStatusFunc(ctx, statusID, limit, cursor)
+	}
+	return nil, missingStub("QuotesService.GetQuoteRelationshipsForStatus")
+}
+
+func (s *QuotesServiceStub) UpdateQuotePermissions(ctx context.Context, permissions *storagemodels.QuotePermissions) error {
+	if s != nil && s.UpdateQuotePermissionsFunc != nil {
+		return s.UpdateQuotePermissionsFunc(ctx, permissions)
+	}
+	return missingStub("QuotesService.UpdateQuotePermissions")
+}
 
 type AccountsServiceStub struct {
 	CreateAuthorizationCodeFunc func(ctx context.Context, cmd *accounts.CreateAuthorizationCodeCommand) (*accounts.CreateAuthorizationCodeResult, error)

--- a/cmd/api/handlers/statuses_unified_boost.go
+++ b/cmd/api/handlers/statuses_unified_boost.go
@@ -256,7 +256,7 @@ func (h *Handler) createQuoteBoostLift(ctx *apptheory.Context, username, statusI
 		return common.RespondInternalServerError(ctx)
 	}
 	if !common.IsPubliclyVisible(quoteTarget.Visibility) {
-		return common.RespondUnprocessableEntity(ctx, quotes.ErrTargetStatusNotQuotable.Message)
+		return common.RespondUnprocessableEntity(ctx, restTargetNotQuotable)
 	}
 	quotesService := h.registry.Quotes()
 	if quotesService == nil {

--- a/cmd/api/handlers/statuses_unified_boost.go
+++ b/cmd/api/handlers/statuses_unified_boost.go
@@ -229,50 +229,9 @@ func (h *Handler) createQuoteBoostLift(ctx *apptheory.Context, username, statusI
 		visibility = storageModels.VisibilityPublic
 	}
 
-	if h.registry == nil {
-		h.logger.Error("service registry unavailable while resolving quote target")
-		return common.RespondInternalServerError(ctx)
-	}
-	notesService := h.registry.Notes()
-	if notesService == nil {
-		h.logger.Error("notes service unavailable while resolving quote target")
-		return common.RespondInternalServerError(ctx)
-	}
-	quoteTarget, err := notesService.ResolveQuoteTarget(ctx.Context(), username, statusID)
-	if err != nil {
-		h.logger.Warn("quote target rejected",
-			zap.String("status_id", statusID),
-			zap.String("viewer", username),
-			zap.Error(err))
-		if appErr, ok := commonerrors.AsAppError(err); ok {
-			return common.RespondWithAppError(ctx, appErr)
-		}
-		return common.RespondInternalServerError(ctx)
-	}
-	if err := notes.ValidateChildReach("quote", quoteTarget, visibility); err != nil {
-		if appErr, ok := commonerrors.AsAppError(err); ok {
-			return common.RespondWithAppError(ctx, appErr)
-		}
-		return common.RespondInternalServerError(ctx)
-	}
-	if !common.IsPubliclyVisible(quoteTarget.Visibility) {
-		return common.RespondUnprocessableEntity(ctx, restTargetNotQuotable)
-	}
-	quotesService := h.registry.Quotes()
-	if quotesService == nil {
-		h.logger.Error("quotes service unavailable while authorizing quote")
-		return common.RespondInternalServerError(ctx)
-	}
-	canQuote, err := quotesService.CheckQuotePermissions(ctx.Context(), username, quoteTarget)
-	if err != nil {
-		h.logger.Error("failed to check quote permissions",
-			zap.String("viewer", username),
-			zap.String("target_author", quoteTarget.AuthorUsername),
-			zap.Error(err))
-		return common.RespondWithAppError(ctx, quotes.ErrCheckQuotePermissions(err))
-	}
-	if !canQuote {
-		return common.RespondWithAppError(ctx, quotes.ErrNotAuthorizedToQuote)
+	quoteTarget, failure, err := h.authorizeQuoteBoostTarget(ctx, username, statusID, visibility)
+	if failure != nil || err != nil {
+		return failure, err
 	}
 	if quoteTarget.Note != nil && strings.TrimSpace(quoteTarget.Note.ID) != "" {
 		objectID = strings.TrimSpace(quoteTarget.Note.ID)
@@ -445,6 +404,65 @@ func (h *Handler) createQuoteBoostLift(ctx *apptheory.Context, username, statusI
 	}
 
 	return okJSON(resp)
+}
+
+func (h *Handler) authorizeQuoteBoostTarget(ctx *apptheory.Context, username, statusID, visibility string) (*storageModels.Status, *apptheory.Response, error) {
+	if h.registry == nil {
+		h.logger.Error("service registry unavailable while resolving quote target")
+		resp, err := common.RespondInternalServerError(ctx)
+		return nil, resp, err
+	}
+	notesService := h.registry.Notes()
+	if notesService == nil {
+		h.logger.Error("notes service unavailable while resolving quote target")
+		resp, err := common.RespondInternalServerError(ctx)
+		return nil, resp, err
+	}
+	quoteTarget, err := notesService.ResolveQuoteTarget(ctx.Context(), username, statusID)
+	if err != nil {
+		h.logger.Warn("quote target rejected",
+			zap.String("status_id", statusID),
+			zap.String("viewer", username),
+			zap.Error(err))
+		if appErr, ok := commonerrors.AsAppError(err); ok {
+			resp, responseErr := common.RespondWithAppError(ctx, appErr)
+			return nil, resp, responseErr
+		}
+		resp, responseErr := common.RespondInternalServerError(ctx)
+		return nil, resp, responseErr
+	}
+	if err := notes.ValidateChildReach("quote", quoteTarget, visibility); err != nil {
+		if appErr, ok := commonerrors.AsAppError(err); ok {
+			resp, responseErr := common.RespondWithAppError(ctx, appErr)
+			return nil, resp, responseErr
+		}
+		resp, responseErr := common.RespondInternalServerError(ctx)
+		return nil, resp, responseErr
+	}
+	if !common.IsPubliclyVisible(quoteTarget.Visibility) {
+		resp, responseErr := common.RespondUnprocessableEntity(ctx, restTargetNotQuotable)
+		return nil, resp, responseErr
+	}
+	quotesService := h.registry.Quotes()
+	if quotesService == nil {
+		h.logger.Error("quotes service unavailable while authorizing quote")
+		resp, responseErr := common.RespondInternalServerError(ctx)
+		return nil, resp, responseErr
+	}
+	canQuote, err := quotesService.CheckQuotePermissions(ctx.Context(), username, quoteTarget)
+	if err != nil {
+		h.logger.Error("failed to check quote permissions",
+			zap.String("viewer", username),
+			zap.String("target_author", quoteTarget.AuthorUsername),
+			zap.Error(err))
+		resp, responseErr := common.RespondWithAppError(ctx, quotes.ErrCheckQuotePermissions(err))
+		return nil, resp, responseErr
+	}
+	if !canQuote {
+		resp, responseErr := common.RespondWithAppError(ctx, quotes.ErrNotAuthorizedToQuote)
+		return nil, resp, responseErr
+	}
+	return quoteTarget, nil, nil
 }
 
 // HandleUndoUnifiedBoostLift handles undoing both traditional boosts and quote boosts

--- a/cmd/api/handlers/statuses_unified_boost.go
+++ b/cmd/api/handlers/statuses_unified_boost.go
@@ -255,6 +255,9 @@ func (h *Handler) createQuoteBoostLift(ctx *apptheory.Context, username, statusI
 		}
 		return common.RespondInternalServerError(ctx)
 	}
+	if !common.IsPubliclyVisible(quoteTarget.Visibility) {
+		return common.RespondUnprocessableEntity(ctx, quotes.ErrTargetStatusNotQuotable.Message)
+	}
 	quotesService := h.registry.Quotes()
 	if quotesService == nil {
 		h.logger.Error("quotes service unavailable while authorizing quote")

--- a/cmd/api/handlers/statuses_unified_boost_quote_permissions_test.go
+++ b/cmd/api/handlers/statuses_unified_boost_quote_permissions_test.go
@@ -83,11 +83,15 @@ func TestRESTQuoteBoostMatchesGraphQLAccountPermissionEnforcement(t *testing.T) 
 		status int
 		body   *common.StandardErrorResponse
 	}
-	requestRESTQuote := func(t *testing.T, handler *Handler) restQuoteResult {
+	requestRESTQuote := func(t *testing.T, handler *Handler, visibility ...string) restQuoteResult {
 		t.Helper()
 		token := round11SignAccessToken(t, cfg.JWTSecret, "mallory", []string{"write"})
+		request := models.ReblogRequest{Comment: &comment}
+		if len(visibility) > 0 {
+			request.Visibility = visibility[0]
+		}
 		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses/status-1/reblog",
-			map[string]string{"Authorization": "Bearer " + token}, nil, models.ReblogRequest{Comment: &comment})
+			map[string]string{"Authorization": "Bearer " + token}, nil, request)
 		require.NoError(t, err)
 		ctx.Params["id"] = "status-1"
 		resp, err := handler.HandleReblogLift(ctx)
@@ -132,8 +136,10 @@ func TestRESTQuoteBoostMatchesGraphQLAccountPermissionEnforcement(t *testing.T) 
 				state.createErrorOnce = stdErrors.New("quote boost persistence must not run")
 			})
 
-		result := requestRESTQuote(t, handler)
+		result := requestRESTQuote(t, handler, storagemodels.VisibilityPrivate)
 		require.Equal(t, http.StatusUnprocessableEntity, result.status)
+		require.NotNil(t, result.body)
+		require.Equal(t, restTargetNotQuotable, result.body.Error)
 		require.Empty(t, state.quoteRelationships, "denial must not persist a quote relationship")
 		require.Empty(t, state.activitiesByID, "denial must not persist a federation activity")
 		require.Len(t, state.objectsByID, 1, "denial must not persist a quote note object")

--- a/cmd/api/handlers/statuses_unified_boost_quote_permissions_test.go
+++ b/cmd/api/handlers/statuses_unified_boost_quote_permissions_test.go
@@ -28,7 +28,7 @@ func TestRESTQuoteBoostMatchesGraphQLAccountPermissionEnforcement(t *testing.T) 
 		permissions *storagemodels.QuotePermissions,
 		permissionErr error,
 		configure func(*round10QueryState, *storagemodels.Status),
-	) (*Handler, *quotes.QuoteService) {
+	) (*Handler, *quotes.QuoteService, *round10QueryState) {
 		t.Helper()
 		targetForHarness := *target
 		state := &round10QueryState{
@@ -76,7 +76,7 @@ func TestRESTQuoteBoostMatchesGraphQLAccountPermissionEnforcement(t *testing.T) 
 			require.NoError(t, repos.Quote().CreateQuotePermissions(context.Background(), permissions))
 		}
 
-		return handler, quoteService
+		return handler, quoteService, state
 	}
 
 	type restQuoteResult struct {
@@ -117,7 +117,7 @@ func TestRESTQuoteBoostMatchesGraphQLAccountPermissionEnforcement(t *testing.T) 
 	}
 
 	t.Run("blocked viewer receives the GraphQL denial class", func(t *testing.T) {
-		handler, quoteService := newHarness(t, &storagemodels.QuotePermissions{
+		handler, quoteService, _ := newHarness(t, &storagemodels.QuotePermissions{
 			AllowPublic: true,
 			BlockList:   []string{"mallory"},
 		}, nil, nil)
@@ -125,8 +125,22 @@ func TestRESTQuoteBoostMatchesGraphQLAccountPermissionEnforcement(t *testing.T) 
 		assertDeniedParity(t, handler, quoteService)
 	})
 
+	t.Run("followers-only target is rejected before any write", func(t *testing.T) {
+		handler, _, state := newHarness(t, nil, nil,
+			func(state *round10QueryState, status *storagemodels.Status) {
+				status.Visibility = storagemodels.VisibilityPrivate
+				state.createErrorOnce = stdErrors.New("quote boost persistence must not run")
+			})
+
+		result := requestRESTQuote(t, handler)
+		require.Equal(t, http.StatusUnprocessableEntity, result.status)
+		require.Empty(t, state.quoteRelationships, "denial must not persist a quote relationship")
+		require.Empty(t, state.activitiesByID, "denial must not persist a federation activity")
+		require.Len(t, state.objectsByID, 1, "denial must not persist a quote note object")
+	})
+
 	t.Run("follower arm allows both REST and GraphQL quote creation", func(t *testing.T) {
-		handler, quoteService := newHarness(t, &storagemodels.QuotePermissions{AllowFollowers: true}, nil,
+		handler, quoteService, _ := newHarness(t, &storagemodels.QuotePermissions{AllowFollowers: true}, nil,
 			func(state *round10QueryState, _ *storagemodels.Status) {
 				state.relationshipRecords = []storagemodels.RelationshipRecord{
 					{PK: "FOLLOW#mallory", SK: "FOLLOWING#alice", State: storagemodels.RelationshipAccepted},
@@ -140,12 +154,12 @@ func TestRESTQuoteBoostMatchesGraphQLAccountPermissionEnforcement(t *testing.T) 
 	})
 
 	t.Run("follower arm denies non-followers identically", func(t *testing.T) {
-		handler, quoteService := newHarness(t, &storagemodels.QuotePermissions{AllowFollowers: true}, nil, nil)
+		handler, quoteService, _ := newHarness(t, &storagemodels.QuotePermissions{AllowFollowers: true}, nil, nil)
 		assertDeniedParity(t, handler, quoteService)
 	})
 
 	t.Run("follower lookup error fails closed as forbidden on both surfaces", func(t *testing.T) {
-		handler, quoteService := newHarness(t, &storagemodels.QuotePermissions{AllowFollowers: true}, nil,
+		handler, quoteService, _ := newHarness(t, &storagemodels.QuotePermissions{AllowFollowers: true}, nil,
 			func(state *round10QueryState, _ *storagemodels.Status) {
 				state.firstErrorPK = map[string]error{"FOLLOW#mallory": stdErrors.New("relationship store unavailable")}
 			})
@@ -153,7 +167,7 @@ func TestRESTQuoteBoostMatchesGraphQLAccountPermissionEnforcement(t *testing.T) 
 	})
 
 	t.Run("mentioned arm allows both REST and GraphQL quote creation", func(t *testing.T) {
-		handler, quoteService := newHarness(t, &storagemodels.QuotePermissions{AllowMentioned: true}, nil,
+		handler, quoteService, _ := newHarness(t, &storagemodels.QuotePermissions{AllowMentioned: true}, nil,
 			func(_ *round10QueryState, status *storagemodels.Status) {
 				status.Mentions = []string{cfg.ActorURL("mallory")}
 			})
@@ -165,12 +179,12 @@ func TestRESTQuoteBoostMatchesGraphQLAccountPermissionEnforcement(t *testing.T) 
 	})
 
 	t.Run("mentioned arm denies unmentioned quoters identically", func(t *testing.T) {
-		handler, quoteService := newHarness(t, &storagemodels.QuotePermissions{AllowMentioned: true}, nil, nil)
+		handler, quoteService, _ := newHarness(t, &storagemodels.QuotePermissions{AllowMentioned: true}, nil, nil)
 		assertDeniedParity(t, handler, quoteService)
 	})
 
 	t.Run("mentioned status read error fails closed as REST forbidden", func(t *testing.T) {
-		handler, quoteService := newHarness(t, &storagemodels.QuotePermissions{AllowMentioned: true}, nil,
+		handler, quoteService, _ := newHarness(t, &storagemodels.QuotePermissions{AllowMentioned: true}, nil,
 			func(state *round10QueryState, _ *storagemodels.Status) {
 				state.firstErrorPK = map[string]error{"status#status-1": stdErrors.New("status store unavailable")}
 			})
@@ -187,7 +201,7 @@ func TestRESTQuoteBoostMatchesGraphQLAccountPermissionEnforcement(t *testing.T) 
 	})
 
 	t.Run("per-note none denies both surfaces after account allow", func(t *testing.T) {
-		handler, quoteService := newHarness(t, &storagemodels.QuotePermissions{AllowPublic: true}, nil,
+		handler, quoteService, _ := newHarness(t, &storagemodels.QuotePermissions{AllowPublic: true}, nil,
 			func(state *round10QueryState, _ *storagemodels.Status) {
 				state.statusMetadataByStatus = map[string]storagemodels.StatusMetadata{
 					"status-1": {StatusID: "status-1", QuoteType: "disabled", AllowQuotes: false},
@@ -211,14 +225,14 @@ func TestRESTQuoteBoostMatchesGraphQLAccountPermissionEnforcement(t *testing.T) 
 			}
 		}
 
-		handler, quoteService := newHarness(t, permissions, nil, withFollowersControl(true))
+		handler, quoteService, _ := newHarness(t, permissions, nil, withFollowersControl(true))
 		_, err := quoteService.AttachQuoteToStatus(context.Background(), &storagemodels.Status{
 			StatusID: "mallory-note-follower-quote", AuthorUsername: "mallory",
 		}, "status-1")
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, requestRESTQuote(t, handler).status)
 
-		handler, quoteService = newHarness(t, &storagemodels.QuotePermissions{AllowPublic: true}, nil, withFollowersControl(false))
+		handler, quoteService, _ = newHarness(t, &storagemodels.QuotePermissions{AllowPublic: true}, nil, withFollowersControl(false))
 		assertDeniedParity(t, handler, quoteService)
 	})
 
@@ -234,19 +248,19 @@ func TestRESTQuoteBoostMatchesGraphQLAccountPermissionEnforcement(t *testing.T) 
 			}
 		}
 
-		handler, quoteService := newHarness(t, &storagemodels.QuotePermissions{AllowPublic: true}, nil, withMentionedControl(true))
+		handler, quoteService, _ := newHarness(t, &storagemodels.QuotePermissions{AllowPublic: true}, nil, withMentionedControl(true))
 		_, err := quoteService.AttachQuoteToStatus(context.Background(), &storagemodels.Status{
 			StatusID: "mallory-note-mentioned-quote", AuthorUsername: "mallory",
 		}, "status-1")
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, requestRESTQuote(t, handler).status)
 
-		handler, quoteService = newHarness(t, &storagemodels.QuotePermissions{AllowPublic: true}, nil, withMentionedControl(false))
+		handler, quoteService, _ = newHarness(t, &storagemodels.QuotePermissions{AllowPublic: true}, nil, withMentionedControl(false))
 		assertDeniedParity(t, handler, quoteService)
 	})
 
 	t.Run("per-note storage error fails closed as forbidden on both surfaces", func(t *testing.T) {
-		handler, quoteService := newHarness(t, &storagemodels.QuotePermissions{AllowPublic: true}, nil,
+		handler, quoteService, _ := newHarness(t, &storagemodels.QuotePermissions{AllowPublic: true}, nil,
 			func(state *round10QueryState, _ *storagemodels.Status) {
 				state.firstErrorPK = map[string]error{"STATUS_META#status-1": stdErrors.New("metadata unavailable")}
 			})
@@ -254,7 +268,7 @@ func TestRESTQuoteBoostMatchesGraphQLAccountPermissionEnforcement(t *testing.T) 
 	})
 
 	t.Run("per-note public cannot widen account denial", func(t *testing.T) {
-		handler, quoteService := newHarness(t, &storagemodels.QuotePermissions{}, nil,
+		handler, quoteService, _ := newHarness(t, &storagemodels.QuotePermissions{}, nil,
 			func(state *round10QueryState, _ *storagemodels.Status) {
 				state.statusMetadataByStatus = map[string]storagemodels.StatusMetadata{
 					"status-1": {StatusID: "status-1", QuoteType: storagemodels.VisibilityPublic, AllowQuotes: true},
@@ -264,7 +278,7 @@ func TestRESTQuoteBoostMatchesGraphQLAccountPermissionEnforcement(t *testing.T) 
 	})
 
 	t.Run("allowed viewer creates the REST quote unchanged", func(t *testing.T) {
-		handler, quoteService := newHarness(t, &storagemodels.QuotePermissions{AllowPublic: true}, nil, nil)
+		handler, quoteService, _ := newHarness(t, &storagemodels.QuotePermissions{AllowPublic: true}, nil, nil)
 		allowed, err := quoteService.CheckQuotePermissions(context.Background(), "mallory", target)
 		require.NoError(t, err)
 		require.True(t, allowed)
@@ -274,7 +288,7 @@ func TestRESTQuoteBoostMatchesGraphQLAccountPermissionEnforcement(t *testing.T) 
 	})
 
 	t.Run("missing permissions row uses the GraphQL permissive default", func(t *testing.T) {
-		handler, quoteService := newHarness(t, nil, nil, nil)
+		handler, quoteService, _ := newHarness(t, nil, nil, nil)
 		allowed, err := quoteService.CheckQuotePermissions(context.Background(), "mallory", target)
 		require.NoError(t, err)
 		require.True(t, allowed)
@@ -285,7 +299,7 @@ func TestRESTQuoteBoostMatchesGraphQLAccountPermissionEnforcement(t *testing.T) 
 
 	t.Run("storage failure is fail closed on both surfaces", func(t *testing.T) {
 		storageErr := stdErrors.New("quote permissions unavailable")
-		handler, quoteService := newHarness(t, nil, storageErr, nil)
+		handler, quoteService, _ := newHarness(t, nil, storageErr, nil)
 
 		_, graphQLErr := quoteService.AttachQuoteToStatus(context.Background(), &storagemodels.Status{
 			StatusID:       "mallory-quote",

--- a/cmd/api/handlers/statuses_unified_boost_round12_coverage_test.go
+++ b/cmd/api/handlers/statuses_unified_boost_round12_coverage_test.go
@@ -432,12 +432,12 @@ func TestHandleReblogLift_EnforcesQuoteReachAndViewerAccess(t *testing.T) {
 	}
 
 	for _, targetVisibility := range []string{storagemodels.VisibilityPrivate, storagemodels.VisibilityDirect} {
-		t.Run(targetVisibility+" target cannot be publicly quoted", func(t *testing.T) {
+		t.Run(targetVisibility+" target cannot be quoted at equal reach", func(t *testing.T) {
 			target := quoteBoostTarget("status-1", cfg.BaseURL()+"/objects/status-1", targetVisibility)
 			h := newQuoteHandler(t, target, nil)
 			ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses/status-1/reblog", headers, nil, models.ReblogRequest{
 				Comment:    &comment,
-				Visibility: storagemodels.VisibilityPublic,
+				Visibility: targetVisibility,
 			})
 			require.NoError(t, err)
 			ctx.Params["id"] = "status-1"
@@ -446,6 +446,7 @@ func TestHandleReblogLift_EnforcesQuoteReachAndViewerAccess(t *testing.T) {
 			var body common.StandardErrorResponse
 			require.NoError(t, json.Unmarshal(resp.Body, &body))
 			require.Equal(t, string(commonerrors.CodeUnprocessableEntity), body.Code)
+			require.Equal(t, restTargetNotQuotable, body.Error)
 		})
 	}
 
@@ -464,7 +465,6 @@ func TestHandleReblogLift_EnforcesQuoteReachAndViewerAccess(t *testing.T) {
 	}{
 		{name: "equal public", targetVisibility: storagemodels.VisibilityPublic, quoteVisibility: storagemodels.VisibilityPublic},
 		{name: "narrower private", targetVisibility: storagemodels.VisibilityPublic, quoteVisibility: storagemodels.VisibilityPrivate},
-		{name: "equal followers", targetVisibility: storagemodels.VisibilityPrivate, quoteVisibility: storagemodels.VisibilityPrivate},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/api/models/quotes.go
+++ b/cmd/api/models/quotes.go
@@ -1,5 +1,13 @@
 package models
 
+// QuotePermissionsResponse represents quote permissions for an account.
+type QuotePermissionsResponse struct {
+	AllowPublic    bool     `json:"allow_public"`
+	AllowFollowers bool     `json:"allow_followers"`
+	AllowMentioned bool     `json:"allow_mentioned"`
+	BlockList      []string `json:"block_list"`
+}
+
 // UpdateQuotePermissionsRequest represents a request to update quote permissions.
 type UpdateQuotePermissionsRequest struct {
 	AllowPublic    *bool    `json:"allow_public,omitempty"`
@@ -15,4 +23,18 @@ type CreateQuotePostRequest struct {
 	SpoilerText string `json:"spoiler_text,omitempty"`
 	Sensitive   bool   `json:"sensitive"`
 	Language    string `json:"language,omitempty"`
+}
+
+// QuoteStatusAccount represents the minimal account payload used by quote endpoints.
+type QuoteStatusAccount struct {
+	ID       string  `json:"id"`
+	Username *string `json:"username,omitempty"`
+}
+
+// QuoteStatusSummary represents the minimal status payload used by quote endpoints.
+type QuoteStatusSummary struct {
+	ID        string             `json:"id"`
+	CreatedAt string             `json:"created_at"`
+	Account   QuoteStatusAccount `json:"account"`
+	Content   string             `json:"content"`
 }

--- a/cmd/api/testdata/auth_surface_golden.json
+++ b/cmd/api/testdata/auth_surface_golden.json
@@ -1634,7 +1634,7 @@
     "method": "GET",
     "path": "/api/v1/statuses/{id}/quotes",
     "runtimePosture": "anonymous",
-    "openapiSecurity": "public",
+    "openapiSecurity": "optional",
     "verdict": "agree"
   },
   {

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -18322,12 +18322,18 @@ paths:
                 - bearerAuth: []
             parameters:
                 - $ref: '#/components/parameters/Limit'
-                - $ref: '#/components/parameters/Offset'
                 - name: id
                   in: path
                   required: true
                   schema:
                     type: string
+                - name: offset
+                  in: query
+                  description: Visible-quote offset. Must not exceed (4 × the requested limit) - 1; larger offsets return 422 rather than a silently truncated empty page.
+                  schema:
+                    type: integer
+                    format: int32
+                    minimum: 0
             responses:
                 "200":
                     description: OK
@@ -18343,6 +18349,8 @@ paths:
                     $ref: '#/components/responses/Forbidden'
                 "404":
                     $ref: '#/components/responses/NotFound'
+                "422":
+                    $ref: '#/components/responses/UnprocessableEntity'
                 "500":
                     $ref: '#/components/responses/InternalServerError'
             x-lesser-handler: HandleGetQuotesOfStatusLift

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -4636,6 +4636,58 @@ components:
                 - data
                 - subscription
             type: object
+        QuotePermissionsResponse:
+            additionalProperties: false
+            properties:
+                allow_followers:
+                    type: boolean
+                allow_mentioned:
+                    type: boolean
+                allow_public:
+                    type: boolean
+                block_list:
+                    items:
+                        type: string
+                    type: array
+            required:
+                - allow_followers
+                - allow_mentioned
+                - allow_public
+                - block_list
+            type: object
+        QuoteStatusAccount:
+            additionalProperties: false
+            properties:
+                id:
+                    type: string
+                username:
+                    anyOf:
+                        - type: string
+                        - type: "null"
+            required:
+                - id
+            type: object
+        QuoteStatusSummary:
+            additionalProperties: false
+            properties:
+                account:
+                    $ref: '#/components/schemas/QuoteStatusAccount'
+                content:
+                    type: string
+                created_at:
+                    type: string
+                id:
+                    type: string
+            required:
+                - account
+                - content
+                - created_at
+                - id
+            type: object
+        QuoteStatusSummaryList:
+            items:
+                $ref: '#/components/schemas/QuoteStatusSummary'
+            type: array
         RFC3339DateTime:
             format: date-time
             type: string
@@ -9700,14 +9752,22 @@ paths:
                   schema:
                     type: string
             responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/QuotePermissionsResponse'
                 "400":
                     $ref: '#/components/responses/BadRequest'
                 "401":
                     $ref: '#/components/responses/Unauthorized'
                 "403":
                     $ref: '#/components/responses/Forbidden'
-                "501":
-                    description: Quote permission reads are not implemented and no settings are retrieved.
+                "404":
+                    $ref: '#/components/responses/NotFound'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
             x-lesser-handler: HandleGetQuotePermissionsLift
             x-lesser-lambda: api
             x-lesser-routeSources:
@@ -9985,14 +10045,22 @@ paths:
                         schema:
                             $ref: '#/components/schemas/UpdateQuotePermissionsRequest'
             responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/QuotePermissionsResponse'
                 "400":
                     $ref: '#/components/responses/BadRequest'
                 "401":
                     $ref: '#/components/responses/Unauthorized'
                 "403":
                     $ref: '#/components/responses/Forbidden'
-                "501":
-                    description: Quote permission updates are not implemented and no settings are persisted.
+                "422":
+                    $ref: '#/components/responses/UnprocessableEntity'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
             x-lesser-handler: HandleUpdateQuotePermissionsLift
             x-lesser-lambda: api
             x-lesser-routeSources:
@@ -18161,16 +18229,42 @@ paths:
                         schema:
                             $ref: '#/components/schemas/CreateQuotePostRequest'
             responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/QuoteStatusSummary'
+                    headers:
+                        X-RateLimit-Limit:
+                            description: Request limit per window.
+                            schema:
+                                type: integer
+                                format: int32
+                        X-RateLimit-Remaining:
+                            description: Requests remaining in the current window.
+                            schema:
+                                type: integer
+                                format: int32
+                        X-RateLimit-Reset:
+                            description: Unix timestamp (seconds) when the current window resets.
+                            schema:
+                                type: integer
+                                format: int64
                 "400":
                     $ref: '#/components/responses/BadRequest'
                 "401":
                     $ref: '#/components/responses/Unauthorized'
                 "403":
                     $ref: '#/components/responses/Forbidden'
+                "404":
+                    $ref: '#/components/responses/NotFound'
+                "422":
+                    $ref: '#/components/responses/UnprocessableEntity'
                 "429":
                     $ref: '#/components/responses/TooManyRequests'
-                "501":
-                    description: Quote creation is not implemented; target IDs are not looked up.
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
             x-lesser-handler: HandleCreateQuotePostLift
             x-lesser-lambda: api
             x-lesser-routeSources:
@@ -18223,6 +18317,9 @@ paths:
             operationId: get_api_v1_statuses_by_id_quotes
             tags:
                 - statuses
+            security:
+                - {}
+                - bearerAuth: []
             parameters:
                 - $ref: '#/components/parameters/Limit'
                 - $ref: '#/components/parameters/Offset'
@@ -18232,14 +18329,28 @@ paths:
                   schema:
                     type: string
             responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/QuoteStatusSummaryList'
                 "400":
                     $ref: '#/components/responses/BadRequest'
-                "501":
-                    description: Quote listing is not implemented; target IDs and quote counts are not looked up.
+                "401":
+                    $ref: '#/components/responses/Unauthorized'
+                "403":
+                    $ref: '#/components/responses/Forbidden'
+                "404":
+                    $ref: '#/components/responses/NotFound'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
             x-lesser-handler: HandleGetQuotesOfStatusLift
             x-lesser-lambda: api
             x-lesser-routeSources:
                 - cmd/api/routes.go
+            x-oauth-scopes:
+                - read:statuses
     /api/v1/statuses/{id}/reblog:
         post:
             operationId: post_api_v1_statuses_by_id_reblog

--- a/docs/security-gaps.md
+++ b/docs/security-gaps.md
@@ -339,22 +339,19 @@ content.
 
 Account-level quote permissions are live: the authenticated GraphQL mutation `updateAccountQuotePermissions` persists
 them, and the GraphQL quote path enforces them through `QuoteService.CheckQuotePermissions` in
-`pkg/services/quotes/quote_service.go`. The REST quote-permission GET and PUT routes return `501 Not Implemented` because
-their REST implementation genuinely does not exist; they do not fabricate or persist preferences.
+`pkg/services/quotes/quote_service.go`. The REST update route persists through that same service. The REST read route
+returns a raw policy only to its authenticated owner; other and missing account IDs share `404 Not Found`, so the block
+list is not exposed and the response does not disclose whether another account exists.
 
 The authenticated GraphQL `accountQuotePermissions(username: ...)` read also returns a not-implemented error for every
 target. It fails closed without fabricating defaults while a real read is pending an explicit authorization decision:
 whether an account owner, another viewer, or both may read the raw block list is a product decision, not a safe default.
-The REST quote-creation twin now uses the same account-level `QuoteService.CheckQuotePermissions` predicate and maps its
-denial and storage-error classes into the established REST error contract.
+The REST quote-creation twin uses the same account-level and per-note `QuoteService.CheckQuotePermissions` predicate and
+maps its denial and storage-error classes into the established REST error contract.
 
-**Shipping decision:** REST reblog-with-comment enforcement ships with the block-list and `allow_public` arms live while
-the `allow_followers` and `allow_mentioned` arms remain fail-closed placeholders tracked by lesser#1317.
+Follower and mentioned account-policy arms are implemented and fail closed on relationship or mention lookup errors.
 `ApplyVisibilityDefaults` assigns those states at registration: private/followers-default accounts rely on
-`allow_followers`, and direct-default accounts rely on `allow_mentioned`. Until lesser#1317 lands, every quoter—including
-an actual follower or mentioned account—is denied for those account classes. This intentionally changes the affected
-client response from `200` before `cf7c8ebdd` to `403 FORBIDDEN`; failing open a privacy control is not an acceptable
-interim behavior.
+`allow_followers`, and direct-default accounts rely on `allow_mentioned`.
 
 Per-note quote controls are separate from those account-level permissions. The GraphQL `updateQuotePermissions` mutation
 persists its control in `StatusMetadata` and now reads that row back so its own payload reflects the stored `quoteable`

--- a/docs/security/hardened-auth-visibility-rollout.md
+++ b/docs/security/hardened-auth-visibility-rollout.md
@@ -28,10 +28,14 @@ with the generated REST contract (`docs/contracts/openapi.yaml`) and generated G
 - Reply and quote reach is ordered `public < unlisted < private/followers < direct`, from widest to narrowest audience.
   REST status replies, GraphQL note/quote mutations, and `POST /api/v1/statuses/{id}/reblog` quote requests with a
   non-empty `comment` reject a child visibility wider than the referenced status with the structured
-  `UNPROCESSABLE_ENTITY` error. GraphQL quote inputs whose visibility is omitted inherit the target visibility; the REST
-  reblog-quote request retains its documented public default, which is therefore rejected when it would widen reach.
-  These paths never silently clamp an explicit author choice.
-- GraphQL quote mutations, the Quote Posts REST creation endpoint, and REST reblog-quotes resolve the target storage-first, fetch and materialize a canonical
+  `UNPROCESSABLE_ENTITY` error. For the public or unlisted targets that remain quotable, GraphQL quote inputs whose
+  visibility is omitted inherit the target visibility; the REST reblog-quote request retains its documented public
+  default, which is therefore rejected when it would widen reach. These paths never silently clamp an explicit author
+  choice.
+- A quote target must be public or unlisted to be quotable at all. This invariant applies to all four creation paths:
+  REST create-quote, REST boost-of-quote, GraphQL `createQuoteNote`, and GraphQL `createNote` with `quoteTargetID`. This is
+  an intentional GraphQL behavior tightening: quoting a followers-only target now returns `BUSINESS_RULE_VIOLATED`
+  rather than inheriting its reach. These paths resolve the target storage-first, fetch and materialize a canonical
   remote ActivityPub Note when absent locally, and then apply viewer-access and reach checks. Deleted or inaccessible
   targets remain indistinguishable from missing statuses. A fetched remote quote target may therefore remain persisted
   locally even when the requesting viewer is denied. This is intentional and mirrors reply-parent materialization

--- a/docs/security/hardened-auth-visibility-rollout.md
+++ b/docs/security/hardened-auth-visibility-rollout.md
@@ -31,35 +31,23 @@ with the generated REST contract (`docs/contracts/openapi.yaml`) and generated G
   `UNPROCESSABLE_ENTITY` error. GraphQL quote inputs whose visibility is omitted inherit the target visibility; the REST
   reblog-quote request retains its documented public default, which is therefore rejected when it would widen reach.
   These paths never silently clamp an explicit author choice.
-- GraphQL quote mutations and REST reblog-quotes resolve the target storage-first, fetch and materialize a canonical
+- GraphQL quote mutations, the Quote Posts REST creation endpoint, and REST reblog-quotes resolve the target storage-first, fetch and materialize a canonical
   remote ActivityPub Note when absent locally, and then apply viewer-access and reach checks. Deleted or inaccessible
   targets remain indistinguishable from missing statuses. A fetched remote quote target may therefore remain persisted
   locally even when the requesting viewer is denied. This is intentional and mirrors reply-parent materialization
-  (operator ruling 2026-08-01); persistence does not grant the denied viewer access. The separate lesser-exclusive
-  `POST /api/v1/statuses/{id}/quote` extension returns **501 Not Implemented** before target lookup pending a real
-  authorization-, persistence-, and federation-aware implementation; it is not the Mastodon-compatible reblog-quote
-  creation path described above and does not disclose whether a target status exists. The companion
-  `GET /api/v1/statuses/{id}/quotes` extension likewise returns **501 Not Implemented** after parameter validation and
-  before storage access so neither target existence nor a real quote-row count is exposed. Authenticated
-  `PUT /api/v1/accounts/quote_permissions` returns **501 Not Implemented** after authentication and body validation
-  until permission persistence exists; it never echoes request values as though they were saved. The
-  `GET /api/v1/accounts/{id}/quote_permissions` extension requires bearer authentication, so anonymous callers receive
-  **401 Unauthorized**. Its handler performs no additional per-target authorization and returns **501 Not Implemented**
-  after path-parameter validation and before storage access for existent, missing, and hostile-text account IDs alike;
-  the route never fabricates all-permissive settings.
-- The REST account quote-permission preference surfaces are deliberately neither settable nor readable: their `PUT` and
-  `GET` handlers remain **501 Not Implemented** even though the authenticated GraphQL mutation persists account-level
-  preferences. REST reblog-with-comment and GraphQL relationship-minting paths enforce that persisted account-level row
-  through the shared `QuoteService.CheckQuotePermissions` predicate.
-- **Shipping decision:** REST reblog-with-comment enforcement ships with the block-list and `allow_public` arms live while
-  the `allow_followers` and `allow_mentioned` arms remain fail-closed placeholders tracked by lesser#1317.
-  `ApplyVisibilityDefaults` assigns those states at registration: private/followers-default accounts rely on
-  `allow_followers`, and direct-default accounts rely on `allow_mentioned`. Until lesser#1317 lands, every quoter—including
-  an actual follower or mentioned account—is denied for those account classes. This intentionally changes the affected
-  client response from **200** before `cf7c8ebdd` to **403 FORBIDDEN**; failing open a privacy control is not an acceptable
-  interim behavior.
-- Per-note quote controls are persisted by GraphQL but are not yet read by general `Status` projections or enforced by
-  production quote-relationship creation. That work needs explicit missing-row semantics and is tracked as lesser#1318.
+  (operator ruling 2026-08-01); persistence does not grant the denied viewer access. Quote Posts REST creation then uses
+  `Notes.CreateNote` and `QuoteService.AttachQuoteToStatus`, the same persistence and federation path as GraphQL quote
+  creation. Missing and invisible targets share the same **404 Not Found** response. Account-level and per-note quote
+  controls are both enforced through `QuoteService.CheckQuotePermissions`; follower, mentioned, and policy-storage error
+  arms fail closed.
+- `GET /api/v1/statuses/{id}/quotes` verifies the target and every returned quote through the notes service's viewer-aware
+  visibility predicate before applying the public `limit` and `offset` window. A missing and an invisible target share the
+  same **404 Not Found** response.
+- `PUT /api/v1/accounts/quote_permissions` updates only the authenticated account through the shared quote service and
+  validates all policy arms. `GET /api/v1/accounts/{id}/quote_permissions` requires `read:accounts` and returns the raw
+  policy only for that authenticated account. Other and missing account IDs share **404 Not Found**, preventing both a
+  block-list disclosure and an account-existence oracle. The GraphQL account quote-permission read remains uniformly
+  unavailable for self, other, and missing targets until its separate consumer contract is activated.
 - Quote deletion deliberately returns the same **404 Not Found** response for a missing relationship and one owned by a
   different account, preventing ownership from becoming an existence oracle; successful owner deletion is unchanged.
 - `UpdateStatus` does not accept or propagate a visibility field, so an existing status cannot be widened by editing it.

--- a/graph/mutation_resolvers_notes.go
+++ b/graph/mutation_resolvers_notes.go
@@ -15,6 +15,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	apperrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/services/notes"
+	"github.com/equaltoai/lesser/pkg/services/quotes"
 	"github.com/equaltoai/lesser/pkg/services/scheduled"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"go.uber.org/zap"
@@ -49,6 +50,9 @@ func (r *mutationResolver) CreateNote(ctx context.Context, input model.CreateNot
 		}
 		if err := validateMutationChildReach("quote", quoteTarget, cmd.Visibility); err != nil {
 			return nil, err
+		}
+		if !common.IsPubliclyVisible(quoteTarget.Visibility) {
+			return nil, quotes.ErrTargetStatusNotQuotable
 		}
 	}
 

--- a/graph/mutation_resolvers_notes.go
+++ b/graph/mutation_resolvers_notes.go
@@ -582,6 +582,21 @@ func (r *mutationResolver) CreateQuoteNote(ctx context.Context, input model.Crea
 	if err := validateMutationChildReach("quote", quoteTarget, visibility); err != nil {
 		return nil, err
 	}
+	if !common.IsPubliclyVisible(quoteTarget.Visibility) {
+		return nil, quotes.ErrTargetStatusNotQuotable
+	}
+
+	quotesService := r.Registry.Quotes()
+	if quotesService == nil {
+		return nil, errors.New("quotes service is not available")
+	}
+	canQuote, err := quotesService.CheckQuotePermissions(ctx, username, quoteTarget)
+	if err != nil {
+		return nil, quotes.ErrCheckQuotePermissions(err)
+	}
+	if !canQuote {
+		return nil, quotes.ErrNotAuthorizedToQuote
+	}
 
 	// Create the quote note using the notes service
 	// Note: QuoteURL would need to be parsed to extract the note ID for quoting
@@ -605,6 +620,9 @@ func (r *mutationResolver) CreateQuoteNote(ctx context.Context, input model.Crea
 	// Convert result to GraphQL model
 	if result.Note == nil {
 		return nil, ErrNoteCreationReturnedNoNote
+	}
+	if err := r.attachQuoteToTarget(ctx, username, quoteTarget.StatusID, result.Note); err != nil {
+		return nil, err
 	}
 
 	return &model.CreateNotePayload{

--- a/graph/mutation_resolvers_reach_test.go
+++ b/graph/mutation_resolvers_reach_test.go
@@ -116,6 +116,26 @@ func TestCreateNoteRejectsQuoteReachWidening(t *testing.T) {
 	requireStructuredReachRefusal(t, err)
 }
 
+func TestCreateNoteRejectsNonPublicQuoteTargetBeforePersistence(t *testing.T) {
+	resolver, storageRepo := newRound12GraphResolver(t)
+	seedMutationReachParent(t, storageRepo.Status(), "parent", models.VisibilityPrivate)
+	quoteID := "parent"
+
+	_, err := resolver.Mutation().CreateNote(round12AuthContext("alice"), model.CreateNoteInput{
+		Content:    "bounded but non-quotable quote",
+		QuoteID:    &quoteID,
+		Visibility: model.VisibilityFollowers,
+	})
+	require.Error(t, err)
+	appErr, ok := apperrors.AsAppError(err)
+	require.True(t, ok)
+	require.Equal(t, apperrors.CodeBusinessRuleViolated, appErr.Code)
+
+	count, countErr := storageRepo.Status().CountStatusesByAuthor(context.Background(), "alice")
+	require.NoError(t, countErr)
+	require.Zero(t, count, "the rejected quote must not persist a new status")
+}
+
 func TestCreateQuoteNoteInheritsReachAndRejectsWidening(t *testing.T) {
 	resolver, storageRepo := newRound12GraphResolver(t)
 	seedMutationReachParent(t, storageRepo.Status(), "parent", models.VisibilityPrivate)

--- a/graph/mutation_resolvers_reach_test.go
+++ b/graph/mutation_resolvers_reach_test.go
@@ -131,6 +131,7 @@ func TestCreateNoteRejectsNonPublicQuoteTargetBeforePersistence(t *testing.T) {
 	appErr, ok := apperrors.AsAppError(err)
 	require.True(t, ok)
 	require.Equal(t, apperrors.CodeBusinessRuleViolated, appErr.Code)
+	require.Equal(t, quotes.ErrTargetStatusNotQuotable.Message, appErr.Message, "GraphQL keeps the bare business-rule error")
 
 	count, countErr := storageRepo.Status().CountStatusesByAuthor(context.Background(), "alice")
 	require.NoError(t, countErr)

--- a/graph/mutation_resolvers_reach_test.go
+++ b/graph/mutation_resolvers_reach_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/equaltoai/lesser/graph/model"
 	"github.com/equaltoai/lesser/pkg/activitypub"
 	apperrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/services/quotes"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/require"
 )
@@ -136,7 +137,7 @@ func TestCreateNoteRejectsNonPublicQuoteTargetBeforePersistence(t *testing.T) {
 	require.Zero(t, count, "the rejected quote must not persist a new status")
 }
 
-func TestCreateQuoteNoteInheritsReachAndRejectsWidening(t *testing.T) {
+func TestCreateQuoteNoteRejectsNonPublicTargetsBeforePersistence(t *testing.T) {
 	resolver, storageRepo := newRound12GraphResolver(t)
 	seedMutationReachParent(t, storageRepo.Status(), "parent", models.VisibilityPrivate)
 
@@ -147,14 +148,54 @@ func TestCreateQuoteNoteInheritsReachAndRejectsWidening(t *testing.T) {
 	})
 	requireStructuredReachRefusal(t, err)
 
-	payload, err := resolver.Mutation().CreateQuoteNote(round12AuthContext("alice"), model.CreateQuoteNoteInput{
+	_, err = resolver.Mutation().CreateQuoteNote(round12AuthContext("alice"), model.CreateQuoteNoteInput{
 		Content:  "inherited quote",
+		QuoteURL: "parent",
+	})
+	require.Error(t, err)
+	appErr, ok := apperrors.AsAppError(err)
+	require.True(t, ok)
+	require.Equal(t, apperrors.CodeBusinessRuleViolated, appErr.Code)
+
+	count, countErr := storageRepo.Status().CountStatusesByAuthor(context.Background(), "alice")
+	require.NoError(t, countErr)
+	require.Zero(t, count, "a followers-only quote target must be rejected before status persistence")
+}
+
+func TestCreateQuoteNoteRejectsBlockedQuoterBeforePersistence(t *testing.T) {
+	resolver, storageRepo := newRound12GraphResolver(t)
+	seedMutationReachParent(t, storageRepo.Status(), "parent", models.VisibilityPublic)
+	storageRepo.SeedQuotePermissions(&models.QuotePermissions{
+		Username:    "alice",
+		AllowPublic: true,
+		BlockList:   []string{"mallory"},
+	})
+
+	_, err := resolver.Mutation().CreateQuoteNote(round12AuthContext("mallory"), model.CreateQuoteNoteInput{
+		Content:  "blocked quote",
+		QuoteURL: "parent",
+	})
+	require.ErrorIs(t, err, quotes.ErrNotAuthorizedToQuote)
+
+	count, countErr := storageRepo.Status().CountStatusesByAuthor(context.Background(), "mallory")
+	require.NoError(t, countErr)
+	require.Zero(t, count, "a blocked quoter must be rejected before status persistence")
+}
+
+func TestCreateQuoteNoteAttachesAuthorizedPublicQuote(t *testing.T) {
+	resolver, storageRepo := newRound12GraphResolver(t)
+	seedMutationReachParent(t, storageRepo.Status(), "parent", models.VisibilityPublic)
+	storageRepo.SeedQuotePermissions(&models.QuotePermissions{Username: "alice", AllowPublic: true})
+
+	payload, err := resolver.Mutation().CreateQuoteNote(round12AuthContext("alice"), model.CreateQuoteNoteInput{
+		Content:  "public quote",
 		QuoteURL: "parent",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, payload)
 	require.NotNil(t, payload.Object)
-	require.Equal(t, model.VisibilityFollowers, payload.Object.Visibility)
+	require.NotNil(t, payload.Object.QuoteURL, "CreateQuoteNote must attach through QuoteService")
+	require.Equal(t, "https://localhost/users/alice/statuses/parent", *payload.Object.QuoteURL)
 }
 
 func ptrVisibility(v model.Visibility) *model.Visibility { return &v }

--- a/pkg/services/quotes/quote_service.go
+++ b/pkg/services/quotes/quote_service.go
@@ -94,6 +94,14 @@ type QuotePostResult struct {
 	TargetStatus      *models.Status
 }
 
+// QuoteRelationshipPage is one storage-backed page of quote relationships.
+// Callers apply viewer-aware status visibility through the notes service before
+// projecting the relationships onto a public API response.
+type QuoteRelationshipPage struct {
+	Relationships []*models.QuoteRelationship
+	NextCursor    string
+}
+
 // CreateQuotePost creates a new quote post
 func (qs *QuoteService) CreateQuotePost(ctx context.Context, req *CreateQuoteRequest) (*QuotePostResult, error) {
 	// Validate input
@@ -293,6 +301,29 @@ func (qs *QuoteService) GetQuotesForStatus(ctx context.Context, statusID string,
 	}
 
 	return quoteStatuses, nil
+}
+
+// GetQuoteRelationshipsForStatus returns one cursor page of active quote
+// relationships without attempting to make a viewer-visibility decision.
+// Visibility remains owned by the notes service's GetNoteWithViewer predicate.
+func (qs *QuoteService) GetQuoteRelationshipsForStatus(ctx context.Context, statusID string, limit int, cursor string) (*QuoteRelationshipPage, error) {
+	result, err := qs.storage.Quote().GetQuotesForStatus(ctx, statusID, interfaces.PaginationOptions{
+		Limit:  limit,
+		Cursor: cursor,
+	})
+	if err != nil {
+		qs.logger.Error("failed to get quote relationships", zap.String("status_id", statusID), zap.Error(err))
+		return nil, ErrGetQuoteRelationships(err)
+	}
+	if result == nil {
+		qs.logger.Error("quote repository returned no relationship page", zap.String("status_id", statusID))
+		return nil, ErrGetQuoteRelationships(apperrors.Internal("quote relationship page is unavailable"))
+	}
+
+	return &QuoteRelationshipPage{
+		Relationships: result.Items,
+		NextCursor:    result.NextCursor,
+	}, nil
 }
 
 // DeleteQuotePost removes a quote post and its relationship

--- a/tools/openapi/operation_overrides.go
+++ b/tools/openapi/operation_overrides.go
@@ -26,34 +26,25 @@ func applyQuoteOverrides(op *operation, route routeDef) {
 
 	switch {
 	case route.Method == methodPOST && route.Path == "/api/v1/statuses/{id}/quote":
-		delete(op.Responses, "200")
-		delete(op.Responses, "404")
-		delete(op.Responses, "422")
-		delete(op.Responses, "500")
-		op.Responses["501"] = response{
-			Description: "Quote creation is not implemented; target IDs are not looked up.",
-		}
+		delete(op.Responses, "501")
+		ensureJSONResponseSchema(op, "200", "QuoteStatusSummary")
+		ensureResponseRef(op.Responses, "404", "NotFound")
+		ensureResponseRef(op.Responses, "422", "UnprocessableEntity")
+		ensureResponseRef(op.Responses, "500", "InternalServerError")
 	case route.Method == methodGET && route.Path == "/api/v1/statuses/{id}/quotes":
-		delete(op.Responses, "200")
-		delete(op.Responses, "404")
-		delete(op.Responses, "500")
-		op.Responses["501"] = response{
-			Description: "Quote listing is not implemented; target IDs and quote counts are not looked up.",
-		}
+		delete(op.Responses, "501")
+		ensureJSONResponseSchema(op, "200", "QuoteStatusSummaryList")
+		ensureResponseRef(op.Responses, "404", "NotFound")
+		ensureResponseRef(op.Responses, "500", "InternalServerError")
 	case route.Method == methodGET && route.Path == "/api/v1/accounts/{id}/quote_permissions":
-		delete(op.Responses, "200")
-		delete(op.Responses, "404")
-		delete(op.Responses, "500")
-		op.Responses["501"] = response{
-			Description: "Quote permission reads are not implemented and no settings are retrieved.",
-		}
+		delete(op.Responses, "501")
+		ensureJSONResponseSchema(op, "200", "QuotePermissionsResponse")
+		ensureResponseRef(op.Responses, "404", "NotFound")
+		ensureResponseRef(op.Responses, "500", "InternalServerError")
 	case route.Method == methodPUT && route.Path == "/api/v1/accounts/quote_permissions":
-		delete(op.Responses, "200")
-		delete(op.Responses, "422")
-		delete(op.Responses, "500")
-		op.Responses["501"] = response{
-			Description: "Quote permission updates are not implemented and no settings are persisted.",
-		}
+		delete(op.Responses, "501")
+		ensureJSONResponseSchema(op, "200", "QuotePermissionsResponse")
+		ensureResponseRef(op.Responses, "500", "InternalServerError")
 	}
 }
 

--- a/tools/openapi/operation_overrides.go
+++ b/tools/openapi/operation_overrides.go
@@ -35,7 +35,19 @@ func applyQuoteOverrides(op *operation, route routeDef) {
 		delete(op.Responses, "501")
 		ensureJSONResponseSchema(op, "200", "QuoteStatusSummaryList")
 		ensureResponseRef(op.Responses, "404", "NotFound")
+		ensureResponseRef(op.Responses, "422", "UnprocessableEntity")
 		ensureResponseRef(op.Responses, "500", "InternalServerError")
+		replaceQueryParam(op, parameter{
+			Name:        "offset",
+			In:          "query",
+			Required:    false,
+			Description: "Visible-quote offset. Must not exceed (4 × the requested limit) - 1; larger offsets return 422 rather than a silently truncated empty page.",
+			Schema: schemaRef{
+				Type:    "integer",
+				Format:  "int32",
+				Minimum: intPtr(0),
+			},
+		})
 	case route.Method == methodGET && route.Path == "/api/v1/accounts/{id}/quote_permissions":
 		delete(op.Responses, "501")
 		ensureJSONResponseSchema(op, "200", "QuotePermissionsResponse")
@@ -659,6 +671,25 @@ func ensureQueryParam(op *operation, p parameter) {
 		}
 	}
 	op.Parameters = append(op.Parameters, p)
+}
+
+func replaceQueryParam(op *operation, p parameter) {
+	if op == nil || strings.TrimSpace(p.Name) == "" || !strings.EqualFold(p.In, "query") {
+		return
+	}
+
+	parameters := op.Parameters[:0]
+	for _, existing := range op.Parameters {
+		if strings.EqualFold(existing.In, "query") && strings.EqualFold(existing.Name, p.Name) {
+			continue
+		}
+		if queryName, ok := componentQueryParamNames[componentNameFromRef(existing.Ref)]; ok && strings.EqualFold(queryName, p.Name) {
+			continue
+		}
+		parameters = append(parameters, existing)
+	}
+	op.Parameters = append(parameters, p)
+	sortOperationParameters(op)
 }
 
 func ensureRedirectResponse(op *operation, statusCode, description, locationHeader string) {

--- a/tools/openapi/route_auth_test.go
+++ b/tools/openapi/route_auth_test.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -28,7 +29,7 @@ func TestApplyOperationOverridesPublishesQuoteRESTResponses(t *testing.T) {
 			name:             "list quotes",
 			route:            routeDef{Method: methodGET, Path: "/api/v1/statuses/{id}/quotes"},
 			initialResponses: []string{"200", "400", "404", "500"},
-			wantResponses:    []string{"200", "400", "404", "500"},
+			wantResponses:    []string{"200", "400", "404", "422", "500"},
 			wantSchema:       "QuoteStatusSummaryList",
 		},
 		{
@@ -69,6 +70,30 @@ func TestApplyOperationOverridesPublishesQuoteRESTResponses(t *testing.T) {
 				t.Fatalf("200 response schema = %q, want %q", gotSchema, wantSchema)
 			}
 		})
+	}
+}
+
+func TestApplyQuoteListOverridePublishesDynamicOffsetBound(t *testing.T) {
+	t.Parallel()
+
+	op := &operation{
+		Parameters: []parameter{{Ref: "#/components/parameters/Offset"}},
+		Responses:  map[string]response{},
+	}
+	applyOperationOverrides(op, routeDef{Method: methodGET, Path: "/api/v1/statuses/{id}/quotes"})
+
+	if len(op.Parameters) != 1 {
+		t.Fatalf("parameters = %#v, want one route-specific offset parameter", op.Parameters)
+	}
+	offset := op.Parameters[0]
+	if offset.Name != "offset" || offset.In != "query" || offset.Ref != "" {
+		t.Fatalf("offset parameter = %#v, want an inline query parameter", offset)
+	}
+	if !strings.Contains(offset.Description, "(4 × the requested limit) - 1") {
+		t.Fatalf("offset description = %q, want the servable bound", offset.Description)
+	}
+	if _, ok := op.Responses["422"]; !ok {
+		t.Fatal("quote-list offset validation must publish a 422 response")
 	}
 }
 

--- a/tools/openapi/route_auth_test.go
+++ b/tools/openapi/route_auth_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestApplyOperationOverridesMakesQuoteStubsNotImplemented(t *testing.T) {
+func TestApplyOperationOverridesPublishesQuoteRESTResponses(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -15,35 +15,35 @@ func TestApplyOperationOverridesMakesQuoteStubsNotImplemented(t *testing.T) {
 		route            routeDef
 		initialResponses []string
 		wantResponses    []string
-		wantDescription  string
+		wantSchema       string
 	}{
 		{
 			name:             "create quote",
 			route:            routeDef{Method: methodPOST, Path: "/api/v1/statuses/{id}/quote"},
 			initialResponses: []string{"200", "400", "401", "403", "404", "422", "429", "500"},
-			wantResponses:    []string{"400", "401", "403", "429", "501"},
-			wantDescription:  "Quote creation is not implemented; target IDs are not looked up.",
+			wantResponses:    []string{"200", "400", "401", "403", "404", "422", "429", "500"},
+			wantSchema:       "QuoteStatusSummary",
 		},
 		{
 			name:             "list quotes",
 			route:            routeDef{Method: methodGET, Path: "/api/v1/statuses/{id}/quotes"},
 			initialResponses: []string{"200", "400", "404", "500"},
-			wantResponses:    []string{"400", "501"},
-			wantDescription:  "Quote listing is not implemented; target IDs and quote counts are not looked up.",
+			wantResponses:    []string{"200", "400", "404", "500"},
+			wantSchema:       "QuoteStatusSummaryList",
 		},
 		{
 			name:             "get quote permissions",
 			route:            routeDef{Method: methodGET, Path: "/api/v1/accounts/{id}/quote_permissions"},
 			initialResponses: []string{"200", "400", "401", "403", "404", "500"},
-			wantResponses:    []string{"400", "401", "403", "501"},
-			wantDescription:  "Quote permission reads are not implemented and no settings are retrieved.",
+			wantResponses:    []string{"200", "400", "401", "403", "404", "500"},
+			wantSchema:       "QuotePermissionsResponse",
 		},
 		{
 			name:             "update quote permissions",
 			route:            routeDef{Method: methodPUT, Path: "/api/v1/accounts/quote_permissions"},
 			initialResponses: []string{"200", "400", "401", "403", "422", "500"},
-			wantResponses:    []string{"400", "401", "403", "501"},
-			wantDescription:  "Quote permission updates are not implemented and no settings are persisted.",
+			wantResponses:    []string{"200", "400", "401", "403", "422", "500"},
+			wantSchema:       "QuotePermissionsResponse",
 		},
 	}
 
@@ -63,8 +63,10 @@ func TestApplyOperationOverridesMakesQuoteStubsNotImplemented(t *testing.T) {
 			if !slices.Equal(gotResponses, tt.wantResponses) {
 				t.Fatalf("responses = %v, want only reachable %v", gotResponses, tt.wantResponses)
 			}
-			if got := op.Responses["501"].Description; got != tt.wantDescription {
-				t.Fatalf("501 description = %q", got)
+			gotSchema := op.Responses["200"].Content["application/json"].Schema.Ref
+			wantSchema := "#/components/schemas/" + tt.wantSchema
+			if gotSchema != wantSchema {
+				t.Fatalf("200 response schema = %q, want %q", gotSchema, wantSchema)
 			}
 		})
 	}


### PR DESCRIPTION
Refs #1327

Implements all four Quote Posts REST endpoints for real, replacing the intentionally inert 501 stubs (#1313). **Parked on staging — no release, tag, or version bump.**

- `POST /api/v1/statuses/:id/quote` — delegates to the same `Notes.CreateNote` → `QuoteService.AttachQuoteToStatus` path as GraphQL quote creation (persistence, streaming, federation fanout included), gated by `notes.ValidateChildReach` and `QuoteService.CheckQuotePermissions` (per-note quoteability, followers/mentioned arms). No parallel predicate.
- `GET /api/v1/statuses/:id/quotes` — visibility-filtered listing; target and every returned quote pass through `Notes.GetNoteWithViewer`.
- `GET /api/v1/accounts/:id/quote_permissions` — self-resolution with uniform 404 for other/missing accounts (protects the raw block list, same pattern as 0f8bfa745).
- `PUT /api/v1/accounts/quote_permissions` — full-arm validation through `QuoteService.GetQuotePermissions`/`UpdateQuotePermissions`.
- Restores `QuotePermissionsResponse`, `QuoteStatusAccount`, `QuoteStatusSummary`, `QuoteStatusSummaryList` in `docs/contracts/openapi.yaml` with honest response codes.
- Fail-closed throughout: storage errors and unavailable services are 5xx, never silent allows; uniform 404 for missing/invisible targets (no existence oracle — the original #1313 defect class).

Gates at head `088ff0eb2`: full Go suite, contract freshness, security/supply-chain/audit/docs gates, `./lesser verify ci` all green (coverage 87.695%).

Implemented by codex. Adversarial review by claude follows on this PR.

Signed-off-by: Aron Price <aron23@gmail.com>