### PR TITLE
Managed Client L1+L2: ambient credentials for client install + automation contract docs

### DIFF
--- a/cmd/lesser/client_install.go
+++ b/cmd/lesser/client_install.go
@@ -203,9 +203,6 @@ func normalizeClientInstallInputs(args clientInstallArgs) (string, string, strin
 	}
 
 	awsProfile := strings.TrimSpace(args.AWSProfile)
-	if awsProfile == "" {
-		return "", "", "", errors.New("aws profile is required")
-	}
 
 	return app, baseDomain, awsProfile, nil
 }
@@ -281,7 +278,7 @@ func resolveClientInstallReceipt(app, baseDomain string, args clientInstallArgs)
 }
 
 func newClientInstallAWSClients(awsProfile string) (*s3.Client, *cloudfront.Client, error) {
-	awsCfg, err := loadAWSConfigFromProfileFn(context.Background(), awsProfile)
+	awsCfg, _, err := loadAWSConfigForCLIFn(context.Background(), awsProfile)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -390,7 +387,7 @@ func parseClientInstallArgs(argv []string) (clientInstallArgs, error) {
 	var args clientInstallArgs
 	fs.StringVar(&args.App, "app", "", "app name slug (e.g. my-lesser)")
 	fs.StringVar(&args.BaseDomain, "base-domain", "", "base domain with an existing public hosted zone (e.g. example.com)")
-	fs.StringVar(&args.AWSProfile, "aws-profile", "", "AWS profile name to use (sets AWS_PROFILE)")
+	fs.StringVar(&args.AWSProfile, "aws-profile", "", "AWS profile override (optional; defaults to the ambient AWS credential chain)")
 	fs.StringVar(&args.Stage, "stage", "both", "stage to install (dev|live|staging|both|all)")
 	fs.StringVar(&args.StatePath, "state", "", "path to deployment receipt (defaults to ~/.lesser/<app>/<base-domain>/state.json)")
 	fs.StringVar(&args.ConfigPath, "config", "", "path to facetheory.lesser.json (defaults to searching from cwd upward)")
@@ -400,8 +397,8 @@ func parseClientInstallArgs(argv []string) (clientInstallArgs, error) {
 		return clientInstallArgs{}, err
 	}
 
-	if strings.TrimSpace(args.App) == "" || strings.TrimSpace(args.BaseDomain) == "" || strings.TrimSpace(args.AWSProfile) == "" {
-		return clientInstallArgs{}, errors.New("required flags: --app, --base-domain, --aws-profile")
+	if strings.TrimSpace(args.App) == "" || strings.TrimSpace(args.BaseDomain) == "" {
+		return clientInstallArgs{}, errors.New("required flags: --app, --base-domain")
 	}
 
 	return args, nil

--- a/cmd/lesser/client_install_test.go
+++ b/cmd/lesser/client_install_test.go
@@ -31,6 +31,19 @@ func TestParseClientInstallArgs_RequiresFlags(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestParseClientInstallArgs_AllowsAmbientCredentials(t *testing.T) {
+	args, err := parseClientInstallArgs([]string{
+		"--app", "app",
+		"--base-domain", "example.com",
+		"--stage", "dev",
+		"--skip-build",
+	})
+	require.NoError(t, err)
+	require.Empty(t, args.AWSProfile)
+	require.Equal(t, "dev", args.Stage)
+	require.True(t, args.SkipBuild)
+}
+
 func TestPrepareClientInstallPackage_BuildsManifest(t *testing.T) {
 	appRoot := t.TempDir()
 	serverDir := filepath.Join(appRoot, "build", "server")
@@ -77,13 +90,13 @@ func TestPrepareClientInstallPackage_BuildsManifest(t *testing.T) {
 }
 
 func TestRunClientInstall_RecordsInstallInReceiptAndPublishesManifest(t *testing.T) {
-	previousLoadAWS := loadAWSConfigFromProfileFn
+	previousLoadAWS := loadAWSConfigForCLIFn
 	previousUploadDir := uploadDirWithPrefixFn
 	previousPutObjectString := putObjectStringFn
 	previousInvalidate := invalidateClientPathsFn
 	previousWriteReceipt := writeReceiptFn
 	t.Cleanup(func() {
-		loadAWSConfigFromProfileFn = previousLoadAWS
+		loadAWSConfigForCLIFn = previousLoadAWS
 		uploadDirWithPrefixFn = previousUploadDir
 		putObjectStringFn = previousPutObjectString
 		invalidateClientPathsFn = previousInvalidate
@@ -162,8 +175,9 @@ func TestRunClientInstall_RecordsInstallInReceiptAndPublishesManifest(t *testing
 	var invalidations []string
 	var wroteReceipt *upReceipt
 
-	loadAWSConfigFromProfileFn = func(context.Context, string) (aws.Config, error) {
-		return aws.Config{Region: "us-east-1"}, nil
+	loadAWSConfigForCLIFn = func(_ context.Context, profile string) (aws.Config, string, error) {
+		require.Equal(t, "profile", profile)
+		return aws.Config{Region: "us-east-1"}, profile, nil
 	}
 	uploadDirWithPrefixFn = func(_ context.Context, _ s3PutObjectAPI, bucket, prefix, dir string) error {
 		uploads = append(uploads, uploadCall{Bucket: bucket, Prefix: prefix, Dir: dir})
@@ -256,13 +270,13 @@ func TestRunClientInstall_PropagatesErrors(t *testing.T) {
 	})
 
 	t.Run("publish stage", func(t *testing.T) {
-		previousLoadAWS := loadAWSConfigFromProfileFn
+		previousLoadAWS := loadAWSConfigForCLIFn
 		previousUploadDir := uploadDirWithPrefixFn
 		previousPutObjectString := putObjectStringFn
 		previousInvalidate := invalidateClientPathsFn
 		previousWriteReceipt := writeReceiptFn
 		t.Cleanup(func() {
-			loadAWSConfigFromProfileFn = previousLoadAWS
+			loadAWSConfigForCLIFn = previousLoadAWS
 			uploadDirWithPrefixFn = previousUploadDir
 			putObjectStringFn = previousPutObjectString
 			invalidateClientPathsFn = previousInvalidate
@@ -271,8 +285,8 @@ func TestRunClientInstall_PropagatesErrors(t *testing.T) {
 
 		appRoot, configPath, statePath := writeClientInstallFixture(t)
 		_ = appRoot
-		loadAWSConfigFromProfileFn = func(context.Context, string) (aws.Config, error) {
-			return aws.Config{Region: "us-east-1"}, nil
+		loadAWSConfigForCLIFn = func(_ context.Context, profile string) (aws.Config, string, error) {
+			return aws.Config{Region: "us-east-1"}, profile, nil
 		}
 		uploadDirWithPrefixFn = func(context.Context, s3PutObjectAPI, string, string, string) error {
 			return errSentinel
@@ -361,13 +375,13 @@ func TestNewClientInstallCommand_PropagatesErrors(t *testing.T) {
 	})
 
 	t.Run("aws client creation", func(t *testing.T) {
-		previousLoadAWS := loadAWSConfigFromProfileFn
-		t.Cleanup(func() { loadAWSConfigFromProfileFn = previousLoadAWS })
+		previousLoadAWS := loadAWSConfigForCLIFn
+		t.Cleanup(func() { loadAWSConfigForCLIFn = previousLoadAWS })
 
 		appRoot, configPath, statePath := writeClientInstallFixture(t)
 		_ = appRoot
-		loadAWSConfigFromProfileFn = func(context.Context, string) (aws.Config, error) {
-			return aws.Config{}, errSentinel
+		loadAWSConfigForCLIFn = func(context.Context, string) (aws.Config, string, error) {
+			return aws.Config{}, "", errSentinel
 		}
 
 		_, err := newClientInstallCommand(clientInstallArgs{
@@ -448,15 +462,17 @@ func TestNormalizeClientInstallInputs_ValidatesAndTrims(t *testing.T) {
 	})
 	require.Error(t, err)
 
-	_, _, _, err = normalizeClientInstallInputs(clientInstallArgs{
+	app, baseDomain, awsProfile, err := normalizeClientInstallInputs(clientInstallArgs{
 		App:        "demo-app",
-		BaseDomain: "example.com",
+		BaseDomain: "Example.COM.",
 		AWSProfile: "   ",
 	})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "aws profile is required")
+	require.NoError(t, err)
+	require.Equal(t, "demo-app", app)
+	require.Equal(t, "example.com", baseDomain)
+	require.Empty(t, awsProfile)
 
-	app, baseDomain, awsProfile, err := normalizeClientInstallInputs(clientInstallArgs{
+	app, baseDomain, awsProfile, err = normalizeClientInstallInputs(clientInstallArgs{
 		App:        " Demo-App ",
 		BaseDomain: " Example.COM. ",
 		AWSProfile: " profile ",
@@ -887,15 +903,30 @@ func TestResolveClientInstallReceipt_ErrorsOnInvalidStage(t *testing.T) {
 }
 
 func TestNewClientInstallAWSClients_PropagatesLoadError(t *testing.T) {
-	previousLoadAWS := loadAWSConfigFromProfileFn
-	t.Cleanup(func() { loadAWSConfigFromProfileFn = previousLoadAWS })
+	previousLoadAWS := loadAWSConfigForCLIFn
+	t.Cleanup(func() { loadAWSConfigForCLIFn = previousLoadAWS })
 
-	loadAWSConfigFromProfileFn = func(context.Context, string) (aws.Config, error) {
-		return aws.Config{}, errSentinel
+	loadAWSConfigForCLIFn = func(context.Context, string) (aws.Config, string, error) {
+		return aws.Config{}, "", errSentinel
 	}
 
 	_, _, err := newClientInstallAWSClients("profile")
 	require.ErrorIs(t, err, errSentinel)
+}
+
+func TestNewClientInstallAWSClients_UsesAmbientCredentialChain(t *testing.T) {
+	previousLoadAWS := loadAWSConfigForCLIFn
+	t.Cleanup(func() { loadAWSConfigForCLIFn = previousLoadAWS })
+
+	loadAWSConfigForCLIFn = func(_ context.Context, profile string) (aws.Config, string, error) {
+		require.Empty(t, profile)
+		return aws.Config{Region: "us-east-1"}, "", nil
+	}
+
+	s3Client, cfClient, err := newClientInstallAWSClients("")
+	require.NoError(t, err)
+	require.NotNil(t, s3Client)
+	require.NotNil(t, cfClient)
 }
 
 func TestPublishClientInstallStage_PropagatesManifestAndInvalidationErrors(t *testing.T) {

--- a/cmd/lesser/main.go
+++ b/cmd/lesser/main.go
@@ -160,7 +160,7 @@ func printUsageTo(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  lesser up --app <slug> --base-domain <example.com> [--aws-profile <profile>] [--stage dev|staging|live] [--provisioning-input <path>] [--release-dir <path>] [--bootstrap-wallet-address <0x...>] [--with-staging] [--out <path>] [--rebuild-lambdas]")
 	_, _ = fmt.Fprintln(w, "  lesser init-admin --app <slug> --base-domain <example.com> [--aws-profile <profile>] --stage dev|staging|live [--provisioning-input <path>] --wallet-address <0x...> --signature <0x...> [--message <string> | --message-file <path>] [--username <username>] [--chain-id <n>]")
 	_, _ = fmt.Fprintln(w, "  lesser down --app <slug> --base-domain <example.com> --aws-profile <profile> [--state <path>] [--purge-artifacts]")
-	_, _ = fmt.Fprintln(w, "  lesser client install --app <slug> --base-domain <example.com> --aws-profile <profile> [--stage dev|live|staging|both|all] [--state <path>] [--config <path>] [--skip-build]")
+	_, _ = fmt.Fprintln(w, "  lesser client install --app <slug> --base-domain <example.com> [--aws-profile <profile>] [--stage dev|live|staging|both|all] [--state <path>] [--config <path>] [--skip-build]")
 	_, _ = fmt.Fprintln(w, "  lesser client deploy ...                                  # deprecated; use `lesser client install`")
 	_, _ = fmt.Fprintln(w, "")
 	_, _ = fmt.Fprintln(w, "  lesser build [--rebuild-lambdas]                # rebuild deployment artifacts (lambdas, auth-ui, go build)")

--- a/cmd/lesser/main_test.go
+++ b/cmd/lesser/main_test.go
@@ -22,6 +22,7 @@ func TestRunCLI_DispatchAndExitCodes(t *testing.T) {
 		require.Equal(t, 0, code)
 		require.Contains(t, buf.String(), "Usage:")
 		require.Contains(t, buf.String(), "--release-dir <path>")
+		require.Contains(t, buf.String(), "base-domain <example.com> [--aws-profile <profile>]")
 	})
 
 	t.Run("version prints version and returns 0", func(t *testing.T) {

--- a/docs/guides/CLIENT_APP_GUIDE.md
+++ b/docs/guides/CLIENT_APP_GUIDE.md
@@ -105,9 +105,34 @@ Recommended command:
 ./lesser client install \
   --app <slug> \
   --base-domain <example.com> \
-  --aws-profile <profile> \
+  --stage dev \
   --config ./facetheory.lesser.json
 ```
+
+The command uses the AWS SDK credential chain by default. In a managed CodeBuild job, the ambient project role and
+`AWS_REGION`/`AWS_DEFAULT_REGION` are therefore sufficient; no interactive login or named profile is required. Pass
+`--aws-profile <profile>` only as an explicit local/operator override.
+
+Automation must always select exactly one concrete stage with `--stage dev`, `--stage staging`, or `--stage live`.
+Do not omit `--stage` and do not use `both` or `all` in managed automation: the default/operator convenience selections
+can update more than one stage.
+
+Noninteractive ambient-credential smoke path (run inside CodeBuild after the app artifacts and Lesser receipt have been
+materialized; this performs real S3 uploads and a CloudFront invalidation):
+
+```bash
+env -u AWS_PROFILE ./lesser client install \
+  --app "$LESSER_APP" \
+  --base-domain "$LESSER_BASE_DOMAIN" \
+  --stage dev \
+  --state "$LESSER_STATE_PATH" \
+  --config ./facetheory.lesser.json \
+  --skip-build </dev/null
+```
+
+`--skip-build` makes this an install-only smoke path: the server bundle and browser assets named by
+`facetheory.lesser.json` must already exist. The command still makes live AWS calls, so run it only against the intended
+dev stage and account.
 
 Useful flags:
 
@@ -128,12 +153,17 @@ What the command does:
 
 ## Receipt and stack outputs
 
-The stage receipt now carries the values the install flow needs:
+For every explicitly selected stage, managed automation requires these four values in
+`stages.<stage>.stack_outputs` of the deployment receipt:
 
-- `ClientBucketName`
-- `ClientArtifactBucketName`
-- `ClientInstallManifestKey`
-- `FrontendDistributionId`
+- `ClientBucketName`: bucket that receives browser assets under `l/_assets/*`.
+- `ClientArtifactBucketName`: private bucket that receives versioned server bundles and manifests under `installs/*`.
+- `ClientInstallManifestKey`: active manifest object key; the managed contract value is `install/current.json`.
+- `FrontendDistributionId`: distribution invalidated after the active manifest is updated.
+
+Treat all four outputs as required receipt inputs for managed installs. The CLI retains naming defaults for compatibility
+with older operator receipts, but managed automation must not reconstruct or guess resource names. Scope each job from
+the outputs of the same selected stage; never combine bucket outputs from one stage with a distribution ID from another.
 
 After an install, Lesser also records the active release under:
 
@@ -143,6 +173,40 @@ After an install, Lesser also records the active release under:
 - `stages.<stage>.client_install.manifest_key`
 - `stages.<stage>.client_install.server_root`
 - `stages.<stage>.client_install.assets_root`
+
+## Install-only IAM policy
+
+The role running `lesser client install` does not need CloudFormation, CDK, bucket-listing, object-read, object-delete, or
+deployment permissions. Substitute the selected stage receipt outputs and account ID into this install-only policy:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "PutClientInstallObjects",
+      "Effect": "Allow",
+      "Action": "s3:PutObject",
+      "Resource": [
+        "arn:aws:s3:::<ClientArtifactBucketName>/installs/*",
+        "arn:aws:s3:::<ClientArtifactBucketName>/install/current.json",
+        "arn:aws:s3:::<ClientBucketName>/l/_assets/*"
+      ]
+    },
+    {
+      "Sid": "InvalidateClientDistribution",
+      "Effect": "Allow",
+      "Action": "cloudfront:CreateInvalidation",
+      "Resource": "arn:aws:cloudfront::<account-id>:distribution/<FrontendDistributionId>"
+    }
+  ]
+}
+```
+
+This is the complete install operation shape: `s3:PutObject` for immutable server bundles and history manifests under
+`installs/*`, the active `install/current.json` manifest, and assets under `l/_assets/*`; plus
+`cloudfront:CreateInvalidation` on exactly the selected stage distribution. If a receipt intentionally publishes a
+different `ClientInstallManifestKey`, replace only the active-manifest resource with that exact object ARN.
 
 ## Verification checklist
 

--- a/pkg/moderation/round24_pattern_cache_test.go
+++ b/pkg/moderation/round24_pattern_cache_test.go
@@ -256,7 +256,7 @@ func TestPatternCacheManager_cleanup_RemovesExpiredFromBothCaches(t *testing.T) 
 	repo := newFakePatternCacheRepository()
 	cfg := &CacheConfig{
 		MaxMemoryPatterns:      10,
-		MemoryCacheTimeout:     time.Millisecond,
+		MemoryCacheTimeout:     time.Hour,
 		PersistentCacheTimeout: time.Hour,
 		EnableStatistics:       false,
 		CleanupInterval:        0,


### PR DESCRIPTION
Refs #1095 Refs #1096 (Project 40).

- L1: `lesser client install --skip-build` works noninteractively from ambient CodeBuild role credentials; `--aws-profile` remains an optional override
- L2: CLIENT_APP_GUIDE documents required receipt outputs, explicit-stage automation, install-only S3/CloudFront IAM shape
- Plus a factory-authorized unrelated flaky-test stabilization (1ms TTL → 1h, pattern cache cleanup test)

Verified by implementer: `go test ./... -count=1` PASS, `./lesser verify ci` PASS. Single adversarial pass (claude) to follow; factory renders go/no-go.