### PR TITLE
feat(auth): grantee MCP access via share grants — grantee-subject tokens and both-identity audit attribution

### DIFF
--- a/cmd/api/handlers/agent_audit.go
+++ b/cmd/api/handlers/agent_audit.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"net/url"
 	"strings"
 	"time"
 
@@ -13,8 +14,21 @@ import (
 )
 
 func (h *Handler) recordAgentAuditEvent(ctx *apptheory.Context, claims *auth.Claims, action string, targetID string, metadata map[string]any) {
-	if h == nil || h.repos == nil || h.repos.Audit() == nil || claims == nil || !claims.IsAgent {
+	if h == nil || h.repos == nil || h.repos.Audit() == nil || claims == nil {
 		return
+	}
+
+	// Grantee-driven agent actions arrive under a grantee-subject token whose
+	// audience is the shared agent's actor MCP URL. They must not silently drop
+	// the audit trail, so admit them and record both identities: the real caller
+	// (grantee) in Username and the agent plus session in Metadata.
+	agentUsername := ""
+	if !claims.IsAgent {
+		agent, ok := actorUsernameFromAudience(claims)
+		if !ok {
+			return
+		}
+		agentUsername = agent
 	}
 
 	action = strings.TrimSpace(action)
@@ -42,6 +56,10 @@ func (h *Handler) recordAgentAuditEvent(ctx *apptheory.Context, claims *auth.Cla
 	}
 
 	if metadata != nil {
+		if agentUsername != "" {
+			metadata["agent_username"] = agentUsername
+			metadata["agent_session_id"] = claims.SessionID
+		}
 		if targetID != "" {
 			metadata["target_id"] = targetID
 		}
@@ -50,12 +68,41 @@ func (h *Handler) recordAgentAuditEvent(ctx *apptheory.Context, claims *auth.Cla
 		} else {
 			h.logger.Debug("failed to marshal agent audit metadata", zap.Error(err))
 		}
-	} else if targetID != "" {
-		raw, _ := json.Marshal(map[string]any{"target_id": targetID})
-		entry.Metadata = string(raw)
+	} else {
+		extra := map[string]any{}
+		if agentUsername != "" {
+			extra["agent_username"] = agentUsername
+			extra["agent_session_id"] = claims.SessionID
+		}
+		if targetID != "" {
+			extra["target_id"] = targetID
+		}
+		if len(extra) > 0 {
+			raw, _ := json.Marshal(extra)
+			entry.Metadata = string(raw)
+		}
 	}
 
 	if err := h.repos.Audit().StoreAuditLog(ctx.Context(), entry); err != nil {
 		h.logger.Debug("failed to store agent audit log", zap.Error(err))
 	}
+}
+
+// actorUsernameFromAudience extracts the agent username from a grantee-subject
+// token whose single audience is the shared agent's actor MCP URL. It returns
+// false for agent-subject tokens and for tokens whose audience is not an actor
+// MCP resource.
+func actorUsernameFromAudience(claims *auth.Claims) (string, bool) {
+	if claims == nil || len(claims.Audience) != 1 {
+		return "", false
+	}
+	parsed, err := url.Parse(strings.TrimSpace(claims.Audience[0]))
+	if err != nil || parsed == nil {
+		return "", false
+	}
+	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(segments) != 2 || segments[0] != oauthMCPSegment || strings.TrimSpace(segments[1]) == "" {
+		return "", false
+	}
+	return strings.TrimSpace(segments[1]), true
 }

--- a/cmd/api/handlers/oauth.go
+++ b/cmd/api/handlers/oauth.go
@@ -54,6 +54,9 @@ const (
 
 	oauthInstanceSurfacePtah = "ptah"
 	oauthInstanceSurfaceBa   = "ba"
+
+	// oauthMCPSegment is the URL path segment identifying an actor-scoped MCP resource.
+	oauthMCPSegment = "mcp"
 )
 
 var errOAuthInvalidTarget = errors.New("invalid_target")
@@ -417,7 +420,7 @@ func (h *Handler) resolveAuthorizeTargetActorFromResource(ctx context.Context, r
 	}
 
 	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
-	if len(segments) != 2 || segments[0] != "mcp" || strings.TrimSpace(segments[1]) == "" {
+	if len(segments) != 2 || segments[0] != oauthMCPSegment || strings.TrimSpace(segments[1]) == "" {
 		return "", "", &oauthAuthorizeTargetError{
 			code:        "invalid_target",
 			description: "resource must be the actor-scoped MCP URL for this server",
@@ -439,11 +442,24 @@ func (h *Handler) resolveAuthorizeTargetActorFromResource(ctx context.Context, r
 			description: "resource must reference an existing local MCP actor",
 		}
 	}
+	// Token subject selection. The owner keeps the agent as subject (unchanged);
+	// an active share grantee keeps the grantee as subject with the agent carried
+	// as the token resource/audience. The grant read is the uncached,
+	// strongly-consistent direct base-table check from the agentshare service and
+	// is consulted only for non-owners, so the owner path stays byte-identical.
+	subjectUsername := actorUsername
 	if !h.agentOwnedByPrincipal(actorUser, principalUsername) {
-		return "", "", &oauthAuthorizeTargetError{
-			code:        "access_denied",
-			description: "principal is not authorized for requested MCP resource",
+		grantActive, grantErr := h.agentShareGrantActive(ctx, actorUsername, principalUsername)
+		if grantErr != nil {
+			return "", "", fmt.Errorf("agent share grant check failed: %w", grantErr)
 		}
+		if !grantActive {
+			return "", "", &oauthAuthorizeTargetError{
+				code:        "access_denied",
+				description: "principal is not authorized for requested MCP resource",
+			}
+		}
+		subjectUsername = strings.TrimSpace(principalUsername)
 	}
 
 	canonicalResource := auth.BuildPublicMCPAccessBundle(h.cfg.BaseURL(), actorUsername).MCPURL
@@ -460,7 +476,7 @@ func (h *Handler) resolveAuthorizeTargetActorFromResource(ctx context.Context, r
 		}
 	}
 
-	return actorUsername, canonicalResource, nil
+	return subjectUsername, canonicalResource, nil
 }
 
 func oauthResourceTargetsInstancePlane(resource string) bool {
@@ -529,7 +545,7 @@ func (h *Handler) resolveAuthorizeTargetInstanceFromResource(ctx context.Context
 	}
 
 	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
-	if len(segments) != 3 || segments[0] != "instance" || segments[2] != "mcp" {
+	if len(segments) != 3 || segments[0] != "instance" || segments[2] != oauthMCPSegment {
 		return "", "", oauthInvalidInstanceResourceTarget()
 	}
 

--- a/cmd/api/handlers/oauth_actor_grantee_round_test.go
+++ b/cmd/api/handlers/oauth_actor_grantee_round_test.go
@@ -1,0 +1,437 @@
+package handlers
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	apimodels "github.com/equaltoai/lesser/cmd/api/models"
+	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/services/accounts"
+	"github.com/equaltoai/lesser/pkg/storage"
+	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func oauthActorGranteePKCE() (verifier, challenge string) {
+	verifier = "lesser-grantee-mcp-verifier"
+	sum := sha256.Sum256([]byte(verifier))
+	return verifier, base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func oauthActorGranteeState(agentOwner string) *round10QueryState {
+	return &round10QueryState{
+		usersByUsername: map[string]storagemodels.User{
+			"agent-one": {Username: "agent-one", IsAgent: true, AgentType: "counsel", AgentOwner: agentOwner},
+			"alice":     {Username: "alice", Approved: true},
+			"owner":     {Username: "owner", Approved: true},
+		},
+	}
+}
+
+func oauthActorGranteeAccountsStub(captured **storage.AuthorizationCode) *AccountsServiceStub {
+	return &AccountsServiceStub{
+		GetUserAppConsentFunc: func(context.Context, *accounts.GetUserAppConsentQuery) (*accounts.GetUserAppConsentResult, error) {
+			return &accounts.GetUserAppConsentResult{
+				Consent: &storage.UserAppConsent{Scopes: []string{auth.ScopeRead, auth.ScopeWrite}},
+			}, nil
+		},
+		CreateAuthorizationCodeFunc: func(_ context.Context, cmd *accounts.CreateAuthorizationCodeCommand) (*accounts.CreateAuthorizationCodeResult, error) {
+			*captured = cmd.AuthCode
+			return &accounts.CreateAuthorizationCodeResult{}, nil
+		},
+	}
+}
+
+func oauthActorGranteeSeedCode(state *round10QueryState, code *storage.AuthorizationCode) {
+	if code == nil {
+		return
+	}
+	state.authorizationCodesByCode = map[string]storagemodels.AuthorizationCode{
+		code.Code: {
+			Code:              code.Code,
+			ClientID:          code.ClientID,
+			RedirectURI:       code.RedirectURI,
+			Resource:          code.Resource,
+			Username:          code.Username,
+			PrincipalUsername: code.PrincipalUsername,
+			CodeChallenge:     code.CodeChallenge,
+			ExpiresAt:         code.ExpiresAt,
+			Scopes:            code.Scopes,
+		},
+	}
+}
+
+func TestOAuthActorResourceGranteeReceivesCodeWithGranteeSubject(t *testing.T) {
+	cfg := round11TestConfig()
+	resource := auth.BuildPublicMCPAccessBundle(cfg.BaseURL(), "agent-one").MCPURL
+	_, challenge := oauthActorGranteePKCE()
+
+	state := oauthActorGranteeState("@owner")
+	state.oauthClientsByID = map[string]storagemodels.OAuthClient{
+		"mcp-client": {
+			ClientID:           "mcp-client",
+			Name:               "Grantee MCP Connector",
+			RedirectURIs:       []string{"https://client.example/callback"},
+			Scopes:             []string{auth.ScopeRead, auth.ScopeWrite},
+			ClientClass:        auth.ClientClassCLI,
+			RegistrationSource: oauthRegistrationSourceDynamic,
+			CreatedAt:          time.Now().Add(-24 * time.Hour),
+		},
+	}
+
+	var issuedAuthCode *storage.AuthorizationCode
+	h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{
+		AccountsSvc:    oauthActorGranteeAccountsStub(&issuedAuthCode),
+		AgentSharesSvc: actAsActiveGrantStub(),
+	})
+
+	ctx, err := round10NewLiftContext(http.MethodGet, "/oauth/authorize", nil, map[string]string{
+		"response_type":         "code",
+		"client_id":             "mcp-client",
+		"redirect_uri":          "https://client.example/callback",
+		"resource":              resource,
+		"scope":                 "read write",
+		"state":                 "grantee",
+		"code_challenge":        challenge,
+		"code_challenge_method": "S256",
+	}, nil)
+	require.NoError(t, err)
+	ctx.Set("username", "alice")
+
+	resp := requireStatus(t, http.StatusFound)(h.HandleOAuthAuthorizeLift(ctx))
+	redirectURL, err := url.Parse(firstStringValue(resp.Headers, "location"))
+	require.NoError(t, err)
+	require.NotEmpty(t, redirectURL.Query().Get("code"))
+	require.NotContains(t, redirectURL.Query().Get("error"), "access_denied")
+
+	require.NotNil(t, issuedAuthCode)
+	require.Equal(t, resource, issuedAuthCode.Resource)
+	require.Equal(t, "alice", issuedAuthCode.Username)
+	require.Equal(t, "alice", issuedAuthCode.PrincipalUsername)
+}
+
+func TestOAuthActorResourceGranteeTokenCarriesGranteeSubjectAndAgentAudience(t *testing.T) {
+	cfg := round11TestConfig()
+	resource := auth.BuildPublicMCPAccessBundle(cfg.BaseURL(), "agent-one").MCPURL
+	verifier, challenge := oauthActorGranteePKCE()
+
+	state := oauthActorGranteeState("@owner")
+	state.oauthClientsByID = map[string]storagemodels.OAuthClient{
+		"mcp-client": {
+			ClientID:           "mcp-client",
+			Name:               "Grantee MCP Connector",
+			RedirectURIs:       []string{"https://client.example/callback"},
+			Scopes:             []string{auth.ScopeRead, auth.ScopeWrite},
+			ClientClass:        auth.ClientClassCLI,
+			RegistrationSource: oauthRegistrationSourceDynamic,
+			CreatedAt:          time.Now().Add(-24 * time.Hour),
+		},
+	}
+
+	var issuedAuthCode *storage.AuthorizationCode
+	h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{
+		AccountsSvc:    oauthActorGranteeAccountsStub(&issuedAuthCode),
+		AgentSharesSvc: actAsActiveGrantStub(),
+	})
+
+	authorizeCtx, err := round10NewLiftContext(http.MethodGet, "/oauth/authorize", nil, map[string]string{
+		"response_type":         "code",
+		"client_id":             "mcp-client",
+		"redirect_uri":          "https://client.example/callback",
+		"resource":              resource,
+		"scope":                 "read write",
+		"state":                 "grantee",
+		"code_challenge":        challenge,
+		"code_challenge_method": "S256",
+	}, nil)
+	require.NoError(t, err)
+	authorizeCtx.Set("username", "alice")
+
+	authorizeResp := requireStatus(t, http.StatusFound)(h.HandleOAuthAuthorizeLift(authorizeCtx))
+	redirectURL, err := url.Parse(firstStringValue(authorizeResp.Headers, "location"))
+	require.NoError(t, err)
+	require.NotEmpty(t, redirectURL.Query().Get("code"))
+	require.NotNil(t, issuedAuthCode)
+
+	oauthActorGranteeSeedCode(state, issuedAuthCode)
+
+	tokenParams := url.Values{
+		"grant_type":    {oauthGrantTypeAuthorizationCode},
+		"code":          {issuedAuthCode.Code},
+		"client_id":     {"mcp-client"},
+		"redirect_uri":  {"https://client.example/callback"},
+		"resource":      {resource},
+		"code_verifier": {verifier},
+	}
+	tokenResp := requireStatus(t, http.StatusOK)(h.HandleOAuthTokenLift(round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte(tokenParams.Encode()))))
+	var tokenBody apimodels.OAuthTokenResponse
+	require.NoError(t, json.Unmarshal(tokenResp.Body, &tokenBody))
+	require.NotEmpty(t, tokenBody.AccessToken)
+
+	claims := round12DecodeJWTClaims(t, tokenBody.AccessToken)
+	require.Equal(t, "alice", claims.Username)
+	require.Equal(t, "alice", claims.Subject)
+	require.Equal(t, []string{resource}, []string(claims.Audience))
+	require.False(t, claims.IsAgent)
+	require.Equal(t, auth.ClientClassCLI, claims.ClientClass)
+
+	storedRefresh, ok := state.refreshTokensByToken[tokenBody.RefreshToken]
+	require.True(t, ok)
+	require.Equal(t, "alice", storedRefresh.Username)
+	require.Equal(t, resource, storedRefresh.Resource)
+}
+
+func TestOAuthActorResourceOwnerPathUnchanged(t *testing.T) {
+	cfg := round11TestConfig()
+	resource := auth.BuildPublicMCPAccessBundle(cfg.BaseURL(), "agent-one").MCPURL
+	verifier, challenge := oauthActorGranteePKCE()
+
+	state := oauthActorGranteeState("owner")
+	state.oauthClientsByID = map[string]storagemodels.OAuthClient{
+		"owner-agent-client": {
+			ClientID:      "owner-agent-client",
+			ClientSecret:  "secret",
+			Name:          "Owner Agent Connector",
+			RedirectURIs:  []string{"https://client.example/callback"},
+			Scopes:        []string{auth.ScopeRead, auth.ScopeWrite},
+			ClientClass:   auth.ClientClassAgent,
+			AgentUsername: "agent-one",
+			CreatedAt:     time.Now().Add(-24 * time.Hour),
+		},
+	}
+
+	var issuedAuthCode *storage.AuthorizationCode
+	h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{
+		AccountsSvc: oauthActorGranteeAccountsStub(&issuedAuthCode),
+		AgentSharesSvc: &actAsShareServiceStub{
+			isActiveFunc: func(context.Context, string, string) (bool, error) {
+				t.Fatal("owner path must not consult the share-grant check")
+				return false, nil
+			},
+		},
+	})
+
+	authorizeCtx, err := round10NewLiftContext(http.MethodGet, "/oauth/authorize", nil, map[string]string{
+		"response_type":         "code",
+		"client_id":             "owner-agent-client",
+		"redirect_uri":          "https://client.example/callback",
+		"resource":              resource,
+		"scope":                 "read write",
+		"state":                 "owner",
+		"code_challenge":        challenge,
+		"code_challenge_method": "S256",
+	}, nil)
+	require.NoError(t, err)
+	authorizeCtx.Set("username", "owner")
+
+	authorizeResp := requireStatus(t, http.StatusFound)(h.HandleOAuthAuthorizeLift(authorizeCtx))
+	redirectURL, err := url.Parse(firstStringValue(authorizeResp.Headers, "location"))
+	require.NoError(t, err)
+	require.NotEmpty(t, redirectURL.Query().Get("code"))
+	require.NotNil(t, issuedAuthCode)
+	require.Equal(t, resource, issuedAuthCode.Resource)
+	require.Equal(t, "agent-one", issuedAuthCode.Username)
+	require.Equal(t, "owner", issuedAuthCode.PrincipalUsername)
+
+	oauthActorGranteeSeedCode(state, issuedAuthCode)
+
+	tokenParams := url.Values{
+		"grant_type":    {oauthGrantTypeAuthorizationCode},
+		"code":          {issuedAuthCode.Code},
+		"client_id":     {"owner-agent-client"},
+		"redirect_uri":  {"https://client.example/callback"},
+		"resource":      {resource},
+		"code_verifier": {verifier},
+	}
+	tokenResp := requireStatus(t, http.StatusOK)(h.HandleOAuthTokenLift(round10NewLiftContextWithBodyBytes(http.MethodPost, "/oauth/token", nil, nil, []byte(tokenParams.Encode()))))
+	var tokenBody apimodels.OAuthTokenResponse
+	require.NoError(t, json.Unmarshal(tokenResp.Body, &tokenBody))
+	require.NotEmpty(t, tokenBody.AccessToken)
+
+	claims := round12DecodeJWTClaims(t, tokenBody.AccessToken)
+	require.Equal(t, "agent-one", claims.Username)
+	require.Equal(t, "agent-one", claims.Subject)
+	require.Equal(t, []string{resource}, []string(claims.Audience))
+	require.True(t, claims.IsAgent)
+	require.Equal(t, auth.ClientClassAgent, claims.ClientClass)
+	require.Equal(t, "@owner", claims.DelegatedBy)
+
+	storedRefresh, ok := state.refreshTokensByToken[tokenBody.RefreshToken]
+	require.True(t, ok)
+	require.Equal(t, "agent-one", storedRefresh.Username)
+	require.Equal(t, resource, storedRefresh.Resource)
+}
+
+func TestOAuthActorResourceNonGranteeDenied(t *testing.T) {
+	cfg := round11TestConfig()
+	resource := auth.BuildPublicMCPAccessBundle(cfg.BaseURL(), "agent-one").MCPURL
+	_, challenge := oauthActorGranteePKCE()
+
+	state := oauthActorGranteeState("@owner")
+	state.oauthClientsByID = map[string]storagemodels.OAuthClient{
+		"mcp-client": {
+			ClientID:           "mcp-client",
+			RedirectURIs:       []string{"https://client.example/callback"},
+			Scopes:             []string{auth.ScopeRead, auth.ScopeWrite},
+			ClientClass:        auth.ClientClassCLI,
+			RegistrationSource: oauthRegistrationSourceDynamic,
+			CreatedAt:          time.Now().Add(-24 * time.Hour),
+		},
+	}
+
+	var issuedAuthCode *storage.AuthorizationCode
+	h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{
+		AccountsSvc: oauthActorGranteeAccountsStub(&issuedAuthCode),
+		AgentSharesSvc: &actAsShareServiceStub{
+			isActiveFunc: func(context.Context, string, string) (bool, error) {
+				return false, nil
+			},
+		},
+	})
+
+	ctx, err := round10NewLiftContext(http.MethodGet, "/oauth/authorize", nil, map[string]string{
+		"response_type":         "code",
+		"client_id":             "mcp-client",
+		"redirect_uri":          "https://client.example/callback",
+		"resource":              resource,
+		"scope":                 "read write",
+		"state":                 "denied",
+		"code_challenge":        challenge,
+		"code_challenge_method": "S256",
+	}, nil)
+	require.NoError(t, err)
+	ctx.Set("username", "alice")
+
+	resp := requireStatus(t, http.StatusFound)(h.HandleOAuthAuthorizeLift(ctx))
+	redirectURL, err := url.Parse(firstStringValue(resp.Headers, "location"))
+	require.NoError(t, err)
+	require.Equal(t, "access_denied", redirectURL.Query().Get("error"))
+	require.Empty(t, redirectURL.Query().Get("code"))
+	require.Nil(t, issuedAuthCode)
+}
+
+func TestOAuthActorResourceGrantCheckErrorFailsClosed(t *testing.T) {
+	cfg := round11TestConfig()
+	resource := auth.BuildPublicMCPAccessBundle(cfg.BaseURL(), "agent-one").MCPURL
+	_, challenge := oauthActorGranteePKCE()
+
+	state := oauthActorGranteeState("@owner")
+	state.oauthClientsByID = map[string]storagemodels.OAuthClient{
+		"mcp-client": {
+			ClientID:           "mcp-client",
+			RedirectURIs:       []string{"https://client.example/callback"},
+			Scopes:             []string{auth.ScopeRead, auth.ScopeWrite},
+			ClientClass:        auth.ClientClassCLI,
+			RegistrationSource: oauthRegistrationSourceDynamic,
+			CreatedAt:          time.Now().Add(-24 * time.Hour),
+		},
+	}
+
+	var issuedAuthCode *storage.AuthorizationCode
+	h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{
+		AccountsSvc: oauthActorGranteeAccountsStub(&issuedAuthCode),
+		AgentSharesSvc: &actAsShareServiceStub{
+			isActiveFunc: func(context.Context, string, string) (bool, error) {
+				return false, errors.New("dynamodb timeout")
+			},
+		},
+	})
+
+	ctx, err := round10NewLiftContext(http.MethodGet, "/oauth/authorize", nil, map[string]string{
+		"response_type":         "code",
+		"client_id":             "mcp-client",
+		"redirect_uri":          "https://client.example/callback",
+		"resource":              resource,
+		"scope":                 "read write",
+		"state":                 "error",
+		"code_challenge":        challenge,
+		"code_challenge_method": "S256",
+	}, nil)
+	require.NoError(t, err)
+	ctx.Set("username", "alice")
+
+	resp := requireStatus(t, http.StatusFound)(h.HandleOAuthAuthorizeLift(ctx))
+	redirectURL, err := url.Parse(firstStringValue(resp.Headers, "location"))
+	require.NoError(t, err)
+	require.Equal(t, "server_error", redirectURL.Query().Get("error"))
+	require.Empty(t, redirectURL.Query().Get("code"))
+	require.Nil(t, issuedAuthCode)
+}
+
+func TestRecordAgentAuditEventGranteeRecordsBothIdentities(t *testing.T) {
+	cfg := round11TestConfig()
+	resource := auth.BuildPublicMCPAccessBundle(cfg.BaseURL(), "agent-one").MCPURL
+
+	state := &round10QueryState{}
+	h, _, _ := round11NewHandler(t, cfg, state)
+
+	claims := &auth.Claims{Username: "alice", SessionID: "sess-grantee"}
+	claims.Audience = jwt.ClaimStrings{resource}
+
+	ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses", map[string]string{
+		"x-forwarded-for": "1.2.3.4",
+		"user-agent":      "test-agent/1.0",
+	}, nil, nil)
+	require.NoError(t, err)
+
+	h.recordAgentAuditEvent(ctx, claims, "agent.status.create", "target-1", map[string]any{"foo": "bar"})
+
+	entries := state.auditLogsByUser["alice"]
+	require.Len(t, entries, 1)
+	entry := entries[0]
+	require.Equal(t, "agent.status.create", entry.EventType)
+	require.Equal(t, "alice", entry.Username)
+	require.Equal(t, "sess-grantee", entry.SessionID)
+	require.Equal(t, "1.2.3.4", entry.IPAddress)
+	require.Equal(t, "test-agent/1.0", entry.UserAgent)
+	require.Contains(t, entry.Metadata, `"agent_username":"agent-one"`)
+	require.Contains(t, entry.Metadata, `"agent_session_id":"sess-grantee"`)
+	require.Contains(t, entry.Metadata, `"target_id":"target-1"`)
+	require.Contains(t, entry.Metadata, `"foo":"bar"`)
+}
+
+func TestRecordAgentAuditEventAgentSubjectUnchanged(t *testing.T) {
+	cfg := round11TestConfig()
+	state := &round10QueryState{}
+	h, _, _ := round11NewHandler(t, cfg, state)
+
+	claims := &auth.Claims{Username: "agent-one", IsAgent: true, AgentSessionID: "asid-1"}
+
+	ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses", nil, nil, nil)
+	require.NoError(t, err)
+
+	h.recordAgentAuditEvent(ctx, claims, "agent.status.create", "target-1", map[string]any{"foo": "bar"})
+
+	entries := state.auditLogsByUser["agent-one"]
+	require.Len(t, entries, 1)
+	entry := entries[0]
+	require.Equal(t, "agent-one", entry.Username)
+	require.Equal(t, "asid-1", entry.SessionID)
+	require.Contains(t, entry.Metadata, `"target_id":"target-1"`)
+	require.Contains(t, entry.Metadata, `"foo":"bar"`)
+	require.NotContains(t, entry.Metadata, "agent_username")
+	require.NotContains(t, entry.Metadata, "agent_session_id")
+}
+
+func TestRecordAgentAuditEventIgnoresNonAgentNonMCPAudience(t *testing.T) {
+	cfg := round11TestConfig()
+	state := &round10QueryState{}
+	h, _, _ := round11NewHandler(t, cfg, state)
+
+	claims := &auth.Claims{Username: "alice"}
+
+	ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/statuses", nil, nil, nil)
+	require.NoError(t, err)
+
+	h.recordAgentAuditEvent(ctx, claims, "agent.status.create", "target-1", map[string]any{"foo": "bar"})
+
+	require.Empty(t, state.auditLogsByUser)
+}

--- a/cmd/api/handlers/oauth_agent_binding.go
+++ b/cmd/api/handlers/oauth_agent_binding.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"context"
+	"errors"
 	"strings"
 
 	"github.com/equaltoai/lesser/pkg/auth"
@@ -30,4 +32,17 @@ func (h *Handler) agentOwnedByPrincipal(agentUser *storage.User, principalUserna
 	}
 
 	return h.agentOwnerMatchesLocalPrincipal(owner, principalUsername)
+}
+
+// agentShareGrantActive reports whether an active (non-revoked) share grant
+// authorizes principalUsername on agentUsername. The read is the uncached,
+// strongly-consistent direct base-table check from the agentshare service; a
+// service or storage error is returned so callers fail closed rather than
+// authorizing on an error path.
+func (h *Handler) agentShareGrantActive(ctx context.Context, agentUsername, principalUsername string) (bool, error) {
+	service := h.agentShareService()
+	if service == nil {
+		return false, errors.New("agent share service unavailable")
+	}
+	return service.IsActive(ctx, agentUsername, principalUsername)
 }

--- a/cmd/api/handlers/oauth_round12_test.go
+++ b/cmd/api/handlers/oauth_round12_test.go
@@ -377,7 +377,14 @@ func TestOAuthAuthorizeFlowRound12(t *testing.T) {
 			},
 		}
 
-		h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{AccountsSvc: &AccountsServiceStub{}})
+		h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{
+			AccountsSvc: &AccountsServiceStub{},
+			AgentSharesSvc: &actAsShareServiceStub{
+				isActiveFunc: func(context.Context, string, string) (bool, error) {
+					return false, nil // no active share grant for the intruder
+				},
+			},
+		})
 		ctx, err := round10NewLiftContext(http.MethodGet, "/oauth/authorize", map[string]string{"Accept": "text/html"}, map[string]string{
 			"response_type": "code",
 			"client_id":     "client-1",


### PR DESCRIPTION
Milestone M1 of GitHub Project 55 — "Shared Agents — MCP Access for Grantees". Parent issue #1397.

Closes the defect where sharing an agent could not grant MCP access.

## The defect

The actor-scoped MCP OAuth flow had exactly one identity model: **the token subject was the agent**. `cmd/api/handlers/oauth.go:388-392` set `flow.username` to the agent (`oauth.go:463`), where the instance-plane branch immediately above (`:380-383`) deliberately does the opposite and documents why.

Two consequences:

1. Non-owners were refused at `oauth.go:442` (`agentOwnedByPrincipal` consults ownership only; `agentshare` appeared nowhere in the OAuth path). A grantee logging into a shared agent's MCP got `access_denied — "principal is not authorized for requested MCP resource"`.
2. `lesser-body`'s already-correct share-grant admission branch (`internal/mcpapp/actor_binding.go`, wired live at `app.go:34`) was **unreachable by construction**: because the subject was always the agent, `AuthIdentity == actor` always matched and the grant branch never executed in production.

## What changed

Two identity models, deliberately distinct (operator decision 2026-08-13):

| Flow | Token subject | Authorized by | Change |
| --- | --- | --- | --- |
| Owner → own agent's MCP | the agent | ownership | **none** |
| Grantee → shared agent's MCP | **the grantee** | active share grant | new |

Purely additive: no currently-issued token changes meaning.

Also fixes a latent trap that had to land in the same commit: `agent_audit.go:15-18` guarded on `!claims.IsAgent`, which is **false** under grantee-subject tokens — so audit recording would have silently stopped for exactly the actions that must be attributed. The guard now admits grantee-driven agent actions and the event carries **both** identities: real caller in `Username`, agent and session in `Metadata`. No schema change (`Metadata` is an unstructured JSON string), and deliberately no index — operator directive: *"I would not index who was logged into an MCP, but its important metadata."*

## Issues

Refs #1398 (authorize accepts grantee) · Refs #1399 (grantee-subject token) · Refs #1400 (owner-path regression proof) · Refs #1401 (audit attribution)

## Tests — composed path, not component isolation

This feature previously shipped green while broken in production, because `lesser-body/internal/mcpapp/actor_binding_test.go` constructs its context directly and never traverses the OAuth layer. These tests go **through** `HandleOAuthAuthorizeLift` / `HandleOAuthTokenLift`:

- `TestOAuthActorResourceGranteeReceivesCodeWithGranteeSubject` — 302 with `code`; authcode `Username`/`PrincipalUsername` = grantee; `Resource` = agent MCP URL
- `TestOAuthActorResourceGranteeTokenCarriesGranteeSubjectAndAgentAudience` — authorize → exchange → decode: `Subject`/`Username` = grantee, `Audience` = agent MCP URL, `IsAgent` false
- `TestOAuthActorResourceOwnerPathUnchanged` — owner subject stays the agent, `IsAgent` true, `ClientClass` agent, and **the grant check is never consulted** (the stub `t.Fatal`s if it is)
- `TestRecordAgentAuditEventGranteeRecordsBothIdentities` — plus guard-boundary tests for the agent-subject and non-MCP-audience cases
- `TestOAuthActorResourceNonGranteeDenied` (`access_denied`) and `TestOAuthActorResourceGrantCheckErrorFailsClosed` (`server_error`)

## Validation

`./lesser verify ci` **green at `2ddbda88a`**:

```
total:   87.800% (149722/170526 statements)     [floor 85.0]
pkg      90.016% (95476/106065)                 [floor 90.0]
cmd      90.192% (43616/48359)                  [floor 90.0]
✓ verify ci complete (auth UI CSP, lint, security, supply chain, verify suite,
  strict contracts, overall/pkg/cmd coverage gates)
```

Scored against `docs/planning/lesser-10of10-rubric.md` v1.1. DCO signed and GPG-signed (`G`); single commit, parent is `origin/staging` `ec3028ea3`.

## Security invariants preserved

- Grant check reuses `agentshare.Service.IsActive` → `IsActiveAgentShareGrant`, a `ConsistentRead()` direct `GetItem` — uncached and strongly consistent, per the contract at `pkg/auth/agent_act_as.go:42-45`. No GSI read on an authorization path.
- Fail-closed on malformed indicator, unknown agent, missing/inactive grant, and storage error.
- Revocation unchanged and still fails closed downstream at actor binding.

## Not in this PR

Owner token issuance behavior; any index or session registry; narrower-than-full grant scope (deferred); `DraftReview.actedBy` (milestone M3); UI work (milestone M2).

Downstream: `lesser-body`#560 verifies the grant branch now fires; #1402 is the end-to-end lab exercise that closes M1.
