### PR TITLE
bump go toolchain to 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/equaltoai/lesser
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/99designs/gqlgen v0.17.88

--- a/infra/cdk/go.mod
+++ b/infra/cdk/go.mod
@@ -1,6 +1,6 @@
 module cdk
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/aws/aws-cdk-go/awscdk/v2 v2.263.0


### PR DESCRIPTION
## Summary

Bumps the Go toolchain from `go 1.26.5` to `go 1.26.6` to clear the `govulncheck` advisories that have red-lined the CI gate for every PR since they landed.

## Change

- `go.mod`: `go 1.26.5` -> `go 1.26.6`
- `infra/cdk/go.mod`: `go 1.26.5` -> `go 1.26.6`

No other Go pins exist: no `toolchain` directive, no Dockerfiles/devcontainer/`.go-version`; `.github/workflows/ci.yml` and `release.yml` read the version from `go.mod` via `go-version-file`; `.golangci.yml` uses `go: "1.26"` (major.minor, unaffected).

## Why 1.26.6 (verified, not assumed)

Baseline `govulncheck` at `go1.26.5` reported **7 affecting stdlib vulnerabilities**, all `Fixed in: go1.26.6`:

- `GO-2026-5972` — `encoding/asn1`
- `GO-2026-6088` — `encoding/xml`
- `GO-2026-6089` — `net/http`
- `GO-2026-6090` — `crypto/tls`
- `GO-2026-6091` — `html/template`
- `GO-2026-6218` — `net/url`
- `GO-2026-5026` — `net/http` (stdlib component)

`GO-2026-5026` also has an `x/net/idna` component, but that is fixed in `x/net v0.55.0`; the repo already pins `v0.57.0`, so **no `x/net` bump was required** (no `go mod tidy` / `go.sum` change).

## Verification

`./lesser verify ci` is green at this head. `govulncheck` section:

```
No vulnerabilities found.

Your code is affected by 0 vulnerabilities.
```

Coverage gates: overall **87.798%**, pkg **90.008%**, cmd **90.202%** (all above the 85.0 / 90.0 / 90.0 thresholds). No code changes were forced by the bump.

## DCO

Commit is `git commit -s`-signed.
