### PR TITLE
feat(graphql): expose agent viewer ownership

### DIFF
--- a/docs/contracts/graphql-schema.graphql
+++ b/docs/contracts/graphql-schema.graphql
@@ -4336,6 +4336,8 @@ type Agent {
   delegatedScopes: [String!]!
   """Whether private ownership, delegation, and soul-binding fields are visible to this viewer."""
   viewerCanSeePrivateFields: Boolean!
+  """True when the requesting viewer is this agent's owner under Lesser's canonical local-identity comparison."""
+  viewerIsOwner: Boolean!
   mcpAccess: AgentMCPAccess!
   verified: Boolean!
   verifiedAt: Time
@@ -5280,6 +5282,7 @@ type DroneWorkflowMutationPayload {
 extend type Query {
   agent(username: String!): Agent
   agents(first: Int = 20, after: Cursor, type: AgentType, query: String, verified: Boolean, ownerUsername: String): AgentConnection!
+  """Agents owned by the viewer. Agents shared with the viewer are served by the shared-with-me index, not this field."""
   myAgents: [Agent!]!
   agentActivity(username: String!, first: Int = 20, after: Cursor): AgentActivityConnection!
   agentAccessLeases(username: String!): [AgentAccessLease!]!

--- a/go.mod
+++ b/go.mod
@@ -54,10 +54,10 @@ require (
 	github.com/yuin/goldmark v1.7.17
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.54.0
-	golang.org/x/image v0.43.0
+	golang.org/x/image v0.45.0
 	golang.org/x/net v0.57.0
 	golang.org/x/sync v0.22.0
-	golang.org/x/text v0.40.0
+	golang.org/x/text v0.41.0
 	golang.org/x/tools v0.48.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -305,8 +305,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
 golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
 golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
-golang.org/x/image v0.43.0 h1:FLxcP4ec2350nTfOC8ysKtqYSIFbk/QGjw1ZHNP4tsY=
-golang.org/x/image v0.43.0/go.mod h1:rrpelvGFt+kLPAjPM4HeWPgrl0FtafueU//e5N0qk/Q=
+golang.org/x/image v0.45.0 h1:FMb1nTbH5H9vF55SriQHgFw5GnNL9Jg6L25BwXKzhB0=
+golang.org/x/image v0.45.0/go.mod h1:n62x/7RqlwXDvGsSU4u6IUTUf6KghUZ9Bt7cG/T9Fx4=
 golang.org/x/mod v0.38.0 h1:MECBjubtXD7yj4HrhIUcywNaGeNVUdfVnxmPajOk4yk=
 golang.org/x/mod v0.38.0/go.mod h1:V6Xz0pq8TQ3dGqVQ1FVHuelZpAL0uNhSkk9ogYP3c40=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -320,8 +320,8 @@ golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.40.0 h1:Ub2Z6/xjgF1WrYQz2nuITOEegKFtiIy+rieRJ5lHZKs=
-golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
+golang.org/x/text v0.41.0 h1:vz/seA0lnX87Othu2f/0L24RcgrXD9/YFTSuGjj3rH8=
+golang.org/x/text v0.41.0/go.mod h1:jvf1O8ajNzZqhSrQBPbutR/EB83Cc0CFrezNQIwbb5M=
 golang.org/x/tools v0.48.0 h1:3+hClM1aLL5mjMKm5ovokw9epgRXPuu2tILgismM6RE=
 golang.org/x/tools v0.48.0/go.mod h1:08xX0orndb/F7jJxGDicx061tyd5pcMto75YMAXr6lk=
 gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=

--- a/graph/actor_agent_info_contract_test.go
+++ b/graph/actor_agent_info_contract_test.go
@@ -23,7 +23,7 @@ func TestActorAgentInfoAppliesPrivateFieldPolicy(t *testing.T) {
 		AgentOwner:  "@owner",
 	}
 	userRepo := storagemocks.NewMockUserRepositoryInterface()
-	userRepo.On("GetUser", mock.Anything, "review-bot").Return(user, nil).Times(3)
+	userRepo.On("GetUser", mock.Anything, "review-bot").Return(user, nil).Times(4)
 	store := pkgtesting.NewMockRepositoryStorage(pkgtesting.WithUserRepository(userRepo))
 	resolver := &Resolver{Storage: store, Config: &config.Config{Domain: "example.com"}}
 	actorResolver := &actorResolver{resolver}
@@ -32,19 +32,35 @@ func TestActorAgentInfoAppliesPrivateFieldPolicy(t *testing.T) {
 	publicAgent, err := actorResolver.AgentInfo(context.Background(), actor)
 	require.NoError(t, err)
 	require.False(t, publicAgent.ViewerCanSeePrivateFields)
+	require.False(t, publicAgent.ViewerIsOwner)
 	require.Nil(t, publicAgent.AgentOwner)
 	require.Empty(t, publicAgent.DelegatedScopes)
+	require.NotNil(t, publicAgent.McpAccess)
 
 	nonOwnerCtx := context.WithValue(context.Background(), common.ContextKeyClaims, &auth.Claims{Username: "someone-else"})
 	nonOwnerAgent, err := actorResolver.AgentInfo(nonOwnerCtx, actor)
 	require.NoError(t, err)
 	require.False(t, nonOwnerAgent.ViewerCanSeePrivateFields)
+	require.False(t, nonOwnerAgent.ViewerIsOwner)
 	require.Nil(t, nonOwnerAgent.AgentOwner)
+	require.NotNil(t, nonOwnerAgent.McpAccess)
+
+	adminCtx := context.WithValue(context.Background(), common.ContextKeyClaims, &auth.Claims{
+		Username: "admin",
+		Scopes:   []string{auth.ScopeAdmin},
+	})
+	adminAgent, err := actorResolver.AgentInfo(adminCtx, actor)
+	require.NoError(t, err)
+	require.True(t, adminAgent.ViewerCanSeePrivateFields)
+	require.False(t, adminAgent.ViewerIsOwner)
+	require.NotNil(t, adminAgent.AgentOwner)
+	require.Equal(t, "@owner", *adminAgent.AgentOwner)
 
 	ownerCtx := context.WithValue(context.Background(), common.ContextKeyClaims, &auth.Claims{Username: "owner"})
 	ownerAgent, err := actorResolver.AgentInfo(ownerCtx, actor)
 	require.NoError(t, err)
 	require.True(t, ownerAgent.ViewerCanSeePrivateFields)
+	require.True(t, ownerAgent.ViewerIsOwner)
 	require.NotNil(t, ownerAgent.AgentOwner)
 	require.Equal(t, "@owner", *ownerAgent.AgentOwner)
 

--- a/graph/agent_governance_helpers.go
+++ b/graph/agent_governance_helpers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/equaltoai/lesser/graph/model"
 	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/common"
 	apperrors "github.com/equaltoai/lesser/pkg/errors"
@@ -98,6 +99,24 @@ func (r *Resolver) canViewAgentPrivateFields(claims *auth.Claims, agentUser *sto
 		return false
 	}
 	return isAgentOwnerOrAdmin(claims, agentUser, r.agentOwnerActorURL(claims.Username))
+}
+
+func (r *Resolver) viewerOwnsAgent(claims *auth.Claims, agentUser *storage.User) bool {
+	if claims == nil || agentUser == nil {
+		return false
+	}
+	return auth.AgentOwnerMatchesLocalPrincipal(agentUser.AgentOwner, claims.Username, r.agentOwnerActorURL)
+}
+
+func (r *Resolver) applyGraphAgentViewerState(agent *model.Agent, claims *auth.Claims, agentUser *storage.User) *model.Agent {
+	if agent == nil {
+		return nil
+	}
+	agent.ViewerIsOwner = r.viewerOwnsAgent(claims, agentUser)
+	if !r.canViewAgentPrivateFields(claims, agentUser) {
+		redactGraphAgentPrivateFields(agent)
+	}
+	return agent
 }
 
 func graphClaimsIsAdmin(claims *auth.Claims) bool {

--- a/graph/agent_governance_helpers.go
+++ b/graph/agent_governance_helpers.go
@@ -101,18 +101,27 @@ func (r *Resolver) canViewAgentPrivateFields(claims *auth.Claims, agentUser *sto
 	return isAgentOwnerOrAdmin(claims, agentUser, r.agentOwnerActorURL(claims.Username))
 }
 
-func (r *Resolver) viewerOwnsAgent(claims *auth.Claims, agentUser *storage.User) bool {
-	if claims == nil || agentUser == nil {
+func (r *Resolver) viewerUsernameOwnsAgent(viewerUsername string, agentUser *storage.User) bool {
+	if agentUser == nil || strings.TrimSpace(viewerUsername) == "" {
 		return false
 	}
-	return auth.AgentOwnerMatchesLocalPrincipal(agentUser.AgentOwner, claims.Username, r.agentOwnerActorURL)
+	return auth.AgentOwnerMatchesLocalPrincipal(agentUser.AgentOwner, viewerUsername, r.agentOwnerActorURL)
 }
 
-func (r *Resolver) applyGraphAgentViewerState(agent *model.Agent, claims *auth.Claims, agentUser *storage.User) *model.Agent {
+func (r *Resolver) applyGraphAgentViewerOwnership(agent *model.Agent, viewerUsername string, agentUser *storage.User) *model.Agent {
 	if agent == nil {
 		return nil
 	}
-	agent.ViewerIsOwner = r.viewerOwnsAgent(claims, agentUser)
+	agent.ViewerIsOwner = r.viewerUsernameOwnsAgent(viewerUsername, agentUser)
+	return agent
+}
+
+func (r *Resolver) applyGraphAgentViewerState(agent *model.Agent, claims *auth.Claims, agentUser *storage.User) *model.Agent {
+	viewerUsername := ""
+	if claims != nil {
+		viewerUsername = claims.Username
+	}
+	agent = r.applyGraphAgentViewerOwnership(agent, viewerUsername, agentUser)
 	if !r.canViewAgentPrivateFields(claims, agentUser) {
 		redactGraphAgentPrivateFields(agent)
 	}

--- a/graph/agent_model_helpers.go
+++ b/graph/agent_model_helpers.go
@@ -78,6 +78,7 @@ func (r *Resolver) convertStorageUserToAgent(user *storage.User, governance *sto
 		AgentOwner:                agentOwner,
 		DelegatedScopes:           delegatedScopes,
 		ViewerCanSeePrivateFields: true,
+		ViewerIsOwner:             false,
 		McpAccess:                 graphAgentMCPAccessModel(auth.BuildPublicMCPAccessBundle(baseURL, username)),
 		Verified:                  verified,
 		VerifiedAt:                verifiedAt,

--- a/graph/agent_resolvers_stubs.go
+++ b/graph/agent_resolvers_stubs.go
@@ -60,10 +60,7 @@ func (r *queryResolver) Agent(ctx context.Context, username string) (*model.Agen
 	}
 
 	agent := r.convertStorageUserToAgent(user, governance)
-	if !r.canViewAgentPrivateFields(optionalGraphAuthClaims(ctx), user) {
-		redactGraphAgentPrivateFields(agent)
-	}
-	return agent, nil
+	return r.applyGraphAgentViewerState(agent, optionalGraphAuthClaims(ctx), user), nil
 }
 
 type agentListFilters struct {
@@ -265,9 +262,7 @@ func (r *queryResolver) Agents(ctx context.Context, first *int, after *model.Cur
 		if agent == nil {
 			continue
 		}
-		if !r.canViewAgentPrivateFields(viewerClaims, user) {
-			redactGraphAgentPrivateFields(agent)
-		}
+		agent = r.applyGraphAgentViewerState(agent, viewerClaims, user)
 
 		edges = append(edges, &model.AgentEdge{
 			Node:   agent,
@@ -338,7 +333,7 @@ func (r *queryResolver) MyAgents(ctx context.Context) ([]*model.Agent, error) {
 			}
 			agent := r.convertStorageUserToAgent(user, governanceStates[strings.ToLower(strings.TrimSpace(user.Username))])
 			if agent != nil {
-				out = append(out, agent)
+				out = append(out, r.applyGraphAgentViewerState(agent, claims, user))
 			}
 		}
 
@@ -623,7 +618,7 @@ func (r *mutationResolver) UpdateAgent(ctx context.Context, username string, inp
 		return nil, err
 	}
 
-	return r.convertStorageUserToAgent(account.User, governance), nil
+	return r.applyGraphAgentViewerState(r.convertStorageUserToAgent(account.User, governance), claims, account.User), nil
 }
 
 func (r *mutationResolver) applyGraphAgentUpdateInput(
@@ -754,7 +749,7 @@ func (r *mutationResolver) DeleteAgent(ctx context.Context, username string) (*m
 		return nil, apperrors.InternalWithCause(err, "failed to delete agent")
 	}
 
-	return r.convertStorageUserToAgent(account.User, governance), nil
+	return r.applyGraphAgentViewerState(r.convertStorageUserToAgent(account.User, governance), claims, account.User), nil
 }
 
 // DelegateToAgent is the resolver for the delegateToAgent field.
@@ -817,7 +812,7 @@ func (r *mutationResolver) DelegateToAgent(ctx context.Context, input model.Dele
 	}
 
 	return &model.DelegationPayload{
-		Agent:        r.convertStorageUserToAgent(account.User, governance),
+		Agent:        r.applyGraphAgentViewerState(r.convertStorageUserToAgent(account.User, governance), claims, account.User),
 		AccessToken:  bundle.AccessToken,
 		RefreshToken: bundle.RefreshToken,
 		TokenType:    "Bearer",
@@ -1163,7 +1158,7 @@ func (r *mutationResolver) AdminVerifyAgent(ctx context.Context, username string
 		return nil, graphAgentGovernanceWriteError(err, "verify")
 	}
 
-	return r.convertStorageUserToAgent(account.User, governance), nil
+	return r.applyGraphAgentViewerState(r.convertStorageUserToAgent(account.User, governance), claims, account.User), nil
 }
 
 // AdminUnverifyAgent is the resolver for the adminUnverifyAgent field.
@@ -1218,7 +1213,7 @@ func (r *mutationResolver) AdminUnverifyAgent(ctx context.Context, username stri
 		return nil, graphAgentGovernanceWriteError(err, "unverify")
 	}
 
-	return r.convertStorageUserToAgent(account.User, governance), nil
+	return r.applyGraphAgentViewerState(r.convertStorageUserToAgent(account.User, governance), claims, account.User), nil
 }
 
 // AdminSuspendAgent is the resolver for the adminSuspendAgent field.
@@ -1259,7 +1254,7 @@ func (r *mutationResolver) AdminSuspendAgent(ctx context.Context, username strin
 		return nil, apperrors.InternalWithCause(err, "failed to suspend agent")
 	}
 
-	return r.convertStorageUserToAgent(account.User, governance), nil
+	return r.applyGraphAgentViewerState(r.convertStorageUserToAgent(account.User, governance), claims, account.User), nil
 }
 
 func (r *Resolver) requireAuthClaims(ctx context.Context) (*auth.Claims, error) {

--- a/graph/agent_viewer_ownership_contract_test.go
+++ b/graph/agent_viewer_ownership_contract_test.go
@@ -1,0 +1,118 @@
+package graph
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/auth"
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/storage/interfaces"
+	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
+	storagemocks "github.com/equaltoai/lesser/pkg/testing/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMyAgentsViewerIsOwnerUsesCanonicalOwnerMatchAndExcludesSharedAgents(t *testing.T) {
+	resolver, graphStorage := newRound12GraphResolver(t)
+	resolver.Config.AllowAgents = true
+
+	policy := storagemodels.NewAgentInstanceConfig()
+	policy.AllowAgents = true
+	require.NoError(t, graphStorage.Instance().SetAgentInstanceConfig(context.Background(), policy))
+
+	now := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+	ownedAtForm := &storage.User{
+		Username:     "alpha",
+		DisplayName:  "Alpha",
+		IsAgent:      true,
+		AgentType:    "ASSISTANT",
+		AgentVersion: "1.0.0",
+		AgentOwner:   "@Alice",
+		CreatedAt:    now,
+	}
+	seedGraphAgentContractUser(graphStorage, ownedAtForm)
+	ownedPlainForm := &storage.User{
+		Username:     "beta",
+		DisplayName:  "Beta",
+		IsAgent:      true,
+		AgentType:    "ASSISTANT",
+		AgentVersion: "1.0.0",
+		AgentOwner:   "ALICE",
+		CreatedAt:    now.Add(time.Minute),
+	}
+	seedGraphAgentContractUser(graphStorage, ownedPlainForm)
+	sharedWithViewer := &storage.User{
+		Username:     "shared-helper",
+		DisplayName:  "Shared Helper",
+		IsAgent:      true,
+		AgentType:    "ASSISTANT",
+		AgentVersion: "1.0.0",
+		AgentOwner:   "@Bob",
+		CreatedAt:    now.Add(2 * time.Minute),
+	}
+	seedGraphAgentContractUser(graphStorage, sharedWithViewer)
+
+	userRepo := storagemocks.NewMockUserRepositoryInterface()
+	userRepo.On("ListAgents", mock.Anything, int32(100), "").Return([]*storage.User{
+		ownedAtForm,
+		ownedPlainForm,
+		sharedWithViewer,
+	}, "", nil).Once()
+	userRepo.On("GetUser", mock.Anything, "shared-helper").Return(sharedWithViewer, nil).Once()
+	resolver.Storage = &agentOwnershipTestStorage{
+		round12GraphStorage: graphStorage,
+		userRepo:            userRepo,
+	}
+
+	grant := &storagemodels.AgentShareGrant{
+		AgentUsername:   "shared-helper",
+		GranteeUsername: "alice",
+		GrantedBy:       "bob",
+		GrantedAt:       now,
+	}
+	require.NoError(t, grant.UpdateKeys())
+	graphStorage.SeedAgentShareGrant(grant)
+
+	ctx := delegatedAgentAuthContext("alice", auth.ScopeRead)
+	ownedAgents, err := resolver.Query().MyAgents(ctx)
+	require.NoError(t, err)
+	require.Len(t, ownedAgents, 2)
+
+	gotUsernames := make([]string, 0, len(ownedAgents))
+	for _, agent := range ownedAgents {
+		require.NotNil(t, agent)
+		require.True(t, agent.ViewerCanSeePrivateFields)
+		require.True(t, agent.ViewerIsOwner)
+		gotUsernames = append(gotUsernames, agent.Username)
+	}
+	require.ElementsMatch(t, []string{"alpha", "beta"}, gotUsernames)
+
+	sharedAgent, err := resolver.Query().Agent(ctx, "shared-helper")
+	require.NoError(t, err)
+	require.NotNil(t, sharedAgent)
+	require.False(t, sharedAgent.ViewerIsOwner)
+	require.False(t, sharedAgent.ViewerCanSeePrivateFields)
+	require.Nil(t, sharedAgent.AgentOwner)
+	require.NotNil(t, sharedAgent.McpAccess)
+
+	userRepo.AssertExpectations(t)
+}
+
+type agentOwnershipTestStorage struct {
+	*round12GraphStorage
+	userRepo interfaces.UserRepository
+}
+
+func (s *agentOwnershipTestStorage) User() interfaces.UserRepository {
+	return s.userRepo
+}
+
+func seedGraphAgentContractUser(graphStorage *round12GraphStorage, user *storage.User) {
+	graphStorage.SeedAgentGovernanceState(&storage.AgentGovernanceState{
+		Username:  user.Username,
+		CreatedAt: user.CreatedAt,
+		UpdatedAt: user.CreatedAt,
+	})
+}

--- a/graph/agents.graphql
+++ b/graph/agents.graphql
@@ -45,6 +45,8 @@ type Agent {
   delegatedScopes: [String!]!
   """Whether private ownership, delegation, and soul-binding fields are visible to this viewer."""
   viewerCanSeePrivateFields: Boolean!
+  """True when the requesting viewer is this agent's owner under Lesser's canonical local-identity comparison."""
+  viewerIsOwner: Boolean!
   mcpAccess: AgentMCPAccess!
   verified: Boolean!
   verifiedAt: Time
@@ -989,6 +991,7 @@ type DroneWorkflowMutationPayload {
 extend type Query {
   agent(username: String!): Agent
   agents(first: Int = 20, after: Cursor, type: AgentType, query: String, verified: Boolean, ownerUsername: String): AgentConnection!
+  """Agents owned by the viewer. Agents shared with the viewer are served by the shared-with-me index, not this field."""
   myAgents: [Agent!]!
   agentActivity(username: String!, first: Int = 20, after: Cursor): AgentActivityConnection!
   agentAccessLeases(username: String!): [AgentAccessLease!]!

--- a/graph/drone_workflow_resolvers.go
+++ b/graph/drone_workflow_resolvers.go
@@ -461,12 +461,8 @@ func (r *Resolver) droneWorkflowMutationPayload(
 	if err != nil {
 		return nil, err
 	}
-	claims := optionalGraphAuthClaims(ctx)
-	if claims == nil && strings.TrimSpace(viewerUsername) != "" {
-		claims = &auth.Claims{Username: viewerUsername}
-	}
 	return &model.DroneWorkflowMutationPayload{
-		Agent:    r.applyGraphAgentViewerState(r.convertStorageUserToAgent(agentUser, governance), claims, agentUser),
+		Agent:    r.applyGraphAgentViewerOwnership(r.convertStorageUserToAgent(agentUser, governance), viewerUsername, agentUser),
 		Workflow: surface,
 	}, nil
 }

--- a/graph/drone_workflow_resolvers.go
+++ b/graph/drone_workflow_resolvers.go
@@ -461,8 +461,12 @@ func (r *Resolver) droneWorkflowMutationPayload(
 	if err != nil {
 		return nil, err
 	}
+	claims := optionalGraphAuthClaims(ctx)
+	if claims == nil && strings.TrimSpace(viewerUsername) != "" {
+		claims = &auth.Claims{Username: viewerUsername}
+	}
 	return &model.DroneWorkflowMutationPayload{
-		Agent:    r.convertStorageUserToAgent(agentUser, governance),
+		Agent:    r.applyGraphAgentViewerState(r.convertStorageUserToAgent(agentUser, governance), claims, agentUser),
 		Workflow: surface,
 	}, nil
 }

--- a/graph/drone_workflow_round13_test.go
+++ b/graph/drone_workflow_round13_test.go
@@ -175,9 +175,11 @@ func TestRound13DroneWorkflowMutationsPersistWorkflowState(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, requestPayload)
+	require.NotNil(t, requestPayload.Agent)
 	require.NotNil(t, requestPayload.Workflow.Request)
 	require.Equal(t, workflow.DroneWorkflowStateRequestSubmitted, requestPayload.Workflow.CurrentState)
 	require.Len(t, requestPayload.Workflow.Request.Artifacts, 1)
+	assertRound13PayloadAgent(t, requestPayload.Agent, true, true, "@owner", []string{auth.ScopeRead, auth.ScopeWrite})
 
 	reviewPayload, err := mut.ReviewSoulPromotion(round13DroneAuthContext("owner", auth.ScopeWrite), model.ReviewSoulPromotionInput{
 		Username:        "drone-beta",
@@ -191,10 +193,12 @@ func TestRound13DroneWorkflowMutationsPersistWorkflowState(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+	require.NotNil(t, reviewPayload.Agent)
 	require.NotNil(t, reviewPayload.Workflow.Review)
 	require.Equal(t, workflow.DroneWorkflowStateReviewApproved, reviewPayload.Workflow.CurrentState)
 	require.NotNil(t, reviewPayload.Workflow.Checkpoint)
 	require.Len(t, reviewPayload.Workflow.Checkpoint.Signers, 1)
+	assertRound13PayloadAgent(t, reviewPayload.Agent, true, true, "@owner", []string{auth.ScopeRead, auth.ScopeWrite})
 
 	finalPayload, err := mut.FinalizeSoulPromotion(round13DroneAuthContext("owner", auth.ScopeWrite), model.FinalizeSoulPromotionInput{
 		Username:              "drone-beta",
@@ -215,12 +219,14 @@ func TestRound13DroneWorkflowMutationsPersistWorkflowState(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, finalPayload)
+	require.NotNil(t, finalPayload.Agent)
 	require.NotNil(t, finalPayload.Workflow.Declaration)
 	require.NotNil(t, finalPayload.Workflow.Graduation)
 	require.NotNil(t, finalPayload.Workflow.Continuity)
 	require.Equal(t, workflow.DroneWorkflowPhaseContinuity, finalPayload.Workflow.CurrentPhase)
 	require.Equal(t, workflow.DroneIdentityStateSouled, finalPayload.Workflow.IdentitySemantics.IdentityState)
 	require.Equal(t, "0xsoul", derefString(finalPayload.Workflow.IdentitySemantics.SoulAgentID))
+	assertRound13PayloadAgent(t, finalPayload.Agent, true, true, "@owner", []string{auth.ScopeRead, auth.ScopeWrite})
 
 	storedUser, err := storageRepo.Account().GetUser(context.Background(), "drone-beta")
 	require.NoError(t, err)
@@ -325,10 +331,39 @@ func TestRound13DroneWorkflowAssignedReviewerAccess(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, reviewPayload)
+	require.NotNil(t, reviewPayload.Agent)
 	require.NotNil(t, reviewPayload.Workflow)
 	require.Equal(t, workflow.DroneWorkflowStateReviewApproved, reviewPayload.Workflow.CurrentState)
 	require.NotNil(t, reviewPayload.Workflow.Review)
 	require.Equal(t, "reviewer", reviewPayload.Workflow.Review.Reviewer.ID)
+	assertRound13PayloadAgent(t, reviewPayload.Agent, true, false, "@owner", []string{auth.ScopeRead, auth.ScopeWrite})
+}
+
+func TestRound13DroneWorkflowMutationPayloadUsesExplicitViewerUsernameForOwnershipOnly(t *testing.T) {
+	resolver, storageRepo := newRound12GraphResolver(t)
+	now := time.Date(2026, 3, 28, 12, 45, 0, 0, time.UTC)
+
+	round13SeedGraphUser(t, storageRepo, &storage.User{
+		Username:    "drone-theta",
+		DisplayName: "Drone Theta",
+		Approved:    true,
+		IsAgent:     true,
+		AgentOwner:  "@owner",
+		CreatedAt:   now.Add(-24 * time.Hour),
+		UpdatedAt:   now,
+	}, &storage.AgentGovernanceState{
+		Username:        "drone-theta",
+		DelegatedScopes: []string{auth.ScopeRead, auth.ScopeWrite},
+	})
+
+	agentUser, governance, err := resolver.loadDroneAgent(context.Background(), "drone-theta")
+	require.NoError(t, err)
+
+	payload, err := resolver.droneWorkflowMutationPayload(context.Background(), "reviewer", agentUser, governance)
+	require.NoError(t, err)
+	require.NotNil(t, payload)
+	require.NotNil(t, payload.Agent)
+	assertRound13PayloadAgent(t, payload.Agent, true, false, "@owner", []string{auth.ScopeRead, auth.ScopeWrite})
 }
 
 func TestRound13DroneWorkflowSouledContinuityStatePreserved(t *testing.T) {
@@ -405,4 +440,15 @@ func round13DroneAuthContext(username string, scopes ...string) context.Context 
 
 func round13StringPtr(value string) *string {
 	return &value
+}
+
+func assertRound13PayloadAgent(t *testing.T, agent *model.Agent, viewerCanSeePrivateFields bool, viewerIsOwner bool, agentOwner string, delegatedScopes []string) {
+	t.Helper()
+
+	require.NotNil(t, agent)
+	require.Equal(t, viewerCanSeePrivateFields, agent.ViewerCanSeePrivateFields)
+	require.Equal(t, viewerIsOwner, agent.ViewerIsOwner)
+	require.NotNil(t, agent.AgentOwner)
+	require.Equal(t, agentOwner, *agent.AgentOwner)
+	require.ElementsMatch(t, delegatedScopes, agent.DelegatedScopes)
 }

--- a/graph/generated.go
+++ b/graph/generated.go
@@ -563,6 +563,7 @@ type ComplexityRoot struct {
 		VerifiedAt                func(childComplexity int) int
 		Version                   func(childComplexity int) int
 		ViewerCanSeePrivateFields func(childComplexity int) int
+		ViewerIsOwner             func(childComplexity int) int
 		Workflow                  func(childComplexity int) int
 	}
 
@@ -6343,6 +6344,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Agent.ViewerCanSeePrivateFields(childComplexity), true
+
+	case "Agent.viewerIsOwner":
+		if e.complexity.Agent.ViewerIsOwner == nil {
+			break
+		}
+
+		return e.complexity.Agent.ViewerIsOwner(childComplexity), true
 
 	case "Agent.workflow":
 		if e.complexity.Agent.Workflow == nil {
@@ -32029,6 +32037,8 @@ func (ec *executionContext) fieldContext_Actor_agentInfo(_ context.Context, fiel
 				return ec.fieldContext_Agent_delegatedScopes(ctx, field)
 			case "viewerCanSeePrivateFields":
 				return ec.fieldContext_Agent_viewerCanSeePrivateFields(ctx, field)
+			case "viewerIsOwner":
+				return ec.fieldContext_Agent_viewerIsOwner(ctx, field)
 			case "mcpAccess":
 				return ec.fieldContext_Agent_mcpAccess(ctx, field)
 			case "verified":
@@ -42878,6 +42888,50 @@ func (ec *executionContext) fieldContext_Agent_viewerCanSeePrivateFields(_ conte
 	return fc, nil
 }
 
+func (ec *executionContext) _Agent_viewerIsOwner(ctx context.Context, field graphql.CollectedField, obj *model.Agent) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Agent_viewerIsOwner(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ViewerIsOwner, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Agent_viewerIsOwner(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Agent",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Agent_mcpAccess(ctx context.Context, field graphql.CollectedField, obj *model.Agent) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Agent_mcpAccess(ctx, field)
 	if err != nil {
@@ -46788,6 +46842,8 @@ func (ec *executionContext) fieldContext_AgentEdge_node(_ context.Context, field
 				return ec.fieldContext_Agent_delegatedScopes(ctx, field)
 			case "viewerCanSeePrivateFields":
 				return ec.fieldContext_Agent_viewerCanSeePrivateFields(ctx, field)
+			case "viewerIsOwner":
+				return ec.fieldContext_Agent_viewerIsOwner(ctx, field)
 			case "mcpAccess":
 				return ec.fieldContext_Agent_mcpAccess(ctx, field)
 			case "verified":
@@ -62241,6 +62297,8 @@ func (ec *executionContext) fieldContext_DelegationPayload_agent(_ context.Conte
 				return ec.fieldContext_Agent_delegatedScopes(ctx, field)
 			case "viewerCanSeePrivateFields":
 				return ec.fieldContext_Agent_viewerCanSeePrivateFields(ctx, field)
+			case "viewerIsOwner":
+				return ec.fieldContext_Agent_viewerIsOwner(ctx, field)
 			case "mcpAccess":
 				return ec.fieldContext_Agent_mcpAccess(ctx, field)
 			case "verified":
@@ -67452,6 +67510,8 @@ func (ec *executionContext) fieldContext_DroneWorkflowMutationPayload_agent(_ co
 				return ec.fieldContext_Agent_delegatedScopes(ctx, field)
 			case "viewerCanSeePrivateFields":
 				return ec.fieldContext_Agent_viewerCanSeePrivateFields(ctx, field)
+			case "viewerIsOwner":
+				return ec.fieldContext_Agent_viewerIsOwner(ctx, field)
 			case "mcpAccess":
 				return ec.fieldContext_Agent_mcpAccess(ctx, field)
 			case "verified":
@@ -103993,6 +104053,8 @@ func (ec *executionContext) fieldContext_Mutation_updateAgent(ctx context.Contex
 				return ec.fieldContext_Agent_delegatedScopes(ctx, field)
 			case "viewerCanSeePrivateFields":
 				return ec.fieldContext_Agent_viewerCanSeePrivateFields(ctx, field)
+			case "viewerIsOwner":
+				return ec.fieldContext_Agent_viewerIsOwner(ctx, field)
 			case "mcpAccess":
 				return ec.fieldContext_Agent_mcpAccess(ctx, field)
 			case "verified":
@@ -104106,6 +104168,8 @@ func (ec *executionContext) fieldContext_Mutation_deleteAgent(ctx context.Contex
 				return ec.fieldContext_Agent_delegatedScopes(ctx, field)
 			case "viewerCanSeePrivateFields":
 				return ec.fieldContext_Agent_viewerCanSeePrivateFields(ctx, field)
+			case "viewerIsOwner":
+				return ec.fieldContext_Agent_viewerIsOwner(ctx, field)
 			case "mcpAccess":
 				return ec.fieldContext_Agent_mcpAccess(ctx, field)
 			case "verified":
@@ -105263,6 +105327,8 @@ func (ec *executionContext) fieldContext_Mutation_adminVerifyAgent(ctx context.C
 				return ec.fieldContext_Agent_delegatedScopes(ctx, field)
 			case "viewerCanSeePrivateFields":
 				return ec.fieldContext_Agent_viewerCanSeePrivateFields(ctx, field)
+			case "viewerIsOwner":
+				return ec.fieldContext_Agent_viewerIsOwner(ctx, field)
 			case "mcpAccess":
 				return ec.fieldContext_Agent_mcpAccess(ctx, field)
 			case "verified":
@@ -105376,6 +105442,8 @@ func (ec *executionContext) fieldContext_Mutation_adminUnverifyAgent(ctx context
 				return ec.fieldContext_Agent_delegatedScopes(ctx, field)
 			case "viewerCanSeePrivateFields":
 				return ec.fieldContext_Agent_viewerCanSeePrivateFields(ctx, field)
+			case "viewerIsOwner":
+				return ec.fieldContext_Agent_viewerIsOwner(ctx, field)
 			case "mcpAccess":
 				return ec.fieldContext_Agent_mcpAccess(ctx, field)
 			case "verified":
@@ -105489,6 +105557,8 @@ func (ec *executionContext) fieldContext_Mutation_adminSuspendAgent(ctx context.
 				return ec.fieldContext_Agent_delegatedScopes(ctx, field)
 			case "viewerCanSeePrivateFields":
 				return ec.fieldContext_Agent_viewerCanSeePrivateFields(ctx, field)
+			case "viewerIsOwner":
+				return ec.fieldContext_Agent_viewerIsOwner(ctx, field)
 			case "mcpAccess":
 				return ec.fieldContext_Agent_mcpAccess(ctx, field)
 			case "verified":
@@ -125490,6 +125560,8 @@ func (ec *executionContext) fieldContext_Query_agent(ctx context.Context, field 
 				return ec.fieldContext_Agent_delegatedScopes(ctx, field)
 			case "viewerCanSeePrivateFields":
 				return ec.fieldContext_Agent_viewerCanSeePrivateFields(ctx, field)
+			case "viewerIsOwner":
+				return ec.fieldContext_Agent_viewerIsOwner(ctx, field)
 			case "mcpAccess":
 				return ec.fieldContext_Agent_mcpAccess(ctx, field)
 			case "verified":
@@ -125666,6 +125738,8 @@ func (ec *executionContext) fieldContext_Query_myAgents(_ context.Context, field
 				return ec.fieldContext_Agent_delegatedScopes(ctx, field)
 			case "viewerCanSeePrivateFields":
 				return ec.fieldContext_Agent_viewerCanSeePrivateFields(ctx, field)
+			case "viewerIsOwner":
+				return ec.fieldContext_Agent_viewerIsOwner(ctx, field)
 			case "mcpAccess":
 				return ec.fieldContext_Agent_mcpAccess(ctx, field)
 			case "verified":
@@ -128749,6 +128823,8 @@ func (ec *executionContext) fieldContext_RegisterAgentPayload_agent(_ context.Co
 				return ec.fieldContext_Agent_delegatedScopes(ctx, field)
 			case "viewerCanSeePrivateFields":
 				return ec.fieldContext_Agent_viewerCanSeePrivateFields(ctx, field)
+			case "viewerIsOwner":
+				return ec.fieldContext_Agent_viewerIsOwner(ctx, field)
 			case "mcpAccess":
 				return ec.fieldContext_Agent_mcpAccess(ctx, field)
 			case "verified":
@@ -167633,6 +167709,11 @@ func (ec *executionContext) _Agent(ctx context.Context, sel ast.SelectionSet, ob
 			}
 		case "viewerCanSeePrivateFields":
 			out.Values[i] = ec._Agent_viewerCanSeePrivateFields(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "viewerIsOwner":
+			out.Values[i] = ec._Agent_viewerIsOwner(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -569,23 +569,25 @@ type Agent struct {
 	AgentOwner        *string                        `json:"agentOwner,omitempty"`
 	DelegatedScopes   []string                       `json:"delegatedScopes"`
 	// Whether private ownership, delegation, and soul-binding fields are visible to this viewer.
-	ViewerCanSeePrivateFields bool                           `json:"viewerCanSeePrivateFields"`
-	McpAccess                 *AgentMCPAccess                `json:"mcpAccess"`
-	Verified                  bool                           `json:"verified"`
-	VerifiedAt                *Time                          `json:"verifiedAt,omitempty"`
-	QuarantineStatus          *string                        `json:"quarantineStatus,omitempty"`
-	QuarantineStart           *Time                          `json:"quarantineStart,omitempty"`
-	QuarantineEnd             *Time                          `json:"quarantineEnd,omitempty"`
-	QuarantineApprovedBy      *string                        `json:"quarantineApprovedBy,omitempty"`
-	QuarantineApprovedAt      *Time                          `json:"quarantineApprovedAt,omitempty"`
-	QuarantineActive          bool                           `json:"quarantineActive"`
-	OwnerActor                *activitypub.Actor             `json:"ownerActor,omitempty"`
-	Type                      AgentType                      `json:"type"`
-	Version                   string                         `json:"version"`
-	Capabilities              *activitypub.AgentCapabilities `json:"capabilities"`
-	Owner                     *activitypub.Actor             `json:"owner,omitempty"`
-	CreatedAt                 Time                           `json:"createdAt"`
-	ActivityCount             int                            `json:"activityCount"`
+	ViewerCanSeePrivateFields bool `json:"viewerCanSeePrivateFields"`
+	// True when the requesting viewer is this agent's owner under Lesser's canonical local-identity comparison.
+	ViewerIsOwner        bool                           `json:"viewerIsOwner"`
+	McpAccess            *AgentMCPAccess                `json:"mcpAccess"`
+	Verified             bool                           `json:"verified"`
+	VerifiedAt           *Time                          `json:"verifiedAt,omitempty"`
+	QuarantineStatus     *string                        `json:"quarantineStatus,omitempty"`
+	QuarantineStart      *Time                          `json:"quarantineStart,omitempty"`
+	QuarantineEnd        *Time                          `json:"quarantineEnd,omitempty"`
+	QuarantineApprovedBy *string                        `json:"quarantineApprovedBy,omitempty"`
+	QuarantineApprovedAt *Time                          `json:"quarantineApprovedAt,omitempty"`
+	QuarantineActive     bool                           `json:"quarantineActive"`
+	OwnerActor           *activitypub.Actor             `json:"ownerActor,omitempty"`
+	Type                 AgentType                      `json:"type"`
+	Version              string                         `json:"version"`
+	Capabilities         *activitypub.AgentCapabilities `json:"capabilities"`
+	Owner                *activitypub.Actor             `json:"owner,omitempty"`
+	CreatedAt            Time                           `json:"createdAt"`
+	ActivityCount        int                            `json:"activityCount"`
 }
 
 type AgentActivityConnection struct {

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -3313,10 +3313,7 @@ func (r *actorResolver) AgentInfo(ctx context.Context, obj *activitypub.Actor) (
 	}
 
 	agent := r.convertStorageUserToAgent(user, governance)
-	if !r.canViewAgentPrivateFields(optionalGraphAuthClaims(ctx), user) {
-		redactGraphAgentPrivateFields(agent)
-	}
-	return agent, nil
+	return r.applyGraphAgentViewerState(agent, optionalGraphAuthClaims(ctx), user), nil
 }
 
 // TrustScore implements ActorResolver

--- a/pkg/activitypub/public_addressing_test.go
+++ b/pkg/activitypub/public_addressing_test.go
@@ -7,6 +7,10 @@ import (
 )
 
 func TestIsPublicAddressedActivity(t *testing.T) {
+	t.Run("nil activity", func(t *testing.T) {
+		require.False(t, IsPublicAddressedActivity(nil))
+	})
+
 	t.Run("top level to", func(t *testing.T) {
 		activity := &Activity{BaseObject: BaseObject{To: []string{PublicAddress}}}
 		require.True(t, IsPublicAddressedActivity(activity))
@@ -22,13 +26,43 @@ func TestIsPublicAddressedActivity(t *testing.T) {
 		require.True(t, IsPublicAddressedActivity(activity))
 	})
 
+	t.Run("embedded note value", func(t *testing.T) {
+		activity := &Activity{Object: Note{BaseObject: BaseObject{CC: []string{PublicAddress}}}}
+		require.True(t, IsPublicAddressedActivity(activity))
+	})
+
 	t.Run("embedded map", func(t *testing.T) {
 		activity := &Activity{Object: map[string]any{"cc": []any{PublicAddress}}}
 		require.True(t, IsPublicAddressedActivity(activity))
 	})
 
+	t.Run("embedded map string", func(t *testing.T) {
+		activity := &Activity{Object: map[string]any{"to": PublicAddress}}
+		require.True(t, IsPublicAddressedActivity(activity))
+	})
+
+	t.Run("embedded map string slice", func(t *testing.T) {
+		activity := &Activity{Object: map[string]any{"to": []string{PublicAddress}}}
+		require.True(t, IsPublicAddressedActivity(activity))
+	})
+
+	t.Run("unsupported embedded object", func(t *testing.T) {
+		activity := &Activity{Object: struct{}{}}
+		require.False(t, IsPublicAddressedActivity(activity))
+	})
+
 	t.Run("private", func(t *testing.T) {
 		activity := &Activity{BaseObject: BaseObject{To: []string{"https://example.com/users/bob"}}}
 		require.False(t, IsPublicAddressedActivity(activity))
+	})
+}
+
+func TestHasPublicAddressValue(t *testing.T) {
+	t.Run("non public string", func(t *testing.T) {
+		require.False(t, hasPublicAddressValue("https://example.com/users/alice"))
+	})
+
+	t.Run("mixed any slice without public", func(t *testing.T) {
+		require.False(t, hasPublicAddressValue([]any{"https://example.com/users/alice", 7}))
 	})
 }


### PR DESCRIPTION
Closes #1417

## What changed
- Added `viewerIsOwner: Boolean!` to `Agent`.
- Reused the existing canonical server rule `auth.AgentOwnerMatchesLocalPrincipal(...)` for a shared ownership-only helper, `applyGraphAgentViewerOwnership(...)`.
- Kept `applyGraphAgentViewerState(...)` as the ownership + private-field-redaction path for the surfaces that already depend on those visibility semantics: `agent`, `agents`, `myAgents`, `Actor.agentInfo`, and the owner/admin-gated Agent-returning mutations.
- Restored the drone workflow mutation payloads to their pre-PR visibility contract: they now apply ownership computation only, so non-owner reviewers still receive `agentOwner` / `delegatedScopes`, while `viewerIsOwner` remains correct for both owners and non-owners.
- Removed the latent bare-username → claims promotion from `droneWorkflowMutationPayload(...)`; payload viewer state is now built from explicit `viewerUsername` input instead of synthesized authorization-bearing claims.
- Added the schema description on `myAgents` clarifying that it is owner-only and that shared-with-viewer agents are served by the shared-with-me index.

## Contract tests
- `TestMyAgentsViewerIsOwnerUsesCanonicalOwnerMatchAndExcludesSharedAgents`
  - proves owner-form (`@Alice`) and normalized (`ALICE`/`alice`) identities resolve through the canonical owner-match rule
  - proves owned agents report `viewerIsOwner=true`
  - proves shared-with-viewer agents remain excluded from `myAgents` and report `viewerIsOwner=false` on `agent`
- `TestActorAgentInfoAppliesPrivateFieldPolicy`
  - proves anonymous/non-owner viewers get `viewerIsOwner=false`
  - proves admin visibility remains distinct from ownership (`viewerCanSeePrivateFields=true` while `viewerIsOwner=false`)
  - proves redaction still preserves `mcpAccess`
- `TestRound13DroneWorkflowMutationsPersistWorkflowState`
  - now asserts `payload.Agent` on the owner request / review / finalize payloads
  - proves owner payloads still expose `agentOwner` / `delegatedScopes` and report `viewerIsOwner=true`
- `TestRound13DroneWorkflowAssignedReviewerAccess`
  - proves the assigned non-owner reviewer still receives `agentOwner` / `delegatedScopes` on the review payload
  - proves that same payload reports `viewerIsOwner=false`
  - keeps the owner-forbidden review path pinned
- `TestRound13DroneWorkflowMutationPayloadUsesExplicitViewerUsernameForOwnershipOnly`
  - proves the payload ownership helper uses explicit viewer input without synthesizing authorization-bearing claims or redacting payload fields

## Rubric-forced remediation carried with this work
- The rubric gate surfaced a required dependency/security lift during this change, so it was remediated in the same branch rather than deferred:
  - `golang.org/x/image` `v0.43.0 -> v0.45.0`
  - `golang.org/x/text` `v0.40.0 -> v0.41.0`
- Added a small `pkg/activitypub/public_addressing_test.go` branch-coverage lift to keep `pkg/` above the exact verify threshold.
- This remediation was discovered by the rubric while doing #1417 and fixed before advancing; it was not smuggled in as unrelated cleanup.

## Validation
Revalidated locally on head `d841f904b506411817a42bfac2dd2499b4911db3` (intentionally not pushed while the Claude review remains in flight):
- `GOTOOLCHAIN=auto go build -o lesser ./cmd/lesser`
- `gofmt -l .` -> empty
- `GOTOOLCHAIN=auto go vet ./...`
- `GOTOOLCHAIN=auto go test ./...`
- targeted:
  - `GOTOOLCHAIN=auto go test ./graph -run 'TestRound13DroneWorkflowMutationsPersistWorkflowState|TestRound13DroneWorkflowAssignedReviewerAccess|TestRound13DroneWorkflowMutationPayloadUsesExplicitViewerUsernameForOwnershipOnly|TestMyAgentsViewerIsOwnerUsesCanonicalOwnerMatchAndExcludesSharedAgents|TestActorAgentInfoAppliesPrivateFieldPolicy'`
- rubric:
  - `GOTOOLCHAIN=auto ./lesser verify ci`
  - result: PASS
  - coverage from rubric:
    - overall `87.826%`
    - pkg `90.003%`
    - cmd `90.215%`

## DCO verification (`origin/staging..HEAD`)
```text
d841f904b506411817a42bfac2dd2499b4911db3 aron23@gmail.com Aron Price <aron23@gmail.com>
467f75daf0516ec952bb5bfefe5ca4964f7d28f3 aron23@gmail.com Aron Price <aron23@gmail.com>
1d3042ba96eb95e8a3074ea9d1e3e770e9f7c3ee aron23@gmail.com Aron Price <aron23@gmail.com>
```

## Exact contentus sync delta for the coordinated pin bump
```graphql
type Agent {
  viewerIsOwner: Boolean!
}

extend type Query {
  """Agents owned by the viewer. Agents shared with the viewer are served by the shared-with-me index, not this field."""
  myAgents: [Agent!]!
}
```

## Explicit non-changes
- `myAgents` behavior is unchanged; it remains owner-only.
- Share-grant authorization is unchanged.
- Drone workflow authorization predicates are unchanged; only payload viewer-state shaping was decoupled from redaction.