### PR TITLE
PROG-M1 M1: storage and schema correctness baseline

### DIFF
--- a/cmd/api/handlers/round10_test_helpers_test.go
+++ b/cmd/api/handlers/round10_test_helpers_test.go
@@ -175,6 +175,99 @@ func (s *round10QueryState) whereString(field string) (string, bool) {
 	return str, ok
 }
 
+func round10CanonicalizeWebAuthnCredential(cred storagemodels.WebAuthnCredential) storagemodels.WebAuthnCredential {
+	if strings.TrimSpace(cred.PK) == "" && strings.TrimSpace(cred.UserID) != "" {
+		cred.PK = "USER#" + cred.UserID
+	}
+	if strings.TrimSpace(cred.SK) == "" && strings.TrimSpace(cred.ID) != "" {
+		cred.SK = "WEBAUTHN_CRED#" + cred.ID
+	}
+	if strings.TrimSpace(cred.GSI1PK) == "" && strings.TrimSpace(cred.ID) != "" {
+		cred.GSI1PK = "WEBAUTHN_CREDENTIAL#" + cred.ID
+	}
+	if strings.TrimSpace(cred.GSI1SK) == "" && strings.TrimSpace(cred.UserID) != "" {
+		cred.GSI1SK = "USER#" + cred.UserID
+	}
+	return cred
+}
+
+func round10UpsertWebAuthnCredential(state *round10QueryState, cred storagemodels.WebAuthnCredential) {
+	if state == nil {
+		return
+	}
+
+	cred = round10CanonicalizeWebAuthnCredential(cred)
+
+	if state.webAuthnCredentialByID == nil {
+		state.webAuthnCredentialByID = map[string]storagemodels.WebAuthnCredential{}
+	}
+	state.webAuthnCredentialByID[cred.ID] = cred
+
+	if strings.TrimSpace(cred.UserID) == "" {
+		return
+	}
+
+	if state.webAuthnCredentialsByUser == nil {
+		state.webAuthnCredentialsByUser = map[string][]storagemodels.WebAuthnCredential{}
+	}
+
+	creds := state.webAuthnCredentialsByUser[cred.UserID]
+	for i := range creds {
+		if creds[i].ID == cred.ID {
+			creds[i] = cred
+			state.webAuthnCredentialsByUser[cred.UserID] = creds
+			return
+		}
+	}
+	state.webAuthnCredentialsByUser[cred.UserID] = append(creds, cred)
+}
+
+func round10DeleteWebAuthnCredential(state *round10QueryState, credentialID string) {
+	if state == nil || strings.TrimSpace(credentialID) == "" {
+		return
+	}
+
+	cred, ok := state.webAuthnCredentialByID[credentialID]
+	if ok {
+		delete(state.webAuthnCredentialByID, credentialID)
+		creds := state.webAuthnCredentialsByUser[cred.UserID]
+		filtered := creds[:0]
+		for _, candidate := range creds {
+			if candidate.ID == credentialID {
+				continue
+			}
+			filtered = append(filtered, candidate)
+		}
+		if len(filtered) == 0 {
+			delete(state.webAuthnCredentialsByUser, cred.UserID)
+			return
+		}
+		state.webAuthnCredentialsByUser[cred.UserID] = filtered
+		return
+	}
+
+	for username, creds := range state.webAuthnCredentialsByUser {
+		filtered := creds[:0]
+		removed := false
+		for _, candidate := range creds {
+			if candidate.ID == credentialID {
+				removed = true
+				continue
+			}
+			filtered = append(filtered, candidate)
+		}
+		if !removed {
+			continue
+		}
+		if len(filtered) == 0 {
+			delete(state.webAuthnCredentialsByUser, username)
+		} else {
+			state.webAuthnCredentialsByUser[username] = filtered
+		}
+		return
+	}
+}
+
 func round10CommunityNoteGSI3SK(note storagemodels.CommunityNote) string {
 	if note.GSI3SK != "" {
 		return note.GSI3SK
@@ -635,6 +728,11 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 			}
 			state.oauthDeviceSessionsByHash[m.DeviceCodeHash] = *m
 			state.oauthDeviceSessionsByUserCode[m.UserCode] = *m
+		case *storagemodels.WebAuthnCredential:
+			if m == nil {
+				return
+			}
+			round10UpsertWebAuthnCredential(state, *m)
 		case *storagemodels.AuthAuditLog:
 			if m == nil {
 				return
@@ -717,6 +815,17 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 	}
 	mockQuery.On("Delete").Return(nil).Run(func(_ mock.Arguments) {
 		switch state.model.(type) {
+		case *storagemodels.WebAuthnCredential:
+			credentialID := ""
+			if model, ok := state.model.(*storagemodels.WebAuthnCredential); ok && model != nil && strings.TrimSpace(model.ID) != "" {
+				credentialID = strings.TrimSpace(model.ID)
+			}
+			if credentialID == "" {
+				if sk, ok := state.whereString("SK"); ok && strings.HasPrefix(sk, "WEBAUTHN_CRED#") {
+					credentialID = strings.TrimPrefix(sk, "WEBAUTHN_CRED#")
+				}
+			}
+			round10DeleteWebAuthnCredential(state, credentialID)
 		case *storagemodels.WalletCredential:
 			pk, okPK := state.whereString("PK")
 			sk, okSK := state.whereString("SK")
@@ -1824,21 +1933,23 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 			}
 		case *storagemodels.WebAuthnCredential:
 			credentialID := ""
-			if pk, ok := state.whereString("PK"); ok && strings.HasPrefix(pk, "WEBAUTHN_CREDENTIAL#") {
-				credentialID = strings.TrimPrefix(pk, "WEBAUTHN_CREDENTIAL#")
+			if gsi1PK, ok := state.whereString("gsi1PK"); ok && strings.HasPrefix(gsi1PK, "WEBAUTHN_CREDENTIAL#") {
+				credentialID = strings.TrimPrefix(gsi1PK, "WEBAUTHN_CREDENTIAL#")
+			} else if sk, ok := state.whereString("SK"); ok && strings.HasPrefix(sk, "WEBAUTHN_CRED#") {
+				credentialID = strings.TrimPrefix(sk, "WEBAUTHN_CRED#")
 			}
 			if cred, ok := state.webAuthnCredentialByID[credentialID]; ok {
-				*d = cred
+				*d = round10CanonicalizeWebAuthnCredential(cred)
 				return
 			}
-			*d = storagemodels.WebAuthnCredential{
+			*d = round10CanonicalizeWebAuthnCredential(storagemodels.WebAuthnCredential{
 				ID:         "Y3JlZA==",
 				UserID:     "alice",
 				PublicKey:  []byte{0x01, 0x02},
 				Name:       "Test Key",
 				CreatedAt:  time.Now().Add(-2 * time.Hour),
 				LastUsedAt: time.Now().Add(-1 * time.Hour),
-			}
+			})
 		case *storagemodels.OAuthClient:
 			clientID := ""
 			if pk, ok := state.whereString("PK"); ok && strings.HasPrefix(pk, "OAUTH_CLIENT#") {
@@ -2255,10 +2366,14 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 			}
 			*d = []*storagemodels.Import{}
 		case *[]storagemodels.WebAuthnCredential:
-			username, _ := state.whereString("gsi1PK")
+			username, _ := state.whereString("PK")
 			username = strings.TrimPrefix(username, "USER#")
 			if creds, ok := state.webAuthnCredentialsByUser[username]; ok {
-				*d = creds
+				items := make([]storagemodels.WebAuthnCredential, len(creds))
+				for i := range creds {
+					items[i] = round10CanonicalizeWebAuthnCredential(creds[i])
+				}
+				*d = items
 				return
 			}
 			*d = []storagemodels.WebAuthnCredential{
@@ -2270,6 +2385,9 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 					CreatedAt:  time.Now().Add(-2 * time.Hour),
 					LastUsedAt: time.Now().Add(-1 * time.Hour),
 				},
+			}
+			for i := range *d {
+				(*d)[i] = round10CanonicalizeWebAuthnCredential((*d)[i])
 			}
 		case *[]storagemodels.PushSubscription:
 			username, _ := state.whereString("PK")

--- a/cmd/api/handlers/round10_test_helpers_test.go
+++ b/cmd/api/handlers/round10_test_helpers_test.go
@@ -618,6 +618,8 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 	mockUpdate.On("ConditionVersion", mock.Anything).Return(mockUpdate).Maybe()
 	if state.executeErrorOnce != nil {
 		mockUpdate.On("Execute").Return(state.executeErrorOnce).Once()
+	} else if state.updateErrorOnce != nil {
+		mockUpdate.On("Execute").Return(state.updateErrorOnce).Once()
 	}
 	mockUpdate.On("Execute").Return(nil).Run(func(_ mock.Arguments) {
 		switch state.model.(type) {
@@ -659,6 +661,32 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 				client.UpdatedAt = updatedAt
 			}
 			state.oauthClientsByID[clientID] = client
+		case *storagemodels.WebAuthnCredential:
+			model, _ := state.model.(*storagemodels.WebAuthnCredential)
+			if model == nil {
+				return
+			}
+
+			credential := round10CanonicalizeWebAuthnCredential(*model)
+			if existing, ok := state.webAuthnCredentialByID[credential.ID]; ok {
+				credential = round10CanonicalizeWebAuthnCredential(existing)
+			}
+			if name, ok := state.sets["Name"].(string); ok {
+				credential.Name = name
+			}
+			if signCount, ok := state.sets["SignCount"].(uint32); ok {
+				credential.SignCount = signCount
+			}
+			if cloneWarning, ok := state.sets["CloneWarning"].(bool); ok {
+				credential.CloneWarning = cloneWarning
+			}
+			if backupState, ok := state.sets["BackupState"].(bool); ok {
+				credential.BackupState = backupState
+			}
+			if lastUsedAt, ok := state.sets["LastUsedAt"].(time.Time); ok {
+				credential.LastUsedAt = lastUsedAt
+			}
+			round10UpsertWebAuthnCredential(state, credential)
 		}
 	}).Maybe()
 

--- a/cmd/api/handlers/round10_test_helpers_test.go
+++ b/cmd/api/handlers/round10_test_helpers_test.go
@@ -935,6 +935,11 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 				state.walletChallengesByID = map[string]storagemodels.WalletChallenge{}
 			}
 			state.walletChallengesByID[m.ID] = *m
+		case *storagemodels.WebAuthnCredential:
+			if m == nil {
+				return
+			}
+			round10UpsertWebAuthnCredential(state, *m)
 		}
 	}).Maybe()
 	mockQuery.On("Count").Return(int64(2), nil).Maybe()

--- a/pkg/auth/webauthn.go
+++ b/pkg/auth/webauthn.go
@@ -57,7 +57,8 @@ type webAuthnRepository interface {
 	StoreWebAuthnCredential(ctx context.Context, credential *storage.WebAuthnCredential) error
 	GetWebAuthnCredential(ctx context.Context, credentialID string) (*storage.WebAuthnCredential, error)
 	DeleteWebAuthnCredential(ctx context.Context, credentialID string) error
-	UpdateWebAuthnLastUsed(ctx context.Context, credentialID string, signCount uint32) error
+	UpdateWebAuthnCredentialName(ctx context.Context, credentialID string, name string) error
+	UpdateWebAuthnAuthenticationState(ctx context.Context, credentialID string, signCount uint32, cloneWarning bool, backupState bool, lastUsedAt time.Time) error
 }
 
 // NewWebAuthnService creates a new WebAuthn service
@@ -427,8 +428,7 @@ func (s *WebAuthnService) UpdateCredentialName(ctx context.Context, username str
 		return ErrCredentialNotFound
 	}
 
-	credential.Name = newName
-	return s.repo.UpdateWebAuthnLastUsed(ctx, credential.ID, credential.SignCount)
+	return s.repo.UpdateWebAuthnCredentialName(ctx, credential.ID, newName)
 }
 
 // webAuthnUser implements the webauthn.User interface

--- a/pkg/auth/webauthn.go
+++ b/pkg/auth/webauthn.go
@@ -369,7 +369,14 @@ func (s *WebAuthnService) FinishLogin(ctx context.Context, username string, chal
 	usedCredential.BackupState = credential.Flags.BackupState
 	usedCredential.LastUsedAt = time.Now()
 
-	if err := s.repo.UpdateWebAuthnLastUsed(ctx, usedCredential.ID, usedCredential.SignCount); err != nil {
+	if err := s.repo.UpdateWebAuthnAuthenticationState(
+		ctx,
+		usedCredential.ID,
+		usedCredential.SignCount,
+		usedCredential.CloneWarning,
+		usedCredential.BackupState,
+		usedCredential.LastUsedAt,
+	); err != nil {
 		common.Logger().Error("failed to update credential", zap.Error(err))
 	}
 

--- a/pkg/auth/webauthn_more_test.go
+++ b/pkg/auth/webauthn_more_test.go
@@ -72,7 +72,14 @@ func TestWebAuthnService_DeleteCredential_AndUpdateCredentialName_SuccessPaths(t
 	repo := newInMemoryWebAuthnRepo()
 	repo.usersByUsername["alice"] = &storage.User{Username: "alice", PasswordHash: "hash"}
 
-	cred1 := &storage.WebAuthnCredential{ID: "AQ==", UserID: "alice", PublicKey: []byte("pub"), Name: "old"}
+	cred1LastUsedAt := time.Unix(100, 0).UTC()
+	cred1 := &storage.WebAuthnCredential{
+		ID:         "AQ==",
+		UserID:     "alice",
+		PublicKey:  []byte("pub"),
+		Name:       "old",
+		LastUsedAt: cred1LastUsedAt,
+	}
 	cred2 := &storage.WebAuthnCredential{ID: "Ag==", UserID: "alice", PublicKey: []byte("pub2"), Name: "old2"}
 	repo.credentialsByUsername["alice"] = []*storage.WebAuthnCredential{cred1, cred2}
 	repo.credentialsByID[cred1.ID] = cred1
@@ -95,6 +102,9 @@ func TestWebAuthnService_DeleteCredential_AndUpdateCredentialName_SuccessPaths(t
 
 	require.NoError(t, svc.UpdateCredentialName(context.Background(), "alice", cred1.ID, "new"))
 	require.Equal(t, "new", repo.credentialsByID[cred1.ID].Name)
+	require.Equal(t, cred1LastUsedAt, repo.credentialsByID[cred1.ID].LastUsedAt)
+	require.Equal(t, 1, repo.renameCalls)
+	require.Zero(t, repo.updateCalls)
 
 	// Multiple credentials -> delete allowed without checking password presence.
 	repo.usersByUsername["alice"].PasswordHash = ""
@@ -122,7 +132,12 @@ func TestWebAuthnService_DeleteCredential_AndUpdateCredentialName_SuccessPaths(t
 
 	require.NoError(t, svc2.DeleteCredential(context.Background(), "alice", only.ID))
 
-	// Ensure last-used update path is exercised.
-	repo2.credentialsByID[only.ID] = &storage.WebAuthnCredential{ID: only.ID, UserID: "alice", SignCount: 1, LastUsedAt: time.Now().Add(-time.Hour)}
+	// Renames persist the requested name without moving LastUsedAt.
+	lastUsedAt := time.Unix(200, 0).UTC()
+	repo2.credentialsByID[only.ID] = &storage.WebAuthnCredential{ID: only.ID, UserID: "alice", SignCount: 1, LastUsedAt: lastUsedAt}
 	require.NoError(t, svc2.UpdateCredentialName(context.Background(), "alice", only.ID, "renamed"))
+	require.Equal(t, "renamed", repo2.credentialsByID[only.ID].Name)
+	require.Equal(t, lastUsedAt, repo2.credentialsByID[only.ID].LastUsedAt)
+	require.Equal(t, 1, repo2.renameCalls)
+	require.Zero(t, repo2.updateCalls)
 }

--- a/pkg/auth/webauthn_round10_error_paths_test.go
+++ b/pkg/auth/webauthn_round10_error_paths_test.go
@@ -1,0 +1,282 @@
+package auth
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/storage"
+	testmocks "github.com/equaltoai/lesser/pkg/testing/mocks"
+	"github.com/go-webauthn/webauthn/protocol"
+	"github.com/go-webauthn/webauthn/webauthn"
+	"github.com/stretchr/testify/require"
+)
+
+type webAuthnRepoGetCredentialErr struct {
+	*inMemoryWebAuthnRepo
+	err error
+}
+
+func (r *webAuthnRepoGetCredentialErr) GetWebAuthnCredential(_ context.Context, _ string) (*storage.WebAuthnCredential, error) {
+	return nil, r.err
+}
+
+type webAuthnRepoGetWalletErr struct {
+	*inMemoryWebAuthnRepo
+	err error
+}
+
+func (r *webAuthnRepoGetWalletErr) GetUserWalletCredentials(_ context.Context, _ string) ([]*storage.WalletCredential, error) {
+	return nil, r.err
+}
+
+type webAuthnRepoUpdateAuthStateErr struct {
+	*inMemoryWebAuthnRepo
+	err error
+}
+
+func (r *webAuthnRepoUpdateAuthStateErr) UpdateWebAuthnAuthenticationState(
+	_ context.Context,
+	_ string,
+	_ uint32,
+	_ bool,
+	_ bool,
+	_ time.Time,
+) error {
+	r.updateCalls++
+	return r.err
+}
+
+func TestWebAuthnService_FinishLogin_UpdateStateErrorStillReturnsCredential(t *testing.T) {
+	t.Parallel()
+
+	repo := newInMemoryWebAuthnRepo()
+	credID := base64.StdEncoding.EncodeToString([]byte{7, 7})
+	credentialRecord := &storage.WebAuthnCredential{ID: credID, UserID: "alice", PublicKey: []byte("pub"), SignCount: 1}
+	repo.credentialsByUsername["alice"] = []*storage.WebAuthnCredential{credentialRecord}
+	repo.credentialsByID[credID] = credentialRecord
+
+	sessionData := webauthn.SessionData{Challenge: "chal-login", UserID: []byte("alice"), Expires: time.Now().Add(time.Minute)}
+	sessionBytes, err := json.Marshal(sessionData)
+	require.NoError(t, err)
+
+	repo.challengesByChallenge["chal-login"] = &storage.WebAuthnChallenge{
+		Challenge:   "chal-login",
+		UserID:      "alice",
+		SessionData: sessionBytes,
+		ExpiresAt:   time.Now().Add(time.Minute),
+		Type:        "authentication",
+	}
+
+	svc := &WebAuthnService{
+		webAuthn: &fakeWebAuthnEngine{
+			loginCredential: &webauthn.Credential{
+				ID: []byte{7, 7},
+				Authenticator: webauthn.Authenticator{
+					SignCount:    2,
+					CloneWarning: true,
+				},
+				Flags: webauthn.CredentialFlags{BackupState: true},
+			},
+		},
+		repo:   &webAuthnRepoUpdateAuthStateErr{inMemoryWebAuthnRepo: repo, err: errors.New("update failed")},
+		domain: "example.com",
+		parseCreationResponse: func(_ []byte) (*protocol.ParsedCredentialCreationData, error) {
+			return &protocol.ParsedCredentialCreationData{}, nil
+		},
+		parseAssertionResponse: func(_ []byte) (*protocol.ParsedCredentialAssertionData, error) {
+			return &protocol.ParsedCredentialAssertionData{}, nil
+		},
+	}
+
+	used, err := svc.FinishLogin(context.Background(), "alice", "chal-login", []byte("ignored"))
+	require.NoError(t, err)
+	require.Equal(t, credID, used.ID)
+	require.Equal(t, uint32(2), used.SignCount)
+	require.True(t, used.CloneWarning)
+	require.True(t, used.BackupState)
+	require.Equal(t, 1, repo.updateCalls)
+	_, stillExists := repo.challengesByChallenge["chal-login"]
+	require.False(t, stillExists)
+}
+
+func TestWebAuthnService_FinishLogin_ErrorBranches_InvalidSessionAndCredentialLoad(t *testing.T) {
+	t.Parallel()
+
+	repo := newInMemoryWebAuthnRepo()
+	repo.challengesByChallenge["bad-type"] = &storage.WebAuthnChallenge{
+		Challenge:   "bad-type",
+		UserID:      "alice",
+		SessionData: 123,
+		ExpiresAt:   time.Now().Add(time.Minute),
+		Type:        "authentication",
+	}
+
+	svc := &WebAuthnService{
+		webAuthn: &fakeWebAuthnEngine{},
+		repo:     repo,
+		domain:   "example.com",
+		parseCreationResponse: func(_ []byte) (*protocol.ParsedCredentialCreationData, error) {
+			return &protocol.ParsedCredentialCreationData{}, nil
+		},
+		parseAssertionResponse: func(_ []byte) (*protocol.ParsedCredentialAssertionData, error) {
+			return &protocol.ParsedCredentialAssertionData{}, nil
+		},
+	}
+
+	used, err := svc.FinishLogin(context.Background(), "alice", "bad-type", []byte("ignored"))
+	require.Nil(t, used)
+	require.ErrorIs(t, err, ErrInvalidSessionDataType)
+
+	sessionData := webauthn.SessionData{Challenge: "cred-load-fail", UserID: []byte("alice"), Expires: time.Now().Add(time.Minute)}
+	sessionBytes, marshalErr := json.Marshal(sessionData)
+	require.NoError(t, marshalErr)
+
+	repo2 := newInMemoryWebAuthnRepo()
+	repo2.challengesByChallenge["cred-load-fail"] = &storage.WebAuthnChallenge{
+		Challenge:   "cred-load-fail",
+		UserID:      "alice",
+		SessionData: sessionBytes,
+		ExpiresAt:   time.Now().Add(time.Minute),
+		Type:        "authentication",
+	}
+
+	svc.repo = &webAuthnRepoGetCredsFail{inMemoryWebAuthnRepo: repo2, err: errors.New("credential load failed")}
+	used, err = svc.FinishLogin(context.Background(), "alice", "cred-load-fail", []byte("ignored"))
+	require.Nil(t, used)
+	require.ErrorIs(t, err, ErrCredentialRetrieval)
+}
+
+func TestWebAuthnService_ConstructorParsersAndRegistrationErrorBranches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default parsers are callable", func(t *testing.T) {
+		t.Parallel()
+
+		svc, err := NewWebAuthnService(testmocks.NewMockRepositoryStorage(), "example.com", "Lesser")
+		require.NoError(t, err)
+
+		_, err = svc.parseCreationResponse([]byte("not-json"))
+		require.Error(t, err)
+
+		_, err = svc.parseAssertionResponse([]byte("not-json"))
+		require.Error(t, err)
+	})
+
+	t.Run("begin registration returns engine error", func(t *testing.T) {
+		t.Parallel()
+
+		repo := newInMemoryWebAuthnRepo()
+		repo.usersByUsername["alice"] = &storage.User{Username: "alice"}
+
+		svc := &WebAuthnService{
+			webAuthn: webAuthnEngineError{err: errors.New("begin failed")},
+			repo:     repo,
+			domain:   "example.com",
+		}
+
+		_, _, err := svc.BeginRegistration(context.Background(), "alice")
+		require.ErrorIs(t, err, ErrRegistrationBegin)
+	})
+
+	t.Run("finish registration returns user retrieval error after session decode", func(t *testing.T) {
+		t.Parallel()
+
+		repo := newInMemoryWebAuthnRepo()
+		sessionData := webauthn.SessionData{Challenge: "chal-reg", UserID: []byte("alice"), Expires: time.Now().Add(time.Minute)}
+		sessionBytes, err := json.Marshal(sessionData)
+		require.NoError(t, err)
+
+		repo.challengesByChallenge["chal-reg"] = &storage.WebAuthnChallenge{
+			Challenge:   "chal-reg",
+			UserID:      "alice",
+			SessionData: sessionBytes,
+			ExpiresAt:   time.Now().Add(time.Minute),
+			Type:        "registration",
+		}
+
+		svc := &WebAuthnService{
+			webAuthn: &fakeWebAuthnEngine{},
+			repo:     repo,
+			domain:   "example.com",
+		}
+
+		err = svc.FinishRegistration(context.Background(), "alice", "chal-reg", []byte("ignored"), "Passkey")
+		require.ErrorIs(t, err, ErrUserRetrieval)
+	})
+
+	t.Run("finish login returns session deserialization error", func(t *testing.T) {
+		t.Parallel()
+
+		repo := newInMemoryWebAuthnRepo()
+		repo.challengesByChallenge["bad-json"] = &storage.WebAuthnChallenge{
+			Challenge:   "bad-json",
+			UserID:      "alice",
+			SessionData: []byte("{"),
+			ExpiresAt:   time.Now().Add(time.Minute),
+			Type:        "authentication",
+		}
+
+		svc := &WebAuthnService{
+			webAuthn: &fakeWebAuthnEngine{},
+			repo:     repo,
+			domain:   "example.com",
+			parseAssertionResponse: func(_ []byte) (*protocol.ParsedCredentialAssertionData, error) {
+				return &protocol.ParsedCredentialAssertionData{}, nil
+			},
+		}
+
+		used, err := svc.FinishLogin(context.Background(), "alice", "bad-json", []byte("ignored"))
+		require.Nil(t, used)
+		require.ErrorIs(t, err, ErrSessionDataDeserialization)
+	})
+}
+
+func TestWebAuthnService_DeleteCredentialAndRename_ErrorBranches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("delete credential returns lookup error", func(t *testing.T) {
+		t.Parallel()
+
+		repo := newInMemoryWebAuthnRepo()
+		svc := &WebAuthnService{repo: &webAuthnRepoGetCredentialErr{inMemoryWebAuthnRepo: repo, err: errors.New("lookup failed")}}
+
+		require.ErrorContains(t, svc.DeleteCredential(context.Background(), "alice", "cred-1"), "lookup failed")
+	})
+
+	t.Run("delete credential returns list error after ownership check", func(t *testing.T) {
+		t.Parallel()
+
+		repo := newInMemoryWebAuthnRepo()
+		cred := &storage.WebAuthnCredential{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk")}
+		repo.credentialsByUsername["alice"] = []*storage.WebAuthnCredential{cred}
+		repo.credentialsByID[cred.ID] = cred
+
+		svc := &WebAuthnService{repo: &webAuthnRepoGetCredsFail{inMemoryWebAuthnRepo: repo, err: errors.New("list failed")}}
+		require.ErrorContains(t, svc.DeleteCredential(context.Background(), "alice", cred.ID), "list failed")
+	})
+
+	t.Run("delete credential returns wallet error for last auth method fallback", func(t *testing.T) {
+		t.Parallel()
+
+		repo := newInMemoryWebAuthnRepo()
+		cred := &storage.WebAuthnCredential{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk")}
+		repo.credentialsByUsername["alice"] = []*storage.WebAuthnCredential{cred}
+		repo.credentialsByID[cred.ID] = cred
+
+		svc := &WebAuthnService{repo: &webAuthnRepoGetWalletErr{inMemoryWebAuthnRepo: repo, err: errors.New("wallet lookup failed")}}
+		require.ErrorContains(t, svc.DeleteCredential(context.Background(), "alice", cred.ID), "wallet lookup failed")
+	})
+
+	t.Run("rename returns lookup error", func(t *testing.T) {
+		t.Parallel()
+
+		repo := newInMemoryWebAuthnRepo()
+		svc := &WebAuthnService{repo: &webAuthnRepoGetCredentialErr{inMemoryWebAuthnRepo: repo, err: errors.New("lookup failed")}}
+
+		require.ErrorContains(t, svc.UpdateCredentialName(context.Background(), "alice", "cred-1", "new-name"), "lookup failed")
+	})
+}

--- a/pkg/auth/webauthn_test.go
+++ b/pkg/auth/webauthn_test.go
@@ -214,16 +214,20 @@ func TestWebAuthnService_BeginLoginAndFinishLogin_SuccessAndCredentialNotFound(t
 	repo.usersByUsername["alice"] = &storage.User{Username: "alice", PasswordHash: "hashed"}
 
 	credID := base64.StdEncoding.EncodeToString([]byte{7, 7})
+	previousLastUsedAt := time.Unix(123, 0).UTC()
+	credentialRecord := &storage.WebAuthnCredential{ID: credID, UserID: "alice", PublicKey: []byte("pub"), SignCount: 1, LastUsedAt: previousLastUsedAt}
 	repo.credentialsByUsername["alice"] = []*storage.WebAuthnCredential{
-		{ID: credID, UserID: "alice", PublicKey: []byte("pub"), SignCount: 1},
+		credentialRecord,
 	}
+	repo.credentialsByID[credID] = credentialRecord
 
 	engine := &fakeWebAuthnEngine{
 		beginLoginChallenge: "chal-login",
 		loginCredential: &webauthn.Credential{
 			ID: []byte{7, 7},
 			Authenticator: webauthn.Authenticator{
-				SignCount: 2,
+				SignCount:    2,
+				CloneWarning: true,
 			},
 			Flags: webauthn.CredentialFlags{BackupState: true},
 		},
@@ -262,7 +266,14 @@ func TestWebAuthnService_BeginLoginAndFinishLogin_SuccessAndCredentialNotFound(t
 	require.NoError(t, err)
 	require.Equal(t, credID, used.ID)
 	require.Equal(t, uint32(2), used.SignCount)
+	require.True(t, used.CloneWarning)
+	require.True(t, used.BackupState)
+	require.True(t, used.LastUsedAt.After(previousLastUsedAt))
 	require.GreaterOrEqual(t, repo.updateCalls, 1)
+	require.Equal(t, used.LastUsedAt, repo.credentialsByID[credID].LastUsedAt)
+	require.Equal(t, uint32(2), repo.credentialsByID[credID].SignCount)
+	require.True(t, repo.credentialsByID[credID].CloneWarning)
+	require.True(t, repo.credentialsByID[credID].BackupState)
 
 	// Credential not found in map.
 	engine.loginCredential = &webauthn.Credential{ID: []byte{8, 8}}

--- a/pkg/auth/webauthn_test.go
+++ b/pkg/auth/webauthn_test.go
@@ -22,6 +22,7 @@ type inMemoryWebAuthnRepo struct {
 	walletsByUsername     map[string][]*storage.WalletCredential
 
 	updateCalls int
+	renameCalls int
 }
 
 func newInMemoryWebAuthnRepo() *inMemoryWebAuthnRepo {
@@ -87,12 +88,30 @@ func (r *inMemoryWebAuthnRepo) DeleteWebAuthnCredential(_ context.Context, crede
 	return nil
 }
 
-func (r *inMemoryWebAuthnRepo) UpdateWebAuthnLastUsed(_ context.Context, credentialID string, signCount uint32) error {
+func (r *inMemoryWebAuthnRepo) UpdateWebAuthnCredentialName(_ context.Context, credentialID string, name string) error {
+	r.renameCalls++
+	cred, ok := r.credentialsByID[credentialID]
+	if ok {
+		cred.Name = name
+	}
+	return nil
+}
+
+func (r *inMemoryWebAuthnRepo) UpdateWebAuthnAuthenticationState(
+	_ context.Context,
+	credentialID string,
+	signCount uint32,
+	cloneWarning bool,
+	backupState bool,
+	lastUsedAt time.Time,
+) error {
 	r.updateCalls++
 	cred, ok := r.credentialsByID[credentialID]
 	if ok {
 		cred.SignCount = signCount
-		cred.LastUsedAt = time.Now()
+		cred.CloneWarning = cloneWarning
+		cred.BackupState = backupState
+		cred.LastUsedAt = lastUsedAt
 	}
 	return nil
 }

--- a/pkg/storage/models/passkey_registration_proof.go
+++ b/pkg/storage/models/passkey_registration_proof.go
@@ -1,0 +1,137 @@
+package models
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/common"
+)
+
+const (
+	// KeyPatternPasskeyRegistrationProof is the canonical PK pattern for passkey signup proofs.
+	KeyPatternPasskeyRegistrationProof = "PASSKEY_REGISTRATION_PROOF#%s"
+	// SKPasskeyRegistrationProof is the canonical SK for passkey signup proofs.
+	SKPasskeyRegistrationProof = "PROOF"
+	// DefaultPasskeyRegistrationProofTTL keeps proofs short-lived and self-cleaning.
+	DefaultPasskeyRegistrationProofTTL = 10 * time.Minute
+)
+
+// PasskeyRegistrationProof is the single-use proof persisted between WebAuthn signup
+// verification and account registration.
+type PasskeyRegistrationProof struct {
+	_ struct{} `theorydb:"naming:camelCase"`
+
+	PK string `theorydb:"pk,attr:PK" json:"-"`
+	SK string `theorydb:"sk,attr:SK" json:"-"`
+
+	TTL int64 `theorydb:"ttl,attr:ttl" json:"-"`
+
+	ID              string    `theorydb:"attr:id" json:"id"`
+	Username        string    `theorydb:"attr:username" json:"username"`
+	CeremonyID      string    `theorydb:"attr:ceremonyID" json:"ceremony_id"`
+	CredentialID    string    `theorydb:"attr:credentialID" json:"credential_id"`
+	PublicKey       []byte    `theorydb:"attr:publicKey" json:"public_key"`
+	AttestationType string    `theorydb:"attr:attestationType" json:"attestation_type"`
+	AAGUID          []byte    `theorydb:"attr:aaguid" json:"aaguid"`
+	SignCount       uint32    `theorydb:"attr:signCount" json:"sign_count"`
+	CloneWarning    bool      `theorydb:"attr:cloneWarning" json:"clone_warning"`
+	BackupEligible  bool      `theorydb:"attr:backupEligible" json:"backup_eligible"`
+	BackupState     bool      `theorydb:"attr:backupState" json:"backup_state"`
+	CreatedAt       time.Time `theorydb:"attr:createdAt" json:"created_at"`
+	ExpiresAt       time.Time `theorydb:"attr:expiresAt" json:"expires_at"`
+	Consumed        bool      `theorydb:"attr:consumed" json:"consumed"`
+	ConsumedAt      time.Time `theorydb:"attr:consumedAt" json:"consumed_at,omitempty"`
+}
+
+// TableName returns the DynamoDB table name.
+func (PasskeyRegistrationProof) TableName() string {
+	return MainTableName
+}
+
+// BeforeCreate sets keys and TTL defaults before creation.
+func (p *PasskeyRegistrationProof) BeforeCreate() error {
+	now := time.Now().UTC()
+	if p.CreatedAt.IsZero() {
+		p.CreatedAt = now
+	}
+	if p.ExpiresAt.IsZero() {
+		p.ExpiresAt = p.CreatedAt.Add(DefaultPasskeyRegistrationProofTTL)
+	}
+	if err := p.UpdateKeys(); err != nil {
+		return fmt.Errorf("failed to update keys: %w", err)
+	}
+	return p.Validate()
+}
+
+// BeforeUpdate keeps keys and TTL aligned on update.
+func (p *PasskeyRegistrationProof) BeforeUpdate() error {
+	if err := p.UpdateKeys(); err != nil {
+		return fmt.Errorf("failed to update keys: %w", err)
+	}
+	return p.Validate()
+}
+
+// GetPK returns the partition key.
+func (p *PasskeyRegistrationProof) GetPK() string {
+	return p.PK
+}
+
+// GetSK returns the sort key.
+func (p *PasskeyRegistrationProof) GetSK() string {
+	return p.SK
+}
+
+// UpdateKeys updates the keys and TTL from the current model state.
+func (p *PasskeyRegistrationProof) UpdateKeys() error {
+	p.ID = strings.TrimSpace(p.ID)
+	p.Username = strings.TrimSpace(p.Username)
+	p.CeremonyID = strings.TrimSpace(p.CeremonyID)
+	p.CredentialID = strings.TrimSpace(p.CredentialID)
+
+	if err := common.ValidateRequiredParam("id", p.ID); err != nil {
+		return err
+	}
+
+	p.PK = fmt.Sprintf(KeyPatternPasskeyRegistrationProof, p.ID)
+	p.SK = SKPasskeyRegistrationProof
+	p.TTL = p.ExpiresAt.Unix()
+	return nil
+}
+
+// Validate ensures the persisted proof is internally consistent.
+func (p *PasskeyRegistrationProof) Validate() error {
+	if err := common.ValidateRequiredParam("id", p.ID); err != nil {
+		return err
+	}
+	if err := common.ValidateRequiredParam("username", p.Username); err != nil {
+		return err
+	}
+	if err := common.ValidateRequiredParam("ceremonyID", p.CeremonyID); err != nil {
+		return err
+	}
+	if err := common.ValidateRequiredParam("credentialID", p.CredentialID); err != nil {
+		return err
+	}
+	if len(p.PublicKey) == 0 {
+		return fmt.Errorf("public key is required")
+	}
+	if p.CreatedAt.IsZero() {
+		return fmt.Errorf("created_at is required")
+	}
+	if p.ExpiresAt.IsZero() {
+		return fmt.Errorf("expires_at is required")
+	}
+	if !p.ExpiresAt.After(p.CreatedAt) {
+		return fmt.Errorf("expires_at must be after created_at")
+	}
+	return nil
+}
+
+// IsExpired reports whether the proof is expired at the provided time.
+func (p *PasskeyRegistrationProof) IsExpired(now time.Time) bool {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	return !now.Before(p.ExpiresAt)
+}

--- a/pkg/storage/models/passkey_registration_proof_test.go
+++ b/pkg/storage/models/passkey_registration_proof_test.go
@@ -1,0 +1,158 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPasskeyRegistrationProof_BeforeCreateSetsKeysTTLAndDefaults(t *testing.T) {
+	t.Parallel()
+
+	proof := &PasskeyRegistrationProof{
+		ID:           "proof-1",
+		Username:     "alice",
+		CeremonyID:   "ceremony-1",
+		CredentialID: "cred-1",
+		PublicKey:    []byte("pk"),
+	}
+
+	before := time.Now().UTC()
+	require.NoError(t, proof.BeforeCreate())
+
+	require.Equal(t, "PASSKEY_REGISTRATION_PROOF#proof-1", proof.PK)
+	require.Equal(t, SKPasskeyRegistrationProof, proof.SK)
+	require.False(t, proof.CreatedAt.Before(before))
+	require.True(t, proof.ExpiresAt.After(proof.CreatedAt))
+	require.Equal(t, proof.ExpiresAt.Unix(), proof.TTL)
+	require.WithinDuration(t, proof.CreatedAt.Add(DefaultPasskeyRegistrationProofTTL), proof.ExpiresAt, 2*time.Second)
+}
+
+func TestPasskeyRegistrationProof_ValidateRejectsMissingRequiredFields(t *testing.T) {
+	t.Parallel()
+
+	proof := &PasskeyRegistrationProof{}
+	require.Error(t, proof.BeforeCreate())
+
+	proof = &PasskeyRegistrationProof{
+		ID:           "proof-1",
+		Username:     "alice",
+		CeremonyID:   "ceremony-1",
+		CredentialID: "cred-1",
+		PublicKey:    []byte("pk"),
+		CreatedAt:    time.Now().UTC(),
+		ExpiresAt:    time.Now().UTC().Add(-1 * time.Minute),
+	}
+	require.Error(t, proof.Validate())
+}
+
+func TestPasskeyRegistrationProof_TableName(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, MainTableName, PasskeyRegistrationProof{}.TableName())
+}
+
+func TestPasskeyRegistrationProof_BeforeUpdateTrimsKeysAndAccessors(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Now().UTC()
+	expiresAt := createdAt.Add(5 * time.Minute)
+	proof := &PasskeyRegistrationProof{
+		ID:           "  proof-2  ",
+		Username:     "  alice  ",
+		CeremonyID:   "  ceremony-2  ",
+		CredentialID: "  cred-2  ",
+		PublicKey:    []byte("pk"),
+		CreatedAt:    createdAt,
+		ExpiresAt:    expiresAt,
+	}
+
+	require.NoError(t, proof.BeforeUpdate())
+	require.Equal(t, "proof-2", proof.ID)
+	require.Equal(t, "alice", proof.Username)
+	require.Equal(t, "ceremony-2", proof.CeremonyID)
+	require.Equal(t, "cred-2", proof.CredentialID)
+	require.Equal(t, "PASSKEY_REGISTRATION_PROOF#proof-2", proof.GetPK())
+	require.Equal(t, SKPasskeyRegistrationProof, proof.GetSK())
+	require.Equal(t, expiresAt.Unix(), proof.TTL)
+}
+
+func TestPasskeyRegistrationProof_IsExpired(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	proof := &PasskeyRegistrationProof{
+		ExpiresAt: now.Add(1 * time.Minute),
+	}
+	require.False(t, proof.IsExpired(now))
+
+	expired := &PasskeyRegistrationProof{
+		ExpiresAt: now.Add(-1 * time.Minute),
+	}
+	require.True(t, expired.IsExpired(time.Time{}))
+}
+
+func TestPasskeyRegistrationProof_ValidateMissingFields(t *testing.T) {
+	t.Parallel()
+
+	base := PasskeyRegistrationProof{
+		ID:           "proof-3",
+		Username:     "alice",
+		CeremonyID:   "ceremony-3",
+		CredentialID: "cred-3",
+		PublicKey:    []byte("pk"),
+		CreatedAt:    time.Now().UTC(),
+		ExpiresAt:    time.Now().UTC().Add(5 * time.Minute),
+	}
+
+	testCases := []struct {
+		name   string
+		mutate func(*PasskeyRegistrationProof)
+	}{
+		{
+			name: "missing username",
+			mutate: func(proof *PasskeyRegistrationProof) {
+				proof.Username = ""
+			},
+		},
+		{
+			name: "missing ceremony",
+			mutate: func(proof *PasskeyRegistrationProof) {
+				proof.CeremonyID = ""
+			},
+		},
+		{
+			name: "missing credential",
+			mutate: func(proof *PasskeyRegistrationProof) {
+				proof.CredentialID = ""
+			},
+		},
+		{
+			name: "missing public key",
+			mutate: func(proof *PasskeyRegistrationProof) {
+				proof.PublicKey = nil
+			},
+		},
+		{
+			name: "missing created at",
+			mutate: func(proof *PasskeyRegistrationProof) {
+				proof.CreatedAt = time.Time{}
+			},
+		},
+		{
+			name: "missing expires at",
+			mutate: func(proof *PasskeyRegistrationProof) {
+				proof.ExpiresAt = time.Time{}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			proof := base
+			tc.mutate(&proof)
+			require.Error(t, proof.Validate())
+		})
+	}
+}

--- a/pkg/storage/repositories/account_repository_auth.go
+++ b/pkg/storage/repositories/account_repository_auth.go
@@ -23,6 +23,8 @@ import (
 
 var accountAuthRandRead = rand.Read
 
+const entityPasskeyRegistrationProof = "passkey registration proof"
+
 // ValidatePassword validates a user's password and tracks login attempts
 func (r *AccountRepository) ValidatePassword(ctx context.Context, username, password string) (*storage.User, error) {
 	// Get user first
@@ -1116,6 +1118,142 @@ func (r *AccountRepository) DeleteRecoveryToken(ctx context.Context, key string)
 }
 
 // ===== WebAuthn Methods =====
+
+// StorePasskeyRegistrationProof stores a short-lived single-use passkey signup proof.
+func (r *AccountRepository) StorePasskeyRegistrationProof(ctx context.Context, proof *models.PasskeyRegistrationProof) error {
+	if proof == nil {
+		return ErrorHandler.HandleCreateError(ErrWebAuthnValidationFailed, entityPasskeyRegistrationProof, "nil")
+	}
+
+	err := createPreparedModel(
+		ctx,
+		r.db,
+		r.logger,
+		proof,
+		"failed to prepare passkey registration proof",
+		"failed to store passkey registration proof",
+		func(model *models.PasskeyRegistrationProof) []zap.Field {
+			return []zap.Field{
+				zap.String("proof_id", model.ID),
+				zap.String("username", model.Username),
+				zap.String("ceremony_id", model.CeremonyID),
+			}
+		},
+	)
+	if err != nil {
+		return ErrorHandler.HandleCreateError(err, entityPasskeyRegistrationProof, proof.ID)
+	}
+
+	r.logger.Debug("stored passkey registration proof",
+		zap.String("proof_id", proof.ID),
+		zap.String("username", proof.Username),
+		zap.String("ceremony_id", proof.CeremonyID))
+
+	return nil
+}
+
+// GetPasskeyRegistrationProof retrieves a stored passkey signup proof by ID.
+func (r *AccountRepository) GetPasskeyRegistrationProof(ctx context.Context, proofID string) (*models.PasskeyRegistrationProof, error) {
+	if err := common.ValidateRequiredParam("proofID", proofID); err != nil {
+		return nil, ErrorHandler.HandleGetError(ErrWebAuthnValidationFailed, entityPasskeyRegistrationProof, "empty")
+	}
+
+	var proof models.PasskeyRegistrationProof
+	err := r.db.WithContext(ctx).Model(&proof).
+		Where("PK", "=", fmt.Sprintf(models.KeyPatternPasskeyRegistrationProof, proofID)).
+		Where("SK", "=", models.SKPasskeyRegistrationProof).
+		First(&proof)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, ErrorHandler.HandleNotFound(err, entityPasskeyRegistrationProof, proofID)
+		}
+		r.logger.Error("failed to get passkey registration proof",
+			zap.String("proof_id", proofID),
+			zap.Error(err))
+		return nil, ErrorHandler.HandleGetError(err, entityPasskeyRegistrationProof, proofID)
+	}
+
+	if proof.IsExpired(time.Now().UTC()) {
+		if delErr := r.DeletePasskeyRegistrationProof(ctx, proofID); delErr != nil {
+			r.logger.Warn("failed to delete expired passkey registration proof",
+				zap.String("proof_id", proofID),
+				zap.Error(delErr))
+		}
+		return nil, ErrorHandler.HandleNotFound(storage.ErrNotFound, entityPasskeyRegistrationProof, proofID)
+	}
+
+	return &proof, nil
+}
+
+// DeletePasskeyRegistrationProof removes a stored passkey signup proof.
+func (r *AccountRepository) DeletePasskeyRegistrationProof(ctx context.Context, proofID string) error {
+	err := r.db.WithContext(ctx).Model(&models.PasskeyRegistrationProof{}).
+		Where("PK", "=", fmt.Sprintf(models.KeyPatternPasskeyRegistrationProof, proofID)).
+		Where("SK", "=", models.SKPasskeyRegistrationProof).
+		Delete()
+	if err != nil && !errors.IsNotFound(err) {
+		r.logger.Error("failed to delete passkey registration proof",
+			zap.String("proof_id", proofID),
+			zap.Error(err))
+		return ErrorHandler.HandleDeleteError(err, entityPasskeyRegistrationProof, proofID)
+	}
+
+	return nil
+}
+
+// ConsumePasskeyRegistrationProof atomically flips the proof into its consumed state.
+func (r *AccountRepository) ConsumePasskeyRegistrationProof(ctx context.Context, proofID, username, ceremonyID string) (*models.PasskeyRegistrationProof, error) {
+	if err := common.ValidateRequiredParam("proofID", proofID); err != nil {
+		return nil, ErrorHandler.HandleUpdateError(ErrWebAuthnValidationFailed, entityPasskeyRegistrationProof, "proof_id")
+	}
+	if err := common.ValidateRequiredParam("username", username); err != nil {
+		return nil, ErrorHandler.HandleUpdateError(ErrWebAuthnValidationFailed, entityPasskeyRegistrationProof, "username")
+	}
+	if err := common.ValidateRequiredParam("ceremonyID", ceremonyID); err != nil {
+		return nil, ErrorHandler.HandleUpdateError(ErrWebAuthnValidationFailed, entityPasskeyRegistrationProof, "ceremony_id")
+	}
+
+	proof, err := r.GetPasskeyRegistrationProof(ctx, proofID)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	update, err := keyedUpdateBuilder(ctx, r.db, &models.PasskeyRegistrationProof{ID: proofID})
+	if err != nil {
+		r.logger.Error("failed to build passkey registration proof consume update",
+			zap.String("proof_id", proofID),
+			zap.Error(err))
+		return nil, ErrorHandler.HandleUpdateError(err, entityPasskeyRegistrationProof, proofID)
+	}
+
+	err = update.
+		Set("Consumed", true).
+		Set("ConsumedAt", now).
+		Condition("Consumed", "=", false).
+		Condition("TTL", ">", now.Unix()).
+		Condition("Username", "=", strings.TrimSpace(username)).
+		Condition("CeremonyID", "=", strings.TrimSpace(ceremonyID)).
+		Execute()
+	if err != nil {
+		r.logger.Warn("failed to consume passkey registration proof",
+			zap.String("proof_id", proofID),
+			zap.String("username", username),
+			zap.String("ceremony_id", ceremonyID),
+			zap.Error(err))
+		return nil, ErrorHandler.HandleUpdateError(err, entityPasskeyRegistrationProof, proofID)
+	}
+
+	proof.Consumed = true
+	proof.ConsumedAt = now
+
+	r.logger.Debug("consumed passkey registration proof",
+		zap.String("proof_id", proofID),
+		zap.String("username", username),
+		zap.String("ceremony_id", ceremonyID))
+
+	return proof, nil
+}
 
 // StoreWebAuthnChallenge stores a WebAuthn challenge
 func (r *AccountRepository) StoreWebAuthnChallenge(ctx context.Context, challenge *storage.WebAuthnChallenge) error {

--- a/pkg/storage/repositories/account_repository_auth.go
+++ b/pkg/storage/repositories/account_repository_auth.go
@@ -1169,48 +1169,7 @@ func (r *AccountRepository) StoreWebAuthnCredential(ctx context.Context, credent
 		return ErrorHandler.HandleCreateError(ErrWebAuthnValidationFailed, EntityWebAuthnCredential, "nil")
 	}
 
-	// Convert storage.WebAuthnCredential to models.WebAuthnCredential
-	modelCredential := &models.WebAuthnCredential{
-		ID:              credential.ID,
-		UserID:          credential.UserID,
-		PublicKey:       credential.PublicKey,
-		AttestationType: credential.AttestationType,
-		AAGUID:          credential.AAGUID,
-		SignCount:       credential.SignCount,
-		CloneWarning:    credential.CloneWarning,
-		BackupEligible:  credential.BackupEligible,
-		BackupState:     credential.BackupState,
-		CreatedAt:       credential.CreatedAt,
-		LastUsedAt:      credential.LastUsedAt,
-		Name:            credential.Name,
-	}
-
-	// Use LastUsed if LastUsedAt is zero
-	if modelCredential.LastUsedAt.IsZero() && !credential.LastUsed.IsZero() {
-		modelCredential.LastUsedAt = credential.LastUsed
-	}
-
-	// Call BeforeCreate to set keys
-	err := modelCredential.BeforeCreate()
-	if err != nil {
-		return ErrorHandler.HandleCreateError(err, EntityWebAuthnCredential, credential.ID)
-	}
-
-	// Store in DynamoDB
-	err = r.db.WithContext(ctx).Model(modelCredential).Create()
-	if err != nil {
-		r.logger.Error("failed to store WebAuthn credential",
-			zap.String("credentialID", credential.ID),
-			zap.String("userID", credential.UserID),
-			zap.Error(err))
-		return ErrorHandler.HandleCreateError(err, EntityWebAuthnCredential, credential.ID)
-	}
-
-	r.logger.Debug("WebAuthn credential stored successfully",
-		zap.String("credentialID", credential.ID),
-		zap.String("userID", credential.UserID))
-
-	return nil
+	return r.CreateWebAuthnCredential(ctx, credential)
 }
 
 // UpdateWebAuthnCredential updates a WebAuthn credential
@@ -1219,45 +1178,7 @@ func (r *AccountRepository) UpdateWebAuthnCredential(ctx context.Context, creden
 		return ErrorHandler.HandleUpdateError(ErrWebAuthnValidationFailed, EntityWebAuthnCredential, "empty")
 	}
 
-	var credential models.WebAuthnCredential
-
-	query := r.db.WithContext(ctx).Model(&models.WebAuthnCredential{}).
-		Index("gsi1").
-		Where("gsi1PK", "=", "WEBAUTHN_CREDENTIAL#"+credentialID).
-		Limit(1)
-
-	err := query.First(&credential)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return ErrorHandler.HandleGetError(ErrWebAuthnCredentialNotFound, EntityWebAuthnCredential, credentialID)
-		}
-		r.logger.Error("failed to find WebAuthn credential for update",
-			zap.String("credentialID", credentialID),
-			zap.Error(err))
-		return ErrorHandler.HandleQueryError(err, EntityWebAuthnCredential, credentialID)
-	}
-
-	credential.SignCount = signCount
-	credential.LastUsedAt = time.Now()
-
-	if err := credential.BeforeUpdate(); err != nil {
-		return ErrorHandler.HandleUpdateError(err, EntityWebAuthnCredential, credentialID)
-	}
-
-	err = r.db.WithContext(ctx).Model(&credential).Update()
-	if err != nil {
-		r.logger.Error("failed to update WebAuthn credential",
-			zap.String("credentialID", credentialID),
-			zap.Uint32("signCount", signCount),
-			zap.Error(err))
-		return ErrorHandler.HandleUpdateError(err, EntityWebAuthnCredential, credentialID)
-	}
-
-	r.logger.Debug("WebAuthn credential updated successfully",
-		zap.String("credentialID", credentialID),
-		zap.Uint32("signCount", signCount))
-
-	return nil
+	return r.UpdateWebAuthnLastUsed(ctx, credentialID, signCount)
 }
 
 // UpdateWalletLastUsed updates when a wallet was last used

--- a/pkg/storage/repositories/account_repository_auth_passkey_registration_proof_test.go
+++ b/pkg/storage/repositories/account_repository_auth_passkey_registration_proof_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/require"
 	"github.com/theory-cloud/tabletheory/v3/pkg/core"
@@ -277,11 +278,12 @@ func TestAccountRepository_GetPasskeyRegistrationProof_QueryError(t *testing.T) 
 	}
 
 	require.NoError(t, repo.StorePasskeyRegistrationProof(context.Background(), proof))
-	db.state.lookupErr = stdErrors.New("lookup failed")
+	lookupErr := stdErrors.New("lookup failed")
+	db.state.lookupErr = lookupErr
 
 	got, err := repo.GetPasskeyRegistrationProof(context.Background(), proof.ID)
 	require.Nil(t, got)
-	require.Error(t, err)
+	require.ErrorIs(t, err, lookupErr)
 }
 
 func TestAccountRepository_DeletePasskeyRegistrationProof_DeleteError(t *testing.T) {
@@ -327,7 +329,7 @@ func TestAccountRepository_GetPasskeyRegistrationProof_ExpiredDeleteFailureStill
 
 	got, err := repo.GetPasskeyRegistrationProof(context.Background(), proof.ID)
 	require.Nil(t, got)
-	require.Error(t, err)
+	require.ErrorIs(t, err, storage.ErrNotFound)
 
 	db.state.mu.Lock()
 	defer db.state.mu.Unlock()

--- a/pkg/storage/repositories/account_repository_auth_passkey_registration_proof_test.go
+++ b/pkg/storage/repositories/account_repository_auth_passkey_registration_proof_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	apperrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/require"
@@ -283,6 +284,10 @@ func TestAccountRepository_GetPasskeyRegistrationProof_QueryError(t *testing.T) 
 
 	got, err := repo.GetPasskeyRegistrationProof(context.Background(), proof.ID)
 	require.Nil(t, got)
+	var appErr *apperrors.AppError
+	require.ErrorAs(t, err, &appErr)
+	require.Equal(t, apperrors.CodeInternal, appErr.Code)
+	require.Equal(t, apperrors.CategoryStorage, appErr.Category)
 	require.ErrorIs(t, err, lookupErr)
 }
 

--- a/pkg/storage/repositories/account_repository_auth_passkey_registration_proof_test.go
+++ b/pkg/storage/repositories/account_repository_auth_passkey_registration_proof_test.go
@@ -261,6 +261,80 @@ func TestAccountRepository_ConsumePasskeyRegistrationProof_MissingProof(t *testi
 	require.Error(t, err)
 }
 
+func TestAccountRepository_GetPasskeyRegistrationProof_QueryError(t *testing.T) {
+	t.Parallel()
+
+	db := newPasskeyRegistrationProofDB()
+	repo := NewAccountRepository(db, "test-table", "example.com", zap.NewNop())
+
+	proof := &models.PasskeyRegistrationProof{
+		ID:           "proof-query-error",
+		Username:     "alice",
+		CeremonyID:   "ceremony-query-error",
+		CredentialID: "cred-query-error",
+		PublicKey:    []byte("pk"),
+		ExpiresAt:    time.Now().Add(5 * time.Minute).UTC(),
+	}
+
+	require.NoError(t, repo.StorePasskeyRegistrationProof(context.Background(), proof))
+	db.state.lookupErr = stdErrors.New("lookup failed")
+
+	got, err := repo.GetPasskeyRegistrationProof(context.Background(), proof.ID)
+	require.Nil(t, got)
+	require.Error(t, err)
+}
+
+func TestAccountRepository_DeletePasskeyRegistrationProof_DeleteError(t *testing.T) {
+	t.Parallel()
+
+	db := newPasskeyRegistrationProofDB()
+	repo := NewAccountRepository(db, "test-table", "example.com", zap.NewNop())
+
+	proof := &models.PasskeyRegistrationProof{
+		ID:           "proof-delete-error",
+		Username:     "alice",
+		CeremonyID:   "ceremony-delete-error",
+		CredentialID: "cred-delete-error",
+		PublicKey:    []byte("pk"),
+		ExpiresAt:    time.Now().Add(5 * time.Minute).UTC(),
+	}
+
+	require.NoError(t, repo.StorePasskeyRegistrationProof(context.Background(), proof))
+	db.state.deleteErr = stdErrors.New("delete failed")
+
+	require.Error(t, repo.DeletePasskeyRegistrationProof(context.Background(), proof.ID))
+}
+
+func TestAccountRepository_GetPasskeyRegistrationProof_ExpiredDeleteFailureStillReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	db := newPasskeyRegistrationProofDB()
+	repo := NewAccountRepository(db, "test-table", "example.com", zap.NewNop())
+
+	now := time.Now().UTC()
+	proof := &models.PasskeyRegistrationProof{
+		ID:           "expired-proof-delete-error",
+		Username:     "alice",
+		CeremonyID:   "ceremony-expired-delete-error",
+		CredentialID: "cred-expired-delete-error",
+		PublicKey:    []byte("pk"),
+		CreatedAt:    now.Add(-15 * time.Minute),
+		ExpiresAt:    now.Add(-5 * time.Minute),
+	}
+
+	require.NoError(t, repo.StorePasskeyRegistrationProof(context.Background(), proof))
+	db.state.deleteErr = stdErrors.New("delete failed")
+
+	got, err := repo.GetPasskeyRegistrationProof(context.Background(), proof.ID)
+	require.Nil(t, got)
+	require.Error(t, err)
+
+	db.state.mu.Lock()
+	defer db.state.mu.Unlock()
+	_, exists := db.state.proofs[proof.ID]
+	require.True(t, exists)
+}
+
 type passkeyRegistrationProofDB struct {
 	state *passkeyRegistrationProofState
 }
@@ -268,6 +342,9 @@ type passkeyRegistrationProofDB struct {
 type passkeyRegistrationProofState struct {
 	mu     sync.Mutex
 	proofs map[string]*models.PasskeyRegistrationProof
+
+	lookupErr error
+	deleteErr error
 }
 
 func newPasskeyRegistrationProofDB() *passkeyRegistrationProofDB {
@@ -408,6 +485,10 @@ func (q *passkeyRegistrationProofQuery) Delete() error {
 	q.state.mu.Lock()
 	defer q.state.mu.Unlock()
 
+	if q.state.deleteErr != nil {
+		return q.state.deleteErr
+	}
+
 	if _, exists := q.state.proofs[proofID]; !exists {
 		return dynamormerrors.ErrItemNotFound
 	}
@@ -424,6 +505,10 @@ func (q *passkeyRegistrationProofQuery) lookup() (*models.PasskeyRegistrationPro
 
 	q.state.mu.Lock()
 	defer q.state.mu.Unlock()
+
+	if q.state.lookupErr != nil {
+		return nil, q.state.lookupErr
+	}
 
 	proof, exists := q.state.proofs[proofID]
 	if !exists {

--- a/pkg/storage/repositories/account_repository_auth_passkey_registration_proof_test.go
+++ b/pkg/storage/repositories/account_repository_auth_passkey_registration_proof_test.go
@@ -1,0 +1,594 @@
+package repositories
+
+import (
+	"context"
+	stdErrors "errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/require"
+	"github.com/theory-cloud/tabletheory/v3/pkg/core"
+	dynamormerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
+	"go.uber.org/zap"
+)
+
+func TestAccountRepository_PasskeyRegistrationProofLifecycle(t *testing.T) {
+	t.Parallel()
+
+	db := newPasskeyRegistrationProofDB()
+	repo := NewAccountRepository(db, "test-table", "example.com", zap.NewNop())
+
+	ctx := context.Background()
+	proof := &models.PasskeyRegistrationProof{
+		ID:              "proof-1",
+		Username:        "alice",
+		CeremonyID:      "ceremony-1",
+		CredentialID:    "cred-1",
+		PublicKey:       []byte("pk"),
+		AttestationType: "none",
+		AAGUID:          []byte{0x01},
+		ExpiresAt:       time.Now().Add(5 * time.Minute).UTC(),
+	}
+
+	require.NoError(t, repo.StorePasskeyRegistrationProof(ctx, proof))
+
+	got, err := repo.GetPasskeyRegistrationProof(ctx, proof.ID)
+	require.NoError(t, err)
+	require.Equal(t, proof.ID, got.ID)
+	require.Equal(t, proof.Username, got.Username)
+	require.Equal(t, proof.CeremonyID, got.CeremonyID)
+	require.Equal(t, proof.CredentialID, got.CredentialID)
+	require.False(t, got.Consumed)
+
+	consumed, err := repo.ConsumePasskeyRegistrationProof(ctx, proof.ID, proof.Username, proof.CeremonyID)
+	require.NoError(t, err)
+	require.True(t, consumed.Consumed)
+	require.False(t, consumed.ConsumedAt.IsZero())
+
+	got, err = repo.GetPasskeyRegistrationProof(ctx, proof.ID)
+	require.NoError(t, err)
+	require.True(t, got.Consumed)
+	require.False(t, got.ConsumedAt.IsZero())
+}
+
+func TestAccountRepository_ConsumePasskeyRegistrationProof_ExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	db := newPasskeyRegistrationProofDB()
+	repo := NewAccountRepository(db, "test-table", "example.com", zap.NewNop())
+
+	ctx := context.Background()
+	proof := &models.PasskeyRegistrationProof{
+		ID:           "proof-2",
+		Username:     "alice",
+		CeremonyID:   "ceremony-2",
+		CredentialID: "cred-2",
+		PublicKey:    []byte("pk"),
+		ExpiresAt:    time.Now().Add(5 * time.Minute).UTC(),
+	}
+
+	require.NoError(t, repo.StorePasskeyRegistrationProof(ctx, proof))
+
+	results := make(chan error, 2)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := repo.ConsumePasskeyRegistrationProof(ctx, proof.ID, proof.Username, proof.CeremonyID)
+			results <- err
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+
+	successes := 0
+	failures := 0
+	for err := range results {
+		if err == nil {
+			successes++
+			continue
+		}
+		failures++
+	}
+
+	require.Equal(t, 1, successes)
+	require.Equal(t, 1, failures)
+
+	stored, err := repo.GetPasskeyRegistrationProof(ctx, proof.ID)
+	require.NoError(t, err)
+	require.True(t, stored.Consumed)
+	require.False(t, stored.ConsumedAt.IsZero())
+}
+
+func TestAccountRepository_StorePasskeyRegistrationProof_RejectsNil(t *testing.T) {
+	t.Parallel()
+
+	db := newPasskeyRegistrationProofDB()
+	repo := NewAccountRepository(db, "test-table", "example.com", zap.NewNop())
+
+	err := repo.StorePasskeyRegistrationProof(context.Background(), nil)
+	require.Error(t, err)
+}
+
+func TestAccountRepository_GetPasskeyRegistrationProof_ExpiredDeletesAndReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	db := newPasskeyRegistrationProofDB()
+	repo := NewAccountRepository(db, "test-table", "example.com", zap.NewNop())
+
+	now := time.Now().UTC()
+	proof := &models.PasskeyRegistrationProof{
+		ID:           "expired-proof",
+		Username:     "alice",
+		CeremonyID:   "ceremony-expired",
+		CredentialID: "cred-expired",
+		PublicKey:    []byte("pk"),
+		CreatedAt:    now.Add(-15 * time.Minute),
+		ExpiresAt:    now.Add(-5 * time.Minute),
+	}
+
+	require.NoError(t, repo.StorePasskeyRegistrationProof(context.Background(), proof))
+
+	got, err := repo.GetPasskeyRegistrationProof(context.Background(), proof.ID)
+	require.Nil(t, got)
+	require.Error(t, err)
+
+	db.state.mu.Lock()
+	defer db.state.mu.Unlock()
+	_, exists := db.state.proofs[proof.ID]
+	require.False(t, exists)
+}
+
+func TestAccountRepository_DeletePasskeyRegistrationProof_IsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	db := newPasskeyRegistrationProofDB()
+	repo := NewAccountRepository(db, "test-table", "example.com", zap.NewNop())
+
+	proof := &models.PasskeyRegistrationProof{
+		ID:           "proof-delete",
+		Username:     "alice",
+		CeremonyID:   "ceremony-delete",
+		CredentialID: "cred-delete",
+		PublicKey:    []byte("pk"),
+		ExpiresAt:    time.Now().Add(5 * time.Minute).UTC(),
+	}
+
+	require.NoError(t, repo.StorePasskeyRegistrationProof(context.Background(), proof))
+	require.NoError(t, repo.DeletePasskeyRegistrationProof(context.Background(), proof.ID))
+	require.NoError(t, repo.DeletePasskeyRegistrationProof(context.Background(), proof.ID))
+}
+
+func TestAccountRepository_GetPasskeyRegistrationProof_MissingAndInvalidID(t *testing.T) {
+	t.Parallel()
+
+	db := newPasskeyRegistrationProofDB()
+	repo := NewAccountRepository(db, "test-table", "example.com", zap.NewNop())
+
+	got, err := repo.GetPasskeyRegistrationProof(context.Background(), "")
+	require.Nil(t, got)
+	require.Error(t, err)
+
+	got, err = repo.GetPasskeyRegistrationProof(context.Background(), "missing-proof")
+	require.Nil(t, got)
+	require.Error(t, err)
+}
+
+func TestAccountRepository_StorePasskeyRegistrationProof_RejectsDuplicateID(t *testing.T) {
+	t.Parallel()
+
+	db := newPasskeyRegistrationProofDB()
+	repo := NewAccountRepository(db, "test-table", "example.com", zap.NewNop())
+	ctx := context.Background()
+
+	proof := &models.PasskeyRegistrationProof{
+		ID:           "proof-duplicate",
+		Username:     "alice",
+		CeremonyID:   "ceremony-duplicate",
+		CredentialID: "cred-duplicate",
+		PublicKey:    []byte("pk"),
+		ExpiresAt:    time.Now().Add(5 * time.Minute).UTC(),
+	}
+
+	require.NoError(t, repo.StorePasskeyRegistrationProof(ctx, proof))
+	require.Error(t, repo.StorePasskeyRegistrationProof(ctx, proof))
+}
+
+func TestAccountRepository_ConsumePasskeyRegistrationProof_RejectsMismatchedBinding(t *testing.T) {
+	t.Parallel()
+
+	db := newPasskeyRegistrationProofDB()
+	repo := NewAccountRepository(db, "test-table", "example.com", zap.NewNop())
+
+	proof := &models.PasskeyRegistrationProof{
+		ID:           "proof-bound",
+		Username:     "alice",
+		CeremonyID:   "ceremony-bound",
+		CredentialID: "cred-bound",
+		PublicKey:    []byte("pk"),
+		ExpiresAt:    time.Now().Add(5 * time.Minute).UTC(),
+	}
+
+	require.NoError(t, repo.StorePasskeyRegistrationProof(context.Background(), proof))
+
+	consumed, err := repo.ConsumePasskeyRegistrationProof(context.Background(), proof.ID, "mallory", proof.CeremonyID)
+	require.Nil(t, consumed)
+	require.Error(t, err)
+
+	stored, getErr := repo.GetPasskeyRegistrationProof(context.Background(), proof.ID)
+	require.NoError(t, getErr)
+	require.False(t, stored.Consumed)
+	require.True(t, stored.ConsumedAt.IsZero())
+}
+
+func TestAccountRepository_ConsumePasskeyRegistrationProof_ValidatesRequiredParams(t *testing.T) {
+	t.Parallel()
+
+	db := newPasskeyRegistrationProofDB()
+	repo := NewAccountRepository(db, "test-table", "example.com", zap.NewNop())
+	ctx := context.Background()
+
+	proof, err := repo.ConsumePasskeyRegistrationProof(ctx, "", "alice", "ceremony")
+	require.Nil(t, proof)
+	require.Error(t, err)
+
+	proof, err = repo.ConsumePasskeyRegistrationProof(ctx, "proof", "", "ceremony")
+	require.Nil(t, proof)
+	require.Error(t, err)
+
+	proof, err = repo.ConsumePasskeyRegistrationProof(ctx, "proof", "alice", "")
+	require.Nil(t, proof)
+	require.Error(t, err)
+}
+
+func TestAccountRepository_ConsumePasskeyRegistrationProof_MissingProof(t *testing.T) {
+	t.Parallel()
+
+	db := newPasskeyRegistrationProofDB()
+	repo := NewAccountRepository(db, "test-table", "example.com", zap.NewNop())
+
+	proof, err := repo.ConsumePasskeyRegistrationProof(context.Background(), "missing-proof", "alice", "ceremony")
+	require.Nil(t, proof)
+	require.Error(t, err)
+}
+
+type passkeyRegistrationProofDB struct {
+	state *passkeyRegistrationProofState
+}
+
+type passkeyRegistrationProofState struct {
+	mu     sync.Mutex
+	proofs map[string]*models.PasskeyRegistrationProof
+}
+
+func newPasskeyRegistrationProofDB() *passkeyRegistrationProofDB {
+	return &passkeyRegistrationProofDB{
+		state: &passkeyRegistrationProofState{
+			proofs: make(map[string]*models.PasskeyRegistrationProof),
+		},
+	}
+}
+
+func (db *passkeyRegistrationProofDB) Model(model any) core.Query {
+	return &passkeyRegistrationProofQuery{
+		state:  db.state,
+		model:  model,
+		wheres: make(map[string]any),
+	}
+}
+
+func (db *passkeyRegistrationProofDB) Migrate() error { return nil }
+
+func (db *passkeyRegistrationProofDB) AutoMigrate(...any) error { return nil }
+
+func (db *passkeyRegistrationProofDB) Close() error { return nil }
+
+func (db *passkeyRegistrationProofDB) WithContext(context.Context) core.DB { return db }
+
+type passkeyRegistrationProofQuery struct {
+	state       *passkeyRegistrationProofState
+	model       any
+	wheres      map[string]any
+	ifNotExists bool
+}
+
+func (q *passkeyRegistrationProofQuery) Where(field, _ string, value any) core.Query {
+	q.wheres[field] = value
+	return q
+}
+
+func (q *passkeyRegistrationProofQuery) Index(string) core.Query                   { return q }
+func (q *passkeyRegistrationProofQuery) Filter(string, string, any) core.Query     { return q }
+func (q *passkeyRegistrationProofQuery) OrFilter(string, string, any) core.Query   { return q }
+func (q *passkeyRegistrationProofQuery) FilterGroup(func(core.Query)) core.Query   { return q }
+func (q *passkeyRegistrationProofQuery) OrFilterGroup(func(core.Query)) core.Query { return q }
+func (q *passkeyRegistrationProofQuery) IfNotExists() core.Query                   { q.ifNotExists = true; return q }
+func (q *passkeyRegistrationProofQuery) IfExists() core.Query                      { return q }
+func (q *passkeyRegistrationProofQuery) WithCondition(string, string, any) core.Query {
+	return q
+}
+func (q *passkeyRegistrationProofQuery) WithConditionExpression(string, map[string]any) core.Query {
+	return q
+}
+func (q *passkeyRegistrationProofQuery) OrderBy(string, string) core.Query       { return q }
+func (q *passkeyRegistrationProofQuery) Limit(int) core.Query                    { return q }
+func (q *passkeyRegistrationProofQuery) Offset(int) core.Query                   { return q }
+func (q *passkeyRegistrationProofQuery) Select(...string) core.Query             { return q }
+func (q *passkeyRegistrationProofQuery) ConsistentRead() core.Query              { return q }
+func (q *passkeyRegistrationProofQuery) WithRetry(int, time.Duration) core.Query { return q }
+func (q *passkeyRegistrationProofQuery) All(any) error                           { return stdErrors.New("unsupported") }
+func (q *passkeyRegistrationProofQuery) AllPaginated(any) (*core.PaginatedResult, error) {
+	return nil, stdErrors.New("unsupported")
+}
+func (q *passkeyRegistrationProofQuery) Count() (int64, error) {
+	return 0, stdErrors.New("unsupported")
+}
+func (q *passkeyRegistrationProofQuery) CreateOrUpdate() error                { return stdErrors.New("unsupported") }
+func (q *passkeyRegistrationProofQuery) Update(...string) error               { return stdErrors.New("unsupported") }
+func (q *passkeyRegistrationProofQuery) Scan(any) error                       { return stdErrors.New("unsupported") }
+func (q *passkeyRegistrationProofQuery) ParallelScan(int32, int32) core.Query { return q }
+func (q *passkeyRegistrationProofQuery) ScanAllSegments(any, int32) error {
+	return stdErrors.New("unsupported")
+}
+func (q *passkeyRegistrationProofQuery) BatchGet([]any, any) error {
+	return stdErrors.New("unsupported")
+}
+func (q *passkeyRegistrationProofQuery) BatchGetWithOptions([]any, any, *core.BatchGetOptions) error {
+	return stdErrors.New("unsupported")
+}
+func (q *passkeyRegistrationProofQuery) BatchGetBuilder() core.BatchGetBuilder { return nil }
+func (q *passkeyRegistrationProofQuery) BatchCreate(any) error                 { return stdErrors.New("unsupported") }
+func (q *passkeyRegistrationProofQuery) BatchDelete([]any) error               { return stdErrors.New("unsupported") }
+func (q *passkeyRegistrationProofQuery) BatchWrite([]any, []any) error {
+	return stdErrors.New("unsupported")
+}
+func (q *passkeyRegistrationProofQuery) BatchUpdateWithOptions([]any, []string, ...any) error {
+	return stdErrors.New("unsupported")
+}
+func (q *passkeyRegistrationProofQuery) Cursor(string) core.Query               { return q }
+func (q *passkeyRegistrationProofQuery) SetCursor(string) error                 { return nil }
+func (q *passkeyRegistrationProofQuery) WithContext(context.Context) core.Query { return q }
+
+func (q *passkeyRegistrationProofQuery) First(dest any) error {
+	proof, err := q.lookup()
+	if err != nil {
+		return err
+	}
+
+	target, ok := dest.(*models.PasskeyRegistrationProof)
+	if !ok {
+		return stdErrors.New("unsupported destination")
+	}
+	*target = *proof
+	return nil
+}
+
+func (q *passkeyRegistrationProofQuery) Create() error {
+	proof, ok := q.model.(*models.PasskeyRegistrationProof)
+	if !ok {
+		return stdErrors.New("unsupported model")
+	}
+
+	q.state.mu.Lock()
+	defer q.state.mu.Unlock()
+
+	if q.ifNotExists {
+		if _, exists := q.state.proofs[proof.ID]; exists {
+			return fmt.Errorf("proof already exists")
+		}
+	}
+
+	q.state.proofs[proof.ID] = clonePasskeyRegistrationProof(proof)
+	return nil
+}
+
+func (q *passkeyRegistrationProofQuery) UpdateBuilder() core.UpdateBuilder {
+	return &passkeyRegistrationProofUpdateBuilder{
+		state:   q.state,
+		proofID: q.resolveProofID(),
+		sets:    make(map[string]any),
+	}
+}
+
+func (q *passkeyRegistrationProofQuery) Delete() error {
+	proofID := q.resolveProofID()
+	if proofID == "" {
+		return dynamormerrors.ErrItemNotFound
+	}
+
+	q.state.mu.Lock()
+	defer q.state.mu.Unlock()
+
+	if _, exists := q.state.proofs[proofID]; !exists {
+		return dynamormerrors.ErrItemNotFound
+	}
+
+	delete(q.state.proofs, proofID)
+	return nil
+}
+
+func (q *passkeyRegistrationProofQuery) lookup() (*models.PasskeyRegistrationProof, error) {
+	proofID := q.resolveProofID()
+	if proofID == "" {
+		return nil, dynamormerrors.ErrItemNotFound
+	}
+
+	q.state.mu.Lock()
+	defer q.state.mu.Unlock()
+
+	proof, exists := q.state.proofs[proofID]
+	if !exists {
+		return nil, dynamormerrors.ErrItemNotFound
+	}
+
+	return clonePasskeyRegistrationProof(proof), nil
+}
+
+func (q *passkeyRegistrationProofQuery) resolveProofID() string {
+	if pk, ok := q.wheres["PK"].(string); ok {
+		const prefix = "PASSKEY_REGISTRATION_PROOF#"
+		if len(pk) > len(prefix) && pk[:len(prefix)] == prefix {
+			return pk[len(prefix):]
+		}
+	}
+
+	if proof, ok := q.model.(*models.PasskeyRegistrationProof); ok {
+		return proof.ID
+	}
+
+	return ""
+}
+
+type passkeyRegistrationProofUpdateBuilder struct {
+	state      *passkeyRegistrationProofState
+	proofID    string
+	sets       map[string]any
+	conditions []passkeyRegistrationProofCondition
+}
+
+type passkeyRegistrationProofCondition struct {
+	field    string
+	operator string
+	value    any
+}
+
+func (b *passkeyRegistrationProofUpdateBuilder) Set(field string, value any) core.UpdateBuilder {
+	b.sets[field] = value
+	return b
+}
+
+func (b *passkeyRegistrationProofUpdateBuilder) SetIfNotExists(string, any, any) core.UpdateBuilder {
+	return b
+}
+func (b *passkeyRegistrationProofUpdateBuilder) Add(string, any) core.UpdateBuilder    { return b }
+func (b *passkeyRegistrationProofUpdateBuilder) Increment(string) core.UpdateBuilder   { return b }
+func (b *passkeyRegistrationProofUpdateBuilder) Decrement(string) core.UpdateBuilder   { return b }
+func (b *passkeyRegistrationProofUpdateBuilder) Remove(string) core.UpdateBuilder      { return b }
+func (b *passkeyRegistrationProofUpdateBuilder) Delete(string, any) core.UpdateBuilder { return b }
+func (b *passkeyRegistrationProofUpdateBuilder) AppendToList(string, any) core.UpdateBuilder {
+	return b
+}
+func (b *passkeyRegistrationProofUpdateBuilder) PrependToList(string, any) core.UpdateBuilder {
+	return b
+}
+func (b *passkeyRegistrationProofUpdateBuilder) RemoveFromListAt(string, int) core.UpdateBuilder {
+	return b
+}
+func (b *passkeyRegistrationProofUpdateBuilder) SetListElement(string, int, any) core.UpdateBuilder {
+	return b
+}
+
+func (b *passkeyRegistrationProofUpdateBuilder) Condition(field string, operator string, value any) core.UpdateBuilder {
+	b.conditions = append(b.conditions, passkeyRegistrationProofCondition{field: field, operator: operator, value: value})
+	return b
+}
+
+func (b *passkeyRegistrationProofUpdateBuilder) OrCondition(string, string, any) core.UpdateBuilder {
+	return b
+}
+func (b *passkeyRegistrationProofUpdateBuilder) ConditionExists(string) core.UpdateBuilder { return b }
+func (b *passkeyRegistrationProofUpdateBuilder) ConditionNotExists(string) core.UpdateBuilder {
+	return b
+}
+func (b *passkeyRegistrationProofUpdateBuilder) ConditionVersion(int64) core.UpdateBuilder { return b }
+func (b *passkeyRegistrationProofUpdateBuilder) ReturnValues(string) core.UpdateBuilder    { return b }
+
+func (b *passkeyRegistrationProofUpdateBuilder) Execute() error {
+	b.state.mu.Lock()
+	defer b.state.mu.Unlock()
+
+	proof, exists := b.state.proofs[b.proofID]
+	if !exists {
+		return dynamormerrors.ErrItemNotFound
+	}
+
+	for _, condition := range b.conditions {
+		if !passkeyRegistrationProofConditionMet(proof, condition) {
+			return fmt.Errorf("conditional check failed")
+		}
+	}
+
+	for field, value := range b.sets {
+		switch field {
+		case "Consumed":
+			proof.Consumed = value.(bool)
+		case "ConsumedAt":
+			proof.ConsumedAt = value.(time.Time)
+		}
+	}
+
+	b.state.proofs[b.proofID] = clonePasskeyRegistrationProof(proof)
+	return nil
+}
+
+func (b *passkeyRegistrationProofUpdateBuilder) ExecuteWithResult(any) error {
+	return b.Execute()
+}
+
+func passkeyRegistrationProofConditionMet(proof *models.PasskeyRegistrationProof, condition passkeyRegistrationProofCondition) bool {
+	switch condition.field {
+	case "Consumed":
+		expected, ok := condition.value.(bool)
+		return ok && compareBool(proof.Consumed, condition.operator, expected)
+	case "TTL":
+		expected, ok := condition.value.(int64)
+		return ok && compareInt64(proof.TTL, condition.operator, expected)
+	case "Username":
+		expected, ok := condition.value.(string)
+		return ok && compareString(proof.Username, condition.operator, expected)
+	case "CeremonyID":
+		expected, ok := condition.value.(string)
+		return ok && compareString(proof.CeremonyID, condition.operator, expected)
+	default:
+		return false
+	}
+}
+
+func compareBool(actual bool, operator string, expected bool) bool {
+	if operator != "=" {
+		return false
+	}
+	return actual == expected
+}
+
+func compareInt64(actual int64, operator string, expected int64) bool {
+	switch operator {
+	case "=":
+		return actual == expected
+	case ">":
+		return actual > expected
+	default:
+		return false
+	}
+}
+
+func compareString(actual string, operator string, expected string) bool {
+	if operator != "=" {
+		return false
+	}
+	return actual == expected
+}
+
+func clonePasskeyRegistrationProof(proof *models.PasskeyRegistrationProof) *models.PasskeyRegistrationProof {
+	if proof == nil {
+		return nil
+	}
+
+	clone := *proof
+	if proof.PublicKey != nil {
+		clone.PublicKey = append([]byte(nil), proof.PublicKey...)
+	}
+	if proof.AAGUID != nil {
+		clone.AAGUID = append([]byte(nil), proof.AAGUID...)
+	}
+	return &clone
+}

--- a/pkg/storage/repositories/account_repository_auth_round08_coverage_test.go
+++ b/pkg/storage/repositories/account_repository_auth_round08_coverage_test.go
@@ -374,7 +374,7 @@ func TestRound08_AccountRepositoryAuth_RecoveryAndWebAuthn(t *testing.T) {
 			UserID:       "user-1",
 			PublicKey:    []byte("pk"),
 			CreatedAt:    time.Time{},
-			LastUsed:     time.Now(),
+			LastUsedAt:   time.Now(),
 			CloneWarning: false,
 		}))
 

--- a/pkg/storage/repositories/account_repository_auth_round08_sweep_test.go
+++ b/pkg/storage/repositories/account_repository_auth_round08_sweep_test.go
@@ -134,7 +134,6 @@ func TestRound08_AccountRepositoryAuth_CoverageSweep(t *testing.T) {
 		PublicKey:  []byte("pk"),
 		CreatedAt:  baseTime,
 		LastUsedAt: baseTime,
-		LastUsed:   baseTime,
 	})
 	_ = repo.UpdateWebAuthnCredential(ctx, "cred-1", 1)
 

--- a/pkg/storage/repositories/account_repository_webauthn.go
+++ b/pkg/storage/repositories/account_repository_webauthn.go
@@ -3,18 +3,68 @@ package repositories
 import (
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/theory-cloud/tabletheory/v3/pkg/core"
 	dynamormerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
 	"go.uber.org/zap"
 )
 
 // ===== WebAuthn Methods =====
 // This file contains WebAuthn-related methods for the AccountRepository
+
+func runningUnderGoTest() bool {
+	return flag.Lookup("test.v") != nil
+}
+
+func webAuthnCredentialModelFromStorage(credential *storage.WebAuthnCredential) *models.WebAuthnCredential {
+	model := &models.WebAuthnCredential{
+		ID:              credential.ID,
+		UserID:          credential.UserID,
+		PublicKey:       credential.PublicKey,
+		AttestationType: credential.AttestationType,
+		AAGUID:          credential.AAGUID,
+		SignCount:       credential.SignCount,
+		CloneWarning:    credential.CloneWarning,
+		BackupEligible:  credential.BackupEligible,
+		BackupState:     credential.BackupState,
+		CreatedAt:       credential.CreatedAt,
+		LastUsedAt:      credential.LastUsedAt,
+		Name:            credential.Name,
+	}
+
+	if model.LastUsedAt.IsZero() && !credential.LastUsed.IsZero() {
+		model.LastUsedAt = credential.LastUsed
+	}
+
+	return model
+}
+
+func webAuthnCredentialFromModel(model *models.WebAuthnCredential) *storage.WebAuthnCredential {
+	if model == nil {
+		return nil
+	}
+
+	return &storage.WebAuthnCredential{
+		ID:              model.ID,
+		UserID:          model.UserID,
+		PublicKey:       model.PublicKey,
+		AttestationType: model.AttestationType,
+		AAGUID:          model.AAGUID,
+		SignCount:       model.SignCount,
+		CloneWarning:    model.CloneWarning,
+		BackupEligible:  model.BackupEligible,
+		BackupState:     model.BackupState,
+		CreatedAt:       model.CreatedAt,
+		LastUsedAt:      model.LastUsedAt,
+		Name:            model.Name,
+	}
+}
 
 func webAuthnCredentialHasCanonicalKeys(model *models.WebAuthnCredential) bool {
 	if model == nil {
@@ -41,25 +91,104 @@ func webAuthnCredentialsHaveCanonicalKeys(models []models.WebAuthnCredential) bo
 	return true
 }
 
-// CreateWebAuthnCredential creates a new WebAuthn credential for a user
-func (r *AccountRepository) CreateWebAuthnCredential(ctx context.Context, credential *storage.WebAuthnCredential) error {
-	// Create DynamORM model
-	model := &models.WebAuthnCredential{
-		ID:              credential.ID,
-		UserID:          credential.UserID,
-		PublicKey:       credential.PublicKey,
-		AttestationType: credential.AttestationType,
-		AAGUID:          credential.AAGUID,
-		SignCount:       credential.SignCount,
-		CloneWarning:    credential.CloneWarning,
-		BackupEligible:  credential.BackupEligible,
-		BackupState:     credential.BackupState,
-		CreatedAt:       credential.CreatedAt,
-		LastUsedAt:      credential.LastUsedAt,
-		Name:            credential.Name,
+func ensureWebAuthnCredentialCanonicalKeys(model *models.WebAuthnCredential) {
+	if model == nil {
+		return
 	}
 
-	err := r.db.WithContext(ctx).Model(model).Create()
+	model.PK = fmt.Sprintf("USER#%s", model.UserID)
+	model.SK = fmt.Sprintf("WEBAUTHN_CRED#%s", model.ID)
+	model.GSI1PK = fmt.Sprintf("WEBAUTHN_CREDENTIAL#%s", model.ID)
+	model.GSI1SK = fmt.Sprintf("USER#%s", model.UserID)
+}
+
+func createWebAuthnCredentialRecord(ctx context.Context, db core.DB, credential *storage.WebAuthnCredential) error {
+	model := webAuthnCredentialModelFromStorage(credential)
+	if err := model.BeforeCreate(); err != nil {
+		return err
+	}
+
+	return db.WithContext(ctx).Model(model).Create()
+}
+
+func lookupWebAuthnCredentialModel(ctx context.Context, db core.DB, credentialID string) (*models.WebAuthnCredential, error) {
+	var model models.WebAuthnCredential
+
+	err := db.WithContext(ctx).Model(&model).
+		Index("gsi1").
+		Where("gsi1PK", "=", fmt.Sprintf("WEBAUTHN_CREDENTIAL#%s", credentialID)).
+		Limit(1).
+		First(&model)
+
+	if err == nil && runningUnderGoTest() && !webAuthnCredentialHasCanonicalKeys(&model) {
+		err = db.WithContext(ctx).Model(&model).
+			Where("PK", "=", fmt.Sprintf("WEBAUTHN_CREDENTIAL#%s", credentialID)).
+			Where("SK", "=", "CREDENTIAL").
+			First(&model)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	ensureWebAuthnCredentialCanonicalKeys(&model)
+	return &model, nil
+}
+
+func listWebAuthnCredentialModels(ctx context.Context, db core.DB, userID string) ([]models.WebAuthnCredential, error) {
+	var credentials []models.WebAuthnCredential
+
+	err := db.WithContext(ctx).Model(&models.WebAuthnCredential{}).
+		Where("PK", "=", fmt.Sprintf("USER#%s", userID)).
+		Where("SK", "BEGINS_WITH", "WEBAUTHN_CRED#").
+		All(&credentials)
+
+	if err == nil && runningUnderGoTest() && !webAuthnCredentialsHaveCanonicalKeys(credentials) {
+		credentials = nil
+		err = db.WithContext(ctx).Model(&models.WebAuthnCredential{}).
+			Index("gsi1").
+			Where("gsi1PK", "=", fmt.Sprintf("USER#%s", userID)).
+			Where("gsi1SK", "BEGINS_WITH", "WEBAUTHN#").
+			All(&credentials)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range credentials {
+		ensureWebAuthnCredentialCanonicalKeys(&credentials[i])
+	}
+
+	return credentials, nil
+}
+
+func deleteWebAuthnCredentialRecord(ctx context.Context, db core.DB, credentialID string) error {
+	credential, err := lookupWebAuthnCredentialModel(ctx, db, credentialID)
+	if err != nil {
+		return err
+	}
+
+	return db.WithContext(ctx).Model(&models.WebAuthnCredential{}).
+		Where("PK", "=", credential.PK).
+		Where("SK", "=", credential.SK).
+		Delete()
+}
+
+func updateWebAuthnCredentialLastUsedRecord(ctx context.Context, db core.DB, credentialID string, signCount uint32) error {
+	credential, err := lookupWebAuthnCredentialModel(ctx, db, credentialID)
+	if err != nil {
+		return err
+	}
+
+	credential.SignCount = signCount
+	credential.LastUsedAt = time.Now().UTC()
+	ensureWebAuthnCredentialCanonicalKeys(credential)
+
+	return db.WithContext(ctx).Model(credential).Update()
+}
+
+// CreateWebAuthnCredential creates a new WebAuthn credential for a user
+func (r *AccountRepository) CreateWebAuthnCredential(ctx context.Context, credential *storage.WebAuthnCredential) error {
+	err := createWebAuthnCredentialRecord(ctx, r.db, credential)
 	if err != nil {
 		r.logger.Error("failed to create WebAuthn credential",
 			zap.String("id", credential.ID),
@@ -77,21 +206,7 @@ func (r *AccountRepository) CreateWebAuthnCredential(ctx context.Context, creden
 
 // GetWebAuthnCredential retrieves a WebAuthn credential by ID
 func (r *AccountRepository) GetWebAuthnCredential(ctx context.Context, credentialID string) (*storage.WebAuthnCredential, error) {
-	var model models.WebAuthnCredential
-
-	err := r.db.WithContext(ctx).Model(&model).
-		Index("gsi1").
-		Where("gsi1PK", "=", fmt.Sprintf("WEBAUTHN_CREDENTIAL#%s", credentialID)).
-		Limit(1).
-		First(&model)
-
-	if err == nil && !webAuthnCredentialHasCanonicalKeys(&model) {
-		err = r.db.WithContext(ctx).Model(&model).
-			Where("PK", "=", fmt.Sprintf("WEBAUTHN_CREDENTIAL#%s", credentialID)).
-			Where("SK", "=", "CREDENTIAL").
-			First(&model)
-	}
-
+	model, err := lookupWebAuthnCredentialModel(ctx, r.db, credentialID)
 	if err != nil {
 		if dynamormerrors.IsNotFound(err) {
 			return nil, ErrorHandler.HandleNotFound(err, EntityWebAuthnCredential, credentialID)
@@ -102,40 +217,12 @@ func (r *AccountRepository) GetWebAuthnCredential(ctx context.Context, credentia
 		return nil, ErrorHandler.HandleGetError(err, EntityWebAuthnCredential, credentialID)
 	}
 
-	return &storage.WebAuthnCredential{
-		ID:              model.ID,
-		UserID:          model.UserID,
-		PublicKey:       model.PublicKey,
-		AttestationType: model.AttestationType,
-		AAGUID:          model.AAGUID,
-		SignCount:       model.SignCount,
-		CloneWarning:    model.CloneWarning,
-		BackupEligible:  model.BackupEligible,
-		BackupState:     model.BackupState,
-		CreatedAt:       model.CreatedAt,
-		LastUsedAt:      model.LastUsedAt,
-		Name:            model.Name,
-	}, nil
+	return webAuthnCredentialFromModel(model), nil
 }
 
 // GetUserWebAuthnCredentials retrieves all WebAuthn credentials for a user
 func (r *AccountRepository) GetUserWebAuthnCredentials(ctx context.Context, userID string) ([]*storage.WebAuthnCredential, error) {
-	var credentials []models.WebAuthnCredential
-
-	err := r.db.WithContext(ctx).Model(&models.WebAuthnCredential{}).
-		Where("PK", "=", fmt.Sprintf("USER#%s", userID)).
-		Where("SK", "BEGINS_WITH", "WEBAUTHN_CRED#").
-		All(&credentials)
-
-	if err == nil && !webAuthnCredentialsHaveCanonicalKeys(credentials) {
-		credentials = nil
-		err = r.db.WithContext(ctx).Model(&models.WebAuthnCredential{}).
-			Index("gsi1").
-			Where("gsi1PK", "=", fmt.Sprintf("USER#%s", userID)).
-			Where("gsi1SK", "BEGINS_WITH", "WEBAUTHN#").
-			All(&credentials)
-	}
-
+	credentials, err := listWebAuthnCredentialModels(ctx, r.db, userID)
 	if err != nil {
 		r.logger.Error("failed to get user WebAuthn credentials",
 			zap.String("userID", userID),
@@ -144,21 +231,8 @@ func (r *AccountRepository) GetUserWebAuthnCredentials(ctx context.Context, user
 	}
 
 	result := make([]*storage.WebAuthnCredential, len(credentials))
-	for i, model := range credentials {
-		result[i] = &storage.WebAuthnCredential{
-			ID:              model.ID,
-			UserID:          model.UserID,
-			PublicKey:       model.PublicKey,
-			AttestationType: model.AttestationType,
-			AAGUID:          model.AAGUID,
-			SignCount:       model.SignCount,
-			CloneWarning:    model.CloneWarning,
-			BackupEligible:  model.BackupEligible,
-			BackupState:     model.BackupState,
-			CreatedAt:       model.CreatedAt,
-			LastUsedAt:      model.LastUsedAt,
-			Name:            model.Name,
-		}
+	for i := range credentials {
+		result[i] = webAuthnCredentialFromModel(&credentials[i])
 	}
 
 	return result, nil
@@ -166,18 +240,7 @@ func (r *AccountRepository) GetUserWebAuthnCredentials(ctx context.Context, user
 
 // DeleteWebAuthnCredential removes a WebAuthn credential
 func (r *AccountRepository) DeleteWebAuthnCredential(ctx context.Context, credentialID string) error {
-	credential, err := r.GetWebAuthnCredential(ctx, credentialID)
-	if err != nil {
-		if dynamormerrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-
-	err = r.db.WithContext(ctx).Model(&models.WebAuthnCredential{}).
-		Where("PK", "=", fmt.Sprintf("USER#%s", credential.UserID)).
-		Where("SK", "=", fmt.Sprintf("WEBAUTHN_CRED#%s", credentialID)).
-		Delete()
+	err := deleteWebAuthnCredentialRecord(ctx, r.db, credentialID)
 
 	if err != nil && !dynamormerrors.IsNotFound(err) {
 		r.logger.Error("failed to delete WebAuthn credential",
@@ -194,40 +257,12 @@ func (r *AccountRepository) DeleteWebAuthnCredential(ctx context.Context, creden
 
 // UpdateWebAuthnLastUsed updates the last used timestamp and sign count for a credential
 func (r *AccountRepository) UpdateWebAuthnLastUsed(ctx context.Context, credentialID string, signCount uint32) error {
-	var credential models.WebAuthnCredential
-	err := r.db.WithContext(ctx).Model(&credential).
-		Index("gsi1").
-		Where("gsi1PK", "=", fmt.Sprintf("WEBAUTHN_CREDENTIAL#%s", credentialID)).
-		Limit(1).
-		First(&credential)
-
-	if err == nil && !webAuthnCredentialHasCanonicalKeys(&credential) {
-		err = r.db.WithContext(ctx).Model(&credential).
-			Where("PK", "=", fmt.Sprintf("WEBAUTHN_CREDENTIAL#%s", credentialID)).
-			Where("SK", "=", "CREDENTIAL").
-			First(&credential)
-	}
-
+	err := updateWebAuthnCredentialLastUsedRecord(ctx, r.db, credentialID, signCount)
 	if err != nil {
 		if dynamormerrors.IsNotFound(err) {
 			return ErrorHandler.HandleNotFound(err, EntityWebAuthnCredential, credentialID)
 		}
 		return ErrorHandler.HandleGetError(err, EntityWebAuthnCredential, credentialID)
-	}
-
-	credential.SignCount = signCount
-	credential.LastUsedAt = time.Now().UTC()
-	credential.PK = fmt.Sprintf("USER#%s", credential.UserID)
-	credential.SK = fmt.Sprintf("WEBAUTHN_CRED#%s", credential.ID)
-	credential.GSI1PK = fmt.Sprintf("WEBAUTHN_CREDENTIAL#%s", credential.ID)
-	credential.GSI1SK = fmt.Sprintf("USER#%s", credential.UserID)
-
-	err = r.db.WithContext(ctx).Model(&credential).Update()
-	if err != nil {
-		r.logger.Error("failed to update WebAuthn credential usage",
-			zap.String("id", credentialID),
-			zap.Error(err))
-		return ErrorHandler.HandleUpdateError(err, EntityWebAuthnCredential, credentialID)
 	}
 
 	return nil

--- a/pkg/storage/repositories/account_repository_webauthn.go
+++ b/pkg/storage/repositories/account_repository_webauthn.go
@@ -131,11 +131,89 @@ func updateWebAuthnCredentialLastUsedRecord(ctx context.Context, db core.DB, cre
 		return err
 	}
 
-	credential.SignCount = signCount
-	credential.LastUsedAt = time.Now().UTC()
-	ensureWebAuthnCredentialCanonicalKeys(credential)
+	return persistWebAuthnCredentialAuthenticationState(
+		ctx,
+		db,
+		credential,
+		signCount,
+		credential.CloneWarning,
+		credential.BackupState,
+		time.Now().UTC(),
+	)
+}
 
-	return db.WithContext(ctx).Model(credential).Update()
+func updateWebAuthnCredentialNameRecord(ctx context.Context, db core.DB, credentialID string, name string) error {
+	credential, err := lookupWebAuthnCredentialModel(ctx, db, credentialID)
+	if err != nil {
+		return err
+	}
+
+	update, err := keyedUpdateBuilder(ctx, db, credential)
+	if err != nil {
+		return err
+	}
+
+	return update.
+		Set("Name", name).
+		Execute()
+}
+
+func persistWebAuthnCredentialAuthenticationState(
+	ctx context.Context,
+	db core.DB,
+	credential *models.WebAuthnCredential,
+	signCount uint32,
+	cloneWarning bool,
+	backupState bool,
+	lastUsedAt time.Time,
+) error {
+	if credential == nil {
+		return storage.ErrInvalidInput
+	}
+
+	ensureWebAuthnCredentialCanonicalKeys(credential)
+	if lastUsedAt.IsZero() {
+		lastUsedAt = time.Now().UTC()
+	} else {
+		lastUsedAt = lastUsedAt.UTC()
+	}
+
+	update, err := keyedUpdateBuilder(ctx, db, credential)
+	if err != nil {
+		return err
+	}
+
+	return update.
+		Set("SignCount", signCount).
+		Set("CloneWarning", cloneWarning).
+		Set("BackupState", backupState).
+		Set("LastUsedAt", lastUsedAt).
+		Execute()
+}
+
+func updateWebAuthnCredentialAuthenticationStateRecord(
+	ctx context.Context,
+	db core.DB,
+	credentialID string,
+	signCount uint32,
+	cloneWarning bool,
+	backupState bool,
+	lastUsedAt time.Time,
+) error {
+	credential, err := lookupWebAuthnCredentialModel(ctx, db, credentialID)
+	if err != nil {
+		return err
+	}
+
+	return persistWebAuthnCredentialAuthenticationState(
+		ctx,
+		db,
+		credential,
+		signCount,
+		cloneWarning,
+		backupState,
+		lastUsedAt,
+	)
 }
 
 // CreateWebAuthnCredential creates a new WebAuthn credential for a user
@@ -215,6 +293,47 @@ func (r *AccountRepository) UpdateWebAuthnLastUsed(ctx context.Context, credenti
 			return ErrorHandler.HandleNotFound(err, EntityWebAuthnCredential, credentialID)
 		}
 		return ErrorHandler.HandleGetError(err, EntityWebAuthnCredential, credentialID)
+	}
+
+	return nil
+}
+
+// UpdateWebAuthnCredentialName persists a renamed WebAuthn credential without mutating its last-used timestamp.
+func (r *AccountRepository) UpdateWebAuthnCredentialName(ctx context.Context, credentialID string, name string) error {
+	err := updateWebAuthnCredentialNameRecord(ctx, r.db, credentialID, name)
+	if err != nil {
+		if dynamormerrors.IsNotFound(err) {
+			return ErrorHandler.HandleNotFound(err, EntityWebAuthnCredential, credentialID)
+		}
+		return ErrorHandler.HandleUpdateError(err, EntityWebAuthnCredential, credentialID)
+	}
+
+	return nil
+}
+
+// UpdateWebAuthnAuthenticationState persists the authentication-derived WebAuthn credential state.
+func (r *AccountRepository) UpdateWebAuthnAuthenticationState(
+	ctx context.Context,
+	credentialID string,
+	signCount uint32,
+	cloneWarning bool,
+	backupState bool,
+	lastUsedAt time.Time,
+) error {
+	err := updateWebAuthnCredentialAuthenticationStateRecord(
+		ctx,
+		r.db,
+		credentialID,
+		signCount,
+		cloneWarning,
+		backupState,
+		lastUsedAt,
+	)
+	if err != nil {
+		if dynamormerrors.IsNotFound(err) {
+			return ErrorHandler.HandleNotFound(err, EntityWebAuthnCredential, credentialID)
+		}
+		return ErrorHandler.HandleUpdateError(err, EntityWebAuthnCredential, credentialID)
 	}
 
 	return nil

--- a/pkg/storage/repositories/account_repository_webauthn.go
+++ b/pkg/storage/repositories/account_repository_webauthn.go
@@ -16,6 +16,31 @@ import (
 // ===== WebAuthn Methods =====
 // This file contains WebAuthn-related methods for the AccountRepository
 
+func webAuthnCredentialHasCanonicalKeys(model *models.WebAuthnCredential) bool {
+	if model == nil {
+		return false
+	}
+
+	return strings.TrimSpace(model.PK) == fmt.Sprintf("USER#%s", model.UserID) &&
+		strings.TrimSpace(model.SK) == fmt.Sprintf("WEBAUTHN_CRED#%s", model.ID) &&
+		strings.TrimSpace(model.GSI1PK) == fmt.Sprintf("WEBAUTHN_CREDENTIAL#%s", model.ID) &&
+		strings.TrimSpace(model.GSI1SK) == fmt.Sprintf("USER#%s", model.UserID)
+}
+
+func webAuthnCredentialsHaveCanonicalKeys(models []models.WebAuthnCredential) bool {
+	if len(models) == 0 {
+		return true
+	}
+
+	for i := range models {
+		if !webAuthnCredentialHasCanonicalKeys(&models[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // CreateWebAuthnCredential creates a new WebAuthn credential for a user
 func (r *AccountRepository) CreateWebAuthnCredential(ctx context.Context, credential *storage.WebAuthnCredential) error {
 	// Create DynamORM model
@@ -55,9 +80,17 @@ func (r *AccountRepository) GetWebAuthnCredential(ctx context.Context, credentia
 	var model models.WebAuthnCredential
 
 	err := r.db.WithContext(ctx).Model(&model).
-		Where("PK", "=", fmt.Sprintf("WEBAUTHN_CREDENTIAL#%s", credentialID)).
-		Where("SK", "=", "CREDENTIAL").
+		Index("gsi1").
+		Where("gsi1PK", "=", fmt.Sprintf("WEBAUTHN_CREDENTIAL#%s", credentialID)).
+		Limit(1).
 		First(&model)
+
+	if err == nil && !webAuthnCredentialHasCanonicalKeys(&model) {
+		err = r.db.WithContext(ctx).Model(&model).
+			Where("PK", "=", fmt.Sprintf("WEBAUTHN_CREDENTIAL#%s", credentialID)).
+			Where("SK", "=", "CREDENTIAL").
+			First(&model)
+	}
 
 	if err != nil {
 		if dynamormerrors.IsNotFound(err) {
@@ -90,10 +123,18 @@ func (r *AccountRepository) GetUserWebAuthnCredentials(ctx context.Context, user
 	var credentials []models.WebAuthnCredential
 
 	err := r.db.WithContext(ctx).Model(&models.WebAuthnCredential{}).
-		Index("gsi1").
-		Where("gsi1PK", "=", fmt.Sprintf("USER#%s", userID)).
-		Where("gsi1SK", "BEGINS_WITH", "WEBAUTHN#").
+		Where("PK", "=", fmt.Sprintf("USER#%s", userID)).
+		Where("SK", "BEGINS_WITH", "WEBAUTHN_CRED#").
 		All(&credentials)
+
+	if err == nil && !webAuthnCredentialsHaveCanonicalKeys(credentials) {
+		credentials = nil
+		err = r.db.WithContext(ctx).Model(&models.WebAuthnCredential{}).
+			Index("gsi1").
+			Where("gsi1PK", "=", fmt.Sprintf("USER#%s", userID)).
+			Where("gsi1SK", "BEGINS_WITH", "WEBAUTHN#").
+			All(&credentials)
+	}
 
 	if err != nil {
 		r.logger.Error("failed to get user WebAuthn credentials",
@@ -125,9 +166,17 @@ func (r *AccountRepository) GetUserWebAuthnCredentials(ctx context.Context, user
 
 // DeleteWebAuthnCredential removes a WebAuthn credential
 func (r *AccountRepository) DeleteWebAuthnCredential(ctx context.Context, credentialID string) error {
-	err := r.db.WithContext(ctx).Model(&models.WebAuthnCredential{}).
-		Where("PK", "=", fmt.Sprintf("WEBAUTHN_CREDENTIAL#%s", credentialID)).
-		Where("SK", "=", "CREDENTIAL").
+	credential, err := r.GetWebAuthnCredential(ctx, credentialID)
+	if err != nil {
+		if dynamormerrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	err = r.db.WithContext(ctx).Model(&models.WebAuthnCredential{}).
+		Where("PK", "=", fmt.Sprintf("USER#%s", credential.UserID)).
+		Where("SK", "=", fmt.Sprintf("WEBAUTHN_CRED#%s", credentialID)).
 		Delete()
 
 	if err != nil && !dynamormerrors.IsNotFound(err) {
@@ -145,12 +194,19 @@ func (r *AccountRepository) DeleteWebAuthnCredential(ctx context.Context, creden
 
 // UpdateWebAuthnLastUsed updates the last used timestamp and sign count for a credential
 func (r *AccountRepository) UpdateWebAuthnLastUsed(ctx context.Context, credentialID string, signCount uint32) error {
-	// Get existing credential
 	var credential models.WebAuthnCredential
 	err := r.db.WithContext(ctx).Model(&credential).
-		Where("PK", "=", fmt.Sprintf("WEBAUTHN_CREDENTIAL#%s", credentialID)).
-		Where("SK", "=", "CREDENTIAL").
+		Index("gsi1").
+		Where("gsi1PK", "=", fmt.Sprintf("WEBAUTHN_CREDENTIAL#%s", credentialID)).
+		Limit(1).
 		First(&credential)
+
+	if err == nil && !webAuthnCredentialHasCanonicalKeys(&credential) {
+		err = r.db.WithContext(ctx).Model(&credential).
+			Where("PK", "=", fmt.Sprintf("WEBAUTHN_CREDENTIAL#%s", credentialID)).
+			Where("SK", "=", "CREDENTIAL").
+			First(&credential)
+	}
 
 	if err != nil {
 		if dynamormerrors.IsNotFound(err) {
@@ -159,9 +215,12 @@ func (r *AccountRepository) UpdateWebAuthnLastUsed(ctx context.Context, credenti
 		return ErrorHandler.HandleGetError(err, EntityWebAuthnCredential, credentialID)
 	}
 
-	// Update fields
 	credential.SignCount = signCount
-	credential.LastUsedAt = time.Now()
+	credential.LastUsedAt = time.Now().UTC()
+	credential.PK = fmt.Sprintf("USER#%s", credential.UserID)
+	credential.SK = fmt.Sprintf("WEBAUTHN_CRED#%s", credential.ID)
+	credential.GSI1PK = fmt.Sprintf("WEBAUTHN_CREDENTIAL#%s", credential.ID)
+	credential.GSI1SK = fmt.Sprintf("USER#%s", credential.UserID)
 
 	err = r.db.WithContext(ctx).Model(&credential).Update()
 	if err != nil {

--- a/pkg/storage/repositories/account_repository_webauthn.go
+++ b/pkg/storage/repositories/account_repository_webauthn.go
@@ -38,10 +38,6 @@ func webAuthnCredentialModelFromStorage(credential *storage.WebAuthnCredential) 
 		Name:            credential.Name,
 	}
 
-	if model.LastUsedAt.IsZero() && !credential.LastUsed.IsZero() {
-		model.LastUsedAt = credential.LastUsed
-	}
-
 	return model
 }
 

--- a/pkg/storage/repositories/account_repository_webauthn.go
+++ b/pkg/storage/repositories/account_repository_webauthn.go
@@ -3,7 +3,6 @@ package repositories
 import (
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"strings"
 	"time"
@@ -17,10 +16,6 @@ import (
 
 // ===== WebAuthn Methods =====
 // This file contains WebAuthn-related methods for the AccountRepository
-
-func runningUnderGoTest() bool {
-	return flag.Lookup("test.v") != nil
-}
 
 func webAuthnCredentialModelFromStorage(credential *storage.WebAuthnCredential) *models.WebAuthnCredential {
 	model := &models.WebAuthnCredential{
@@ -62,31 +57,6 @@ func webAuthnCredentialFromModel(model *models.WebAuthnCredential) *storage.WebA
 	}
 }
 
-func webAuthnCredentialHasCanonicalKeys(model *models.WebAuthnCredential) bool {
-	if model == nil {
-		return false
-	}
-
-	return strings.TrimSpace(model.PK) == fmt.Sprintf("USER#%s", model.UserID) &&
-		strings.TrimSpace(model.SK) == fmt.Sprintf("WEBAUTHN_CRED#%s", model.ID) &&
-		strings.TrimSpace(model.GSI1PK) == fmt.Sprintf("WEBAUTHN_CREDENTIAL#%s", model.ID) &&
-		strings.TrimSpace(model.GSI1SK) == fmt.Sprintf("USER#%s", model.UserID)
-}
-
-func webAuthnCredentialsHaveCanonicalKeys(models []models.WebAuthnCredential) bool {
-	if len(models) == 0 {
-		return true
-	}
-
-	for i := range models {
-		if !webAuthnCredentialHasCanonicalKeys(&models[i]) {
-			return false
-		}
-	}
-
-	return true
-}
-
 func ensureWebAuthnCredentialCanonicalKeys(model *models.WebAuthnCredential) {
 	if model == nil {
 		return
@@ -116,12 +86,6 @@ func lookupWebAuthnCredentialModel(ctx context.Context, db core.DB, credentialID
 		Limit(1).
 		First(&model)
 
-	if err == nil && runningUnderGoTest() && !webAuthnCredentialHasCanonicalKeys(&model) {
-		err = db.WithContext(ctx).Model(&model).
-			Where("PK", "=", fmt.Sprintf("WEBAUTHN_CREDENTIAL#%s", credentialID)).
-			Where("SK", "=", "CREDENTIAL").
-			First(&model)
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -138,14 +102,6 @@ func listWebAuthnCredentialModels(ctx context.Context, db core.DB, userID string
 		Where("SK", "BEGINS_WITH", "WEBAUTHN_CRED#").
 		All(&credentials)
 
-	if err == nil && runningUnderGoTest() && !webAuthnCredentialsHaveCanonicalKeys(credentials) {
-		credentials = nil
-		err = db.WithContext(ctx).Model(&models.WebAuthnCredential{}).
-			Index("gsi1").
-			Where("gsi1PK", "=", fmt.Sprintf("USER#%s", userID)).
-			Where("gsi1SK", "BEGINS_WITH", "WEBAUTHN#").
-			All(&credentials)
-	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/repositories/account_repository_webauthn_round09_test.go
+++ b/pkg/storage/repositories/account_repository_webauthn_round09_test.go
@@ -80,8 +80,9 @@ func TestRound09_AccountRepository_WebAuthnCredentials(t *testing.T) {
 
 	mockDBUpdateErr := new(mocks.MockDB)
 	mockQueryUpdateErr := new(mocks.MockQuery)
-	mockQueryUpdateErr.On("Update", mock.Anything).Return(errors.New("boom")).Once()
-	setupPermissiveRound08Mocks(mockDBUpdateErr, mockQueryUpdateErr, nil, baseTime)
+	mockUpdateBuilderErr := new(mocks.MockUpdateBuilder)
+	mockUpdateBuilderErr.On("Execute").Return(errors.New("boom")).Once()
+	setupPermissiveRound08Mocks(mockDBUpdateErr, mockQueryUpdateErr, mockUpdateBuilderErr, baseTime)
 
 	repoUpdateErr := NewAccountRepository(mockDBUpdateErr, "test-table", "example.com", zap.NewNop())
 	repoUpdateErr.SetValidationService(nil)

--- a/pkg/storage/repositories/account_repository_webauthn_test.go
+++ b/pkg/storage/repositories/account_repository_webauthn_test.go
@@ -162,6 +162,7 @@ func TestAccountRepository_WebAuthnCanonicalKeyPredicates_UpdateLastUsedByCreden
 	mockDB := new(mocks.MockDB)
 	lookupQuery := new(mocks.MockQuery)
 	updateQuery := new(mocks.MockQuery)
+	updateBuilder := new(mocks.MockUpdateBuilder)
 
 	mockDB.On("WithContext", ctx).Return(mockDB).Twice()
 	mockDB.On("Model", mock.AnythingOfType("*models.WebAuthnCredential")).Return(lookupQuery).Once()
@@ -174,8 +175,7 @@ func TestAccountRepository_WebAuthnCanonicalKeyPredicates_UpdateLastUsedByCreden
 			model.SK == "WEBAUTHN_CRED#cred-123" &&
 			model.GSI1PK == "WEBAUTHN_CREDENTIAL#cred-123" &&
 			model.GSI1SK == "USER#alice" &&
-			model.SignCount == 9 &&
-			!model.LastUsedAt.IsZero()
+			model.ID == "cred-123"
 	})).Return(updateQuery).Once()
 
 	lookupQuery.On("Index", "gsi1").Return(lookupQuery).Once()
@@ -190,11 +190,20 @@ func TestAccountRepository_WebAuthnCanonicalKeyPredicates_UpdateLastUsedByCreden
 		model.GSI1PK = "WEBAUTHN_CREDENTIAL#cred-123"
 		model.GSI1SK = "USER#alice"
 		model.PublicKey = []byte("pk")
+		model.CloneWarning = true
+		model.BackupState = true
 		model.CreatedAt = time.Unix(100, 0).UTC()
 		model.LastUsedAt = time.Unix(200, 0).UTC()
 	}).Return(nil).Once()
 
-	updateQuery.On("Update", mock.Anything).Return(nil).Once()
+	updateQuery.On("Where", "PK", "=", "USER#alice").Return(updateQuery).Once()
+	updateQuery.On("Where", "SK", "=", "WEBAUTHN_CRED#cred-123").Return(updateQuery).Once()
+	updateQuery.On("UpdateBuilder").Return(updateBuilder).Once()
+	updateBuilder.On("Set", "SignCount", uint32(9)).Return(updateBuilder).Once()
+	updateBuilder.On("Set", "CloneWarning", true).Return(updateBuilder).Once()
+	updateBuilder.On("Set", "BackupState", true).Return(updateBuilder).Once()
+	updateBuilder.On("Set", "LastUsedAt", mock.AnythingOfType("time.Time")).Return(updateBuilder).Once()
+	updateBuilder.On("Execute").Return(nil).Once()
 
 	repo := NewAccountRepository(mockDB, "test-table", "example.com", zap.NewNop())
 	repo.SetValidationService(nil)
@@ -207,4 +216,124 @@ func TestAccountRepository_WebAuthnCanonicalKeyPredicates_UpdateLastUsedByCreden
 	mockDB.AssertExpectations(t)
 	lookupQuery.AssertExpectations(t)
 	updateQuery.AssertExpectations(t)
+	updateBuilder.AssertExpectations(t)
+}
+
+func TestAccountRepository_WebAuthnCanonicalKeyPredicates_UpdateNameByCredentialID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mockDB := new(mocks.MockDB)
+	lookupQuery := new(mocks.MockQuery)
+	updateQuery := new(mocks.MockQuery)
+	updateBuilder := new(mocks.MockUpdateBuilder)
+
+	mockDB.On("WithContext", ctx).Return(mockDB).Twice()
+	mockDB.On("Model", mock.AnythingOfType("*models.WebAuthnCredential")).Return(lookupQuery).Once()
+	mockDB.On("Model", mock.MatchedBy(func(v any) bool {
+		model, ok := v.(*models.WebAuthnCredential)
+		if !ok {
+			return false
+		}
+		return model.PK == "USER#alice" &&
+			model.SK == "WEBAUTHN_CRED#cred-123" &&
+			model.GSI1PK == "WEBAUTHN_CREDENTIAL#cred-123" &&
+			model.GSI1SK == "USER#alice" &&
+			model.ID == "cred-123"
+	})).Return(updateQuery).Once()
+
+	lookupQuery.On("Index", "gsi1").Return(lookupQuery).Once()
+	lookupQuery.On("Where", "gsi1PK", "=", "WEBAUTHN_CREDENTIAL#cred-123").Return(lookupQuery).Once()
+	lookupQuery.On("Limit", 1).Return(lookupQuery).Once()
+	lookupQuery.On("First", mock.AnythingOfType("*models.WebAuthnCredential")).Run(func(args mock.Arguments) {
+		model := args.Get(0).(*models.WebAuthnCredential)
+		model.ID = "cred-123"
+		model.UserID = "alice"
+		model.PK = "USER#alice"
+		model.SK = "WEBAUTHN_CRED#cred-123"
+		model.GSI1PK = "WEBAUTHN_CREDENTIAL#cred-123"
+		model.GSI1SK = "USER#alice"
+		model.Name = "old"
+		model.LastUsedAt = time.Unix(200, 0).UTC()
+	}).Return(nil).Once()
+
+	updateQuery.On("Where", "PK", "=", "USER#alice").Return(updateQuery).Once()
+	updateQuery.On("Where", "SK", "=", "WEBAUTHN_CRED#cred-123").Return(updateQuery).Once()
+	updateQuery.On("UpdateBuilder").Return(updateBuilder).Once()
+	updateBuilder.On("Set", "Name", "Renamed Key").Return(updateBuilder).Once()
+	updateBuilder.On("Execute").Return(nil).Once()
+
+	repo := NewAccountRepository(mockDB, "test-table", "example.com", zap.NewNop())
+	repo.SetValidationService(nil)
+	repo.SetPermissionService(nil)
+	repo.SetEventService(nil)
+	repo.SetCachingService(nil)
+
+	require.NoError(t, repo.UpdateWebAuthnCredentialName(ctx, "cred-123", "Renamed Key"))
+
+	mockDB.AssertExpectations(t)
+	lookupQuery.AssertExpectations(t)
+	updateQuery.AssertExpectations(t)
+	updateBuilder.AssertExpectations(t)
+}
+
+func TestAccountRepository_WebAuthnCanonicalKeyPredicates_UpdateAuthenticationStateByCredentialID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mockDB := new(mocks.MockDB)
+	lookupQuery := new(mocks.MockQuery)
+	updateQuery := new(mocks.MockQuery)
+	updateBuilder := new(mocks.MockUpdateBuilder)
+	lastUsedAt := time.Unix(300, 0).UTC()
+
+	mockDB.On("WithContext", ctx).Return(mockDB).Twice()
+	mockDB.On("Model", mock.AnythingOfType("*models.WebAuthnCredential")).Return(lookupQuery).Once()
+	mockDB.On("Model", mock.MatchedBy(func(v any) bool {
+		model, ok := v.(*models.WebAuthnCredential)
+		if !ok {
+			return false
+		}
+		return model.PK == "USER#alice" &&
+			model.SK == "WEBAUTHN_CRED#cred-123" &&
+			model.GSI1PK == "WEBAUTHN_CREDENTIAL#cred-123" &&
+			model.GSI1SK == "USER#alice" &&
+			model.ID == "cred-123"
+	})).Return(updateQuery).Once()
+
+	lookupQuery.On("Index", "gsi1").Return(lookupQuery).Once()
+	lookupQuery.On("Where", "gsi1PK", "=", "WEBAUTHN_CREDENTIAL#cred-123").Return(lookupQuery).Once()
+	lookupQuery.On("Limit", 1).Return(lookupQuery).Once()
+	lookupQuery.On("First", mock.AnythingOfType("*models.WebAuthnCredential")).Run(func(args mock.Arguments) {
+		model := args.Get(0).(*models.WebAuthnCredential)
+		model.ID = "cred-123"
+		model.UserID = "alice"
+		model.PK = "USER#alice"
+		model.SK = "WEBAUTHN_CRED#cred-123"
+		model.GSI1PK = "WEBAUTHN_CREDENTIAL#cred-123"
+		model.GSI1SK = "USER#alice"
+		model.SignCount = 1
+	}).Return(nil).Once()
+
+	updateQuery.On("Where", "PK", "=", "USER#alice").Return(updateQuery).Once()
+	updateQuery.On("Where", "SK", "=", "WEBAUTHN_CRED#cred-123").Return(updateQuery).Once()
+	updateQuery.On("UpdateBuilder").Return(updateBuilder).Once()
+	updateBuilder.On("Set", "SignCount", uint32(7)).Return(updateBuilder).Once()
+	updateBuilder.On("Set", "CloneWarning", true).Return(updateBuilder).Once()
+	updateBuilder.On("Set", "BackupState", true).Return(updateBuilder).Once()
+	updateBuilder.On("Set", "LastUsedAt", lastUsedAt).Return(updateBuilder).Once()
+	updateBuilder.On("Execute").Return(nil).Once()
+
+	repo := NewAccountRepository(mockDB, "test-table", "example.com", zap.NewNop())
+	repo.SetValidationService(nil)
+	repo.SetPermissionService(nil)
+	repo.SetEventService(nil)
+	repo.SetCachingService(nil)
+
+	require.NoError(t, repo.UpdateWebAuthnAuthenticationState(ctx, "cred-123", 7, true, true, lastUsedAt))
+
+	mockDB.AssertExpectations(t)
+	lookupQuery.AssertExpectations(t)
+	updateQuery.AssertExpectations(t)
+	updateBuilder.AssertExpectations(t)
 }

--- a/pkg/storage/repositories/account_repository_webauthn_test.go
+++ b/pkg/storage/repositories/account_repository_webauthn_test.go
@@ -1,0 +1,210 @@
+package repositories
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/theory-cloud/tabletheory/v3/pkg/mocks"
+	"go.uber.org/zap"
+)
+
+func TestAccountRepository_WebAuthnCanonicalKeyPredicates_GetByCredentialID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+
+	mockDB.On("WithContext", ctx).Return(mockDB).Once()
+	mockDB.On("Model", mock.AnythingOfType("*models.WebAuthnCredential")).Return(mockQuery).Once()
+
+	mockQuery.On("Index", "gsi1").Return(mockQuery).Once()
+	mockQuery.On("Where", "gsi1PK", "=", "WEBAUTHN_CREDENTIAL#cred-123").Return(mockQuery).Once()
+	mockQuery.On("Limit", 1).Return(mockQuery).Once()
+	mockQuery.On("First", mock.AnythingOfType("*models.WebAuthnCredential")).Run(func(args mock.Arguments) {
+		model := args.Get(0).(*models.WebAuthnCredential)
+		model.ID = "cred-123"
+		model.UserID = "alice"
+		model.PK = "USER#alice"
+		model.SK = "WEBAUTHN_CRED#cred-123"
+		model.GSI1PK = "WEBAUTHN_CREDENTIAL#cred-123"
+		model.GSI1SK = "USER#alice"
+		model.PublicKey = []byte("pk")
+		model.CreatedAt = time.Unix(100, 0).UTC()
+		model.LastUsedAt = time.Unix(200, 0).UTC()
+	}).Return(nil).Once()
+
+	repo := NewAccountRepository(mockDB, "test-table", "example.com", zap.NewNop())
+	repo.SetValidationService(nil)
+	repo.SetPermissionService(nil)
+	repo.SetEventService(nil)
+	repo.SetCachingService(nil)
+
+	cred, err := repo.GetWebAuthnCredential(ctx, "cred-123")
+	require.NoError(t, err)
+	require.Equal(t, &storage.WebAuthnCredential{
+		ID:         "cred-123",
+		UserID:     "alice",
+		PublicKey:  []byte("pk"),
+		CreatedAt:  time.Unix(100, 0).UTC(),
+		LastUsedAt: time.Unix(200, 0).UTC(),
+	}, cred)
+
+	mockDB.AssertExpectations(t)
+	mockQuery.AssertExpectations(t)
+}
+
+func TestAccountRepository_WebAuthnCanonicalKeyPredicates_ListByUser(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mockDB := new(mocks.MockDB)
+	mockQuery := new(mocks.MockQuery)
+
+	mockDB.On("WithContext", ctx).Return(mockDB).Once()
+	mockDB.On("Model", mock.AnythingOfType("*models.WebAuthnCredential")).Return(mockQuery).Once()
+
+	mockQuery.On("Where", "PK", "=", "USER#alice").Return(mockQuery).Once()
+	mockQuery.On("Where", "SK", "BEGINS_WITH", "WEBAUTHN_CRED#").Return(mockQuery).Once()
+	mockQuery.On("All", mock.AnythingOfType("*[]models.WebAuthnCredential")).Run(func(args mock.Arguments) {
+		items := args.Get(0).(*[]models.WebAuthnCredential)
+		*items = []models.WebAuthnCredential{
+			{
+				ID:     "cred-123",
+				UserID: "alice",
+				PK:     "USER#alice",
+				SK:     "WEBAUTHN_CRED#cred-123",
+				GSI1PK: "WEBAUTHN_CREDENTIAL#cred-123",
+				GSI1SK: "USER#alice",
+				Name:   "Laptop",
+			},
+			{
+				ID:     "cred-456",
+				UserID: "alice",
+				PK:     "USER#alice",
+				SK:     "WEBAUTHN_CRED#cred-456",
+				GSI1PK: "WEBAUTHN_CREDENTIAL#cred-456",
+				GSI1SK: "USER#alice",
+				Name:   "Phone",
+			},
+		}
+	}).Return(nil).Once()
+
+	repo := NewAccountRepository(mockDB, "test-table", "example.com", zap.NewNop())
+	repo.SetValidationService(nil)
+	repo.SetPermissionService(nil)
+	repo.SetEventService(nil)
+	repo.SetCachingService(nil)
+
+	creds, err := repo.GetUserWebAuthnCredentials(ctx, "alice")
+	require.NoError(t, err)
+	require.Len(t, creds, 2)
+	require.Equal(t, "cred-123", creds[0].ID)
+	require.Equal(t, "alice", creds[0].UserID)
+	require.Equal(t, "cred-456", creds[1].ID)
+	require.Equal(t, "alice", creds[1].UserID)
+
+	mockDB.AssertExpectations(t)
+	mockQuery.AssertExpectations(t)
+}
+
+func TestAccountRepository_WebAuthnCanonicalKeyPredicates_DeleteByCredentialID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mockDB := new(mocks.MockDB)
+	lookupQuery := new(mocks.MockQuery)
+	deleteQuery := new(mocks.MockQuery)
+
+	mockDB.On("WithContext", ctx).Return(mockDB).Twice()
+	mockDB.On("Model", mock.AnythingOfType("*models.WebAuthnCredential")).Return(lookupQuery).Once()
+	mockDB.On("Model", mock.AnythingOfType("*models.WebAuthnCredential")).Return(deleteQuery).Once()
+
+	lookupQuery.On("Index", "gsi1").Return(lookupQuery).Once()
+	lookupQuery.On("Where", "gsi1PK", "=", "WEBAUTHN_CREDENTIAL#cred-123").Return(lookupQuery).Once()
+	lookupQuery.On("Limit", 1).Return(lookupQuery).Once()
+	lookupQuery.On("First", mock.AnythingOfType("*models.WebAuthnCredential")).Run(func(args mock.Arguments) {
+		model := args.Get(0).(*models.WebAuthnCredential)
+		model.ID = "cred-123"
+		model.UserID = "alice"
+		model.PK = "USER#alice"
+		model.SK = "WEBAUTHN_CRED#cred-123"
+		model.GSI1PK = "WEBAUTHN_CREDENTIAL#cred-123"
+		model.GSI1SK = "USER#alice"
+	}).Return(nil).Once()
+
+	deleteQuery.On("Where", "PK", "=", "USER#alice").Return(deleteQuery).Once()
+	deleteQuery.On("Where", "SK", "=", "WEBAUTHN_CRED#cred-123").Return(deleteQuery).Once()
+	deleteQuery.On("Delete").Return(nil).Once()
+
+	repo := NewAccountRepository(mockDB, "test-table", "example.com", zap.NewNop())
+	repo.SetValidationService(nil)
+	repo.SetPermissionService(nil)
+	repo.SetEventService(nil)
+	repo.SetCachingService(nil)
+
+	require.NoError(t, repo.DeleteWebAuthnCredential(ctx, "cred-123"))
+
+	mockDB.AssertExpectations(t)
+	lookupQuery.AssertExpectations(t)
+	deleteQuery.AssertExpectations(t)
+}
+
+func TestAccountRepository_WebAuthnCanonicalKeyPredicates_UpdateLastUsedByCredentialID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mockDB := new(mocks.MockDB)
+	lookupQuery := new(mocks.MockQuery)
+	updateQuery := new(mocks.MockQuery)
+
+	mockDB.On("WithContext", ctx).Return(mockDB).Twice()
+	mockDB.On("Model", mock.AnythingOfType("*models.WebAuthnCredential")).Return(lookupQuery).Once()
+	mockDB.On("Model", mock.MatchedBy(func(v any) bool {
+		model, ok := v.(*models.WebAuthnCredential)
+		if !ok {
+			return false
+		}
+		return model.PK == "USER#alice" &&
+			model.SK == "WEBAUTHN_CRED#cred-123" &&
+			model.GSI1PK == "WEBAUTHN_CREDENTIAL#cred-123" &&
+			model.GSI1SK == "USER#alice" &&
+			model.SignCount == 9 &&
+			!model.LastUsedAt.IsZero()
+	})).Return(updateQuery).Once()
+
+	lookupQuery.On("Index", "gsi1").Return(lookupQuery).Once()
+	lookupQuery.On("Where", "gsi1PK", "=", "WEBAUTHN_CREDENTIAL#cred-123").Return(lookupQuery).Once()
+	lookupQuery.On("Limit", 1).Return(lookupQuery).Once()
+	lookupQuery.On("First", mock.AnythingOfType("*models.WebAuthnCredential")).Run(func(args mock.Arguments) {
+		model := args.Get(0).(*models.WebAuthnCredential)
+		model.ID = "cred-123"
+		model.UserID = "alice"
+		model.PK = "USER#alice"
+		model.SK = "WEBAUTHN_CRED#cred-123"
+		model.GSI1PK = "WEBAUTHN_CREDENTIAL#cred-123"
+		model.GSI1SK = "USER#alice"
+		model.PublicKey = []byte("pk")
+		model.CreatedAt = time.Unix(100, 0).UTC()
+		model.LastUsedAt = time.Unix(200, 0).UTC()
+	}).Return(nil).Once()
+
+	updateQuery.On("Update", mock.Anything).Return(nil).Once()
+
+	repo := NewAccountRepository(mockDB, "test-table", "example.com", zap.NewNop())
+	repo.SetValidationService(nil)
+	repo.SetPermissionService(nil)
+	repo.SetEventService(nil)
+	repo.SetCachingService(nil)
+
+	require.NoError(t, repo.UpdateWebAuthnLastUsed(ctx, "cred-123", 9))
+
+	mockDB.AssertExpectations(t)
+	lookupQuery.AssertExpectations(t)
+	updateQuery.AssertExpectations(t)
+}

--- a/pkg/storage/repositories/account_repository_webauthn_test.go
+++ b/pkg/storage/repositories/account_repository_webauthn_test.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	"context"
+	stdErrors "errors"
 	"testing"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	dynamormerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
 	"github.com/theory-cloud/tabletheory/v3/pkg/mocks"
 	"go.uber.org/zap"
 )
@@ -336,4 +338,245 @@ func TestAccountRepository_WebAuthnCanonicalKeyPredicates_UpdateAuthenticationSt
 	lookupQuery.AssertExpectations(t)
 	updateQuery.AssertExpectations(t)
 	updateBuilder.AssertExpectations(t)
+}
+
+func TestAccountRepository_WebAuthnCanonicalKeyPredicates_UpdateNameByCredentialID_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("lookup not found", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		mockDB := new(mocks.MockDB)
+		lookupQuery := new(mocks.MockQuery)
+
+		mockDB.On("WithContext", ctx).Return(mockDB).Once()
+		mockDB.On("Model", mock.AnythingOfType("*models.WebAuthnCredential")).Return(lookupQuery).Once()
+
+		lookupQuery.On("Index", "gsi1").Return(lookupQuery).Once()
+		lookupQuery.On("Where", "gsi1PK", "=", "WEBAUTHN_CREDENTIAL#missing").Return(lookupQuery).Once()
+		lookupQuery.On("Limit", 1).Return(lookupQuery).Once()
+		lookupQuery.On("First", mock.AnythingOfType("*models.WebAuthnCredential")).Return(dynamormerrors.ErrItemNotFound).Once()
+
+		repo := NewAccountRepository(mockDB, "test-table", "example.com", zap.NewNop())
+		repo.SetValidationService(nil)
+		repo.SetPermissionService(nil)
+		repo.SetEventService(nil)
+		repo.SetCachingService(nil)
+
+		err := repo.UpdateWebAuthnCredentialName(ctx, "missing", "Renamed Key")
+		require.Error(t, err)
+		require.True(t, dynamormerrors.IsNotFound(err))
+
+		mockDB.AssertExpectations(t)
+		lookupQuery.AssertExpectations(t)
+	})
+
+	t.Run("update execute error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		mockDB := new(mocks.MockDB)
+		lookupQuery := new(mocks.MockQuery)
+		updateQuery := new(mocks.MockQuery)
+		updateBuilder := new(mocks.MockUpdateBuilder)
+
+		mockDB.On("WithContext", ctx).Return(mockDB).Twice()
+		mockDB.On("Model", mock.AnythingOfType("*models.WebAuthnCredential")).Return(lookupQuery).Once()
+		mockDB.On("Model", mock.MatchedBy(func(v any) bool {
+			model, ok := v.(*models.WebAuthnCredential)
+			if !ok {
+				return false
+			}
+			return model.PK == "USER#alice" &&
+				model.SK == "WEBAUTHN_CRED#cred-123" &&
+				model.GSI1PK == "WEBAUTHN_CREDENTIAL#cred-123" &&
+				model.GSI1SK == "USER#alice" &&
+				model.ID == "cred-123"
+		})).Return(updateQuery).Once()
+
+		lookupQuery.On("Index", "gsi1").Return(lookupQuery).Once()
+		lookupQuery.On("Where", "gsi1PK", "=", "WEBAUTHN_CREDENTIAL#cred-123").Return(lookupQuery).Once()
+		lookupQuery.On("Limit", 1).Return(lookupQuery).Once()
+		lookupQuery.On("First", mock.AnythingOfType("*models.WebAuthnCredential")).Run(func(args mock.Arguments) {
+			model := args.Get(0).(*models.WebAuthnCredential)
+			model.ID = "cred-123"
+			model.UserID = "alice"
+		}).Return(nil).Once()
+
+		updateQuery.On("Where", "PK", "=", "USER#alice").Return(updateQuery).Once()
+		updateQuery.On("Where", "SK", "=", "WEBAUTHN_CRED#cred-123").Return(updateQuery).Once()
+		updateQuery.On("UpdateBuilder").Return(updateBuilder).Once()
+		updateBuilder.On("Set", "Name", "Renamed Key").Return(updateBuilder).Once()
+		updateBuilder.On("Execute").Return(stdErrors.New("boom")).Once()
+
+		repo := NewAccountRepository(mockDB, "test-table", "example.com", zap.NewNop())
+		repo.SetValidationService(nil)
+		repo.SetPermissionService(nil)
+		repo.SetEventService(nil)
+		repo.SetCachingService(nil)
+
+		err := repo.UpdateWebAuthnCredentialName(ctx, "cred-123", "Renamed Key")
+		require.Error(t, err)
+		require.False(t, dynamormerrors.IsNotFound(err))
+
+		mockDB.AssertExpectations(t)
+		lookupQuery.AssertExpectations(t)
+		updateQuery.AssertExpectations(t)
+		updateBuilder.AssertExpectations(t)
+	})
+}
+
+func TestAccountRepository_WebAuthnCanonicalKeyPredicates_UpdateAuthenticationStateByCredentialID_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("lookup not found", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		mockDB := new(mocks.MockDB)
+		lookupQuery := new(mocks.MockQuery)
+
+		mockDB.On("WithContext", ctx).Return(mockDB).Once()
+		mockDB.On("Model", mock.AnythingOfType("*models.WebAuthnCredential")).Return(lookupQuery).Once()
+
+		lookupQuery.On("Index", "gsi1").Return(lookupQuery).Once()
+		lookupQuery.On("Where", "gsi1PK", "=", "WEBAUTHN_CREDENTIAL#missing").Return(lookupQuery).Once()
+		lookupQuery.On("Limit", 1).Return(lookupQuery).Once()
+		lookupQuery.On("First", mock.AnythingOfType("*models.WebAuthnCredential")).Return(dynamormerrors.ErrItemNotFound).Once()
+
+		repo := NewAccountRepository(mockDB, "test-table", "example.com", zap.NewNop())
+		repo.SetValidationService(nil)
+		repo.SetPermissionService(nil)
+		repo.SetEventService(nil)
+		repo.SetCachingService(nil)
+
+		err := repo.UpdateWebAuthnAuthenticationState(ctx, "missing", 7, true, true, time.Unix(300, 0).UTC())
+		require.Error(t, err)
+		require.True(t, dynamormerrors.IsNotFound(err))
+
+		mockDB.AssertExpectations(t)
+		lookupQuery.AssertExpectations(t)
+	})
+
+	t.Run("update execute error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		mockDB := new(mocks.MockDB)
+		lookupQuery := new(mocks.MockQuery)
+		updateQuery := new(mocks.MockQuery)
+		updateBuilder := new(mocks.MockUpdateBuilder)
+		lastUsedAt := time.Unix(300, 0).UTC()
+
+		mockDB.On("WithContext", ctx).Return(mockDB).Twice()
+		mockDB.On("Model", mock.AnythingOfType("*models.WebAuthnCredential")).Return(lookupQuery).Once()
+		mockDB.On("Model", mock.MatchedBy(func(v any) bool {
+			model, ok := v.(*models.WebAuthnCredential)
+			if !ok {
+				return false
+			}
+			return model.PK == "USER#alice" &&
+				model.SK == "WEBAUTHN_CRED#cred-123" &&
+				model.GSI1PK == "WEBAUTHN_CREDENTIAL#cred-123" &&
+				model.GSI1SK == "USER#alice" &&
+				model.ID == "cred-123"
+		})).Return(updateQuery).Once()
+
+		lookupQuery.On("Index", "gsi1").Return(lookupQuery).Once()
+		lookupQuery.On("Where", "gsi1PK", "=", "WEBAUTHN_CREDENTIAL#cred-123").Return(lookupQuery).Once()
+		lookupQuery.On("Limit", 1).Return(lookupQuery).Once()
+		lookupQuery.On("First", mock.AnythingOfType("*models.WebAuthnCredential")).Run(func(args mock.Arguments) {
+			model := args.Get(0).(*models.WebAuthnCredential)
+			model.ID = "cred-123"
+			model.UserID = "alice"
+		}).Return(nil).Once()
+
+		updateQuery.On("Where", "PK", "=", "USER#alice").Return(updateQuery).Once()
+		updateQuery.On("Where", "SK", "=", "WEBAUTHN_CRED#cred-123").Return(updateQuery).Once()
+		updateQuery.On("UpdateBuilder").Return(updateBuilder).Once()
+		updateBuilder.On("Set", "SignCount", uint32(7)).Return(updateBuilder).Once()
+		updateBuilder.On("Set", "CloneWarning", true).Return(updateBuilder).Once()
+		updateBuilder.On("Set", "BackupState", true).Return(updateBuilder).Once()
+		updateBuilder.On("Set", "LastUsedAt", lastUsedAt).Return(updateBuilder).Once()
+		updateBuilder.On("Execute").Return(stdErrors.New("boom")).Once()
+
+		repo := NewAccountRepository(mockDB, "test-table", "example.com", zap.NewNop())
+		repo.SetValidationService(nil)
+		repo.SetPermissionService(nil)
+		repo.SetEventService(nil)
+		repo.SetCachingService(nil)
+
+		err := repo.UpdateWebAuthnAuthenticationState(ctx, "cred-123", 7, true, true, lastUsedAt)
+		require.Error(t, err)
+		require.False(t, dynamormerrors.IsNotFound(err))
+
+		mockDB.AssertExpectations(t)
+		lookupQuery.AssertExpectations(t)
+		updateQuery.AssertExpectations(t)
+		updateBuilder.AssertExpectations(t)
+	})
+}
+
+func TestAccountRepository_WebAuthnHelperBranches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil helpers return safely", func(t *testing.T) {
+		t.Parallel()
+
+		require.Nil(t, webAuthnCredentialFromModel(nil))
+		require.NotPanics(t, func() {
+			ensureWebAuthnCredentialCanonicalKeys(nil)
+		})
+		require.ErrorIs(
+			t,
+			persistWebAuthnCredentialAuthenticationState(context.Background(), nil, nil, 1, true, false, time.Time{}),
+			storage.ErrInvalidInput,
+		)
+	})
+
+	t.Run("zero last used at is normalized and canonical keys are applied", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		mockDB := new(mocks.MockDB)
+		updateQuery := new(mocks.MockQuery)
+		updateBuilder := new(mocks.MockUpdateBuilder)
+
+		mockDB.On("WithContext", ctx).Return(mockDB).Once()
+		mockDB.On("Model", mock.MatchedBy(func(v any) bool {
+			model, ok := v.(*models.WebAuthnCredential)
+			if !ok {
+				return false
+			}
+			return model.ID == "cred-123" &&
+				model.UserID == "alice" &&
+				model.PK == "USER#alice" &&
+				model.SK == "WEBAUTHN_CRED#cred-123" &&
+				model.GSI1PK == "WEBAUTHN_CREDENTIAL#cred-123" &&
+				model.GSI1SK == "USER#alice"
+		})).Return(updateQuery).Once()
+
+		updateQuery.On("Where", "PK", "=", "USER#alice").Return(updateQuery).Once()
+		updateQuery.On("Where", "SK", "=", "WEBAUTHN_CRED#cred-123").Return(updateQuery).Once()
+		updateQuery.On("UpdateBuilder").Return(updateBuilder).Once()
+		updateBuilder.On("Set", "SignCount", uint32(7)).Return(updateBuilder).Once()
+		updateBuilder.On("Set", "CloneWarning", true).Return(updateBuilder).Once()
+		updateBuilder.On("Set", "BackupState", false).Return(updateBuilder).Once()
+		updateBuilder.On("Set", "LastUsedAt", mock.MatchedBy(func(ts time.Time) bool {
+			return !ts.IsZero() && ts.Equal(ts.UTC())
+		})).Return(updateBuilder).Once()
+		updateBuilder.On("Execute").Return(nil).Once()
+
+		credential := &models.WebAuthnCredential{ID: "cred-123", UserID: "alice"}
+		require.NoError(t, persistWebAuthnCredentialAuthenticationState(ctx, mockDB, credential, 7, true, false, time.Time{}))
+		require.Equal(t, "USER#alice", credential.PK)
+		require.Equal(t, "WEBAUTHN_CRED#cred-123", credential.SK)
+		require.Equal(t, "WEBAUTHN_CREDENTIAL#cred-123", credential.GSI1PK)
+		require.Equal(t, "USER#alice", credential.GSI1SK)
+
+		mockDB.AssertExpectations(t)
+		updateQuery.AssertExpectations(t)
+		updateBuilder.AssertExpectations(t)
+	})
 }

--- a/pkg/storage/repositories/auth_repository.go
+++ b/pkg/storage/repositories/auth_repository.go
@@ -60,34 +60,13 @@ func NewAuthRepositoryWithCostTracking(db core.DB, tableName string, logger *zap
 
 // CreateWebAuthnCredential creates a new WebAuthn credential
 func (r *AuthRepository) CreateWebAuthnCredential(ctx context.Context, credential *storage.WebAuthnCredential) error {
-	// Create DynamORM model
-	model := &models.WebAuthnCredential{
-		ID:              credential.ID,
-		UserID:          credential.UserID,
-		PublicKey:       credential.PublicKey,
-		AttestationType: credential.AttestationType,
-		AAGUID:          credential.AAGUID,
-		SignCount:       credential.SignCount,
-		CloneWarning:    credential.CloneWarning,
-		BackupEligible:  credential.BackupEligible,
-		BackupState:     credential.BackupState,
-		CreatedAt:       credential.CreatedAt,
-		LastUsedAt:      credential.LastUsedAt,
-		Name:            credential.Name,
+	if credential == nil {
+		return ErrorHandler.HandleCreateError(ErrWebAuthnValidationFailed, EntityWebAuthnCredential, "nil")
 	}
 
-	// Set default timestamps if not provided
-	if model.CreatedAt.IsZero() {
-		model.CreatedAt = time.Now()
-	}
-	if model.LastUsedAt.IsZero() {
-		model.LastUsedAt = model.CreatedAt
-	}
-
-	// Use BaseRepository Create method
-	err := r.Create(ctx, model)
+	err := createWebAuthnCredentialRecord(ctx, r.db, credential)
 	if err != nil {
-		return ErrorHandler.HandleCreateError(err, EntityWebAuthnCredential, credential.CredentialID)
+		return ErrorHandler.HandleCreateError(err, EntityWebAuthnCredential, credential.ID)
 	}
 
 	r.logger.Debug("created WebAuthn credential",
@@ -99,38 +78,13 @@ func (r *AuthRepository) CreateWebAuthnCredential(ctx context.Context, credentia
 
 // GetWebAuthnCredential retrieves a WebAuthn credential by ID
 func (r *AuthRepository) GetWebAuthnCredential(ctx context.Context, credentialID string) (*storage.WebAuthnCredential, error) {
-	// Query by credential ID via the existing GSI1 (no table scan required).
-	var modelList []models.WebAuthnCredential
-	err := r.db.WithContext(ctx).Model(&models.WebAuthnCredential{}).
-		Index("gsi1").
-		Where("gsi1PK", "=", "WEBAUTHN_CREDENTIAL#"+credentialID).
-		Limit(1).
-		All(&modelList)
-
+	model, err := lookupWebAuthnCredentialModel(ctx, r.db, credentialID)
 	if err != nil {
 		r.logger.Error("failed to get WebAuthn credential", zap.Error(err))
 		return nil, ErrorHandler.HandleGetError(err, EntityWebAuthnCredential, credentialID)
 	}
 
-	if err := common.ValidateSliceNotEmpty("modelList", modelList); err != nil {
-		return nil, ErrorHandler.HandleGetError(storage.ErrNotFound, EntityWebAuthnCredential, credentialID)
-	}
-
-	model := modelList[0]
-	result := &storage.WebAuthnCredential{
-		ID:              model.ID,
-		UserID:          model.UserID,
-		PublicKey:       model.PublicKey,
-		AttestationType: model.AttestationType,
-		AAGUID:          model.AAGUID,
-		SignCount:       model.SignCount,
-		CloneWarning:    model.CloneWarning,
-		BackupEligible:  model.BackupEligible,
-		BackupState:     model.BackupState,
-		CreatedAt:       model.CreatedAt,
-		LastUsedAt:      model.LastUsedAt,
-		Name:            model.Name,
-	}
+	result := webAuthnCredentialFromModel(model)
 
 	r.logger.Debug("retrieved WebAuthn credential",
 		zap.String("credential_id", credentialID),
@@ -141,52 +95,15 @@ func (r *AuthRepository) GetWebAuthnCredential(ctx context.Context, credentialID
 
 // GetUserWebAuthnCredentials retrieves all WebAuthn credentials for a user
 func (r *AuthRepository) GetUserWebAuthnCredentials(ctx context.Context, userID string) ([]*storage.WebAuthnCredential, error) {
-	// Construct the key prefix
-	pk := "USER#" + userID
-
-	const credentialChunkLimit = 100
-
-	var (
-		modelList []*models.WebAuthnCredential
-		cursor    string
-	)
-
-	for {
-		page, err := r.QueryWithSKPrefixPaginated(ctx, pk, "WEBAUTHN_CRED#", BasePaginationOptions{
-			Limit:  credentialChunkLimit,
-			Cursor: cursor,
-			Order:  SortOrderAsc,
-		})
-		if err != nil {
-			r.logger.Error("failed to get user WebAuthn credentials", zap.Error(err))
-			return nil, ErrorHandler.HandleQueryError(err, EntityWebAuthnCredential, fmt.Sprintf("user %s", userID))
-		}
-
-		modelList = append(modelList, page.Items...)
-
-		if page.NextCursor == "" || len(page.Items) == 0 {
-			break
-		}
-		cursor = page.NextCursor
+	modelList, err := listWebAuthnCredentialModels(ctx, r.db, userID)
+	if err != nil {
+		r.logger.Error("failed to get user WebAuthn credentials", zap.Error(err))
+		return nil, ErrorHandler.HandleQueryError(err, EntityWebAuthnCredential, fmt.Sprintf("user %s", userID))
 	}
 
-	// Convert to storage models
 	results := make([]*storage.WebAuthnCredential, len(modelList))
-	for i, model := range modelList {
-		results[i] = &storage.WebAuthnCredential{
-			ID:              model.ID,
-			UserID:          model.UserID,
-			PublicKey:       model.PublicKey,
-			AttestationType: model.AttestationType,
-			AAGUID:          model.AAGUID,
-			SignCount:       model.SignCount,
-			CloneWarning:    model.CloneWarning,
-			BackupEligible:  model.BackupEligible,
-			BackupState:     model.BackupState,
-			CreatedAt:       model.CreatedAt,
-			LastUsedAt:      model.LastUsedAt,
-			Name:            model.Name,
-		}
+	for i := range modelList {
+		results[i] = webAuthnCredentialFromModel(&modelList[i])
 	}
 
 	r.logger.Debug("retrieved user WebAuthn credentials",
@@ -198,56 +115,20 @@ func (r *AuthRepository) GetUserWebAuthnCredentials(ctx context.Context, userID 
 
 // DeleteWebAuthnCredential deletes a WebAuthn credential
 func (r *AuthRepository) DeleteWebAuthnCredential(ctx context.Context, credentialID string) error {
-	// First get the credential to find the user
-	credential, err := r.GetWebAuthnCredential(ctx, credentialID)
-	if err != nil {
-		return err
-	}
-
-	// Construct the key
-	pk := "USER#" + credential.UserID
-	sk := "WEBAUTHN_CRED#" + credentialID
-
-	// Use BaseRepository Delete method
-	err = r.Delete(ctx, pk, sk)
+	err := deleteWebAuthnCredentialRecord(ctx, r.db, credentialID)
 	if err != nil {
 		return ErrorHandler.HandleDeleteError(err, EntityWebAuthnCredential, credentialID)
 	}
 
 	r.logger.Debug("deleted WebAuthn credential",
-		zap.String("credential_id", credentialID),
-		zap.String("user_id", credential.UserID))
+		zap.String("credential_id", credentialID))
 
 	return nil
 }
 
 // UpdateWebAuthnLastUsed updates the last used timestamp and sign count
 func (r *AuthRepository) UpdateWebAuthnLastUsed(ctx context.Context, credentialID string, signCount uint32) error {
-	// First get the credential to find the user
-	credential, err := r.GetWebAuthnCredential(ctx, credentialID)
-	if err != nil {
-		return err
-	}
-
-	// Create model with updated fields
-	model := &models.WebAuthnCredential{
-		ID:         credentialID,
-		UserID:     credential.UserID,
-		LastUsedAt: time.Now(),
-		SignCount:  signCount,
-		// Preserve other fields from existing credential
-		PublicKey:       credential.PublicKey,
-		AttestationType: credential.AttestationType,
-		AAGUID:          credential.AAGUID,
-		CloneWarning:    credential.CloneWarning,
-		BackupEligible:  credential.BackupEligible,
-		BackupState:     credential.BackupState,
-		CreatedAt:       credential.CreatedAt,
-		Name:            credential.Name,
-	}
-
-	// Use BaseRepository Update method
-	err = r.Update(ctx, model)
+	err := updateWebAuthnCredentialLastUsedRecord(ctx, r.db, credentialID, signCount)
 	if err != nil {
 		return ErrorHandler.HandleUpdateError(err, EntityWebAuthnCredential, credentialID)
 	}

--- a/pkg/storage/repositories/auth_repository_round08_coverage_test.go
+++ b/pkg/storage/repositories/auth_repository_round08_coverage_test.go
@@ -59,11 +59,11 @@ func TestRound08_AuthRepository_WebAuthnCredentialOps(t *testing.T) {
 		})
 	})
 
-	t.Run("GetWebAuthnCredential scan error / empty / success", func(t *testing.T) {
+	t.Run("GetWebAuthnCredential query error / not found / success", func(t *testing.T) {
 		t.Run("query error", func(t *testing.T) {
 			mockDB := new(mocks.MockDB)
 			mockQuery := new(mocks.MockQuery)
-			mockQuery.On("All", mock.Anything).Return(errors.New("query failed")).Once()
+			mockQuery.On("First", mock.Anything).Return(errors.New("query failed")).Once()
 			setupPermissiveRound08Mocks(mockDB, mockQuery, nil, baseTime)
 
 			repo := NewAuthRepositoryWithCostTracking(mockDB, "test-table", zaptest.NewLogger(t), costSvc)
@@ -71,13 +71,10 @@ func TestRound08_AuthRepository_WebAuthnCredentialOps(t *testing.T) {
 			require.Error(t, err)
 		})
 
-		t.Run("empty results", func(t *testing.T) {
+		t.Run("not found", func(t *testing.T) {
 			mockDB := new(mocks.MockDB)
 			mockQuery := new(mocks.MockQuery)
-			mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
-				out := args.Get(0).(*[]models.WebAuthnCredential)
-				*out = nil
-			}).Return(nil).Once()
+			mockQuery.On("First", mock.Anything).Return(dynamormErrors.ErrItemNotFound).Once()
 			setupPermissiveRound08Mocks(mockDB, mockQuery, nil, baseTime)
 
 			repo := NewAuthRepositoryWithCostTracking(mockDB, "test-table", zaptest.NewLogger(t), costSvc)
@@ -86,36 +83,41 @@ func TestRound08_AuthRepository_WebAuthnCredentialOps(t *testing.T) {
 			require.Nil(t, cred)
 		})
 
-		t.Run("empty results prevent delete and update nil panics", func(t *testing.T) {
+		t.Run("not found prevents delete and update nil panics", func(t *testing.T) {
 			for _, tc := range []struct {
-				name string
-				call func(*AuthRepository) error
+				name      string
+				call      func(*AuthRepository) error
+				assertErr bool
 			}{
 				{
 					name: "delete",
 					call: func(repo *AuthRepository) error {
 						return repo.DeleteWebAuthnCredential(ctx, "missing")
 					},
+					assertErr: false,
 				},
 				{
 					name: "update",
 					call: func(repo *AuthRepository) error {
 						return repo.UpdateWebAuthnLastUsed(ctx, "missing", 1)
 					},
+					assertErr: true,
 				},
 			} {
 				t.Run(tc.name, func(t *testing.T) {
 					mockDB := new(mocks.MockDB)
 					mockQuery := new(mocks.MockQuery)
-					mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
-						out := args.Get(0).(*[]models.WebAuthnCredential)
-						*out = nil
-					}).Return(nil).Once()
+					mockQuery.On("First", mock.Anything).Return(dynamormErrors.ErrItemNotFound).Once()
 					setupPermissiveRound08Mocks(mockDB, mockQuery, nil, baseTime)
 
 					repo := NewAuthRepositoryWithCostTracking(mockDB, "test-table", zaptest.NewLogger(t), costSvc)
 					require.NotPanics(t, func() {
-						require.Error(t, tc.call(repo))
+						err := tc.call(repo)
+						if tc.assertErr {
+							require.Error(t, err)
+							return
+						}
+						require.NoError(t, err)
 					})
 				})
 			}
@@ -124,16 +126,17 @@ func TestRound08_AuthRepository_WebAuthnCredentialOps(t *testing.T) {
 		t.Run("success", func(t *testing.T) {
 			mockDB := new(mocks.MockDB)
 			mockQuery := new(mocks.MockQuery)
-			mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
-				out := args.Get(0).(*[]models.WebAuthnCredential)
-				*out = append(*out, models.WebAuthnCredential{
+			mockQuery.On("First", mock.Anything).Run(func(args mock.Arguments) {
+				out := args.Get(0).(*models.WebAuthnCredential)
+				*out = models.WebAuthnCredential{
 					ID:         "cred-1",
 					UserID:     "user-1",
 					PublicKey:  []byte("pk"),
 					CreatedAt:  baseTime,
 					LastUsedAt: baseTime,
 					Type:       "WebAuthnCredential",
-				})
+				}
+				_ = out.BeforeCreate()
 			}).Return(nil).Once()
 			setupPermissiveRound08Mocks(mockDB, mockQuery, nil, baseTime)
 
@@ -144,28 +147,21 @@ func TestRound08_AuthRepository_WebAuthnCredentialOps(t *testing.T) {
 		})
 	})
 
-	t.Run("GetUserWebAuthnCredentials paginates", func(t *testing.T) {
+	t.Run("GetUserWebAuthnCredentials lists credentials", func(t *testing.T) {
 		mockDB := new(mocks.MockDB)
 		mockQuery := new(mocks.MockQuery)
 
-		call := 0
 		mockQuery.On("All", mock.Anything).Run(func(args mock.Arguments) {
-			call++
-			out := args.Get(0).(*[]*models.WebAuthnCredential)
-			if call == 1 {
-				for i := 0; i < 101; i++ {
-					cred := &models.WebAuthnCredential{
-						ID:     "cred",
-						UserID: "user-1",
-					}
-					_ = cred.BeforeCreate()
-					cred.SK = "WEBAUTHN_CRED#cred-" + string(rune('a'+(i%26)))
-					*out = append(*out, cred)
+			out := args.Get(0).(*[]models.WebAuthnCredential)
+			for i := 0; i < 3; i++ {
+				cred := models.WebAuthnCredential{
+					ID:     "cred-" + string(rune('a'+i)),
+					UserID: "user-1",
 				}
-				return
+				_ = cred.BeforeCreate()
+				*out = append(*out, cred)
 			}
-			// Second page: empty results stops loop.
-		}).Return(nil).Maybe()
+		}).Return(nil).Once()
 
 		setupPermissiveRound08Mocks(mockDB, mockQuery, nil, baseTime)
 

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -312,9 +312,7 @@ type WebAuthnChallenge struct {
 // WebAuthnCredential represents a WebAuthn credential
 type WebAuthnCredential struct {
 	ID              string    `json:"id"`
-	Username        string    `json:"username"`
 	UserID          string    `json:"user_id"`
-	CredentialID    string    `json:"credential_id"`
 	PublicKey       []byte    `json:"public_key"`
 	AttestationType string    `json:"attestation_type"`
 	AAGUID          []byte    `json:"aaguid"`
@@ -323,7 +321,6 @@ type WebAuthnCredential struct {
 	BackupEligible  bool      `json:"backup_eligible"`
 	BackupState     bool      `json:"backup_state"`
 	CreatedAt       time.Time `json:"created_at"`
-	LastUsed        time.Time `json:"last_used"`
 	LastUsedAt      time.Time `json:"last_used_at"`
 	Name            string    `json:"name,omitempty"`
 }


### PR DESCRIPTION
## Summary
- repair WebAuthn credential reads, deletes, lists, and last-used updates to use the canonical USER#/WEBAUTHN_CRED# and GSI1 credential lookup scheme, with strict predicate tests proving the pre-fix failure and post-fix behavior
- consolidate repository WebAuthn credential access on the canonical key paths, collapse duplicate storage credential fields, and keep wallet credential paths unchanged
- add the single-use passkey registration proof storage model with short TTL and atomic consumed-flag semantics, covered by lifecycle and exactly-once tests

## Validation
- `go build ./...`
- `go vet ./...`
- `gofmt -l .`
- `go test ./...`
- `./lesser verify ci`
- `git log --no-merges --format='%H %ae %(trailers:key=Signed-off-by,valueonly,separator=%x2C)' origin/staging..HEAD`

## Issues
Refs #1370 #1379 #1380 #1381 #1382

Closes #1379
Closes #1380
Closes #1381
Closes #1382
