### PR TITLE
feat(auth): passkey-first signup API end-to-end

### DIFF
--- a/cmd/api/auth_surface_reconciliation_test.go
+++ b/cmd/api/auth_surface_reconciliation_test.go
@@ -566,6 +566,8 @@ var authSurfaceExpectedPublicMutations = map[string]bool{
 	"POST /api/v1/agents/register/challenge":                                       true,
 	"POST /api/v1/auth/webauthn/login/begin":                                       true,
 	"POST /api/v1/auth/webauthn/login/finish":                                      true,
+	"POST /api/v1/auth/webauthn/signup/begin":                                      true,
+	"POST /api/v1/auth/webauthn/signup/finish":                                     true,
 	"POST /api/v1/search/statuses":                                                 true,
 	"POST /api/v1/agents/{username}/access-leases/{leaseID}/renew/challenge":       true,
 	"POST /api/v1/agents/{username}/access-leases/{leaseID}/session-key":           true,

--- a/cmd/api/handlers/accounts.go
+++ b/cmd/api/handlers/accounts.go
@@ -76,18 +76,29 @@ func (h *Handler) HandleRegistrationLift(ctx *apptheory.Context) (*apptheory.Res
 	}
 
 	challengeID := strings.TrimSpace(req.WalletChallengeID)
-	challenge, err := authService.GetWalletChallenge(ctx.Context(), challengeID)
-	if err != nil || challenge == nil {
-		return common.RespondUnprocessableEntity(ctx, "wallet_challenge_id is invalid or expired")
-	}
-	if strings.TrimSpace(challenge.Username) != strings.TrimSpace(req.Username) {
-		return common.RespondUnprocessableEntity(ctx, "wallet challenge was created for a different username")
-	}
-	if !challenge.Used {
-		return common.RespondUnprocessableEntity(ctx, "wallet challenge has not been verified")
-	}
-	if challenge.Spent {
-		return common.RespondUnprocessableEntity(ctx, "wallet challenge was already spent")
+	passkeyProofID := strings.TrimSpace(req.PasskeyRegistrationProof)
+	if challengeID != "" {
+		challenge, err := authService.GetWalletChallenge(ctx.Context(), challengeID)
+		if err != nil || challenge == nil {
+			return common.RespondUnprocessableEntity(ctx, "wallet_challenge_id is invalid or expired")
+		}
+		if strings.TrimSpace(challenge.Username) != strings.TrimSpace(req.Username) {
+			return common.RespondUnprocessableEntity(ctx, "wallet challenge was created for a different username")
+		}
+		if !challenge.Used {
+			return common.RespondUnprocessableEntity(ctx, "wallet challenge has not been verified")
+		}
+		if challenge.Spent {
+			return common.RespondUnprocessableEntity(ctx, "wallet challenge was already spent")
+		}
+	} else {
+		proof, err := authService.GetPasskeyRegistrationProof(ctx.Context(), passkeyProofID)
+		if err != nil || proof == nil || proof.Consumed {
+			return common.RespondUnprocessableEntity(ctx, "passkey_registration_proof is invalid or expired")
+		}
+		if strings.TrimSpace(proof.Username) != strings.TrimSpace(req.Username) {
+			return common.RespondUnprocessableEntity(ctx, "passkey registration proof was created for a different username")
+		}
 	}
 
 	// NOTE: Password-based authentication is disabled. This system uses WebAuthn/crypto wallet authentication only.
@@ -109,6 +120,7 @@ func (h *Handler) HandleRegistrationLift(ctx *apptheory.Context) (*apptheory.Res
 		Reason:                   req.Reason,
 		DefaultPostingVisibility: req.DefaultPostingVisibility,
 		RegistrationChallengeID:  challengeID,
+		PasskeyRegistrationProof: passkeyProofID,
 	})
 	if err != nil {
 		if errors.Is(err, accounts.ErrUsernameAlreadyTaken) {
@@ -1311,8 +1323,13 @@ func (h *Handler) validateRegistrationRequestLift(req models.AccountRegistration
 		}
 	}
 
-	if strings.TrimSpace(req.WalletChallengeID) == "" {
-		return errors.New("wallet_challenge_id is required")
+	walletChallengeID := strings.TrimSpace(req.WalletChallengeID)
+	passkeyProofID := strings.TrimSpace(req.PasskeyRegistrationProof)
+	switch {
+	case walletChallengeID != "" && passkeyProofID != "":
+		return errors.New("wallet_challenge_id and passkey_registration_proof cannot both be provided")
+	case walletChallengeID == "" && passkeyProofID == "":
+		return errors.New("exactly one of wallet_challenge_id or passkey_registration_proof is required")
 	}
 
 	return nil

--- a/cmd/api/handlers/accounts.go
+++ b/cmd/api/handlers/accounts.go
@@ -67,6 +67,7 @@ func (h *Handler) HandleRegistrationLift(ctx *apptheory.Context) (*apptheory.Res
 	if err := h.validateRegistrationRequestLift(req); err != nil {
 		return common.RespondUnprocessableEntity(ctx, err.Error())
 	}
+	req.Username = accounts.NormalizeUsernameForDomain(req.Username, h.cfg.Domain)
 
 	// Require wallet verification as the registration proof (passwordless signup).
 	// The auth-ui flow calls POST /auth/wallet/verify first, which marks the challenge as used.
@@ -82,7 +83,7 @@ func (h *Handler) HandleRegistrationLift(ctx *apptheory.Context) (*apptheory.Res
 		if err != nil || challenge == nil {
 			return common.RespondUnprocessableEntity(ctx, "wallet_challenge_id is invalid or expired")
 		}
-		if strings.TrimSpace(challenge.Username) != strings.TrimSpace(req.Username) {
+		if accounts.NormalizeUsernameForDomain(challenge.Username, h.cfg.Domain) != req.Username {
 			return common.RespondUnprocessableEntity(ctx, "wallet challenge was created for a different username")
 		}
 		if !challenge.Used {
@@ -96,7 +97,7 @@ func (h *Handler) HandleRegistrationLift(ctx *apptheory.Context) (*apptheory.Res
 		if err != nil || proof == nil || proof.Consumed {
 			return common.RespondUnprocessableEntity(ctx, "passkey_registration_proof is invalid or expired")
 		}
-		if strings.TrimSpace(proof.Username) != strings.TrimSpace(req.Username) {
+		if accounts.NormalizeUsernameForDomain(proof.Username, h.cfg.Domain) != req.Username {
 			return common.RespondUnprocessableEntity(ctx, "passkey registration proof was created for a different username")
 		}
 	}

--- a/cmd/api/handlers/accounts_round12_test.go
+++ b/cmd/api/handlers/accounts_round12_test.go
@@ -295,6 +295,56 @@ func TestAccountsRound12_HandleRegistrationLift(t *testing.T) {
 		require.Equal(t, "alice", regResp.Username)
 		require.True(t, regResp.Created)
 	})
+
+	t.Run("passkey_registration_proof_mixed_case_username_is_canonicalized_at_handler_boundary", func(t *testing.T) {
+		cfg := round10TestConfig()
+
+		var gotCmd *accounts.RegisterAccountCommand
+		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{
+			passkeyRegistrationProofsByID: map[string]storagemodels.PasskeyRegistrationProof{
+				"proof-1": {
+					ID:         "proof-1",
+					Username:   "alice",
+					CeremonyID: "signup-1",
+					PublicKey:  []byte{0x01},
+					CreatedAt:  time.Now().Add(-time.Minute),
+					ExpiresAt:  time.Now().Add(5 * time.Minute),
+				},
+			},
+		}, &RegistryStub{
+			AccountsSvc: &AccountsServiceStub{
+				RegisterAccountFunc: func(_ context.Context, cmd *accounts.RegisterAccountCommand) (*accounts.RegisterAccountResult, error) {
+					gotCmd = cmd
+					return &accounts.RegisterAccountResult{
+						Account: &storage.Account{User: &storage.User{Username: cmd.Username}},
+						Actor: &activitypub.Actor{
+							BaseObject:        activitypub.BaseObject{ID: cfg.BaseURL() + "/users/" + cmd.Username},
+							PreferredUsername: cmd.Username,
+						},
+					}, nil
+				},
+			},
+		})
+
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/accounts", nil, nil, apimodels.AccountRegistrationRequest{
+			Username:                 "Alice",
+			Agreement:                true,
+			PasskeyRegistrationProof: "proof-1",
+		})
+		require.NoError(t, err)
+
+		resp := requireStatus(t, http.StatusCreated)(h.HandleRegistrationLift(ctx))
+
+		require.NotNil(t, gotCmd)
+		require.Equal(t, "alice", gotCmd.Username)
+		require.Equal(t, "proof-1", gotCmd.PasskeyRegistrationProof)
+
+		var regResp apimodels.AccountRegistrationResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &regResp))
+		require.Equal(t, cfg.BaseURL()+"/users/alice", regResp.ID)
+		require.Equal(t, "alice", regResp.Username)
+		require.True(t, regResp.Created)
+	})
 }
 
 func TestAccountsRound12_HandleVerifyCredentialsLift(t *testing.T) {

--- a/cmd/api/handlers/accounts_round12_test.go
+++ b/cmd/api/handlers/accounts_round12_test.go
@@ -168,6 +168,133 @@ func TestAccountsRound12_HandleRegistrationLift(t *testing.T) {
 			WalletChallengeID: "c1",
 		}))
 	})
+
+	t.Run("validateRegistrationRequestLift_requires_exactly_one_registration_proof", func(t *testing.T) {
+		h, _, _ := round11NewHandler(t, round10TestConfig(), &round10QueryState{}, &RegistryStub{})
+
+		err := h.validateRegistrationRequestLift(apimodels.AccountRegistrationRequest{
+			Username:  "alice",
+			Agreement: true,
+		})
+		require.EqualError(t, err, "exactly one of wallet_challenge_id or passkey_registration_proof is required")
+
+		err = h.validateRegistrationRequestLift(apimodels.AccountRegistrationRequest{
+			Username:                 "alice",
+			Agreement:                true,
+			WalletChallengeID:        "c1",
+			PasskeyRegistrationProof: "proof-1",
+		})
+		require.EqualError(t, err, "wallet_challenge_id and passkey_registration_proof cannot both be provided")
+	})
+
+	t.Run("passkey_registration_proof_errors_are_mapped", func(t *testing.T) {
+		cfg := round10TestConfig()
+
+		t.Run("invalid_or_expired", func(t *testing.T) {
+			h, _, _ := round11NewHandler(t, cfg, &round10QueryState{
+				notFoundPKSK: map[string]bool{"PASSKEY_REGISTRATION_PROOF#proof-1#PROOF": true},
+			}, &RegistryStub{
+				AccountsSvc: &AccountsServiceStub{
+					RegisterAccountFunc: func(context.Context, *accounts.RegisterAccountCommand) (*accounts.RegisterAccountResult, error) {
+						return nil, errors.New("unexpected service call")
+					},
+				},
+			})
+
+			ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/accounts", nil, nil, apimodels.AccountRegistrationRequest{
+				Username:                 "alice",
+				Agreement:                true,
+				PasskeyRegistrationProof: "proof-1",
+			})
+			require.NoError(t, err)
+
+			requireStatus(t, http.StatusUnprocessableEntity)(h.HandleRegistrationLift(ctx))
+		})
+
+		t.Run("proof_bound_to_different_username", func(t *testing.T) {
+			h, _, _ := round11NewHandler(t, cfg, &round10QueryState{
+				passkeyRegistrationProofsByID: map[string]storagemodels.PasskeyRegistrationProof{
+					"proof-1": {
+						ID:         "proof-1",
+						Username:   "bob",
+						CeremonyID: "signup-1",
+						PublicKey:  []byte{0x01},
+						CreatedAt:  time.Now().Add(-time.Minute),
+						ExpiresAt:  time.Now().Add(5 * time.Minute),
+					},
+				},
+			}, &RegistryStub{
+				AccountsSvc: &AccountsServiceStub{
+					RegisterAccountFunc: func(context.Context, *accounts.RegisterAccountCommand) (*accounts.RegisterAccountResult, error) {
+						return nil, errors.New("unexpected service call")
+					},
+				},
+			})
+
+			ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/accounts", nil, nil, apimodels.AccountRegistrationRequest{
+				Username:                 "alice",
+				Agreement:                true,
+				PasskeyRegistrationProof: "proof-1",
+			})
+			require.NoError(t, err)
+
+			requireStatus(t, http.StatusUnprocessableEntity)(h.HandleRegistrationLift(ctx))
+		})
+	})
+
+	t.Run("passkey_registration_proof_success", func(t *testing.T) {
+		cfg := round10TestConfig()
+
+		var gotCmd *accounts.RegisterAccountCommand
+		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{
+			passkeyRegistrationProofsByID: map[string]storagemodels.PasskeyRegistrationProof{
+				"proof-1": {
+					ID:         "proof-1",
+					Username:   "alice",
+					CeremonyID: "signup-1",
+					PublicKey:  []byte{0x01},
+					CreatedAt:  time.Now().Add(-time.Minute),
+					ExpiresAt:  time.Now().Add(5 * time.Minute),
+				},
+			},
+		}, &RegistryStub{
+			AccountsSvc: &AccountsServiceStub{
+				RegisterAccountFunc: func(_ context.Context, cmd *accounts.RegisterAccountCommand) (*accounts.RegisterAccountResult, error) {
+					gotCmd = cmd
+					return &accounts.RegisterAccountResult{
+						Account: &storage.Account{User: &storage.User{Username: cmd.Username}},
+						Actor: &activitypub.Actor{
+							BaseObject:        activitypub.BaseObject{ID: cfg.BaseURL() + "/users/" + cmd.Username},
+							PreferredUsername: cmd.Username,
+						},
+					}, nil
+				},
+			},
+		})
+
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/accounts", nil, nil, apimodels.AccountRegistrationRequest{
+			Username:                 "alice",
+			Password:                 "ignored",
+			Agreement:                true,
+			PasskeyRegistrationProof: "proof-1",
+		})
+		require.NoError(t, err)
+
+		resp := requireStatus(t, http.StatusCreated)(h.HandleRegistrationLift(ctx))
+
+		require.NotNil(t, gotCmd)
+		require.Equal(t, "alice", gotCmd.Username)
+		require.Empty(t, gotCmd.Email)
+		require.Empty(t, gotCmd.Password)
+		require.Empty(t, gotCmd.RegistrationChallengeID)
+		require.Equal(t, "proof-1", gotCmd.PasskeyRegistrationProof)
+
+		var regResp apimodels.AccountRegistrationResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &regResp))
+		require.Equal(t, cfg.BaseURL()+"/users/alice", regResp.ID)
+		require.Equal(t, "alice", regResp.Username)
+		require.True(t, regResp.Created)
+	})
 }
 
 func TestAccountsRound12_HandleVerifyCredentialsLift(t *testing.T) {

--- a/cmd/api/handlers/accounts_round12_test.go
+++ b/cmd/api/handlers/accounts_round12_test.go
@@ -160,6 +160,60 @@ func TestAccountsRound12_HandleRegistrationLift(t *testing.T) {
 		require.True(t, regResp.Created)
 	})
 
+	t.Run("wallet_challenge_mixed_case_stored_username_is_canonicalized_at_handler_boundary", func(t *testing.T) {
+		cfg := round10TestConfig()
+		now := time.Now()
+
+		var gotCmd *accounts.RegisterAccountCommand
+		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{
+			walletChallengesByID: map[string]storagemodels.WalletChallenge{
+				"challenge-noncanonical": {
+					ID:        "challenge-noncanonical",
+					Username:  "Alice",
+					Address:   "0xabc",
+					ChainID:   1,
+					Nonce:     "nonce",
+					Message:   "msg",
+					IssuedAt:  now.Add(-time.Minute),
+					ExpiresAt: now.Add(10 * time.Minute),
+					Used:      true,
+				},
+			},
+		}, &RegistryStub{
+			AccountsSvc: &AccountsServiceStub{
+				RegisterAccountFunc: func(_ context.Context, cmd *accounts.RegisterAccountCommand) (*accounts.RegisterAccountResult, error) {
+					gotCmd = cmd
+					return &accounts.RegisterAccountResult{
+						Account: &storage.Account{User: &storage.User{Username: cmd.Username}},
+						Actor: &activitypub.Actor{
+							BaseObject:        activitypub.BaseObject{ID: cfg.BaseURL() + "/users/" + cmd.Username},
+							PreferredUsername: cmd.Username,
+						},
+					}, nil
+				},
+			},
+		})
+
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/accounts", nil, nil, apimodels.AccountRegistrationRequest{
+			Username:          "Alice",
+			Agreement:         true,
+			WalletChallengeID: "challenge-noncanonical",
+		})
+		require.NoError(t, err)
+
+		resp := requireStatus(t, http.StatusCreated)(h.HandleRegistrationLift(ctx))
+
+		require.NotNil(t, gotCmd)
+		require.Equal(t, "alice", gotCmd.Username)
+		require.Equal(t, "challenge-noncanonical", gotCmd.RegistrationChallengeID)
+
+		var regResp apimodels.AccountRegistrationResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &regResp))
+		require.Equal(t, cfg.BaseURL()+"/users/alice", regResp.ID)
+		require.Equal(t, "alice", regResp.Username)
+		require.True(t, regResp.Created)
+	})
+
 	t.Run("validateRegistrationRequestLift_allows_empty_visibility", func(t *testing.T) {
 		h, _, _ := round11NewHandler(t, round10TestConfig(), &round10QueryState{}, &RegistryStub{})
 		require.NoError(t, h.validateRegistrationRequestLift(apimodels.AccountRegistrationRequest{
@@ -296,16 +350,16 @@ func TestAccountsRound12_HandleRegistrationLift(t *testing.T) {
 		require.True(t, regResp.Created)
 	})
 
-	t.Run("passkey_registration_proof_mixed_case_username_is_canonicalized_at_handler_boundary", func(t *testing.T) {
+	t.Run("passkey_registration_proof_mixed_case_stored_username_is_canonicalized_at_handler_boundary", func(t *testing.T) {
 		cfg := round10TestConfig()
 
 		var gotCmd *accounts.RegisterAccountCommand
 		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{
 			passkeyRegistrationProofsByID: map[string]storagemodels.PasskeyRegistrationProof{
-				"proof-1": {
-					ID:         "proof-1",
-					Username:   "alice",
-					CeremonyID: "signup-1",
+				"proof-noncanonical": {
+					ID:         "proof-noncanonical",
+					Username:   "Alice",
+					CeremonyID: "signup-noncanonical",
 					PublicKey:  []byte{0x01},
 					CreatedAt:  time.Now().Add(-time.Minute),
 					ExpiresAt:  time.Now().Add(5 * time.Minute),
@@ -329,7 +383,7 @@ func TestAccountsRound12_HandleRegistrationLift(t *testing.T) {
 		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/accounts", nil, nil, apimodels.AccountRegistrationRequest{
 			Username:                 "Alice",
 			Agreement:                true,
-			PasskeyRegistrationProof: "proof-1",
+			PasskeyRegistrationProof: "proof-noncanonical",
 		})
 		require.NoError(t, err)
 
@@ -337,7 +391,7 @@ func TestAccountsRound12_HandleRegistrationLift(t *testing.T) {
 
 		require.NotNil(t, gotCmd)
 		require.Equal(t, "alice", gotCmd.Username)
-		require.Equal(t, "proof-1", gotCmd.PasskeyRegistrationProof)
+		require.Equal(t, "proof-noncanonical", gotCmd.PasskeyRegistrationProof)
 
 		var regResp apimodels.AccountRegistrationResponse
 		require.NoError(t, json.Unmarshal(resp.Body, &regResp))

--- a/cmd/api/handlers/round10_test_helpers_test.go
+++ b/cmd/api/handlers/round10_test_helpers_test.go
@@ -59,6 +59,7 @@ type round10QueryState struct {
 	webAuthnCredentialsByUser     map[string][]storagemodels.WebAuthnCredential
 	webAuthnCredentialByID        map[string]storagemodels.WebAuthnCredential
 	webAuthnChallengesByID        map[string]storagemodels.WebAuthnChallenge
+	passkeyRegistrationProofsByID map[string]storagemodels.PasskeyRegistrationProof
 	oauthClientsByID              map[string]storagemodels.OAuthClient
 	authorizationCodesByCode      map[string]storagemodels.AuthorizationCode
 	refreshTokensByToken          map[string]storagemodels.RefreshToken
@@ -940,6 +941,14 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 				return
 			}
 			round10UpsertWebAuthnCredential(state, *m)
+		case *storagemodels.PasskeyRegistrationProof:
+			if m == nil {
+				return
+			}
+			if state.passkeyRegistrationProofsByID == nil {
+				state.passkeyRegistrationProofsByID = map[string]storagemodels.PasskeyRegistrationProof{}
+			}
+			state.passkeyRegistrationProofsByID[m.ID] = *m
 		}
 	}).Maybe()
 	mockQuery.On("Count").Return(int64(2), nil).Maybe()
@@ -1963,6 +1972,24 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 				UserID:    "alice",
 				Type:      "registration",
 				ExpiresAt: time.Now().Add(5 * time.Minute),
+			}
+		case *storagemodels.PasskeyRegistrationProof:
+			proofID := ""
+			if pk, ok := state.whereString("PK"); ok && strings.HasPrefix(pk, "PASSKEY_REGISTRATION_PROOF#") {
+				proofID = strings.TrimPrefix(pk, "PASSKEY_REGISTRATION_PROOF#")
+			}
+			if proof, ok := state.passkeyRegistrationProofsByID[proofID]; ok {
+				*d = proof
+				return
+			}
+			*d = storagemodels.PasskeyRegistrationProof{
+				ID:           proofID,
+				Username:     "alice",
+				CeremonyID:   "signup-1",
+				CredentialID: "cred-1",
+				PublicKey:    []byte{0x01},
+				CreatedAt:    time.Now().Add(-1 * time.Minute),
+				ExpiresAt:    time.Now().Add(5 * time.Minute),
 			}
 		case *storagemodels.WebAuthnCredential:
 			credentialID := ""

--- a/cmd/api/handlers/round10_test_helpers_test.go
+++ b/cmd/api/handlers/round10_test_helpers_test.go
@@ -936,6 +936,14 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 				state.walletChallengesByID = map[string]storagemodels.WalletChallenge{}
 			}
 			state.walletChallengesByID[m.ID] = *m
+		case *storagemodels.WebAuthnChallenge:
+			if m == nil {
+				return
+			}
+			if state.webAuthnChallengesByID == nil {
+				state.webAuthnChallengesByID = map[string]storagemodels.WebAuthnChallenge{}
+			}
+			state.webAuthnChallengesByID[m.Challenge] = *m
 		case *storagemodels.WebAuthnCredential:
 			if m == nil {
 				return

--- a/cmd/api/handlers/setup.go
+++ b/cmd/api/handlers/setup.go
@@ -422,6 +422,7 @@ func (h *Handler) ensureSetupAdminAccount(ctx *apptheory.Context, username strin
 		Reason:                   "",
 		InviteCode:               "",
 		DefaultPostingVisibility: "",
+		RegistrationMode:         accounts.RegisterAccountModeSetupAdminBootstrap,
 	})
 	if err != nil {
 		if !errors.Is(err, accounts.ErrUsernameAlreadyTaken) {

--- a/cmd/api/handlers/setup_round12_test.go
+++ b/cmd/api/handlers/setup_round12_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/config"
 	apperrors "github.com/equaltoai/lesser/pkg/errors"
+	"github.com/equaltoai/lesser/pkg/services"
 	"github.com/equaltoai/lesser/pkg/services/accounts"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/require"
@@ -681,6 +682,36 @@ func TestEnsureSetupAdminAccountRound12(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, resp)
 		require.Equal(t, cfg.ActorURL("alice"), actorID)
+	})
+
+	t.Run("real accounts service bootstrap mode creates admin without public proofs", func(t *testing.T) {
+		handler, repos, _ := round11NewHandler(t, cfg, &round10QueryState{})
+		repos.Account().SetEncryptor(noopEncryptor{})
+
+		registry, err := services.NewRegistry(
+			services.WithStorage(repos),
+			services.WithLogger(round10TestLogger(t)),
+			services.WithConfig(&services.ServiceConfig{
+				BaseURL:   cfg.BaseURL(),
+				JWTSecret: cfg.JWTSecret,
+				Config:    cfg,
+			}),
+		)
+		require.NoError(t, err)
+		handler.registry = newServiceRegistry(registry)
+
+		ctx, err := round10NewLiftContext(http.MethodPost, "/setup/admin", nil, nil, nil)
+		require.NoError(t, err)
+
+		actorID, resp, err := handler.ensureSetupAdminAccount(ctx, "Alice")
+		require.NoError(t, err)
+		require.Nil(t, resp)
+		require.Equal(t, cfg.ActorURL("alice"), actorID)
+
+		account, err := repos.Account().GetAccount(ctx.Context(), "alice")
+		require.NoError(t, err)
+		require.NotNil(t, account)
+		require.Equal(t, "alice", account.User.Username)
 	})
 }
 

--- a/cmd/api/handlers/webauthn.go
+++ b/cmd/api/handlers/webauthn.go
@@ -13,6 +13,16 @@ import (
 	"go.uber.org/zap"
 )
 
+type webAuthnSignupFinishRequest struct {
+	Username  string         `json:"username"`
+	Challenge string         `json:"challenge"`
+	Response  map[string]any `json:"response"`
+}
+
+type webAuthnSignupFinishResponse struct {
+	PasskeyRegistrationProof string `json:"passkey_registration_proof"`
+}
+
 func webAuthnPublicKeyMap(options any) (map[string]any, error) {
 	if options == nil {
 		return nil, nil
@@ -40,6 +50,76 @@ func webAuthnPublicKeyMap(options any) (map[string]any, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+// HandleBeginWebAuthnSignupLift starts the public WebAuthn signup process.
+// POST /api/v1/auth/webauthn/signup/begin
+func (h *Handler) HandleBeginWebAuthnSignupLift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	var req apimodels.WebAuthnBeginLoginRequest
+	if err := h.parseRequestBody(ctx, &req); err != nil {
+		return h.respondBadRequest(ctx, "invalid request body")
+	}
+
+	if err := common.ValidateRequiredParam("username", req.Username); err != nil {
+		return h.respondBadRequest(ctx, "username required")
+	}
+
+	authService, resp, err := h.requireAuthService(ctx)
+	if resp != nil || err != nil {
+		return resp, err
+	}
+
+	options, challenge, err := authService.BeginWebAuthnSignup(ctx.Context(), req.Username)
+	if err != nil {
+		return h.handleAuthServiceError(ctx, err, "begin signup")
+	}
+
+	publicKey, err := webAuthnPublicKeyMap(options)
+	if err != nil {
+		h.logger.Error("failed to serialize webauthn signup options", zap.Error(err))
+		return h.respondInternalError(ctx, "failed to begin signup")
+	}
+
+	return okJSON(apimodels.WebAuthnBeginResponse{
+		PublicKey: publicKey,
+		Challenge: challenge,
+	})
+}
+
+// HandleFinishWebAuthnSignupLift completes the public WebAuthn signup process
+// and returns a single-use registration proof.
+// POST /api/v1/auth/webauthn/signup/finish
+func (h *Handler) HandleFinishWebAuthnSignupLift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	var req webAuthnSignupFinishRequest
+	if err := h.parseRequestBody(ctx, &req); err != nil {
+		return h.respondBadRequest(ctx, "invalid request body")
+	}
+
+	if err := common.ValidateRequiredParam("username", req.Username); err != nil {
+		return h.respondBadRequest(ctx, "username required")
+	}
+	if err := common.ValidateRequiredParam("challenge", req.Challenge); err != nil {
+		return h.respondBadRequest(ctx, "challenge required")
+	}
+
+	authService, resp, err := h.requireAuthService(ctx)
+	if resp != nil || err != nil {
+		return resp, err
+	}
+
+	rawResponse, err := json.Marshal(req.Response)
+	if err != nil {
+		return h.respondBadRequest(ctx, "invalid response payload")
+	}
+
+	proofID, err := authService.FinishWebAuthnSignup(ctx.Context(), req.Username, req.Challenge, rawResponse)
+	if err != nil {
+		return h.handleAuthServiceError(ctx, err, "complete signup")
+	}
+
+	return okJSON(webAuthnSignupFinishResponse{
+		PasskeyRegistrationProof: proofID,
+	})
 }
 
 // HandleBeginWebAuthnRegistrationLift starts the WebAuthn registration process

--- a/cmd/api/handlers/webauthn_signup_round12_test.go
+++ b/cmd/api/handlers/webauthn_signup_round12_test.go
@@ -1,0 +1,156 @@
+package handlers
+
+import (
+	"encoding/json"
+	stdErrors "errors"
+	"net/http"
+	"testing"
+	"time"
+
+	apimodels "github.com/equaltoai/lesser/cmd/api/models"
+	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/go-webauthn/webauthn/protocol"
+	libwebauthn "github.com/go-webauthn/webauthn/webauthn"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	webauthnSignupFixtureChallenge = "W8GzFU8pGjhoRbWrLDlamAfq_y4S1CZG1VuoeRLARrE"
+	webauthnSignupFixtureResponse  = `{
+  "id":"6xrtBhJQW6QU4tOaB4rrHaS2Ks0yDDL_q8jDC16DEjZ-VLVf4kCRkvl2xp2D71sTPYns-exsHQHTy3G-zJRK8g",
+  "rawId":"6xrtBhJQW6QU4tOaB4rrHaS2Ks0yDDL_q8jDC16DEjZ-VLVf4kCRkvl2xp2D71sTPYns-exsHQHTy3G-zJRK8g",
+  "type":"public-key",
+  "authenticatorAttachment":"platform",
+  "clientExtensionResults":{"appid":true},
+  "response":{
+    "attestationObject":"o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjEdKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvBBAAAAAAAAAAAAAAAAAAAAAAAAAAAAQOsa7QYSUFukFOLTmgeK6x2ktirNMgwy_6vIwwtegxI2flS1X-JAkZL5dsadg-9bEz2J7PnsbB0B08txvsyUSvKlAQIDJiABIVggLKF5xS0_BntttUIrm2Z2tgZ4uQDwllbdIfrrBMABCNciWCDHwin8Zdkr56iSIh0MrB5qZiEzYLQpEOREhMUkY6q4Vw",
+    "clientDataJSON":"eyJjaGFsbGVuZ2UiOiJXOEd6RlU4cEdqaG9SYldyTERsYW1BZnFfeTRTMUNaRzFWdW9lUkxBUnJFIiwib3JpZ2luIjoiaHR0cHM6Ly93ZWJhdXRobi5pbyIsInR5cGUiOiJ3ZWJhdXRobi5jcmVhdGUifQ",
+    "transports":["usb","nfc","fake"]
+  }
+}`
+)
+
+func TestWebAuthn_Round12_SignupBeginAndFinish_Coverage(t *testing.T) {
+	cfg := round11TestConfig()
+
+	t.Run("begin_signup_parse_error_returns_400", func(t *testing.T) {
+		handler, _, _ := round11NewHandler(t, cfg, &round10QueryState{}, &RegistryStub{})
+
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/api/v1/auth/webauthn/signup/begin", nil, nil, []byte("{"))
+		requireStatus(t, http.StatusBadRequest)(handler.HandleBeginWebAuthnSignupLift(ctx))
+	})
+
+	t.Run("begin_signup_username_required", func(t *testing.T) {
+		handler, _, _ := round11NewHandler(t, cfg, &round10QueryState{}, &RegistryStub{})
+
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/auth/webauthn/signup/begin", nil, nil, apimodels.WebAuthnBeginLoginRequest{})
+		require.NoError(t, err)
+		requireStatus(t, http.StatusBadRequest)(handler.HandleBeginWebAuthnSignupLift(ctx))
+	})
+
+	t.Run("begin_signup_success", func(t *testing.T) {
+		handler, _, _ := round11NewHandler(t, cfg, &round10QueryState{}, &RegistryStub{})
+
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/auth/webauthn/signup/begin", nil, nil, apimodels.WebAuthnBeginLoginRequest{Username: "alice"})
+		require.NoError(t, err)
+		resp := requireStatus(t, http.StatusOK)(handler.HandleBeginWebAuthnSignupLift(ctx))
+
+		var body apimodels.WebAuthnBeginResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.NotEmpty(t, body.Challenge)
+		require.NotEmpty(t, body.PublicKey)
+	})
+
+	t.Run("begin_signup_storage_error_maps_to_500", func(t *testing.T) {
+		handler, _, _ := round11NewHandler(t, cfg, &round10QueryState{
+			createErrorOnce: stdErrors.New("create failed"),
+		}, &RegistryStub{})
+
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/auth/webauthn/signup/begin", nil, nil, apimodels.WebAuthnBeginLoginRequest{Username: "alice"})
+		require.NoError(t, err)
+		requireStatus(t, http.StatusInternalServerError)(handler.HandleBeginWebAuthnSignupLift(ctx))
+	})
+
+	t.Run("finish_signup_parse_error_returns_400", func(t *testing.T) {
+		handler, _, _ := round11NewHandler(t, cfg, &round10QueryState{}, &RegistryStub{})
+
+		ctx := round10NewLiftContextWithBodyBytes(http.MethodPost, "/api/v1/auth/webauthn/signup/finish", nil, nil, []byte("{"))
+		requireStatus(t, http.StatusBadRequest)(handler.HandleFinishWebAuthnSignupLift(ctx))
+	})
+
+	t.Run("finish_signup_required_fields", func(t *testing.T) {
+		handler, _, _ := round11NewHandler(t, cfg, &round10QueryState{}, &RegistryStub{})
+
+		ctxMissingUser, err := round10NewLiftContext(http.MethodPost, "/api/v1/auth/webauthn/signup/finish", nil, nil, webAuthnSignupFinishRequest{
+			Challenge: "c1",
+			Response:  map[string]any{},
+		})
+		require.NoError(t, err)
+		requireStatus(t, http.StatusBadRequest)(handler.HandleFinishWebAuthnSignupLift(ctxMissingUser))
+
+		ctxMissingChallenge, err := round10NewLiftContext(http.MethodPost, "/api/v1/auth/webauthn/signup/finish", nil, nil, webAuthnSignupFinishRequest{
+			Username: "alice",
+			Response: map[string]any{},
+		})
+		require.NoError(t, err)
+		requireStatus(t, http.StatusBadRequest)(handler.HandleFinishWebAuthnSignupLift(ctxMissingChallenge))
+	})
+
+	t.Run("finish_signup_missing_or_expired_challenge_returns_400", func(t *testing.T) {
+		handler, _, _ := round11NewHandler(t, cfg, &round10QueryState{
+			notFoundPKs: map[string]bool{"CHALLENGE#missing": true},
+		}, &RegistryStub{})
+
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/auth/webauthn/signup/finish", nil, nil, webAuthnSignupFinishRequest{
+			Username:  "alice",
+			Challenge: "missing",
+			Response:  map[string]any{},
+		})
+		require.NoError(t, err)
+		requireStatus(t, http.StatusBadRequest)(handler.HandleFinishWebAuthnSignupLift(ctx))
+	})
+
+	t.Run("finish_signup_success_returns_passkey_registration_proof", func(t *testing.T) {
+		cfg := round11TestConfig()
+		cfg.Domain = "webauthn.io"
+
+		sessionDataBytes, err := json.Marshal(libwebauthn.SessionData{
+			Challenge:        webauthnSignupFixtureChallenge,
+			RelyingPartyID:   cfg.Domain,
+			UserID:           []byte("alice"),
+			CredParams:       libwebauthn.CredentialParametersDefault(),
+			Expires:          time.Now().Add(5 * time.Minute),
+			UserVerification: protocol.VerificationPreferred,
+		})
+		require.NoError(t, err)
+
+		var responseMap map[string]any
+		require.NoError(t, json.Unmarshal([]byte(webauthnSignupFixtureResponse), &responseMap))
+
+		state := &round10QueryState{
+			webAuthnChallengesByID: map[string]storagemodels.WebAuthnChallenge{
+				webauthnSignupFixtureChallenge: {
+					Challenge:   webauthnSignupFixtureChallenge,
+					UserID:      "alice",
+					Type:        "signup",
+					ExpiresAt:   time.Now().Add(5 * time.Minute),
+					SessionData: sessionDataBytes,
+				},
+			},
+		}
+
+		handler, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{})
+		ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/auth/webauthn/signup/finish", nil, nil, webAuthnSignupFinishRequest{
+			Username:  "alice",
+			Challenge: webauthnSignupFixtureChallenge,
+			Response:  responseMap,
+		})
+		require.NoError(t, err)
+
+		resp := requireStatus(t, http.StatusOK)(handler.HandleFinishWebAuthnSignupLift(ctx))
+
+		var body webAuthnSignupFinishResponse
+		require.NoError(t, json.Unmarshal(resp.Body, &body))
+		require.NotEmpty(t, body.PasskeyRegistrationProof)
+	})
+}

--- a/cmd/api/models/mastodon.go
+++ b/cmd/api/models/mastodon.go
@@ -17,6 +17,9 @@ type AccountRegistrationRequest struct {
 	// WalletChallengeID is required for passwordless wallet-based registration flows.
 	// The challenge must have been verified via POST /auth/wallet/verify before registration.
 	WalletChallengeID string `json:"wallet_challenge_id,omitempty"`
+
+	// PasskeyRegistrationProof is the single-use proof emitted by POST /api/v1/auth/webauthn/signup/finish.
+	PasskeyRegistrationProof string `json:"passkey_registration_proof,omitempty"`
 }
 
 // AccountRegistrationResponse represents the response after successful registration

--- a/cmd/api/public_surface_equivalence_test.go
+++ b/cmd/api/public_surface_equivalence_test.go
@@ -97,6 +97,8 @@ func TestPublicSurfacePackageMatchesLegacyGateDecision(t *testing.T) {
 		{"post setup finalize", http.MethodPost, "/setup/finalize", true},
 		{"post webauthn login begin", http.MethodPost, "/api/v1/auth/webauthn/login/begin", true},
 		{"post webauthn login finish", http.MethodPost, "/api/v1/auth/webauthn/login/finish", true},
+		{"post webauthn signup begin", http.MethodPost, "/api/v1/auth/webauthn/signup/begin", true},
+		{"post webauthn signup finish", http.MethodPost, "/api/v1/auth/webauthn/signup/finish", true},
 		{"post wallet challenge", http.MethodPost, "/auth/wallet/challenge", true},
 		{"post wallet verify", http.MethodPost, "/auth/wallet/verify", true},
 		{"post wallet login", http.MethodPost, "/auth/wallet/login", true},

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -79,6 +79,13 @@ func configureRoutes(app *apptheory.App) {
 	app.Post("/api/v1/auth/webauthn/login/finish", ratelimit.ApplyRateLimit(
 		apiHandler.HandleFinishWebAuthnLoginLift,
 		20, 5*time.Minute, logger))
+	// Signup begin/finish is public (username provided), but rate limited.
+	app.Post("/api/v1/auth/webauthn/signup/begin", ratelimit.ApplyRateLimit(
+		apiHandler.HandleBeginWebAuthnSignupLift,
+		20, 5*time.Minute, logger))
+	app.Post("/api/v1/auth/webauthn/signup/finish", ratelimit.ApplyRateLimit(
+		apiHandler.HandleFinishWebAuthnSignupLift,
+		20, 5*time.Minute, logger))
 
 	app.Get("/api/v1/auth/webauthn/credentials", apiHandler.HandleListWebAuthnCredentialsLift, requireAuth)
 	app.Delete("/api/v1/auth/webauthn/credentials/{credentialId}", apiHandler.HandleDeleteWebAuthnCredentialLift, requireAuth)

--- a/cmd/api/routes_auth_options_test.go
+++ b/cmd/api/routes_auth_options_test.go
@@ -27,6 +27,8 @@ func TestConfigureRoutes_AuthOptions(t *testing.T) {
 	routes := configuredRouteAuthStates(t, app)
 
 	require.Equal(t, routeAuthState{optionalAuth: true}, routes["POST /api/v1/apps"])
+	require.Equal(t, routeAuthState{}, routes["POST /api/v1/auth/webauthn/signup/begin"])
+	require.Equal(t, routeAuthState{}, routes["POST /api/v1/auth/webauthn/signup/finish"])
 	require.Equal(t, routeAuthState{
 		authRequired:   true,
 		requiredScopes: []string{"read"},

--- a/cmd/api/testdata/auth_surface_golden.json
+++ b/cmd/api/testdata/auth_surface_golden.json
@@ -931,6 +931,20 @@
     "verdict": "agree"
   },
   {
+    "method": "POST",
+    "path": "/api/v1/auth/webauthn/signup/begin",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
+    "method": "POST",
+    "path": "/api/v1/auth/webauthn/signup/finish",
+    "runtimePosture": "anonymous",
+    "openapiSecurity": "public",
+    "verdict": "agree"
+  },
+  {
     "method": "GET",
     "path": "/api/v1/blocks",
     "runtimePosture": "auth-required",

--- a/cmd/api/testdata/routes_manifest.txt
+++ b/cmd/api/testdata/routes_manifest.txt
@@ -239,6 +239,8 @@ POST /api/v1/auth/webauthn/login/begin
 POST /api/v1/auth/webauthn/login/finish
 POST /api/v1/auth/webauthn/register/begin
 POST /api/v1/auth/webauthn/register/finish
+POST /api/v1/auth/webauthn/signup/begin
+POST /api/v1/auth/webauthn/signup/finish
 POST /api/v1/conversations/{id}/read
 POST /api/v1/domain_blocks
 POST /api/v1/exports

--- a/docs/contracts/graphql-schema.graphql
+++ b/docs/contracts/graphql-schema.graphql
@@ -1338,7 +1338,7 @@ type Query {
 # Mutations
 type Mutation {
   # Accounts
-  registerAccount(input: RegisterAccountInput!): RegisterAccountPayload!
+  registerAccount(input: RegisterAccountInput!): RegisterAccountPayload! @deprecated(reason: "Registration is not supported over GraphQL; use POST /api/v1/accounts.")
   updateAccountQuotePermissions(input: UpdateAccountQuotePermissionsInput!): AccountQuotePermissions!
   acceptFollowRequest(accountId: ID!): Relationship!
   rejectFollowRequest(accountId: ID!): Relationship!

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -128,12 +128,20 @@ components:
             type: array
         AccountRegistrationRequest:
             additionalProperties: false
+            oneOf:
+                - required:
+                    - wallet_challenge_id
+                - required:
+                    - passkey_registration_proof
             properties:
                 agreement:
                     type: boolean
                 default_posting_visibility:
                     type: string
                 locale:
+                    type: string
+                passkey_registration_proof:
+                    description: Single-use proof emitted by `POST /api/v1/auth/webauthn/signup/finish`. Exactly one of `wallet_challenge_id` or `passkey_registration_proof` is required.
                     type: string
                 password:
                     type: string
@@ -142,6 +150,7 @@ components:
                 username:
                     type: string
                 wallet_challenge_id:
+                    description: Single-use wallet registration proof. Exactly one of `wallet_challenge_id` or `passkey_registration_proof` is required.
                     type: string
             required:
                 - agreement

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -9090,6 +9090,29 @@ components:
                 - credential_name
                 - response
             type: object
+        WebAuthnSignupFinishRequest:
+            additionalProperties: false
+            properties:
+                challenge:
+                    type: string
+                response:
+                    additionalProperties: {}
+                    type: object
+                username:
+                    type: string
+            required:
+                - challenge
+                - response
+                - username
+            type: object
+        WebAuthnSignupFinishResponse:
+            additionalProperties: false
+            properties:
+                passkey_registration_proof:
+                    type: string
+            required:
+                - passkey_registration_proof
+            type: object
         WebAuthnUpdateCredentialRequest:
             additionalProperties: false
             properties:
@@ -14348,6 +14371,96 @@ paths:
                 - cmd/api/routes.go
             x-oauth-scopes:
                 - write
+    /api/v1/auth/webauthn/signup/begin:
+        post:
+            operationId: post_api_v1_auth_webauthn_signup_begin
+            tags:
+                - auth
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/WebAuthnBeginLoginRequest'
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/WebAuthnBeginResponse'
+                    headers:
+                        X-RateLimit-Limit:
+                            description: Request limit per window.
+                            schema:
+                                type: integer
+                                format: int32
+                        X-RateLimit-Remaining:
+                            description: Requests remaining in the current window.
+                            schema:
+                                type: integer
+                                format: int32
+                        X-RateLimit-Reset:
+                            description: Unix timestamp (seconds) when the current window resets.
+                            schema:
+                                type: integer
+                                format: int64
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "422":
+                    $ref: '#/components/responses/UnprocessableEntity'
+                "429":
+                    $ref: '#/components/responses/TooManyRequests'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+            x-lesser-handler: HandleBeginWebAuthnSignupLift
+            x-lesser-lambda: api
+            x-lesser-routeSources:
+                - cmd/api/routes.go
+    /api/v1/auth/webauthn/signup/finish:
+        post:
+            operationId: post_api_v1_auth_webauthn_signup_finish
+            tags:
+                - auth
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/WebAuthnSignupFinishRequest'
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/WebAuthnSignupFinishResponse'
+                    headers:
+                        X-RateLimit-Limit:
+                            description: Request limit per window.
+                            schema:
+                                type: integer
+                                format: int32
+                        X-RateLimit-Remaining:
+                            description: Requests remaining in the current window.
+                            schema:
+                                type: integer
+                                format: int32
+                        X-RateLimit-Reset:
+                            description: Unix timestamp (seconds) when the current window resets.
+                            schema:
+                                type: integer
+                                format: int64
+                "400":
+                    $ref: '#/components/responses/BadRequest'
+                "422":
+                    $ref: '#/components/responses/UnprocessableEntity'
+                "429":
+                    $ref: '#/components/responses/TooManyRequests'
+                "500":
+                    $ref: '#/components/responses/InternalServerError'
+            x-lesser-handler: HandleFinishWebAuthnSignupLift
+            x-lesser-lambda: api
+            x-lesser-routeSources:
+                - cmd/api/routes.go
     /api/v1/blocks:
         get:
             operationId: get_api_v1_blocks

--- a/docs/security-gaps.md
+++ b/docs/security-gaps.md
@@ -271,15 +271,20 @@ turns “link wallet” into an account-takeover vector.
 
 ## P1 — Registration proof missing: `/api/v1/accounts` does not require wallet/WebAuthn verification
 
-**Status:** confirmed  
+**Status:** fixed (2026-08-17)  
 **Confidence:** 8/10  
 
-Registration currently accepts a username + agreement without requiring a passwordless proof-of-control step (wallet
-signature or WebAuthn attestation). This makes “registration” a remotely callable operation without the intended
-WebAuthn/wallet proof.
+Public registration no longer accepts username + agreement alone. `POST /api/v1/accounts` now requires exactly one
+passwordless proof-of-control step before account creation:
+- a verified wallet challenge, or
+- a single-use WebAuthn passkey registration proof produced by the public signup ceremony.
+
+The legacy GraphQL `registerAccount` mutation is now deprecated and fails closed with an actionable error directing
+callers to `POST /api/v1/accounts`; it no longer provides a proof-less registration path.
 
 **Primary location:**
 - `cmd/api/handlers/accounts.go` (`HandleRegistrationLift`)
+- `graph/mutation_resolvers_accounts.go` (`RegisterAccount`)
 
 **Recommendation (implemented as part of remediation):**
 - Require a verified wallet challenge (or WebAuthn flow) as a precondition to account creation.

--- a/docs/security-public-surface.md
+++ b/docs/security-public-surface.md
@@ -135,6 +135,8 @@ The `tools/authsurface_doc` Go test asserts that the committed section matches t
 | POST | exact | `/setup/finalize` | gate-reachable setup finalization; handler enforces OAuth bearer/admin scope |
 | POST | exact | `/api/v1/auth/webauthn/login/begin` | WebAuthn login begin |
 | POST | exact | `/api/v1/auth/webauthn/login/finish` | WebAuthn login finish |
+| POST | exact | `/api/v1/auth/webauthn/signup/begin` | WebAuthn signup begin |
+| POST | exact | `/api/v1/auth/webauthn/signup/finish` | WebAuthn signup finish |
 | POST | exact | `/auth/wallet/challenge` | wallet challenge |
 | POST | exact | `/auth/wallet/verify` | wallet verification |
 | POST | exact | `/auth/wallet/login` | wallet login |

--- a/docs/specs/graphql_coverage.yaml
+++ b/docs/specs/graphql_coverage.yaml
@@ -12,6 +12,7 @@ exemptions:
       reason: Wallet auth, WebAuthn, and setup bootstrap flows are REST-only.
       match:
         exact:
+            - /api/v1/accounts
             - /auth/device
         prefixes:
             - /auth/wallet
@@ -122,10 +123,8 @@ routes:
       exemptedBy: embeds
     - method: POST
       path: /api/v1/accounts
-      policy: graphql_required
-      status: covered
-      graphql:
-        - Mutation.registerAccount
+      policy: rest_only
+      exemptedBy: auth_setup
     - method: GET
       path: /api/v1/accounts/lookup
       policy: graphql_required

--- a/docs/specs/graphql_coverage.yaml
+++ b/docs/specs/graphql_coverage.yaml
@@ -126,18 +126,18 @@ routes:
       status: covered
       graphql:
         - Mutation.registerAccount
-    - method: PUT
-      path: /api/v1/accounts/quote_permissions
-      policy: graphql_required
-      status: covered
-      graphql:
-        - Mutation.updateAccountQuotePermissions
     - method: GET
       path: /api/v1/accounts/lookup
       policy: graphql_required
       status: covered
       graphql:
         - Query.actor
+    - method: PUT
+      path: /api/v1/accounts/quote_permissions
+      policy: graphql_required
+      status: covered
+      graphql:
+        - Mutation.updateAccountQuotePermissions
     - method: GET
       path: /api/v1/accounts/relationships
       policy: graphql_required
@@ -806,6 +806,14 @@ routes:
       path: /api/v1/auth/webauthn/register/finish
       policy: rest_only
       exemptedBy: auth_setup
+    - method: POST
+      path: /api/v1/auth/webauthn/signup/begin
+      policy: rest_only
+      exemptedBy: auth_setup
+    - method: POST
+      path: /api/v1/auth/webauthn/signup/finish
+      policy: rest_only
+      exemptedBy: auth_setup
     - method: GET
       path: /api/v1/blocks
       policy: graphql_required
@@ -828,6 +836,12 @@ routes:
       path: /api/v1/conversations/lookup
       policy: rest_only
       exemptedBy: agent_usable_dm_lookup
+    - method: DELETE
+      path: /api/v1/conversations/{id}
+      policy: graphql_required
+      status: covered
+      graphql:
+        - Mutation.deleteConversation
     - method: GET
       path: /api/v1/conversations/{id}
       policy: graphql_required
@@ -835,12 +849,6 @@ routes:
       graphql:
         - Query.conversation
         - Query.conversationMessages
-    - method: DELETE
-      path: /api/v1/conversations/{id}
-      policy: graphql_required
-      status: covered
-      graphql:
-        - Mutation.deleteConversation
     - method: POST
       path: /api/v1/conversations/{id}/read
       policy: graphql_required
@@ -1297,12 +1305,12 @@ routes:
       path: /api/v1/skills/{skillId}/revisions/{revisionNumber}/bundle
       policy: rest_only
       exemptedBy: canonical_skill_authority
-    - method: GET
-      path: /api/v1/souls/bindings/{agentId}
-      policy: rest_only
-      exemptedBy: lesser_body_mcp
     - method: POST
       path: /api/v1/souls/bindings
+      policy: rest_only
+      exemptedBy: lesser_body_mcp
+    - method: GET
+      path: /api/v1/souls/bindings/{agentId}
       policy: rest_only
       exemptedBy: lesser_body_mcp
     - method: GET
@@ -1847,3 +1855,4 @@ routes:
       path: /setup/status
       policy: rest_only
       exemptedBy: auth_setup
+

--- a/graph/core.graphql
+++ b/graph/core.graphql
@@ -1335,7 +1335,7 @@ type Query {
 # Mutations
 type Mutation {
   # Accounts
-  registerAccount(input: RegisterAccountInput!): RegisterAccountPayload!
+  registerAccount(input: RegisterAccountInput!): RegisterAccountPayload! @deprecated(reason: "Registration is not supported over GraphQL; use POST /api/v1/accounts.")
   updateAccountQuotePermissions(input: UpdateAccountQuotePermissionsInput!): AccountQuotePermissions!
   acceptFollowRequest(accountId: ID!): Relationship!
   rejectFollowRequest(accountId: ID!): Relationship!

--- a/graph/mutation_resolvers_accounts.go
+++ b/graph/mutation_resolvers_accounts.go
@@ -5,12 +5,16 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/99designs/gqlgen/graphql"
 	"github.com/equaltoai/lesser/graph/model"
 	"github.com/equaltoai/lesser/pkg/common"
+	apperrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/services/accounts"
 	storageModels "github.com/equaltoai/lesser/pkg/storage/models"
 	"go.uber.org/zap"
 )
+
+const registerAccountGraphQLUnsupportedMessage = "registration is not supported over GraphQL; use POST /api/v1/accounts"
 
 // RegisterAccount creates a new local user account.
 func (r *mutationResolver) RegisterAccount(ctx context.Context, input model.RegisterAccountInput) (*model.RegisterAccountPayload, error) {
@@ -23,44 +27,10 @@ func (r *mutationResolver) RegisterAccount(ctx context.Context, input model.Regi
 		return nil, errors.New("accounts service is not available")
 	}
 
-	locale := ""
-	if input.Locale != nil {
-		locale = strings.TrimSpace(*input.Locale)
-	}
-
-	reason := ""
-	if input.Reason != nil {
-		reason = strings.TrimSpace(*input.Reason)
-	}
-
-	defaultVisibility := ""
-	if input.DefaultPostingVisibility != nil {
-		defaultVisibility = postingVisibilityFromGraphQL(*input.DefaultPostingVisibility)
-	}
-
-	result, err := accountService.RegisterAccount(ctx, &accounts.RegisterAccountCommand{
-		Username:                 strings.TrimSpace(input.Username),
-		Email:                    "", // Email is not supported for wallet-first auth.
-		Password:                 "",
-		Locale:                   locale,
-		Agreement:                input.Agreement,
-		Reason:                   reason,
-		DefaultPostingVisibility: defaultVisibility,
-	})
-	if err != nil {
-		r.Logger.Error("Failed to register account",
-			zap.String("username", input.Username),
-			zap.Error(err))
-		return nil, err
-	}
-	if result == nil || result.Actor == nil {
-		return nil, errors.New("registration succeeded but no actor was returned")
-	}
-
-	return &model.RegisterAccountPayload{
-		Actor:   result.Actor,
-		Created: true,
-	}, nil
+	r.Logger.Warn("registerAccount GraphQL mutation is deprecated and disabled",
+		zap.Any("path", graphql.GetPath(ctx)),
+		zap.String("username", input.Username))
+	return nil, apperrors.NewValidationError("registerAccount", registerAccountGraphQLUnsupportedMessage)
 }
 
 // UpdateAccountQuotePermissions updates quote permissions for the current viewer.

--- a/graph/mutation_resolvers_accounts_round12_test.go
+++ b/graph/mutation_resolvers_accounts_round12_test.go
@@ -2,14 +2,18 @@ package graph
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/equaltoai/lesser/graph/model"
+	apperrors "github.com/equaltoai/lesser/pkg/errors"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestRound12MutationResolvers_Accounts_RegisterAccount_AndVisibility(t *testing.T) {
+	const expectedGraphQLError = "registration is not supported over GraphQL; use POST /api/v1/accounts"
+
 	resolver, _ := newRound12GraphResolver(t)
 	mut := &mutationResolver{resolver}
 
@@ -23,6 +27,10 @@ func TestRound12MutationResolvers_Accounts_RegisterAccount_AndVisibility(t *test
 		Agreement: true,
 	})
 	require.Error(t, err)
+	require.ErrorContains(t, err, expectedGraphQLError)
+	var appErr *apperrors.AppError
+	require.True(t, errors.As(err, &appErr))
+	require.Equal(t, 400, appErr.HTTPStatusCode)
 
 	require.Equal(t, "public", postingVisibilityFromGraphQL(model.VisibilityPublic))
 	require.Equal(t, "unlisted", postingVisibilityFromGraphQL(model.VisibilityUnlisted))

--- a/pkg/auth/publicsurface/publicsurface.go
+++ b/pkg/auth/publicsurface/publicsurface.go
@@ -493,6 +493,18 @@ var publicRules = []PublicRule{
 	},
 	{
 		Methods:     []string{http.MethodPost},
+		Path:        "/api/v1/auth/webauthn/signup/begin",
+		Match:       RuleMatchExact,
+		Description: "WebAuthn signup begin",
+	},
+	{
+		Methods:     []string{http.MethodPost},
+		Path:        "/api/v1/auth/webauthn/signup/finish",
+		Match:       RuleMatchExact,
+		Description: "WebAuthn signup finish",
+	},
+	{
+		Methods:     []string{http.MethodPost},
 		Path:        "/auth/wallet/challenge",
 		Match:       RuleMatchExact,
 		Description: "wallet challenge",

--- a/pkg/auth/publicsurface/publicsurface_test.go
+++ b/pkg/auth/publicsurface/publicsurface_test.go
@@ -108,6 +108,15 @@ func TestAgentRegistrationAndAuthProofRoutesArePublic(t *testing.T) {
 	}
 }
 
+func TestWebAuthnSignupRoutesArePublic(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, IsPublic(http.MethodPost, "/api/v1/auth/webauthn/signup/begin"))
+	require.True(t, IsPublic(http.MethodPost, "/api/v1/auth/webauthn/signup/finish"))
+	require.Equal(t, ClassificationAnonymous, Classify(http.MethodPost, "/api/v1/auth/webauthn/signup/begin").Kind)
+	require.Equal(t, ClassificationAnonymous, Classify(http.MethodPost, "/api/v1/auth/webauthn/signup/finish").Kind)
+}
+
 func TestPublicProfileRoutesDoNotOpenPrivateSiblings(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/storage"
 	storageinterfaces "github.com/equaltoai/lesser/pkg/storage/interfaces"
+	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 
 	"github.com/golang-jwt/jwt/v5"
 	"go.uber.org/zap"
@@ -282,6 +283,30 @@ func (as *AuthService) FinishWebAuthnRegistration(ctx context.Context, username 
 		return ErrWebAuthnNotConfigured
 	}
 	return as.webAuthnService.FinishRegistration(ctx, username, challenge, response, credentialName)
+}
+
+// BeginWebAuthnSignup starts the public WebAuthn signup process.
+func (as *AuthService) BeginWebAuthnSignup(ctx context.Context, username string) (any, string, error) {
+	if as.webAuthnService == nil {
+		return nil, "", ErrWebAuthnNotConfigured
+	}
+	return as.webAuthnService.BeginSignup(ctx, username)
+}
+
+// FinishWebAuthnSignup completes the public WebAuthn signup process and returns a single-use registration proof.
+func (as *AuthService) FinishWebAuthnSignup(ctx context.Context, username string, challenge string, response []byte) (string, error) {
+	if as.webAuthnService == nil {
+		return "", ErrWebAuthnNotConfigured
+	}
+	return as.webAuthnService.FinishSignup(ctx, username, challenge, response)
+}
+
+// GetPasskeyRegistrationProof retrieves a stored single-use passkey signup proof.
+func (as *AuthService) GetPasskeyRegistrationProof(ctx context.Context, proofID string) (*storagemodels.PasskeyRegistrationProof, error) {
+	if as.webAuthnService == nil {
+		return nil, ErrWebAuthnNotConfigured
+	}
+	return as.webAuthnService.GetPasskeyRegistrationProof(ctx, proofID)
 }
 
 // BeginWebAuthnLogin starts the WebAuthn login process

--- a/pkg/auth/webauthn.go
+++ b/pkg/auth/webauthn.go
@@ -6,13 +6,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/storage"
+	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
+	"github.com/google/uuid"
 	"go.uber.org/zap"
 )
 
@@ -28,6 +31,10 @@ var (
 const (
 	ChallengeDuration     = 5 * time.Minute // WebAuthn challenges expire after 5 minutes
 	MaxCredentialsPerUser = 10              // Maximum passkeys per user
+
+	webAuthnChallengeTypeRegistration   = "registration"
+	webAuthnChallengeTypeAuthentication = "authentication"
+	webAuthnChallengeTypeSignup         = "signup"
 )
 
 // WebAuthnService handles WebAuthn operations
@@ -59,6 +66,8 @@ type webAuthnRepository interface {
 	DeleteWebAuthnCredential(ctx context.Context, credentialID string) error
 	UpdateWebAuthnCredentialName(ctx context.Context, credentialID string, name string) error
 	UpdateWebAuthnAuthenticationState(ctx context.Context, credentialID string, signCount uint32, cloneWarning bool, backupState bool, lastUsedAt time.Time) error
+	StorePasskeyRegistrationProof(ctx context.Context, proof *storagemodels.PasskeyRegistrationProof) error
+	GetPasskeyRegistrationProof(ctx context.Context, proofID string) (*storagemodels.PasskeyRegistrationProof, error)
 }
 
 // NewWebAuthnService creates a new WebAuthn service
@@ -136,7 +145,46 @@ func (s *WebAuthnService) BeginRegistration(ctx context.Context, username string
 		UserID:      username,
 		SessionData: sessionDataBytes,
 		ExpiresAt:   time.Now().Add(ChallengeDuration),
-		Type:        "registration",
+		Type:        webAuthnChallengeTypeRegistration,
+	}
+
+	if err := s.repo.StoreWebAuthnChallenge(ctx, challengeData); err != nil {
+		return nil, "", errors.Join(ErrWebAuthnChallengeStorage, err)
+	}
+
+	return options, challengeData.Challenge, nil
+}
+
+// BeginSignup starts the public WebAuthn signup process for a not-yet-created account.
+func (s *WebAuthnService) BeginSignup(ctx context.Context, username string) (any, string, error) {
+	username = strings.TrimSpace(username)
+	if err := common.ValidateRequiredParam("username", username); err != nil {
+		return nil, "", err
+	}
+
+	webAuthnUser := &webAuthnUser{
+		id:          username,
+		name:        username,
+		displayName: username,
+		credentials: []webauthn.Credential{},
+	}
+
+	options, sessionData, err := s.webAuthn.BeginRegistration(webAuthnUser, signupRegistrationOptions()...)
+	if err != nil {
+		return nil, "", errors.Join(ErrRegistrationBegin, err)
+	}
+
+	sessionDataBytes, err := json.Marshal(sessionData)
+	if err != nil {
+		return nil, "", errors.Join(ErrSessionDataSerialization, err)
+	}
+
+	challengeData := &storage.WebAuthnChallenge{
+		Challenge:   sessionData.Challenge,
+		UserID:      username,
+		SessionData: sessionDataBytes,
+		ExpiresAt:   time.Now().Add(ChallengeDuration),
+		Type:        webAuthnChallengeTypeSignup,
 	}
 
 	if err := s.repo.StoreWebAuthnChallenge(ctx, challengeData); err != nil {
@@ -155,7 +203,7 @@ func (s *WebAuthnService) FinishRegistration(ctx context.Context, username strin
 	}
 
 	// Verify challenge belongs to user and hasn't expired
-	if challengeData.UserID != username || challengeData.Type != "registration" {
+	if challengeData.UserID != username || challengeData.Type != webAuthnChallengeTypeRegistration {
 		return ErrChallengeNotFound
 	}
 	if time.Now().After(challengeData.ExpiresAt) {
@@ -240,6 +288,78 @@ func (s *WebAuthnService) FinishRegistration(ctx context.Context, username strin
 	return nil
 }
 
+// FinishSignup completes the public WebAuthn signup process and produces a single-use registration proof.
+func (s *WebAuthnService) FinishSignup(ctx context.Context, username string, challenge string, response []byte) (string, error) {
+	username = strings.TrimSpace(username)
+	challenge = strings.TrimSpace(challenge)
+
+	challengeData, err := s.repo.GetWebAuthnChallenge(ctx, challenge)
+	if err != nil {
+		return "", ErrChallengeNotFound
+	}
+
+	if challengeData.UserID != username || challengeData.Type != webAuthnChallengeTypeSignup {
+		return "", ErrChallengeNotFound
+	}
+	if time.Now().After(challengeData.ExpiresAt) {
+		return "", ErrChallengeNotFound
+	}
+
+	// Deserialize session data
+	var sessionData webauthn.SessionData
+	sessionBytes, ok := challengeData.SessionData.([]byte)
+	if !ok {
+		// Try to handle it as a string (base64 encoded)
+		if sessionStr, ok := challengeData.SessionData.(string); ok {
+			sessionBytes = []byte(sessionStr)
+		} else {
+			return "", ErrInvalidSessionDataType
+		}
+	}
+	if err := json.Unmarshal(sessionBytes, &sessionData); err != nil {
+		return "", errors.Join(ErrSessionDataDeserialization, err)
+	}
+
+	webAuthnUser := &webAuthnUser{
+		id:          username,
+		name:        username,
+		displayName: username,
+		credentials: []webauthn.Credential{},
+	}
+
+	parsedResponse, err := s.parseCreationResponse(response)
+	if err != nil {
+		return "", errors.Join(ErrCredentialResponse, err)
+	}
+
+	credential, err := s.webAuthn.CreateCredential(webAuthnUser, sessionData, parsedResponse)
+	if err != nil {
+		return "", errors.Join(ErrCredentialCreation, err)
+	}
+
+	proof := &storagemodels.PasskeyRegistrationProof{
+		ID:              uuid.NewString(),
+		Username:        username,
+		CeremonyID:      challenge,
+		CredentialID:    base64.StdEncoding.EncodeToString(credential.ID),
+		PublicKey:       append([]byte(nil), credential.PublicKey...),
+		AttestationType: credential.AttestationType,
+		AAGUID:          append([]byte(nil), credential.Authenticator.AAGUID...),
+		SignCount:       credential.Authenticator.SignCount,
+		CloneWarning:    credential.Authenticator.CloneWarning,
+		BackupEligible:  credential.Flags.BackupEligible,
+		BackupState:     credential.Flags.BackupState,
+	}
+
+	if err := s.repo.StorePasskeyRegistrationProof(ctx, proof); err != nil {
+		return "", errors.Join(ErrCredentialStorage, err)
+	}
+
+	_ = s.repo.DeleteWebAuthnChallenge(ctx, challenge)
+
+	return proof.ID, nil
+}
+
 // BeginLogin starts the WebAuthn login process
 func (s *WebAuthnService) BeginLogin(ctx context.Context, username string) (any, string, error) {
 	// Get user credentials
@@ -282,7 +402,7 @@ func (s *WebAuthnService) BeginLogin(ctx context.Context, username string) (any,
 		UserID:      username,
 		SessionData: sessionDataBytes,
 		ExpiresAt:   time.Now().Add(ChallengeDuration),
-		Type:        "authentication",
+		Type:        webAuthnChallengeTypeAuthentication,
 	}
 
 	if err := s.repo.StoreWebAuthnChallenge(ctx, challengeData); err != nil {
@@ -301,7 +421,7 @@ func (s *WebAuthnService) FinishLogin(ctx context.Context, username string, chal
 	}
 
 	// Verify challenge belongs to user and hasn't expired
-	if challengeData.UserID != username || challengeData.Type != "authentication" {
+	if challengeData.UserID != username || challengeData.Type != webAuthnChallengeTypeAuthentication {
 		return nil, ErrChallengeNotFound
 	}
 	if time.Now().After(challengeData.ExpiresAt) {
@@ -436,6 +556,19 @@ func (s *WebAuthnService) UpdateCredentialName(ctx context.Context, username str
 	}
 
 	return s.repo.UpdateWebAuthnCredentialName(ctx, credential.ID, newName)
+}
+
+// GetPasskeyRegistrationProof retrieves a stored single-use signup proof by ID.
+func (s *WebAuthnService) GetPasskeyRegistrationProof(ctx context.Context, proofID string) (*storagemodels.PasskeyRegistrationProof, error) {
+	return s.repo.GetPasskeyRegistrationProof(ctx, strings.TrimSpace(proofID))
+}
+
+func signupRegistrationOptions() []webauthn.RegistrationOption {
+	return []webauthn.RegistrationOption{
+		webauthn.WithAuthenticatorSelection(protocol.AuthenticatorSelection{
+			UserVerification: protocol.VerificationRequired,
+		}),
+	}
 }
 
 // webAuthnUser implements the webauthn.User interface

--- a/pkg/auth/webauthn.go
+++ b/pkg/auth/webauthn.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/equaltoai/lesser/pkg/common"
+	accountservice "github.com/equaltoai/lesser/pkg/services/accounts"
 	"github.com/equaltoai/lesser/pkg/storage"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 
@@ -157,7 +158,7 @@ func (s *WebAuthnService) BeginRegistration(ctx context.Context, username string
 
 // BeginSignup starts the public WebAuthn signup process for a not-yet-created account.
 func (s *WebAuthnService) BeginSignup(ctx context.Context, username string) (any, string, error) {
-	username = strings.TrimSpace(username)
+	username = accountservice.NormalizeUsernameForDomain(username, s.domain)
 	if err := common.ValidateRequiredParam("username", username); err != nil {
 		return nil, "", err
 	}
@@ -290,7 +291,7 @@ func (s *WebAuthnService) FinishRegistration(ctx context.Context, username strin
 
 // FinishSignup completes the public WebAuthn signup process and produces a single-use registration proof.
 func (s *WebAuthnService) FinishSignup(ctx context.Context, username string, challenge string, response []byte) (string, error) {
-	username = strings.TrimSpace(username)
+	username = accountservice.NormalizeUsernameForDomain(username, s.domain)
 	challenge = strings.TrimSpace(challenge)
 
 	challengeData, err := s.repo.GetWebAuthnChallenge(ctx, challenge)

--- a/pkg/auth/webauthn_signup_test.go
+++ b/pkg/auth/webauthn_signup_test.go
@@ -211,3 +211,28 @@ func TestWebAuthnService_FinishSignup_ErrorBranches(t *testing.T) {
 		require.True(t, ok)
 	})
 }
+
+func TestWebAuthnService_FinishSignup_RejectsNonSignupChallengeTypes(t *testing.T) {
+	t.Parallel()
+
+	baseChallenge := &storage.WebAuthnChallenge{
+		Challenge:   "chal-signup",
+		UserID:      "alice",
+		SessionData: []byte(`{"challenge":"chal-signup"}`),
+		ExpiresAt:   time.Now().Add(time.Minute),
+	}
+
+	for _, challengeType := range []string{webAuthnChallengeTypeRegistration, webAuthnChallengeTypeAuthentication} {
+		t.Run(challengeType, func(t *testing.T) {
+			repo := newInMemoryWebAuthnRepo()
+			challenge := *baseChallenge
+			challenge.Type = challengeType
+			repo.challengesByChallenge["chal-signup"] = &challenge
+
+			svc := &WebAuthnService{repo: repo}
+			proofID, err := svc.FinishSignup(context.Background(), "alice", "chal-signup", []byte("ignored"))
+			require.Empty(t, proofID)
+			require.ErrorIs(t, err, ErrChallengeNotFound)
+		})
+	}
+}

--- a/pkg/auth/webauthn_signup_test.go
+++ b/pkg/auth/webauthn_signup_test.go
@@ -1,0 +1,213 @@
+package auth
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/storage"
+	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/go-webauthn/webauthn/protocol"
+	"github.com/go-webauthn/webauthn/webauthn"
+	"github.com/stretchr/testify/require"
+)
+
+type webAuthnRepoStoreProofErr struct {
+	*inMemoryWebAuthnRepo
+	err error
+}
+
+func (r *webAuthnRepoStoreProofErr) StorePasskeyRegistrationProof(context.Context, *storagemodels.PasskeyRegistrationProof) error {
+	return r.err
+}
+
+func TestSignupRegistrationOptions_RequireUserVerification(t *testing.T) {
+	t.Parallel()
+
+	options := &protocol.PublicKeyCredentialCreationOptions{}
+	for _, opt := range signupRegistrationOptions() {
+		opt(options)
+	}
+
+	require.Equal(t, protocol.VerificationRequired, options.AuthenticatorSelection.UserVerification)
+}
+
+func TestWebAuthnService_BeginAndFinishSignup_Success(t *testing.T) {
+	t.Parallel()
+
+	repo := newInMemoryWebAuthnRepo()
+	svc := &WebAuthnService{
+		webAuthn: &fakeWebAuthnEngine{
+			beginRegChallenge: "chal-signup",
+			createCredential: &webauthn.Credential{
+				ID:              []byte("cred-signup"),
+				PublicKey:       []byte("public-key"),
+				AttestationType: "packed",
+				Flags: webauthn.CredentialFlags{
+					UserPresent:    true,
+					UserVerified:   true,
+					BackupEligible: true,
+					BackupState:    true,
+				},
+				Authenticator: webauthn.Authenticator{
+					AAGUID:       []byte("aaguid"),
+					SignCount:    7,
+					CloneWarning: true,
+				},
+			},
+		},
+		repo: repo,
+		parseCreationResponse: func([]byte) (*protocol.ParsedCredentialCreationData, error) {
+			return &protocol.ParsedCredentialCreationData{}, nil
+		},
+	}
+
+	options, challenge, err := svc.BeginSignup(context.Background(), "alice")
+	require.NoError(t, err)
+	require.NotNil(t, options)
+	require.Equal(t, "chal-signup", challenge)
+
+	storedChallenge, ok := repo.challengesByChallenge[challenge]
+	require.True(t, ok)
+	require.Equal(t, "alice", storedChallenge.UserID)
+	require.Equal(t, webAuthnChallengeTypeSignup, storedChallenge.Type)
+
+	proofID, err := svc.FinishSignup(context.Background(), "alice", challenge, []byte("ignored"))
+	require.NoError(t, err)
+	require.NotEmpty(t, proofID)
+
+	proof, ok := repo.proofsByID[proofID]
+	require.True(t, ok)
+	require.Equal(t, "alice", proof.Username)
+	require.Equal(t, challenge, proof.CeremonyID)
+	require.Equal(t, base64.StdEncoding.EncodeToString([]byte("cred-signup")), proof.CredentialID)
+	require.Equal(t, []byte("public-key"), proof.PublicKey)
+	require.Equal(t, "packed", proof.AttestationType)
+	require.Equal(t, []byte("aaguid"), proof.AAGUID)
+	require.EqualValues(t, 7, proof.SignCount)
+	require.True(t, proof.CloneWarning)
+	require.True(t, proof.BackupEligible)
+	require.True(t, proof.BackupState)
+	require.False(t, proof.Consumed)
+
+	_, challengeStillStored := repo.challengesByChallenge[challenge]
+	require.False(t, challengeStillStored)
+}
+
+func TestWebAuthnService_FinishSignup_ErrorBranches(t *testing.T) {
+	t.Parallel()
+
+	baseChallenge := func() *storage.WebAuthnChallenge {
+		return &storage.WebAuthnChallenge{
+			Challenge:   "chal-signup",
+			UserID:      "alice",
+			SessionData: []byte(`{"challenge":"chal-signup"}`),
+			ExpiresAt:   time.Now().Add(time.Minute),
+			Type:        webAuthnChallengeTypeSignup,
+		}
+	}
+
+	baseCredential := &webauthn.Credential{
+		ID:              []byte("cred-signup"),
+		PublicKey:       []byte("public-key"),
+		AttestationType: "packed",
+		Flags: webauthn.CredentialFlags{
+			UserPresent:  true,
+			UserVerified: true,
+		},
+		Authenticator: webauthn.Authenticator{
+			AAGUID:    []byte("aaguid"),
+			SignCount: 9,
+		},
+	}
+
+	t.Run("missing challenge", func(t *testing.T) {
+		repo := newInMemoryWebAuthnRepo()
+		svc := &WebAuthnService{repo: repo}
+		proofID, err := svc.FinishSignup(context.Background(), "alice", "missing", []byte("ignored"))
+		require.Empty(t, proofID)
+		require.ErrorIs(t, err, ErrChallengeNotFound)
+	})
+
+	t.Run("username mismatch", func(t *testing.T) {
+		repo := newInMemoryWebAuthnRepo()
+		repo.challengesByChallenge["chal-signup"] = baseChallenge()
+		svc := &WebAuthnService{repo: repo}
+		proofID, err := svc.FinishSignup(context.Background(), "mallory", "chal-signup", []byte("ignored"))
+		require.Empty(t, proofID)
+		require.ErrorIs(t, err, ErrChallengeNotFound)
+	})
+
+	t.Run("expired challenge", func(t *testing.T) {
+		repo := newInMemoryWebAuthnRepo()
+		challenge := baseChallenge()
+		challenge.ExpiresAt = time.Now().Add(-time.Minute)
+		repo.challengesByChallenge["chal-signup"] = challenge
+		svc := &WebAuthnService{repo: repo}
+		proofID, err := svc.FinishSignup(context.Background(), "alice", "chal-signup", []byte("ignored"))
+		require.Empty(t, proofID)
+		require.ErrorIs(t, err, ErrChallengeNotFound)
+	})
+
+	t.Run("invalid session data type", func(t *testing.T) {
+		repo := newInMemoryWebAuthnRepo()
+		challenge := baseChallenge()
+		challenge.SessionData = 123
+		repo.challengesByChallenge["chal-signup"] = challenge
+		svc := &WebAuthnService{repo: repo}
+		proofID, err := svc.FinishSignup(context.Background(), "alice", "chal-signup", []byte("ignored"))
+		require.Empty(t, proofID)
+		require.ErrorIs(t, err, ErrInvalidSessionDataType)
+	})
+
+	t.Run("parse response failure", func(t *testing.T) {
+		repo := newInMemoryWebAuthnRepo()
+		repo.challengesByChallenge["chal-signup"] = baseChallenge()
+		svc := &WebAuthnService{
+			repo: repo,
+			parseCreationResponse: func([]byte) (*protocol.ParsedCredentialCreationData, error) {
+				return nil, errors.New("bad-response")
+			},
+		}
+		proofID, err := svc.FinishSignup(context.Background(), "alice", "chal-signup", []byte("ignored"))
+		require.Empty(t, proofID)
+		require.ErrorIs(t, err, ErrCredentialResponse)
+	})
+
+	t.Run("credential verification failure", func(t *testing.T) {
+		repo := newInMemoryWebAuthnRepo()
+		repo.challengesByChallenge["chal-signup"] = baseChallenge()
+		svc := &WebAuthnService{
+			webAuthn: webAuthnEngineError{err: errors.New("credential failed")},
+			repo:     repo,
+			parseCreationResponse: func([]byte) (*protocol.ParsedCredentialCreationData, error) {
+				return &protocol.ParsedCredentialCreationData{}, nil
+			},
+		}
+		proofID, err := svc.FinishSignup(context.Background(), "alice", "chal-signup", []byte("ignored"))
+		require.Empty(t, proofID)
+		require.ErrorIs(t, err, ErrCredentialCreation)
+	})
+
+	t.Run("proof storage failure leaves challenge intact", func(t *testing.T) {
+		repo := &webAuthnRepoStoreProofErr{
+			inMemoryWebAuthnRepo: newInMemoryWebAuthnRepo(),
+			err:                  errors.New("store failed"),
+		}
+		repo.challengesByChallenge["chal-signup"] = baseChallenge()
+		svc := &WebAuthnService{
+			webAuthn: &fakeWebAuthnEngine{createCredential: baseCredential},
+			repo:     repo,
+			parseCreationResponse: func([]byte) (*protocol.ParsedCredentialCreationData, error) {
+				return &protocol.ParsedCredentialCreationData{}, nil
+			},
+		}
+		proofID, err := svc.FinishSignup(context.Background(), "alice", "chal-signup", []byte("ignored"))
+		require.Empty(t, proofID)
+		require.ErrorIs(t, err, ErrCredentialStorage)
+		_, ok := repo.challengesByChallenge["chal-signup"]
+		require.True(t, ok)
+	})
+}

--- a/pkg/auth/webauthn_signup_test.go
+++ b/pkg/auth/webauthn_signup_test.go
@@ -236,3 +236,17 @@ func TestWebAuthnService_FinishSignup_RejectsNonSignupChallengeTypes(t *testing.
 		})
 	}
 }
+
+func TestWebAuthnService_GetPasskeyRegistrationProof_TrimsID(t *testing.T) {
+	t.Parallel()
+
+	repo := newInMemoryWebAuthnRepo()
+	repo.proofsByID["proof-1"] = &storagemodels.PasskeyRegistrationProof{ID: "proof-1", Username: "alice"}
+
+	svc := &WebAuthnService{repo: repo}
+	proof, err := svc.GetPasskeyRegistrationProof(context.Background(), "  proof-1  ")
+	require.NoError(t, err)
+	require.NotNil(t, proof)
+	require.Equal(t, "proof-1", proof.ID)
+	require.Equal(t, "alice", proof.Username)
+}

--- a/pkg/auth/webauthn_signup_test.go
+++ b/pkg/auth/webauthn_signup_test.go
@@ -64,7 +64,7 @@ func TestWebAuthnService_BeginAndFinishSignup_Success(t *testing.T) {
 		},
 	}
 
-	options, challenge, err := svc.BeginSignup(context.Background(), "alice")
+	options, challenge, err := svc.BeginSignup(context.Background(), "Alice")
 	require.NoError(t, err)
 	require.NotNil(t, options)
 	require.Equal(t, "chal-signup", challenge)
@@ -74,7 +74,7 @@ func TestWebAuthnService_BeginAndFinishSignup_Success(t *testing.T) {
 	require.Equal(t, "alice", storedChallenge.UserID)
 	require.Equal(t, webAuthnChallengeTypeSignup, storedChallenge.Type)
 
-	proofID, err := svc.FinishSignup(context.Background(), "alice", challenge, []byte("ignored"))
+	proofID, err := svc.FinishSignup(context.Background(), "Alice", challenge, []byte("ignored"))
 	require.NoError(t, err)
 	require.NotEmpty(t, proofID)
 

--- a/pkg/auth/webauthn_test.go
+++ b/pkg/auth/webauthn_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/equaltoai/lesser/pkg/storage"
+	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
 	"github.com/stretchr/testify/require"
@@ -19,6 +20,7 @@ type inMemoryWebAuthnRepo struct {
 	credentialsByUsername map[string][]*storage.WebAuthnCredential
 	credentialsByID       map[string]*storage.WebAuthnCredential
 	challengesByChallenge map[string]*storage.WebAuthnChallenge
+	proofsByID            map[string]*storagemodels.PasskeyRegistrationProof
 	walletsByUsername     map[string][]*storage.WalletCredential
 
 	updateCalls int
@@ -31,6 +33,7 @@ func newInMemoryWebAuthnRepo() *inMemoryWebAuthnRepo {
 		credentialsByUsername: make(map[string][]*storage.WebAuthnCredential),
 		credentialsByID:       make(map[string]*storage.WebAuthnCredential),
 		challengesByChallenge: make(map[string]*storage.WebAuthnChallenge),
+		proofsByID:            make(map[string]*storagemodels.PasskeyRegistrationProof),
 		walletsByUsername:     make(map[string][]*storage.WalletCredential),
 	}
 }
@@ -114,6 +117,25 @@ func (r *inMemoryWebAuthnRepo) UpdateWebAuthnAuthenticationState(
 		cred.LastUsedAt = lastUsedAt
 	}
 	return nil
+}
+
+func (r *inMemoryWebAuthnRepo) StorePasskeyRegistrationProof(_ context.Context, proof *storagemodels.PasskeyRegistrationProof) error {
+	clone := *proof
+	clone.PublicKey = append([]byte(nil), proof.PublicKey...)
+	clone.AAGUID = append([]byte(nil), proof.AAGUID...)
+	r.proofsByID[proof.ID] = &clone
+	return nil
+}
+
+func (r *inMemoryWebAuthnRepo) GetPasskeyRegistrationProof(_ context.Context, proofID string) (*storagemodels.PasskeyRegistrationProof, error) {
+	proof, ok := r.proofsByID[proofID]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	clone := *proof
+	clone.PublicKey = append([]byte(nil), proof.PublicKey...)
+	clone.AAGUID = append([]byte(nil), proof.AAGUID...)
+	return &clone, nil
 }
 
 type fakeWebAuthnEngine struct {

--- a/pkg/services/accounts/register_passkey_race_test.go
+++ b/pkg/services/accounts/register_passkey_race_test.go
@@ -1,0 +1,1053 @@
+package accounts
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/equaltoai/lesser/pkg/storage/repositories"
+	"github.com/equaltoai/lesser/pkg/streaming"
+	testmocks "github.com/equaltoai/lesser/pkg/testing/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	dynamormcore "github.com/theory-cloud/tabletheory/v3/pkg/core"
+	dynamormerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
+	"go.uber.org/zap"
+)
+
+func TestService_RegisterAccount_WithPasskeyRegistrationProof_ConcurrentSameProofPreservesWinner(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+	baseTime := time.Now().UTC()
+
+	db := newRegistrationPasskeyDB(2)
+	accountRepo, storageImpl := newRegistrationPasskeyTestStorage(t, db, logger)
+
+	require.NoError(t, accountRepo.StorePasskeyRegistrationProof(ctx, &models.PasskeyRegistrationProof{
+		ID:              "proof-1",
+		Username:        "alice",
+		CeremonyID:      "ceremony-1",
+		CredentialID:    "cred-1",
+		PublicKey:       []byte("credential-public-key"),
+		AttestationType: "packed",
+		AAGUID:          []byte("aaguid"),
+		SignCount:       11,
+		BackupEligible:  true,
+		BackupState:     true,
+		CreatedAt:       baseTime,
+		ExpiresAt:       baseTime.Add(time.Hour),
+	}))
+
+	services := []*Service{
+		newRegistrationPasskeyTestService(storageImpl, logger, "PUBLIC KEY A", "PRIVATE KEY A"),
+		newRegistrationPasskeyTestService(storageImpl, logger, "PUBLIC KEY B", "PRIVATE KEY B"),
+	}
+
+	type result struct {
+		account *RegisterAccountResult
+		err     error
+	}
+	results := make([]result, len(services))
+
+	var wg sync.WaitGroup
+	wg.Add(len(services))
+	for i, svc := range services {
+		i := i
+		svc := svc
+		go func() {
+			defer wg.Done()
+			results[i].account, results[i].err = svc.RegisterAccount(ctx, &RegisterAccountCommand{
+				Username:                 "alice",
+				Agreement:                true,
+				Locale:                   "en",
+				PasskeyRegistrationProof: "proof-1",
+			})
+		}()
+	}
+	wg.Wait()
+
+	var winner *RegisterAccountResult
+	var loserErr error
+	for _, res := range results {
+		if res.err == nil {
+			require.Nil(t, winner, "expected exactly one successful registration")
+			winner = res.account
+			continue
+		}
+		require.Nil(t, loserErr, "expected exactly one failed registration")
+		loserErr = res.err
+	}
+
+	require.NotNil(t, winner, "one registration must succeed")
+	require.Error(t, loserErr, "one registration must fail cleanly")
+	require.True(t,
+		strings.Contains(loserErr.Error(), "already exists") || strings.Contains(loserErr.Error(), "already taken"),
+		"expected duplicate registration loser to fail cleanly, got %q", loserErr.Error(),
+	)
+
+	storedAccount, err := accountRepo.GetAccount(ctx, "alice")
+	require.NoError(t, err)
+	require.NotNil(t, storedAccount)
+	require.NotNil(t, storedAccount.Actor)
+	require.NotNil(t, storedAccount.Actor.PublicKey)
+	require.Equal(t, winner.Actor.PublicKey.PublicKeyPem, storedAccount.Actor.PublicKey.PublicKeyPem)
+
+	credentials, err := accountRepo.GetUserWebAuthnCredentials(ctx, "alice")
+	require.NoError(t, err)
+	require.Len(t, credentials, 1)
+	require.Equal(t, "cred-1", credentials[0].ID)
+	require.Equal(t, "alice", credentials[0].UserID)
+	require.Equal(t, []byte("credential-public-key"), credentials[0].PublicKey)
+
+	proof, err := accountRepo.GetPasskeyRegistrationProof(ctx, "proof-1")
+	require.NoError(t, err)
+	require.True(t, proof.Consumed)
+	require.Equal(t, 1, db.consumeSuccessCount())
+}
+
+func TestService_RegisterAccount_WithPasskeyRegistrationProof_RejectsDifferentUsernameBeforeCreate(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+	baseTime := time.Now().UTC()
+
+	db := newRegistrationPasskeyDB(0)
+	accountRepo, storageImpl := newRegistrationPasskeyTestStorage(t, db, logger)
+
+	require.NoError(t, accountRepo.StorePasskeyRegistrationProof(ctx, &models.PasskeyRegistrationProof{
+		ID:              "proof-1",
+		Username:        "alice",
+		CeremonyID:      "ceremony-1",
+		CredentialID:    "cred-1",
+		PublicKey:       []byte("credential-public-key"),
+		AttestationType: "packed",
+		AAGUID:          []byte("aaguid"),
+		SignCount:       11,
+		CreatedAt:       baseTime,
+		ExpiresAt:       baseTime.Add(time.Hour),
+	}))
+
+	svc := newRegistrationPasskeyTestService(storageImpl, logger, "PUBLIC KEY", "PRIVATE KEY")
+
+	got, err := svc.RegisterAccount(ctx, &RegisterAccountCommand{
+		Username:                 "mallory",
+		Agreement:                true,
+		Locale:                   "en",
+		PasskeyRegistrationProof: "proof-1",
+	})
+	require.Nil(t, got)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "different username")
+
+	_, err = accountRepo.GetAccount(ctx, "mallory")
+	require.Error(t, err)
+	credentials, err := accountRepo.GetUserWebAuthnCredentials(ctx, "mallory")
+	require.NoError(t, err)
+	require.Empty(t, credentials)
+
+	proof, err := accountRepo.GetPasskeyRegistrationProof(ctx, "proof-1")
+	require.NoError(t, err)
+	require.False(t, proof.Consumed)
+}
+
+func TestService_RegisterAccount_WithPasskeyRegistrationProof_RejectsCaseDifferingUsernameBeforeCreate(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+	baseTime := time.Now().UTC()
+
+	db := newRegistrationPasskeyDB(0)
+	accountRepo, storageImpl := newRegistrationPasskeyTestStorage(t, db, logger)
+
+	require.NoError(t, accountRepo.StorePasskeyRegistrationProof(ctx, &models.PasskeyRegistrationProof{
+		ID:              "proof-1",
+		Username:        "Alice",
+		CeremonyID:      "ceremony-1",
+		CredentialID:    "cred-1",
+		PublicKey:       []byte("credential-public-key"),
+		AttestationType: "packed",
+		AAGUID:          []byte("aaguid"),
+		SignCount:       11,
+		CreatedAt:       baseTime,
+		ExpiresAt:       baseTime.Add(time.Hour),
+	}))
+
+	svc := newRegistrationPasskeyTestService(storageImpl, logger, "PUBLIC KEY", "PRIVATE KEY")
+
+	got, err := svc.RegisterAccount(ctx, &RegisterAccountCommand{
+		Username:                 "alice",
+		Agreement:                true,
+		Locale:                   "en",
+		PasskeyRegistrationProof: "proof-1",
+	})
+	require.Nil(t, got)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "different username")
+
+	_, err = accountRepo.GetAccount(ctx, "alice")
+	require.Error(t, err)
+	credentials, err := accountRepo.GetUserWebAuthnCredentials(ctx, "alice")
+	require.NoError(t, err)
+	require.Empty(t, credentials)
+
+	proof, err := accountRepo.GetPasskeyRegistrationProof(ctx, "proof-1")
+	require.NoError(t, err)
+	require.False(t, proof.Consumed)
+}
+
+func newRegistrationPasskeyTestStorage(t *testing.T, db dynamormcore.DB, logger *zap.Logger) (*repositories.AccountRepository, *permissiveAccountsStorage) {
+	t.Helper()
+
+	accountRepo := repositories.NewAccountRepository(db, "test-table", "example.com", logger)
+	accountRepo.SetEncryptor(noopEncryptor{})
+	accountRepo.SetPermissionService(nil)
+	accountRepo.SetEventService(nil)
+	accountRepo.SetCachingService(nil)
+
+	quoteRepo := repositories.NewQuoteRepository(db, "test-table", logger, nil)
+	activityRepo := testmocks.NewMockActivityRepository()
+	activityRepo.On("RecordActivity", mock.Anything, "registration", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	storageImpl := &permissiveAccountsStorage{
+		MockRepositoryStorage: NewMockRepositoryStorage(),
+		db:                    db,
+		tableName:             "test-table",
+		logger:                logger,
+		account:               accountRepo,
+		quote:                 quoteRepo,
+		activity:              activityRepo,
+	}
+
+	return accountRepo, storageImpl
+}
+
+func newRegistrationPasskeyTestService(storageImpl *permissiveAccountsStorage, logger *zap.Logger, publicKeyPEM string, privateKeyPEM string) *Service {
+	return NewService(
+		storageImpl,
+		streaming.NewMockPublisher(),
+		nil,
+		staticCryptoService{
+			publicKeyPEM:  []byte(publicKeyPEM),
+			privateKeyPEM: []byte(privateKeyPEM),
+			key:           struct{}{},
+		},
+		staticAuthService{hash: "hash"},
+		logger,
+		"example.com",
+	)
+}
+
+func storeRegistrationWalletChallenge(t *testing.T, repo *repositories.AccountRepository, username string, challengeID string) {
+	t.Helper()
+
+	baseTime := time.Now().UTC()
+	require.NoError(t, repo.StoreWalletChallenge(context.Background(), &storage.WalletChallenge{
+		ID:        challengeID,
+		Username:  username,
+		Address:   "0xabc",
+		ChainID:   1,
+		Nonce:     "nonce",
+		Message:   "message",
+		IssuedAt:  baseTime,
+		ExpiresAt: baseTime.Add(time.Hour),
+	}))
+}
+
+type registrationPasskeyBarrier struct {
+	mu      sync.Mutex
+	release chan struct{}
+	target  int
+	arrived int
+}
+
+func newRegistrationPasskeyBarrier(target int) *registrationPasskeyBarrier {
+	if target <= 0 {
+		return nil
+	}
+	return &registrationPasskeyBarrier{
+		release: make(chan struct{}),
+		target:  target,
+	}
+}
+
+func (b *registrationPasskeyBarrier) Wait() {
+	if b == nil {
+		return
+	}
+
+	b.mu.Lock()
+	b.arrived++
+	if b.arrived == b.target {
+		close(b.release)
+	}
+	release := b.release
+	b.mu.Unlock()
+
+	<-release
+}
+
+type registrationPasskeyDB struct {
+	state *registrationPasskeyState
+}
+
+type registrationPasskeyState struct {
+	mu sync.Mutex
+
+	actors           map[string]*models.Actor
+	credentials      map[string]*models.WebAuthnCredential
+	numericMappings  map[string]*models.NumericIDMapping
+	preferences      map[string]*models.UserPreference
+	proofs           map[string]*models.PasskeyRegistrationProof
+	quotePermissions map[string]*models.QuotePermissions
+	users            map[string]*models.User
+
+	consumeSuccesses  int
+	userCreateBarrier *registrationPasskeyBarrier
+}
+
+func newRegistrationPasskeyDB(concurrentUserCreates int) *registrationPasskeyDB {
+	return &registrationPasskeyDB{
+		state: &registrationPasskeyState{
+			actors:            make(map[string]*models.Actor),
+			credentials:       make(map[string]*models.WebAuthnCredential),
+			numericMappings:   make(map[string]*models.NumericIDMapping),
+			preferences:       make(map[string]*models.UserPreference),
+			proofs:            make(map[string]*models.PasskeyRegistrationProof),
+			quotePermissions:  make(map[string]*models.QuotePermissions),
+			users:             make(map[string]*models.User),
+			userCreateBarrier: newRegistrationPasskeyBarrier(concurrentUserCreates),
+		},
+	}
+}
+
+func (db *registrationPasskeyDB) Model(model any) dynamormcore.Query {
+	return &registrationPasskeyQuery{
+		state:  db.state,
+		model:  model,
+		wheres: make(map[string]registrationPasskeyWhere),
+		index:  "",
+	}
+}
+
+func (db *registrationPasskeyDB) Migrate() error                              { return nil }
+func (db *registrationPasskeyDB) AutoMigrate(...any) error                    { return nil }
+func (db *registrationPasskeyDB) Close() error                                { return nil }
+func (db *registrationPasskeyDB) WithContext(context.Context) dynamormcore.DB { return db }
+
+func (db *registrationPasskeyDB) consumeSuccessCount() int {
+	db.state.mu.Lock()
+	defer db.state.mu.Unlock()
+	return db.state.consumeSuccesses
+}
+
+type registrationPasskeyWhere struct {
+	op    string
+	value any
+}
+
+type registrationPasskeyQuery struct {
+	state       *registrationPasskeyState
+	model       any
+	wheres      map[string]registrationPasskeyWhere
+	index       string
+	ifNotExists bool
+}
+
+func (q *registrationPasskeyQuery) Where(field, op string, value any) dynamormcore.Query {
+	q.wheres[field] = registrationPasskeyWhere{op: op, value: value}
+	return q
+}
+
+func (q *registrationPasskeyQuery) Index(name string) dynamormcore.Query                    { q.index = name; return q }
+func (q *registrationPasskeyQuery) Filter(string, string, any) dynamormcore.Query           { return q }
+func (q *registrationPasskeyQuery) OrFilter(string, string, any) dynamormcore.Query         { return q }
+func (q *registrationPasskeyQuery) FilterGroup(func(dynamormcore.Query)) dynamormcore.Query { return q }
+func (q *registrationPasskeyQuery) OrFilterGroup(func(dynamormcore.Query)) dynamormcore.Query {
+	return q
+}
+func (q *registrationPasskeyQuery) IfNotExists() dynamormcore.Query                      { q.ifNotExists = true; return q }
+func (q *registrationPasskeyQuery) IfExists() dynamormcore.Query                         { return q }
+func (q *registrationPasskeyQuery) WithCondition(string, string, any) dynamormcore.Query { return q }
+func (q *registrationPasskeyQuery) WithConditionExpression(string, map[string]any) dynamormcore.Query {
+	return q
+}
+func (q *registrationPasskeyQuery) OrderBy(string, string) dynamormcore.Query       { return q }
+func (q *registrationPasskeyQuery) Limit(int) dynamormcore.Query                    { return q }
+func (q *registrationPasskeyQuery) Offset(int) dynamormcore.Query                   { return q }
+func (q *registrationPasskeyQuery) Select(...string) dynamormcore.Query             { return q }
+func (q *registrationPasskeyQuery) ConsistentRead() dynamormcore.Query              { return q }
+func (q *registrationPasskeyQuery) WithRetry(int, time.Duration) dynamormcore.Query { return q }
+func (q *registrationPasskeyQuery) Cursor(string) dynamormcore.Query                { return q }
+func (q *registrationPasskeyQuery) SetCursor(string) error                          { return nil }
+func (q *registrationPasskeyQuery) WithContext(context.Context) dynamormcore.Query  { return q }
+func (q *registrationPasskeyQuery) Scan(any) error                                  { return fmt.Errorf("unsupported") }
+func (q *registrationPasskeyQuery) ParallelScan(int32, int32) dynamormcore.Query    { return q }
+func (q *registrationPasskeyQuery) ScanAllSegments(any, int32) error {
+	return fmt.Errorf("unsupported")
+}
+func (q *registrationPasskeyQuery) BatchGet([]any, any) error { return fmt.Errorf("unsupported") }
+func (q *registrationPasskeyQuery) BatchGetWithOptions([]any, any, *dynamormcore.BatchGetOptions) error {
+	return fmt.Errorf("unsupported")
+}
+func (q *registrationPasskeyQuery) BatchGetBuilder() dynamormcore.BatchGetBuilder { return nil }
+func (q *registrationPasskeyQuery) BatchCreate(any) error                         { return fmt.Errorf("unsupported") }
+func (q *registrationPasskeyQuery) BatchDelete([]any) error                       { return fmt.Errorf("unsupported") }
+func (q *registrationPasskeyQuery) BatchWrite([]any, []any) error                 { return fmt.Errorf("unsupported") }
+func (q *registrationPasskeyQuery) BatchUpdateWithOptions([]any, []string, ...any) error {
+	return fmt.Errorf("unsupported")
+}
+func (q *registrationPasskeyQuery) Count() (int64, error) { return 0, fmt.Errorf("unsupported") }
+func (q *registrationPasskeyQuery) CreateOrUpdate() error { return fmt.Errorf("unsupported") }
+func (q *registrationPasskeyQuery) AllPaginated(any) (*dynamormcore.PaginatedResult, error) {
+	return nil, fmt.Errorf("unsupported")
+}
+
+func (q *registrationPasskeyQuery) First(dest any) error {
+	q.state.mu.Lock()
+	defer q.state.mu.Unlock()
+
+	if handled, err := q.loadUser(dest); handled {
+		return err
+	}
+	if handled, err := q.loadActor(dest); handled {
+		return err
+	}
+	if handled, err := q.loadNumericMapping(dest); handled {
+		return err
+	}
+	if handled, err := q.loadPasskeyProof(dest); handled {
+		return err
+	}
+	if handled, err := q.loadWebAuthnCredential(dest); handled {
+		return err
+	}
+	if handled, err := q.loadUserPreference(dest); handled {
+		return err
+	}
+	if handled, err := q.loadQuotePermissions(dest); handled {
+		return err
+	}
+
+	return fmt.Errorf("unsupported destination %T", dest)
+}
+
+func (q *registrationPasskeyQuery) All(dest any) error {
+	q.state.mu.Lock()
+	defer q.state.mu.Unlock()
+
+	slicePtr := reflect.ValueOf(dest)
+	if slicePtr.Kind() != reflect.Ptr || slicePtr.IsNil() {
+		return fmt.Errorf("destination must be a non-nil pointer")
+	}
+	sliceValue := slicePtr.Elem()
+	if sliceValue.Kind() != reflect.Slice {
+		return fmt.Errorf("destination must point to a slice")
+	}
+
+	sliceValue.Set(reflect.MakeSlice(sliceValue.Type(), 0, 0))
+
+	switch sliceValue.Type().Elem() {
+	case reflect.TypeOf(models.WebAuthnCredential{}):
+		pk := q.whereString("PK")
+		for _, credential := range q.state.credentials {
+			if credential == nil || credential.PK != pk {
+				continue
+			}
+			if where, ok := q.wheres["SK"]; ok && strings.EqualFold(where.op, "BEGINS_WITH") {
+				prefix, _ := where.value.(string)
+				if !strings.HasPrefix(credential.SK, prefix) {
+					continue
+				}
+			}
+			sliceValue.Set(reflect.Append(sliceValue, reflect.ValueOf(*cloneRegistrationPasskeyCredential(credential))))
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported destination %T", dest)
+	}
+}
+
+func (q *registrationPasskeyQuery) Create() error {
+	if user, ok := q.model.(*models.User); ok && user != nil {
+		q.state.userCreateBarrier.Wait()
+	}
+
+	q.state.mu.Lock()
+	defer q.state.mu.Unlock()
+
+	switch model := q.model.(type) {
+	case *models.User:
+		if model == nil {
+			return fmt.Errorf("nil user model")
+		}
+		if q.ifNotExists {
+			if _, exists := q.state.users[model.PK]; exists {
+				return dynamormerrors.ErrConditionFailed
+			}
+		}
+		q.state.users[model.PK] = cloneRegistrationPasskeyUser(model)
+		return nil
+	case *models.Actor:
+		if model == nil {
+			return fmt.Errorf("nil actor model")
+		}
+		if q.ifNotExists {
+			if _, exists := q.state.actors[model.PK]; exists {
+				return dynamormerrors.ErrConditionFailed
+			}
+		}
+		q.state.actors[model.PK] = cloneRegistrationPasskeyActor(model)
+		return nil
+	case *models.NumericIDMapping:
+		if model == nil {
+			return fmt.Errorf("nil numeric mapping model")
+		}
+		if _, exists := q.state.numericMappings[model.PK]; exists {
+			return dynamormerrors.ErrConditionFailed
+		}
+		q.state.numericMappings[model.PK] = cloneRegistrationPasskeyNumericMapping(model)
+		return nil
+	case *models.PasskeyRegistrationProof:
+		if model == nil {
+			return fmt.Errorf("nil passkey proof model")
+		}
+		if q.ifNotExists {
+			if _, exists := q.state.proofs[model.PK]; exists {
+				return dynamormerrors.ErrConditionFailed
+			}
+		}
+		q.state.proofs[model.PK] = cloneRegistrationPasskeyProof(model)
+		return nil
+	case *models.WebAuthnCredential:
+		if model == nil {
+			return fmt.Errorf("nil credential model")
+		}
+		if q.ifNotExists {
+			if _, exists := q.state.credentials[model.GSI1PK]; exists {
+				return dynamormerrors.ErrConditionFailed
+			}
+		}
+		q.state.credentials[model.GSI1PK] = cloneRegistrationPasskeyCredential(model)
+		return nil
+	case *models.UserPreference:
+		if model == nil {
+			return fmt.Errorf("nil user preference model")
+		}
+		q.state.preferences[registrationPasskeyKey(model.PK, model.SK)] = cloneRegistrationPasskeyPreference(model)
+		return nil
+	case *models.QuotePermissions:
+		if model == nil {
+			return fmt.Errorf("nil quote permissions model")
+		}
+		if q.ifNotExists {
+			if _, exists := q.state.quotePermissions[model.PK]; exists {
+				return dynamormerrors.ErrConditionFailed
+			}
+		}
+		q.state.quotePermissions[model.PK] = cloneRegistrationPasskeyQuotePermissions(model)
+		return nil
+	default:
+		return fmt.Errorf("unsupported model %T", q.model)
+	}
+}
+
+func (q *registrationPasskeyQuery) Update(fields ...string) error {
+	q.state.mu.Lock()
+	defer q.state.mu.Unlock()
+
+	switch model := q.model.(type) {
+	case *models.UserPreference:
+		if model == nil {
+			return fmt.Errorf("nil user preference model")
+		}
+		key := registrationPasskeyKey(model.PK, model.SK)
+		if _, exists := q.state.preferences[key]; !exists {
+			return dynamormerrors.ErrItemNotFound
+		}
+		q.state.preferences[key] = cloneRegistrationPasskeyPreference(model)
+		return nil
+	default:
+		if len(fields) > 0 {
+			return fmt.Errorf("unsupported update model %T", q.model)
+		}
+		return nil
+	}
+}
+
+func (q *registrationPasskeyQuery) Delete() error {
+	q.state.mu.Lock()
+	defer q.state.mu.Unlock()
+
+	switch q.model.(type) {
+	case *models.User:
+		pk := q.whereString("PK")
+		if _, exists := q.state.users[pk]; !exists {
+			return dynamormerrors.ErrItemNotFound
+		}
+		delete(q.state.users, pk)
+		return nil
+	case *models.Actor:
+		pk := q.whereString("PK")
+		if _, exists := q.state.actors[pk]; !exists {
+			return dynamormerrors.ErrItemNotFound
+		}
+		delete(q.state.actors, pk)
+		return nil
+	case *models.NumericIDMapping:
+		pk := q.whereString("PK")
+		if _, exists := q.state.numericMappings[pk]; !exists {
+			return dynamormerrors.ErrItemNotFound
+		}
+		delete(q.state.numericMappings, pk)
+		return nil
+	case *models.PasskeyRegistrationProof:
+		pk := q.whereString("PK")
+		if _, exists := q.state.proofs[pk]; !exists {
+			return dynamormerrors.ErrItemNotFound
+		}
+		delete(q.state.proofs, pk)
+		return nil
+	case *models.WebAuthnCredential:
+		pk := q.whereString("PK")
+		sk := q.whereString("SK")
+		for key, credential := range q.state.credentials {
+			if credential != nil && credential.PK == pk && credential.SK == sk {
+				delete(q.state.credentials, key)
+				return nil
+			}
+		}
+		return dynamormerrors.ErrItemNotFound
+	case *models.UserPreference:
+		key := registrationPasskeyKey(q.whereString("PK"), q.whereString("SK"))
+		if _, exists := q.state.preferences[key]; !exists {
+			return dynamormerrors.ErrItemNotFound
+		}
+		delete(q.state.preferences, key)
+		return nil
+	case *models.QuotePermissions:
+		pk := q.whereString("PK")
+		if _, exists := q.state.quotePermissions[pk]; !exists {
+			return dynamormerrors.ErrItemNotFound
+		}
+		delete(q.state.quotePermissions, pk)
+		return nil
+	default:
+		return fmt.Errorf("unsupported delete model %T", q.model)
+	}
+}
+
+func (q *registrationPasskeyQuery) UpdateBuilder() dynamormcore.UpdateBuilder {
+	return &registrationPasskeyUpdateBuilder{
+		state:      q.state,
+		model:      q.model,
+		proofPK:    q.whereString("PK"),
+		sets:       make(map[string]any),
+		conditions: make([]registrationPasskeyCondition, 0),
+	}
+}
+
+func (q *registrationPasskeyQuery) whereString(field string) string {
+	where, ok := q.wheres[field]
+	if !ok {
+		return ""
+	}
+	value, _ := where.value.(string)
+	return value
+}
+
+func (q *registrationPasskeyQuery) loadUser(dest any) (bool, error) {
+	switch target := dest.(type) {
+	case *models.User:
+		pk := q.whereString("PK")
+		user, ok := q.state.users[pk]
+		if !ok {
+			return true, dynamormerrors.ErrItemNotFound
+		}
+		*target = *cloneRegistrationPasskeyUser(user)
+		return true, nil
+	default:
+		typeName := reflect.TypeOf(dest).String()
+		if typeName != "*repositories.userCoreProjection" && typeName != "*repositories.userMetadataProjection" {
+			return false, nil
+		}
+
+		pk := q.whereString("PK")
+		user, ok := q.state.users[pk]
+		if !ok {
+			return true, dynamormerrors.ErrItemNotFound
+		}
+
+		value := reflect.ValueOf(dest).Elem()
+		setAccountsProjectionField(value, "Table", "test-table")
+		setAccountsProjectionField(value, "PK", user.PK)
+		setAccountsProjectionField(value, "SK", user.SK)
+		if typeName == "*repositories.userMetadataProjection" {
+			setAccountsProjectionField(value, "Metadata", cloneRegistrationPasskeyMetadata(user.Metadata))
+			return true, nil
+		}
+
+		setAccountsProjectionField(value, "Username", user.Username)
+		setAccountsProjectionField(value, "Email", user.Email)
+		setAccountsProjectionField(value, "PasswordHash", user.PasswordHash)
+		setAccountsProjectionField(value, "DisplayName", user.DisplayName)
+		setAccountsProjectionField(value, "Note", user.Note)
+		setAccountsProjectionField(value, "Avatar", user.Avatar)
+		setAccountsProjectionField(value, "Header", user.Header)
+		setAccountsProjectionField(value, "URL", user.URL)
+		setAccountsProjectionField(value, "Locked", user.Locked)
+		setAccountsProjectionField(value, "Discoverable", user.Discoverable)
+		setAccountsProjectionField(value, "Fields", cloneRegistrationPasskeyFields(user.Fields))
+		setAccountsProjectionField(value, "CreatedAt", user.CreatedAt)
+		setAccountsProjectionField(value, "UpdatedAt", user.UpdatedAt)
+		setAccountsProjectionField(value, "Approved", user.Approved)
+		setAccountsProjectionField(value, "Suspended", user.Suspended)
+		setAccountsProjectionField(value, "Silenced", user.Silenced)
+		setAccountsProjectionField(value, "Role", user.Role)
+		setAccountsProjectionField(value, "Locale", user.Locale)
+		setAccountsProjectionField(value, "RecoveryMethods", append([]string(nil), user.RecoveryMethods...))
+		setAccountsProjectionField(value, "AllowNSFW", user.AllowNSFW)
+		setAccountsProjectionField(value, "RequireNSFWWarning", user.RequireNSFWWarning)
+		setAccountsProjectionField(value, "Metadata", cloneRegistrationPasskeyMetadata(user.Metadata))
+		setAccountsProjectionField(value, "IsAgent", user.IsAgent)
+		setAccountsProjectionField(value, "AgentType", user.AgentType)
+		setAccountsProjectionField(value, "AgentCapabilities", user.AgentCapabilities)
+		setAccountsProjectionField(value, "AgentVersion", user.AgentVersion)
+		setAccountsProjectionField(value, "AgentOwner", user.AgentOwner)
+		setAccountsProjectionField(value, "AgentCreatedBy", user.AgentCreatedBy)
+		setAccountsProjectionField(value, "AgentPublicKey", user.AgentPublicKey)
+		setAccountsProjectionField(value, "AgentKeyType", user.AgentKeyType)
+		setAccountsProjectionField(value, "Version", user.Version)
+		return true, nil
+	}
+}
+
+func (q *registrationPasskeyQuery) loadActor(dest any) (bool, error) {
+	target, ok := dest.(*models.Actor)
+	if !ok {
+		return false, nil
+	}
+
+	pk := q.whereString("PK")
+	actor, exists := q.state.actors[pk]
+	if !exists {
+		return true, dynamormerrors.ErrItemNotFound
+	}
+	*target = *cloneRegistrationPasskeyActor(actor)
+	return true, nil
+}
+
+func (q *registrationPasskeyQuery) loadNumericMapping(dest any) (bool, error) {
+	target, ok := dest.(*models.NumericIDMapping)
+	if !ok {
+		return false, nil
+	}
+
+	pk := q.whereString("PK")
+	mapping, exists := q.state.numericMappings[pk]
+	if !exists {
+		return true, dynamormerrors.ErrItemNotFound
+	}
+	*target = *cloneRegistrationPasskeyNumericMapping(mapping)
+	return true, nil
+}
+
+func (q *registrationPasskeyQuery) loadPasskeyProof(dest any) (bool, error) {
+	target, ok := dest.(*models.PasskeyRegistrationProof)
+	if !ok {
+		return false, nil
+	}
+
+	pk := q.whereString("PK")
+	proof, exists := q.state.proofs[pk]
+	if !exists {
+		return true, dynamormerrors.ErrItemNotFound
+	}
+	*target = *cloneRegistrationPasskeyProof(proof)
+	return true, nil
+}
+
+func (q *registrationPasskeyQuery) loadWebAuthnCredential(dest any) (bool, error) {
+	target, ok := dest.(*models.WebAuthnCredential)
+	if !ok {
+		return false, nil
+	}
+
+	var credential *models.WebAuthnCredential
+	if q.index == "gsi1" {
+		credential = q.state.credentials[q.whereString("gsi1PK")]
+	} else {
+		pk := q.whereString("PK")
+		sk := q.whereString("SK")
+		for _, candidate := range q.state.credentials {
+			if candidate != nil && candidate.PK == pk && candidate.SK == sk {
+				credential = candidate
+				break
+			}
+		}
+	}
+	if credential == nil {
+		return true, dynamormerrors.ErrItemNotFound
+	}
+	*target = *cloneRegistrationPasskeyCredential(credential)
+	return true, nil
+}
+
+func (q *registrationPasskeyQuery) loadUserPreference(dest any) (bool, error) {
+	target, ok := dest.(*models.UserPreference)
+	if !ok {
+		return false, nil
+	}
+
+	pref, exists := q.state.preferences[registrationPasskeyKey(q.whereString("PK"), q.whereString("SK"))]
+	if !exists {
+		return true, dynamormerrors.ErrItemNotFound
+	}
+	*target = *cloneRegistrationPasskeyPreference(pref)
+	return true, nil
+}
+
+func (q *registrationPasskeyQuery) loadQuotePermissions(dest any) (bool, error) {
+	target, ok := dest.(*models.QuotePermissions)
+	if !ok {
+		return false, nil
+	}
+
+	permissions, exists := q.state.quotePermissions[q.whereString("PK")]
+	if !exists {
+		return true, dynamormerrors.ErrItemNotFound
+	}
+	*target = *cloneRegistrationPasskeyQuotePermissions(permissions)
+	return true, nil
+}
+
+type registrationPasskeyCondition struct {
+	field string
+	op    string
+	value any
+}
+
+type registrationPasskeyUpdateBuilder struct {
+	state      *registrationPasskeyState
+	model      any
+	proofPK    string
+	sets       map[string]any
+	conditions []registrationPasskeyCondition
+}
+
+func (b *registrationPasskeyUpdateBuilder) Set(field string, value any) dynamormcore.UpdateBuilder {
+	b.sets[field] = value
+	return b
+}
+
+func (b *registrationPasskeyUpdateBuilder) SetIfNotExists(string, any, any) dynamormcore.UpdateBuilder {
+	return b
+}
+func (b *registrationPasskeyUpdateBuilder) Add(string, any) dynamormcore.UpdateBuilder    { return b }
+func (b *registrationPasskeyUpdateBuilder) Increment(string) dynamormcore.UpdateBuilder   { return b }
+func (b *registrationPasskeyUpdateBuilder) Decrement(string) dynamormcore.UpdateBuilder   { return b }
+func (b *registrationPasskeyUpdateBuilder) Remove(string) dynamormcore.UpdateBuilder      { return b }
+func (b *registrationPasskeyUpdateBuilder) Delete(string, any) dynamormcore.UpdateBuilder { return b }
+func (b *registrationPasskeyUpdateBuilder) AppendToList(string, any) dynamormcore.UpdateBuilder {
+	return b
+}
+func (b *registrationPasskeyUpdateBuilder) PrependToList(string, any) dynamormcore.UpdateBuilder {
+	return b
+}
+func (b *registrationPasskeyUpdateBuilder) RemoveFromListAt(string, int) dynamormcore.UpdateBuilder {
+	return b
+}
+func (b *registrationPasskeyUpdateBuilder) SetListElement(string, int, any) dynamormcore.UpdateBuilder {
+	return b
+}
+
+func (b *registrationPasskeyUpdateBuilder) Condition(field string, op string, value any) dynamormcore.UpdateBuilder {
+	b.conditions = append(b.conditions, registrationPasskeyCondition{field: field, op: op, value: value})
+	return b
+}
+
+func (b *registrationPasskeyUpdateBuilder) OrCondition(string, string, any) dynamormcore.UpdateBuilder {
+	return b
+}
+func (b *registrationPasskeyUpdateBuilder) ConditionExists(string) dynamormcore.UpdateBuilder {
+	return b
+}
+func (b *registrationPasskeyUpdateBuilder) ConditionNotExists(string) dynamormcore.UpdateBuilder {
+	return b
+}
+func (b *registrationPasskeyUpdateBuilder) ConditionVersion(int64) dynamormcore.UpdateBuilder {
+	return b
+}
+func (b *registrationPasskeyUpdateBuilder) ReturnValues(string) dynamormcore.UpdateBuilder { return b }
+
+func (b *registrationPasskeyUpdateBuilder) Execute() error {
+	b.state.mu.Lock()
+	defer b.state.mu.Unlock()
+
+	proof, exists := b.state.proofs[b.proofPK]
+	if !exists {
+		return dynamormerrors.ErrItemNotFound
+	}
+
+	for _, condition := range b.conditions {
+		if !registrationPasskeyConditionMet(proof, condition) {
+			return dynamormerrors.ErrConditionFailed
+		}
+	}
+
+	for field, value := range b.sets {
+		switch field {
+		case "Consumed":
+			proof.Consumed = value.(bool)
+		case "ConsumedAt":
+			proof.ConsumedAt = value.(time.Time)
+		}
+	}
+	if proof.Consumed {
+		b.state.consumeSuccesses++
+	}
+	b.state.proofs[b.proofPK] = cloneRegistrationPasskeyProof(proof)
+	return nil
+}
+
+func (b *registrationPasskeyUpdateBuilder) ExecuteWithResult(any) error { return b.Execute() }
+
+func registrationPasskeyConditionMet(proof *models.PasskeyRegistrationProof, condition registrationPasskeyCondition) bool {
+	switch condition.field {
+	case "Consumed":
+		expected, ok := condition.value.(bool)
+		return ok && condition.op == "=" && proof.Consumed == expected
+	case "TTL":
+		expected, ok := condition.value.(int64)
+		if !ok {
+			return false
+		}
+		switch condition.op {
+		case ">":
+			return proof.TTL > expected
+		case "=":
+			return proof.TTL == expected
+		default:
+			return false
+		}
+	case "Username":
+		expected, ok := condition.value.(string)
+		return ok && condition.op == "=" && proof.Username == expected
+	case "CeremonyID":
+		expected, ok := condition.value.(string)
+		return ok && condition.op == "=" && proof.CeremonyID == expected
+	default:
+		return false
+	}
+}
+
+func registrationPasskeyKey(pk string, sk string) string {
+	return pk + "|" + sk
+}
+
+func cloneRegistrationPasskeyActor(src *models.Actor) *models.Actor {
+	if src == nil {
+		return nil
+	}
+	clone := *src
+	if src.Actor != nil {
+		actorClone := *src.Actor
+		if src.Actor.PublicKey != nil {
+			publicKeyClone := *src.Actor.PublicKey
+			actorClone.PublicKey = &publicKeyClone
+		}
+		clone.Actor = &actorClone
+	}
+	if src.LastStatusAt != nil {
+		lastStatusAt := *src.LastStatusAt
+		clone.LastStatusAt = &lastStatusAt
+	}
+	clone.Fields = append([]models.ActorField(nil), src.Fields...)
+	return &clone
+}
+
+func cloneRegistrationPasskeyCredential(src *models.WebAuthnCredential) *models.WebAuthnCredential {
+	if src == nil {
+		return nil
+	}
+	clone := *src
+	clone.PublicKey = append([]byte(nil), src.PublicKey...)
+	clone.AAGUID = append([]byte(nil), src.AAGUID...)
+	return &clone
+}
+
+func cloneRegistrationPasskeyFields(src []map[string]string) []map[string]string {
+	if src == nil {
+		return nil
+	}
+	clone := make([]map[string]string, 0, len(src))
+	for _, field := range src {
+		clonedField := make(map[string]string, len(field))
+		for key, value := range field {
+			clonedField[key] = value
+		}
+		clone = append(clone, clonedField)
+	}
+	return clone
+}
+
+func cloneRegistrationPasskeyMetadata(src map[string]interface{}) map[string]interface{} {
+	if src == nil {
+		return nil
+	}
+	clone := make(map[string]interface{}, len(src))
+	for key, value := range src {
+		clone[key] = value
+	}
+	return clone
+}
+
+func cloneRegistrationPasskeyNumericMapping(src *models.NumericIDMapping) *models.NumericIDMapping {
+	if src == nil {
+		return nil
+	}
+	clone := *src
+	return &clone
+}
+
+func cloneRegistrationPasskeyPreference(src *models.UserPreference) *models.UserPreference {
+	if src == nil {
+		return nil
+	}
+	clone := *src
+	return &clone
+}
+
+func cloneRegistrationPasskeyQuotePermissions(src *models.QuotePermissions) *models.QuotePermissions {
+	if src == nil {
+		return nil
+	}
+	clone := *src
+	clone.BlockList = append([]string(nil), src.BlockList...)
+	return &clone
+}
+
+func cloneRegistrationPasskeyUser(src *models.User) *models.User {
+	if src == nil {
+		return nil
+	}
+	clone := *src
+	clone.Fields = cloneRegistrationPasskeyFields(src.Fields)
+	clone.RecoveryMethods = append([]string(nil), src.RecoveryMethods...)
+	clone.Metadata = cloneRegistrationPasskeyMetadata(src.Metadata)
+	return &clone
+}
+
+func cloneRegistrationPasskeyProof(src *models.PasskeyRegistrationProof) *models.PasskeyRegistrationProof {
+	if src == nil {
+		return nil
+	}
+
+	clone := *src
+	clone.PublicKey = append([]byte(nil), src.PublicKey...)
+	clone.AAGUID = append([]byte(nil), src.AAGUID...)
+	return &clone
+}

--- a/pkg/services/accounts/register_passkey_test.go
+++ b/pkg/services/accounts/register_passkey_test.go
@@ -69,7 +69,7 @@ func TestService_RegisterAccount_WithPasskeyRegistrationProof_Succeeds(t *testin
 	svc := NewService(storageImpl, streaming.NewMockPublisher(), nil, cryptoSvc, staticAuthService{hash: "hash"}, logger, "example.com")
 
 	got, err := svc.RegisterAccount(ctx, &RegisterAccountCommand{
-		Username:                 "alice",
+		Username:                 "Alice",
 		Agreement:                true,
 		Locale:                   "en",
 		PasskeyRegistrationProof: "proof-1",
@@ -77,6 +77,7 @@ func TestService_RegisterAccount_WithPasskeyRegistrationProof_Succeeds(t *testin
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.NotNil(t, got.Actor)
+	require.Equal(t, "alice", got.Account.User.Username)
 
 	credentials, err := accountRepo.GetUserWebAuthnCredentials(ctx, "alice")
 	require.NoError(t, err)
@@ -180,6 +181,30 @@ func TestService_validateRegisterAccountCommand_RequiresExactlyOneRegistrationPr
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exactly one")
+}
+
+func TestService_validateRegisterAccountCommand_AllowsSetupAdminBootstrapWithoutPublicProof(t *testing.T) {
+	svc := NewService(nil, streaming.NewMockPublisher(), nil, nil, nil, zap.NewNop(), "example.com")
+
+	err := svc.validateRegisterAccountCommand(context.Background(), &RegisterAccountCommand{
+		Username:         "alice",
+		Agreement:        true,
+		RegistrationMode: RegisterAccountModeSetupAdminBootstrap,
+	})
+	require.NoError(t, err)
+}
+
+func TestService_validateRegisterAccountCommand_RejectsPublicProofsInSetupAdminBootstrapMode(t *testing.T) {
+	svc := NewService(nil, streaming.NewMockPublisher(), nil, nil, nil, zap.NewNop(), "example.com")
+
+	err := svc.validateRegisterAccountCommand(context.Background(), &RegisterAccountCommand{
+		Username:                "alice",
+		Agreement:               true,
+		RegistrationChallengeID: "wallet-proof",
+		RegistrationMode:        RegisterAccountModeSetupAdminBootstrap,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "setup admin bootstrap")
 }
 
 func TestPasskeyRegistrationProofToCredential(t *testing.T) {

--- a/pkg/services/accounts/register_passkey_test.go
+++ b/pkg/services/accounts/register_passkey_test.go
@@ -162,7 +162,7 @@ func TestService_RegisterAccount_WithConsumedPasskeyRegistrationProof_DeletesCre
 	require.Empty(t, credentials)
 }
 
-func TestService_validateRegisterAccountCommand_RejectsBothRegistrationProofTypes(t *testing.T) {
+func TestService_validateRegisterAccountCommand_RequiresExactlyOneRegistrationProof(t *testing.T) {
 	svc := NewService(nil, streaming.NewMockPublisher(), nil, nil, nil, zap.NewNop(), "example.com")
 
 	err := svc.validateRegisterAccountCommand(context.Background(), &RegisterAccountCommand{
@@ -172,7 +172,14 @@ func TestService_validateRegisterAccountCommand_RejectsBothRegistrationProofType
 		PasskeyRegistrationProof: "passkey-proof",
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot both be provided")
+	assert.Contains(t, err.Error(), "exactly one")
+
+	err = svc.validateRegisterAccountCommand(context.Background(), &RegisterAccountCommand{
+		Username:  "alice",
+		Agreement: true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly one")
 }
 
 func TestPasskeyRegistrationProofToCredential(t *testing.T) {

--- a/pkg/services/accounts/register_passkey_test.go
+++ b/pkg/services/accounts/register_passkey_test.go
@@ -1,0 +1,207 @@
+package accounts
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/equaltoai/lesser/pkg/storage/repositories"
+	"github.com/equaltoai/lesser/pkg/streaming"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestService_RegisterAccount_WithPasskeyRegistrationProof_Succeeds(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+	baseTime := time.Now().UTC()
+	tableName := "test-table"
+
+	db := newPermissiveDynamormDB(t, permissiveDBOptions{forceUserNotFound: true})
+	accountRepo := repositories.NewAccountRepository(db, tableName, "example.com", logger)
+	accountRepo.SetEncryptor(noopEncryptor{})
+	accountRepo.SetPermissionService(nil)
+	accountRepo.SetEventService(nil)
+	accountRepo.SetCachingService(nil)
+
+	storageImpl := &permissiveAccountsStorage{
+		MockRepositoryStorage: NewMockRepositoryStorage(),
+		db:                    db,
+		tableName:             tableName,
+		logger:                logger,
+		account:               accountRepo,
+		actor:                 repositories.NewActorRepository(db, tableName, logger),
+		relationship:          repositories.NewRelationshipRepository(db, tableName, logger),
+		social:                repositories.NewSocialRepository(db, tableName, logger, nil),
+		user:                  repositories.NewUserRepository(db, tableName, logger),
+		marker:                repositories.NewMarkerRepository(db, tableName, logger, nil),
+		analytics:             repositories.NewTrendingRepository(db, logger, nil),
+		instance:              repositories.NewInstanceRepository(db, tableName, logger),
+		domainBlock:           repositories.NewDomainBlockRepository(db, tableName, logger),
+		quote:                 repositories.NewQuoteRepository(db, tableName, logger, nil),
+		activity:              repositories.NewActivityRepository(db, tableName, logger, nil),
+	}
+
+	require.NoError(t, accountRepo.StorePasskeyRegistrationProof(ctx, &models.PasskeyRegistrationProof{
+		ID:              "proof-1",
+		Username:        "alice",
+		CeremonyID:      "ceremony-1",
+		CredentialID:    "cred-1",
+		PublicKey:       []byte("public-key"),
+		AttestationType: "packed",
+		AAGUID:          []byte("aaguid"),
+		SignCount:       11,
+		BackupEligible:  true,
+		BackupState:     true,
+		CreatedAt:       baseTime,
+		ExpiresAt:       baseTime.Add(time.Hour),
+	}))
+
+	cryptoSvc := staticCryptoService{
+		publicKeyPEM:  []byte("PUBLIC KEY"),
+		privateKeyPEM: []byte("PRIVATE KEY"),
+		key:           struct{}{},
+	}
+
+	svc := NewService(storageImpl, streaming.NewMockPublisher(), nil, cryptoSvc, staticAuthService{hash: "hash"}, logger, "example.com")
+
+	got, err := svc.RegisterAccount(ctx, &RegisterAccountCommand{
+		Username:                 "alice",
+		Agreement:                true,
+		Locale:                   "en",
+		PasskeyRegistrationProof: "proof-1",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, got.Actor)
+
+	credentials, err := accountRepo.GetUserWebAuthnCredentials(ctx, "alice")
+	require.NoError(t, err)
+	require.Len(t, credentials, 1)
+	require.Equal(t, "cred-1", credentials[0].ID)
+	require.Equal(t, "alice", credentials[0].UserID)
+	require.Equal(t, "Passkey 1", credentials[0].Name)
+	require.Equal(t, []byte("public-key"), credentials[0].PublicKey)
+	require.True(t, credentials[0].BackupEligible)
+	require.True(t, credentials[0].BackupState)
+
+	proof, err := accountRepo.GetPasskeyRegistrationProof(ctx, "proof-1")
+	require.NoError(t, err)
+	require.True(t, proof.Consumed)
+	require.False(t, proof.ConsumedAt.IsZero())
+}
+
+func TestService_RegisterAccount_WithConsumedPasskeyRegistrationProof_DeletesCredential(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+	baseTime := time.Now().UTC()
+	tableName := "test-table"
+
+	db := newPermissiveDynamormDB(t, permissiveDBOptions{forceUserNotFound: true})
+	accountRepo := repositories.NewAccountRepository(db, tableName, "example.com", logger)
+	accountRepo.SetEncryptor(noopEncryptor{})
+	accountRepo.SetPermissionService(nil)
+	accountRepo.SetEventService(nil)
+	accountRepo.SetCachingService(nil)
+
+	storageImpl := &permissiveAccountsStorage{
+		MockRepositoryStorage: NewMockRepositoryStorage(),
+		db:                    db,
+		tableName:             tableName,
+		logger:                logger,
+		account:               accountRepo,
+		actor:                 repositories.NewActorRepository(db, tableName, logger),
+		relationship:          repositories.NewRelationshipRepository(db, tableName, logger),
+		social:                repositories.NewSocialRepository(db, tableName, logger, nil),
+		user:                  repositories.NewUserRepository(db, tableName, logger),
+		marker:                repositories.NewMarkerRepository(db, tableName, logger, nil),
+		analytics:             repositories.NewTrendingRepository(db, logger, nil),
+		instance:              repositories.NewInstanceRepository(db, tableName, logger),
+		domainBlock:           repositories.NewDomainBlockRepository(db, tableName, logger),
+		quote:                 repositories.NewQuoteRepository(db, tableName, logger, nil),
+		activity:              repositories.NewActivityRepository(db, tableName, logger, nil),
+	}
+
+	require.NoError(t, accountRepo.StorePasskeyRegistrationProof(ctx, &models.PasskeyRegistrationProof{
+		ID:              "proof-1",
+		Username:        "alice",
+		CeremonyID:      "ceremony-1",
+		CredentialID:    "cred-1",
+		PublicKey:       []byte("public-key"),
+		AttestationType: "packed",
+		AAGUID:          []byte("aaguid"),
+		SignCount:       11,
+		CreatedAt:       baseTime,
+		ExpiresAt:       baseTime.Add(time.Hour),
+	}))
+	_, err := accountRepo.ConsumePasskeyRegistrationProof(ctx, "proof-1", "alice", "ceremony-1")
+	require.NoError(t, err)
+
+	cryptoSvc := staticCryptoService{
+		publicKeyPEM:  []byte("PUBLIC KEY"),
+		privateKeyPEM: []byte("PRIVATE KEY"),
+		key:           struct{}{},
+	}
+
+	svc := NewService(storageImpl, streaming.NewMockPublisher(), nil, cryptoSvc, staticAuthService{hash: "hash"}, logger, "example.com")
+
+	got, err := svc.RegisterAccount(ctx, &RegisterAccountCommand{
+		Username:                 "alice",
+		Agreement:                true,
+		Locale:                   "en",
+		PasskeyRegistrationProof: "proof-1",
+	})
+	require.Nil(t, got)
+	require.Error(t, err)
+
+	credentials, err := accountRepo.GetUserWebAuthnCredentials(ctx, "alice")
+	require.NoError(t, err)
+	require.Empty(t, credentials)
+}
+
+func TestService_validateRegisterAccountCommand_RejectsBothRegistrationProofTypes(t *testing.T) {
+	svc := NewService(nil, streaming.NewMockPublisher(), nil, nil, nil, zap.NewNop(), "example.com")
+
+	err := svc.validateRegisterAccountCommand(context.Background(), &RegisterAccountCommand{
+		Username:                 "alice",
+		Agreement:                true,
+		RegistrationChallengeID:  "wallet-proof",
+		PasskeyRegistrationProof: "passkey-proof",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot both be provided")
+}
+
+func TestPasskeyRegistrationProofToCredential(t *testing.T) {
+	credential := passkeyRegistrationProofToCredential(&models.PasskeyRegistrationProof{
+		Username:        "alice",
+		CredentialID:    "cred-1",
+		PublicKey:       []byte("public-key"),
+		AttestationType: "packed",
+		AAGUID:          []byte("aaguid"),
+		SignCount:       3,
+		CloneWarning:    true,
+		BackupEligible:  true,
+		BackupState:     true,
+	})
+
+	require.Equal(t, &storage.WebAuthnCredential{
+		ID:              "cred-1",
+		UserID:          "alice",
+		PublicKey:       []byte("public-key"),
+		AttestationType: "packed",
+		AAGUID:          []byte("aaguid"),
+		SignCount:       3,
+		CloneWarning:    true,
+		BackupEligible:  true,
+		BackupState:     true,
+		Name:            "Passkey 1",
+		CreatedAt:       credential.CreatedAt,
+		LastUsedAt:      credential.LastUsedAt,
+	}, credential)
+	require.False(t, credential.CreatedAt.IsZero())
+	require.False(t, credential.LastUsedAt.IsZero())
+}

--- a/pkg/services/accounts/service.go
+++ b/pkg/services/accounts/service.go
@@ -244,7 +244,25 @@ func NewService(
 	return svc
 }
 
-func (s *Service) normalizeUsername(username string) string {
+// RegisterAccountMode names the registration caller context for explicit service-level exceptions.
+type RegisterAccountMode string
+
+const (
+	// RegisterAccountModeSetupAdminBootstrap is the setup-only bootstrap lane.
+	// It is allowed to create the first admin account without a public registration proof because
+	// /setup/admin already runs behind the bootstrap setup-session + wallet-verification gate.
+	RegisterAccountModeSetupAdminBootstrap RegisterAccountMode = "setup_admin_bootstrap"
+)
+
+// NormalizeUsernameForDomain applies the account-service canonical username normalization
+// rules against the supplied local domain.
+func NormalizeUsernameForDomain(username, localDomain string) string {
+	return normalizeUsernameWithLocalDomainMatcher(username, func(domain string) bool {
+		return isLocalDomainForUsername(domain, localDomain)
+	})
+}
+
+func normalizeUsernameWithLocalDomainMatcher(username string, isLocalDomain func(string) bool) string {
 	trimmed := strings.TrimSpace(username)
 	if trimmed == "" {
 		return trimmed
@@ -263,7 +281,7 @@ func (s *Service) normalizeUsername(username string) string {
 		// https://remote.example/users/admin would normalize to "admin" and
 		// collide with a same-named local account. (CSR-052)
 		parsed, parseErr := neturl.Parse(urlWithoutScheme)
-		if parseErr == nil && parsed != nil && strings.TrimSpace(parsed.Hostname()) != "" && !s.isLocalDomain(parsed.Hostname()) {
+		if parseErr == nil && parsed != nil && strings.TrimSpace(parsed.Hostname()) != "" && !isLocalDomain(parsed.Hostname()) {
 			remoteDomain = strings.ToLower(strings.TrimSpace(parsed.Hostname()))
 		}
 
@@ -288,12 +306,20 @@ func (s *Service) normalizeUsername(username string) string {
 	if at := strings.LastIndex(trimmed, "@"); at != -1 {
 		localPart := trimmed[:at]
 		domainPart := trimmed[at+1:]
-		if s.isLocalDomain(domainPart) {
+		if isLocalDomain(domainPart) {
 			trimmed = localPart
 		}
 	}
 
 	return strings.ToLower(strings.TrimSpace(trimmed))
+}
+
+func (s *Service) normalizeUsername(username string) string {
+	return normalizeUsernameWithLocalDomainMatcher(username, s.isLocalDomain)
+}
+
+func (s *Service) isLocalDomain(domain string) bool {
+	return isLocalDomainForUsername(domain, s.domainName)
 }
 
 func storedUsernameMatches(storedUsername, candidate string) bool {
@@ -306,11 +332,11 @@ func storedUsernameMatches(storedUsername, candidate string) bool {
 	return strings.EqualFold(storedUsername, candidate)
 }
 
-func (s *Service) isLocalDomain(domain string) bool {
+func isLocalDomainForUsername(domain, localDomain string) bool {
 	if domain == "" {
 		return false
 	}
-	return normalizeDomain(domain) == normalizeDomain(s.domainName)
+	return normalizeDomain(domain) == normalizeDomain(localDomain)
 }
 
 func normalizeDomain(domain string) string {
@@ -340,6 +366,10 @@ type RegisterAccountCommand struct {
 
 	// PasskeyRegistrationProof is the single-use proof emitted by the public WebAuthn signup finish ceremony.
 	PasskeyRegistrationProof string `json:"passkey_registration_proof,omitempty"`
+
+	// RegistrationMode is an explicit service-path selector for non-public registration lanes.
+	// Zero-value callers remain on the public exactly-one-proof path.
+	RegistrationMode RegisterAccountMode `json:"registration_mode,omitempty"`
 }
 
 // UpdateProfileCommand contains all data needed to update a user's profile
@@ -2064,6 +2094,17 @@ func (s *Service) validateRegisterAccountCommand(_ context.Context, cmd *Registe
 	}
 	hasWalletChallenge := strings.TrimSpace(cmd.RegistrationChallengeID) != ""
 	hasPasskeyProof := strings.TrimSpace(cmd.PasskeyRegistrationProof) != ""
+	switch cmd.RegistrationMode {
+	case "", RegisterAccountModeSetupAdminBootstrap:
+	default:
+		return fmt.Errorf("unsupported register account mode %q", cmd.RegistrationMode)
+	}
+	if cmd.RegistrationMode == RegisterAccountModeSetupAdminBootstrap {
+		if hasWalletChallenge || hasPasskeyProof {
+			return errors.New("setup admin bootstrap registration must not include public registration proofs")
+		}
+		return nil
+	}
 	if hasWalletChallenge == hasPasskeyProof {
 		return errors.New("exactly one of wallet challenge and passkey registration proof must be provided")
 	}

--- a/pkg/services/accounts/service.go
+++ b/pkg/services/accounts/service.go
@@ -337,6 +337,9 @@ type RegisterAccountCommand struct {
 	// RegistrationChallengeID is a registration-time proof reference (e.g. wallet challenge ID).
 	// Successful registration binds that proof to the typed wallet challenge row.
 	RegistrationChallengeID string `json:"registration_challenge_id,omitempty"`
+
+	// PasskeyRegistrationProof is the single-use proof emitted by the public WebAuthn signup finish ceremony.
+	PasskeyRegistrationProof string `json:"passkey_registration_proof,omitempty"`
 }
 
 // UpdateProfileCommand contains all data needed to update a user's profile
@@ -1911,6 +1914,21 @@ func (s *Service) RegisterAccount(ctx context.Context, cmd *RegisterAccountComma
 		return nil, ErrUsernameAlreadyTaken
 	}
 
+	registrationChallengeID := strings.TrimSpace(cmd.RegistrationChallengeID)
+	passkeyRegistrationProofID := strings.TrimSpace(cmd.PasskeyRegistrationProof)
+
+	var err error
+	var passkeyProof *models.PasskeyRegistrationProof
+	if passkeyRegistrationProofID != "" {
+		passkeyProof, err = accountRepo.GetPasskeyRegistrationProof(ctx, passkeyRegistrationProofID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get passkey registration proof: %w", err)
+		}
+		if !strings.EqualFold(strings.TrimSpace(passkeyProof.Username), strings.TrimSpace(cmd.Username)) {
+			return nil, fmt.Errorf("passkey registration proof was created for a different username")
+		}
+	}
+
 	// Generate RSA keypair for the actor
 	privateKey, err := s.generateRSAKeyPair()
 	if err != nil {
@@ -1999,8 +2017,17 @@ func (s *Service) RegisterAccount(ctx context.Context, cmd *RegisterAccountComma
 		return nil, err
 	}
 
-	registrationChallengeID := strings.TrimSpace(cmd.RegistrationChallengeID)
-	if registrationChallengeID != "" {
+	if passkeyProof != nil {
+		credential := passkeyRegistrationProofToCredential(passkeyProof)
+		if err := accountRepo.StoreWebAuthnCredential(ctx, credential); err != nil {
+			s.rollbackAccountCreationWithCredential(ctx, accountRepo, cmd.Username, credential.ID, err)
+			return nil, fmt.Errorf("failed to store initial passkey credential: %w", err)
+		}
+		if _, err := accountRepo.ConsumePasskeyRegistrationProof(ctx, passkeyProof.ID, cmd.Username, passkeyProof.CeremonyID); err != nil {
+			s.rollbackAccountCreationWithCredential(ctx, accountRepo, cmd.Username, credential.ID, err)
+			return nil, fmt.Errorf("failed to finalize passkey registration proof: %w", err)
+		}
+	} else if registrationChallengeID != "" {
 		if err := accountRepo.MarkWalletChallengeRegistrationCompleted(ctx, registrationChallengeID); err != nil {
 			s.rollbackAccountCreation(ctx, accountRepo, cmd.Username, err)
 			return nil, fmt.Errorf("failed to finalize wallet registration challenge: %w", err)
@@ -2051,6 +2078,9 @@ func (s *Service) validateRegisterAccountCommand(_ context.Context, cmd *Registe
 
 	if cmd.DefaultPostingVisibility != "" && !isValidPostingVisibility(cmd.DefaultPostingVisibility) {
 		return common.ErrValidation("default_posting_visibility", fmt.Sprintf("Visibility '%s' is not valid", cmd.DefaultPostingVisibility)).InternalError
+	}
+	if strings.TrimSpace(cmd.RegistrationChallengeID) != "" && strings.TrimSpace(cmd.PasskeyRegistrationProof) != "" {
+		return errors.New("wallet challenge and passkey registration proof cannot both be provided")
 	}
 	// Additional validation can be added here
 	return nil
@@ -2143,6 +2173,38 @@ func (s *Service) rollbackAccountCreation(ctx context.Context, repo accountRegis
 	s.logger.Warn("rolled back account after registration failure",
 		zap.String("username", username),
 		zap.NamedError("cause", cause))
+}
+
+func (s *Service) rollbackAccountCreationWithCredential(ctx context.Context, repo *repositories.AccountRepository, username string, credentialID string, cause error) {
+	if strings.TrimSpace(credentialID) != "" {
+		if err := repo.DeleteWebAuthnCredential(ctx, credentialID); err != nil {
+			s.logger.Error("failed to rollback passkey credential after registration failure",
+				zap.String("username", username),
+				zap.String("credential_id", credentialID),
+				zap.NamedError("rollback_error", err),
+				zap.NamedError("cause", cause))
+		}
+	}
+
+	s.rollbackAccountCreation(ctx, repo, username, cause)
+}
+
+func passkeyRegistrationProofToCredential(proof *models.PasskeyRegistrationProof) *storage.WebAuthnCredential {
+	now := time.Now().UTC()
+	return &storage.WebAuthnCredential{
+		ID:              proof.CredentialID,
+		UserID:          strings.TrimSpace(proof.Username),
+		PublicKey:       append([]byte(nil), proof.PublicKey...),
+		AttestationType: proof.AttestationType,
+		AAGUID:          append([]byte(nil), proof.AAGUID...),
+		SignCount:       proof.SignCount,
+		CloneWarning:    proof.CloneWarning,
+		BackupEligible:  proof.BackupEligible,
+		BackupState:     proof.BackupState,
+		CreatedAt:       now,
+		LastUsedAt:      now,
+		Name:            "Passkey 1",
+	}
 }
 
 // Helper methods for account registration

--- a/pkg/services/accounts/service.go
+++ b/pkg/services/accounts/service.go
@@ -1920,16 +1920,9 @@ func (s *Service) RegisterAccount(ctx context.Context, cmd *RegisterAccountComma
 	registrationChallengeID := strings.TrimSpace(cmd.RegistrationChallengeID)
 	passkeyRegistrationProofID := strings.TrimSpace(cmd.PasskeyRegistrationProof)
 
-	var err error
-	var passkeyProof *models.PasskeyRegistrationProof
-	if passkeyRegistrationProofID != "" {
-		passkeyProof, err = accountRepo.GetPasskeyRegistrationProof(ctx, passkeyRegistrationProofID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get passkey registration proof: %w", err)
-		}
-		if strings.TrimSpace(passkeyProof.Username) != username {
-			return nil, fmt.Errorf("passkey registration proof was created for a different username")
-		}
+	passkeyProof, err := s.loadRegistrationPasskeyProof(ctx, accountRepo, username, passkeyRegistrationProofID)
+	if err != nil {
+		return nil, err
 	}
 
 	// Generate RSA keypair for the actor
@@ -2008,7 +2001,6 @@ func (s *Service) RegisterAccount(ctx context.Context, cmd *RegisterAccountComma
 		// Return the actual error instead of wrapping it
 		return nil, fmt.Errorf("failed to create account: %w", err)
 	}
-	accountCreated := true
 
 	initialVisibility := s.initialPostingVisibility(cmd.DefaultPostingVisibility)
 	if err := s.ensureQuotePermissionsForNewUser(ctx, s.storage.Quote(), username, initialVisibility); err != nil {
@@ -2021,29 +2013,8 @@ func (s *Service) RegisterAccount(ctx context.Context, cmd *RegisterAccountComma
 		return nil, err
 	}
 
-	if passkeyProof != nil {
-		credential := passkeyRegistrationProofToCredential(passkeyProof)
-		if err := accountRepo.StoreWebAuthnCredential(ctx, credential); err != nil {
-			if accountCreated {
-				s.rollbackAccountCreation(ctx, accountRepo, username, err)
-			}
-			return nil, fmt.Errorf("failed to store initial passkey credential: %w", err)
-		}
-		credentialCreated := true
-		if _, err := accountRepo.ConsumePasskeyRegistrationProof(ctx, passkeyProof.ID, passkeyProof.Username, passkeyProof.CeremonyID); err != nil {
-			if credentialCreated {
-				s.rollbackPasskeyCredentialCreation(ctx, accountRepo, username, credential.ID, err)
-			}
-			if accountCreated {
-				s.rollbackAccountCreation(ctx, accountRepo, username, err)
-			}
-			return nil, fmt.Errorf("failed to finalize passkey registration proof: %w", err)
-		}
-	} else if registrationChallengeID != "" {
-		if err := accountRepo.MarkWalletChallengeRegistrationCompleted(ctx, registrationChallengeID); err != nil {
-			s.rollbackAccountCreation(ctx, accountRepo, username, err)
-			return nil, fmt.Errorf("failed to finalize wallet registration challenge: %w", err)
-		}
+	if err := s.finalizeRegistrationProof(ctx, accountRepo, username, registrationChallengeID, passkeyProof); err != nil {
+		return nil, err
 	}
 
 	s.logger.Info("account created successfully, recording activity",
@@ -2120,6 +2091,54 @@ func (s *Service) initialPostingVisibility(requested string) string {
 	}
 
 	return models.VisibilityPublic
+}
+
+func (s *Service) loadRegistrationPasskeyProof(ctx context.Context, repo *repositories.AccountRepository, username, proofID string) (*models.PasskeyRegistrationProof, error) {
+	if strings.TrimSpace(proofID) == "" {
+		return nil, nil
+	}
+
+	proof, err := repo.GetPasskeyRegistrationProof(ctx, proofID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get passkey registration proof: %w", err)
+	}
+	if strings.TrimSpace(proof.Username) != username {
+		return nil, fmt.Errorf("passkey registration proof was created for a different username")
+	}
+
+	return proof, nil
+}
+
+func (s *Service) finalizeRegistrationProof(ctx context.Context, repo *repositories.AccountRepository, username, walletChallengeID string, passkeyProof *models.PasskeyRegistrationProof) error {
+	if passkeyProof != nil {
+		return s.finalizePasskeyRegistrationProof(ctx, repo, username, passkeyProof)
+	}
+	if strings.TrimSpace(walletChallengeID) == "" {
+		return nil
+	}
+
+	if err := repo.MarkWalletChallengeRegistrationCompleted(ctx, walletChallengeID); err != nil {
+		s.rollbackAccountCreation(ctx, repo, username, err)
+		return fmt.Errorf("failed to finalize wallet registration challenge: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Service) finalizePasskeyRegistrationProof(ctx context.Context, repo *repositories.AccountRepository, username string, passkeyProof *models.PasskeyRegistrationProof) error {
+	credential := passkeyRegistrationProofToCredential(passkeyProof)
+	if err := repo.StoreWebAuthnCredential(ctx, credential); err != nil {
+		s.rollbackAccountCreation(ctx, repo, username, err)
+		return fmt.Errorf("failed to store initial passkey credential: %w", err)
+	}
+
+	if _, err := repo.ConsumePasskeyRegistrationProof(ctx, passkeyProof.ID, passkeyProof.Username, passkeyProof.CeremonyID); err != nil {
+		s.rollbackPasskeyCredentialCreation(ctx, repo, username, credential.ID, err)
+		s.rollbackAccountCreation(ctx, repo, username, err)
+		return fmt.Errorf("failed to finalize passkey registration proof: %w", err)
+	}
+
+	return nil
 }
 
 func isNilInterface(value any) bool {

--- a/pkg/services/accounts/service.go
+++ b/pkg/services/accounts/service.go
@@ -2091,8 +2091,10 @@ func (s *Service) validateRegisterAccountCommand(_ context.Context, cmd *Registe
 	if cmd.DefaultPostingVisibility != "" && !isValidPostingVisibility(cmd.DefaultPostingVisibility) {
 		return common.ErrValidation("default_posting_visibility", fmt.Sprintf("Visibility '%s' is not valid", cmd.DefaultPostingVisibility)).InternalError
 	}
-	if strings.TrimSpace(cmd.RegistrationChallengeID) != "" && strings.TrimSpace(cmd.PasskeyRegistrationProof) != "" {
-		return errors.New("wallet challenge and passkey registration proof cannot both be provided")
+	hasWalletChallenge := strings.TrimSpace(cmd.RegistrationChallengeID) != ""
+	hasPasskeyProof := strings.TrimSpace(cmd.PasskeyRegistrationProof) != ""
+	if hasWalletChallenge == hasPasskeyProof {
+		return errors.New("exactly one of wallet challenge and passkey registration proof must be provided")
 	}
 	// Additional validation can be added here
 	return nil

--- a/pkg/services/accounts/service.go
+++ b/pkg/services/accounts/service.go
@@ -1898,6 +1898,8 @@ func (s *Service) buildNextPageID(collectionID, nextCursor string) string {
 
 // RegisterAccount creates a new user account with actor
 func (s *Service) RegisterAccount(ctx context.Context, cmd *RegisterAccountCommand) (*RegisterAccountResult, error) {
+	cmd.Username = s.normalizeUsername(cmd.Username)
+
 	// Validate command
 	if err := s.validateRegisterAccountCommand(ctx, cmd); err != nil {
 		return nil, ErrValidationFailed
@@ -1914,6 +1916,7 @@ func (s *Service) RegisterAccount(ctx context.Context, cmd *RegisterAccountComma
 		return nil, ErrUsernameAlreadyTaken
 	}
 
+	username := cmd.Username
 	registrationChallengeID := strings.TrimSpace(cmd.RegistrationChallengeID)
 	passkeyRegistrationProofID := strings.TrimSpace(cmd.PasskeyRegistrationProof)
 
@@ -1924,7 +1927,7 @@ func (s *Service) RegisterAccount(ctx context.Context, cmd *RegisterAccountComma
 		if err != nil {
 			return nil, fmt.Errorf("failed to get passkey registration proof: %w", err)
 		}
-		if !strings.EqualFold(strings.TrimSpace(passkeyProof.Username), strings.TrimSpace(cmd.Username)) {
+		if strings.TrimSpace(passkeyProof.Username) != username {
 			return nil, fmt.Errorf("passkey registration proof was created for a different username")
 		}
 	}
@@ -1953,7 +1956,7 @@ func (s *Service) RegisterAccount(ctx context.Context, cmd *RegisterAccountComma
 
 	// Create user object
 	user := &storage.User{
-		Username:     cmd.Username,
+		Username:     username,
 		Email:        cmd.Email,
 		PasswordHash: "",   // Will be set if password provided
 		Approved:     true, // Auto-approve for now
@@ -1973,10 +1976,10 @@ func (s *Service) RegisterAccount(ctx context.Context, cmd *RegisterAccountComma
 	}
 
 	// Create corresponding actor
-	actorID := fmt.Sprintf("https://%s/users/%s", s.domainName, cmd.Username)
-	actor := activitypub.NewActor(activitypub.PersonType, actorID, cmd.Username)
-	actor.Name = cmd.Username
-	actor.URL = fmt.Sprintf("https://%s/@%s", s.domainName, cmd.Username)
+	actorID := fmt.Sprintf("https://%s/users/%s", s.domainName, username)
+	actor := activitypub.NewActor(activitypub.PersonType, actorID, username)
+	actor.Name = username
+	actor.URL = fmt.Sprintf("https://%s/@%s", s.domainName, username)
 	actor.CreatedAt = &user.CreatedAt
 	actor.PublicKey = &activitypub.PublicKey{
 		ID:           fmt.Sprintf("%s#main-key", actorID),
@@ -1985,7 +1988,7 @@ func (s *Service) RegisterAccount(ctx context.Context, cmd *RegisterAccountComma
 	}
 
 	// Set manifest-driven local actor identifiers.
-	activitypubutil.ApplyLocalActorIdentifiers(actor, fmt.Sprintf("https://%s", s.domainName), cmd.Username)
+	activitypubutil.ApplyLocalActorIdentifiers(actor, fmt.Sprintf("https://%s", s.domainName), username)
 
 	// Create account with actor
 	account := &storage.Account{
@@ -1995,47 +1998,56 @@ func (s *Service) RegisterAccount(ctx context.Context, cmd *RegisterAccountComma
 	}
 
 	// Save to storage
-	if err := accountRepo.CreateAccount(ctx, account); err != nil {
+	if err := accountRepo.CreateAccountIfNotExists(ctx, account); err != nil {
 		if strings.Contains(err.Error(), "already exists") {
 			return nil, ErrUsernameAlreadyTaken
 		}
 		s.logger.Error("failed to create account",
-			zap.String("username", cmd.Username),
+			zap.String("username", username),
 			zap.Error(err))
 		// Return the actual error instead of wrapping it
 		return nil, fmt.Errorf("failed to create account: %w", err)
 	}
+	accountCreated := true
 
 	initialVisibility := s.initialPostingVisibility(cmd.DefaultPostingVisibility)
-	if err := s.ensureQuotePermissionsForNewUser(ctx, s.storage.Quote(), cmd.Username, initialVisibility); err != nil {
-		s.rollbackAccountCreation(ctx, accountRepo, cmd.Username, err)
+	if err := s.ensureQuotePermissionsForNewUser(ctx, s.storage.Quote(), username, initialVisibility); err != nil {
+		s.rollbackAccountCreation(ctx, accountRepo, username, err)
 		return nil, fmt.Errorf("failed to create default quote permissions: %w", err)
 	}
 
-	if err := s.persistDefaultPostingVisibility(ctx, accountRepo, cmd.Username, initialVisibility); err != nil {
-		s.rollbackAccountCreation(ctx, accountRepo, cmd.Username, err)
+	if err := s.persistDefaultPostingVisibility(ctx, accountRepo, username, initialVisibility); err != nil {
+		s.rollbackAccountCreation(ctx, accountRepo, username, err)
 		return nil, err
 	}
 
 	if passkeyProof != nil {
 		credential := passkeyRegistrationProofToCredential(passkeyProof)
 		if err := accountRepo.StoreWebAuthnCredential(ctx, credential); err != nil {
-			s.rollbackAccountCreationWithCredential(ctx, accountRepo, cmd.Username, credential.ID, err)
+			if accountCreated {
+				s.rollbackAccountCreation(ctx, accountRepo, username, err)
+			}
 			return nil, fmt.Errorf("failed to store initial passkey credential: %w", err)
 		}
-		if _, err := accountRepo.ConsumePasskeyRegistrationProof(ctx, passkeyProof.ID, cmd.Username, passkeyProof.CeremonyID); err != nil {
-			s.rollbackAccountCreationWithCredential(ctx, accountRepo, cmd.Username, credential.ID, err)
+		credentialCreated := true
+		if _, err := accountRepo.ConsumePasskeyRegistrationProof(ctx, passkeyProof.ID, passkeyProof.Username, passkeyProof.CeremonyID); err != nil {
+			if credentialCreated {
+				s.rollbackPasskeyCredentialCreation(ctx, accountRepo, username, credential.ID, err)
+			}
+			if accountCreated {
+				s.rollbackAccountCreation(ctx, accountRepo, username, err)
+			}
 			return nil, fmt.Errorf("failed to finalize passkey registration proof: %w", err)
 		}
 	} else if registrationChallengeID != "" {
 		if err := accountRepo.MarkWalletChallengeRegistrationCompleted(ctx, registrationChallengeID); err != nil {
-			s.rollbackAccountCreation(ctx, accountRepo, cmd.Username, err)
+			s.rollbackAccountCreation(ctx, accountRepo, username, err)
 			return nil, fmt.Errorf("failed to finalize wallet registration challenge: %w", err)
 		}
 	}
 
 	s.logger.Info("account created successfully, recording activity",
-		zap.String("username", cmd.Username))
+		zap.String("username", username))
 
 	// Record registration activity for metrics
 	if err := s.storage.Activity().RecordActivity(ctx, "registration", actor.ID, time.Now()); err != nil {
@@ -2044,13 +2056,13 @@ func (s *Service) RegisterAccount(ctx context.Context, cmd *RegisterAccountComma
 	}
 
 	s.logger.Info("emitting account created events",
-		zap.String("username", cmd.Username))
+		zap.String("username", username))
 
 	// Create events for streaming
 	events := s.emitAccountCreatedEvents(ctx, account)
 
 	s.logger.Info("returning registration result",
-		zap.String("username", cmd.Username),
+		zap.String("username", username),
 		zap.String("actor_id", actor.ID))
 
 	return &RegisterAccountResult{
@@ -2175,7 +2187,7 @@ func (s *Service) rollbackAccountCreation(ctx context.Context, repo accountRegis
 		zap.NamedError("cause", cause))
 }
 
-func (s *Service) rollbackAccountCreationWithCredential(ctx context.Context, repo *repositories.AccountRepository, username string, credentialID string, cause error) {
+func (s *Service) rollbackPasskeyCredentialCreation(ctx context.Context, repo *repositories.AccountRepository, username string, credentialID string, cause error) {
 	if strings.TrimSpace(credentialID) != "" {
 		if err := repo.DeleteWebAuthnCredential(ctx, credentialID); err != nil {
 			s.logger.Error("failed to rollback passkey credential after registration failure",
@@ -2185,8 +2197,6 @@ func (s *Service) rollbackAccountCreationWithCredential(ctx context.Context, rep
 				zap.NamedError("cause", cause))
 		}
 	}
-
-	s.rollbackAccountCreation(ctx, repo, username, cause)
 }
 
 func passkeyRegistrationProofToCredential(proof *models.PasskeyRegistrationProof) *storage.WebAuthnCredential {

--- a/pkg/services/accounts/service.go
+++ b/pkg/services/accounts/service.go
@@ -369,7 +369,7 @@ type RegisterAccountCommand struct {
 
 	// RegistrationMode is an explicit service-path selector for non-public registration lanes.
 	// Zero-value callers remain on the public exactly-one-proof path.
-	RegistrationMode RegisterAccountMode `json:"registration_mode,omitempty"`
+	RegistrationMode RegisterAccountMode
 }
 
 // UpdateProfileCommand contains all data needed to update a user's profile

--- a/pkg/services/accounts/service_round12_coverage_test.go
+++ b/pkg/services/accounts/service_round12_coverage_test.go
@@ -27,6 +27,27 @@ func (f *federationRecorder) QueueActivity(ctx context.Context, activity *activi
 	return f.err
 }
 
+func TestNormalizeUsernameForDomain(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		username    string
+		localDomain string
+		expected    string
+	}{
+		{name: "local handle strips domain", username: " Alice@Example.com ", localDomain: "example.com", expected: "alice"},
+		{name: "remote users url preserves foreign host", username: "https://Remote.Social/users/Alice", localDomain: "example.com", expected: "alice@remote.social"},
+		{name: "remote at-url preserves foreign host", username: "https://Remote.Social/@Alice", localDomain: "example.com", expected: "alice@remote.social"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, NormalizeUsernameForDomain(tt.username, tt.localDomain))
+		})
+	}
+}
+
 func TestService_normalizeUsername(t *testing.T) {
 	svc := NewService(nil, streaming.NewMockPublisher(), nil, nil, nil, zap.NewNop(), "example.com")
 

--- a/pkg/services/accounts/service_round13_more_coverage_test.go
+++ b/pkg/services/accounts/service_round13_more_coverage_test.go
@@ -130,17 +130,36 @@ type permissiveDBOptions struct {
 	firstMuteFirstError         error
 }
 
+type permissiveUpdateCondition struct {
+	field string
+	op    string
+	value any
+}
+
+type permissiveUpdateBuilder struct {
+	currentModel func() any
+	getProof     func(string) (models.PasskeyRegistrationProof, bool)
+	storeProof   func(models.PasskeyRegistrationProof)
+
+	sets       map[string]any
+	conditions []permissiveUpdateCondition
+}
+
 func newPermissiveDynamormDB(t *testing.T, opts permissiveDBOptions) dynamormcore.DB {
 	t.Helper()
 
 	db := new(dynamormMocks.MockDB)
 	q := new(dynamormMocks.MockQuery)
-	updateBuilder := new(dynamormMocks.MockUpdateBuilder)
+	updateBuilder := &permissiveUpdateBuilder{
+		sets: make(map[string]any),
+	}
 	batchGetBuilder := new(dynamormMocks.MockBatchGetBuilder)
 
 	var mu sync.Mutex
 	where := make(map[string]any)
 	walletChallenges := make(map[string]models.WalletChallenge)
+	passkeyProofs := make(map[string]models.PasskeyRegistrationProof)
+	webAuthnCredentials := make(map[string]models.WebAuthnCredential)
 	var currentModel any
 	resetWhere := func() {
 		mu.Lock()
@@ -169,6 +188,44 @@ func newPermissiveDynamormDB(t *testing.T, opts permissiveDBOptions) dynamormcor
 		model, ok := walletChallenges[challengeID]
 		return model, ok
 	}
+	storePasskeyProof := func(model models.PasskeyRegistrationProof) {
+		mu.Lock()
+		defer mu.Unlock()
+		passkeyProofs[model.ID] = model
+	}
+	getPasskeyProof := func(proofID string) (models.PasskeyRegistrationProof, bool) {
+		mu.Lock()
+		defer mu.Unlock()
+		model, ok := passkeyProofs[proofID]
+		return model, ok
+	}
+	storeWebAuthnCredential := func(model models.WebAuthnCredential) {
+		mu.Lock()
+		defer mu.Unlock()
+		webAuthnCredentials[model.ID] = model
+	}
+	deleteWebAuthnCredential := func(credentialID string) {
+		mu.Lock()
+		defer mu.Unlock()
+		delete(webAuthnCredentials, credentialID)
+	}
+	getWebAuthnCredential := func(credentialID string) (models.WebAuthnCredential, bool) {
+		mu.Lock()
+		defer mu.Unlock()
+		model, ok := webAuthnCredentials[credentialID]
+		return model, ok
+	}
+	getWebAuthnCredentialsByUser := func(userID string) []models.WebAuthnCredential {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]models.WebAuthnCredential, 0)
+		for _, credential := range webAuthnCredentials {
+			if strings.EqualFold(strings.TrimSpace(credential.UserID), strings.TrimSpace(userID)) {
+				out = append(out, credential)
+			}
+		}
+		return out
+	}
 	setCurrentModel := func(model any) {
 		mu.Lock()
 		defer mu.Unlock()
@@ -179,6 +236,9 @@ func newPermissiveDynamormDB(t *testing.T, opts permissiveDBOptions) dynamormcor
 		defer mu.Unlock()
 		return currentModel
 	}
+	updateBuilder.currentModel = getCurrentModel
+	updateBuilder.getProof = getPasskeyProof
+	updateBuilder.storeProof = storePasskeyProof
 
 	db.On("WithContext", mock.Anything).Return(db).Maybe()
 	db.On("Model", mock.Anything).Run(func(arguments mock.Arguments) {
@@ -244,13 +304,49 @@ func newPermissiveDynamormDB(t *testing.T, opts permissiveDBOptions) dynamormcor
 		q.On("First", mock.AnythingOfType("*models.Mute")).Return(opts.firstMuteFirstError).Once()
 	}
 	q.On("Create").Run(func(_ mock.Arguments) {
-		if model, ok := getCurrentModel().(*models.WalletChallenge); ok && model != nil {
-			storeWalletChallenge(*model)
+		switch model := getCurrentModel().(type) {
+		case *models.WalletChallenge:
+			if model != nil {
+				storeWalletChallenge(*model)
+			}
+		case *models.PasskeyRegistrationProof:
+			if model != nil {
+				storePasskeyProof(*model)
+			}
+		case *models.WebAuthnCredential:
+			if model != nil {
+				storeWebAuthnCredential(*model)
+			}
 		}
 	}).Return(nil).Maybe()
 	q.On("Update", mock.Anything).Run(func(_ mock.Arguments) {
 		if model, ok := getCurrentModel().(*models.WalletChallenge); ok && model != nil {
 			storeWalletChallenge(*model)
+		}
+	}).Return(nil).Maybe()
+	q.On("Delete").Run(func(_ mock.Arguments) {
+		switch model := getCurrentModel().(type) {
+		case *models.WebAuthnCredential:
+			if model == nil {
+				return
+			}
+			credentialID := strings.TrimPrefix(extractStringFromWhere(getWhere, "gsi1PK"), "WEBAUTHN_CREDENTIAL#")
+			if credentialID == "" {
+				credentialID = strings.TrimPrefix(extractStringFromWhere(getWhere, "SK"), "WEBAUTHN_CRED#")
+			}
+			if credentialID != "" {
+				deleteWebAuthnCredential(credentialID)
+			}
+		case *models.PasskeyRegistrationProof:
+			proofID := strings.TrimPrefix(extractStringFromWhere(getWhere, "PK"), "PASSKEY_REGISTRATION_PROOF#")
+			if proofID == "" && model != nil {
+				proofID = strings.TrimSpace(model.ID)
+			}
+			if proofID != "" {
+				mu.Lock()
+				delete(passkeyProofs, proofID)
+				mu.Unlock()
+			}
 		}
 	}).Return(nil).Maybe()
 	q.On("First", mock.AnythingOfType("*models.WalletChallenge")).Run(func(arguments mock.Arguments) {
@@ -270,6 +366,22 @@ func newPermissiveDynamormDB(t *testing.T, opts permissiveDBOptions) dynamormcor
 		dest.ExpiresAt = time.Now().Add(5 * time.Minute)
 		_ = dest.UpdateKeys()
 	}).Return(nil).Maybe()
+	q.On("First", mock.AnythingOfType("*models.PasskeyRegistrationProof")).Run(func(arguments mock.Arguments) {
+		dest := arguments.Get(0).(*models.PasskeyRegistrationProof)
+		proofID := extractUsernameFromWhere(getWhere, "PK", "PASSKEY_REGISTRATION_PROOF#", "")
+		if stored, ok := getPasskeyProof(proofID); ok {
+			*dest = stored
+			return
+		}
+	}).Return(nil).Maybe()
+	q.On("First", mock.AnythingOfType("*models.WebAuthnCredential")).Run(func(arguments mock.Arguments) {
+		dest := arguments.Get(0).(*models.WebAuthnCredential)
+		credentialID := strings.TrimPrefix(extractStringFromWhere(getWhere, "gsi1PK"), "WEBAUTHN_CREDENTIAL#")
+		if stored, ok := getWebAuthnCredential(credentialID); ok {
+			*dest = stored
+			return
+		}
+	}).Return(nil).Maybe()
 
 	q.On("First", mock.Anything).Run(func(arguments mock.Arguments) {
 		dest := arguments.Get(0)
@@ -278,22 +390,22 @@ func newPermissiveDynamormDB(t *testing.T, opts permissiveDBOptions) dynamormcor
 
 	q.On("All", mock.Anything).Run(func(arguments mock.Arguments) {
 		dest := arguments.Get(0)
-		fillSlicePointer(t, dest, getWhere, opts)
+		fillSlicePointer(t, dest, getWhere, opts, getWebAuthnCredentialsByUser)
 	}).Return(nil).Maybe()
 
 	q.On("Scan", mock.Anything).Run(func(arguments mock.Arguments) {
 		dest := arguments.Get(0)
-		fillSlicePointer(t, dest, getWhere, opts)
+		fillSlicePointer(t, dest, getWhere, opts, getWebAuthnCredentialsByUser)
 	}).Return(nil).Maybe()
 
 	q.On("BatchGet", mock.Anything).Run(func(arguments mock.Arguments) {
 		dest := arguments.Get(0)
-		fillSlicePointer(t, dest, getWhere, opts)
+		fillSlicePointer(t, dest, getWhere, opts, getWebAuthnCredentialsByUser)
 	}).Return(batchGetBuilder).Maybe()
 
 	q.On("ScanAllSegments", mock.Anything).Run(func(arguments mock.Arguments) {
 		dest := arguments.Get(0)
-		fillSlicePointer(t, dest, getWhere, opts)
+		fillSlicePointer(t, dest, getWhere, opts, getWebAuthnCredentialsByUser)
 	}).Return(nil).Maybe()
 
 	if opts.firstCountError != nil {
@@ -314,7 +426,7 @@ func newPermissiveDynamormDB(t *testing.T, opts permissiveDBOptions) dynamormcor
 
 		// Already handled above with custom behavior.
 		switch method.Name {
-		case "Where", "UpdateBuilder", "First", "All", "Scan", "BatchGet", "ScanAllSegments", "Count":
+		case "Where", "UpdateBuilder", "First", "All", "Scan", "BatchGet", "ScanAllSegments", "Count", "Delete":
 			continue
 		}
 
@@ -356,35 +468,6 @@ func newPermissiveDynamormDB(t *testing.T, opts permissiveDBOptions) dynamormcor
 		}
 	}
 
-	// Permissive UpdateBuilder behavior.
-	updateBuilderType := reflect.TypeOf((*dynamormcore.UpdateBuilder)(nil)).Elem()
-	for i := 0; i < updateBuilderType.NumMethod(); i++ {
-		method := updateBuilderType.Method(i)
-		args := make([]any, method.Type.NumIn())
-		for j := range args {
-			args[j] = mock.Anything
-		}
-
-		switch method.Type.NumOut() {
-		case 0:
-			updateBuilder.On(method.Name, args...).Return().Maybe()
-		case 1:
-			out0 := method.Type.Out(0)
-			switch {
-			case out0.Implements(updateBuilderType) || out0.AssignableTo(updateBuilderType):
-				updateBuilder.On(method.Name, args...).Return(updateBuilder).Maybe()
-			default:
-				updateBuilder.On(method.Name, args...).Return(reflect.Zero(out0).Interface()).Maybe()
-			}
-		default:
-			zero := make([]any, method.Type.NumOut())
-			for j := range zero {
-				zero[j] = reflect.Zero(method.Type.Out(j)).Interface()
-			}
-			updateBuilder.On(method.Name, args...).Return(zero...).Maybe()
-		}
-	}
-
 	// Permissive BatchGetBuilder behavior.
 	batchGetBuilderType := reflect.TypeOf((*dynamormcore.BatchGetBuilder)(nil)).Elem()
 	for i := 0; i < batchGetBuilderType.NumMethod(); i++ {
@@ -415,6 +498,110 @@ func newPermissiveDynamormDB(t *testing.T, opts permissiveDBOptions) dynamormcor
 	}
 
 	return db
+}
+
+func (b *permissiveUpdateBuilder) Set(field string, value any) dynamormcore.UpdateBuilder {
+	if b.sets == nil {
+		b.sets = make(map[string]any)
+	}
+	b.sets[field] = value
+	return b
+}
+
+func (b *permissiveUpdateBuilder) SetIfNotExists(string, any, any) dynamormcore.UpdateBuilder {
+	return b
+}
+func (b *permissiveUpdateBuilder) Add(string, any) dynamormcore.UpdateBuilder              { return b }
+func (b *permissiveUpdateBuilder) Increment(string) dynamormcore.UpdateBuilder             { return b }
+func (b *permissiveUpdateBuilder) Decrement(string) dynamormcore.UpdateBuilder             { return b }
+func (b *permissiveUpdateBuilder) Remove(string) dynamormcore.UpdateBuilder                { return b }
+func (b *permissiveUpdateBuilder) Delete(string, any) dynamormcore.UpdateBuilder           { return b }
+func (b *permissiveUpdateBuilder) AppendToList(string, any) dynamormcore.UpdateBuilder     { return b }
+func (b *permissiveUpdateBuilder) PrependToList(string, any) dynamormcore.UpdateBuilder    { return b }
+func (b *permissiveUpdateBuilder) RemoveFromListAt(string, int) dynamormcore.UpdateBuilder { return b }
+func (b *permissiveUpdateBuilder) SetListElement(string, int, any) dynamormcore.UpdateBuilder {
+	return b
+}
+
+func (b *permissiveUpdateBuilder) Condition(field string, op string, value any) dynamormcore.UpdateBuilder {
+	b.conditions = append(b.conditions, permissiveUpdateCondition{field: field, op: op, value: value})
+	return b
+}
+
+func (b *permissiveUpdateBuilder) OrCondition(string, string, any) dynamormcore.UpdateBuilder {
+	return b
+}
+func (b *permissiveUpdateBuilder) ConditionExists(string) dynamormcore.UpdateBuilder    { return b }
+func (b *permissiveUpdateBuilder) ConditionNotExists(string) dynamormcore.UpdateBuilder { return b }
+func (b *permissiveUpdateBuilder) ConditionVersion(int64) dynamormcore.UpdateBuilder    { return b }
+func (b *permissiveUpdateBuilder) ReturnValues(string) dynamormcore.UpdateBuilder       { return b }
+
+func (b *permissiveUpdateBuilder) Execute() error {
+	defer func() {
+		b.sets = make(map[string]any)
+		b.conditions = nil
+	}()
+
+	currentProof, ok := b.currentModel().(*models.PasskeyRegistrationProof)
+	if !ok || currentProof == nil {
+		return nil
+	}
+
+	proof, ok := b.getProof(strings.TrimSpace(currentProof.ID))
+	if !ok {
+		return dynamormErrors.ErrItemNotFound
+	}
+
+	for _, condition := range b.conditions {
+		if !permissivePasskeyProofConditionMet(&proof, condition) {
+			return dynamormErrors.ErrConditionFailed
+		}
+	}
+
+	for field, value := range b.sets {
+		switch field {
+		case "Consumed":
+			boolValue, _ := value.(bool)
+			proof.Consumed = boolValue
+		case "ConsumedAt":
+			if ts, ok := value.(time.Time); ok {
+				proof.ConsumedAt = ts
+			}
+		}
+	}
+
+	b.storeProof(proof)
+	return nil
+}
+
+func (b *permissiveUpdateBuilder) ExecuteWithResult(any) error {
+	return b.Execute()
+}
+
+func permissivePasskeyProofConditionMet(proof *models.PasskeyRegistrationProof, condition permissiveUpdateCondition) bool {
+	switch condition.field {
+	case "Consumed":
+		expected, _ := condition.value.(bool)
+		return condition.op == "=" && proof.Consumed == expected
+	case "TTL":
+		expected, _ := condition.value.(int64)
+		switch condition.op {
+		case ">":
+			return proof.TTL > expected
+		case "=":
+			return proof.TTL == expected
+		default:
+			return false
+		}
+	case "Username":
+		expected, _ := condition.value.(string)
+		return condition.op == "=" && strings.TrimSpace(proof.Username) == strings.TrimSpace(expected)
+	case "CeremonyID":
+		expected, _ := condition.value.(string)
+		return condition.op == "=" && strings.TrimSpace(proof.CeremonyID) == strings.TrimSpace(expected)
+	default:
+		return true
+	}
 }
 
 func fillModelPointer(t *testing.T, dest any, getWhere func(string) (any, bool), opts permissiveDBOptions) {
@@ -558,7 +745,7 @@ func setAccountsProjectionField(target reflect.Value, name string, value any) {
 	}
 }
 
-func fillSlicePointer(t *testing.T, dest any, getWhere func(string) (any, bool), opts permissiveDBOptions) {
+func fillSlicePointer(t *testing.T, dest any, getWhere func(string) (any, bool), opts permissiveDBOptions, getWebAuthnCredentialsByUser func(string) []models.WebAuthnCredential) {
 	t.Helper()
 
 	ptr := reflect.ValueOf(dest)
@@ -571,6 +758,14 @@ func fillSlicePointer(t *testing.T, dest any, getWhere func(string) (any, bool),
 	}
 
 	switch elem.Type().Elem() {
+	case reflect.TypeOf(models.WebAuthnCredential{}):
+		userID := extractUsernameFromWhere(getWhere, "PK", "USER#", "alice")
+		credentials := getWebAuthnCredentialsByUser(userID)
+		elem.Set(reflect.MakeSlice(elem.Type(), 0, len(credentials)))
+		for _, credential := range credentials {
+			elem.Set(reflect.Append(elem, reflect.ValueOf(credential)))
+		}
+		return
 	case reflect.TypeOf(models.User{}):
 		// SearchAccounts expects users with mixed suspended statuses.
 		elem.Set(reflect.MakeSlice(elem.Type(), 0, 3))

--- a/pkg/services/accounts/service_round13_more_coverage_test.go
+++ b/pkg/services/accounts/service_round13_more_coverage_test.go
@@ -1256,6 +1256,7 @@ func TestService_Round13_RegisterAccount_SucceedsWithoutEmail(t *testing.T) {
 	}
 
 	svc := NewService(storageImpl, streaming.NewMockPublisher(), nil, cryptoSvc, staticAuthService{hash: "hash"}, logger, "example.com")
+	storeRegistrationWalletChallenge(t, accountRepo, "alice", "wc-1")
 
 	got, err := svc.RegisterAccount(ctx, &RegisterAccountCommand{
 		Username:                 "alice",
@@ -1264,6 +1265,7 @@ func TestService_Round13_RegisterAccount_SucceedsWithoutEmail(t *testing.T) {
 		Locale:                   "en",
 		Agreement:                true,
 		DefaultPostingVisibility: "public",
+		RegistrationChallengeID:  "wc-1",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, got)
@@ -1599,11 +1601,13 @@ func TestService_Round13_RegisterAccount_ErrorsAndRollbacks(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("username already taken", func(t *testing.T) {
-		svc, _ := newPermissiveAccountsService(t, permissiveDBOptions{domain: "example.com"})
+		svc, storageIface := newPermissiveAccountsService(t, permissiveDBOptions{domain: "example.com"})
+		storeRegistrationWalletChallenge(t, storageIface.(*permissiveAccountsStorage).account, "alice", "wc-1")
 		_, err := svc.RegisterAccount(ctx, &RegisterAccountCommand{
-			Username:  "alice",
-			Email:     "",
-			Agreement: true,
+			Username:                "alice",
+			Email:                   "",
+			Agreement:               true,
+			RegistrationChallengeID: "wc-1",
 		})
 		assert.ErrorIs(t, err, ErrUsernameAlreadyTaken)
 	})
@@ -1612,9 +1616,10 @@ func TestService_Round13_RegisterAccount_ErrorsAndRollbacks(t *testing.T) {
 		storageImpl := NewMockRepositoryStorage()
 		svc := NewService(storageImpl, streaming.NewMockPublisher(), nil, nil, nil, zap.NewNop(), "example.com")
 		_, err := svc.RegisterAccount(ctx, &RegisterAccountCommand{
-			Username:  "alice",
-			Email:     "",
-			Agreement: true,
+			Username:                "alice",
+			Email:                   "",
+			Agreement:               true,
+			RegistrationChallengeID: "wc-1",
 		})
 		assert.ErrorIs(t, err, ErrAccountRepositoryNotAvailable)
 	})
@@ -1638,9 +1643,10 @@ func TestService_Round13_RegisterAccount_ErrorsAndRollbacks(t *testing.T) {
 
 		svc := NewService(storageImpl, streaming.NewMockPublisher(), nil, nil, nil, logger, "example.com")
 		_, err := svc.RegisterAccount(ctx, &RegisterAccountCommand{
-			Username:  "alice",
-			Email:     "",
-			Agreement: true,
+			Username:                "alice",
+			Email:                   "",
+			Agreement:               true,
+			RegistrationChallengeID: "wc-1",
 		})
 		assert.ErrorIs(t, err, ErrGenerateKeypair)
 	})
@@ -1673,9 +1679,10 @@ func TestService_Round13_RegisterAccount_ErrorsAndRollbacks(t *testing.T) {
 
 		svc := NewService(storageImpl, streaming.NewMockPublisher(), nil, cryptoSvc, nil, logger, "example.com")
 		_, err := svc.RegisterAccount(ctx, &RegisterAccountCommand{
-			Username:  "alice",
-			Email:     "",
-			Agreement: true,
+			Username:                "alice",
+			Email:                   "",
+			Agreement:               true,
+			RegistrationChallengeID: "wc-1",
 		})
 		require.Error(t, err)
 	})

--- a/pkg/storage/repositories/account_repository.go
+++ b/pkg/storage/repositories/account_repository.go
@@ -17,6 +17,7 @@ import (
 	"github.com/equaltoai/lesser/pkg/common"
 	"github.com/equaltoai/lesser/pkg/config"
 	"github.com/equaltoai/lesser/pkg/cost"
+	pkgErrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/interfaces"
 	"github.com/equaltoai/lesser/pkg/storage/models"
@@ -242,6 +243,16 @@ func (r *AccountRepository) SetStorage(_ interface{}) {
 // CreateAccount creates both User and Actor entities atomically using enhanced patterns
 // This ensures consistency between authentication and federation data
 func (r *AccountRepository) CreateAccount(ctx context.Context, account *storage.Account) error {
+	return r.createAccount(ctx, account, false)
+}
+
+// CreateAccountIfNotExists creates both User and Actor entities while rejecting duplicate user creation.
+// This is used by registration flows that must fail loudly under concurrent duplicate submits.
+func (r *AccountRepository) CreateAccountIfNotExists(ctx context.Context, account *storage.Account) error {
+	return r.createAccount(ctx, account, true)
+}
+
+func (r *AccountRepository) createAccount(ctx context.Context, account *storage.Account, createUserIfNotExists bool) error {
 	if account == nil || account.User == nil {
 		return common.ValidationError{Field: "account", Message: "account and user are required"}
 	}
@@ -292,7 +303,7 @@ func (r *AccountRepository) CreateAccount(ctx context.Context, account *storage.
 	r.setUserDefaults(userModel)
 
 	// Use enhanced validation and creation with event emission
-	if err := r.ValidateAndCreate(ctx, userModel); err != nil {
+	if err := r.validateAndCreateUser(ctx, userModel, createUserIfNotExists); err != nil {
 		if dynamormErrors.IsConditionFailed(err) {
 			return common.ConflictError{Resource: "user", Message: fmt.Sprintf("user %s already exists", user.Username)}
 		}
@@ -322,6 +333,40 @@ func (r *AccountRepository) CreateAccount(ctx context.Context, account *storage.
 		zap.Bool("with_actor", actor != nil),
 		zap.Bool("validation_enabled", r.HasValidation()),
 		zap.Bool("events_enabled", r.HasEvents()))
+
+	return nil
+}
+
+func (r *AccountRepository) validateAndCreateUser(ctx context.Context, userModel *models.User, ifNotExists bool) error {
+	if r.validator != nil {
+		if err := r.validator.ValidateRequiredFields(ctx, userModel); err != nil {
+			return pkgErrors.ValidationFailed("required fields", err.Error())
+		}
+
+		if err := r.validator.ValidateBusinessRules(ctx, userModel, "create"); err != nil {
+			return pkgErrors.ValidationFailed("business rules", err.Error())
+		}
+	}
+
+	if err := r.checkCreatePermissions(ctx, userModel); err != nil {
+		return err
+	}
+
+	var err error
+	if ifNotExists {
+		err = r.CreateIfNotExists(ctx, userModel)
+	} else {
+		err = r.Create(ctx, userModel)
+	}
+	if err != nil {
+		return err
+	}
+
+	if r.events != nil {
+		event := NewEvent("entity.created", r.entityName, userModel.GetPK(), "create", userModel)
+		event.Actor = r.getActorFromContext(ctx)
+		_ = r.events.Emit(ctx, event)
+	}
 
 	return nil
 }

--- a/tools/openapi/schema_overrides.go
+++ b/tools/openapi/schema_overrides.go
@@ -7,9 +7,46 @@ func applySchemaOverrides(spec *openAPISpec) {
 	}
 
 	overrideCreateStatusRequest(spec.Components.Schemas)
+	overrideAccountRegistrationRequest(spec.Components.Schemas)
 	overrideOAuthClientSchemas(spec.Components.Schemas)
 	overrideCommunityNoteSchemas(spec.Components.Schemas)
 	overrideSoulMintConversationSchemas(spec.Components.Schemas)
+}
+
+func overrideAccountRegistrationRequest(schemas map[string]any) {
+	overrideSchemaProperty(
+		schemas,
+		"AccountRegistrationRequest",
+		"wallet_challenge_id",
+		"Single-use wallet registration proof. Exactly one of `wallet_challenge_id` or `passkey_registration_proof` is required.",
+		false,
+	)
+	overrideSchemaProperty(
+		schemas,
+		"AccountRegistrationRequest",
+		"passkey_registration_proof",
+		"Single-use proof emitted by `POST /api/v1/auth/webauthn/signup/finish`. Exactly one of `wallet_challenge_id` or `passkey_registration_proof` is required.",
+		false,
+	)
+
+	raw, ok := schemas["AccountRegistrationRequest"]
+	if !ok {
+		return
+	}
+
+	schemaMap, ok := raw.(map[string]any)
+	if !ok {
+		return
+	}
+
+	schemaMap["oneOf"] = []any{
+		map[string]any{
+			"required": []string{"wallet_challenge_id"},
+		},
+		map[string]any{
+			"required": []string{"passkey_registration_proof"},
+		},
+	}
 }
 
 func overrideCreateStatusRequest(schemas map[string]any) {


### PR DESCRIPTION
## Summary
- add a distinct public WebAuthn signup begin/finish ceremony that mints single-use passkey registration proofs
- allow `/api/v1/accounts` registration to consume either a wallet challenge or a passkey registration proof while keeping the existing RegisterAccount actor-key path intact
- expose the new passkey-first API flow in routes, validation, public-surface policy, and OpenAPI / generated contract artifacts

## Issue linkage
Refs #1371 #1383 #1384 #1385 #1386

Closes #1383
Closes #1384
Closes #1385
Closes #1386

## Validation
- `GOTOOLCHAIN=go1.26.6 go build ./...`
- `GOTOOLCHAIN=go1.26.6 go vet ./...`
- `gofmt -l .`
- `GOTOOLCHAIN=go1.26.6 go test ./...`
- `GOTOOLCHAIN=go1.26.6 ./lesser verify ci`

## Notes
- includes one generated-artifact follow-up commit after the four planned feature commits: `chore(docs): refresh graphql coverage manifest`
- wallet-first registration path is re-guarded by `if challengeID != ""`; behavior is equivalent to the prior lane selection, but the code path is not byte-identical
- `registerAccount` is deprecated and fails closed in GraphQL with an explicit `use POST /api/v1/accounts` error; `RegisterAccountInput` never carried a wallet challenge ID or passkey registration proof field, so no legitimate GraphQL client could complete registration there