### PR TITLE
fix(auth): harden authenticator removal and credential audit logging

### DIFF
--- a/cmd/api/handlers/accounts.go
+++ b/cmd/api/handlers/accounts.go
@@ -55,7 +55,7 @@ func (req updateCredentialsPatchRequest) accountParams() map[string]interface{} 
 	return params
 }
 
-type passkeyProofAuditRecorder func(eventType auth.AuditEventType, success bool, failure error, metadata map[string]interface{})
+type registrationProofAuditRecorder func(eventType auth.AuditEventType, success bool, failure error, metadata map[string]interface{})
 
 // HandleRegistrationLift handles user registration requests
 func (h *Handler) HandleRegistrationLift(ctx *apptheory.Context) (*apptheory.Response, error) {
@@ -82,7 +82,16 @@ func (h *Handler) HandleRegistrationLift(ctx *apptheory.Context) (*apptheory.Res
 	challengeID := strings.TrimSpace(req.WalletChallengeID)
 	passkeyProofID := strings.TrimSpace(req.PasskeyRegistrationProof)
 	recordPasskeyProofAudit := h.newPasskeyProofAuditRecorder(ctx, req.Username, passkeyProofID, userAgent, ipAddress)
-	if proofResp := h.validateRegistrationCredentialProofLift(ctx, authService, req.Username, challengeID, passkeyProofID, recordPasskeyProofAudit); proofResp != nil {
+	recordWalletChallengeAudit := h.newWalletChallengeAuditRecorder(ctx, req.Username, challengeID, userAgent, ipAddress)
+	if proofResp := h.validateRegistrationCredentialProofLift(
+		ctx,
+		authService,
+		req.Username,
+		challengeID,
+		passkeyProofID,
+		recordWalletChallengeAudit,
+		recordPasskeyProofAudit,
+	); proofResp != nil {
 		return proofResp, nil
 	}
 
@@ -143,44 +152,76 @@ func (h *Handler) HandleRegistrationLift(ctx *apptheory.Context) (*apptheory.Res
 	return h.respondCreated(ctx, resp)
 }
 
-func (h *Handler) newPasskeyProofAuditRecorder(ctx *apptheory.Context, username, passkeyProofID, userAgent, ipAddress string) passkeyProofAuditRecorder {
-	passkeyAuditLogger := auth.NewAuditLogger(h.repos, h.logger, auth.DefaultAuditConfig())
+func (h *Handler) newRegistrationAuditRecorder(
+	ctx *apptheory.Context,
+	username string,
+	proofID string,
+	userAgent string,
+	ipAddress string,
+	authenticationMethod string,
+) registrationProofAuditRecorder {
+	auditLogger := auth.NewAuditLogger(h.repos, h.logger, auth.DefaultAuditConfig())
 	return func(eventType auth.AuditEventType, success bool, failure error, metadata map[string]interface{}) {
-		if passkeyProofID == "" || passkeyAuditLogger == nil {
+		if proofID == "" || auditLogger == nil {
 			return
 		}
 		metadataWithDefaults := map[string]interface{}{
-			"authentication_method": "webauthn",
+			"authentication_method": authenticationMethod,
 			"registration_mode":     "signup",
 		}
 		for key, value := range metadata {
 			metadataWithDefaults[key] = value
 		}
-		passkeyAuditLogger.LogAuthEvent(ctx.Context(), username, ipAddress, userAgent, eventType, metadataWithDefaults, success, failure)
+		auditLogger.LogAuthEvent(ctx.Context(), username, ipAddress, userAgent, eventType, metadataWithDefaults, success, failure)
 	}
+}
+
+func (h *Handler) newPasskeyProofAuditRecorder(ctx *apptheory.Context, username, passkeyProofID, userAgent, ipAddress string) registrationProofAuditRecorder {
+	return h.newRegistrationAuditRecorder(ctx, username, passkeyProofID, userAgent, ipAddress, "webauthn")
+}
+
+func (h *Handler) newWalletChallengeAuditRecorder(ctx *apptheory.Context, username, challengeID, userAgent, ipAddress string) registrationProofAuditRecorder {
+	return h.newRegistrationAuditRecorder(ctx, username, challengeID, userAgent, ipAddress, "wallet")
 }
 
 func (h *Handler) validateRegistrationCredentialProofLift(
 	ctx *apptheory.Context,
 	authService *auth.AuthService,
 	username, challengeID, passkeyProofID string,
-	recordPasskeyProofAudit passkeyProofAuditRecorder,
+	recordWalletChallengeAudit registrationProofAuditRecorder,
+	recordPasskeyProofAudit registrationProofAuditRecorder,
 ) *apptheory.Response {
 	if challengeID != "" {
 		challenge, err := authService.GetWalletChallenge(ctx.Context(), challengeID)
 		if err != nil || challenge == nil {
+			recordWalletChallengeAudit(auth.AuditRegistrationFailed, false, err, map[string]interface{}{
+				"credential_event": "rejected",
+				"rejection_reason": "challenge_invalid_or_expired",
+			})
 			resp, _ := common.RespondUnprocessableEntity(ctx, "wallet_challenge_id is invalid or expired")
 			return resp
 		}
 		if accounts.NormalizeUsernameForDomain(challenge.Username, h.cfg.Domain) != username {
+			recordWalletChallengeAudit(auth.AuditRegistrationFailed, false, nil, map[string]interface{}{
+				"credential_event": "rejected",
+				"rejection_reason": "challenge_cross_user_rejected",
+			})
 			resp, _ := common.RespondUnprocessableEntity(ctx, "wallet challenge was created for a different username")
 			return resp
 		}
 		if !challenge.Used {
+			recordWalletChallengeAudit(auth.AuditRegistrationFailed, false, nil, map[string]interface{}{
+				"credential_event": "rejected",
+				"rejection_reason": "challenge_unverified",
+			})
 			resp, _ := common.RespondUnprocessableEntity(ctx, "wallet challenge has not been verified")
 			return resp
 		}
 		if challenge.Spent {
+			recordWalletChallengeAudit(auth.AuditRegistrationFailed, false, nil, map[string]interface{}{
+				"credential_event": "rejected",
+				"rejection_reason": "challenge_replayed",
+			})
 			resp, _ := common.RespondUnprocessableEntity(ctx, "wallet challenge was already spent")
 			return resp
 		}

--- a/cmd/api/handlers/accounts.go
+++ b/cmd/api/handlers/accounts.go
@@ -55,6 +55,8 @@ func (req updateCredentialsPatchRequest) accountParams() map[string]interface{} 
 	return params
 }
 
+type passkeyProofAuditRecorder func(eventType auth.AuditEventType, success bool, failure error, metadata map[string]interface{})
+
 // HandleRegistrationLift handles user registration requests
 func (h *Handler) HandleRegistrationLift(ctx *apptheory.Context) (*apptheory.Response, error) {
 	// Parse request body
@@ -68,6 +70,7 @@ func (h *Handler) HandleRegistrationLift(ctx *apptheory.Context) (*apptheory.Res
 		return common.RespondUnprocessableEntity(ctx, err.Error())
 	}
 	req.Username = accounts.NormalizeUsernameForDomain(req.Username, h.cfg.Domain)
+	userAgent, ipAddress := h.getDeviceInfo(ctx)
 
 	// Require wallet verification as the registration proof (passwordless signup).
 	// The auth-ui flow calls POST /auth/wallet/verify first, which marks the challenge as used.
@@ -78,28 +81,9 @@ func (h *Handler) HandleRegistrationLift(ctx *apptheory.Context) (*apptheory.Res
 
 	challengeID := strings.TrimSpace(req.WalletChallengeID)
 	passkeyProofID := strings.TrimSpace(req.PasskeyRegistrationProof)
-	if challengeID != "" {
-		challenge, err := authService.GetWalletChallenge(ctx.Context(), challengeID)
-		if err != nil || challenge == nil {
-			return common.RespondUnprocessableEntity(ctx, "wallet_challenge_id is invalid or expired")
-		}
-		if accounts.NormalizeUsernameForDomain(challenge.Username, h.cfg.Domain) != req.Username {
-			return common.RespondUnprocessableEntity(ctx, "wallet challenge was created for a different username")
-		}
-		if !challenge.Used {
-			return common.RespondUnprocessableEntity(ctx, "wallet challenge has not been verified")
-		}
-		if challenge.Spent {
-			return common.RespondUnprocessableEntity(ctx, "wallet challenge was already spent")
-		}
-	} else {
-		proof, err := authService.GetPasskeyRegistrationProof(ctx.Context(), passkeyProofID)
-		if err != nil || proof == nil || proof.Consumed {
-			return common.RespondUnprocessableEntity(ctx, "passkey_registration_proof is invalid or expired")
-		}
-		if accounts.NormalizeUsernameForDomain(proof.Username, h.cfg.Domain) != req.Username {
-			return common.RespondUnprocessableEntity(ctx, "passkey registration proof was created for a different username")
-		}
+	recordPasskeyProofAudit := h.newPasskeyProofAuditRecorder(ctx, req.Username, passkeyProofID, userAgent, ipAddress)
+	if proofResp := h.validateRegistrationCredentialProofLift(ctx, authService, req.Username, challengeID, passkeyProofID, recordPasskeyProofAudit); proofResp != nil {
+		return proofResp, nil
 	}
 
 	// NOTE: Password-based authentication is disabled. This system uses WebAuthn/crypto wallet authentication only.
@@ -130,6 +114,12 @@ func (h *Handler) HandleRegistrationLift(ctx *apptheory.Context) (*apptheory.Res
 		if errors.Is(err, accounts.ErrValidationFailed) {
 			return common.RespondUnprocessableEntity(ctx, err.Error())
 		}
+		if passkeyProofID != "" && strings.Contains(err.Error(), "failed to finalize passkey registration proof") {
+			recordPasskeyProofAudit(auth.AuditWebAuthnRegistrationFailed, false, err, map[string]interface{}{
+				"credential_event": "rejected",
+				"rejection_reason": "proof_consume_rejected",
+			})
+		}
 		// Log the full error for debugging
 		h.logger.Error("failed to register account",
 			zap.String("username", req.Username),
@@ -144,8 +134,86 @@ func (h *Handler) HandleRegistrationLift(ctx *apptheory.Context) (*apptheory.Res
 		Username: result.Account.User.Username,
 		Created:  true,
 	}
+	if passkeyProofID != "" {
+		recordPasskeyProofAudit(auth.AuditWebAuthnRegistrationCompleted, true, nil, map[string]interface{}{
+			"credential_event": "added",
+		})
+	}
 
 	return h.respondCreated(ctx, resp)
+}
+
+func (h *Handler) newPasskeyProofAuditRecorder(ctx *apptheory.Context, username, passkeyProofID, userAgent, ipAddress string) passkeyProofAuditRecorder {
+	passkeyAuditLogger := auth.NewAuditLogger(h.repos, h.logger, auth.DefaultAuditConfig())
+	return func(eventType auth.AuditEventType, success bool, failure error, metadata map[string]interface{}) {
+		if passkeyProofID == "" || passkeyAuditLogger == nil {
+			return
+		}
+		metadataWithDefaults := map[string]interface{}{
+			"authentication_method": "webauthn",
+			"registration_mode":     "signup",
+		}
+		for key, value := range metadata {
+			metadataWithDefaults[key] = value
+		}
+		passkeyAuditLogger.LogAuthEvent(ctx.Context(), username, ipAddress, userAgent, eventType, metadataWithDefaults, success, failure)
+	}
+}
+
+func (h *Handler) validateRegistrationCredentialProofLift(
+	ctx *apptheory.Context,
+	authService *auth.AuthService,
+	username, challengeID, passkeyProofID string,
+	recordPasskeyProofAudit passkeyProofAuditRecorder,
+) *apptheory.Response {
+	if challengeID != "" {
+		challenge, err := authService.GetWalletChallenge(ctx.Context(), challengeID)
+		if err != nil || challenge == nil {
+			resp, _ := common.RespondUnprocessableEntity(ctx, "wallet_challenge_id is invalid or expired")
+			return resp
+		}
+		if accounts.NormalizeUsernameForDomain(challenge.Username, h.cfg.Domain) != username {
+			resp, _ := common.RespondUnprocessableEntity(ctx, "wallet challenge was created for a different username")
+			return resp
+		}
+		if !challenge.Used {
+			resp, _ := common.RespondUnprocessableEntity(ctx, "wallet challenge has not been verified")
+			return resp
+		}
+		if challenge.Spent {
+			resp, _ := common.RespondUnprocessableEntity(ctx, "wallet challenge was already spent")
+			return resp
+		}
+		return nil
+	}
+
+	proof, err := authService.GetPasskeyRegistrationProof(ctx.Context(), passkeyProofID)
+	if err != nil || proof == nil {
+		recordPasskeyProofAudit(auth.AuditWebAuthnRegistrationFailed, false, err, map[string]interface{}{
+			"credential_event": "rejected",
+			"rejection_reason": "proof_invalid_or_expired",
+		})
+		resp, _ := common.RespondUnprocessableEntity(ctx, "passkey_registration_proof is invalid or expired")
+		return resp
+	}
+	if proof.Consumed {
+		recordPasskeyProofAudit(auth.AuditWebAuthnRegistrationFailed, false, nil, map[string]interface{}{
+			"credential_event": "rejected",
+			"rejection_reason": "proof_replayed",
+		})
+		resp, _ := common.RespondUnprocessableEntity(ctx, "passkey_registration_proof is invalid or expired")
+		return resp
+	}
+	if accounts.NormalizeUsernameForDomain(proof.Username, h.cfg.Domain) != username {
+		recordPasskeyProofAudit(auth.AuditWebAuthnRegistrationFailed, false, nil, map[string]interface{}{
+			"credential_event": "rejected",
+			"rejection_reason": "proof_cross_user_rejected",
+		})
+		resp, _ := common.RespondUnprocessableEntity(ctx, "passkey registration proof was created for a different username")
+		return resp
+	}
+
+	return nil
 }
 
 // HandleVerifyCredentialsLift returns the current user's information

--- a/cmd/api/handlers/accounts_round12_test.go
+++ b/cmd/api/handlers/accounts_round12_test.go
@@ -393,6 +393,126 @@ func TestAccountsRound12_HandleRegistrationLift(t *testing.T) {
 		})
 	})
 
+	t.Run("wallet_registration_proof_errors_are_audited", func(t *testing.T) {
+		cfg := round10TestConfig()
+
+		cases := []struct {
+			name                 string
+			state                *round10QueryState
+			username             string
+			wantReason           string
+			wantResponseFragment string
+		}{
+			{
+				name: "invalid_or_expired",
+				state: &round10QueryState{
+					notFoundPKSK: map[string]bool{"WALLET_CHALLENGE#c1#CHALLENGE": true},
+				},
+				username:             "alice",
+				wantReason:           "challenge_invalid_or_expired",
+				wantResponseFragment: "wallet_challenge_id is invalid or expired",
+			},
+			{
+				name: "challenge_bound_to_different_username",
+				state: &round10QueryState{
+					walletChallengesByID: map[string]storagemodels.WalletChallenge{
+						"c1": {
+							ID:        "c1",
+							Username:  "bob",
+							Address:   "0xabc",
+							ChainID:   1,
+							Nonce:     "nonce",
+							Message:   "message",
+							IssuedAt:  time.Now().Add(-time.Minute),
+							ExpiresAt: time.Now().Add(5 * time.Minute),
+							Used:      true,
+						},
+					},
+				},
+				username:             "alice",
+				wantReason:           "challenge_cross_user_rejected",
+				wantResponseFragment: "wallet challenge was created for a different username",
+			},
+			{
+				name: "challenge_not_verified",
+				state: &round10QueryState{
+					walletChallengesByID: map[string]storagemodels.WalletChallenge{
+						"c1": {
+							ID:        "c1",
+							Username:  "alice",
+							Address:   "0xabc",
+							ChainID:   1,
+							Nonce:     "nonce",
+							Message:   "message",
+							IssuedAt:  time.Now().Add(-time.Minute),
+							ExpiresAt: time.Now().Add(5 * time.Minute),
+							Used:      false,
+						},
+					},
+				},
+				username:             "alice",
+				wantReason:           "challenge_unverified",
+				wantResponseFragment: "wallet challenge has not been verified",
+			},
+			{
+				name: "challenge_replayed",
+				state: &round10QueryState{
+					walletChallengesByID: map[string]storagemodels.WalletChallenge{
+						"c1": {
+							ID:        "c1",
+							Username:  "alice",
+							Address:   "0xabc",
+							ChainID:   1,
+							Nonce:     "nonce",
+							Message:   "message",
+							IssuedAt:  time.Now().Add(-time.Minute),
+							ExpiresAt: time.Now().Add(5 * time.Minute),
+							Used:      true,
+							Spent:     true,
+						},
+					},
+				},
+				username:             "alice",
+				wantReason:           "challenge_replayed",
+				wantResponseFragment: "wallet challenge was already spent",
+			},
+		}
+
+		for _, tc := range cases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				h, _, _ := round11NewHandler(t, cfg, tc.state, &RegistryStub{
+					AccountsSvc: &AccountsServiceStub{
+						RegisterAccountFunc: func(context.Context, *accounts.RegisterAccountCommand) (*accounts.RegisterAccountResult, error) {
+							return nil, errors.New("unexpected service call")
+						},
+					},
+				})
+
+				ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/accounts", nil, nil, apimodels.AccountRegistrationRequest{
+					Username:          tc.username,
+					Agreement:         true,
+					WalletChallengeID: "c1",
+				})
+				require.NoError(t, err)
+
+				resp := requireStatus(t, http.StatusUnprocessableEntity)(h.HandleRegistrationLift(ctx))
+				require.Contains(t, string(resp.Body), tc.wantResponseFragment)
+
+				entry := requireSingleAuditLog(t, tc.state, tc.username)
+				metadata := mustParseAuditMetadata(t, entry)
+				require.Equal(t, string(auth.AuditRegistrationFailed), entry.EventType)
+				require.False(t, entry.Success)
+				require.Equal(t, "wallet", metadata["authentication_method"])
+				require.Equal(t, "signup", metadata["registration_mode"])
+				require.Equal(t, "rejected", metadata["credential_event"])
+				require.Equal(t, tc.wantReason, metadata["rejection_reason"])
+				require.NotContains(t, entry.Metadata, "c1")
+				require.NotContains(t, entry.FailureReason, "c1")
+			})
+		}
+	})
+
 	t.Run("passkey_registration_proof_success", func(t *testing.T) {
 		cfg := round10TestConfig()
 

--- a/cmd/api/handlers/accounts_round12_test.go
+++ b/cmd/api/handlers/accounts_round12_test.go
@@ -245,9 +245,10 @@ func TestAccountsRound12_HandleRegistrationLift(t *testing.T) {
 		cfg := round10TestConfig()
 
 		t.Run("invalid_or_expired", func(t *testing.T) {
-			h, _, _ := round11NewHandler(t, cfg, &round10QueryState{
+			state := &round10QueryState{
 				notFoundPKSK: map[string]bool{"PASSKEY_REGISTRATION_PROOF#proof-1#PROOF": true},
-			}, &RegistryStub{
+			}
+			h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{
 				AccountsSvc: &AccountsServiceStub{
 					RegisterAccountFunc: func(context.Context, *accounts.RegisterAccountCommand) (*accounts.RegisterAccountResult, error) {
 						return nil, errors.New("unexpected service call")
@@ -263,10 +264,60 @@ func TestAccountsRound12_HandleRegistrationLift(t *testing.T) {
 			require.NoError(t, err)
 
 			requireStatus(t, http.StatusUnprocessableEntity)(h.HandleRegistrationLift(ctx))
+			entry := requireSingleAuditLog(t, state, "alice")
+			metadata := mustParseAuditMetadata(t, entry)
+			require.Equal(t, string(auth.AuditWebAuthnRegistrationFailed), entry.EventType)
+			require.False(t, entry.Success)
+			require.Equal(t, "webauthn", metadata["authentication_method"])
+			require.Equal(t, "signup", metadata["registration_mode"])
+			require.Equal(t, "rejected", metadata["credential_event"])
+			require.Equal(t, "proof_invalid_or_expired", metadata["rejection_reason"])
+			require.NotContains(t, entry.Metadata, "proof-1")
+			require.NotContains(t, entry.FailureReason, "proof-1")
+		})
+
+		t.Run("proof_replayed", func(t *testing.T) {
+			state := &round10QueryState{
+				passkeyRegistrationProofsByID: map[string]storagemodels.PasskeyRegistrationProof{
+					"proof-1": {
+						ID:         "proof-1",
+						Username:   "alice",
+						CeremonyID: "signup-1",
+						PublicKey:  []byte{0x01},
+						Consumed:   true,
+						CreatedAt:  time.Now().Add(-time.Minute),
+						ExpiresAt:  time.Now().Add(5 * time.Minute),
+					},
+				},
+			}
+			h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{
+				AccountsSvc: &AccountsServiceStub{
+					RegisterAccountFunc: func(context.Context, *accounts.RegisterAccountCommand) (*accounts.RegisterAccountResult, error) {
+						return nil, errors.New("unexpected service call")
+					},
+				},
+			})
+
+			ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/accounts", nil, nil, apimodels.AccountRegistrationRequest{
+				Username:                 "alice",
+				Agreement:                true,
+				PasskeyRegistrationProof: "proof-1",
+			})
+			require.NoError(t, err)
+
+			requireStatus(t, http.StatusUnprocessableEntity)(h.HandleRegistrationLift(ctx))
+			entry := requireSingleAuditLog(t, state, "alice")
+			metadata := mustParseAuditMetadata(t, entry)
+			require.Equal(t, string(auth.AuditWebAuthnRegistrationFailed), entry.EventType)
+			require.False(t, entry.Success)
+			require.Equal(t, "rejected", metadata["credential_event"])
+			require.Equal(t, "proof_replayed", metadata["rejection_reason"])
+			require.NotContains(t, entry.Metadata, "proof-1")
+			require.Empty(t, entry.FailureReason)
 		})
 
 		t.Run("proof_bound_to_different_username", func(t *testing.T) {
-			h, _, _ := round11NewHandler(t, cfg, &round10QueryState{
+			state := &round10QueryState{
 				passkeyRegistrationProofsByID: map[string]storagemodels.PasskeyRegistrationProof{
 					"proof-1": {
 						ID:         "proof-1",
@@ -277,7 +328,8 @@ func TestAccountsRound12_HandleRegistrationLift(t *testing.T) {
 						ExpiresAt:  time.Now().Add(5 * time.Minute),
 					},
 				},
-			}, &RegistryStub{
+			}
+			h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{
 				AccountsSvc: &AccountsServiceStub{
 					RegisterAccountFunc: func(context.Context, *accounts.RegisterAccountCommand) (*accounts.RegisterAccountResult, error) {
 						return nil, errors.New("unexpected service call")
@@ -293,6 +345,51 @@ func TestAccountsRound12_HandleRegistrationLift(t *testing.T) {
 			require.NoError(t, err)
 
 			requireStatus(t, http.StatusUnprocessableEntity)(h.HandleRegistrationLift(ctx))
+			entry := requireSingleAuditLog(t, state, "alice")
+			metadata := mustParseAuditMetadata(t, entry)
+			require.Equal(t, string(auth.AuditWebAuthnRegistrationFailed), entry.EventType)
+			require.False(t, entry.Success)
+			require.Equal(t, "rejected", metadata["credential_event"])
+			require.Equal(t, "proof_cross_user_rejected", metadata["rejection_reason"])
+			require.NotContains(t, entry.Metadata, "proof-1")
+		})
+
+		t.Run("proof_consume_rejected", func(t *testing.T) {
+			state := &round10QueryState{
+				passkeyRegistrationProofsByID: map[string]storagemodels.PasskeyRegistrationProof{
+					"proof-1": {
+						ID:         "proof-1",
+						Username:   "alice",
+						CeremonyID: "signup-1",
+						PublicKey:  []byte{0x01},
+						CreatedAt:  time.Now().Add(-time.Minute),
+						ExpiresAt:  time.Now().Add(5 * time.Minute),
+					},
+				},
+			}
+			h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{
+				AccountsSvc: &AccountsServiceStub{
+					RegisterAccountFunc: func(context.Context, *accounts.RegisterAccountCommand) (*accounts.RegisterAccountResult, error) {
+						return nil, errors.New("failed to finalize passkey registration proof: conditional check failed")
+					},
+				},
+			})
+
+			ctx, err := round10NewLiftContext(http.MethodPost, "/api/v1/accounts", nil, nil, apimodels.AccountRegistrationRequest{
+				Username:                 "alice",
+				Agreement:                true,
+				PasskeyRegistrationProof: "proof-1",
+			})
+			require.NoError(t, err)
+
+			requireStatus(t, http.StatusUnprocessableEntity)(h.HandleRegistrationLift(ctx))
+			entry := requireSingleAuditLog(t, state, "alice")
+			metadata := mustParseAuditMetadata(t, entry)
+			require.Equal(t, string(auth.AuditWebAuthnRegistrationFailed), entry.EventType)
+			require.False(t, entry.Success)
+			require.Equal(t, "rejected", metadata["credential_event"])
+			require.Equal(t, "proof_consume_rejected", metadata["rejection_reason"])
+			require.NotContains(t, entry.Metadata, "proof-1")
 		})
 	})
 
@@ -300,7 +397,7 @@ func TestAccountsRound12_HandleRegistrationLift(t *testing.T) {
 		cfg := round10TestConfig()
 
 		var gotCmd *accounts.RegisterAccountCommand
-		h, _, _ := round11NewHandler(t, cfg, &round10QueryState{
+		state := &round10QueryState{
 			passkeyRegistrationProofsByID: map[string]storagemodels.PasskeyRegistrationProof{
 				"proof-1": {
 					ID:         "proof-1",
@@ -311,7 +408,8 @@ func TestAccountsRound12_HandleRegistrationLift(t *testing.T) {
 					ExpiresAt:  time.Now().Add(5 * time.Minute),
 				},
 			},
-		}, &RegistryStub{
+		}
+		h, _, _ := round11NewHandler(t, cfg, state, &RegistryStub{
 			AccountsSvc: &AccountsServiceStub{
 				RegisterAccountFunc: func(_ context.Context, cmd *accounts.RegisterAccountCommand) (*accounts.RegisterAccountResult, error) {
 					gotCmd = cmd
@@ -348,6 +446,14 @@ func TestAccountsRound12_HandleRegistrationLift(t *testing.T) {
 		require.Equal(t, cfg.BaseURL()+"/users/alice", regResp.ID)
 		require.Equal(t, "alice", regResp.Username)
 		require.True(t, regResp.Created)
+		entry := requireSingleAuditLog(t, state, "alice")
+		metadata := mustParseAuditMetadata(t, entry)
+		require.Equal(t, string(auth.AuditWebAuthnRegistrationCompleted), entry.EventType)
+		require.True(t, entry.Success)
+		require.Equal(t, "webauthn", metadata["authentication_method"])
+		require.Equal(t, "signup", metadata["registration_mode"])
+		require.Equal(t, "added", metadata["credential_event"])
+		require.NotContains(t, entry.Metadata, "proof-1")
 	})
 
 	t.Run("passkey_registration_proof_mixed_case_stored_username_is_canonicalized_at_handler_boundary", func(t *testing.T) {
@@ -399,6 +505,25 @@ func TestAccountsRound12_HandleRegistrationLift(t *testing.T) {
 		require.Equal(t, "alice", regResp.Username)
 		require.True(t, regResp.Created)
 	})
+}
+
+func requireSingleAuditLog(t *testing.T, state *round10QueryState, username string) *storagemodels.AuthAuditLog {
+	t.Helper()
+
+	require.NotNil(t, state)
+	require.Contains(t, state.auditLogsByUser, username)
+	require.Len(t, state.auditLogsByUser[username], 1)
+
+	return state.auditLogsByUser[username][0]
+}
+
+func mustParseAuditMetadata(t *testing.T, entry *storagemodels.AuthAuditLog) map[string]any {
+	t.Helper()
+
+	require.NotNil(t, entry)
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal([]byte(entry.Metadata), &metadata))
+	return metadata
 }
 
 func TestAccountsRound12_HandleVerifyCredentialsLift(t *testing.T) {

--- a/cmd/api/handlers/round10_test_helpers_test.go
+++ b/cmd/api/handlers/round10_test_helpers_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -16,6 +17,7 @@ import (
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
 	"github.com/stretchr/testify/mock"
 	apptheory "github.com/theory-cloud/apptheory/v3/runtime"
+	dynamormcore "github.com/theory-cloud/tabletheory/v3/pkg/core"
 	dynamormerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
 	"github.com/theory-cloud/tabletheory/v3/pkg/mocks"
 	"go.uber.org/zap"
@@ -522,10 +524,229 @@ func round10NewLiftContextWithBodyBytes(method, path string, headers, query map[
 }
 
 type round10DynamoHarness struct {
-	db     *mocks.MockDB
+	db     *round10TransactionalDB
 	query  *mocks.MockQuery
 	update *mocks.MockUpdateBuilder
 	state  *round10QueryState
+}
+
+type round10TransactionalDB struct {
+	inner *mocks.MockDB
+	state *round10QueryState
+}
+
+func (db *round10TransactionalDB) Model(model any) dynamormcore.Query {
+	return db.inner.Model(model)
+}
+
+func (db *round10TransactionalDB) Migrate() error {
+	return db.inner.Migrate()
+}
+
+func (db *round10TransactionalDB) AutoMigrate(models ...any) error {
+	return db.inner.AutoMigrate(models...)
+}
+
+func (db *round10TransactionalDB) Close() error {
+	return db.inner.Close()
+}
+
+func (db *round10TransactionalDB) WithContext(context.Context) dynamormcore.DB {
+	return db
+}
+
+func (db *round10TransactionalDB) Transact() dynamormcore.TransactionBuilder {
+	return &round10TransactionBuilder{state: db.state}
+}
+
+func (db *round10TransactionalDB) TransactWrite(_ context.Context, fn func(dynamormcore.TransactionBuilder) error) error {
+	builder := &round10TransactionBuilder{state: db.state}
+	if err := fn(builder); err != nil {
+		return err
+	}
+	return builder.Execute()
+}
+
+type round10TransactionBuilder struct {
+	state      *round10QueryState
+	operations []round10TransactionOperation
+}
+
+type round10TransactionOperation struct {
+	kind       string
+	model      any
+	conditions []dynamormcore.TransactCondition
+}
+
+func (b *round10TransactionBuilder) Put(any, ...dynamormcore.TransactCondition) dynamormcore.TransactionBuilder {
+	return b
+}
+
+func (b *round10TransactionBuilder) Create(any, ...dynamormcore.TransactCondition) dynamormcore.TransactionBuilder {
+	return b
+}
+
+func (b *round10TransactionBuilder) Update(any, []string, ...dynamormcore.TransactCondition) dynamormcore.TransactionBuilder {
+	return b
+}
+
+func (b *round10TransactionBuilder) UpdateWithBuilder(any, func(dynamormcore.UpdateBuilder) error, ...dynamormcore.TransactCondition) dynamormcore.TransactionBuilder {
+	return b
+}
+
+func (b *round10TransactionBuilder) Delete(model any, conditions ...dynamormcore.TransactCondition) dynamormcore.TransactionBuilder {
+	b.operations = append(b.operations, round10TransactionOperation{
+		kind:       "delete",
+		model:      model,
+		conditions: append([]dynamormcore.TransactCondition(nil), conditions...),
+	})
+	return b
+}
+
+func (b *round10TransactionBuilder) ConditionCheck(model any, conditions ...dynamormcore.TransactCondition) dynamormcore.TransactionBuilder {
+	b.operations = append(b.operations, round10TransactionOperation{
+		kind:       "condition_check",
+		model:      model,
+		conditions: append([]dynamormcore.TransactCondition(nil), conditions...),
+	})
+	return b
+}
+
+func (b *round10TransactionBuilder) WithContext(context.Context) dynamormcore.TransactionBuilder {
+	return b
+}
+
+func (b *round10TransactionBuilder) Execute() error {
+	for idx, operation := range b.operations {
+		if !round10TransactionConditionsMet(b.state, operation.model, operation.conditions) {
+			return &dynamormerrors.TransactionError{
+				Err:            dynamormerrors.ErrConditionFailed,
+				Operation:      operation.kind,
+				OperationIndex: idx,
+				Reason:         "ConditionalCheckFailed",
+			}
+		}
+	}
+
+	for idx, operation := range b.operations {
+		if operation.kind != "delete" {
+			continue
+		}
+		if b.state.deleteErrorOnce != nil {
+			err := b.state.deleteErrorOnce
+			b.state.deleteErrorOnce = nil
+			return err
+		}
+		if !round10TransactionDeleteModel(b.state, operation.model) {
+			return &dynamormerrors.TransactionError{
+				Err:            dynamormerrors.ErrConditionFailed,
+				Operation:      operation.kind,
+				OperationIndex: idx,
+				Reason:         "ConditionalCheckFailed",
+			}
+		}
+	}
+
+	return nil
+}
+
+func (b *round10TransactionBuilder) ExecuteWithContext(context.Context) error {
+	return b.Execute()
+}
+
+func round10TransactionConditionsMet(state *round10QueryState, model any, conditions []dynamormcore.TransactCondition) bool {
+	for _, condition := range conditions {
+		switch condition.Kind {
+		case dynamormcore.TransactConditionKindPrimaryKeyExists:
+			if !round10TransactionModelExists(state, model) {
+				return false
+			}
+		case dynamormcore.TransactConditionKindPrimaryKeyNotExists:
+			if round10TransactionModelExists(state, model) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func round10TransactionModelExists(state *round10QueryState, model any) bool {
+	switch typed := model.(type) {
+	case *storagemodels.WebAuthnCredential:
+		if typed == nil {
+			return false
+		}
+		credential := round10CanonicalizeWebAuthnCredential(*typed)
+		if _, ok := state.webAuthnCredentialByID[credential.ID]; ok {
+			return true
+		}
+		for _, creds := range state.webAuthnCredentialsByUser {
+			for _, candidate := range creds {
+				if candidate.ID == credential.ID {
+					return true
+				}
+			}
+		}
+		return false
+	case *storagemodels.WalletCredential:
+		if typed == nil {
+			return false
+		}
+		username := strings.TrimSpace(typed.Username)
+		address := strings.ToLower(strings.TrimSpace(typed.Address))
+		if _, ok := state.walletCredentialsByAddress[address]; ok {
+			return true
+		}
+		for _, wallet := range state.walletCredentialsByUser[username] {
+			if strings.EqualFold(wallet.Address, address) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+func round10TransactionDeleteModel(state *round10QueryState, model any) bool {
+	switch typed := model.(type) {
+	case *storagemodels.WebAuthnCredential:
+		if typed == nil {
+			return false
+		}
+		credential := round10CanonicalizeWebAuthnCredential(*typed)
+		if !round10TransactionModelExists(state, typed) {
+			return false
+		}
+		round10DeleteWebAuthnCredential(state, credential.ID)
+		return true
+	case *storagemodels.WalletCredential:
+		if typed == nil {
+			return false
+		}
+		username := strings.TrimSpace(typed.Username)
+		address := strings.ToLower(strings.TrimSpace(typed.Address))
+		if !round10TransactionModelExists(state, typed) {
+			return false
+		}
+		delete(state.walletCredentialsByAddress, address)
+		wallets := state.walletCredentialsByUser[username]
+		filtered := wallets[:0]
+		for _, wallet := range wallets {
+			if strings.EqualFold(wallet.Address, address) {
+				continue
+			}
+			filtered = append(filtered, wallet)
+		}
+		if len(filtered) == 0 {
+			delete(state.walletCredentialsByUser, username)
+		} else {
+			state.walletCredentialsByUser[username] = filtered
+		}
+		return true
+	default:
+		return false
+	}
 }
 
 func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10DynamoHarness {
@@ -2980,7 +3201,7 @@ func round10NewDynamoHarness(t *testing.T, state *round10QueryState) *round10Dyn
 	}).Maybe()
 
 	return &round10DynamoHarness{
-		db:     mockDB,
+		db:     &round10TransactionalDB{inner: mockDB, state: state},
 		query:  mockQuery,
 		update: mockUpdate,
 		state:  state,

--- a/cmd/api/handlers/round11_wallet_test.go
+++ b/cmd/api/handlers/round11_wallet_test.go
@@ -40,6 +40,9 @@ func TestWalletHandlers_FullFlow(t *testing.T) {
 		usersByUsername: map[string]storagemodels.User{
 			"alice": {PK: "USER#alice", SK: storagemodels.SKMetadata, Username: "alice", Role: "user", Approved: true, Version: 1, CreatedAt: now.Add(-24 * time.Hour)},
 		},
+		webAuthnCredentialsByUser: map[string][]storagemodels.WebAuthnCredential{
+			"alice": {{ID: "cred-1", UserID: "alice"}},
+		},
 		walletCredentialsByUser: map[string][]storagemodels.WalletCredential{
 			"alice": {{Username: "alice", Address: address, ChainID: 1, Type: "ethereum", LinkedAt: now.Add(-2 * time.Hour)}},
 		},

--- a/cmd/api/handlers/wallet.go
+++ b/cmd/api/handlers/wallet.go
@@ -183,6 +183,9 @@ func (h *Handler) HandleLinkWalletLift(ctx *apptheory.Context) (*apptheory.Respo
 		return resp, err
 	}
 
+	userAgent, ipAddress := h.getDeviceInfo(ctx)
+	requestCtx := auth.WithAuditRequestMetadata(ctx.Context(), ipAddress, userAgent)
+
 	// Get the challenge to verify username binding
 	challenge, err := authService.GetWalletChallenge(ctx.Context(), req.ChallengeID)
 	if err != nil {
@@ -250,7 +253,7 @@ func (h *Handler) HandleLinkWalletLift(ctx *apptheory.Context) (*apptheory.Respo
 	}
 
 	// Link the wallet
-	walletLinkCreated, err := authService.LinkWallet(ctx.Context(), username, req.Address, req.ChainID, req.WalletType)
+	walletLinkCreated, err := authService.LinkWallet(requestCtx, username, req.Address, req.ChainID, req.WalletType)
 	if err != nil {
 		if resetErr := authService.ResetWalletChallengeSpent(ctx.Context(), req.ChallengeID); resetErr != nil {
 			h.logger.Error("failed to restore wallet challenge after wallet-link failure",
@@ -270,8 +273,6 @@ func (h *Handler) HandleLinkWalletLift(ctx *apptheory.Context) (*apptheory.Respo
 	// This creates a server-side session so /oauth/authorize can authenticate the user
 	// Signature was already verified in /auth/wallet/verify, so we can create session directly
 	if !isAuthenticated {
-		// Get device info for session creation
-		userAgent, ipAddress := h.getDeviceInfo(ctx)
 		deviceName := userAgent
 		if deviceName == "" {
 			deviceName = "Unknown Device"
@@ -281,31 +282,18 @@ func (h *Handler) HandleLinkWalletLift(ctx *apptheory.Context) (*apptheory.Respo
 		// This session will be used by /oauth/authorize to generate authorization code
 		authResponse, err := authService.LoginWithWalletAfterLinking(ctx.Context(), username, deviceName, userAgent, ipAddress)
 		if err != nil {
-			if walletLinkCreated {
-				if unlinkErr := authService.UnlinkWallet(ctx.Context(), username, req.Address); unlinkErr != nil {
-					h.logger.Error("failed to rollback wallet link after session creation failure",
-						zap.String("username", username),
-						zap.String("address", req.Address),
-						zap.String("challengeId", req.ChallengeID),
-						zap.Error(unlinkErr))
-				} else if resetErr := authService.ResetWalletChallengeSpent(ctx.Context(), req.ChallengeID); resetErr != nil {
-					h.logger.Error("failed to restore wallet challenge after session creation failure",
-						zap.String("username", username),
-						zap.String("address", req.Address),
-						zap.String("challengeId", req.ChallengeID),
-						zap.Error(resetErr))
-					if _, relinkErr := authService.LinkWallet(ctx.Context(), username, req.Address, req.ChainID, req.WalletType); relinkErr != nil {
-						h.logger.Error("failed to restore wallet link after challenge reset failure",
-							zap.String("username", username),
-							zap.String("address", req.Address),
-							zap.String("challengeId", req.ChallengeID),
-							zap.Error(relinkErr))
-					}
-				}
+			if resetErr := authService.ResetWalletChallengeSpent(ctx.Context(), req.ChallengeID); resetErr != nil {
+				h.logger.Error("failed to restore wallet challenge after session creation failure",
+					zap.String("username", username),
+					zap.String("address", req.Address),
+					zap.String("challengeId", req.ChallengeID),
+					zap.Bool("wallet_link_created", walletLinkCreated),
+					zap.Error(resetErr))
 			}
 			h.logger.Error("failed to create session after wallet linking",
 				zap.String("username", username),
 				zap.String("address", req.Address),
+				zap.Bool("wallet_link_created", walletLinkCreated),
 				zap.Error(err))
 			return h.respondWithError(ctx, http.StatusInternalServerError, "failed to create session")
 		}
@@ -349,8 +337,11 @@ func (h *Handler) HandleUnlinkWalletLift(ctx *apptheory.Context) (*apptheory.Res
 		return resp, err
 	}
 
+	userAgent, ipAddress := h.getDeviceInfo(ctx)
+	requestCtx := auth.WithAuditRequestMetadata(ctx.Context(), ipAddress, userAgent)
+
 	// Unlink the wallet
-	if err := authService.UnlinkWallet(ctx.Context(), username, address); err != nil {
+	if err := authService.UnlinkWallet(requestCtx, username, address); err != nil {
 		if errors.Is(err, auth.ErrLastAuthMethodDelete) {
 			return h.respondBadRequest(ctx, "cannot delete last authentication method")
 		}

--- a/cmd/api/handlers/wallet.go
+++ b/cmd/api/handlers/wallet.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
@@ -350,6 +351,9 @@ func (h *Handler) HandleUnlinkWalletLift(ctx *apptheory.Context) (*apptheory.Res
 
 	// Unlink the wallet
 	if err := authService.UnlinkWallet(ctx.Context(), username, address); err != nil {
+		if errors.Is(err, auth.ErrLastAuthMethodDelete) {
+			return h.respondBadRequest(ctx, "cannot delete last authentication method")
+		}
 		h.logger.Error("failed to unlink wallet",
 			zap.String("username", username),
 			zap.String("address", address),

--- a/cmd/api/handlers/wallet.go
+++ b/cmd/api/handlers/wallet.go
@@ -8,6 +8,7 @@ import (
 	apimodels "github.com/equaltoai/lesser/cmd/api/models"
 	"github.com/equaltoai/lesser/pkg/auth"
 	"github.com/equaltoai/lesser/pkg/common"
+	apperrors "github.com/equaltoai/lesser/pkg/errors"
 	apptheory "github.com/theory-cloud/apptheory/v3/runtime"
 	"go.uber.org/zap"
 )
@@ -342,6 +343,9 @@ func (h *Handler) HandleUnlinkWalletLift(ctx *apptheory.Context) (*apptheory.Res
 
 	// Unlink the wallet
 	if err := authService.UnlinkWallet(requestCtx, username, address); err != nil {
+		if apperrors.HasCode(err, apperrors.CodeNotFound) {
+			return h.respondWithError(ctx, http.StatusNotFound, "wallet not found")
+		}
 		if errors.Is(err, auth.ErrLastAuthMethodDelete) {
 			return h.respondBadRequest(ctx, "cannot delete last authentication method")
 		}

--- a/cmd/api/handlers/wallet_round12_coverage_test.go
+++ b/cmd/api/handlers/wallet_round12_coverage_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -364,7 +365,7 @@ func TestWalletHandlers_Round12_Coverage(t *testing.T) {
 		require.True(t, state.walletChallengesByID["c1"].Spent)
 	})
 
-	t.Run("link_wallet_session_creation_error_restores_retry_for_new_link", func(t *testing.T) {
+	t.Run("link_wallet_session_creation_error_restores_retry_without_unlinking_new_wallet", func(t *testing.T) {
 		key, address := round11GenerateWalletKey(t)
 		message := "hello"
 		signature := round11SignWalletMessage(t, key, message)
@@ -392,7 +393,8 @@ func TestWalletHandlers_Round12_Coverage(t *testing.T) {
 
 		challenge := state.walletChallengesByID["c1"]
 		require.False(t, challenge.Spent)
-		require.Empty(t, state.walletCredentialsByAddress)
+		require.Len(t, state.walletCredentialsByAddress, 1)
+		require.Contains(t, state.walletCredentialsByAddress, strings.ToLower(address))
 
 		user := state.usersByUsername["alice"]
 		user.Approved = true
@@ -409,6 +411,7 @@ func TestWalletHandlers_Round12_Coverage(t *testing.T) {
 		require.NoError(t, err)
 		requireStatus(t, http.StatusOK)(handler.HandleLinkWalletLift(ctxRetry))
 		require.True(t, state.walletChallengesByID["c1"].Spent)
+		require.Len(t, state.walletCredentialsByAddress, 1)
 	})
 
 	t.Run("unlink_wallet_unauthorized_returns_401", func(t *testing.T) {
@@ -451,7 +454,25 @@ func TestWalletHandlers_Round12_Coverage(t *testing.T) {
 	})
 
 	t.Run("unlink_wallet_delete_error_returns_500", func(t *testing.T) {
-		state := &round10QueryState{deleteErrorOnce: errors.New("delete failed")}
+		state := &round10QueryState{
+			deleteErrorOnce: errors.New("delete failed"),
+			webAuthnCredentialByID: map[string]storagemodels.WebAuthnCredential{
+				"Y3JlZA==": {ID: "Y3JlZA==", UserID: "alice"},
+			},
+			webAuthnCredentialsByUser: map[string][]storagemodels.WebAuthnCredential{
+				"alice": {
+					{ID: "Y3JlZA==", UserID: "alice"},
+				},
+			},
+			walletCredentialsByAddress: map[string]storagemodels.WalletCredential{
+				"0xabc": {Username: "alice", Address: "0xabc", ChainID: 1, Type: "ethereum"},
+			},
+			walletCredentialsByUser: map[string][]storagemodels.WalletCredential{
+				"alice": {
+					{Username: "alice", Address: "0xabc", ChainID: 1, Type: "ethereum"},
+				},
+			},
+		}
 		handler, _, _ := round11NewHandler(t, cfg, state)
 
 		ctx, err := round10NewLiftContext(http.MethodDelete, "/auth/wallet/unlink/0xabc", writeHeaders, nil, nil)

--- a/cmd/api/handlers/wallet_round12_coverage_test.go
+++ b/cmd/api/handlers/wallet_round12_coverage_test.go
@@ -453,6 +453,38 @@ func TestWalletHandlers_Round12_Coverage(t *testing.T) {
 		requireStatus(t, http.StatusBadRequest)(handler.HandleUnlinkWalletLift(ctx))
 	})
 
+	t.Run("unlink_wallet_double_unlink_returns_404", func(t *testing.T) {
+		state := &round10QueryState{
+			usersByUsername: map[string]storagemodels.User{
+				"alice": {PK: "USER#alice", SK: storagemodels.SKMetadata, Username: "alice", Role: "user", Approved: true, Version: 1, CreatedAt: now.Add(-time.Hour)},
+			},
+			webAuthnCredentialsByUser: map[string][]storagemodels.WebAuthnCredential{
+				"alice": {
+					{ID: "cred-1", UserID: "alice"},
+				},
+			},
+			walletCredentialsByAddress: map[string]storagemodels.WalletCredential{
+				"0xabc": {Username: "alice", Address: "0xabc", ChainID: 1, Type: "ethereum"},
+			},
+			walletCredentialsByUser: map[string][]storagemodels.WalletCredential{
+				"alice": {
+					{Username: "alice", Address: "0xabc", ChainID: 1, Type: "ethereum"},
+				},
+			},
+		}
+		handler, _, _ := round11NewHandler(t, cfg, state)
+
+		ctxFirst, err := round10NewLiftContext(http.MethodDelete, "/auth/wallet/unlink/0xabc", writeHeaders, nil, nil)
+		require.NoError(t, err)
+		ctxFirst.Params["address"] = "0xabc"
+		requireStatus(t, http.StatusOK)(handler.HandleUnlinkWalletLift(ctxFirst))
+
+		ctxSecond, err := round10NewLiftContext(http.MethodDelete, "/auth/wallet/unlink/0xabc", writeHeaders, nil, nil)
+		require.NoError(t, err)
+		ctxSecond.Params["address"] = "0xabc"
+		requireStatus(t, http.StatusNotFound)(handler.HandleUnlinkWalletLift(ctxSecond))
+	})
+
 	t.Run("unlink_wallet_delete_error_returns_500", func(t *testing.T) {
 		state := &round10QueryState{
 			deleteErrorOnce: errors.New("delete failed"),

--- a/cmd/api/handlers/wallet_round12_coverage_test.go
+++ b/cmd/api/handlers/wallet_round12_coverage_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -424,6 +425,28 @@ func TestWalletHandlers_Round12_Coverage(t *testing.T) {
 
 		ctx, err := round10NewLiftContext(http.MethodDelete, "/auth/wallet/unlink/", writeHeaders, nil, nil)
 		require.NoError(t, err)
+		requireStatus(t, http.StatusBadRequest)(handler.HandleUnlinkWalletLift(ctx))
+	})
+
+	t.Run("unlink_wallet_last_authenticator_returns_400", func(t *testing.T) {
+		state := &round10QueryState{
+			webAuthnCredentialsByUser: map[string][]storagemodels.WebAuthnCredential{
+				"alice": {},
+			},
+			walletCredentialsByUser: map[string][]storagemodels.WalletCredential{
+				"alice": {
+					{Username: "alice", Address: "0xabc", ChainID: 1, Type: "ethereum"},
+				},
+			},
+		}
+		handler, repos, _ := round11NewHandler(t, cfg, state)
+		authService, err := auth.NewAuthService(cfg, repos)
+		require.NoError(t, err)
+		require.ErrorIs(t, authService.UnlinkWallet(context.Background(), "alice", "0xabc"), auth.ErrLastAuthMethodDelete)
+
+		ctx, err := round10NewLiftContext(http.MethodDelete, "/auth/wallet/unlink/0xabc", writeHeaders, nil, nil)
+		require.NoError(t, err)
+		ctx.Params["address"] = "0xabc"
 		requireStatus(t, http.StatusBadRequest)(handler.HandleUnlinkWalletLift(ctx))
 	})
 

--- a/cmd/api/handlers/webauthn.go
+++ b/cmd/api/handlers/webauthn.go
@@ -189,7 +189,10 @@ func (h *Handler) HandleFinishWebAuthnRegistrationLift(ctx *apptheory.Context) (
 		return h.respondBadRequest(ctx, "invalid response payload")
 	}
 
-	err = authService.FinishWebAuthnRegistration(ctx.Context(), username, req.Challenge, rawResponse, req.CredentialName)
+	userAgent, ipAddress := h.getDeviceInfo(ctx)
+	requestCtx := auth.WithAuditRequestMetadata(ctx.Context(), ipAddress, userAgent)
+
+	err = authService.FinishWebAuthnRegistration(requestCtx, username, req.Challenge, rawResponse, req.CredentialName)
 	if err != nil {
 		return h.handleAuthServiceError(ctx, err, "complete registration")
 	}
@@ -338,8 +341,11 @@ func (h *Handler) HandleDeleteWebAuthnCredentialLift(ctx *apptheory.Context) (*a
 		return resp, err
 	}
 
+	userAgent, ipAddress := h.getDeviceInfo(ctx)
+	requestCtx := auth.WithAuditRequestMetadata(ctx.Context(), ipAddress, userAgent)
+
 	// Delete credential
-	err = authService.DeleteWebAuthnCredential(ctx.Context(), username, credentialID)
+	err = authService.DeleteWebAuthnCredential(requestCtx, username, credentialID)
 	if err != nil {
 		if errors.Is(err, auth.ErrCredentialNotFound) {
 			return h.respondWithError(ctx, http.StatusNotFound, "credential not found")

--- a/cmd/api/handlers/webauthn.go
+++ b/cmd/api/handlers/webauthn.go
@@ -2,8 +2,8 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
-	"strings"
 
 	apimodels "github.com/equaltoai/lesser/cmd/api/models"
 	"github.com/equaltoai/lesser/pkg/auth"
@@ -341,10 +341,10 @@ func (h *Handler) HandleDeleteWebAuthnCredentialLift(ctx *apptheory.Context) (*a
 	// Delete credential
 	err = authService.DeleteWebAuthnCredential(ctx.Context(), username, credentialID)
 	if err != nil {
-		if err == auth.ErrCredentialNotFound {
+		if errors.Is(err, auth.ErrCredentialNotFound) {
 			return h.respondWithError(ctx, http.StatusNotFound, "credential not found")
 		}
-		if strings.Contains(strings.ToLower(err.Error()), "cannot delete last authentication method") {
+		if errors.Is(err, auth.ErrLastAuthMethodDelete) {
 			return h.respondBadRequest(ctx, "cannot delete last authentication method")
 		}
 		h.logger.Error("failed to delete WebAuthn credential", zap.Error(err))

--- a/pkg/auth/audit.go
+++ b/pkg/auth/audit.go
@@ -463,11 +463,19 @@ func (al *AuditLogger) LogOAuthClientSecretRotation(ctx context.Context, usernam
 	al.logEventBestEffort(ctx, event)
 }
 
-// LogWebAuthn logs WebAuthn operations
-func (al *AuditLogger) LogWebAuthn(ctx context.Context, username, ipAddress, userAgent string, eventType AuditEventType, credentialID string, success bool, err error) {
+// LogAuthEvent logs a generic authentication audit event with caller-supplied safe metadata.
+func (al *AuditLogger) LogAuthEvent(ctx context.Context, username, ipAddress, userAgent string, eventType AuditEventType, metadata map[string]interface{}, success bool, err error) {
 	failureReason := ""
 	if err != nil {
 		failureReason = err.Error()
+	}
+
+	var safeMetadata map[string]interface{}
+	if len(metadata) > 0 {
+		safeMetadata = make(map[string]interface{}, len(metadata))
+		for key, value := range metadata {
+			safeMetadata[key] = value
+		}
 	}
 
 	event := &AuditEvent{
@@ -477,13 +485,22 @@ func (al *AuditLogger) LogWebAuthn(ctx context.Context, username, ipAddress, use
 		UserAgent:     userAgent,
 		Success:       success,
 		FailureReason: failureReason,
-		Metadata: map[string]interface{}{
-			"credential_id":         credentialID,
-			"authentication_method": "webauthn",
-		},
+		Metadata:      safeMetadata,
 	}
 
 	al.logEventBestEffort(ctx, event)
+}
+
+// LogWebAuthn logs WebAuthn operations
+func (al *AuditLogger) LogWebAuthn(ctx context.Context, username, ipAddress, userAgent string, eventType AuditEventType, credentialID string, success bool, err error) {
+	metadata := map[string]interface{}{
+		"authentication_method": "webauthn",
+	}
+	if strings.TrimSpace(credentialID) != "" {
+		metadata["credential_reference_present"] = true
+	}
+
+	al.LogAuthEvent(ctx, username, ipAddress, userAgent, eventType, metadata, success, err)
 }
 
 // LogSession logs session operations
@@ -702,6 +719,7 @@ func (al *AuditLogger) determineSeverity(eventType AuditEventType, success bool)
 			AuditPasswordChangeFailed,
 			AuditOAuthAuthorizeFailed,
 			AuditOAuthClientSecretRotationFailed,
+			AuditWebAuthnRegistrationFailed,
 			AuditWebAuthnLoginFailed,
 			AuditWalletLoginFailed,
 			AuditTwoFactorFailed,
@@ -920,7 +938,14 @@ func (al *AuditLogger) redactSensitiveData(event *AuditEvent) {
 	// Redact sensitive fields in metadata
 	if event.Metadata != nil {
 		sensitiveKeys := []string{"password", "token", "secret", "key", "credential"}
+		safeKeys := map[string]struct{}{
+			"credential_event":             {},
+			"credential_reference_present": {},
+		}
 		for key := range event.Metadata {
+			if _, ok := safeKeys[key]; ok {
+				continue
+			}
 			for _, sensitive := range sensitiveKeys {
 				if strings.Contains(strings.ToLower(key), sensitive) {
 					event.Metadata[key] = "[REDACTED]"

--- a/pkg/auth/audit.go
+++ b/pkg/auth/audit.go
@@ -470,6 +470,16 @@ func (al *AuditLogger) LogAuthEvent(ctx context.Context, username, ipAddress, us
 		failureReason = err.Error()
 	}
 
+	if ipAddress == "" || userAgent == "" {
+		ctxIPAddress, ctxUserAgent := auditRequestMetadataFromContext(ctx)
+		if ipAddress == "" {
+			ipAddress = ctxIPAddress
+		}
+		if userAgent == "" {
+			userAgent = ctxUserAgent
+		}
+	}
+
 	var safeMetadata map[string]interface{}
 	if len(metadata) > 0 {
 		safeMetadata = make(map[string]interface{}, len(metadata))
@@ -716,6 +726,7 @@ func (al *AuditLogger) determineSeverity(eventType AuditEventType, success bool)
 	if !success {
 		errorEvents := []AuditEventType{
 			AuditLoginFailed,
+			AuditRegistrationFailed,
 			AuditPasswordChangeFailed,
 			AuditOAuthAuthorizeFailed,
 			AuditOAuthClientSecretRotationFailed,
@@ -739,6 +750,8 @@ func (al *AuditLogger) determineSeverity(eventType AuditEventType, success bool)
 		AuditAnomalousLocation,
 		AuditDeviceNotRecognized,
 		AuditIPBlocked,
+		AuditWebAuthnCredentialRemoved,
+		AuditWalletDisconnected,
 	}
 	for _, e := range warningEvents {
 		if eventType == e {
@@ -768,6 +781,10 @@ func (al *AuditLogger) calculateRiskScore(ctx context.Context, event *AuditEvent
 	}
 
 	if event.EventType == AuditDeviceNotRecognized {
+		score += 15.0
+	}
+
+	if event.EventType == AuditWebAuthnCredentialRemoved || event.EventType == AuditWalletDisconnected {
 		score += 15.0
 	}
 

--- a/pkg/auth/audit_credential_events_test.go
+++ b/pkg/auth/audit_credential_events_test.go
@@ -1,0 +1,132 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/go-webauthn/webauthn/protocol"
+	"github.com/go-webauthn/webauthn/webauthn"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestWebAuthnService_CredentialLifecycleAuditsExcludeSensitiveMaterial(t *testing.T) {
+	t.Parallel()
+
+	t.Run("authenticated_registration_emits_added_event", func(t *testing.T) {
+		t.Parallel()
+
+		repo := newInMemoryWebAuthnRepo()
+		repo.usersByUsername["alice"] = &storage.User{Username: "alice", PasswordHash: "hash"}
+		engine := &fakeWebAuthnEngine{
+			beginRegChallenge: "chal-reg",
+			createCredential:  &webauthnCredentialFixture,
+		}
+		auditRepo := newInMemoryAuditRepo()
+
+		svc := &WebAuthnService{
+			webAuthn:    engine,
+			repo:        repo,
+			domain:      "example.com",
+			auditLogger: newAuditLoggerForTests(auditRepo),
+			parseCreationResponse: func(_ []byte) (*protocol.ParsedCredentialCreationData, error) {
+				return &protocol.ParsedCredentialCreationData{}, nil
+			},
+			parseAssertionResponse: func(_ []byte) (*protocol.ParsedCredentialAssertionData, error) {
+				return &protocol.ParsedCredentialAssertionData{}, nil
+			},
+		}
+
+		_, challenge, err := svc.BeginRegistration(context.Background(), "alice")
+		require.NoError(t, err)
+		require.NoError(t, svc.FinishRegistration(context.Background(), "alice", challenge, []byte("ignored"), ""))
+
+		require.Equal(t, string(AuditWebAuthnRegistrationCompleted), auditRepo.lastStore.eventType)
+		require.Equal(t, "webauthn", auditRepo.lastStore.metadata["authentication_method"])
+		require.Equal(t, "added", auditRepo.lastStore.metadata["credential_event"])
+		require.Equal(t, "authenticated", auditRepo.lastStore.metadata["registration_mode"])
+		require.NotContains(t, auditRepo.lastStore.metadata, "credential_id")
+	})
+
+	t.Run("delete_emits_removed_event_without_credential_reference", func(t *testing.T) {
+		t.Parallel()
+
+		repo := newInMemoryWebAuthnRepo()
+		cred := &storage.WebAuthnCredential{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk")}
+		repo.credentialsByUsername["alice"] = []*storage.WebAuthnCredential{cred}
+		repo.credentialsByID[cred.ID] = cred
+		repo.walletsByUsername["alice"] = []*storage.WalletCredential{{Username: "alice", Address: "0xabc", Type: "ethereum", ChainID: 1}}
+		auditRepo := newInMemoryAuditRepo()
+
+		svc := &WebAuthnService{
+			repo:        repo,
+			auditLogger: newAuditLoggerForTests(auditRepo),
+		}
+
+		require.NoError(t, svc.DeleteCredential(context.Background(), "alice", cred.ID))
+		require.Equal(t, string(AuditWebAuthnCredentialRemoved), auditRepo.lastStore.eventType)
+		require.Equal(t, "webauthn", auditRepo.lastStore.metadata["authentication_method"])
+		require.Equal(t, "removed", auditRepo.lastStore.metadata["credential_event"])
+		require.NotContains(t, auditRepo.lastStore.metadata, "credential_id")
+	})
+}
+
+func TestWalletService_CredentialLifecycleAuditsExcludeSensitiveMaterial(t *testing.T) {
+	t.Parallel()
+
+	repo := newInMemoryWalletRepo()
+	repo.passkeysByUser["alice"] = []*storage.WebAuthnCredential{
+		{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk")},
+	}
+	auditRepo := newInMemoryAuditRepo()
+	svc := &WalletService{
+		repo:        repo,
+		logger:      zap.NewNop(),
+		auditLogger: newAuditLoggerForTests(auditRepo),
+	}
+
+	created, err := svc.LinkWallet(context.Background(), "alice", "0xabc", 1, "ethereum")
+	require.NoError(t, err)
+	require.True(t, created)
+	require.Equal(t, string(AuditWalletConnected), auditRepo.lastStore.eventType)
+	require.Equal(t, "wallet", auditRepo.lastStore.metadata["authentication_method"])
+	require.Equal(t, "added", auditRepo.lastStore.metadata["credential_event"])
+	require.Equal(t, "ethereum", auditRepo.lastStore.metadata["wallet_type"])
+	require.NotContains(t, auditRepo.lastStore.metadata, "address")
+	require.NotContains(t, auditRepo.lastStore.metadata, "signature")
+
+	require.NoError(t, svc.UnlinkWallet(context.Background(), "alice", "0xabc"))
+	require.Equal(t, string(AuditWalletDisconnected), auditRepo.lastStore.eventType)
+	require.Equal(t, "wallet", auditRepo.lastStore.metadata["authentication_method"])
+	require.Equal(t, "removed", auditRepo.lastStore.metadata["credential_event"])
+	require.NotContains(t, auditRepo.lastStore.metadata, "address")
+	require.NotContains(t, auditRepo.lastStore.metadata, "signature")
+}
+
+var webauthnCredentialFixture = webauthn.Credential{
+	ID:              []byte{9, 9},
+	PublicKey:       []byte("pub"),
+	AttestationType: "none",
+	Flags: webauthn.CredentialFlags{
+		BackupEligible: true,
+		BackupState:    false,
+	},
+	Authenticator: webauthn.Authenticator{
+		AAGUID:    []byte{0, 1, 2},
+		SignCount: 7,
+	},
+}
+
+func newAuditLoggerForTests(repo *inMemoryAuditRepo) *AuditLogger {
+	return &AuditLogger{
+		auditRepo: repo,
+		logger:    zap.NewNop(),
+		config: &AuditConfig{
+			Enabled:     true,
+			StoreToDB:   true,
+			StoreToFile: false,
+			StoreToSIEM: false,
+		},
+	}
+}

--- a/pkg/auth/audit_credential_events_test.go
+++ b/pkg/auth/audit_credential_events_test.go
@@ -66,6 +66,7 @@ func TestWebAuthnService_CredentialLifecycleAuditsExcludeSensitiveMaterial(t *te
 
 		require.NoError(t, svc.DeleteCredential(context.Background(), "alice", cred.ID))
 		require.Equal(t, string(AuditWebAuthnCredentialRemoved), auditRepo.lastStore.eventType)
+		require.Equal(t, string(SeverityWarning), auditRepo.lastStore.severity)
 		require.Equal(t, "webauthn", auditRepo.lastStore.metadata["authentication_method"])
 		require.Equal(t, "removed", auditRepo.lastStore.metadata["credential_event"])
 		require.NotContains(t, auditRepo.lastStore.metadata, "credential_id")
@@ -98,10 +99,93 @@ func TestWalletService_CredentialLifecycleAuditsExcludeSensitiveMaterial(t *test
 
 	require.NoError(t, svc.UnlinkWallet(context.Background(), "alice", "0xabc"))
 	require.Equal(t, string(AuditWalletDisconnected), auditRepo.lastStore.eventType)
+	require.Equal(t, string(SeverityWarning), auditRepo.lastStore.severity)
 	require.Equal(t, "wallet", auditRepo.lastStore.metadata["authentication_method"])
 	require.Equal(t, "removed", auditRepo.lastStore.metadata["credential_event"])
 	require.NotContains(t, auditRepo.lastStore.metadata, "address")
 	require.NotContains(t, auditRepo.lastStore.metadata, "signature")
+}
+
+func TestAuditLogger_CredentialSafeKeysSurviveProductionRedaction(t *testing.T) {
+	t.Parallel()
+
+	auditRepo := newInMemoryAuditRepo()
+	logger := newAuditLoggerForTests(auditRepo)
+
+	logger.LogAuthEvent(context.Background(), "alice", "192.0.2.10", "ua", AuditWalletConnected, map[string]interface{}{
+		"credential_event":             "added",
+		"credential_reference_present": true,
+		"credential_secret":            "should-not-survive",
+	}, true, nil)
+
+	require.Equal(t, "added", auditRepo.lastStore.metadata["credential_event"])
+	require.Equal(t, true, auditRepo.lastStore.metadata["credential_reference_present"])
+	require.Equal(t, "[REDACTED]", auditRepo.lastStore.metadata["credential_secret"])
+}
+
+func TestCredentialLifecycleAuditsCarryRequestMetadataFromContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("webauthn_delete", func(t *testing.T) {
+		t.Parallel()
+
+		repo := newInMemoryWebAuthnRepo()
+		cred := &storage.WebAuthnCredential{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk")}
+		repo.credentialsByUsername["alice"] = []*storage.WebAuthnCredential{cred}
+		repo.credentialsByID[cred.ID] = cred
+		repo.walletsByUsername["alice"] = []*storage.WalletCredential{{Username: "alice", Address: "0xabc", Type: "ethereum", ChainID: 1}}
+		auditRepo := newInMemoryAuditRepo()
+
+		svc := &WebAuthnService{
+			repo:        repo,
+			auditLogger: newAuditLoggerForTests(auditRepo),
+		}
+
+		ctx := WithAuditRequestMetadata(context.Background(), "198.51.100.20", "passkey-agent")
+		require.NoError(t, svc.DeleteCredential(ctx, "alice", cred.ID))
+		require.Equal(t, "198.51.100.20", auditRepo.lastStore.ipAddress)
+		require.Equal(t, "passkey-agent", auditRepo.lastStore.userAgent)
+	})
+
+	t.Run("wallet_link_and_unlink", func(t *testing.T) {
+		t.Parallel()
+
+		repo := newInMemoryWalletRepo()
+		repo.passkeysByUser["alice"] = []*storage.WebAuthnCredential{
+			{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk")},
+		}
+		auditRepo := newInMemoryAuditRepo()
+		svc := &WalletService{
+			repo:        repo,
+			logger:      zap.NewNop(),
+			auditLogger: newAuditLoggerForTests(auditRepo),
+		}
+
+		ctx := WithAuditRequestMetadata(context.Background(), "198.51.100.21", "wallet-agent")
+		created, err := svc.LinkWallet(ctx, "alice", "0xabc", 1, "ethereum")
+		require.NoError(t, err)
+		require.True(t, created)
+		require.Equal(t, "198.51.100.21", auditRepo.lastStore.ipAddress)
+		require.Equal(t, "wallet-agent", auditRepo.lastStore.userAgent)
+
+		require.NoError(t, svc.UnlinkWallet(ctx, "alice", "0xabc"))
+		require.Equal(t, "198.51.100.21", auditRepo.lastStore.ipAddress)
+		require.Equal(t, "wallet-agent", auditRepo.lastStore.userAgent)
+	})
+}
+
+func TestAuthenticatorRemovalRiskScoreHasSecurityBaseline(t *testing.T) {
+	t.Parallel()
+
+	logger := newAuditLoggerForTests(newInMemoryAuditRepo())
+	require.Equal(t, 15.0, logger.calculateRiskScore(context.Background(), &AuditEvent{
+		EventType: AuditWebAuthnCredentialRemoved,
+		Success:   true,
+	}))
+	require.Equal(t, 15.0, logger.calculateRiskScore(context.Background(), &AuditEvent{
+		EventType: AuditWalletDisconnected,
+		Success:   true,
+	}))
 }
 
 var webauthnCredentialFixture = webauthn.Credential{
@@ -123,10 +207,11 @@ func newAuditLoggerForTests(repo *inMemoryAuditRepo) *AuditLogger {
 		auditRepo: repo,
 		logger:    zap.NewNop(),
 		config: &AuditConfig{
-			Enabled:     true,
-			StoreToDB:   true,
-			StoreToFile: false,
-			StoreToSIEM: false,
+			Enabled:         true,
+			StoreToDB:       true,
+			StoreToFile:     false,
+			StoreToSIEM:     false,
+			RedactSensitive: true,
 		},
 	}
 }

--- a/pkg/auth/audit_request_context.go
+++ b/pkg/auth/audit_request_context.go
@@ -1,0 +1,37 @@
+package auth
+
+import "context"
+
+type auditRequestContextKey struct{}
+
+type auditRequestMetadata struct {
+	ipAddress string
+	userAgent string
+}
+
+// WithAuditRequestMetadata stores request-derived audit metadata on the context so
+// service-layer audit emitters can reuse handler-collected device information
+// without widening every method signature.
+func WithAuditRequestMetadata(ctx context.Context, ipAddress, userAgent string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if ipAddress == "" && userAgent == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, auditRequestContextKey{}, auditRequestMetadata{
+		ipAddress: ipAddress,
+		userAgent: userAgent,
+	})
+}
+
+func auditRequestMetadataFromContext(ctx context.Context) (ipAddress, userAgent string) {
+	if ctx == nil {
+		return "", ""
+	}
+	metadata, ok := ctx.Value(auditRequestContextKey{}).(auditRequestMetadata)
+	if !ok {
+		return "", ""
+	}
+	return metadata.ipAddress, metadata.userAgent
+}

--- a/pkg/auth/audit_request_context_test.go
+++ b/pkg/auth/audit_request_context_test.go
@@ -1,0 +1,22 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditRequestMetadataHelpers_HandleNilAndEmptyContexts(t *testing.T) {
+	t.Parallel()
+
+	ctx := WithAuditRequestMetadata(nil, "", "")
+	require.NotNil(t, ctx)
+
+	ipAddress, userAgent := auditRequestMetadataFromContext(ctx)
+	require.Empty(t, ipAddress)
+	require.Empty(t, userAgent)
+
+	ipAddress, userAgent = auditRequestMetadataFromContext(nil)
+	require.Empty(t, ipAddress)
+	require.Empty(t, userAgent)
+}

--- a/pkg/auth/audit_test.go
+++ b/pkg/auth/audit_test.go
@@ -106,7 +106,8 @@ func TestAuditLogger_LogWebAuthn_LogSession_AndStoreFallbacks(t *testing.T) {
 	require.Equal(t, "ua", repo.lastStore.userAgent)
 	require.True(t, repo.lastStore.success)
 	require.Empty(t, repo.lastStore.failureReason)
-	require.Equal(t, "cred-1", repo.lastStore.metadata["credential_id"])
+	require.Equal(t, true, repo.lastStore.metadata["credential_reference_present"])
+	require.Equal(t, "webauthn", repo.lastStore.metadata["authentication_method"])
 
 	al.LogSession(context.Background(), "alice", "sid-1", "192.0.2.10", AuditSessionCreated)
 	require.Equal(t, 2, repo.storeCalls)

--- a/pkg/auth/authenticator_invariant.go
+++ b/pkg/auth/authenticator_invariant.go
@@ -79,16 +79,6 @@ func planAuthenticatorRemoval(
 	return authenticatorRemovalPlan{}, ErrLastAuthMethodDelete
 }
 
-func classifyGuardedAuthenticatorRemovalFailure(err error) error {
-	if err == nil {
-		return nil
-	}
-	if dynamormerrors.IsConditionFailed(err) || stdErrors.Is(err, dynamormerrors.ErrTransactionConflict) {
-		return ErrLastAuthMethodDelete
-	}
-	return err
-}
-
 func classifyGuardedWebAuthnRemovalFailure(
 	ctx context.Context,
 	repo webAuthnRepository,
@@ -98,12 +88,6 @@ func classifyGuardedWebAuthnRemovalFailure(
 ) error {
 	if err == nil {
 		return nil
-	}
-	if stdErrors.Is(err, dynamormerrors.ErrTransactionConflict) {
-		return ErrLastAuthMethodDelete
-	}
-	if !dynamormerrors.IsConditionFailed(err) {
-		return err
 	}
 
 	credential, lookupErr := repo.GetWebAuthnCredential(ctx, credentialID)
@@ -117,7 +101,46 @@ func classifyGuardedWebAuthnRemovalFailure(
 		return ErrCredentialNotFound
 	}
 
-	return ErrLastAuthMethodDelete
+	_, planErr := planAuthenticatorRemoval(ctx, repo, username, authenticatorRemovalPasskey, credentialID, "")
+	if planErr == nil {
+		return err
+	}
+	if stdErrors.Is(planErr, ErrLastAuthMethodDelete) {
+		return ErrLastAuthMethodDelete
+	}
+	return planErr
+}
+
+func classifyGuardedWalletRemovalFailure(
+	ctx context.Context,
+	repo walletRepository,
+	username string,
+	address string,
+	err error,
+) error {
+	if err == nil {
+		return nil
+	}
+
+	wallet, lookupErr := repo.GetWalletCredential(ctx, address)
+	if lookupErr != nil {
+		if isAuthenticatorRemovalTargetNotFound(lookupErr) {
+			return lessererrors.CredentialNotFound()
+		}
+		return lookupErr
+	}
+	if wallet == nil || wallet.Username != username {
+		return lessererrors.CredentialNotFound()
+	}
+
+	_, planErr := planAuthenticatorRemoval(ctx, repo, username, authenticatorRemovalWallet, "", address)
+	if planErr == nil {
+		return err
+	}
+	if stdErrors.Is(planErr, ErrLastAuthMethodDelete) {
+		return ErrLastAuthMethodDelete
+	}
+	return planErr
 }
 
 func isAuthenticatorRemovalTargetNotFound(err error) bool {

--- a/pkg/auth/authenticator_invariant.go
+++ b/pkg/auth/authenticator_invariant.go
@@ -2,9 +2,12 @@ package auth
 
 import (
 	"context"
+	stdErrors "errors"
 	"strings"
 
+	lessererrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/storage"
+	dynamormerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
 )
 
 type authenticatorInventoryRepository interface {
@@ -74,4 +77,55 @@ func planAuthenticatorRemoval(
 	}
 
 	return authenticatorRemovalPlan{}, ErrLastAuthMethodDelete
+}
+
+func classifyGuardedAuthenticatorRemovalFailure(err error) error {
+	if err == nil {
+		return nil
+	}
+	if dynamormerrors.IsConditionFailed(err) || stdErrors.Is(err, dynamormerrors.ErrTransactionConflict) {
+		return ErrLastAuthMethodDelete
+	}
+	return err
+}
+
+func classifyGuardedWebAuthnRemovalFailure(
+	ctx context.Context,
+	repo webAuthnRepository,
+	username string,
+	credentialID string,
+	err error,
+) error {
+	if err == nil {
+		return nil
+	}
+	if stdErrors.Is(err, dynamormerrors.ErrTransactionConflict) {
+		return ErrLastAuthMethodDelete
+	}
+	if !dynamormerrors.IsConditionFailed(err) {
+		return err
+	}
+
+	credential, lookupErr := repo.GetWebAuthnCredential(ctx, credentialID)
+	if lookupErr != nil {
+		if isAuthenticatorRemovalTargetNotFound(lookupErr) {
+			return ErrCredentialNotFound
+		}
+		return lookupErr
+	}
+	if credential == nil || credential.UserID != username {
+		return ErrCredentialNotFound
+	}
+
+	return ErrLastAuthMethodDelete
+}
+
+func isAuthenticatorRemovalTargetNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	if lessererrors.HasCode(err, lessererrors.CodeNotFound) || dynamormerrors.IsNotFound(err) {
+		return true
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "not found")
 }

--- a/pkg/auth/authenticator_invariant.go
+++ b/pkg/auth/authenticator_invariant.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"strings"
 
 	"github.com/equaltoai/lesser/pkg/storage"
 )
@@ -18,35 +19,59 @@ const (
 	authenticatorRemovalWallet  authenticatorRemovalKind = "wallet"
 )
 
-func ensureAuthenticatorRemovalAllowed(
+type authenticatorRemovalPlan struct {
+	survivingPasskeyID     string
+	survivingWalletAddress string
+}
+
+func planAuthenticatorRemoval(
 	ctx context.Context,
 	repo authenticatorInventoryRepository,
 	username string,
 	removing authenticatorRemovalKind,
-) error {
+	targetCredentialID string,
+	targetWalletAddress string,
+) (authenticatorRemovalPlan, error) {
 	passkeys, err := repo.GetUserWebAuthnCredentials(ctx, username)
 	if err != nil {
-		return err
+		return authenticatorRemovalPlan{}, err
 	}
 
 	wallets, err := repo.GetUserWalletCredentials(ctx, username)
 	if err != nil {
-		return err
+		return authenticatorRemovalPlan{}, err
 	}
-
-	passkeyCount := len(passkeys)
-	walletCount := len(wallets)
 
 	switch removing {
 	case authenticatorRemovalPasskey:
-		if passkeyCount == 1 && walletCount == 0 {
-			return ErrLastAuthMethodDelete
+		for _, passkey := range passkeys {
+			if passkey == nil || passkey.ID == targetCredentialID {
+				continue
+			}
+			return authenticatorRemovalPlan{survivingPasskeyID: passkey.ID}, nil
+		}
+		for _, wallet := range wallets {
+			if wallet == nil {
+				continue
+			}
+			return authenticatorRemovalPlan{survivingWalletAddress: wallet.Address}, nil
 		}
 	case authenticatorRemovalWallet:
-		if walletCount == 1 && passkeyCount == 0 {
-			return ErrLastAuthMethodDelete
+		for _, wallet := range wallets {
+			if wallet == nil || strings.EqualFold(wallet.Address, targetWalletAddress) {
+				continue
+			}
+			return authenticatorRemovalPlan{survivingWalletAddress: wallet.Address}, nil
 		}
+		for _, passkey := range passkeys {
+			if passkey == nil {
+				continue
+			}
+			return authenticatorRemovalPlan{survivingPasskeyID: passkey.ID}, nil
+		}
+	default:
+		return authenticatorRemovalPlan{}, ErrLastAuthMethodDelete
 	}
 
-	return nil
+	return authenticatorRemovalPlan{}, ErrLastAuthMethodDelete
 }

--- a/pkg/auth/authenticator_invariant.go
+++ b/pkg/auth/authenticator_invariant.go
@@ -1,0 +1,52 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/equaltoai/lesser/pkg/storage"
+)
+
+type authenticatorInventoryRepository interface {
+	GetUserWebAuthnCredentials(ctx context.Context, username string) ([]*storage.WebAuthnCredential, error)
+	GetUserWalletCredentials(ctx context.Context, username string) ([]*storage.WalletCredential, error)
+}
+
+type authenticatorRemovalKind string
+
+const (
+	authenticatorRemovalPasskey authenticatorRemovalKind = "passkey"
+	authenticatorRemovalWallet  authenticatorRemovalKind = "wallet"
+)
+
+func ensureAuthenticatorRemovalAllowed(
+	ctx context.Context,
+	repo authenticatorInventoryRepository,
+	username string,
+	removing authenticatorRemovalKind,
+) error {
+	passkeys, err := repo.GetUserWebAuthnCredentials(ctx, username)
+	if err != nil {
+		return err
+	}
+
+	wallets, err := repo.GetUserWalletCredentials(ctx, username)
+	if err != nil {
+		return err
+	}
+
+	passkeyCount := len(passkeys)
+	walletCount := len(wallets)
+
+	switch removing {
+	case authenticatorRemovalPasskey:
+		if passkeyCount == 1 && walletCount == 0 {
+			return ErrLastAuthMethodDelete
+		}
+	case authenticatorRemovalWallet:
+		if walletCount == 1 && passkeyCount == 0 {
+			return ErrLastAuthMethodDelete
+		}
+	}
+
+	return nil
+}

--- a/pkg/auth/authenticator_invariant_race_test.go
+++ b/pkg/auth/authenticator_invariant_race_test.go
@@ -1,0 +1,657 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/equaltoai/lesser/pkg/storage/repositories"
+	"github.com/stretchr/testify/require"
+	dynamormcore "github.com/theory-cloud/tabletheory/v3/pkg/core"
+	dynamormerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
+	"go.uber.org/zap"
+)
+
+func TestAuthenticatorInvariant_ConcurrentCrossKindRemovalPreservesSurvivor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sequential control updates live inventory", func(t *testing.T) {
+		repo := newAuthenticatorInvariantAccountRepo(t, newAuthenticatorInvariantDB(), 0)
+		seedAuthenticatorInventory(t, repo, "alice", "cred-1", "0xabc")
+
+		webAuthnSvc := &WebAuthnService{repo: repo}
+		walletSvc := &WalletService{repo: repo, logger: zap.NewNop()}
+
+		require.NoError(t, webAuthnSvc.DeleteCredential(context.Background(), "alice", "cred-1"))
+		err := walletSvc.UnlinkWallet(context.Background(), "alice", "0xabc")
+		require.ErrorIs(t, err, ErrLastAuthMethodDelete)
+
+		passkeys, wallets := authenticatorCounts(t, repo, "alice")
+		require.Equal(t, 0, passkeys)
+		require.Equal(t, 1, wallets)
+	})
+
+	t.Run("concurrent passkey delete and wallet unlink leave exactly one authenticator", func(t *testing.T) {
+		repo := newAuthenticatorInvariantAccountRepo(t, newAuthenticatorInvariantDB(), 2)
+		seedAuthenticatorInventory(t, repo, "alice", "cred-1", "0xabc")
+
+		webAuthnSvc := &WebAuthnService{repo: repo}
+		walletSvc := &WalletService{repo: repo, logger: zap.NewNop()}
+
+		errs := make([]error, 2)
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			errs[0] = webAuthnSvc.DeleteCredential(context.Background(), "alice", "cred-1")
+		}()
+		go func() {
+			defer wg.Done()
+			errs[1] = walletSvc.UnlinkWallet(context.Background(), "alice", "0xabc")
+		}()
+		wg.Wait()
+
+		successes := 0
+		var loser error
+		for _, err := range errs {
+			if err == nil {
+				successes++
+				continue
+			}
+			require.Nil(t, loser, "expected exactly one clean loser")
+			loser = err
+		}
+
+		require.Equal(t, 1, successes, "expected exactly one removal to commit")
+		require.ErrorIs(t, loser, ErrLastAuthMethodDelete)
+
+		passkeys, wallets := authenticatorCounts(t, repo, "alice")
+		require.Equal(t, 1, passkeys+wallets, "account must retain exactly one authenticator")
+	})
+}
+
+type authenticatorInvariantAccountRepo struct {
+	*repositories.AccountRepository
+	deleteBarrier *authenticatorInvariantBarrier
+}
+
+type conditionedWebAuthnDeleter interface {
+	DeleteWebAuthnCredentialConditionedOnSurvivor(
+		ctx context.Context,
+		username string,
+		credentialID string,
+		survivingPasskeyID string,
+		survivingWalletAddress string,
+	) error
+}
+
+type conditionedWalletDeleter interface {
+	DeleteWalletCredentialConditionedOnSurvivor(
+		ctx context.Context,
+		username, address, walletType string,
+		survivingPasskeyID string,
+		survivingWalletAddress string,
+	) error
+}
+
+func newAuthenticatorInvariantAccountRepo(t *testing.T, db dynamormcore.DB, concurrentDeletes int) *authenticatorInvariantAccountRepo {
+	t.Helper()
+
+	repo := repositories.NewAccountRepository(db, "test-table", "example.com", zap.NewNop())
+	repo.SetPermissionService(nil)
+	repo.SetEventService(nil)
+	repo.SetCachingService(nil)
+	return &authenticatorInvariantAccountRepo{
+		AccountRepository: repo,
+		deleteBarrier:     newAuthenticatorInvariantBarrier(concurrentDeletes),
+	}
+}
+
+func (r *authenticatorInvariantAccountRepo) DeleteWebAuthnCredential(ctx context.Context, credentialID string) error {
+	r.deleteBarrier.Wait()
+	return r.AccountRepository.DeleteWebAuthnCredential(ctx, credentialID)
+}
+
+func (r *authenticatorInvariantAccountRepo) DeleteWalletCredential(ctx context.Context, username, address string) error {
+	r.deleteBarrier.Wait()
+	return r.AccountRepository.DeleteWalletCredential(ctx, username, address)
+}
+
+func (r *authenticatorInvariantAccountRepo) DeleteWebAuthnCredentialConditionedOnSurvivor(
+	ctx context.Context,
+	username string,
+	credentialID string,
+	survivingPasskeyID string,
+	survivingWalletAddress string,
+) error {
+	r.deleteBarrier.Wait()
+	if conditioned, ok := any(r.AccountRepository).(conditionedWebAuthnDeleter); ok {
+		return conditioned.DeleteWebAuthnCredentialConditionedOnSurvivor(
+			ctx,
+			username,
+			credentialID,
+			survivingPasskeyID,
+			survivingWalletAddress,
+		)
+	}
+	return r.AccountRepository.DeleteWebAuthnCredential(ctx, credentialID)
+}
+
+func (r *authenticatorInvariantAccountRepo) DeleteWalletCredentialConditionedOnSurvivor(
+	ctx context.Context,
+	username, address, walletType string,
+	survivingPasskeyID string,
+	survivingWalletAddress string,
+) error {
+	r.deleteBarrier.Wait()
+	if conditioned, ok := any(r.AccountRepository).(conditionedWalletDeleter); ok {
+		return conditioned.DeleteWalletCredentialConditionedOnSurvivor(
+			ctx,
+			username,
+			address,
+			walletType,
+			survivingPasskeyID,
+			survivingWalletAddress,
+		)
+	}
+	return r.AccountRepository.DeleteWalletCredential(ctx, username, address)
+}
+
+func seedAuthenticatorInventory(t *testing.T, repo *authenticatorInvariantAccountRepo, username, credentialID, walletAddress string) {
+	t.Helper()
+
+	require.NoError(t, repo.CreateWebAuthnCredential(context.Background(), &storage.WebAuthnCredential{
+		ID:         credentialID,
+		UserID:     username,
+		PublicKey:  []byte("pk"),
+		CreatedAt:  time.Now().Add(-time.Minute),
+		LastUsedAt: time.Now().Add(-time.Minute),
+	}))
+	require.NoError(t, repo.StoreWalletCredential(context.Background(), &storage.WalletCredential{
+		Username: username,
+		Address:  walletAddress,
+		ChainID:  1,
+		Type:     "ethereum",
+		LinkedAt: time.Now().Add(-time.Minute),
+		LastUsed: time.Now().Add(-time.Minute),
+	}))
+}
+
+func authenticatorCounts(t *testing.T, repo *authenticatorInvariantAccountRepo, username string) (int, int) {
+	t.Helper()
+
+	passkeys, err := repo.GetUserWebAuthnCredentials(context.Background(), username)
+	require.NoError(t, err)
+	wallets, err := repo.GetUserWalletCredentials(context.Background(), username)
+	require.NoError(t, err)
+	return len(passkeys), len(wallets)
+}
+
+type authenticatorInvariantBarrier struct {
+	mu      sync.Mutex
+	release chan struct{}
+	target  int
+	arrived int
+}
+
+func newAuthenticatorInvariantBarrier(target int) *authenticatorInvariantBarrier {
+	if target <= 0 {
+		return nil
+	}
+	return &authenticatorInvariantBarrier{
+		release: make(chan struct{}),
+		target:  target,
+	}
+}
+
+func (b *authenticatorInvariantBarrier) Wait() {
+	if b == nil {
+		return
+	}
+
+	b.mu.Lock()
+	b.arrived++
+	if b.arrived == b.target {
+		close(b.release)
+	}
+	release := b.release
+	b.mu.Unlock()
+
+	<-release
+}
+
+type authenticatorInvariantDB struct {
+	state *authenticatorInvariantState
+}
+
+type authenticatorInvariantState struct {
+	mu sync.Mutex
+
+	credentials   map[string]*models.WebAuthnCredential
+	wallets       map[string]*models.WalletCredential
+	walletIndexes map[string]*models.WalletIndex
+}
+
+func newAuthenticatorInvariantDB() *authenticatorInvariantDB {
+	return &authenticatorInvariantDB{
+		state: &authenticatorInvariantState{
+			credentials:   make(map[string]*models.WebAuthnCredential),
+			wallets:       make(map[string]*models.WalletCredential),
+			walletIndexes: make(map[string]*models.WalletIndex),
+		},
+	}
+}
+
+func (db *authenticatorInvariantDB) Model(model any) dynamormcore.Query {
+	return &authenticatorInvariantQuery{
+		state:  db.state,
+		model:  model,
+		wheres: make(map[string]authenticatorInvariantWhere),
+	}
+}
+
+func (db *authenticatorInvariantDB) Migrate() error                              { return nil }
+func (db *authenticatorInvariantDB) AutoMigrate(...any) error                    { return nil }
+func (db *authenticatorInvariantDB) Close() error                                { return nil }
+func (db *authenticatorInvariantDB) WithContext(context.Context) dynamormcore.DB { return db }
+func (db *authenticatorInvariantDB) Transact() dynamormcore.TransactionBuilder {
+	return &authenticatorInvariantTransactionBuilder{state: db.state}
+}
+func (db *authenticatorInvariantDB) TransactWrite(_ context.Context, fn func(dynamormcore.TransactionBuilder) error) error {
+	builder := &authenticatorInvariantTransactionBuilder{state: db.state}
+	if err := fn(builder); err != nil {
+		return err
+	}
+	return builder.Execute()
+}
+
+type authenticatorInvariantWhere struct {
+	op    string
+	value any
+}
+
+type authenticatorInvariantQuery struct {
+	state  *authenticatorInvariantState
+	model  any
+	wheres map[string]authenticatorInvariantWhere
+	index  string
+}
+
+func (q *authenticatorInvariantQuery) Where(field, op string, value any) dynamormcore.Query {
+	q.wheres[field] = authenticatorInvariantWhere{op: op, value: value}
+	return q
+}
+
+func (q *authenticatorInvariantQuery) Index(name string) dynamormcore.Query            { q.index = name; return q }
+func (q *authenticatorInvariantQuery) Filter(string, string, any) dynamormcore.Query   { return q }
+func (q *authenticatorInvariantQuery) OrFilter(string, string, any) dynamormcore.Query { return q }
+func (q *authenticatorInvariantQuery) FilterGroup(func(dynamormcore.Query)) dynamormcore.Query {
+	return q
+}
+func (q *authenticatorInvariantQuery) OrFilterGroup(func(dynamormcore.Query)) dynamormcore.Query {
+	return q
+}
+func (q *authenticatorInvariantQuery) IfNotExists() dynamormcore.Query                      { return q }
+func (q *authenticatorInvariantQuery) IfExists() dynamormcore.Query                         { return q }
+func (q *authenticatorInvariantQuery) WithCondition(string, string, any) dynamormcore.Query { return q }
+func (q *authenticatorInvariantQuery) WithConditionExpression(string, map[string]any) dynamormcore.Query {
+	return q
+}
+func (q *authenticatorInvariantQuery) OrderBy(string, string) dynamormcore.Query       { return q }
+func (q *authenticatorInvariantQuery) Limit(int) dynamormcore.Query                    { return q }
+func (q *authenticatorInvariantQuery) Offset(int) dynamormcore.Query                   { return q }
+func (q *authenticatorInvariantQuery) Select(...string) dynamormcore.Query             { return q }
+func (q *authenticatorInvariantQuery) ConsistentRead() dynamormcore.Query              { return q }
+func (q *authenticatorInvariantQuery) WithRetry(int, time.Duration) dynamormcore.Query { return q }
+func (q *authenticatorInvariantQuery) Cursor(string) dynamormcore.Query                { return q }
+func (q *authenticatorInvariantQuery) SetCursor(string) error                          { return nil }
+func (q *authenticatorInvariantQuery) WithContext(context.Context) dynamormcore.Query  { return q }
+func (q *authenticatorInvariantQuery) Scan(any) error                                  { return fmt.Errorf("unsupported") }
+func (q *authenticatorInvariantQuery) ParallelScan(int32, int32) dynamormcore.Query    { return q }
+func (q *authenticatorInvariantQuery) ScanAllSegments(any, int32) error {
+	return fmt.Errorf("unsupported")
+}
+func (q *authenticatorInvariantQuery) BatchGet([]any, any) error { return fmt.Errorf("unsupported") }
+func (q *authenticatorInvariantQuery) BatchGetWithOptions([]any, any, *dynamormcore.BatchGetOptions) error {
+	return fmt.Errorf("unsupported")
+}
+func (q *authenticatorInvariantQuery) BatchGetBuilder() dynamormcore.BatchGetBuilder { return nil }
+func (q *authenticatorInvariantQuery) BatchCreate(any) error                         { return fmt.Errorf("unsupported") }
+func (q *authenticatorInvariantQuery) BatchDelete([]any) error                       { return fmt.Errorf("unsupported") }
+func (q *authenticatorInvariantQuery) BatchWrite([]any, []any) error {
+	return fmt.Errorf("unsupported")
+}
+func (q *authenticatorInvariantQuery) BatchUpdateWithOptions([]any, []string, ...any) error {
+	return fmt.Errorf("unsupported")
+}
+func (q *authenticatorInvariantQuery) Count() (int64, error) { return 0, fmt.Errorf("unsupported") }
+func (q *authenticatorInvariantQuery) CreateOrUpdate() error { return fmt.Errorf("unsupported") }
+func (q *authenticatorInvariantQuery) AllPaginated(any) (*dynamormcore.PaginatedResult, error) {
+	return nil, fmt.Errorf("unsupported")
+}
+
+func (q *authenticatorInvariantQuery) First(dest any) error {
+	q.state.mu.Lock()
+	defer q.state.mu.Unlock()
+
+	switch target := dest.(type) {
+	case *models.WebAuthnCredential:
+		if q.index == "gsi1" {
+			credential := q.state.credentials[q.whereString("gsi1PK")]
+			if credential == nil {
+				return dynamormerrors.ErrItemNotFound
+			}
+			*target = *cloneAuthenticatorInvariantCredential(credential)
+			return nil
+		}
+		pk := q.whereString("PK")
+		sk := q.whereString("SK")
+		for _, credential := range q.state.credentials {
+			if credential != nil && credential.PK == pk && credential.SK == sk {
+				*target = *cloneAuthenticatorInvariantCredential(credential)
+				return nil
+			}
+		}
+		return dynamormerrors.ErrItemNotFound
+	default:
+		return fmt.Errorf("unsupported destination %T", dest)
+	}
+}
+
+func (q *authenticatorInvariantQuery) All(dest any) error {
+	q.state.mu.Lock()
+	defer q.state.mu.Unlock()
+
+	slicePtr := reflect.ValueOf(dest)
+	if slicePtr.Kind() != reflect.Ptr || slicePtr.IsNil() {
+		return fmt.Errorf("destination must be a non-nil pointer")
+	}
+	sliceValue := slicePtr.Elem()
+	if sliceValue.Kind() != reflect.Slice {
+		return fmt.Errorf("destination must point to a slice")
+	}
+	sliceValue.Set(reflect.MakeSlice(sliceValue.Type(), 0, 0))
+
+	switch sliceValue.Type().Elem() {
+	case reflect.TypeOf(models.WebAuthnCredential{}):
+		pk := q.whereString("PK")
+		prefix := q.whereString("SK")
+		for _, credential := range q.state.credentials {
+			if credential == nil || credential.PK != pk {
+				continue
+			}
+			if where, ok := q.wheres["SK"]; ok && strings.EqualFold(where.op, "BEGINS_WITH") && !strings.HasPrefix(credential.SK, prefix) {
+				continue
+			}
+			sliceValue.Set(reflect.Append(sliceValue, reflect.ValueOf(*cloneAuthenticatorInvariantCredential(credential))))
+		}
+		return nil
+	case reflect.TypeOf(models.WalletCredential{}):
+		pk := q.whereString("PK")
+		prefix := q.whereString("SK")
+		for _, wallet := range q.state.wallets {
+			if wallet == nil || wallet.PK != pk {
+				continue
+			}
+			if where, ok := q.wheres["SK"]; ok && strings.EqualFold(where.op, "BEGINS_WITH") && !strings.HasPrefix(wallet.SK, prefix) {
+				continue
+			}
+			sliceValue.Set(reflect.Append(sliceValue, reflect.ValueOf(*cloneAuthenticatorInvariantWallet(wallet))))
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported destination %T", dest)
+	}
+}
+
+func (q *authenticatorInvariantQuery) Create() error {
+	q.state.mu.Lock()
+	defer q.state.mu.Unlock()
+
+	switch model := q.model.(type) {
+	case *models.WebAuthnCredential:
+		if model == nil {
+			return fmt.Errorf("nil WebAuthn credential")
+		}
+		q.state.credentials[model.GSI1PK] = cloneAuthenticatorInvariantCredential(model)
+		return nil
+	case *models.WalletCredential:
+		if model == nil {
+			return fmt.Errorf("nil wallet credential")
+		}
+		q.state.wallets[authenticatorInvariantWalletKey(model.Username, model.Address)] = cloneAuthenticatorInvariantWallet(model)
+		return nil
+	case *models.WalletIndex:
+		if model == nil {
+			return fmt.Errorf("nil wallet index")
+		}
+		q.state.walletIndexes[authenticatorInvariantWalletIndexKey(model.PK, model.SK)] = cloneAuthenticatorInvariantWalletIndex(model)
+		return nil
+	default:
+		return fmt.Errorf("unsupported model %T", q.model)
+	}
+}
+
+func (q *authenticatorInvariantQuery) Update(...string) error                    { return fmt.Errorf("unsupported") }
+func (q *authenticatorInvariantQuery) UpdateBuilder() dynamormcore.UpdateBuilder { return nil }
+
+func (q *authenticatorInvariantQuery) Delete() error {
+	q.state.mu.Lock()
+	defer q.state.mu.Unlock()
+
+	switch q.model.(type) {
+	case *models.WebAuthnCredential:
+		pk := q.whereString("PK")
+		sk := q.whereString("SK")
+		for key, credential := range q.state.credentials {
+			if credential != nil && credential.PK == pk && credential.SK == sk {
+				delete(q.state.credentials, key)
+				return nil
+			}
+		}
+		return dynamormerrors.ErrItemNotFound
+	case *models.WalletCredential:
+		pk := q.whereString("PK")
+		sk := q.whereString("SK")
+		for key, wallet := range q.state.wallets {
+			if wallet != nil && wallet.PK == pk && wallet.SK == sk {
+				delete(q.state.wallets, key)
+				return nil
+			}
+		}
+		return dynamormerrors.ErrItemNotFound
+	case *models.WalletIndex:
+		key := authenticatorInvariantWalletIndexKey(q.whereString("PK"), q.whereString("SK"))
+		if _, ok := q.state.walletIndexes[key]; !ok {
+			return dynamormerrors.ErrItemNotFound
+		}
+		delete(q.state.walletIndexes, key)
+		return nil
+	default:
+		return fmt.Errorf("unsupported delete model %T", q.model)
+	}
+}
+
+func (q *authenticatorInvariantQuery) whereString(field string) string {
+	where, ok := q.wheres[field]
+	if !ok {
+		return ""
+	}
+	value, _ := where.value.(string)
+	return value
+}
+
+type authenticatorInvariantTransactionBuilder struct {
+	state      *authenticatorInvariantState
+	operations []authenticatorInvariantTransactionOperation
+}
+
+type authenticatorInvariantTransactionOperation struct {
+	kind       string
+	model      any
+	conditions []dynamormcore.TransactCondition
+}
+
+func (b *authenticatorInvariantTransactionBuilder) Put(any, ...dynamormcore.TransactCondition) dynamormcore.TransactionBuilder {
+	return b
+}
+func (b *authenticatorInvariantTransactionBuilder) Create(any, ...dynamormcore.TransactCondition) dynamormcore.TransactionBuilder {
+	return b
+}
+func (b *authenticatorInvariantTransactionBuilder) Update(any, []string, ...dynamormcore.TransactCondition) dynamormcore.TransactionBuilder {
+	return b
+}
+func (b *authenticatorInvariantTransactionBuilder) UpdateWithBuilder(any, func(dynamormcore.UpdateBuilder) error, ...dynamormcore.TransactCondition) dynamormcore.TransactionBuilder {
+	return b
+}
+func (b *authenticatorInvariantTransactionBuilder) Delete(model any, conditions ...dynamormcore.TransactCondition) dynamormcore.TransactionBuilder {
+	b.operations = append(b.operations, authenticatorInvariantTransactionOperation{kind: "delete", model: model, conditions: append([]dynamormcore.TransactCondition(nil), conditions...)})
+	return b
+}
+func (b *authenticatorInvariantTransactionBuilder) ConditionCheck(model any, conditions ...dynamormcore.TransactCondition) dynamormcore.TransactionBuilder {
+	b.operations = append(b.operations, authenticatorInvariantTransactionOperation{kind: "condition_check", model: model, conditions: append([]dynamormcore.TransactCondition(nil), conditions...)})
+	return b
+}
+func (b *authenticatorInvariantTransactionBuilder) WithContext(context.Context) dynamormcore.TransactionBuilder {
+	return b
+}
+
+func (b *authenticatorInvariantTransactionBuilder) Execute() error {
+	b.state.mu.Lock()
+	defer b.state.mu.Unlock()
+
+	for idx, operation := range b.operations {
+		if !authenticatorInvariantConditionsMet(b.state, operation.model, operation.conditions) {
+			return &dynamormerrors.TransactionError{
+				Err:            dynamormerrors.ErrConditionFailed,
+				Operation:      operation.kind,
+				OperationIndex: idx,
+				Reason:         "ConditionalCheckFailed",
+			}
+		}
+	}
+
+	for idx, operation := range b.operations {
+		if operation.kind != "delete" {
+			continue
+		}
+		if !authenticatorInvariantDeleteModel(b.state, operation.model) {
+			return &dynamormerrors.TransactionError{
+				Err:            dynamormerrors.ErrConditionFailed,
+				Operation:      operation.kind,
+				OperationIndex: idx,
+				Reason:         "ConditionalCheckFailed",
+			}
+		}
+	}
+
+	return nil
+}
+
+func (b *authenticatorInvariantTransactionBuilder) ExecuteWithContext(context.Context) error {
+	return b.Execute()
+}
+
+func authenticatorInvariantConditionsMet(state *authenticatorInvariantState, model any, conditions []dynamormcore.TransactCondition) bool {
+	for _, condition := range conditions {
+		switch condition.Kind {
+		case dynamormcore.TransactConditionKindPrimaryKeyExists:
+			if !authenticatorInvariantModelExists(state, model) {
+				return false
+			}
+		case dynamormcore.TransactConditionKindPrimaryKeyNotExists:
+			if authenticatorInvariantModelExists(state, model) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func authenticatorInvariantModelExists(state *authenticatorInvariantState, model any) bool {
+	switch typed := model.(type) {
+	case *models.WebAuthnCredential:
+		for _, credential := range state.credentials {
+			if credential != nil && credential.PK == typed.PK && credential.SK == typed.SK {
+				return true
+			}
+		}
+	case *models.WalletCredential:
+		for _, wallet := range state.wallets {
+			if wallet != nil && wallet.PK == typed.PK && wallet.SK == typed.SK {
+				return true
+			}
+		}
+	case *models.WalletIndex:
+		_, ok := state.walletIndexes[authenticatorInvariantWalletIndexKey(typed.PK, typed.SK)]
+		return ok
+	}
+	return false
+}
+
+func authenticatorInvariantDeleteModel(state *authenticatorInvariantState, model any) bool {
+	switch typed := model.(type) {
+	case *models.WebAuthnCredential:
+		for key, credential := range state.credentials {
+			if credential != nil && credential.PK == typed.PK && credential.SK == typed.SK {
+				delete(state.credentials, key)
+				return true
+			}
+		}
+	case *models.WalletCredential:
+		for key, wallet := range state.wallets {
+			if wallet != nil && wallet.PK == typed.PK && wallet.SK == typed.SK {
+				delete(state.wallets, key)
+				return true
+			}
+		}
+	case *models.WalletIndex:
+		key := authenticatorInvariantWalletIndexKey(typed.PK, typed.SK)
+		if _, ok := state.walletIndexes[key]; ok {
+			delete(state.walletIndexes, key)
+			return true
+		}
+	}
+	return false
+}
+
+func cloneAuthenticatorInvariantCredential(src *models.WebAuthnCredential) *models.WebAuthnCredential {
+	if src == nil {
+		return nil
+	}
+	clone := *src
+	clone.PublicKey = append([]byte(nil), src.PublicKey...)
+	clone.AAGUID = append([]byte(nil), src.AAGUID...)
+	return &clone
+}
+
+func cloneAuthenticatorInvariantWallet(src *models.WalletCredential) *models.WalletCredential {
+	if src == nil {
+		return nil
+	}
+	clone := *src
+	return &clone
+}
+
+func cloneAuthenticatorInvariantWalletIndex(src *models.WalletIndex) *models.WalletIndex {
+	if src == nil {
+		return nil
+	}
+	clone := *src
+	return &clone
+}
+
+func authenticatorInvariantWalletKey(username, address string) string {
+	return username + "|" + strings.ToLower(address)
+}
+
+func authenticatorInvariantWalletIndexKey(pk, sk string) string {
+	return pk + "|" + sk
+}

--- a/pkg/auth/authenticator_invariant_race_test.go
+++ b/pkg/auth/authenticator_invariant_race_test.go
@@ -360,6 +360,16 @@ func (q *authenticatorInvariantQuery) First(dest any) error {
 			}
 		}
 		return dynamormerrors.ErrItemNotFound
+	case *models.WalletCredential:
+		pk := q.whereString("PK")
+		sk := q.whereString("SK")
+		for _, wallet := range q.state.wallets {
+			if wallet != nil && wallet.PK == pk && wallet.SK == sk {
+				*target = *cloneAuthenticatorInvariantWallet(wallet)
+				return nil
+			}
+		}
+		return dynamormerrors.ErrItemNotFound
 	default:
 		return fmt.Errorf("unsupported destination %T", dest)
 	}
@@ -406,6 +416,15 @@ func (q *authenticatorInvariantQuery) All(dest any) error {
 			sliceValue.Set(reflect.Append(sliceValue, reflect.ValueOf(*cloneAuthenticatorInvariantWallet(wallet))))
 		}
 		return nil
+	case reflect.TypeOf(models.WalletIndex{}):
+		pk := q.whereString("PK")
+		for _, index := range q.state.walletIndexes {
+			if index == nil || index.PK != pk {
+				continue
+			}
+			sliceValue.Set(reflect.Append(sliceValue, reflect.ValueOf(*cloneAuthenticatorInvariantWalletIndex(index))))
+		}
+		return nil
 	default:
 		return fmt.Errorf("unsupported destination %T", dest)
 	}
@@ -427,6 +446,16 @@ func (q *authenticatorInvariantQuery) Create() error {
 			return fmt.Errorf("nil wallet credential")
 		}
 		q.state.wallets[authenticatorInvariantWalletKey(model.Username, model.Address)] = cloneAuthenticatorInvariantWallet(model)
+		q.state.walletIndexes[authenticatorInvariantWalletIndexKey(
+			fmt.Sprintf("WALLET#%s#%s", model.Type, strings.ToLower(model.Address)),
+			fmt.Sprintf("USER#%s", model.Username),
+		)] = &models.WalletIndex{
+			PK:         fmt.Sprintf("WALLET#%s#%s", model.Type, strings.ToLower(model.Address)),
+			SK:         fmt.Sprintf("USER#%s", model.Username),
+			Username:   model.Username,
+			Address:    strings.ToLower(model.Address),
+			WalletType: model.Type,
+		}
 		return nil
 	case *models.WalletIndex:
 		if model == nil {

--- a/pkg/auth/authenticator_invariant_test.go
+++ b/pkg/auth/authenticator_invariant_test.go
@@ -16,6 +16,96 @@ type authenticatorInventory struct {
 	wallets  int
 }
 
+type authenticatorInventoryRepoStub struct {
+	passkeys   []*storage.WebAuthnCredential
+	wallets    []*storage.WalletCredential
+	passkeyErr error
+	walletErr  error
+}
+
+func (s authenticatorInventoryRepoStub) GetUserWebAuthnCredentials(context.Context, string) ([]*storage.WebAuthnCredential, error) {
+	if s.passkeyErr != nil {
+		return nil, s.passkeyErr
+	}
+	return s.passkeys, nil
+}
+
+func (s authenticatorInventoryRepoStub) GetUserWalletCredentials(context.Context, string) ([]*storage.WalletCredential, error) {
+	if s.walletErr != nil {
+		return nil, s.walletErr
+	}
+	return s.wallets, nil
+}
+
+func TestPlanAuthenticatorRemoval_PrefersSameKindSurvivorsAndSurfacesErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("passkey removal prefers another passkey before wallet", func(t *testing.T) {
+		t.Parallel()
+
+		plan, err := planAuthenticatorRemoval(
+			context.Background(),
+			authenticatorInventoryRepoStub{
+				passkeys: []*storage.WebAuthnCredential{{ID: "cred-1"}, {ID: "cred-2"}},
+				wallets:  []*storage.WalletCredential{{Address: "0xabc"}},
+			},
+			"alice",
+			authenticatorRemovalPasskey,
+			"cred-1",
+			"",
+		)
+		require.NoError(t, err)
+		require.Equal(t, authenticatorRemovalPlan{survivingPasskeyID: "cred-2"}, plan)
+	})
+
+	t.Run("wallet removal prefers another wallet before passkey", func(t *testing.T) {
+		t.Parallel()
+
+		plan, err := planAuthenticatorRemoval(
+			context.Background(),
+			authenticatorInventoryRepoStub{
+				passkeys: []*storage.WebAuthnCredential{{ID: "cred-1"}},
+				wallets:  []*storage.WalletCredential{{Address: "0xabc"}, {Address: "0xdef"}},
+			},
+			"alice",
+			authenticatorRemovalWallet,
+			"",
+			"0xabc",
+		)
+		require.NoError(t, err)
+		require.Equal(t, authenticatorRemovalPlan{survivingWalletAddress: "0xdef"}, plan)
+	})
+
+	t.Run("unknown removal kind is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := planAuthenticatorRemoval(
+			context.Background(),
+			authenticatorInventoryRepoStub{},
+			"alice",
+			authenticatorRemovalKind("unknown"),
+			"",
+			"",
+		)
+		require.ErrorIs(t, err, ErrLastAuthMethodDelete)
+	})
+
+	t.Run("wallet inventory errors are surfaced", func(t *testing.T) {
+		t.Parallel()
+
+		boom := errors.New("boom")
+		_, err := planAuthenticatorRemoval(
+			context.Background(),
+			authenticatorInventoryRepoStub{walletErr: boom},
+			"alice",
+			authenticatorRemovalPasskey,
+			"cred-1",
+			"",
+		)
+		require.ErrorIs(t, err, boom)
+	})
+}
+
 func TestWebAuthnService_DeleteCredential_RejectsLastPasskeyWithoutWallet(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/auth/authenticator_invariant_test.go
+++ b/pkg/auth/authenticator_invariant_test.go
@@ -1,0 +1,165 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type authenticatorInventory struct {
+	passkeys int
+	wallets  int
+}
+
+func TestWebAuthnService_DeleteCredential_RejectsLastPasskeyWithoutWallet(t *testing.T) {
+	t.Parallel()
+
+	repo := newInMemoryWebAuthnRepo()
+	only := &storage.WebAuthnCredential{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk")}
+	repo.credentialsByUsername["alice"] = []*storage.WebAuthnCredential{only}
+	repo.credentialsByID[only.ID] = only
+
+	svc := &WebAuthnService{repo: repo}
+	err := svc.DeleteCredential(context.Background(), "alice", only.ID)
+	require.ErrorIs(t, err, ErrLastAuthMethodDelete)
+}
+
+func TestWalletService_UnlinkWallet_RejectsLastWalletWithoutPasskey(t *testing.T) {
+	t.Parallel()
+
+	repo := newInMemoryWalletRepo()
+	repo.walletsByAddr["0xabc"] = &storage.WalletCredential{Username: "alice", Address: "0xabc", Type: "ethereum", ChainID: 1}
+	repo.walletsByUserAddr[walletKey("alice", "0xabc")] = repo.walletsByAddr["0xabc"]
+
+	svc := &WalletService{repo: repo, logger: zap.NewNop()}
+	err := svc.UnlinkWallet(context.Background(), "alice", "0xabc")
+	require.ErrorIs(t, err, ErrLastAuthMethodDelete)
+}
+
+func TestAuthenticatorInvariant_AllowsRemovalWhenAnotherAuthenticatorRemains(t *testing.T) {
+	t.Parallel()
+
+	t.Run("delete_passkey_with_second_passkey_present", func(t *testing.T) {
+		t.Parallel()
+
+		repo := newInMemoryWebAuthnRepo()
+		cred1 := &storage.WebAuthnCredential{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk1")}
+		cred2 := &storage.WebAuthnCredential{ID: "cred-2", UserID: "alice", PublicKey: []byte("pk2")}
+		repo.credentialsByUsername["alice"] = []*storage.WebAuthnCredential{cred1, cred2}
+		repo.credentialsByID[cred1.ID] = cred1
+		repo.credentialsByID[cred2.ID] = cred2
+
+		svc := &WebAuthnService{repo: repo}
+		require.NoError(t, svc.DeleteCredential(context.Background(), "alice", cred1.ID))
+	})
+
+	t.Run("unlink_wallet_with_passkey_present", func(t *testing.T) {
+		t.Parallel()
+
+		repo := newInMemoryWalletRepo()
+		repo.passkeysByUser["alice"] = []*storage.WebAuthnCredential{
+			{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk")},
+		}
+		repo.walletsByAddr["0xabc"] = &storage.WalletCredential{Username: "alice", Address: "0xabc", Type: "ethereum", ChainID: 1}
+		repo.walletsByUserAddr[walletKey("alice", "0xabc")] = repo.walletsByAddr["0xabc"]
+
+		svc := &WalletService{repo: repo, logger: zap.NewNop()}
+		require.NoError(t, svc.UnlinkWallet(context.Background(), "alice", "0xabc"))
+	})
+}
+
+func TestAuthenticatorInvariant_MirroredRemovalRulesStayInSync(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name            string
+		passkeyScenario authenticatorInventory
+		walletScenario  authenticatorInventory
+		wantReject      bool
+	}{
+		{
+			name:            "last_authenticator_rejected_in_both_paths",
+			passkeyScenario: authenticatorInventory{passkeys: 1, wallets: 0},
+			walletScenario:  authenticatorInventory{passkeys: 0, wallets: 1},
+			wantReject:      true,
+		},
+		{
+			name:            "alternate_authenticator_present_allows_both_paths",
+			passkeyScenario: authenticatorInventory{passkeys: 1, wallets: 1},
+			walletScenario:  authenticatorInventory{passkeys: 1, wallets: 1},
+			wantReject:      false,
+		},
+		{
+			name:            "same_type_spare_allows_both_paths",
+			passkeyScenario: authenticatorInventory{passkeys: 2, wallets: 0},
+			walletScenario:  authenticatorInventory{passkeys: 0, wallets: 2},
+			wantReject:      false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			deleteErr := deletePasskeyForInventory(tc.passkeyScenario)
+			unlinkErr := unlinkWalletForInventory(tc.walletScenario)
+
+			require.Equal(t, tc.wantReject, errors.Is(deleteErr, ErrLastAuthMethodDelete))
+			require.Equal(t, tc.wantReject, errors.Is(unlinkErr, ErrLastAuthMethodDelete))
+		})
+	}
+}
+
+func deletePasskeyForInventory(inv authenticatorInventory) error {
+	repo := newInMemoryWebAuthnRepo()
+	for i := 0; i < inv.passkeys; i++ {
+		id := fmt.Sprintf("cred-%d", i)
+		cred := &storage.WebAuthnCredential{ID: id, UserID: "alice", PublicKey: []byte(id)}
+		repo.credentialsByUsername["alice"] = append(repo.credentialsByUsername["alice"], cred)
+		repo.credentialsByID[id] = cred
+	}
+	for i := 0; i < inv.wallets; i++ {
+		repo.walletsByUsername["alice"] = append(repo.walletsByUsername["alice"], &storage.WalletCredential{
+			Username: "alice",
+			Address:  fmt.Sprintf("0xwallet%d", i),
+			Type:     "ethereum",
+			ChainID:  1,
+		})
+	}
+
+	svc := &WebAuthnService{repo: repo}
+	if len(repo.credentialsByUsername["alice"]) == 0 {
+		return nil
+	}
+	return svc.DeleteCredential(context.Background(), "alice", repo.credentialsByUsername["alice"][0].ID)
+}
+
+func unlinkWalletForInventory(inv authenticatorInventory) error {
+	repo := newInMemoryWalletRepo()
+	for i := 0; i < inv.passkeys; i++ {
+		id := fmt.Sprintf("cred-%d", i)
+		repo.passkeysByUser["alice"] = append(repo.passkeysByUser["alice"], &storage.WebAuthnCredential{
+			ID:        id,
+			UserID:    "alice",
+			PublicKey: []byte(id),
+		})
+	}
+	for i := 0; i < inv.wallets; i++ {
+		address := fmt.Sprintf("0xwallet%d", i)
+		wallet := &storage.WalletCredential{Username: "alice", Address: address, Type: "ethereum", ChainID: 1}
+		repo.walletsByAddr[address] = wallet
+		repo.walletsByUserAddr[walletKey("alice", address)] = wallet
+	}
+
+	svc := &WalletService{repo: repo, logger: zap.NewNop()}
+	if len(repo.walletsByAddr) == 0 {
+		return nil
+	}
+	return svc.UnlinkWallet(context.Background(), "alice", "0xwallet0")
+}

--- a/pkg/auth/authenticator_removal_classifier_test.go
+++ b/pkg/auth/authenticator_removal_classifier_test.go
@@ -12,124 +12,284 @@ import (
 	"go.uber.org/zap"
 )
 
-func TestWebAuthnService_DeleteCredential_ClassifiesTransactionConflictAsInvariantRejection(t *testing.T) {
+func TestWebAuthnService_DeleteCredential_ClassifiesGuardedRemovalFailuresFromPostState(t *testing.T) {
+	t.Parallel()
+
+	for _, txFailure := range []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "condition_failed",
+			err:  guardedRemovalTransactionError(dynamormerrors.ErrConditionFailed, "delete", 0, "ConditionalCheckFailed"),
+		},
+		{
+			name: "transaction_failed",
+			err:  guardedRemovalTransactionError(dynamormerrors.ErrTransactionFailed, "delete", 0, "TransactionConflict"),
+		},
+	} {
+		txFailure := txFailure
+		t.Run(txFailure.name, func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("target already removed returns credential not found", func(t *testing.T) {
+				t.Parallel()
+
+				repo := newInMemoryWebAuthnRepo()
+				target := &storage.WebAuthnCredential{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk1")}
+				survivor := &storage.WebAuthnCredential{ID: "cred-2", UserID: "alice", PublicKey: []byte("pk2")}
+				repo.credentialsByUsername["alice"] = []*storage.WebAuthnCredential{target, survivor}
+				repo.credentialsByID[target.ID] = target
+				repo.credentialsByID[survivor.ID] = survivor
+				repo.walletsByUsername["alice"] = []*storage.WalletCredential{
+					{Username: "alice", Address: "0xabc", Type: "ethereum"},
+				}
+				repo.deleteConditionedFunc = func(context.Context, string, string, string, string) error {
+					require.NoError(t, repo.DeleteWebAuthnCredential(context.Background(), target.ID))
+					return txFailure.err
+				}
+
+				svc := &WebAuthnService{repo: repo}
+				err := svc.DeleteCredential(context.Background(), "alice", target.ID)
+				require.ErrorIs(t, err, ErrCredentialNotFound)
+				require.NotErrorIs(t, err, ErrLastAuthMethodDelete)
+			})
+
+			t.Run("target still present and no survivor returns invariant rejection", func(t *testing.T) {
+				t.Parallel()
+
+				repo := newInMemoryWebAuthnRepo()
+				target := &storage.WebAuthnCredential{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk")}
+				survivorWallet := &storage.WalletCredential{Username: "alice", Address: "0xabc", Type: "ethereum"}
+				repo.credentialsByUsername["alice"] = []*storage.WebAuthnCredential{target}
+				repo.credentialsByID[target.ID] = target
+				repo.walletsByUsername["alice"] = []*storage.WalletCredential{survivorWallet}
+				repo.deleteConditionedFunc = func(context.Context, string, string, string, string) error {
+					repo.walletsByUsername["alice"] = []*storage.WalletCredential{}
+					return txFailure.err
+				}
+
+				svc := &WebAuthnService{repo: repo}
+				err := svc.DeleteCredential(context.Background(), "alice", target.ID)
+				require.ErrorIs(t, err, ErrLastAuthMethodDelete)
+				require.NotErrorIs(t, err, ErrCredentialNotFound)
+			})
+
+			t.Run("target still present and survivor remains returns original failure", func(t *testing.T) {
+				t.Parallel()
+
+				repo := newInMemoryWebAuthnRepo()
+				target := &storage.WebAuthnCredential{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk1")}
+				survivor := &storage.WebAuthnCredential{ID: "cred-2", UserID: "alice", PublicKey: []byte("pk2")}
+				repo.credentialsByUsername["alice"] = []*storage.WebAuthnCredential{target, survivor}
+				repo.credentialsByID[target.ID] = target
+				repo.credentialsByID[survivor.ID] = survivor
+				repo.deleteConditionedFunc = func(context.Context, string, string, string, string) error {
+					return txFailure.err
+				}
+
+				svc := &WebAuthnService{repo: repo}
+				err := svc.DeleteCredential(context.Background(), "alice", target.ID)
+				require.ErrorIs(t, err, txFailure.err)
+				require.NotErrorIs(t, err, ErrCredentialNotFound)
+				require.NotErrorIs(t, err, ErrLastAuthMethodDelete)
+			})
+		})
+	}
+}
+
+func TestWalletService_UnlinkWallet_ClassifiesGuardedRemovalFailuresFromPostState(t *testing.T) {
+	t.Parallel()
+
+	for _, txFailure := range []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "condition_failed",
+			err:  guardedRemovalTransactionError(dynamormerrors.ErrConditionFailed, "delete", 0, "ConditionalCheckFailed"),
+		},
+		{
+			name: "transaction_failed",
+			err:  guardedRemovalTransactionError(dynamormerrors.ErrTransactionFailed, "delete", 0, "TransactionConflict"),
+		},
+	} {
+		txFailure := txFailure
+		t.Run(txFailure.name, func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("target already removed returns not found", func(t *testing.T) {
+				t.Parallel()
+
+				repo := newInMemoryWalletRepo()
+				repo.passkeysByUser["alice"] = []*storage.WebAuthnCredential{
+					{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk")},
+				}
+				repo.walletsByAddr["0xabc"] = &storage.WalletCredential{Username: "alice", Address: "0xabc", Type: "ethereum", ChainID: 1}
+				repo.walletsByUserAddr[walletKey("alice", "0xabc")] = repo.walletsByAddr["0xabc"]
+				repo.deleteConditioned = func(context.Context, string, string, string, string, string) error {
+					require.NoError(t, repo.DeleteWalletCredential(context.Background(), "alice", "0xabc"))
+					return txFailure.err
+				}
+
+				svc := &WalletService{repo: repo, logger: zap.NewNop()}
+				err := svc.UnlinkWallet(context.Background(), "alice", "0xabc")
+				require.True(t, isAuthenticatorRemovalTargetNotFound(err))
+				require.NotErrorIs(t, err, ErrLastAuthMethodDelete)
+			})
+
+			t.Run("target still present and no survivor returns invariant rejection", func(t *testing.T) {
+				t.Parallel()
+
+				repo := newInMemoryWalletRepo()
+				repo.passkeysByUser["alice"] = []*storage.WebAuthnCredential{
+					{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk")},
+				}
+				repo.walletsByAddr["0xabc"] = &storage.WalletCredential{Username: "alice", Address: "0xabc", Type: "ethereum", ChainID: 1}
+				repo.walletsByUserAddr[walletKey("alice", "0xabc")] = repo.walletsByAddr["0xabc"]
+				repo.deleteConditioned = func(context.Context, string, string, string, string, string) error {
+					repo.passkeysByUser["alice"] = nil
+					return txFailure.err
+				}
+
+				svc := &WalletService{repo: repo, logger: zap.NewNop()}
+				err := svc.UnlinkWallet(context.Background(), "alice", "0xabc")
+				require.ErrorIs(t, err, ErrLastAuthMethodDelete)
+			})
+
+			t.Run("target still present and survivor remains returns delete failure", func(t *testing.T) {
+				t.Parallel()
+
+				repo := newInMemoryWalletRepo()
+				repo.passkeysByUser["alice"] = []*storage.WebAuthnCredential{
+					{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk")},
+				}
+				repo.walletsByAddr["0xabc"] = &storage.WalletCredential{Username: "alice", Address: "0xabc", Type: "ethereum", ChainID: 1}
+				repo.walletsByUserAddr[walletKey("alice", "0xabc")] = repo.walletsByAddr["0xabc"]
+				repo.deleteConditioned = func(context.Context, string, string, string, string, string) error {
+					return txFailure.err
+				}
+
+				svc := &WalletService{repo: repo, logger: zap.NewNop()}
+				err := svc.UnlinkWallet(context.Background(), "alice", "0xabc")
+				require.ErrorIs(t, err, ErrWalletDeletion)
+				require.ErrorIs(t, err, txFailure.err)
+				require.NotErrorIs(t, err, ErrLastAuthMethodDelete)
+				require.False(t, isAuthenticatorRemovalTargetNotFound(err))
+			})
+		})
+	}
+}
+
+func TestWebAuthnService_DeleteCredential_RereadFailureReturns500(t *testing.T) {
 	t.Parallel()
 
 	repo := newInMemoryWebAuthnRepo()
 	target := &storage.WebAuthnCredential{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk")}
 	repo.credentialsByUsername["alice"] = []*storage.WebAuthnCredential{target}
 	repo.credentialsByID[target.ID] = target
-	repo.walletsByUsername["alice"] = []*storage.WalletCredential{
-		{Username: "alice", Address: "0xabc", Type: "ethereum"},
-	}
 	repo.deleteConditionedFunc = func(context.Context, string, string, string, string) error {
-		return guardedRemovalTransactionError(dynamormerrors.ErrTransactionConflict, "delete", 0, "TransactionConflict")
+		return guardedRemovalTransactionError(dynamormerrors.ErrTransactionFailed, "delete", 0, "TransactionConflict")
 	}
 
-	svc := &WebAuthnService{repo: repo}
+	lookupErr := errors.New("lookup failed")
+	svc := &WebAuthnService{
+		repo: &webAuthnRepoGetCredentialErr{
+			inMemoryWebAuthnRepo: repo,
+			err:                  lookupErr,
+		},
+	}
 	err := svc.DeleteCredential(context.Background(), "alice", target.ID)
-	require.ErrorIs(t, err, ErrLastAuthMethodDelete)
+	require.ErrorIs(t, err, lookupErr)
 }
 
-func TestWalletService_UnlinkWallet_ClassifiesTransactionConflictAsInvariantRejection(t *testing.T) {
-	t.Parallel()
-
-	repo := newInMemoryWalletRepo()
-	repo.passkeysByUser["alice"] = []*storage.WebAuthnCredential{
-		{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk")},
-	}
-	repo.walletsByAddr["0xabc"] = &storage.WalletCredential{Username: "alice", Address: "0xabc", Type: "ethereum", ChainID: 1}
-	repo.walletsByUserAddr[walletKey("alice", "0xabc")] = repo.walletsByAddr["0xabc"]
-	repo.deleteConditioned = func(context.Context, string, string, string, string, string) error {
-		return guardedRemovalTransactionError(dynamormerrors.ErrTransactionConflict, "delete", 0, "TransactionConflict")
-	}
-
-	svc := &WalletService{repo: repo, logger: zap.NewNop()}
-	err := svc.UnlinkWallet(context.Background(), "alice", "0xabc")
-	require.ErrorIs(t, err, ErrLastAuthMethodDelete)
-}
-
-func TestWebAuthnService_DeleteCredential_ClassifiesConditionFailuresByRereadingTarget(t *testing.T) {
-	t.Parallel()
-
-	t.Run("target already removed returns credential not found", func(t *testing.T) {
-		t.Parallel()
-
-		repo := newInMemoryWebAuthnRepo()
-		target := &storage.WebAuthnCredential{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk1")}
-		survivor := &storage.WebAuthnCredential{ID: "cred-2", UserID: "alice", PublicKey: []byte("pk2")}
-		repo.credentialsByUsername["alice"] = []*storage.WebAuthnCredential{target, survivor}
-		repo.credentialsByID[target.ID] = target
-		repo.credentialsByID[survivor.ID] = survivor
-		repo.walletsByUsername["alice"] = []*storage.WalletCredential{
-			{Username: "alice", Address: "0xabc", Type: "ethereum"},
-		}
-		repo.deleteConditionedFunc = func(context.Context, string, string, string, string) error {
-			require.NoError(t, repo.DeleteWebAuthnCredential(context.Background(), target.ID))
-			return guardedRemovalTransactionError(dynamormerrors.ErrConditionFailed, "delete", 0, "ConditionalCheckFailed")
-		}
-
-		svc := &WebAuthnService{repo: repo}
-		err := svc.DeleteCredential(context.Background(), "alice", target.ID)
-		require.ErrorIs(t, err, ErrCredentialNotFound)
-		require.NotErrorIs(t, err, ErrLastAuthMethodDelete)
-	})
-
-	t.Run("target still present keeps invariant rejection", func(t *testing.T) {
-		t.Parallel()
-
-		repo := newInMemoryWebAuthnRepo()
-		target := &storage.WebAuthnCredential{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk")}
-		repo.credentialsByUsername["alice"] = []*storage.WebAuthnCredential{target}
-		repo.credentialsByID[target.ID] = target
-		repo.walletsByUsername["alice"] = []*storage.WalletCredential{
-			{Username: "alice", Address: "0xabc", Type: "ethereum"},
-		}
-		repo.deleteConditionedFunc = func(context.Context, string, string, string, string) error {
-			return guardedRemovalTransactionError(dynamormerrors.ErrConditionFailed, "condition_check", 1, "ConditionalCheckFailed")
-		}
-
-		svc := &WebAuthnService{repo: repo}
-		err := svc.DeleteCredential(context.Background(), "alice", target.ID)
-		require.ErrorIs(t, err, ErrLastAuthMethodDelete)
-		require.NotErrorIs(t, err, ErrCredentialNotFound)
-	})
-}
-
-func TestClassifyGuardedAuthenticatorRemovalFailure(t *testing.T) {
-	t.Parallel()
-
-	require.NoError(t, classifyGuardedAuthenticatorRemovalFailure(nil))
-
-	plainErr := errors.New("boom")
-	require.Same(t, plainErr, classifyGuardedAuthenticatorRemovalFailure(plainErr))
-}
-
-func TestClassifyGuardedWebAuthnRemovalFailure_Passthroughs(t *testing.T) {
+func TestClassifyGuardedWebAuthnRemovalFailure_DirectBranches(t *testing.T) {
 	t.Parallel()
 
 	repo := newInMemoryWebAuthnRepo()
 	require.NoError(t, classifyGuardedWebAuthnRemovalFailure(context.Background(), repo, "alice", "cred-1", nil))
 
-	plainErr := errors.New("boom")
-	require.Same(t, plainErr, classifyGuardedWebAuthnRemovalFailure(context.Background(), repo, "alice", "cred-1", plainErr))
-
-	lookupErr := errors.New("lookup failed")
-	repo.deleteConditionedFunc = nil
-	repo.credentialsByID = map[string]*storage.WebAuthnCredential{}
-	require.Same(t, lookupErr, classifyGuardedWebAuthnRemovalFailure(
+	target := &storage.WebAuthnCredential{ID: "cred-1", UserID: "bob", PublicKey: []byte("pk")}
+	repo.credentialsByID[target.ID] = target
+	require.ErrorIs(t, classifyGuardedWebAuthnRemovalFailure(
 		context.Background(),
-		&webAuthnRepoGetCredentialErr{inMemoryWebAuthnRepo: repo, err: lookupErr},
+		repo,
 		"alice",
-		"cred-1",
-		guardedRemovalTransactionError(dynamormerrors.ErrConditionFailed, "condition_check", 1, "ConditionalCheckFailed"),
-	))
+		target.ID,
+		guardedRemovalTransactionError(dynamormerrors.ErrTransactionFailed, "delete", 0, "TransactionConflict"),
+	), ErrCredentialNotFound)
+
+	repo.credentialsByID[target.ID] = &storage.WebAuthnCredential{ID: target.ID, UserID: "alice", PublicKey: []byte("pk")}
+	inventoryErr := errors.New("wallet inventory failed")
+	require.ErrorIs(t, classifyGuardedWebAuthnRemovalFailure(
+		context.Background(),
+		&webAuthnRepoGetWalletErr{inMemoryWebAuthnRepo: repo, err: inventoryErr},
+		"alice",
+		target.ID,
+		guardedRemovalTransactionError(dynamormerrors.ErrTransactionFailed, "delete", 0, "TransactionConflict"),
+	), inventoryErr)
+}
+
+type walletRepoGetCredentialErr struct {
+	*inMemoryWalletRepo
+	err error
+}
+
+func (r *walletRepoGetCredentialErr) GetWalletCredential(_ context.Context, _ string) (*storage.WalletCredential, error) {
+	return nil, r.err
+}
+
+type walletRepoGetPasskeysErr struct {
+	*inMemoryWalletRepo
+	err error
+}
+
+func (r *walletRepoGetPasskeysErr) GetUserWebAuthnCredentials(_ context.Context, _ string) ([]*storage.WebAuthnCredential, error) {
+	return nil, r.err
+}
+
+func TestClassifyGuardedWalletRemovalFailure_DirectBranches(t *testing.T) {
+	t.Parallel()
+
+	repo := newInMemoryWalletRepo()
+	require.NoError(t, classifyGuardedWalletRemovalFailure(context.Background(), repo, "alice", "0xabc", nil))
+
+	lookupErr := errors.New("wallet lookup failed")
+	require.ErrorIs(t, classifyGuardedWalletRemovalFailure(
+		context.Background(),
+		&walletRepoGetCredentialErr{inMemoryWalletRepo: repo, err: lookupErr},
+		"alice",
+		"0xabc",
+		guardedRemovalTransactionError(dynamormerrors.ErrTransactionFailed, "delete", 0, "TransactionConflict"),
+	), lookupErr)
+
+	repo.walletsByAddr["0xabc"] = &storage.WalletCredential{Username: "bob", Address: "0xabc", Type: "ethereum", ChainID: 1}
+	repo.walletsByUserAddr[walletKey("bob", "0xabc")] = repo.walletsByAddr["0xabc"]
+	require.True(t, isAuthenticatorRemovalTargetNotFound(classifyGuardedWalletRemovalFailure(
+		context.Background(),
+		repo,
+		"alice",
+		"0xabc",
+		guardedRemovalTransactionError(dynamormerrors.ErrTransactionFailed, "delete", 0, "TransactionConflict"),
+	)))
+
+	repo.walletsByAddr["0xabc"] = &storage.WalletCredential{Username: "alice", Address: "0xabc", Type: "ethereum", ChainID: 1}
+	repo.walletsByUserAddr[walletKey("alice", "0xabc")] = repo.walletsByAddr["0xabc"]
+	passkeyErr := errors.New("passkey inventory failed")
+	require.ErrorIs(t, classifyGuardedWalletRemovalFailure(
+		context.Background(),
+		&walletRepoGetPasskeysErr{inMemoryWalletRepo: repo, err: passkeyErr},
+		"alice",
+		"0xabc",
+		guardedRemovalTransactionError(dynamormerrors.ErrTransactionFailed, "delete", 0, "TransactionConflict"),
+	), passkeyErr)
 }
 
 func TestIsAuthenticatorRemovalTargetNotFound(t *testing.T) {
 	t.Parallel()
 
 	require.True(t, isAuthenticatorRemovalTargetNotFound(lessererrors.ItemNotFoundWithID("credential", "cred-1")))
+	require.True(t, isAuthenticatorRemovalTargetNotFound(lessererrors.CredentialNotFound()))
 	require.True(t, isAuthenticatorRemovalTargetNotFound(dynamormerrors.ErrItemNotFound))
 	require.False(t, isAuthenticatorRemovalTargetNotFound(errors.New("boom")))
 }

--- a/pkg/auth/authenticator_removal_classifier_test.go
+++ b/pkg/auth/authenticator_removal_classifier_test.go
@@ -2,8 +2,10 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	lessererrors "github.com/equaltoai/lesser/pkg/errors"
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/stretchr/testify/require"
 	dynamormerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
@@ -92,6 +94,44 @@ func TestWebAuthnService_DeleteCredential_ClassifiesConditionFailuresByRereading
 		require.ErrorIs(t, err, ErrLastAuthMethodDelete)
 		require.NotErrorIs(t, err, ErrCredentialNotFound)
 	})
+}
+
+func TestClassifyGuardedAuthenticatorRemovalFailure(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, classifyGuardedAuthenticatorRemovalFailure(nil))
+
+	plainErr := errors.New("boom")
+	require.Same(t, plainErr, classifyGuardedAuthenticatorRemovalFailure(plainErr))
+}
+
+func TestClassifyGuardedWebAuthnRemovalFailure_Passthroughs(t *testing.T) {
+	t.Parallel()
+
+	repo := newInMemoryWebAuthnRepo()
+	require.NoError(t, classifyGuardedWebAuthnRemovalFailure(context.Background(), repo, "alice", "cred-1", nil))
+
+	plainErr := errors.New("boom")
+	require.Same(t, plainErr, classifyGuardedWebAuthnRemovalFailure(context.Background(), repo, "alice", "cred-1", plainErr))
+
+	lookupErr := errors.New("lookup failed")
+	repo.deleteConditionedFunc = nil
+	repo.credentialsByID = map[string]*storage.WebAuthnCredential{}
+	require.Same(t, lookupErr, classifyGuardedWebAuthnRemovalFailure(
+		context.Background(),
+		&webAuthnRepoGetCredentialErr{inMemoryWebAuthnRepo: repo, err: lookupErr},
+		"alice",
+		"cred-1",
+		guardedRemovalTransactionError(dynamormerrors.ErrConditionFailed, "condition_check", 1, "ConditionalCheckFailed"),
+	))
+}
+
+func TestIsAuthenticatorRemovalTargetNotFound(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, isAuthenticatorRemovalTargetNotFound(lessererrors.ItemNotFoundWithID("credential", "cred-1")))
+	require.True(t, isAuthenticatorRemovalTargetNotFound(dynamormerrors.ErrItemNotFound))
+	require.False(t, isAuthenticatorRemovalTargetNotFound(errors.New("boom")))
 }
 
 func guardedRemovalTransactionError(err error, operation string, operationIndex int, reason string) error {

--- a/pkg/auth/authenticator_removal_classifier_test.go
+++ b/pkg/auth/authenticator_removal_classifier_test.go
@@ -1,0 +1,104 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/stretchr/testify/require"
+	dynamormerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
+	"go.uber.org/zap"
+)
+
+func TestWebAuthnService_DeleteCredential_ClassifiesTransactionConflictAsInvariantRejection(t *testing.T) {
+	t.Parallel()
+
+	repo := newInMemoryWebAuthnRepo()
+	target := &storage.WebAuthnCredential{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk")}
+	repo.credentialsByUsername["alice"] = []*storage.WebAuthnCredential{target}
+	repo.credentialsByID[target.ID] = target
+	repo.walletsByUsername["alice"] = []*storage.WalletCredential{
+		{Username: "alice", Address: "0xabc", Type: "ethereum"},
+	}
+	repo.deleteConditionedFunc = func(context.Context, string, string, string, string) error {
+		return guardedRemovalTransactionError(dynamormerrors.ErrTransactionConflict, "delete", 0, "TransactionConflict")
+	}
+
+	svc := &WebAuthnService{repo: repo}
+	err := svc.DeleteCredential(context.Background(), "alice", target.ID)
+	require.ErrorIs(t, err, ErrLastAuthMethodDelete)
+}
+
+func TestWalletService_UnlinkWallet_ClassifiesTransactionConflictAsInvariantRejection(t *testing.T) {
+	t.Parallel()
+
+	repo := newInMemoryWalletRepo()
+	repo.passkeysByUser["alice"] = []*storage.WebAuthnCredential{
+		{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk")},
+	}
+	repo.walletsByAddr["0xabc"] = &storage.WalletCredential{Username: "alice", Address: "0xabc", Type: "ethereum", ChainID: 1}
+	repo.walletsByUserAddr[walletKey("alice", "0xabc")] = repo.walletsByAddr["0xabc"]
+	repo.deleteConditioned = func(context.Context, string, string, string, string, string) error {
+		return guardedRemovalTransactionError(dynamormerrors.ErrTransactionConflict, "delete", 0, "TransactionConflict")
+	}
+
+	svc := &WalletService{repo: repo, logger: zap.NewNop()}
+	err := svc.UnlinkWallet(context.Background(), "alice", "0xabc")
+	require.ErrorIs(t, err, ErrLastAuthMethodDelete)
+}
+
+func TestWebAuthnService_DeleteCredential_ClassifiesConditionFailuresByRereadingTarget(t *testing.T) {
+	t.Parallel()
+
+	t.Run("target already removed returns credential not found", func(t *testing.T) {
+		t.Parallel()
+
+		repo := newInMemoryWebAuthnRepo()
+		target := &storage.WebAuthnCredential{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk1")}
+		survivor := &storage.WebAuthnCredential{ID: "cred-2", UserID: "alice", PublicKey: []byte("pk2")}
+		repo.credentialsByUsername["alice"] = []*storage.WebAuthnCredential{target, survivor}
+		repo.credentialsByID[target.ID] = target
+		repo.credentialsByID[survivor.ID] = survivor
+		repo.walletsByUsername["alice"] = []*storage.WalletCredential{
+			{Username: "alice", Address: "0xabc", Type: "ethereum"},
+		}
+		repo.deleteConditionedFunc = func(context.Context, string, string, string, string) error {
+			require.NoError(t, repo.DeleteWebAuthnCredential(context.Background(), target.ID))
+			return guardedRemovalTransactionError(dynamormerrors.ErrConditionFailed, "delete", 0, "ConditionalCheckFailed")
+		}
+
+		svc := &WebAuthnService{repo: repo}
+		err := svc.DeleteCredential(context.Background(), "alice", target.ID)
+		require.ErrorIs(t, err, ErrCredentialNotFound)
+		require.NotErrorIs(t, err, ErrLastAuthMethodDelete)
+	})
+
+	t.Run("target still present keeps invariant rejection", func(t *testing.T) {
+		t.Parallel()
+
+		repo := newInMemoryWebAuthnRepo()
+		target := &storage.WebAuthnCredential{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk")}
+		repo.credentialsByUsername["alice"] = []*storage.WebAuthnCredential{target}
+		repo.credentialsByID[target.ID] = target
+		repo.walletsByUsername["alice"] = []*storage.WalletCredential{
+			{Username: "alice", Address: "0xabc", Type: "ethereum"},
+		}
+		repo.deleteConditionedFunc = func(context.Context, string, string, string, string) error {
+			return guardedRemovalTransactionError(dynamormerrors.ErrConditionFailed, "condition_check", 1, "ConditionalCheckFailed")
+		}
+
+		svc := &WebAuthnService{repo: repo}
+		err := svc.DeleteCredential(context.Background(), "alice", target.ID)
+		require.ErrorIs(t, err, ErrLastAuthMethodDelete)
+		require.NotErrorIs(t, err, ErrCredentialNotFound)
+	})
+}
+
+func guardedRemovalTransactionError(err error, operation string, operationIndex int, reason string) error {
+	return &dynamormerrors.TransactionError{
+		Err:            err,
+		Operation:      operation,
+		OperationIndex: operationIndex,
+		Reason:         reason,
+	}
+}

--- a/pkg/auth/service_additional_test.go
+++ b/pkg/auth/service_additional_test.go
@@ -184,6 +184,9 @@ func TestAuthService_WalletFlows(t *testing.T) {
 	wallets, err := as.GetUserWallets(context.Background(), "alice")
 	require.NoError(t, err)
 	require.Len(t, wallets, 1)
+	walletRepo.passkeysByUser["alice"] = []*storage.WebAuthnCredential{
+		{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk")},
+	}
 	require.NoError(t, as.UnlinkWallet(context.Background(), "alice", address))
 
 	// Challenge helpers.

--- a/pkg/auth/wallet.go
+++ b/pkg/auth/wallet.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/google/uuid"
 	"github.com/spruceid/siwe-go"
+	dynamormerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -72,6 +73,7 @@ type walletRepository interface {
 	GetUserWalletCredentials(ctx context.Context, username string) ([]*storage.WalletCredential, error)
 	StoreWalletCredential(ctx context.Context, credential *storage.WalletCredential) error
 	DeleteWalletCredential(ctx context.Context, username, address string) error
+	DeleteWalletCredentialConditionedOnSurvivor(ctx context.Context, username, address, walletType string, survivingPasskeyID string, survivingWalletAddress string) error
 }
 
 // NewWalletService creates a new wallet service
@@ -298,12 +300,36 @@ func (s *WalletService) UnlinkWallet(ctx context.Context, username, address stri
 	// Normalize address
 	address = strings.ToLower(address)
 
-	if err := ensureAuthenticatorRemovalAllowed(ctx, s.repo, username, authenticatorRemovalWallet); err != nil {
+	plan, err := planAuthenticatorRemoval(ctx, s.repo, username, authenticatorRemovalWallet, "", address)
+	if err != nil {
 		return err
 	}
 
+	wallets, err := s.repo.GetUserWalletCredentials(ctx, username)
+	if err != nil {
+		s.logger.Error("failed to get user wallet credentials", zap.Error(err), zap.String("username", username))
+		return errors.Join(ErrWalletRetrieval, err)
+	}
+	walletType := ""
+	for _, wallet := range wallets {
+		if wallet != nil && strings.EqualFold(wallet.Address, address) {
+			walletType = wallet.Type
+			break
+		}
+	}
+
 	// Delete wallet credential
-	if err := s.repo.DeleteWalletCredential(ctx, username, address); err != nil {
+	if err := s.repo.DeleteWalletCredentialConditionedOnSurvivor(
+		ctx,
+		username,
+		address,
+		walletType,
+		plan.survivingPasskeyID,
+		plan.survivingWalletAddress,
+	); err != nil {
+		if dynamormerrors.IsConditionFailed(err) {
+			return ErrLastAuthMethodDelete
+		}
 		s.logger.Error("failed to delete wallet credential", zap.Error(err), zap.String("username", username), zap.String("address", address))
 		return errors.Join(ErrWalletDeletion, err)
 	}

--- a/pkg/auth/wallet.go
+++ b/pkg/auth/wallet.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/google/uuid"
 	"github.com/spruceid/siwe-go"
-	dynamormerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -327,11 +326,13 @@ func (s *WalletService) UnlinkWallet(ctx context.Context, username, address stri
 		plan.survivingPasskeyID,
 		plan.survivingWalletAddress,
 	); err != nil {
-		if dynamormerrors.IsConditionFailed(err) {
-			return ErrLastAuthMethodDelete
+		if classifiedErr := classifyGuardedAuthenticatorRemovalFailure(err); classifiedErr != nil {
+			if errors.Is(classifiedErr, ErrLastAuthMethodDelete) {
+				return classifiedErr
+			}
+			s.logger.Error("failed to delete wallet credential", zap.Error(classifiedErr), zap.String("username", username), zap.String("address", address))
+			return errors.Join(ErrWalletDeletion, classifiedErr)
 		}
-		s.logger.Error("failed to delete wallet credential", zap.Error(err), zap.String("username", username), zap.String("address", address))
-		return errors.Join(ErrWalletDeletion, err)
 	}
 	if s.auditLogger != nil {
 		s.auditLogger.LogAuthEvent(ctx, username, "", "", AuditWalletDisconnected, map[string]interface{}{

--- a/pkg/auth/wallet.go
+++ b/pkg/auth/wallet.go
@@ -326,8 +326,8 @@ func (s *WalletService) UnlinkWallet(ctx context.Context, username, address stri
 		plan.survivingPasskeyID,
 		plan.survivingWalletAddress,
 	); err != nil {
-		if classifiedErr := classifyGuardedAuthenticatorRemovalFailure(err); classifiedErr != nil {
-			if errors.Is(classifiedErr, ErrLastAuthMethodDelete) {
+		if classifiedErr := classifyGuardedWalletRemovalFailure(ctx, s.repo, username, address, err); classifiedErr != nil {
+			if errors.Is(classifiedErr, ErrLastAuthMethodDelete) || isAuthenticatorRemovalTargetNotFound(classifiedErr) {
 				return classifiedErr
 			}
 			s.logger.Error("failed to delete wallet credential", zap.Error(classifiedErr), zap.String("username", username), zap.String("address", address))

--- a/pkg/auth/wallet.go
+++ b/pkg/auth/wallet.go
@@ -65,6 +65,7 @@ type walletRepository interface {
 	DeleteWalletChallenge(ctx context.Context, challengeID string) error
 	MarkWalletChallengeUsed(ctx context.Context, challengeID string) error
 
+	GetUserWebAuthnCredentials(ctx context.Context, username string) ([]*storage.WebAuthnCredential, error)
 	GetWalletCredential(ctx context.Context, address string) (*storage.WalletCredential, error)
 	UpdateWalletLastUsed(ctx context.Context, username, address string) error
 	GetUserWalletCredentials(ctx context.Context, username string) ([]*storage.WalletCredential, error)
@@ -289,6 +290,10 @@ func (s *WalletService) GetUserWallets(ctx context.Context, username string) ([]
 func (s *WalletService) UnlinkWallet(ctx context.Context, username, address string) error {
 	// Normalize address
 	address = strings.ToLower(address)
+
+	if err := ensureAuthenticatorRemovalAllowed(ctx, s.repo, username, authenticatorRemovalWallet); err != nil {
+		return err
+	}
 
 	// Delete wallet credential
 	if err := s.repo.DeleteWalletCredential(ctx, username, address); err != nil {

--- a/pkg/auth/wallet.go
+++ b/pkg/auth/wallet.go
@@ -55,8 +55,9 @@ type WalletVerifyRequest struct {
 
 // WalletService handles wallet authentication
 type WalletService struct {
-	repo   walletRepository
-	logger *zap.Logger
+	repo        walletRepository
+	logger      *zap.Logger
+	auditLogger *AuditLogger
 }
 
 type walletRepository interface {
@@ -79,8 +80,9 @@ func NewWalletService(repos StorageProvider) *WalletService {
 		return &WalletService{logger: common.Logger()}
 	}
 	return &WalletService{
-		repo:   repos.Account(),
-		logger: common.Logger(),
+		repo:        repos.Account(),
+		logger:      common.Logger(),
+		auditLogger: NewAuditLogger(repos, common.Logger(), DefaultAuditConfig()),
 	}
 }
 
@@ -125,14 +127,15 @@ func (s *WalletService) CreateChallenge(ctx context.Context, address string, cha
 
 	// Store challenge in DynamoDB
 	if err := s.repo.StoreWalletChallenge(ctx, challenge); err != nil {
-		s.logger.Error("failed to store wallet challenge", zap.Error(err), zap.String("challengeId", challenge.ID))
+		s.logger.Error("failed to store wallet challenge", append([]zap.Field{zap.Error(err)}, challengeLogFields(challenge.ID)...)...)
 		return nil, errors.Join(ErrChallengeStorage, err)
 	}
 
-	s.logger.Info("created wallet challenge",
-		zap.String("challengeId", challenge.ID),
+	fields := append(challengeLogFields(challenge.ID),
 		zap.String("address", address),
-		zap.Int("chainId", chainID))
+		zap.Int("chainId", chainID),
+	)
+	s.logger.Info("created wallet challenge", fields...)
 
 	return challenge, nil
 }
@@ -142,7 +145,7 @@ func (s *WalletService) VerifySignature(ctx context.Context, req *WalletVerifyRe
 	// Get challenge from DynamoDB
 	challenge, err := s.repo.GetWalletChallenge(ctx, req.ChallengeID)
 	if err != nil {
-		s.logger.Error("failed to retrieve wallet challenge", zap.Error(err), zap.String("challengeId", req.ChallengeID))
+		s.logger.Error("failed to retrieve wallet challenge", append([]zap.Field{zap.Error(err)}, challengeLogFields(req.ChallengeID)...)...)
 		return "", errors.Join(ErrChallengeRetrieval, err)
 	}
 
@@ -155,9 +158,8 @@ func (s *WalletService) VerifySignature(ctx context.Context, req *WalletVerifyRe
 
 	// Check if challenge is already spent (used twice)
 	if challenge.Spent {
-		s.logger.Warn("challenge already spent",
-			zap.String("challengeId", req.ChallengeID),
-			zap.String("address", req.Address))
+		fields := append(challengeLogFields(req.ChallengeID), zap.String("address", req.Address))
+		s.logger.Warn("challenge already spent", fields...)
 		return "", ErrChallengeExpired
 	}
 
@@ -179,12 +181,10 @@ func (s *WalletService) VerifySignature(ctx context.Context, req *WalletVerifyRe
 	// This prevents replay attacks where someone uses your signature for a different username
 	// The username was embedded in the message and signed by the wallet
 	if challenge.Username != "" {
-		s.logger.Info("challenge has username binding",
-			zap.String("challengeId", req.ChallengeID),
-			zap.String("bound_username", challenge.Username))
+		fields := append(challengeLogFields(req.ChallengeID), zap.String("bound_username", challenge.Username))
+		s.logger.Info("challenge has username binding", fields...)
 	} else {
-		s.logger.Warn("challenge created without username binding - this is a security risk",
-			zap.String("challengeId", req.ChallengeID))
+		s.logger.Warn("challenge created without username binding - this is a security risk", challengeLogFields(req.ChallengeID)...)
 	}
 
 	// Verify Ethereum signature
@@ -262,6 +262,13 @@ func (s *WalletService) LinkWallet(ctx context.Context, username, address string
 		s.logger.Error("failed to store wallet credential", zap.Error(err), zap.String("username", username), zap.String("address", address))
 		return false, errors.Join(ErrWalletStorage, err)
 	}
+	if s.auditLogger != nil {
+		s.auditLogger.LogAuthEvent(ctx, username, "", "", AuditWalletConnected, map[string]interface{}{
+			"authentication_method": "wallet",
+			"credential_event":      "added",
+			"wallet_type":           walletType,
+		}, true, nil)
+	}
 
 	s.logger.Info("linked wallet to account",
 		zap.String("username", username),
@@ -299,6 +306,12 @@ func (s *WalletService) UnlinkWallet(ctx context.Context, username, address stri
 	if err := s.repo.DeleteWalletCredential(ctx, username, address); err != nil {
 		s.logger.Error("failed to delete wallet credential", zap.Error(err), zap.String("username", username), zap.String("address", address))
 		return errors.Join(ErrWalletDeletion, err)
+	}
+	if s.auditLogger != nil {
+		s.auditLogger.LogAuthEvent(ctx, username, "", "", AuditWalletDisconnected, map[string]interface{}{
+			"authentication_method": "wallet",
+			"credential_event":      "removed",
+		}, true, nil)
 	}
 
 	s.logger.Info("unlinked wallet from account",
@@ -367,6 +380,12 @@ func (s *WalletService) verifyEthereumSignature(address, message, signature stri
 	}
 
 	return nil
+}
+
+func challengeLogFields(challengeID string) []zap.Field {
+	return []zap.Field{
+		zap.Bool("challenge_reference_present", strings.TrimSpace(challengeID) != ""),
+	}
 }
 
 func generateNonce() (string, error) {

--- a/pkg/auth/wallet_more_test.go
+++ b/pkg/auth/wallet_more_test.go
@@ -106,6 +106,11 @@ func TestWalletService_LinkAndUnlink_ErrorBranches(t *testing.T) {
 	require.ErrorIs(t, err, ErrWalletCheck)
 
 	repo.errGetUserWallets = nil
+	repo.passkeysByUser["alice"] = []*storage.WebAuthnCredential{
+		{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk")},
+	}
+	repo.walletsByAddr["0xabc"] = &storage.WalletCredential{Username: "alice", Address: "0xabc", Type: "ethereum", ChainID: 1}
+	repo.walletsByUserAddr[walletKey("alice", "0xabc")] = repo.walletsByAddr["0xabc"]
 	repo.errDeleteWallet = errors.New("delete failed")
 	require.ErrorIs(t, svc.UnlinkWallet(context.Background(), "alice", "0xabc"), ErrWalletDeletion)
 }

--- a/pkg/auth/wallet_test.go
+++ b/pkg/auth/wallet_test.go
@@ -19,6 +19,7 @@ type inMemoryWalletRepo struct {
 	challenges        map[string]*storage.WalletChallenge
 	walletsByUserAddr map[string]*storage.WalletCredential
 	walletsByAddr     map[string]*storage.WalletCredential
+	passkeysByUser    map[string][]*storage.WebAuthnCredential
 
 	errGetUserWallets error
 	errStoreWallet    error
@@ -32,6 +33,7 @@ func newInMemoryWalletRepo() *inMemoryWalletRepo {
 		challenges:        make(map[string]*storage.WalletChallenge),
 		walletsByUserAddr: make(map[string]*storage.WalletCredential),
 		walletsByAddr:     make(map[string]*storage.WalletCredential),
+		passkeysByUser:    make(map[string][]*storage.WebAuthnCredential),
 	}
 }
 
@@ -48,6 +50,10 @@ func (r *inMemoryWalletRepo) GetWalletChallenge(_ context.Context, challengeID s
 		return nil, lessererrors.ItemNotFoundWithID("wallet_challenge", challengeID)
 	}
 	return challenge, nil
+}
+
+func (r *inMemoryWalletRepo) GetUserWebAuthnCredentials(_ context.Context, username string) ([]*storage.WebAuthnCredential, error) {
+	return append([]*storage.WebAuthnCredential(nil), r.passkeysByUser[username]...), nil
 }
 
 func (r *inMemoryWalletRepo) DeleteWalletChallenge(_ context.Context, challengeID string) error {
@@ -172,6 +178,9 @@ func TestWalletService_CreateChallenge_VerifySignatureAndLinkFlow(t *testing.T) 
 	require.NoError(t, err)
 	require.Len(t, wallets, 1)
 
+	repo.passkeysByUser["alice"] = []*storage.WebAuthnCredential{
+		{ID: "cred-1", UserID: "alice", PublicKey: []byte("pk")},
+	}
 	require.NoError(t, svc.UnlinkWallet(context.Background(), "alice", address))
 }
 

--- a/pkg/auth/wallet_test.go
+++ b/pkg/auth/wallet_test.go
@@ -21,6 +21,7 @@ type inMemoryWalletRepo struct {
 	walletsByUserAddr map[string]*storage.WalletCredential
 	walletsByAddr     map[string]*storage.WalletCredential
 	passkeysByUser    map[string][]*storage.WebAuthnCredential
+	deleteConditioned func(context.Context, string, string, string, string, string) error
 
 	errGetUserWallets error
 	errStoreWallet    error
@@ -134,6 +135,9 @@ func (r *inMemoryWalletRepo) DeleteWalletCredentialConditionedOnSurvivor(
 	survivingPasskeyID string,
 	survivingWalletAddress string,
 ) error {
+	if r.deleteConditioned != nil {
+		return r.deleteConditioned(context.Background(), username, address, "", survivingPasskeyID, survivingWalletAddress)
+	}
 	if survivingPasskeyID != "" {
 		found := false
 		for _, passkey := range r.passkeysByUser[username] {

--- a/pkg/auth/wallet_test.go
+++ b/pkg/auth/wallet_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
+	dynamormerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -125,6 +126,31 @@ func (r *inMemoryWalletRepo) DeleteWalletCredential(_ context.Context, username,
 	delete(r.walletsByUserAddr, walletKey(username, address))
 	delete(r.walletsByAddr, address)
 	return nil
+}
+
+func (r *inMemoryWalletRepo) DeleteWalletCredentialConditionedOnSurvivor(
+	_ context.Context,
+	username, address, _ string,
+	survivingPasskeyID string,
+	survivingWalletAddress string,
+) error {
+	if survivingPasskeyID != "" {
+		found := false
+		for _, passkey := range r.passkeysByUser[username] {
+			if passkey != nil && passkey.ID == survivingPasskeyID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return dynamormerrors.ErrConditionFailed
+		}
+	} else if survivingWalletAddress != "" {
+		if _, ok := r.walletsByUserAddr[walletKey(username, survivingWalletAddress)]; !ok {
+			return dynamormerrors.ErrConditionFailed
+		}
+	}
+	return r.DeleteWalletCredential(context.Background(), username, address)
 }
 
 func TestWalletService_CreateChallenge_VerifySignatureAndLinkFlow(t *testing.T) {

--- a/pkg/auth/webauthn.go
+++ b/pkg/auth/webauthn.go
@@ -13,7 +13,6 @@ import (
 	accountservice "github.com/equaltoai/lesser/pkg/services/accounts"
 	"github.com/equaltoai/lesser/pkg/storage"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
-	dynamormerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
 
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
@@ -547,10 +546,7 @@ func (s *WebAuthnService) DeleteCredential(ctx context.Context, username string,
 		plan.survivingPasskeyID,
 		plan.survivingWalletAddress,
 	); err != nil {
-		if dynamormerrors.IsConditionFailed(err) {
-			return ErrLastAuthMethodDelete
-		}
-		return err
+		return classifyGuardedWebAuthnRemovalFailure(ctx, s.repo, username, credentialID, err)
 	}
 	if s.auditLogger != nil {
 		s.auditLogger.LogAuthEvent(ctx, username, "", "", AuditWebAuthnCredentialRemoved, map[string]interface{}{

--- a/pkg/auth/webauthn.go
+++ b/pkg/auth/webauthn.go
@@ -524,21 +524,8 @@ func (s *WebAuthnService) DeleteCredential(ctx context.Context, username string,
 		return ErrCredentialNotFound
 	}
 
-	// Make sure user has at least one other auth method
-	credentials, err := s.repo.GetUserWebAuthnCredentials(ctx, username)
-	if err != nil {
+	if err := ensureAuthenticatorRemovalAllowed(ctx, s.repo, username, authenticatorRemovalPasskey); err != nil {
 		return err
-	}
-
-	if len(credentials) <= 1 {
-		// Ensure the user has at least one other auth method (wallet).
-		wallets, err := s.repo.GetUserWalletCredentials(ctx, username)
-		if err != nil {
-			return err
-		}
-		if len(wallets) == 0 {
-			return ErrLastAuthMethodDelete
-		}
 	}
 
 	return s.repo.DeleteWebAuthnCredential(ctx, credentialID)

--- a/pkg/auth/webauthn.go
+++ b/pkg/auth/webauthn.go
@@ -13,6 +13,7 @@ import (
 	accountservice "github.com/equaltoai/lesser/pkg/services/accounts"
 	"github.com/equaltoai/lesser/pkg/storage"
 	storagemodels "github.com/equaltoai/lesser/pkg/storage/models"
+	dynamormerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
 
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
@@ -66,6 +67,7 @@ type webAuthnRepository interface {
 	StoreWebAuthnCredential(ctx context.Context, credential *storage.WebAuthnCredential) error
 	GetWebAuthnCredential(ctx context.Context, credentialID string) (*storage.WebAuthnCredential, error)
 	DeleteWebAuthnCredential(ctx context.Context, credentialID string) error
+	DeleteWebAuthnCredentialConditionedOnSurvivor(ctx context.Context, username string, credentialID string, survivingPasskeyID string, survivingWalletAddress string) error
 	UpdateWebAuthnCredentialName(ctx context.Context, credentialID string, name string) error
 	UpdateWebAuthnAuthenticationState(ctx context.Context, credentialID string, signCount uint32, cloneWarning bool, backupState bool, lastUsedAt time.Time) error
 	StorePasskeyRegistrationProof(ctx context.Context, proof *storagemodels.PasskeyRegistrationProof) error
@@ -533,11 +535,21 @@ func (s *WebAuthnService) DeleteCredential(ctx context.Context, username string,
 		return ErrCredentialNotFound
 	}
 
-	if err := ensureAuthenticatorRemovalAllowed(ctx, s.repo, username, authenticatorRemovalPasskey); err != nil {
+	plan, err := planAuthenticatorRemoval(ctx, s.repo, username, authenticatorRemovalPasskey, credential.ID, "")
+	if err != nil {
 		return err
 	}
 
-	if err := s.repo.DeleteWebAuthnCredential(ctx, credentialID); err != nil {
+	if err := s.repo.DeleteWebAuthnCredentialConditionedOnSurvivor(
+		ctx,
+		username,
+		credentialID,
+		plan.survivingPasskeyID,
+		plan.survivingWalletAddress,
+	); err != nil {
+		if dynamormerrors.IsConditionFailed(err) {
+			return ErrLastAuthMethodDelete
+		}
 		return err
 	}
 	if s.auditLogger != nil {

--- a/pkg/auth/webauthn.go
+++ b/pkg/auth/webauthn.go
@@ -40,9 +40,10 @@ const (
 
 // WebAuthnService handles WebAuthn operations
 type WebAuthnService struct {
-	webAuthn webAuthnEngine
-	repo     webAuthnRepository
-	domain   string
+	webAuthn    webAuthnEngine
+	repo        webAuthnRepository
+	domain      string
+	auditLogger *AuditLogger
 
 	parseCreationResponse  func([]byte) (*protocol.ParsedCredentialCreationData, error)
 	parseAssertionResponse func([]byte) (*protocol.ParsedCredentialAssertionData, error)
@@ -90,9 +91,10 @@ func NewWebAuthnService(repos StorageProvider, domain string, displayName string
 	}
 
 	return &WebAuthnService{
-		webAuthn: webAuthn,
-		repo:     repos.Account(),
-		domain:   domain,
+		webAuthn:    webAuthn,
+		repo:        repos.Account(),
+		domain:      domain,
+		auditLogger: NewAuditLogger(repos, common.Logger(), DefaultAuditConfig()),
 		parseCreationResponse: func(data []byte) (*protocol.ParsedCredentialCreationData, error) {
 			return protocol.ParseCredentialCreationResponseBytes(data)
 		},
@@ -281,6 +283,13 @@ func (s *WebAuthnService) FinishRegistration(ctx context.Context, username strin
 
 	if err := s.repo.StoreWebAuthnCredential(ctx, storedCredential); err != nil {
 		return errors.Join(ErrCredentialStorage, err)
+	}
+	if s.auditLogger != nil {
+		s.auditLogger.LogAuthEvent(ctx, username, "", "", AuditWebAuthnRegistrationCompleted, map[string]interface{}{
+			"authentication_method": "webauthn",
+			"credential_event":      "added",
+			"registration_mode":     "authenticated",
+		}, true, nil)
 	}
 
 	// Delete the used challenge
@@ -528,7 +537,17 @@ func (s *WebAuthnService) DeleteCredential(ctx context.Context, username string,
 		return err
 	}
 
-	return s.repo.DeleteWebAuthnCredential(ctx, credentialID)
+	if err := s.repo.DeleteWebAuthnCredential(ctx, credentialID); err != nil {
+		return err
+	}
+	if s.auditLogger != nil {
+		s.auditLogger.LogAuthEvent(ctx, username, "", "", AuditWebAuthnCredentialRemoved, map[string]interface{}{
+			"authentication_method": "webauthn",
+			"credential_event":      "removed",
+		}, true, nil)
+	}
+
+	return nil
 }
 
 // UpdateCredentialName updates the display name of a credential

--- a/pkg/auth/webauthn_test.go
+++ b/pkg/auth/webauthn_test.go
@@ -23,6 +23,7 @@ type inMemoryWebAuthnRepo struct {
 	challengesByChallenge map[string]*storage.WebAuthnChallenge
 	proofsByID            map[string]*storagemodels.PasskeyRegistrationProof
 	walletsByUsername     map[string][]*storage.WalletCredential
+	deleteConditionedFunc func(context.Context, string, string, string, string) error
 
 	updateCalls int
 	renameCalls int
@@ -111,6 +112,9 @@ func (r *inMemoryWebAuthnRepo) DeleteWebAuthnCredentialConditionedOnSurvivor(
 	survivingPasskeyID string,
 	survivingWalletAddress string,
 ) error {
+	if r.deleteConditionedFunc != nil {
+		return r.deleteConditionedFunc(context.Background(), username, credentialID, survivingPasskeyID, survivingWalletAddress)
+	}
 	if survivingPasskeyID != "" {
 		survivor, ok := r.credentialsByID[survivingPasskeyID]
 		if !ok || survivor.UserID != username {

--- a/pkg/auth/webauthn_test.go
+++ b/pkg/auth/webauthn_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
 	"github.com/stretchr/testify/require"
+	dynamormerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
 )
 
 type inMemoryWebAuthnRepo struct {
@@ -87,8 +88,47 @@ func (r *inMemoryWebAuthnRepo) GetWebAuthnCredential(_ context.Context, credenti
 }
 
 func (r *inMemoryWebAuthnRepo) DeleteWebAuthnCredential(_ context.Context, credentialID string) error {
+	credential, ok := r.credentialsByID[credentialID]
 	delete(r.credentialsByID, credentialID)
+	if ok {
+		credentials := r.credentialsByUsername[credential.UserID]
+		filtered := credentials[:0]
+		for _, existing := range credentials {
+			if existing == nil || existing.ID == credentialID {
+				continue
+			}
+			filtered = append(filtered, existing)
+		}
+		r.credentialsByUsername[credential.UserID] = append([]*storage.WebAuthnCredential(nil), filtered...)
+	}
 	return nil
+}
+
+func (r *inMemoryWebAuthnRepo) DeleteWebAuthnCredentialConditionedOnSurvivor(
+	_ context.Context,
+	username string,
+	credentialID string,
+	survivingPasskeyID string,
+	survivingWalletAddress string,
+) error {
+	if survivingPasskeyID != "" {
+		survivor, ok := r.credentialsByID[survivingPasskeyID]
+		if !ok || survivor.UserID != username {
+			return dynamormerrors.ErrConditionFailed
+		}
+	} else if survivingWalletAddress != "" {
+		found := false
+		for _, wallet := range r.walletsByUsername[username] {
+			if wallet != nil && wallet.Address == survivingWalletAddress {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return dynamormerrors.ErrConditionFailed
+		}
+	}
+	return r.DeleteWebAuthnCredential(context.Background(), credentialID)
 }
 
 func (r *inMemoryWebAuthnRepo) UpdateWebAuthnCredentialName(_ context.Context, credentialID string, name string) error {

--- a/pkg/storage/repositories/account_repository_auth.go
+++ b/pkg/storage/repositories/account_repository_auth.go
@@ -25,6 +25,29 @@ var accountAuthRandRead = rand.Read
 
 const entityPasskeyRegistrationProof = "passkey registration proof"
 
+func passkeyProofLogFields(proofID, username, ceremonyID string) []zap.Field {
+	fields := []zap.Field{
+		zap.Bool("proof_reference_present", strings.TrimSpace(proofID) != ""),
+	}
+	if strings.TrimSpace(username) != "" {
+		fields = append(fields, zap.String("username", username))
+	}
+	if strings.TrimSpace(ceremonyID) != "" {
+		fields = append(fields, zap.Bool("ceremony_reference_present", true))
+	}
+	return fields
+}
+
+func webAuthnChallengeLogFields(challengeID, userID string) []zap.Field {
+	fields := []zap.Field{
+		zap.Bool("challenge_reference_present", strings.TrimSpace(challengeID) != ""),
+	}
+	if strings.TrimSpace(userID) != "" {
+		fields = append(fields, zap.String("userID", userID))
+	}
+	return fields
+}
+
 // ValidatePassword validates a user's password and tracks login attempts
 func (r *AccountRepository) ValidatePassword(ctx context.Context, username, password string) (*storage.User, error) {
 	// Get user first
@@ -1133,21 +1156,14 @@ func (r *AccountRepository) StorePasskeyRegistrationProof(ctx context.Context, p
 		"failed to prepare passkey registration proof",
 		"failed to store passkey registration proof",
 		func(model *models.PasskeyRegistrationProof) []zap.Field {
-			return []zap.Field{
-				zap.String("proof_id", model.ID),
-				zap.String("username", model.Username),
-				zap.String("ceremony_id", model.CeremonyID),
-			}
+			return passkeyProofLogFields(model.ID, model.Username, model.CeremonyID)
 		},
 	)
 	if err != nil {
 		return ErrorHandler.HandleCreateError(err, entityPasskeyRegistrationProof, proof.ID)
 	}
 
-	r.logger.Debug("stored passkey registration proof",
-		zap.String("proof_id", proof.ID),
-		zap.String("username", proof.Username),
-		zap.String("ceremony_id", proof.CeremonyID))
+	r.logger.Debug("stored passkey registration proof", passkeyProofLogFields(proof.ID, proof.Username, proof.CeremonyID)...)
 
 	return nil
 }
@@ -1167,17 +1183,15 @@ func (r *AccountRepository) GetPasskeyRegistrationProof(ctx context.Context, pro
 		if errors.IsNotFound(err) {
 			return nil, ErrorHandler.HandleNotFound(err, entityPasskeyRegistrationProof, proofID)
 		}
-		r.logger.Error("failed to get passkey registration proof",
-			zap.String("proof_id", proofID),
-			zap.Error(err))
+		fields := append(passkeyProofLogFields(proofID, "", ""), zap.Error(err))
+		r.logger.Error("failed to get passkey registration proof", fields...)
 		return nil, ErrorHandler.HandleGetError(err, entityPasskeyRegistrationProof, proofID)
 	}
 
 	if proof.IsExpired(time.Now().UTC()) {
 		if delErr := r.DeletePasskeyRegistrationProof(ctx, proofID); delErr != nil {
-			r.logger.Warn("failed to delete expired passkey registration proof",
-				zap.String("proof_id", proofID),
-				zap.Error(delErr))
+			fields := append(passkeyProofLogFields(proofID, "", ""), zap.Error(delErr))
+			r.logger.Warn("failed to delete expired passkey registration proof", fields...)
 		}
 		return nil, ErrorHandler.HandleNotFound(storage.ErrNotFound, entityPasskeyRegistrationProof, proofID)
 	}
@@ -1192,9 +1206,8 @@ func (r *AccountRepository) DeletePasskeyRegistrationProof(ctx context.Context, 
 		Where("SK", "=", models.SKPasskeyRegistrationProof).
 		Delete()
 	if err != nil && !errors.IsNotFound(err) {
-		r.logger.Error("failed to delete passkey registration proof",
-			zap.String("proof_id", proofID),
-			zap.Error(err))
+		fields := append(passkeyProofLogFields(proofID, "", ""), zap.Error(err))
+		r.logger.Error("failed to delete passkey registration proof", fields...)
 		return ErrorHandler.HandleDeleteError(err, entityPasskeyRegistrationProof, proofID)
 	}
 
@@ -1221,9 +1234,8 @@ func (r *AccountRepository) ConsumePasskeyRegistrationProof(ctx context.Context,
 	now := time.Now().UTC()
 	update, err := keyedUpdateBuilder(ctx, r.db, &models.PasskeyRegistrationProof{ID: proofID})
 	if err != nil {
-		r.logger.Error("failed to build passkey registration proof consume update",
-			zap.String("proof_id", proofID),
-			zap.Error(err))
+		fields := append(passkeyProofLogFields(proofID, "", ceremonyID), zap.Error(err))
+		r.logger.Error("failed to build passkey registration proof consume update", fields...)
 		return nil, ErrorHandler.HandleUpdateError(err, entityPasskeyRegistrationProof, proofID)
 	}
 
@@ -1236,21 +1248,15 @@ func (r *AccountRepository) ConsumePasskeyRegistrationProof(ctx context.Context,
 		Condition("CeremonyID", "=", strings.TrimSpace(ceremonyID)).
 		Execute()
 	if err != nil {
-		r.logger.Warn("failed to consume passkey registration proof",
-			zap.String("proof_id", proofID),
-			zap.String("username", username),
-			zap.String("ceremony_id", ceremonyID),
-			zap.Error(err))
+		fields := append(passkeyProofLogFields(proofID, username, ceremonyID), zap.Error(err))
+		r.logger.Warn("failed to consume passkey registration proof", fields...)
 		return nil, ErrorHandler.HandleUpdateError(err, entityPasskeyRegistrationProof, proofID)
 	}
 
 	proof.Consumed = true
 	proof.ConsumedAt = now
 
-	r.logger.Debug("consumed passkey registration proof",
-		zap.String("proof_id", proofID),
-		zap.String("username", username),
-		zap.String("ceremony_id", ceremonyID))
+	r.logger.Debug("consumed passkey registration proof", passkeyProofLogFields(proofID, username, ceremonyID)...)
 
 	return proof, nil
 }
@@ -1287,16 +1293,12 @@ func (r *AccountRepository) StoreWebAuthnChallenge(ctx context.Context, challeng
 	// Store in DynamoDB
 	err = r.db.WithContext(ctx).Model(modelChallenge).Create()
 	if err != nil {
-		r.logger.Error("failed to store WebAuthn challenge",
-			zap.String("challenge", challenge.Challenge),
-			zap.String("userID", challenge.UserID),
-			zap.Error(err))
+		fields := append(webAuthnChallengeLogFields(challenge.Challenge, challenge.UserID), zap.Error(err))
+		r.logger.Error("failed to store WebAuthn challenge", fields...)
 		return ErrorHandler.HandleCreateError(err, EntityWebAuthnChallenge, challenge.Challenge)
 	}
 
-	r.logger.Debug("WebAuthn challenge stored successfully",
-		zap.String("challenge", challenge.Challenge),
-		zap.String("userID", challenge.UserID))
+	r.logger.Debug("WebAuthn challenge stored successfully", webAuthnChallengeLogFields(challenge.Challenge, challenge.UserID)...)
 
 	return nil
 }

--- a/pkg/storage/repositories/account_repository_auth_passkey_registration_proof_test.go
+++ b/pkg/storage/repositories/account_repository_auth_passkey_registration_proof_test.go
@@ -2,8 +2,10 @@ package repositories
 
 import (
 	"context"
+	"encoding/json"
 	stdErrors "errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -15,6 +17,8 @@ import (
 	"github.com/theory-cloud/tabletheory/v3/pkg/core"
 	dynamormerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestAccountRepository_PasskeyRegistrationProofLifecycle(t *testing.T) {
@@ -261,6 +265,48 @@ func TestAccountRepository_ConsumePasskeyRegistrationProof_MissingProof(t *testi
 	proof, err := repo.ConsumePasskeyRegistrationProof(context.Background(), "missing-proof", "alice", "ceremony")
 	require.Nil(t, proof)
 	require.Error(t, err)
+}
+
+func TestAccountRepository_PasskeyProofLogsRedactSensitiveMaterial(t *testing.T) {
+	t.Parallel()
+
+	core, observed := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core)
+
+	db := newPasskeyRegistrationProofDB()
+	repo := NewAccountRepository(db, "test-table", "example.com", logger)
+
+	ctx := context.Background()
+	proof := &models.PasskeyRegistrationProof{
+		ID:              "proof-sensitive-raw",
+		Username:        "alice",
+		CeremonyID:      "ceremony-sensitive-raw",
+		CredentialID:    "cred-sensitive-raw",
+		PublicKey:       []byte("public-key-sensitive-raw"),
+		AttestationType: "none",
+		AAGUID:          []byte("aaguid-sensitive-raw"),
+		ExpiresAt:       time.Now().Add(5 * time.Minute).UTC(),
+	}
+
+	require.NoError(t, repo.StorePasskeyRegistrationProof(ctx, proof))
+
+	_, err := repo.ConsumePasskeyRegistrationProof(ctx, proof.ID, "mallory", proof.CeremonyID)
+	require.Error(t, err)
+
+	var rendered []string
+	for _, entry := range observed.All() {
+		payload, marshalErr := json.Marshal(entry.ContextMap())
+		require.NoError(t, marshalErr)
+		rendered = append(rendered, entry.Message+" "+string(payload))
+	}
+	combined := strings.Join(rendered, "\n")
+
+	require.NotContains(t, combined, proof.ID)
+	require.NotContains(t, combined, proof.CeremonyID)
+	require.NotContains(t, combined, string(proof.PublicKey))
+	require.NotContains(t, combined, string(proof.AAGUID))
+	require.Contains(t, combined, "proof_reference_present")
+	require.Contains(t, combined, "ceremony_reference_present")
 }
 
 func TestAccountRepository_GetPasskeyRegistrationProof_QueryError(t *testing.T) {

--- a/pkg/storage/repositories/account_repository_guarded_delete_test.go
+++ b/pkg/storage/repositories/account_repository_guarded_delete_test.go
@@ -1,0 +1,152 @@
+package repositories
+
+import (
+	"context"
+	"testing"
+
+	"github.com/equaltoai/lesser/pkg/storage"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/theory-cloud/tabletheory/v3/pkg/core"
+	dynamormerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
+	"github.com/theory-cloud/tabletheory/v3/pkg/mocks"
+	"go.uber.org/zap"
+)
+
+type guardedDeleteTestDB struct {
+	query     *mocks.MockQuery
+	txBuilder core.TransactionBuilder
+	txErr     error
+}
+
+func (db *guardedDeleteTestDB) Model(any) core.Query {
+	if db.query == nil {
+		db.query = new(mocks.MockQuery)
+	}
+	return db.query
+}
+
+func (db *guardedDeleteTestDB) Migrate() error                      { return nil }
+func (db *guardedDeleteTestDB) AutoMigrate(...any) error            { return nil }
+func (db *guardedDeleteTestDB) Close() error                        { return nil }
+func (db *guardedDeleteTestDB) WithContext(context.Context) core.DB { return db }
+
+func (db *guardedDeleteTestDB) TransactWrite(_ context.Context, fn func(core.TransactionBuilder) error) error {
+	builder := db.txBuilder
+	if builder == nil {
+		builder = new(mocks.MockTransactionBuilder)
+	}
+	if err := fn(builder); err != nil {
+		return err
+	}
+	if db.txErr != nil {
+		return db.txErr
+	}
+	return builder.Execute()
+}
+
+func TestAccountRepository_GuardedDeleteTransactionalHelpers(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	repoWithoutTx := NewAccountRepository(new(mocks.MockDB), "test-table", "example.com", zap.NewNop())
+	require.Error(t, repoWithoutTx.transactWrite(ctx, func(core.TransactionBuilder) error { return nil }))
+	_, err := repoWithoutTx.transactionalDB()
+	require.Error(t, err)
+
+	repoWithTx := NewAccountRepository(&guardedDeleteTestDB{}, "test-table", "example.com", zap.NewNop())
+	require.NoError(t, repoWithTx.transactWrite(ctx, func(core.TransactionBuilder) error { return nil }))
+}
+
+func TestAccountRepository_DeleteWebAuthnCredentialConditionedOnSurvivor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		repo := NewAccountRepository(&guardedDeleteTestDB{}, "test-table", "example.com", zap.NewNop())
+
+		require.NoError(t, repo.DeleteWebAuthnCredentialConditionedOnSurvivor(
+			context.Background(),
+			"alice",
+			"cred-1",
+			"",
+			"0xabc",
+		))
+	})
+
+	t.Run("condition failure is surfaced without wrapping", func(t *testing.T) {
+		txErr := &dynamormerrors.TransactionError{
+			Err:            dynamormerrors.ErrConditionFailed,
+			Operation:      "condition_check",
+			OperationIndex: 1,
+			Reason:         "ConditionalCheckFailed",
+		}
+
+		repo := NewAccountRepository(&guardedDeleteTestDB{txErr: txErr}, "test-table", "example.com", zap.NewNop())
+
+		err := repo.DeleteWebAuthnCredentialConditionedOnSurvivor(
+			context.Background(),
+			"alice",
+			"cred-1",
+			"",
+			"0xabc",
+		)
+		require.ErrorIs(t, err, dynamormerrors.ErrConditionFailed)
+	})
+}
+
+func TestAccountRepository_DeleteWalletCredentialConditionedOnSurvivor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success cleans up wallet index entries best effort", func(t *testing.T) {
+		query := new(mocks.MockQuery)
+		query.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(query).Maybe()
+		query.On("Delete").Return(nil).Maybe()
+
+		repo := NewAccountRepository(&guardedDeleteTestDB{query: query}, "test-table", "example.com", zap.NewNop())
+
+		require.NoError(t, repo.DeleteWalletCredentialConditionedOnSurvivor(
+			context.Background(),
+			"alice",
+			"0xabc",
+			"ethereum",
+			"cred-1",
+			"",
+		))
+	})
+
+	t.Run("condition failure is surfaced without wrapping", func(t *testing.T) {
+		txErr := &dynamormerrors.TransactionError{
+			Err:            dynamormerrors.ErrConditionFailed,
+			Operation:      "condition_check",
+			OperationIndex: 1,
+			Reason:         "ConditionalCheckFailed",
+		}
+
+		repo := NewAccountRepository(&guardedDeleteTestDB{txErr: txErr}, "test-table", "example.com", zap.NewNop())
+
+		err := repo.DeleteWalletCredentialConditionedOnSurvivor(
+			context.Background(),
+			"alice",
+			"0xabc",
+			"ethereum",
+			"cred-1",
+			"",
+		)
+		require.ErrorIs(t, err, dynamormerrors.ErrConditionFailed)
+	})
+
+	t.Run("empty survivor is rejected", func(t *testing.T) {
+		repo := NewAccountRepository(&guardedDeleteTestDB{}, "test-table", "example.com", zap.NewNop())
+
+		err := repo.DeleteWalletCredentialConditionedOnSurvivor(
+			context.Background(),
+			"alice",
+			"0xabc",
+			"ethereum",
+			"",
+			"",
+		)
+		require.ErrorIs(t, err, storage.ErrInvalidInput)
+	})
+}

--- a/pkg/storage/repositories/account_repository_transactions.go
+++ b/pkg/storage/repositories/account_repository_transactions.go
@@ -1,0 +1,28 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/theory-cloud/tabletheory/v3/pkg/core"
+)
+
+type accountRepositoryTransactionalDB interface {
+	core.DB
+	TransactWrite(ctx context.Context, fn func(core.TransactionBuilder) error) error
+}
+
+func (r *AccountRepository) transactWrite(ctx context.Context, fn func(core.TransactionBuilder) error) error {
+	txDB, err := r.transactionalDB()
+	if err != nil {
+		return err
+	}
+	return txDB.TransactWrite(ctx, fn)
+}
+
+func (r *AccountRepository) transactionalDB() (accountRepositoryTransactionalDB, error) {
+	if txDB, ok := r.db.(accountRepositoryTransactionalDB); ok && txDB != nil {
+		return txDB, nil
+	}
+	return nil, fmt.Errorf("database does not support transact write operations")
+}

--- a/pkg/storage/repositories/account_repository_webauthn.go
+++ b/pkg/storage/repositories/account_repository_webauthn.go
@@ -2,13 +2,14 @@ package repositories
 
 import (
 	"context"
-	"errors"
+	stdErrors "errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/equaltoai/lesser/pkg/storage"
 	"github.com/equaltoai/lesser/pkg/storage/models"
+	"github.com/theory-cloud/tabletheory/v3"
 	"github.com/theory-cloud/tabletheory/v3/pkg/core"
 	dynamormerrors "github.com/theory-cloud/tabletheory/v3/pkg/errors"
 	"go.uber.org/zap"
@@ -123,6 +124,30 @@ func deleteWebAuthnCredentialRecord(ctx context.Context, db core.DB, credentialI
 		Where("PK", "=", credential.PK).
 		Where("SK", "=", credential.SK).
 		Delete()
+}
+
+func newWebAuthnCredentialKeyModel(username, credentialID string) *models.WebAuthnCredential {
+	model := &models.WebAuthnCredential{
+		ID:     credentialID,
+		UserID: username,
+	}
+	ensureWebAuthnCredentialCanonicalKeys(model)
+	return model
+}
+
+func newWalletCredentialKeyModel(username, address string) *models.WalletCredential {
+	model := &models.WalletCredential{
+		Username: username,
+		Address:  strings.ToLower(address),
+	}
+	_ = model.UpdateKeys()
+	return model
+}
+
+func newWalletIndexKeyModel(username, address, walletType string) *models.WalletIndex {
+	index := &models.WalletIndex{}
+	index.UpdateKeys(walletType, address, username)
+	return index
 }
 
 func updateWebAuthnCredentialLastUsedRecord(ctx context.Context, db core.DB, credentialID string, signCount uint32) error {
@@ -285,6 +310,45 @@ func (r *AccountRepository) DeleteWebAuthnCredential(ctx context.Context, creden
 	return nil
 }
 
+// DeleteWebAuthnCredentialConditionedOnSurvivor removes a passkey only if the
+// caller-provided surviving authenticator still exists at commit time.
+func (r *AccountRepository) DeleteWebAuthnCredentialConditionedOnSurvivor(
+	ctx context.Context,
+	username string,
+	credentialID string,
+	survivingPasskeyID string,
+	survivingWalletAddress string,
+) error {
+	target := newWebAuthnCredentialKeyModel(username, credentialID)
+	survivor, err := guardedAuthenticatorModel(username, survivingPasskeyID, survivingWalletAddress)
+	if err != nil {
+		return err
+	}
+
+	err = r.transactWrite(ctx, func(tx core.TransactionBuilder) error {
+		tx.Delete(target, tabletheory.IfExists())
+		tx.ConditionCheck(survivor, tabletheory.IfExists())
+		return nil
+	})
+	if err != nil {
+		r.logAuthenticatorTransactionError("guarded WebAuthn delete failed", err,
+			zap.String("username", username),
+			zap.String("credential_id", credentialID),
+			zap.String("surviving_passkey_id", survivingPasskeyID),
+			zap.String("surviving_wallet_address", survivingWalletAddress),
+		)
+		if dynamormerrors.IsConditionFailed(err) {
+			return err
+		}
+		return ErrorHandler.HandleDeleteError(err, EntityWebAuthnCredential, credentialID)
+	}
+
+	r.logger.Info("deleted WebAuthn credential with survivor guard",
+		zap.String("username", username),
+		zap.String("credential_id", credentialID))
+	return nil
+}
+
 // UpdateWebAuthnLastUsed updates the last used timestamp and sign count for a credential
 func (r *AccountRepository) UpdateWebAuthnLastUsed(ctx context.Context, credentialID string, signCount uint32) error {
 	err := updateWebAuthnCredentialLastUsedRecord(ctx, r.db, credentialID, signCount)
@@ -394,7 +458,7 @@ func (r *AccountRepository) GetWebAuthnChallenge(ctx context.Context, challenge 
 				zap.String("challenge", challenge),
 				zap.Error(err))
 		}
-		return nil, ErrorHandler.HandleNotFound(errors.New("challenge expired"), EntityWebAuthnChallenge, challenge)
+		return nil, ErrorHandler.HandleNotFound(stdErrors.New("challenge expired"), EntityWebAuthnChallenge, challenge)
 	}
 
 	return &storage.WebAuthnChallenge{
@@ -429,12 +493,12 @@ func (r *AccountRepository) StoreWalletCredential(ctx context.Context, credentia
 	if credential.Username == "" {
 		r.logger.Error("username is required for wallet credential",
 			zap.String("address", credential.Address))
-		return ErrorHandler.HandleCreateError(errors.New("username is required"), EntityWalletCredential, credential.Address)
+		return ErrorHandler.HandleCreateError(stdErrors.New("username is required"), EntityWalletCredential, credential.Address)
 	}
 	if credential.Address == "" {
 		r.logger.Error("address is required for wallet credential",
 			zap.String("username", credential.Username))
-		return ErrorHandler.HandleCreateError(errors.New("address is required"), EntityWalletCredential, credential.Username)
+		return ErrorHandler.HandleCreateError(stdErrors.New("address is required"), EntityWalletCredential, credential.Username)
 	}
 
 	model := &models.WalletCredential{
@@ -459,7 +523,7 @@ func (r *AccountRepository) StoreWalletCredential(ctx context.Context, credentia
 	err := r.db.WithContext(ctx).Model(model).Create()
 	if err != nil {
 		if dynamormerrors.IsConditionFailed(err) {
-			return ErrorHandler.HandleCreateError(errors.New("already exists"), EntityWalletCredential, credential.Address)
+			return ErrorHandler.HandleCreateError(stdErrors.New("already exists"), EntityWalletCredential, credential.Address)
 		}
 		r.logger.Error("failed to store wallet credential",
 			zap.String("address", credential.Address),
@@ -698,7 +762,7 @@ func (r *AccountRepository) GetWalletChallenge(ctx context.Context, challengeID 
 				zap.String("challengeID", challengeID),
 				zap.Error(err))
 		}
-		return nil, ErrorHandler.HandleNotFound(errors.New("challenge expired"), EntityWalletChallenge, challengeID)
+		return nil, ErrorHandler.HandleNotFound(stdErrors.New("challenge expired"), EntityWalletChallenge, challengeID)
 	}
 
 	return &storage.WalletChallenge{
@@ -847,7 +911,7 @@ func (r *AccountRepository) GetWalletByAddress(ctx context.Context, walletType, 
 
 	// Filter by wallet type if specified
 	if walletType != "" && wallet.Type != walletType {
-		return nil, ErrorHandler.HandleNotFound(errors.New("type mismatch"), EntityWalletCredential, address)
+		return nil, ErrorHandler.HandleNotFound(stdErrors.New("type mismatch"), EntityWalletCredential, address)
 	}
 
 	return wallet, nil
@@ -896,4 +960,90 @@ func (r *AccountRepository) DeleteWalletCredential(ctx context.Context, username
 	}
 
 	return nil
+}
+
+// DeleteWalletCredentialConditionedOnSurvivor removes a wallet only if the
+// caller-provided surviving authenticator still exists at commit time.
+func (r *AccountRepository) DeleteWalletCredentialConditionedOnSurvivor(
+	ctx context.Context,
+	username, address, walletType string,
+	survivingPasskeyID string,
+	survivingWalletAddress string,
+) error {
+	address = strings.ToLower(address)
+	target := newWalletCredentialKeyModel(username, address)
+	survivor, err := guardedAuthenticatorModel(username, survivingPasskeyID, survivingWalletAddress)
+	if err != nil {
+		return err
+	}
+
+	err = r.transactWrite(ctx, func(tx core.TransactionBuilder) error {
+		tx.Delete(target, tabletheory.IfExists())
+		tx.ConditionCheck(survivor, tabletheory.IfExists())
+		return nil
+	})
+	if err != nil {
+		r.logAuthenticatorTransactionError("guarded wallet delete failed", err,
+			zap.String("username", username),
+			zap.String("address", address),
+			zap.String("surviving_passkey_id", survivingPasskeyID),
+			zap.String("surviving_wallet_address", survivingWalletAddress),
+		)
+		if dynamormerrors.IsConditionFailed(err) {
+			return err
+		}
+		return ErrorHandler.HandleDeleteError(err, EntityWalletCredential, address)
+	}
+
+	r.deleteWalletIndexEntriesBestEffort(ctx, username, address, walletType)
+
+	r.logger.Info("deleted wallet credential with survivor guard",
+		zap.String("username", username),
+		zap.String("address", address),
+		zap.String("wallet_type", walletType))
+	return nil
+}
+
+func guardedAuthenticatorModel(username, survivingPasskeyID, survivingWalletAddress string) (any, error) {
+	if strings.TrimSpace(survivingPasskeyID) != "" {
+		return newWebAuthnCredentialKeyModel(username, survivingPasskeyID), nil
+	}
+	if strings.TrimSpace(survivingWalletAddress) != "" {
+		return newWalletCredentialKeyModel(username, survivingWalletAddress), nil
+	}
+	return nil, storage.ErrInvalidInput
+}
+
+func (r *AccountRepository) deleteWalletIndexEntriesBestEffort(ctx context.Context, username, address, walletType string) {
+	walletTypes := []string{"ethereum", "solana", "bitcoin"}
+	if strings.TrimSpace(walletType) != "" {
+		walletTypes = []string{walletType}
+	}
+
+	for _, candidateType := range walletTypes {
+		indexErr := r.db.WithContext(ctx).Model(newWalletIndexKeyModel(username, address, candidateType)).
+			Where("PK", "=", fmt.Sprintf("WALLET#%s#%s", candidateType, strings.ToLower(address))).
+			Where("SK", "=", fmt.Sprintf("USER#%s", username)).
+			Delete()
+
+		if indexErr != nil && !dynamormerrors.IsNotFound(indexErr) {
+			r.logger.Warn("failed to delete wallet index entry after guarded wallet delete",
+				zap.String("username", username),
+				zap.String("address", address),
+				zap.String("walletType", candidateType),
+				zap.Error(indexErr))
+		}
+	}
+}
+
+func (r *AccountRepository) logAuthenticatorTransactionError(message string, err error, fields ...zap.Field) {
+	var txErr *dynamormerrors.TransactionError
+	if stdErrors.As(err, &txErr) {
+		fields = append(fields,
+			zap.Int("transaction_op_index", txErr.OperationIndex),
+			zap.String("transaction_operation", txErr.Operation),
+			zap.String("transaction_reason", txErr.Reason),
+		)
+	}
+	r.logger.Warn(message, append(fields, zap.Error(err))...)
 }


### PR DESCRIPTION
## Milestone
PROG-M1 M3 (part 1 of 2) — backend auth security hardening for last-authenticator enforcement and redacted credential auditability.

## Classification
security

## Surfaces affected
- `pkg/auth/`
- `cmd/api/handlers/accounts.go`
- `pkg/storage/repositories/account_repository_auth.go`

## Specialist walks referenced
- Federation trust: none
- Contract / API: no client-facing contract changes expected
- Schema: no schema or GSI changes
- Framework: idiomatic TableTheory conditional-update usage, aligned with M1/M2 precedent

## Consumer impact
- Operators: users cannot strand themselves without an authenticator; audit trail is safer and more complete
- Mastodon clients: none
- Remote AP peers: none
- Sibling repos: none

## Tasks
- [x] #1387 — enforce the shared last-authenticator invariant across passkey delete and wallet unlink
- [x] #1388 — redact WebAuthn/auth credential logging and emit credential audit events

Closes #1387, Closes #1388
Refs #1372 #1387 #1388

## Validation
- `GOTOOLCHAIN=go1.26.6 go build ./...`
- `GOTOOLCHAIN=go1.26.6 go vet ./...`
- `gofmt -l .` (empty)
- `GOTOOLCHAIN=go1.26.6 go test ./...`
- `GOTOOLCHAIN=go1.26.6 ./lesser verify ci`
- Mutation kill: shared-check regression in wallet unlink path fails `TestAuthenticatorInvariant_MirroredRemovalRulesStayInSync`
- Mutation kill: raw passkey proof identifier logging fails `TestAccountRepository_PasskeyProofLogsRedactSensitiveMaterial`
- Mutation kill: removed passkey-proof audit emission fails `TestAccountsRound12_HandleRegistrationLift`

## Stage rollout plan (handoff to deploy-instance)
- [ ] Merged to staging
- [ ] Deployed to dev
- [ ] Dev soak complete
- [ ] Deployed to staging (if used)
- [ ] Staging soak complete
- [ ] Deployed to live

## Cross-repo coordination
none
